### PR TITLE
Client callbacks

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -71,7 +71,7 @@ def create_app():
 def init_app(app):
     @app.before_request
     def required_authentication():
-        if request.path != url_for('status.show_status'):
+        if request.path not in [url_for('status.show_status'), url_for('notifications.process_firetext_response')]:
             from app.authentication import auth
             error = auth.requires_auth()
             if error:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -71,7 +71,12 @@ def create_app():
 def init_app(app):
     @app.before_request
     def required_authentication():
-        if request.path not in [url_for('status.show_status'), url_for('notifications.process_firetext_response')]:
+        no_auth_req = [
+            url_for('status.show_status'),
+            url_for('notifications.process_ses_response'),
+            url_for('notifications.process_firetext_response')
+        ]
+        if request.path not in no_auth_req:
             from app.authentication import auth
             error = auth.requires_auth()
             if error:

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -295,7 +295,9 @@ def send_email(service_id, notification_id, subject, from_address, encrypted_not
 def send_sms_code(encrypted_verification):
     verification_message = encryption.decrypt(encrypted_verification)
     try:
-        firetext_client.send_sms(verification_message['to'], verification_message['secret_code'])
+        firetext_client.send_sms(
+            verification_message['to'], verification_message['secret_code'], 'send-sms-code'
+        )
     except FiretextClientException as e:
         current_app.logger.exception(e)
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -282,7 +282,7 @@ def send_email(service_id, notification_id, subject, from_address, encrypted_not
                 )
                 update_notification_reference_by_id(notification_id, reference)
             except AwsSesClientException as e:
-                current_app.logger.debug(e)
+                current_app.logger.exception(e)
                 notification_db_object.status = 'failed'
                 dao_update_notification(notification_db_object)
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -208,6 +208,9 @@ def send_sms(service_id, notification_id, encrypted_notification, created_at):
                     notification_id=notification_id
                 )
             except FiretextClientException as e:
+                current_app.logger.error(
+                    "SMS notification {} failed".format(notification_id)
+                )
                 current_app.logger.exception(e)
                 notification_db_object.status = 'failed'
                 dao_update_notification(notification_db_object)

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -203,8 +203,9 @@ def send_sms(service_id, notification_id, encrypted_notification, created_at):
                 )
 
                 client.send_sms(
-                    notification['to'],
-                    template.replaced
+                    to=notification['to'],
+                    content=template.replaced,
+                    notification_id=notification_id
                 )
             except FiretextClientException as e:
                 current_app.logger.exception(e)

--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -3,6 +3,21 @@ from flask import current_app
 from monotonic import monotonic
 from app.clients.email import (EmailClientException, EmailClient)
 
+ses_response_status = {
+    'Bounce': {
+        "success": False,
+        "notify_status": 'bounce'
+    },
+    'Delivery': {
+        "success": True,
+        "notify_status": 'delivered'
+    },
+    'Complaint': {
+        "success": False,
+        "notify_status": 'complaint'
+    }
+}
+
 
 class AwsSesClientException(EmailClientException):
     pass

--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -9,6 +9,24 @@ from requests import request, RequestException, HTTPError
 
 logger = logging.getLogger(__name__)
 
+firetext_response_status = {
+    '0': {
+        "firetext_message": 'delivered',
+        "success": True,
+        "notify_status": 'delivered'
+    },
+    '1': {
+        "firetext_message": 'declined',
+        "success": False,
+        "notify_status": 'failed'
+    },
+    '2': {
+        "firetext_message": 'Undelivered (Pending with Network)',
+        "success": False,
+        "notify_status": 'sent'
+    }
+}
+
 
 class FiretextClientException(SmsClientException):
     def __init__(self, response):

--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -51,19 +51,15 @@ class FiretextClient(SmsClient):
     def get_name(self):
         return self.name
 
