### PR TITLE
Refactor user/<user_id>/code into two endpoints.

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -2,6 +2,8 @@ from flask import (
     jsonify,
     current_app
 )
+from sqlalchemy.exc import SQLAlchemyError, DataError
+from sqlalchemy.orm.exc import NoResultFound
 
 
 def register_errors(blueprint):
@@ -32,3 +34,18 @@ def register_errors(blueprint):
     def internal_server_error(e):
         current_app.logger.exception(e)
         return jsonify(error="Internal error"), 500
+
+    @blueprint.app_errorhandler(NoResultFound)
+    def no_result_found(e):
+        current_app.logger.error(e)
+        return jsonify(error="No result found"), 404
+
+    @blueprint.app_errorhandler(DataError)
+    def no_result_found(e):
+        current_app.logger.error(e)
+        return jsonify(error="No result found"), 404
+
+    @blueprint.app_errorhandler(SQLAlchemyError)
+    def db_error(e):
+        current_app.logger.error(e)
+        return jsonify(error="Database error occurred"), 500

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -62,7 +62,8 @@ class JobSchema(BaseSchema):
         model = models.Job
 
 
-class RequestVerifyCodeSchema(ma.Schema):
+# TODO: Remove this schema once the admin app has stopped using the /user/<user_id>code endpoint
+class OldRequestVerifyCodeSchema(ma.Schema):
 
     code_type = fields.Str(required=True)
     to = fields.Str(required=False)
@@ -71,6 +72,10 @@ class RequestVerifyCodeSchema(ma.Schema):
     def validate_code_type(self, code):
         if code not in models.VERIFY_CODE_TYPES:
             raise ValidationError('Invalid code type')
+
+
+class RequestVerifyCodeSchema(ma.Schema):
+    to = fields.Str(required=False)
 
 
 # TODO main purpose to be added later
@@ -154,6 +159,8 @@ api_keys_schema = ApiKeySchema(many=True)
 job_schema = JobSchema()
 job_schema_load_json = JobSchema(load_json=True)
 jobs_schema = JobSchema(many=True)
+# TODO: Remove this schema once the admin app has stopped using the /user/<user_id>code endpoint
+old_request_verify_code_schema = OldRequestVerifyCodeSchema()
 request_verify_code_schema = RequestVerifyCodeSchema()
 sms_admin_notification_schema = SmsAdminNotificationSchema()
 sms_template_notification_schema = SmsTemplateNotificationSchema()

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -261,7 +261,7 @@ def test_put_user_not_exists(notify_api, notify_db, notify_db_session, sample_us
             assert User.query.count() == 2
             user = User.query.filter_by(id=sample_user.id).first()
             json_resp = json.loads(resp.get_data(as_text=True))
-            assert json_resp == {'result': 'error', 'message': 'User not found'}
+            assert json_resp == {'error': 'No result found'}
             assert user == sample_user
             assert user.email_address != new_email
 
@@ -318,8 +318,7 @@ def test_get_user_service(notify_api, notify_db, notify_db_session, sample_servi
             assert json_resp['data']['id'] == str(another_service.id)
 
 
-def test_get_user_service_user_not_exists(notify_api, notify_db, notify_db_session, sample_service,
-                                          sample_admin_service_id):
+def test_get_user_service_user_not_exists(notify_api, sample_service, sample_admin_service_id):
     """
     Tests GET endpoint "/<user_id>/service/<service_id>" 404 is returned for invalid user.
     """
@@ -330,28 +329,25 @@ def test_get_user_service_user_not_exists(notify_api, notify_db, notify_db_sessi
                                                       path=url_for('user.get_service_by_user_id', user_id="123423",
                                                                    service_id=sample_service.id),
                                                       method='GET')
-            print('** service users{}'.format(sample_service.users[0].id))
             resp = client.get(
                 url_for('user.get_service_by_user_id', user_id="123423", service_id=sample_service.id),
                 headers=[('Content-Type', 'application/json'), auth_header])
             assert resp.status_code == 404
             json_resp = json.loads(resp.get_data(as_text=True))
-            assert "User not found" in json_resp['message']
+            assert json_resp == {'error': 'No result found'}
 
 
-def test_get_user_service_service_not_exists(notify_api, notify_db, notify_db_session, sample_service,
-                                             sample_admin_service_id):
+def test_get_user_service_service_not_exists(notify_api, sample_service):
     """
     Tests GET endpoint "/<user_id>/service/<service_id>" 404 is returned for invalid service.
     """
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             user = User.query.first()
-            assert Service.query.count() == 2
+            assert Service.query.count() == 1
             import uuid
             missing_service_id = uuid.uuid4()
-            auth_header = create_authorization_header(service_id=sample_admin_service_id,
-                                                      path=url_for('user.get_service_by_user_id', user_id=user.id,
+            auth_header = create_authorization_header(path=url_for('user.get_service_by_user_id', user_id=user.id,
                                                                    service_id=missing_service_id),
                                                       method='GET')
             resp = client.get(
@@ -359,10 +355,10 @@ def test_get_user_service_service_not_exists(notify_api, notify_db, notify_db_se
                 headers=[('Content-Type', 'application/json'), auth_header])
             assert resp.status_code == 404
             json_resp = json.loads(resp.get_data(as_text=True))
-            assert "Service not found" in json_resp['message']
+            assert json_resp == {'error': 'No result found'}
 
 
-def test_delete_user(notify_api, notify_db, notify_db_session, sample_user, sample_admin_service_id):
+def test_delete_user(notify_api, sample_user, sample_admin_service_id):
     """
     Tests DELETE endpoint '/<user_id>' delete user.
     """
@@ -407,3 +403,5 @@ def test_delete_user_not_exists(notify_api, notify_db, notify_db_session, sample
                 headers=[('Content-Type', 'application/json'), auth_header])
             assert resp.status_code == 404
             assert User.query.count() == 2
+            json_resp = json.loads(resp.get_data(as_text=True))
+            assert json_resp == {'error': 'No result found'}

--- a/tests/app/user/test_rest_verify.py
+++ b/tests/app/user/test_rest_verify.py
@@ -373,7 +373,7 @@ def test_send_user_code_for_sms_with_optional_to_field(notify_api,
    """
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
-            data = json.dumps({'code_type': 'sms', 'to': '+441119876757'})
+            data = json.dumps({'to': '+441119876757'})
             auth_header = create_authorization_header(
                 path=url_for('user.send_user_sms_code', user_id=sample_sms_code.user.id),
                 method='POST',


### PR DESCRIPTION
- Created new endpoint user/<user_id>/sms-code to send the sms verification code to the user.
- Create new endpoirtn user/<user_id>/email-code to send the email verifcation code to the user.
- Marked the old methods, schema, tests with a TODO to be deleted when the admin app is no longer sending messages to /user/<user_id>/code
- Added error handlers for DataError and NoResultFound. Data error catches invalid input errors.
- Added error handler for SqlAlchemyError which catches any other database errors.
- Removed the need for the try catches around the db calls in the user endpoints with the addition of the db error handlers.
- We may want to wrap db exceptions in the dao, if we want the No results found message to be more specific and say no result found for user.