### PR TITLE
Remove send email code task

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -336,19 +336,6 @@ def send_sms_via_firetext(to, content, reference):
         current_app.logger.exception(e)
 
 
-@notify_celery.task(name='send-email-code')
-def send_email_code(encrypted_verification_message):
-    verification_message = encryption.decrypt(encrypted_verification_message)
-    try:
-        aws_ses_client.send_email(current_app.config['VERIFY_CODE_FROM_EMAIL_ADDRESS'],
-                                  verification_message['to'],
-                                  "Verification code",
-                                  "{} is your Notify authentication code".format(
-                                      verification_message['secret_code']))
-    except AwsSesClientException as e:
-        current_app.logger.exception(e)
-
-
 # TODO: when placeholders in templates work, this will be a real template
 def invitation_template(user_name, service_name, url, expiry_date):
     from string import Template

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -26,7 +26,6 @@ from app.schemas import (
 
 from app.celery.tasks import (
     send_sms_code,
-    send_email_code,
     email_reset_password,
     email_registration_verification
 )
@@ -131,25 +130,6 @@ def send_user_sms_code(user_id):
     verification_message = {'to': mobile, 'secret_code': secret_code}
 
     send_sms_code.apply_async([encryption.encrypt(verification_message)], queue='sms-code')
-
-    return jsonify({}), 204
-
-
-@user.route('/<uuid:user_id>/email-code', methods=['POST'])
-def send_user_email_code(user_id):
-    user_to_send_to = get_model_users(user_id=user_id)
-    verify_code, errors = request_verify_code_schema.load(request.get_json())
-    if errors:
-        return jsonify(result="error", message=errors), 400
-
-    from app.dao.users_dao import create_secret_code
-    secret_code = create_secret_code()
-    create_user_code(user_to_send_to, secret_code, 'email')
-
-    email = user_to_send_to.email_address if verify_code.get('to', None) is None else verify_code.get('to')
-    verification_message = {'to': email, 'secret_code': secret_code}
-
-    send_email_code.apply_async([encryption.encrypt(verification_message)], queue='email-code')
 
     return jsonify({}), 204
 

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -6,7 +6,6 @@ from notifications_utils.recipients import validate_phone_number, format_phone_n
 from app.celery.tasks import (
     send_sms,
     send_sms_code,
-    send_email_code,
     send_email,
     process_job,
     email_invited_user,
@@ -761,23 +760,6 @@ def test_should_throw_mmg_client_exception(mocker):
         format_phone_number(validate_phone_number(notification['to'])),
         "{} is your Notify authentication code".format(notification['secret_code']),
         'send-sms-code')
-
-
-def test_should_send_email_code(mocker):
-    verification = {'to': 'someone@it.gov.uk',
-                    'secret_code': 11111}
-
-    encrypted_verification = encryption.encrypt(verification)
-    mocker.patch('app.aws_ses_client.send_email')
-
-    send_email_code(encrypted_verification)
-
-    aws_ses_client.send_email.assert_called_once_with(
-        current_app.config['VERIFY_CODE_FROM_EMAIL_ADDRESS'],
-        verification['to'],
-        "Verification code",
-        "{} is your Notify authentication code".format(verification['secret_code'])
-    )
 
 
 def test_email_invited_user_should_send_email(notify_api, mocker):

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -345,11 +345,6 @@ def mock_celery_send_sms_code(mocker):
 
 
 @pytest.fixture(scope='function')
-def mock_celery_send_email_code(mocker):
-    return mocker.patch('app.celery.tasks.send_email_code.apply_async')
-
-
-@pytest.fixture(scope='function')
 def mock_celery_email_registration_verification(mocker):
     return mocker.patch('app.celery.tasks.email_registration_verification.apply_async')
 

--- a/tests/app/user/test_rest_verify.py
+++ b/tests/app/user/test_rest_verify.py
@@ -313,51 +313,6 @@ def test_send_sms_code_returns_404_for_bad_input_data(notify_api, notify_db, not
             assert json.loads(resp.get_data(as_text=True))['message'] == 'No result found'
 
 
-def test_send_user_email_code(notify_api,
-                              sample_email_code,
-                              mock_celery_send_email_code,
-                              mock_encryption):
-    """
-    Tests POST endpoint /user/<user_id>/email-code
-    """
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = json.dumps({})
-            auth_header = create_authorization_header(
-                path=url_for('user.send_user_email_code', user_id=sample_email_code.user.id),
-                method='POST',
-                request_body=data)
-            resp = client.post(
-                url_for('user.send_user_email_code', user_id=sample_email_code.user.id),
-                data=data,
-                headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 204
-            app.celery.tasks.send_email_code.apply_async.assert_called_once_with(['something_encrypted'],
-                                                                                 queue='email-code')
-
-
-def test_send_user_email_code_returns_404_for_when_user_does_not_exist(notify_api,
-                                                                       notify_db,
-                                                                       notify_db_session,
-                                                                       fake_uuid):
-    """
-    Tests POST endpoint /user/<user_id>/email-code return 404 for missing user
-    """
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = json.dumps({})
-            auth_header = create_authorization_header(
-                path=url_for('user.send_user_email_code', user_id=fake_uuid),
-                method='POST',
-                request_body=data)
-            resp = client.post(
-                url_for('user.send_user_email_code', user_id=fake_uuid),
-                data=data,
-                headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 404
-            assert json.loads(resp.get_data(as_text=True))['message'] == 'No result found'
-
-
 def test_send_user_email_verification(notify_api,
                                       sample_email_code,
                                       mock_celery_email_registration_verification,


### PR DESCRIPTION
We don’t send email codes any more.

No corresponding API client method here: https://github.com/alphagov/notifications-admin/blob/master/app/notify_client/user_api_client.py

So it’s definitely not being used. 