### PR TITLE
Ensure restricted service are respected by tasks:

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -207,7 +207,7 @@ class VerifyCode(db.Model):
         return check_hash(cde, self._code)
 
 
-NOTIFICATION_STATUS_TYPES = ['sent', 'failed']
+NOTIFICATION_STATUS_TYPES = ['sent', 'failed', 'failed - restricted service']
 
 
 class Notification(db.Model):

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -13,6 +13,11 @@ from app.celery import tasks
 from tests.app import load_example_csv
 from datetime import datetime, timedelta
 from freezegun import freeze_time
+from tests.app.conftest import (
+    sample_service,
+    sample_user,
+    sample_template
+)
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
@@ -137,6 +142,89 @@ def test_should_send_sms_without_personalisation(sample_template, mocker):
     )
 
     firetext_client.send_sms.assert_called_once_with("+441234123123", "Sample service: This is a template")
+
+
+def test_should_send_sms_if_restricted_service_and_valid_number(notify_db, notify_db_session, mocker):
+
+    user = sample_user(notify_db, notify_db_session, mobile_numnber="+441234123123")
+    service = sample_service(notify_db, notify_db_session, user=user, restricted=True)
+    template = sample_template(notify_db, notify_db_session, service=service)
+
+    notification = {
+        "template": template.id,
+        "to": "+441234123123"
+    }
+    mocker.patch('app.encryption.decrypt', return_value=notification)
+    mocker.patch('app.firetext_client.send_sms')
+    mocker.patch('app.firetext_client.get_name', return_value="firetext")
+
+    notification_id = uuid.uuid4()
+    now = datetime.utcnow()
+    send_sms(
+        service.id,
+        notification_id,
+        "encrypted-in-reality",
+        now
+    )
+
+    firetext_client.send_sms.assert_called_once_with("+441234123123", "Sample service: This is a template")
+
+
+def test_should_not_send_sms_if_restricted_service_and_invalid_number(notify_db, notify_db_session, mocker):
+
+    user = sample_user(notify_db, notify_db_session, mobile_numnber="+441234123123")
+    service = sample_service(notify_db, notify_db_session, user=user, restricted=True)
+    template = sample_template(notify_db, notify_db_session, service=service)
+
+    notification = {
+        "template": template.id,
+        "to": "+440000000000"
+    }
+    mocker.patch('app.encryption.decrypt', return_value=notification)
+    mocker.patch('app.firetext_client.send_sms')
+    mocker.patch('app.firetext_client.get_name', return_value="firetext")
+
+    notification_id = uuid.uuid4()
+    now = datetime.utcnow()
+    send_sms(
+        service.id,
+        notification_id,
+        "encrypted-in-reality",
+        now
+    )
+
+    firetext_client.send_sms.assert_not_called()
+
+
+def test_should_send_email_if_restricted_service_and_valid_email(notify_db, notify_db_session, mocker):
+
+    user = sample_user(notify_db, notify_db_session, email="test@restricted.com")
+    service = sample_service(notify_db, notify_db_session, user=user, restricted=True)
+    template = sample_template(notify_db, notify_db_session, service=service)
+
+    notification = {
+        "template": template.id,
+        "to": "test@restricted.com"
+    }
+    mocker.patch('app.encryption.decrypt', return_value=notification)
+    mocker.patch('app.aws_ses_client.send_email')
+
+    notification_id = uuid.uuid4()
+    now = datetime.utcnow()
+    send_email(
+        service.id,
+        notification_id,
+        'subject',
+        'email_from',
+        "encrypted-in-reality",
+        now)
+
+    aws_ses_client.send_email.assert_called_once_with(
+        "email_from",
+        "test@restricted.com",
+        "subject",
+        template.content
+    )
 
 
 def test_should_send_template_to_correct_sms_provider_and_persist_with_job_id(sample_job, mocker):

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -42,12 +42,13 @@ def service_factory(notify_db, notify_db_session):
 @pytest.fixture(scope='function')
 def sample_user(notify_db,
                 notify_db_session,
+                mobile_numnber="+447700900986",
                 email="notify@digital.cabinet-office.gov.uk"):
     data = {
         'name': 'Test User',
         'email_address': email,
         'password': 'password',
-        'mobile_number': '+447700900986',
+        'mobile_number': mobile_numnber,
         'state': 'active'
     }
     usr = User.query.filter_by(email_address=email).first()
@@ -99,14 +100,15 @@ def sample_sms_code(notify_db,
 def sample_service(notify_db,
                    notify_db_session,
                    service_name="Sample service",
-                   user=None):
+                   user=None,
+                   restricted=False):
     if user is None:
         user = sample_user(notify_db, notify_db_session)
     data = {
         'name': service_name,
         'limit': 1000,
         'active': False,
-        'restricted': False,
+        'restricted': restricted,
         'email_from': email_safe(service_name)
     }
     service = Service.query.filter_by(name=service_name).first()


### PR DESCRIPTION
This is checked on 3rd party API calls, but jobs (CSV files) were able expected to only allow valid files.

Change in tack means we want to have restricted notification failures reported in the UI.