### PR TITLE
Simplify jwt

### DIFF
--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -1,6 +1,6 @@
 from flask import request, jsonify, _request_ctx_stack, current_app
 from notifications_python_client.authentication import decode_jwt_token, get_token_issuer
-from notifications_python_client.errors import TokenDecodeError, TokenRequestError, TokenExpiredError, TokenPayloadError
+from notifications_python_client.errors import TokenDecodeError, TokenExpiredError
 from werkzeug.exceptions import abort
 from app.dao.api_key_dao import get_unsigned_secrets
 from app import api_user
@@ -43,12 +43,8 @@ def requires_auth():
             )
             _request_ctx_stack.top.api_user = api_client
             return
-        except TokenRequestError:
-            errors_resp = authentication_response("Invalid token: request", 403)
         except TokenExpiredError:
             errors_resp = authentication_response("Invalid token: expired", 403)
-        except TokenPayloadError:
-            errors_resp = authentication_response("Invalid token: payload", 403)
         except TokenDecodeError:
             errors_resp = authentication_response("Invalid token: signature", 403)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ twilio==4.6.0
 monotonic==0.3
 
 
-git+https://github.com/alphagov/notifications-python-client.git@0.2.6#egg=notifications-python-client==0.2.6
+git+https://github.com/alphagov/notifications-python-client.git@0.5.0#egg=notifications-python-client==0.5.0
+
 
 git+https://github.com/alphagov/notifications-utils.git@4.1.1#egg=notifications-utils==4.1.1

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 import pytest
 from notifications_python_client.authentication import create_jwt_token
-from flask import json, url_for, current_app
+from flask import json, current_app
 from app.dao.api_key_dao import get_unsigned_secrets, save_model_api_key, get_unsigned_secret
 from app.models import ApiKey, Service
 


### PR DESCRIPTION
This pull request removes the need for the req and pay in the claims JWT.
Use the new version of the notifications-python-client. This version no longer adds the req and pay to the claims of the jwt.

The change is backward compatible so an older client that sends a JWT with the extra claims will pass authentication.
Once all the clients have been updated to not include the extra claims some updates to exclude them from the method signatures will happen as well.


https://www.pivotaltracker.com/story/show/116971293

