### PR TITLE
Added task for sending email verification links

### DIFF
--- a/config.py
+++ b/config.py
@@ -69,7 +69,8 @@ class Config(object):
         Queue('process-job', Exchange('default'), routing_key='process-job'),
         Queue('bulk-sms', Exchange('default'), routing_key='bulk-sms'),
         Queue('bulk-email', Exchange('default'), routing_key='bulk-email'),
-        Queue('email-invited-user', Exchange('default'), routing_key='email-invited-user')
+        Queue('email-invited-user', Exchange('default'), routing_key='email-invited-user'),
+        Queue('email-registration-verification', Exchange('default'), routing_key='email-registration-verification')
     ]
     TWILIO_ACCOUNT_SID = os.getenv('TWILIO_ACCOUNT_SID')
     TWILIO_AUTH_TOKEN = os.getenv('TWILIO_AUTH_TOKEN')

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -328,6 +328,11 @@ def mock_celery_send_email_code(mocker):
 
 
 @pytest.fixture(scope='function')
+def mock_celery_email_registration_verification(mocker):
+    return mocker.patch('app.celery.tasks.email_registration_verification.apply_async')
+
+
+@pytest.fixture(scope='function')
 def mock_encryption(mocker):
     return mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
 


### PR DESCRIPTION
On initial registration user is sent a link to click on to verify email address.

Left original email code endpoint in as it is still used for things like email change.

The work in this pr is needed for https://github.com/alphagov/notifications-admin/pull/293