### PR TITLE
Pass application name in from start scripts

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -94,10 +94,8 @@ def init_app(app):
 
 def email_safe(string):
     return "".join([
-                       character.lower()
-                       if character.isalnum() or character == "."
-                       else "" for character in re.sub("\s+", ".", string.strip())
-                       ])
+        character.lower() if character.isalnum() or character == "." else "" for character in re.sub("\s+", ".", string.strip())  # noqa
+    ])
 
 
 def create_uuid():

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -27,10 +27,12 @@ encryption = Encryption()
 api_user = LocalProxy(lambda: _request_ctx_stack.top.api_user)
 
 
-def create_app():
+def create_app(app_name=None):
     application = Flask(__name__)
 
     application.config.from_object(os.environ['NOTIFY_API_ENVIRONMENT'])
+    if app_name:
+        application.config['NOTIFY_APP_NAME'] = app_name
 
     init_app(application)
     db.init_app(application)
@@ -92,10 +94,10 @@ def init_app(app):
 
 def email_safe(string):
     return "".join([
-        character.lower()
-        if character.isalnum() or character == "."
-        else "" for character in re.sub("\s+", ".", string.strip())
-    ])
+                       character.lower()
+                       if character.isalnum() or character == "."
+                       else "" for character in re.sub("\s+", ".", string.strip())
+                       ])
 
 
 def create_uuid():

--- a/run_celery.py
+++ b/run_celery.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 from app import notify_celery, create_app
 
-application = create_app()
+application = create_app('delivery')
 application.app_context().push()


### PR DESCRIPTION
- allows logger to log as correct application

This allows the delivery api to set app name as 'delivery' to allow easier log filtering