-    def send_sms(self, to, content, notification_id=None):
+    def send_sms(self, to, content, reference):
 
         data = {
             "apiKey": self.api_key,
             "from": self.from_number,
             "to": to.replace('+', ''),
-            "message": content
+            "message": content,
+            "reference": reference
         }
-
-        if notification_id:
-            data.update({
-                "reference": notification_id
-            })
 
         start_time = monotonic()
         try:

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -68,6 +68,28 @@ def dao_update_notification(notification):
     db.session.commit()
 
 
+def update_notification_status_by_id(notification_id, status):
+    count = db.session.query(Notification).filter_by(
+        id=notification_id
+    ).update({
+        Notification.status: status,
+        Notification.updated_at: datetime.utcnow()
+    })
+    db.session.commit()
+    return count
+
+
+def update_notification_status_by_to(to, status):
+    count = db.session.query(Notification).filter_by(
+        to=to
+    ).update({
+        Notification.status: status,
+        Notification.updated_at: datetime.utcnow()
+    })
+    db.session.commit()
+    return count
+
+
 def get_notification_for_job(service_id, job_id, notification_id):
     return Notification.query.filter_by(service_id=service_id, job_id=job_id, id=notification_id).one()
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -86,6 +86,10 @@ def get_notification(service_id, notification_id):
     return Notification.query.filter_by(service_id=service_id, id=notification_id).one()
 
 
+def get_notification_by_id(notification_id):
+    return Notification.query.filter_by(id=notification_id).first()
+
+
 def get_notifications_for_service(service_id, page=1):
     query = Notification.query.filter_by(service_id=service_id).order_by(desc(Notification.created_at)).paginate(
         page=page,

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -64,6 +64,7 @@ def update_job_sent_count(notification):
 
 
 def dao_update_notification(notification):
+    notification.updated_at = datetime.utcnow()
     db.session.add(notification)
     db.session.commit()
 
@@ -84,6 +85,28 @@ def update_notification_status_by_to(to, status):
         to=to
     ).update({
         Notification.status: status,
+        Notification.updated_at: datetime.utcnow()
+    })
+    db.session.commit()
+    return count
+
+
+def update_notification_status_by_reference(reference, status):
+    count = db.session.query(Notification).filter_by(
+        refernce=reference
+    ).update({
+        Notification.status: status,
+        Notification.updated_at: datetime.utcnow()
+    })
+    db.session.commit()
+    return count
+
+
+def update_notification_reference_by_id(id, reference):
+    count = db.session.query(Notification).filter_by(
+        id=id
+    ).update({
+        Notification.reference: reference,
         Notification.updated_at: datetime.utcnow()
     })
     db.session.commit()

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -80,20 +80,9 @@ def update_notification_status_by_id(notification_id, status):
     return count
 
 
-def update_notification_status_by_to(to, status):
-    count = db.session.query(Notification).filter_by(
-        to=to
-    ).update({
-        Notification.status: status,
-        Notification.updated_at: datetime.utcnow()
-    })
-    db.session.commit()
-    return count
-
-
 def update_notification_status_by_reference(reference, status):
     count = db.session.query(Notification).filter_by(
-        refernce=reference
+        reference=reference
     ).update({
         Notification.status: status,
         Notification.updated_at: datetime.utcnow()

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -61,6 +61,7 @@ def update_job_sent_count(notification):
         Job.notifications_sent: Job.notifications_sent + 1,
         Job.updated_at: datetime.utcnow()
     })
+    db.session.commit()
 
 
 def dao_update_notification(notification):

--- a/app/models.py
+++ b/app/models.py
@@ -265,6 +265,7 @@ class Notification(db.Model):
         onupdate=datetime.datetime.now)
     status = db.Column(
         db.Enum(*NOTIFICATION_STATUS_TYPES, name='notification_status_types'), nullable=False, default='sent')
+    reference = db.Column(db.String, nullable=True, index=True)
 
 
 INVITED_USER_STATUS_TYPES = ['pending', 'accepted', 'cancelled']

