### PR TITLE
Catch sending to restricted recipients in Celery

### DIFF
--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -343,6 +343,31 @@ def test_should_send_sms_if_restricted_service_and_valid_number(notify_db, notif
     )
 
 
+def test_should_not_send_sms_if_restricted_service_and_invalid_number(notify_db, notify_db_session, mocker):
+    user = sample_user(notify_db, notify_db_session, mobile_numnber="07700 900205")
+    service = sample_service(notify_db, notify_db_session, user=user, restricted=True)
+    template = sample_template(notify_db, notify_db_session, service=service)
+
+    notification = {
+        "template": template.id,
+        "to": "07700 900849"
+    }
+    mocker.patch('app.encryption.decrypt', return_value=notification)
+    mocker.patch('app.firetext_client.send_sms')
+    mocker.patch('app.firetext_client.get_name', return_value="firetext")
+
+    notification_id = uuid.uuid4()
+    now = datetime.utcnow()
+    send_sms(
+        service.id,
+        notification_id,
+        "encrypted-in-reality",
+        now.strftime(DATETIME_FORMAT)
+    )
+
+    firetext_client.send_sms.assert_not_called()
+
+
 def test_should_send_email_if_restricted_service_and_valid_email(notify_db, notify_db_session, mocker):
     user = sample_user(notify_db, notify_db_session, email="test@restricted.com")
     service = sample_service(notify_db, notify_db_session, user=user, restricted=True)

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -400,6 +400,32 @@ def test_should_send_email_if_restricted_service_and_valid_email(notify_db, noti
     )
 
 
+def test_should_not_send_email_if_restricted_service_and_invalid_email_address(notify_db, notify_db_session, mocker):
+    user = sample_user(notify_db, notify_db_session)
+    service = sample_service(notify_db, notify_db_session, user=user, restricted=True)
+    template = sample_template(
+        notify_db, notify_db_session, service=service, template_type='email', subject_line='Hello'
+    )
+
+    notification = {
+        "template": template.id,
+        "to": "test@example.com"
+    }
+    mocker.patch('app.encryption.decrypt', return_value=notification)
+    mocker.patch('app.aws_ses_client.send_email')
+
+    notification_id = uuid.uuid4()
+    now = datetime.utcnow()
+    send_sms(
+        service.id,
+        notification_id,
+        "encrypted-in-reality",
+        now.strftime(DATETIME_FORMAT)
+    )
+
+    aws_ses_client.send_email.assert_not_called()
+
+
 def test_should_send_template_to_correct_sms_provider_and_persist_with_job_id(sample_job, mocker):
     notification = {
         "template": sample_job.template.id,


### PR DESCRIPTION
The Celery `send_sms` and `send_email` tasks _could_ assume that all the recipients it gets are safe, because they have been checked either:
- when the admin app processes the CSV
- in the `/notifications/sms|email` endpoint

**However**, it’s probably safer to make the check again when the Celery task runs and passes the message off to the third party.

This also means that changing a service _back_ to restricted would have an effect on messages that were queued, as well as all subsequent messages.

This commit:
- restores the test that was removed here: https://github.com/alphagov/notifications-api/commit/e56aee5d1d77142b78434f3faeddfd2cb1a6e9bf#diff-e5627619e387fccc04783c32a23e6859L346
- adds a similar test for sending email while a service is in restricted mode
- adds checks back into the Celery tasks for sending email and SMS, using the `allowed_to_send_to` function that was introduced into utils in https://github.com/alphagov/notifications-utils/pull/16