### PR TITLE
New endpoint for delivery app to use.

### DIFF
--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -58,6 +58,11 @@ def fetch_client(client):
             "client": client,
             "secret": [current_app.config.get('ADMIN_CLIENT_SECRET')]
         }
+    elif client == current_app.config.get('DELIVERY_CLIENT_USER_NAME'):
+        return {
+            "client": client,
+            "secret": [current_app.config.get('DELIVERY_CLIENT_SECRET')]
+        }
     else:
         return {
             "client": client,

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -90,6 +90,7 @@ class SmsNotificationSchema(NotificationSchema):
 
 class SmsTemplateNotificationSchema(SmsNotificationSchema):
     template = fields.Int(required=True)
+    job = fields.String()
 
     @validates('template')
     def validate_template(self, value):

--- a/config.py
+++ b/config.py
@@ -13,6 +13,8 @@ class Config(object):
     NOTIFY_DATA_API_AUTH_TOKEN = os.getenv('NOTIFY_API_TOKEN', "dev-token")
     ADMIN_CLIENT_USER_NAME = None
     ADMIN_CLIENT_SECRET = None
+    DELIVERY_CLIENT_USER_NAME = None
+    DELIVERY_CLIENT_SECRET = None
 
     AWS_REGION = 'eu-west-1'
     NOTIFY_JOB_QUEUE = os.getenv('NOTIFY_JOB_QUEUE', 'notify-jobs-queue')
@@ -26,15 +28,12 @@ class Development(Config):
     DANGEROUS_SALT = 'dangerous-salt'
     ADMIN_CLIENT_USER_NAME = 'dev-notify-admin'
     ADMIN_CLIENT_SECRET = 'dev-notify-secret-key'
+    DELIVERY_CLIENT_USER_NAME = 'dev-notify-delivery'
+    DELIVERY_CLIENT_SECRET = 'dev-notify-secret-key'
 
 
-class Test(Config):
-    DEBUG = True
+class Test(Development):
     SQLALCHEMY_DATABASE_URI = 'postgresql://localhost/test_notification_api'
-    SECRET_KEY = 'secret-key'
-    DANGEROUS_SALT = 'dangerous-salt'
-    ADMIN_CLIENT_USER_NAME = 'dev-notify-admin'
-    ADMIN_CLIENT_SECRET = 'dev-notify-secret-key'
 
 
 class Live(Config):


### PR DESCRIPTION
Once removal of code that uses existing alpha is done, then
duplicated code from /notifications/sms and the new endpoint
can be merged.

Job id is now available in notification but is not used yet.