### PR TITLE
Added logging from notifications-utils.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,8 @@ from flask._compat import string_types
 from flask import Flask, _request_ctx_stack
 from werkzeug.local import LocalProxy
 from config import configs
+from utils import logging
+
 
 api_user = LocalProxy(lambda: _request_ctx_stack.top.api_user)
 
@@ -15,6 +17,8 @@ def create_app(config_name):
     application.config.from_object(configs[config_name])
 
     init_app(application)
+
+    logging.init_app(application)
 
     from .main import main as main_blueprint
     application.register_blueprint(main_blueprint)

--- a/config.py
+++ b/config.py
@@ -1,6 +1,9 @@
 
 class Config(object):
     DEBUG = False
+    NOTIFY_LOG_LEVEL = 'DEBUG'
+    NOTIFY_APP_NAME = 'api'
+    NOTIFY_LOG_PATH = '/var/log/notify/application.log'
 
 
 class Development(Config):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ Flask-Script==2.0.5
 PyJWT==1.4.0
 
 git+https://github.com/alphagov/notifications-python-client.git@0.1.5#egg=notifications-python-client==0.1.5
+
+git+https://github.com/alphagov/notifications-utils.git@0.0.3#egg=notifications-utils==0.0.3


### PR DESCRIPTION
Adds logging from notifications-utils

- log level, location and app name set from config
    
    NOTIFY_LOG_LEVEL = 'DEBUG'
    NOTIFY_APP_NAME = 'api'
    NOTIFY_LOG_PATH = '/var/log/notify/application.log'

- Application logs to console when running in DEBUG mode

- Application logs to file when not in DEBUG mode, logs in text and in json.

- Need to create folder locally in the required location for app to work.