### PR TITLE
Fix for job urls that should have been within context of a service.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -36,7 +36,7 @@ def create_app(config_name):
     application.register_blueprint(user_blueprint, url_prefix='/user')
     application.register_blueprint(template_blueprint, url_prefix="/template")
     application.register_blueprint(status_blueprint, url_prefix='/status')
-    application.register_blueprint(job_blueprint, url_prefix='/job')
+    application.register_blueprint(job_blueprint)
 
     return application
 

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -7,13 +7,13 @@ def save_job(job):
     db.session.commit()
 
 
-def get_job_by_id(job_id):
-    return Job.query.filter_by(id=job_id).one()
+def get_job(service_id, job_id):
+    return Job.query.filter_by(service_id=service_id, id=job_id).one()
 
 
 def get_jobs_by_service(service_id):
     return Job.query.filter_by(service_id=service_id).all()
 
 
-def get_jobs():
+def _get_jobs():
     return Job.query.all()

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -9,8 +9,8 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from app.dao.jobs_dao import (
     save_job,
-    get_job_by_id,
-    get_jobs
+    get_job,
+    get_jobs_by_service
 )
 
 from app.schemas import (
@@ -18,15 +18,15 @@ from app.schemas import (
     jobs_schema
 )
 
-job = Blueprint('job', __name__)
+job = Blueprint('job', __name__, url_prefix='/service/<int:service_id>/job')
 
 
 @job.route('/<job_id>', methods=['GET'])
 @job.route('', methods=['GET'])
-def get_job(job_id=None):
+def get_job_for_service(service_id, job_id=None):
     if job_id:
         try:
-            job = get_job_by_id(job_id)
+            job = get_job(service_id, job_id)
             data, errors = job_schema.dump(job)
             return jsonify(data=data)
         except DataError:
@@ -34,13 +34,13 @@ def get_job(job_id=None):
         except NoResultFound:
             return jsonify(result="error", message="Job not found"), 404
     else:
-        jobs = get_jobs()
+        jobs = get_jobs_by_service(service_id)
         data, errors = jobs_schema.dump(jobs)
         return jsonify(data=data)
 
 
 @job.route('', methods=['POST'])
-def create_job():
+def create_job(service_id):
     job, errors = job_schema.load(request.get_json())
     if errors:
         return jsonify(result="error", message=errors), 400


### PR DESCRIPTION
The service id path parameter is captured in the url prefix for the
job blueprint.