### PR TITLE
Allow filtering of notification stats by days

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -69,6 +69,19 @@ def dao_get_notification_statistics_for_service_and_day(service_id, day):
     ).order_by(desc(NotificationStatistics.day)).first()
 
 
+def dao_get_notification_statistics_for_service_and_previous_days(service_id, limit_days):
+    return NotificationStatistics.query.filter_by(
+        service_id=service_id
+    ).filter(
+        NotificationStatistics.day.in_((
+            (date.today() - timedelta(days=days_ago)).strftime('%Y-%m-%d')
+            for days_ago in range(0, limit_days + 1)
+        ))
+    ).order_by(
+        desc(NotificationStatistics.day)
+    ).all()
+
+
 def dao_get_template_statistics_for_service(service_id, limit_days=None):
     filter = [TemplateStatistics.service_id == service_id]
     if limit_days:

--- a/app/notifications_statistics/rest.py
+++ b/app/notifications_statistics/rest.py
@@ -4,7 +4,8 @@ from flask import (
 )
 
 from app.dao.notifications_dao import (
-    dao_get_notification_statistics_for_service
+    dao_get_notification_statistics_for_service,
+    dao_get_notification_statistics_for_service_and_previous_days
 )
 from app.schemas import notifications_statistics_schema
 
@@ -19,7 +20,20 @@ register_errors(notifications_statistics)
 
 
 @notifications_statistics.route('', methods=['GET'])
-def get_all_templates_for_service(service_id):
-    templates = dao_get_notification_statistics_for_service(service_id=service_id)
-    data, errors = notifications_statistics_schema.dump(templates, many=True)
+def get_all_notification_statistics_for_service(service_id):
+
+    if request.args.get('limit_days'):
+        try:
+            statistics = dao_get_notification_statistics_for_service_and_previous_days(
+                service_id=service_id,
+                limit_days=int(request.args['limit_days'])
+            )
+        except ValueError as e:
+            error = '{} is not an integer'.format(request.args['limit_days'])
+            current_app.logger.error(error)
+            return jsonify(result="error", message={'limit_days': [error]}), 400
+    else:
+        statistics = dao_get_notification_statistics_for_service(service_id=service_id)
+
+    data, errors = notifications_statistics_schema.dump(statistics, many=True)
     return jsonify(data=data)


### PR DESCRIPTION
On the dashboard we want to show counts of notifications sent in the last 7 days, plus today. So the API endpoint needs to accept an argument to limit how many days worth of statistics it will return.

This is a bit fiddly at the DAO level because the date is just stored as a string.

https://www.pivotaltracker.com/story/show/117920839