### PR TITLE
Use short dates when selection notifications for deletion.

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -1,5 +1,5 @@
 import math
-from sqlalchemy import desc
+from sqlalchemy import desc, func
 
 from datetime import (
     datetime,
@@ -257,18 +257,20 @@ def filter_query(query, filter_dict=None):
 
 
 def delete_notifications_created_more_than_a_day_ago(status):
+    one_day_ago = date.today() - timedelta(days=1)
     deleted = db.session.query(Notification).filter(
-        Notification.created_at < datetime.utcnow() - timedelta(days=1),
+        func.date(Notification.created_at) < one_day_ago,
         Notification.status == status
-    ).delete()
+    ).delete(synchronize_session='fetch')
     db.session.commit()
     return deleted
 
 
 def delete_notifications_created_more_than_a_week_ago(status):
+    seven_days_ago = date.today() - timedelta(days=7)
     deleted = db.session.query(Notification).filter(
-        Notification.created_at < datetime.utcnow() - timedelta(days=7),
+        func.date(Notification.created_at) < seven_days_ago,
         Notification.status == status
-    ).delete()
+    ).delete(synchronize_session='fetch')
     db.session.commit()
     return deleted

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -256,16 +256,6 @@ def filter_query(query, filter_dict=None):
     return query
 
 
-def delete_notifications_created_more_than_a_day_ago(status):
-    one_day_ago = date.today() - timedelta(days=1)
-    deleted = db.session.query(Notification).filter(
-        func.date(Notification.created_at) < one_day_ago,
-        Notification.status == status
-    ).delete(synchronize_session='fetch')
-    db.session.commit()
-    return deleted
-
-
 def delete_notifications_created_more_than_a_week_ago(status):
     seven_days_ago = date.today() - timedelta(days=7)
     deleted = db.session.query(Notification).filter(

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,10 @@
 import uuid
 import datetime
 
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import (
+    UUID,
+    JSON
+)
 
 from sqlalchemy import UniqueConstraint
 
@@ -410,3 +413,12 @@ class TemplateStatistics(db.Model):
         unique=False,
         nullable=False,
         default=datetime.datetime.utcnow)
+
+
+class Event(object):
+
+    __tablename__ = 'events'
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    type = db.Column(db.String(255), nullable=False)
+    details = db.Column(JSON, nullable=False)

--- a/app/models.py
+++ b/app/models.py
@@ -413,12 +413,3 @@ class TemplateStatistics(db.Model):
         unique=False,
         nullable=False,
         default=datetime.datetime.utcnow)
-
-
-class Event(object):
-
-    __tablename__ = 'events'
-
-    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    type = db.Column(db.String(255), nullable=False)
-    details = db.Column(JSON, nullable=False)

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from celery.schedules import crontab
 from kombu import Exchange, Queue
 import os
 
@@ -51,12 +52,12 @@ class Config(object):
         },
         'delete-failed-notifications': {
             'task': 'delete-failed-notifications',
-            'schedule': timedelta(minutes=60),
+            'schedule': crontab(minute=0, hour=0),
             'options': {'queue': 'periodic'}
         },
         'delete-successful-notifications': {
             'task': 'delete-successful-notifications',
-            'schedule': timedelta(minutes=31),
+            'schedule': crontab(minute=0, hour=0),
             'options': {'queue': 'periodic'}
         }
     }

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -22,7 +22,6 @@ from app.dao.notifications_dao import (
     get_notification_for_job,
     get_notifications_for_job,
     dao_get_notification_statistics_for_service,
-    delete_notifications_created_more_than_a_day_ago,
     delete_notifications_created_more_than_a_week_ago,
     dao_get_notification_statistics_for_service_and_day,
     dao_get_notification_statistics_for_service_and_previous_days,
@@ -765,15 +764,6 @@ def test_update_notification(sample_notification, sample_template):
     assert notification_from_db.status == 'failed'
 
 
-def test_should_delete_notifications_after_one_day(notify_db, notify_db_session):
-    created_at = datetime.utcnow() - timedelta(days=2)
-    sample_notification(notify_db, notify_db_session, created_at=created_at)
-    sample_notification(notify_db, notify_db_session, created_at=created_at)
-    assert len(Notification.query.all()) == 2
-    delete_notifications_created_more_than_a_day_ago('sending')
-    assert len(Notification.query.all()) == 0
-
-
 @freeze_time("2016-01-10 12:00:00.000000")
 def test_should_delete_notifications_after_seven_days(notify_db, notify_db_session):
 
@@ -793,18 +783,6 @@ def test_should_delete_notifications_after_seven_days(notify_db, notify_db_sessi
     remaining_notifications = Notification.query.all()
     assert len(remaining_notifications) == 8
     assert remaining_notifications[0].created_at.date() == date(2016, 1, 3)
-
-
-def test_should_not_delete_sent_notifications_before_one_day(notify_db, notify_db_session):
-    should_delete = datetime.utcnow() - timedelta(days=2)
-    do_not_delete = datetime.utcnow() - timedelta(days=1)
-    sample_notification(notify_db, notify_db_session, created_at=should_delete, to_field="expired")
-    sample_notification(notify_db, notify_db_session, created_at=do_not_delete, to_field="valid")
-
-    assert len(Notification.query.all()) == 2
-    delete_notifications_created_more_than_a_day_ago('sending')
-    assert len(Notification.query.all()) == 1
-    assert Notification.query.first().to == 'valid'
 
 
 def test_should_not_delete_failed_notifications_before_seven_days(notify_db, notify_db_session):


### PR DESCRIPTION
This means we will retain notifications for a full week and not
delete records that are 7 x 24 hours older than the time of the run of
the deletion task.

Also the task only needs to run once a day now, so I have changed
the celery config for the deletion tasks.