### PR TITLE
Updated aws start/stop scripts to handle multiple start/stop scripts

### DIFF
--- a/scripts/aws_start_app.sh
+++ b/scripts/aws_start_app.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
 
-echo "Starting application"
-sudo service notifications-api start
+if [ -e "/etc/init/notifications-api.conf" ]
+then
+  echo "Starting api"
+  sudo service notifications-api start
+fi
+
+if [ -e "/etc/init/notifications-api-celery-worker.conf" ]
+then
+  echo "Starting celery worker"
+  sudo service notifications-api-celery-worker start
+fi
+
+if [ -e "/etc/init/notifications-api-celery-beat.conf" ]
+then
+  echo "Starting celery beat"
+  sudo service notifications-api-celery-beat start
+fi

--- a/scripts/aws_stop_app.sh
+++ b/scripts/aws_stop_app.sh
@@ -7,9 +7,29 @@ function error_exit
 	exit 0
 }
 
-echo "Stopping application"
-if sudo service notifications-api stop; then
-    exit 0
-else
-    error_exit "Could not stop application"
+if [ -e "/etc/init/notifications-api.conf" ]; then
+    echo "stopping notifications-api"
+    if sudo service notifications-api stop; then
+        echo "notifications-api stopped"
+    else
+        error_exit "Could not stop notifications-api"
+    fi
+fi
+
+if [ -e "/etc/init/notifications-api-celery-beat.conf" ]; then
+    echo "stopping notifications-api-celery-beat"
+    if sudo service notifications-api-celery-beat stop; then
+        echo "notifications-api stopped"
+    else
+        error_exit "Could not stop notifications-celery-beat"
+    fi
+fi
+
+if [ -e "/etc/init/notifications-api-celery-worker.conf" ]; then
+    echo "stopping notifications-api-celery-worker"
+    if sudo service notifications-api-celery-worker stop; then
+        echo "notifications-api stopped"
+    else
+        error_exit "Could not stop notifications-celery-worker"
+    fi
 fi


### PR DESCRIPTION
Primarily to handle the two celery processes

- On the environments we have start/stop scripts for the 3 API types

- Normal API
- Celery Workers
- Celery Beat

We now have a different upstart script for each, and there may be more than one on a box, so check for the upstart scripts and if present use them.