### PR TITLE
Moved the deinition of which queues the worker will consume from

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,3 +1,4 @@
+from kombu import Exchange, Queue
 import os
 
 
@@ -48,6 +49,16 @@ class Config(object):
     TWILIO_NUMBER = os.getenv('TWILIO_NUMBER')
     FIRETEXT_NUMBER = os.getenv('FIRETEXT_NUMBER')
     FIRETEXT_API_KEY = os.getenv("FIRETEXT_API_KEY")
+    CELERY_QUEUES = [
+        Queue('sms', Exchange('default'), routing_key='default'),
+        Queue('email', Exchange('default'), routing_key='default'),
+        Queue('sms-code', Exchange('default'), routing_key='default'),
+        Queue('email-code', Exchange('default'), routing_key='default'),
+        Queue('process-job', Exchange('default'), routing_key='default'),
+        Queue('bulk-sms', Exchange('default'), routing_key='default'),
+        Queue('bulk-email', Exchange('default'), routing_key='default'),
+        Queue('email-invited-user', Exchange('default'), routing_key='default')
+    ]
 
 
 class Development(Config):

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -3,4 +3,4 @@
 set -e
 
 source environment.sh
-celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 -Q sms,sms-code,email-code,email,process-job,bulk-sms,bulk-email,email-invited-user
+celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4


### PR DESCRIPTION
- now in config not the script

Note - uses default exchange / routing keys, TBD if this is OK for production.