### PR TITLE
Temp history of endpoint

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -280,6 +280,29 @@ class TemplateStatisticsSchema(BaseSchema):
         model = models.TemplateStatistics
 
 
+class ServiceHistorySchema(ma.Schema):
+    id = fields.UUID()
+    name = fields.String()
+    created_at = fields.DateTime()
+    updated_at = fields.DateTime()
+    active = fields.Boolean()
+    message_limit = fields.Integer()
+    restricted = fields.Boolean()
+    email_from = fields.String()
+    created_by_id = fields.UUID()
+    version = fields.Integer()
+
+
+class ApiKeyHistorySchema(ma.Schema):
+    id = fields.UUID()
+    name = fields.String()
+    service_id = fields.UUID()
+    expiry_date = fields.DateTime()
+    created_at = fields.DateTime()
+    updated_at = fields.DateTime()
+    created_by_id = fields.UUID()
+
+
 user_schema = UserSchema()
 user_schema_load_json = UserSchema(load_json=True)
 service_schema = ServiceSchema()
@@ -304,3 +327,5 @@ email_data_request_schema = EmailDataSchema()
 notifications_statistics_schema = NotificationsStatisticsSchema()
 notifications_filter_schema = NotificationsFilterSchema()
 template_statistics_schema = TemplateStatisticsSchema()
+service_history_schema = ServiceHistorySchema()
+api_key_history_schema = ApiKeyHistorySchema()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -179,3 +179,27 @@ def _process_permissions(user, service, permission_groups):
         permission.user = user
         permission.service = service
     return permissions
+
+
+# This is placeholder get method until more thought
+# goes into how we want to fetch and view various items in history
+# tables. This is so product owner can pass stories as done
+@service.route('/<uuid:service_id>/history', methods=['GET'])
+def get_service_and_api_key_history(service_id):
+    from app.models import Service, ApiKey
+    from app.schemas import service_history_schema, api_key_history_schema
+
+    service_history = Service.get_history_model().query.filter_by(id=service_id).all()
+    service_data, errors = service_history_schema.dump(service_history, many=True)
+    if errors:
+        return jsonify(result="error", message=errors), 400
+
+    api_key_history = ApiKey.get_history_model().query.filter_by(service_id=service_id).all()
+
+    api_keys_data, errors = api_key_history_schema.dump(api_key_history, many=True)
+    if errors:
+        return jsonify(result="error", message=errors), 400
+
+    data = {'service_history': service_data, 'api_key_history': api_keys_data}
+
+    return jsonify(data=data)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -981,3 +981,28 @@ def test_cannot_remove_only_user_from_service(notify_api,
             assert resp.status_code == 400
             result = json.loads(resp.get_data(as_text=True))
             assert result['message'] == 'You cannot remove the only user for a service'
+
+
+# This test is just here verify get_service_and_api_key_history that is a temp solution
+# until proper ui is sorted out on admin app
+def test_get_service_and_api_key_history(notify_api, notify_db, notify_db_session, sample_service):
+
+    from tests.app.conftest import sample_api_key as create_sample_api_key
+    api_key = create_sample_api_key(notify_db, notify_db_session, service=sample_service)
+
+    with notify_api.test_request_context():
+        with notify_api.test_client() as client:
+
+            auth_header = create_authorization_header(
+                path='/service/{}/history'.format(sample_service.id),
+                method='GET'
+            )
+            response = client.get(
+                path='/service/{}/history'.format(sample_service.id),
+                headers=[auth_header]
+            )
+            assert response.status_code == 200
+
+            json_resp = json.loads(response.get_data(as_text=True))
+            assert json_resp['data']['service_history'][0]['id'] == str(sample_service.id)
+            assert json_resp['data']['api_key_history'][0]['id'] == str(api_key.id)


### PR DESCRIPTION
This is a temporary endpoint to get history of service and api key updates. 

This will be surfaced on a simple log page on admin app until product team work out who/how/when etc. of viewing history data.