### PR TITLE
Fix for date range required for template stats

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -63,11 +63,8 @@ def dao_get_notification_statistics_for_service_and_day(service_id, day):
 def dao_get_template_statistics_for_service(service_id, limit_days=None):
     filter = [TemplateStatistics.service_id == service_id]
     if limit_days:
-        latest_stat = TemplateStatistics.query.filter_by(service_id=service_id).order_by(
-            desc(TemplateStatistics.day)).limit(1).first()
-        if latest_stat:
-            last_date_to_fetch = latest_stat.day - timedelta(days=limit_days)
-            filter.append(TemplateStatistics.day > last_date_to_fetch)
+        last_date_to_fetch = date.today() - timedelta(days=limit_days)
+        filter.append(TemplateStatistics.day > last_date_to_fetch)
     return TemplateStatistics.query.filter(*filter).order_by(
         desc(TemplateStatistics.updated_at)).all()
 

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -974,7 +974,7 @@ def test_get_template_stats_for_service_returns_stats_returns_all_stats_if_no_li
 
 
 @freeze_time('2016-04-30')
-def test_get_template_stats_for_service_returns_results_from_first_day_with_data(sample_template):
+def test_get_template_stats_for_service_returns_no_result_if_no_usage_within_limit_days(sample_template):
 
     template_stats = dao_get_template_statistics_for_service(sample_template.service.id)
     assert len(template_stats) == 0
@@ -988,29 +988,13 @@ def test_get_template_stats_for_service_returns_results_from_first_day_with_data
             db.session.add(template_stats)
             db.session.commit()
 
-    # Retrieve one day of stats - read date is 2016-04-30
-    template_stats = dao_get_template_statistics_for_service(sample_template.service_id, limit_days=1)
-    assert len(template_stats) == 1
-    assert template_stats[0].day == date(2016, 4, 9)
+    # Retrieve a week of stats - read date is 2016-04-30
+    template_stats = dao_get_template_statistics_for_service(sample_template.service_id, limit_days=7)
+    assert len(template_stats) == 0
 
-    # Retrieve three days of stats
-    template_stats = dao_get_template_statistics_for_service(sample_template.service_id, limit_days=3)
-    assert len(template_stats) == 3
-    assert template_stats[0].day == date(2016, 4, 9)
-    assert template_stats[1].day == date(2016, 4, 8)
-    assert template_stats[2].day == date(2016, 4, 7)
-
-    # Retrieve nine days of stats
-    template_stats = dao_get_template_statistics_for_service(sample_template.service_id, limit_days=9)
+    # Retrieve a month of stats - read date is 2016-04-30
+    template_stats = dao_get_template_statistics_for_service(sample_template.service_id, limit_days=30)
     assert len(template_stats) == 9
-    assert template_stats[0].day == date(2016, 4, 9)
-    assert template_stats[8].day == date(2016, 4, 1)
-
-    # Retrieve with no limit
-    template_stats = dao_get_template_statistics_for_service(sample_template.service_id)
-    assert len(template_stats) == 9
-    assert template_stats[0].day == date(2016, 4, 9)
-    assert template_stats[8].day == date(2016, 4, 1)
 
 
 def test_get_template_stats_for_service_with_limit_if_no_records_returns_empty_list(sample_template):

--- a/tests/app/template_statistics/test_rest.py
+++ b/tests/app/template_statistics/test_rest.py
@@ -41,7 +41,7 @@ def test_get_template_statistics_for_service_for_last_week(notify_api, sample_te
 
 
 @freeze_time('2016-04-30')
-def test_get_template_statistics_for_service_for_last_actual_week_with_data(notify_api, sample_template):
+def test_get_template_statistics_for_service_for_last_week_with_no_data(notify_api, sample_template):
 
     # make 9 stats records from 1st to 9th April
     for i in range(1, 10):
@@ -69,9 +69,17 @@ def test_get_template_statistics_for_service_for_last_actual_week_with_data(noti
 
             assert response.status_code == 200
             json_resp = json.loads(response.get_data(as_text=True))
-            assert len(json_resp['data']) == 7
-            assert json_resp['data'][0]['day'] == '2016-04-09'
-            assert json_resp['data'][6]['day'] == '2016-04-03'
+            assert len(json_resp['data']) == 0
+
+            response = client.get(
+                '/service/{}/template-statistics'.format(sample_template.service_id),
+                headers=[('Content-Type', 'application/json'), auth_header],
+                query_string={'limit_days': 30}
+            )
+
+            assert response.status_code == 200
+            json_resp = json.loads(response.get_data(as_text=True))
+            assert len(json_resp['data']) == 9
 
 
 def test_get_all_template_statistics_for_service(notify_api, sample_template):


### PR DESCRIPTION
It should always be last n days, whether or not there is data.