### PR TITLE
Add HTML email

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -267,7 +267,8 @@ def send_email(service_id, notification_id, subject, from_address, encrypted_not
                     from_address,
                     notification['to'],
                     subject,
-                    template.replaced
+                    body=template.replaced,
+                    html_body=template.as_HTML_email,
                 )
                 update_notification_reference_by_id(notification_id, reference)
             except AwsSesClientException as e:

--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -41,6 +41,7 @@ class AwsSesClient(EmailClient):
                    to_addresses,
                    subject,
                    body,
+                   html_body='',
                    reply_to_addresses=None):
         try:
             if isinstance(to_addresses, str):
@@ -49,6 +50,15 @@ class AwsSesClient(EmailClient):
                 reply_to_addresses = [reply_to_addresses]
             elif reply_to_addresses is None:
                 reply_to_addresses = []
+
+            body = {
+                'Text': {'Data': body}
+            }
+
+            if html_body:
+                body.update({
+                    'Html': {'Data': html_body}
+                })
 
             start_time = monotonic()
             response = self._client.send_email(
@@ -62,9 +72,7 @@ class AwsSesClient(EmailClient):
                     'Subject': {
                         'Data': subject,
                     },
-                    'Body': {
-                        'Text': {
-                            'Data': body}}
+                    'Body': body
                 },
                 ReplyToAddresses=reply_to_addresses)
             elapsed_time = monotonic() - start_time

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ monotonic==0.3
 
 git+https://github.com/alphagov/notifications-python-client.git@0.2.6#egg=notifications-python-client==0.2.6
 
-git+https://github.com/alphagov/notifications-utils.git@2.0.1#egg=notifications-utils==2.0.1
+git+https://github.com/alphagov/notifications-utils.git@3.1.0#egg=notifications-utils==3.1.0

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -37,6 +37,11 @@ from tests.app.conftest import (
 )
 
 
+class AnyStringWith(str):
+    def __eq__(self, other):
+        return self in other
+
+
 def firetext_error():
     return {'code': 0, 'description': 'error'}
 
@@ -390,7 +395,8 @@ def test_should_send_email_if_restricted_service_and_valid_email(notify_db, noti
         "email_from",
         "test@restricted.com",
         "subject",
-        template.content
+        body=template.content,
+        html_body=AnyStringWith(template.content)
     )
 
 
@@ -452,7 +458,8 @@ def test_should_use_email_template_and_persist(sample_email_template_with_placeh
         "email_from",
         "my_email@my_email.com",
         "subject",
-        "Hello Jo"
+        body="Hello Jo",
+        html_body=AnyStringWith("Hello Jo")
     )
     persisted_notification = notifications_dao.get_notification(
         sample_email_template_with_placeholders.service_id, notification_id
@@ -515,7 +522,8 @@ def test_should_use_email_template_and_persist_without_personalisation(
         "email_from",
         "my_email@my_email.com",
         "subject",
-        "This is a template"
+        body="This is a template",
+        html_body=AnyStringWith("This is a template")
     )
 
 
@@ -577,7 +585,8 @@ def test_should_persist_notification_as_failed_if_email_client_fails(sample_emai
         "email_from",
         "my_email@my_email.com",
         "subject",
-        sample_email_template.content
+        body=sample_email_template.content,
+        html_body=AnyStringWith(sample_email_template.content)
     )
     persisted_notification = notifications_dao.get_notification(sample_email_template.service_id, notification_id)
     assert persisted_notification.id == notification_id


### PR DESCRIPTION
Make the SES client optionally pass through HTML and text body, as per:
http://docs.aws.amazon.com/ses/latest/APIReference/API_Body.html

Gets the message as HTML from:
https://github.com/alphagov/notifications-utils/pull/12


## In an email client

![image](https://cloud.githubusercontent.com/assets/355079/13880539/842fa9b4-ed14-11e5-81e5-17a1d74b8c60.png)


## Raw message contents

![image](https://cloud.githubusercontent.com/assets/355079/13880506/6ddb3390-ed14-11e5-9897-3bc9200038c0.png)
