### PR TITLE
Fix test for duplicate service name

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -64,6 +64,8 @@ def register_errors(blueprint):
                 'duplicate key value violates unique constraint "services_email_from_key"' in e.orig.pgerror):
             return jsonify(
                 result='error',
-                message={'name': ["Duplicate service name '{}'".format(e.params.get('name', ''))]}
+                message={'name': ["Duplicate service name '{}'".format(
+                    e.params.get('name', e.params.get('email_from', ''))
+                )]}
             ), 400
         return jsonify(result='error', message="Internal server error"), 500

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -494,7 +494,10 @@ def test_should_not_update_service_with_duplicate_email_from(notify_api,
             assert resp.status_code == 400
             json_resp = json.loads(resp.get_data(as_text=True))
             assert json_resp['result'] == 'error'
-            assert "Duplicate service name '{}'".format(service_name) in json_resp['message']['name']
+            assert (
+                "Duplicate service name '{}'".format(service_name) in json_resp['message']['name'] or
+                "Duplicate service name '{}'".format(email_from) in json_resp['message']['name']
+            )
 
 
 def test_update_service_should_404_if_id_is_invalid(notify_api, notify_db, notify_db_session):


### PR DESCRIPTION
There is a uniqueness constraint on service `name` and `email_from`.

When you try to insert a row which has _both_ constraints, there is no guarantee which one the operation will fail on.

This means that, when handling the exception, service `name` is not reliably available, because sometimes the operation fails on the `email_from` constraint instead.

This caused the tests to fail non-deterministically because they were looking for the service `name` in the error message. As a fix, this commit does two things:

1. Return either the service `name` or `email_from` in the error message, depending which is available.

2. Modify the test to pass on _either_ of the two possible error messages.

This is not ideal, but I can’t think of a way to maintain the original behaviour, and have reliably passing tests.