### PR TITLE
Fix bug where sending messages failed

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -69,7 +69,8 @@ def send_sms(service_id, notification_id, encrypted_notification, created_at):
     template = Template(
         dao_get_template_by_id(notification['template']).__dict__,
         values=notification.get('personalisation', {}),
-        prefix=service.name
+        prefix=service.name,
+        drop_values={first_column_heading['sms']}
     )
 
     client = firetext_client
@@ -111,7 +112,8 @@ def send_email(service_id, notification_id, subject, from_address, encrypted_not
     notification = encryption.decrypt(encrypted_notification)
     template = Template(
         dao_get_template_by_id(notification['template']).__dict__,
-        values=notification.get('personalisation', {})
+        values=notification.get('personalisation', {}),
+        drop_values={first_column_heading['email']}
     )
 
     client = aws_ses_client


### PR DESCRIPTION
When building the template it was looking for a placeholder called ((phone number)). This caused it to fail because the template it had did not match the personalisation it was being given.

`Template` has an optional parameter for specifying personalisation values that should be ignored. The recipient of a message is an example of such a value.

This commit passes that extra parameter, which fixes that bug.