### PR TITLE
Use version of crown logo hosted by admin app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ monotonic==0.3
 
 git+https://github.com/alphagov/notifications-python-client.git@0.2.6#egg=notifications-python-client==0.2.6
 
-git+https://github.com/alphagov/notifications-utils.git@3.2.1#egg=notifications-utils==3.2.1
+git+https://github.com/alphagov/notifications-utils.git@3.3.1#egg=notifications-utils==3.3.1


### PR DESCRIPTION
Implements and depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/19

Depends on this admin app deploy:
- [x] https://github.com/alphagov/notifications-admin/pull/410 (so that https://www.notifications.service.gov.uk/static/images/email-template/crown-32px.gif is present)