--- a/app/models.py
+++ b/app/models.py
@@ -231,7 +231,7 @@ class VerifyCode(db.Model):
         return check_hash(cde, self._code)
 
 
-NOTIFICATION_STATUS_TYPES = ['sent', 'failed']
+NOTIFICATION_STATUS_TYPES = ['sent', 'delivered', 'failed']
 
 
 class Notification(db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -231,7 +231,7 @@ class VerifyCode(db.Model):
         return check_hash(cde, self._code)
 
 
-NOTIFICATION_STATUS_TYPES = ['sent', 'delivered', 'failed']
+NOTIFICATION_STATUS_TYPES = ['sent', 'delivered', 'failed', 'complaint', 'bounce']
 
 
 class Notification(db.Model):

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from json import JSONDecodeError
 import uuid
 
 from flask import (
@@ -10,6 +9,8 @@ from flask import (
     url_for,
     json
 )
+
+from json.decoder import JSONDecodeError
 
 from utils.template import Template
 from app.clients.sms.firetext import firetext_response_status
@@ -91,8 +92,8 @@ def process_ses_response():
             ), 400
 
     except JSONDecodeError as ex:
-        current_app.logger.error(
-            "SES callback failed: invalid json"
+        current_app.logger.exception(
+            "SES callback failed: invalid json {}".format(ex)
         )
         return jsonify(
             result="error", message="SES callback failed: invalid json"

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -10,8 +10,6 @@ from flask import (
     json
 )
 
-from json import JSONDecodeError
-
 from utils.template import Template
 from app.clients.sms.firetext import firetext_response_status
 from app.clients.email.aws_ses import ses_response_status
@@ -91,7 +89,7 @@ def process_ses_response():
                 result="error", message="SES callback failed: destination missing"
             ), 400
 
-    except JSONDecodeError as ex:
+    except ValueError as ex:
         current_app.logger.exception(
             "SES callback failed: invalid json {}".format(ex)
         )

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -10,7 +10,7 @@ from flask import (
     json
 )
 
-from json.decoder import JSONDecodeError
+from json import JSONDecodeError
 
 from utils.template import Template
 from app.clients.sms.firetext import firetext_response_status

--- a/migrations/versions/0039_more_notification_states.py
+++ b/migrations/versions/0039_more_notification_states.py
@@ -1,0 +1,31 @@
+"""empty message
+
+Revision ID: 0039_more_notification_states
+Revises: 0038_reduce_limits
+Create Date: 2016-03-08 11:16:25.659463
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0039_more_notification_states'
+down_revision = '0038_reduce_limits'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+def upgrade():
+    op.drop_column('notifications', 'status')
+    op.execute('DROP TYPE notification_status_types')
+    notification_status_types = sa.Enum('sent', 'delivered', 'failed', name='notification_status_types')
+    notification_status_types.create(op.get_bind())
+    op.add_column('notifications', sa.Column('status', notification_status_types, nullable=True))
+    op.get_bind()
+    op.execute("update notifications set status='delivered'")
+    op.alter_column('notifications', 'status', nullable=False)
+
+
+def downgrade():
+    op.drop_column('notifications', 'status')
+    op.execute('DROP TYPE notification_status_types')

--- a/migrations/versions/0039_more_notification_states.py
+++ b/migrations/versions/0039_more_notification_states.py
@@ -18,7 +18,7 @@ from sqlalchemy.dialects import postgresql
 def upgrade():
     op.drop_column('notifications', 'status')
     op.execute('DROP TYPE notification_status_types')
-    notification_status_types = sa.Enum('sent', 'delivered', 'failed', name='notification_status_types')
+    notification_status_types = sa.Enum('sent', 'delivered', 'failed', 'complaint', 'bounce', name='notification_status_types')
     notification_status_types.create(op.get_bind())
     op.add_column('notifications', sa.Column('status', notification_status_types, nullable=True))
     op.get_bind()

--- a/migrations/versions/0040_add_reference.py
+++ b/migrations/versions/0040_add_reference.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: 0040_add_reference
+Revises: 0039_more_notification_states
+Create Date: 2016-03-11 09:15:57.900192
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0040_add_reference'
+down_revision = '0039_more_notification_states'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('notifications', sa.Column('reference', sa.String(), nullable=True))
+    op.create_index(op.f('ix_notifications_reference'), 'notifications', ['reference'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_notifications_reference'), table_name='notifications')
+    op.drop_column('notifications', 'reference')

--- a/test_ses_responses/ses_response.json
+++ b/test_ses_responses/ses_response.json
@@ -1,0 +1,32 @@
+{
+  "MessageId": "35efe472-ba36-5808-89bb-ab2925158b13",
+  "UnsubscribeURL": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:123456789012:preview-emails:12345678-1234-1234-1234-123456789012",
+  "SignatureVersion": "1",
+  "TopicArn": "arn:aws:sns:eu-west-1:123456789012:testing",
+  "Timestamp": "2016-03-10T16:12:19.876Z",
+  "Type": "Notification",
+  "Signature": "sig",
+  "Message": {
+    "notificationType": "Delivery",
+    "mail": {
+      "timestamp": "2016-03-10T16:12:19.016Z",
+      "source": "invites@testing-notify.com",
+      "sourceArn": "arn:aws:ses:eu-west-1:123456789012:identity/testing-notify",
+      "sendingAccountId": "123456789012",
+      "messageId": "01020153614cd6c8-2ec4bd32-7ddc-4344-811e-65d05519251f-000000",
+      "destination": [
+        "testing@digital.cabinet-office.gov.uk"
+      ]
+    },
+    "delivery": {
+      "timestamp": "2016-03-10T16:12:19.751Z",
+      "processingTimeMillis": 735,
+      "recipients": [
+        "testing@digital.cabinet-office.gov.uk"
+      ],
+      "smtpResponse": "250 2.0.0 OK 1457626339 u62si5491824wme.91 - gsmtp",
+      "reportingMTA": "a6-15.smtp-out.eu-west-1.amazonses.com"
+    }
+  },
+  "SigningCertURL": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-bb750dd426d95ee9390147a5624348ee.pem"
+}

--- a/tests/app/__init__.py
+++ b/tests/app/__init__.py
@@ -5,3 +5,9 @@ def load_example_csv(file):
     file_path = os.path.join("test_csv_files", "{}.csv".format(file))
     with open(file_path) as f:
         return f.read()
+
+
+def load_example_ses(file):
+    file_path = os.path.join("test_ses_responses", "{}.json".format(file))
+    with open(file_path) as f:
+        return f.read()

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -260,7 +260,11 @@ def test_should_send_template_to_correct_sms_provider_and_persist(sample_templat
         now.strftime(DATETIME_FORMAT)
     )
 
-    firetext_client.send_sms.assert_called_once_with("+441234123123", "Sample service: Hello Jo")
+    firetext_client.send_sms.assert_called_once_with(
+        to="+441234123123",
+        content="Sample service: Hello Jo",
+        notification_id=notification_id
+    )
     persisted_notification = notifications_dao.get_notification(
         sample_template_with_placeholders.service_id, notification_id
     )
@@ -292,7 +296,11 @@ def test_should_send_sms_without_personalisation(sample_template, mocker):
         now.strftime(DATETIME_FORMAT)
     )
 
-    firetext_client.send_sms.assert_called_once_with("+441234123123", "Sample service: This is a template")
+    firetext_client.send_sms.assert_called_once_with(
+        to="+441234123123",
+        content="Sample service: This is a template",
+        notification_id=notification_id
+    )
 
 
 def test_should_send_sms_if_restricted_service_and_valid_number(notify_db, notify_db_session, mocker):
@@ -317,7 +325,11 @@ def test_should_send_sms_if_restricted_service_and_valid_number(notify_db, notif
         now.strftime(DATETIME_FORMAT)
     )
 
-    firetext_client.send_sms.assert_called_once_with("+441234123123", "Sample service: This is a template")
+    firetext_client.send_sms.assert_called_once_with(
+        to="+441234123123",
+        content="Sample service: This is a template",
+        notification_id=notification_id
+    )
 
 
 def test_should_not_send_sms_if_restricted_service_and_invalid_number(notify_db, notify_db_session, mocker):
@@ -394,7 +406,11 @@ def test_should_send_template_to_correct_sms_provider_and_persist_with_job_id(sa
         "encrypted-in-reality",
         now.strftime(DATETIME_FORMAT)
     )
-    firetext_client.send_sms.assert_called_once_with("+441234123123", "Sample service: This is a template")
+    firetext_client.send_sms.assert_called_once_with(
+        to="+441234123123",
+        content="Sample service: This is a template",
+        notification_id=notification_id
+    )
     persisted_notification = notifications_dao.get_notification(sample_job.template.service_id, notification_id)
     assert persisted_notification.id == notification_id
     assert persisted_notification.to == '+441234123123'
@@ -490,7 +506,10 @@ def test_should_persist_notification_as_failed_if_sms_client_fails(sample_templa
         "encrypted-in-reality",
         now.strftime(DATETIME_FORMAT)
     )
-    firetext_client.send_sms.assert_called_once_with("+441234123123", "Sample service: This is a template")
+    firetext_client.send_sms.assert_called_once_with(
+        to="+441234123123",
+        content="Sample service: This is a template",
+        notification_id=notification_id)
     persisted_notification = notifications_dao.get_notification(sample_template.service_id, notification_id)
     assert persisted_notification.id == notification_id
     assert persisted_notification.to == '+441234123123'

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -35,6 +35,10 @@ from tests.app.conftest import (
 )
 
 
+def firetext_error():
+    return {'code': 0, 'description': 'error'}
+
+
 def test_should_call_delete_successful_notifications_in_task(notify_api, mocker):
     mocker.patch('app.celery.tasks.delete_successful_notifications_created_more_than_a_day_ago')
     delete_successful_notifications()
@@ -494,7 +498,7 @@ def test_should_persist_notification_as_failed_if_sms_client_fails(sample_templa
         "to": "+441234123123"
     }
     mocker.patch('app.encryption.decrypt', return_value=notification)
-    mocker.patch('app.firetext_client.send_sms', side_effect=FiretextClientException())
+    mocker.patch('app.firetext_client.send_sms', side_effect=FiretextClientException(firetext_error()))
     mocker.patch('app.firetext_client.get_name', return_value="firetext")
     now = datetime.utcnow()
 
@@ -623,7 +627,7 @@ def test_should_throw_firetext_client_exception(mocker):
                     'secret_code': '12345'}
 
     encrypted_notification = encryption.encrypt(notification)
-    mocker.patch('app.firetext_client.send_sms', side_effect=FiretextClientException)
+    mocker.patch('app.firetext_client.send_sms', side_effect=FiretextClientException(firetext_error()))
     send_sms_code(encrypted_notification)
     firetext_client.send_sms.assert_called_once_with(notification['to'], notification['secret_code'])
 

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -619,7 +619,7 @@ def test_should_send_sms_code(mocker):
 
     mocker.patch('app.firetext_client.send_sms')
     send_sms_code(encrypted_notification)
-    firetext_client.send_sms.assert_called_once_with(notification['to'], notification['secret_code'])
+    firetext_client.send_sms.assert_called_once_with(notification['to'], notification['secret_code'], 'send-sms-code')
 
 
 def test_should_throw_firetext_client_exception(mocker):
@@ -629,7 +629,7 @@ def test_should_throw_firetext_client_exception(mocker):
     encrypted_notification = encryption.encrypt(notification)
     mocker.patch('app.firetext_client.send_sms', side_effect=FiretextClientException(firetext_error()))
     send_sms_code(encrypted_notification)
-    firetext_client.send_sms.assert_called_once_with(notification['to'], notification['secret_code'])
+    firetext_client.send_sms.assert_called_once_with(notification['to'], notification['secret_code'], 'send-sms-code')
 
 
 def test_should_send_email_code(mocker):

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -282,6 +282,7 @@ def sample_notification(notify_db,
                         job=None,
                         to_field=None,
                         status='sent',
+                        reference=None,
                         created_at=datetime.utcnow()):
     if service is None:
         service = sample_service(notify_db, notify_db_session)
@@ -305,6 +306,7 @@ def sample_notification(notify_db,
         'service': service,
         'template': template,
         'status': status,
+        'reference': reference,
         'created_at': created_at
     }
     notification = Notification(**data)

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -18,10 +18,18 @@ from app.dao.notifications_dao import (
     delete_failed_notifications_created_more_than_a_week_ago,
     dao_get_notification_statistics_for_service_and_day,
     update_notification_status_by_id,
-    update_notification_status_by_to
+    update_notification_status_by_to,
+    update_notification_reference_by_id
 )
 from tests.app.conftest import sample_job
 from tests.app.conftest import sample_notification
+
+
+def test_should_by_able_to_update_reference_by_id(sample_notification):
+    assert not Notification.query.get(sample_notification.id).reference
+    count = update_notification_reference_by_id(sample_notification.id, 'reference')
+    assert count == 1
+    assert Notification.query.get(sample_notification.id).reference == 'reference'
 
 
 def test_should_by_able_to_update_status_by_id(sample_notification):

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -18,8 +18,8 @@ from app.dao.notifications_dao import (
     delete_failed_notifications_created_more_than_a_week_ago,
     dao_get_notification_statistics_for_service_and_day,
     update_notification_status_by_id,
-    update_notification_status_by_to,
-    update_notification_reference_by_id
+    update_notification_reference_by_id,
+    update_notification_status_by_reference
 )
 from tests.app.conftest import sample_job
 from tests.app.conftest import sample_notification
@@ -30,6 +30,13 @@ def test_should_by_able_to_update_reference_by_id(sample_notification):
     count = update_notification_reference_by_id(sample_notification.id, 'reference')
     assert count == 1
     assert Notification.query.get(sample_notification.id).reference == 'reference'
+
+
+def test_should_by_able_to_update_status_by_reference(sample_notification):
+    assert Notification.query.get(sample_notification.id).status == "sent"
+    update_notification_reference_by_id(sample_notification.id, 'reference')
+    update_notification_status_by_reference('reference', 'delivered')
+    assert Notification.query.get(sample_notification.id).status == 'delivered'
 
 
 def test_should_by_able_to_update_status_by_id(sample_notification):
@@ -43,15 +50,8 @@ def test_should_return_zero_count_if_no_notification_with_id():
     assert update_notification_status_by_id(str(uuid.uuid4()), 'delivered') == 0
 
 
-def test_should_return_zero_count_if_no_notification_with_to():
-    assert update_notification_status_by_to('something', 'delivered') == 0
-
-
-def test_should_by_able_to_update_status_by_to(sample_notification):
-    assert Notification.query.get(sample_notification.id).status == 'sent'
-    count = update_notification_status_by_to(sample_notification.to, 'delivered')
-    assert count == 1
-    assert Notification.query.get(sample_notification.id).status == 'delivered'
+def test_should_return_zero_count_if_no_notification_with_reference():
+    assert update_notification_status_by_reference('something', 'delivered') == 0
 
 
 def test_should_be_able_to_get_statistics_for_a_service(sample_template):

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -16,10 +16,34 @@ from app.dao.notifications_dao import (
     dao_get_notification_statistics_for_service,
     delete_successful_notifications_created_more_than_a_day_ago,
     delete_failed_notifications_created_more_than_a_week_ago,
-    dao_get_notification_statistics_for_service_and_day
+    dao_get_notification_statistics_for_service_and_day,
+    update_notification_status_by_id,
+    update_notification_status_by_to
 )
 from tests.app.conftest import sample_job
 from tests.app.conftest import sample_notification
+
+
+def test_should_by_able_to_update_status_by_id(sample_notification):
+    assert Notification.query.get(sample_notification.id).status == 'sent'
+    count = update_notification_status_by_id(sample_notification.id, 'delivered')
+    assert count == 1
+    assert Notification.query.get(sample_notification.id).status == 'delivered'
+
+
+def test_should_return_zero_count_if_no_notification_with_id():
+    assert update_notification_status_by_id(str(uuid.uuid4()), 'delivered') == 0
+
+
+def test_should_return_zero_count_if_no_notification_with_to():
+    assert update_notification_status_by_to('something', 'delivered') == 0
+
+
+def test_should_by_able_to_update_status_by_to(sample_notification):
+    assert Notification.query.get(sample_notification.id).status == 'sent'
+    count = update_notification_status_by_to(sample_notification.to, 'delivered')
+    assert count == 1
+    assert Notification.query.get(sample_notification.id).status == 'delivered'
 
 
 def test_should_be_able_to_get_statistics_for_a_service(sample_template):
@@ -568,7 +592,7 @@ def test_should_not_delete_sent_notifications_before_one_day(notify_db, notify_d
 
 def test_should_not_delete_failed_notifications_before_seven_days(notify_db, notify_db_session):
     expired = datetime.utcnow() - timedelta(hours=24 * 7)
-    valid = datetime.utcnow() - timedelta(hours=(24 * 6) + 23,  minutes=59, seconds=59)
+    valid = datetime.utcnow() - timedelta(hours=(24 * 6) + 23, minutes=59, seconds=59)
     sample_notification(notify_db, notify_db_session, created_at=expired, status="failed", to_field="expired")
     sample_notification(notify_db, notify_db_session, created_at=valid, status="failed", to_field="valid")
     assert len(Notification.query.all()) == 2

--- a/tests/app/notifications/test_rest.py
+++ b/tests/app/notifications/test_rest.py
@@ -866,13 +866,13 @@ def test_firetext_callback_should_not_need_auth(notify_api):
         with notify_api.test_client() as client:
             response = client.post(
                 path='/notifications/sms/firetext',
-                data='mobile=441234123123&status=0&reference=&time=2016-03-10 14:17:00',
+                data='mobile=441234123123&status=0&reference=send-sms-code&time=2016-03-10 14:17:00',
                 headers=[('Content-Type', 'application/x-www-form-urlencoded')])
 
             assert response.status_code == 200
 
 
-def test_firetext_callback_should_return_200_if_empty_reference(notify_api):
+def test_firetext_callback_should_return_400_if_empty_reference(notify_api):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             response = client.post(
@@ -881,12 +881,12 @@ def test_firetext_callback_should_return_200_if_empty_reference(notify_api):
                 headers=[('Content-Type', 'application/x-www-form-urlencoded')])
 
             json_resp = json.loads(response.get_data(as_text=True))
-            assert response.status_code == 200
-            assert json_resp['result'] == 'success'
-            assert json_resp['message'] == 'Firetext callback succeeded'
+            assert response.status_code == 400
+            assert json_resp['result'] == 'error'
+            assert json_resp['message'] == 'Firetext callback failed: reference missing'
 
 
-def test_firetext_callback_should_return_200_if_no_reference(notify_api):
+def test_firetext_callback_should_return_400_if_no_reference(notify_api):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             response = client.post(
@@ -895,9 +895,23 @@ def test_firetext_callback_should_return_200_if_no_reference(notify_api):
                 headers=[('Content-Type', 'application/x-www-form-urlencoded')])
 
             json_resp = json.loads(response.get_data(as_text=True))
+            assert response.status_code == 400
+            assert json_resp['result'] == 'error'
+            assert json_resp['message'] == 'Firetext callback failed: reference missing'
+
+
+def test_firetext_callback_should_return_200_if_send_sms_reference(notify_api):
+    with notify_api.test_request_context():
+        with notify_api.test_client() as client:
+            response = client.post(
+                path='/notifications/sms/firetext',
+                data='mobile=441234123123&status=0&time=2016-03-10 14:17:00&reference=send-sms-code',
+                headers=[('Content-Type', 'application/x-www-form-urlencoded')])
+
+            json_resp = json.loads(response.get_data(as_text=True))
             assert response.status_code == 200
             assert json_resp['result'] == 'success'
-            assert json_resp['message'] == 'Firetext callback succeeded'
+            assert json_resp['message'] == 'Firetext callback succeeded: send-sms-code'
 
 
 def test_firetext_callback_should_return_400_if_no_status(notify_api):


### PR DESCRIPTION
I'm not in today so this could wait till Monday for demos, raising pull request for code review only, and to park this work.

Commented the files a bit in this pull request to help reviews.

This pull request wires in the callbacks from Firetext and AWS SES. In both cases when a message has been processed by those platforms they call back to a URL on Notify to update the status:

Firetext:
- Update to SMS task to send notification id as a "reference". This is passed back in the callback to allow status updates
- Validation codes use the 'send-sms-code' as the reference to allow us to know whether to attempt a notification update
- Firetext client has an object to map firetext status codes to notifcation states.
- New endpoint in the notification rest controller - POST /notifications/sms/firetext
- Fire text response is a from encoded string (example curl)
`curl -X POST http://localhost:6011/notifications/sms/firetext -d'mobile=441234123123&status=0&reference=145ad964-d0e3-476b-ae08-7ed1bbb43612'`
- Endpoint does a large amount of logging - this is because we can't wire this in locally and we may need some help debugging on preview.

SES:
- These is no reference on SES so there is an update to the Notification object to store the 'reference' which is the messageId from SES, generated as part of the API call to AWS.
- This is then used to update the notification as part of the SES callback
- SES callback is a big blob of JSON. There is again a lot of debug / logging in the endpoint to help deployment to AWS.
- Same principles as in fire text, new endpoint (POST /notifications/email/ses), example curl

` curl -H "Content-type: text/plain; charset=UTF-8" -X POST http://localhost:6011/notifications/email/ses -d'{ "MessageId": "35efe472-ba36-5808-89bb-ab2925158b13", "UnsubscribeURL": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:123456789012:preview-emails:12345678-1234-1234-1234-123456789012", "SignatureVersion": "1", "TopicArn": "arn:aws:sns:eu-west-1:123456789012:testing", "Timestamp": "2016-03-10T16:12:19.876Z", "Type": "Notification", "Signature": "sig", "Message": { "notificationType": "Delivery", "mail": { "timestamp": "2016-03-10T16:12:19.016Z", "source": "invites@testing-notify.com", "sourceArn": "arn:aws:ses:eu-west-1:123456789012:identity/testing-notify", "sendingAccountId": "123456789012", "messageId": "01020153614cd6c8-2ec4bd32-7ddc-4344-811e-65d05519251f-000000", "destination": ["+447827992607"] }, "delivery": { "timestamp": "2016-03-10T16:12:19.751Z", "processingTimeMillis": 735, "recipients": ["testing@digital.cabinet-office.gov.uk"], "smtpResponse": "250 2.0.0 OK 1457626339 u62si5491824wme.91 - gsmtp", "reportingMTA": "a6-15.smtp-out.eu-west-1.amazonses.com" } }, "SigningCertURL": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-bb750dd426d95ee9390147a5624348ee.pem" }'
`

- For emails we use the source field to identify invites/validation codes. If the email was sent from these accounts we don't try and update the notification.

Using these curls we can test locally - update messageId/reference to match notifications your local schema.
