### PR TITLE
Use utils to validate and iterate over recipients

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -6,7 +6,11 @@ from . import models
 from app.dao.permissions_dao import permission_dao
 from marshmallow import (post_load, ValidationError, validates, validates_schema)
 from marshmallow_sqlalchemy import field_for
-from utils.recipients import validate_email_address, InvalidEmailError, validate_phone_number, InvalidPhoneError
+from utils.recipients import (
+    validate_email_address, InvalidEmailError,
+    validate_phone_number, InvalidPhoneError,
+    format_phone_number
+)
 
 
 # TODO I think marshmallow provides a better integration and error handling.
@@ -129,6 +133,13 @@ class SmsNotificationSchema(NotificationSchema):
             validate_phone_number(value)
         except InvalidPhoneError as error:
             raise ValidationError('Invalid phone number: {}'.format(error))
+
+    @post_load
+    def format_phone_number(self, item):
+        item['to'] = format_phone_number(validate_phone_number(
+            item['to'])
+        )
+        return item
 
 
 class EmailNotificationSchema(NotificationSchema):

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ monotonic==0.3
 
 git+https://github.com/alphagov/notifications-python-client.git@0.2.6#egg=notifications-python-client==0.2.6
 
-git+https://github.com/alphagov/notifications-utils.git@1.0.0#egg=notifications-utils==1.0.0
+git+https://github.com/alphagov/notifications-utils.git@2.0.0#egg=notifications-utils==2.0.0

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -277,7 +277,7 @@ def sample_notification(notify_db,
     if to_field:
         to = to_field
     else:
-        to = '+44709123456'
+        to = '+447700900855'
 
     data = {
         'id': notification_id,

--- a/tests/app/notifications/test_rest.py
+++ b/tests/app/notifications/test_rest.py
@@ -504,7 +504,7 @@ def test_should_allow_valid_sms_notification(notify_api, sample_template, mocker
             mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
 
             data = {
-                'to': '+447700900855',
+                'to': '07700 900 855',
                 'template': sample_template.id
             }
 
@@ -521,6 +521,7 @@ def test_should_allow_valid_sms_notification(notify_api, sample_template, mocker
                 headers=[('Content-Type', 'application/json'), auth_header])
 
             notification_id = json.loads(response.data)['notification_id']
+            assert app.encryption.encrypt.call_args[0][0]['to'] == '+447700900855'
             app.celery.tasks.send_sms.apply_async.assert_called_once_with(
                 (str(sample_template.service_id),
                  notification_id,

--- a/tests/app/notifications/test_rest.py
+++ b/tests/app/notifications/test_rest.py
@@ -24,7 +24,7 @@ def test_get_notification_by_id(notify_api, sample_notification):
             notification = json.loads(response.get_data(as_text=True))['notification']
             assert notification['status'] == 'sent'
             assert notification['template'] == sample_notification.template.id
-            assert notification['to'] == '+44709123456'
+            assert notification['to'] == '+447700900855'
             assert notification['service'] == str(sample_notification.service_id)
             assert response.status_code == 200
 
@@ -63,7 +63,7 @@ def test_get_all_notifications(notify_api, sample_notification):
             notifications = json.loads(response.get_data(as_text=True))
             assert notifications['notifications'][0]['status'] == 'sent'
             assert notifications['notifications'][0]['template'] == sample_notification.template.id
-            assert notifications['notifications'][0]['to'] == '+44709123456'
+            assert notifications['notifications'][0]['to'] == '+447700900855'
             assert notifications['notifications'][0]['service'] == str(sample_notification.service_id)
             assert response.status_code == 200
 
@@ -296,7 +296,7 @@ def test_should_reject_bad_phone_numbers(notify_api, sample_template, mocker):
 
             assert json_resp['result'] == 'error'
             assert len(json_resp['message'].keys()) == 1
-            assert 'Invalid phone number, must be of format +441234123123' in json_resp['message']['to']
+            assert 'Invalid phone number: Must not contain letters or symbols' in json_resp['message']['to']
             assert response.status_code == 400
 
 
@@ -306,7 +306,7 @@ def test_send_notification_invalid_template_id(notify_api, sample_template, mock
             mocker.patch('app.celery.tasks.send_sms.apply_async')
 
             data = {
-                'to': '+441234123123',
+                'to': '+447700900855',
                 'template': 9999
             }
             auth_header = create_authorization_header(
@@ -337,7 +337,7 @@ def test_send_notification_with_placeholders_replaced(notify_api, sample_templat
             mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
 
             data = {
-                'to': '+441234123123',
+                'to': '+447700900855',
                 'template': sample_template_with_placeholders.id,
                 'personalisation': {
                     'name': 'Jo'
@@ -373,7 +373,7 @@ def test_send_notification_with_missing_personalisation(
             mocker.patch('app.celery.tasks.send_sms.apply_async')
 
             data = {
-                'to': '+441234123123',
+                'to': '+447700900855',
                 'template': sample_template_with_placeholders.id,
                 'personalisation': {
                     'foo': 'bar'
@@ -405,7 +405,7 @@ def test_send_notification_with_too_much_personalisation_data(
             mocker.patch('app.celery.tasks.send_sms.apply_async')
 
             data = {
-                'to': '+441234123123',
+                'to': '+447700900855',
                 'template': sample_template_with_placeholders.id,
                 'personalisation': {
                     'name': 'Jo', 'foo': 'bar'
@@ -439,7 +439,7 @@ def test_prevents_sending_to_any_mobile_on_restricted_service(notify_api, sample
             ).update(
                 {'restricted': True}
             )
-            invalid_mob = '+449999999999'
+            invalid_mob = '+447700900855'
             data = {
                 'to': invalid_mob,
                 'template': sample_template.id
@@ -504,7 +504,7 @@ def test_should_allow_valid_sms_notification(notify_api, sample_template, mocker
             mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
 
             data = {
-                'to': '+441234123123',
+                'to': '+447700900855',
                 'template': sample_template.id
             }
 


### PR DESCRIPTION
### _Depends on: https://github.com/alphagov/notifications-utils/pull/9_

***

## Use `RecipientCSV` from utils for processing CSVs

See alphagov/notifications-utils#9 for details of the changes.

## Use validation of recipients from utils

This was added to utils in alphagov/notifications-utils@5914da7

This means that:
- we are doing the exact same validation in the API and admin app
- we are actually validating phone numbers for the correct format (hence all the changes to the tests)

## Accept phone numbers in any reasonable format

This uses the `format_phone_number` method from utils to output phone numbers in a consistent format. It is added to the schemas, so will be applied before the API tries to do anything with a provided phone number.

So now the API will accept any of the following:
- 07123456789
- 07123 456789
- 07123-456-789
- 00447123456789
- 00 44 7123456789
- +447123456789
- +44 7123 456 789
- +44 (0)7123 456 789

…but the API will always hand off phone numbers to 3rd party APIs in the format
- +447123456789

The test for this is slightly convoluted, because template IDs are still database IDs, and can’t consistently be mocked, therefore we have to ignore that part of the call to `encrypt()`.