### PR TITLE
Added limit_days filter to get notifications dao.

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -221,10 +221,16 @@ def get_notification_by_id(notification_id):
     return Notification.query.filter_by(id=notification_id).first()
 
 
-def get_notifications_for_service(service_id, filter_dict=None, page=1, page_size=None):
+def get_notifications_for_service(service_id, filter_dict=None, page=1, page_size=None, limit_days=None):
     if page_size is None:
         page_size = current_app.config['PAGE_SIZE']
-    query = Notification.query.filter_by(service_id=service_id)
+    filters = [Notification.service_id == service_id]
+
+    if limit_days is not None:
+        days_ago = date.today() - timedelta(days=limit_days)
+        filters.append(func.date(Notification.created_at) >= days_ago)
+
+    query = Notification.query.filter(*filters)
     query = filter_query(query, filter_dict)
     pagination = query.order_by(desc(Notification.created_at)).paginate(
         page=page,

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -191,12 +191,14 @@ def get_all_notifications():
 
     page = data['page'] if 'page' in data else 1
     page_size = data['page_size'] if 'page_size' in data else current_app.config.get('PAGE_SIZE')
+    limit_days = data.get('limit_days')
 
     pagination = notifications_dao.get_notifications_for_service(
         api_user['client'],
         filter_dict=data,
         page=page,
-        page_size=page_size)
+        page_size=page_size,
+        limit_days=limit_days)
     return jsonify(
         notifications=notification_status_schema.dump(pagination.items, many=True).data,
         page_size=page_size,
@@ -218,12 +220,14 @@ def get_all_notifications_for_service(service_id):
 
     page = data['page'] if 'page' in data else 1
     page_size = data['page_size'] if 'page_size' in data else current_app.config.get('PAGE_SIZE')
+    limit_days = data.get('limit_days')
 
     pagination = notifications_dao.get_notifications_for_service(
         service_id,
         filter_dict=data,
         page=page,
-        page_size=page_size)
+        page_size=page_size,
+        limit_days=limit_days)
     kwargs = request.args.to_dict()
     kwargs['service_id'] = service_id
     return jsonify(

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -245,6 +245,7 @@ class NotificationsFilterSchema(ma.Schema):
     status = fields.Nested(NotificationModelSchema, only=['status'], many=True)
     page = fields.Int(required=False)
     page_size = fields.Int(required=False)
+    limit_days = fields.Int(required=False)
 
     @pre_load
     def handle_multidict(self, in_data):

--- a/config.py
+++ b/config.py
@@ -52,12 +52,12 @@ class Config(object):
         },
         'delete-failed-notifications': {
             'task': 'delete-failed-notifications',
-            'schedule': crontab(minute=0, hour=0),
+            'schedule': crontab(minute=0, hour='0,1,2'),
             'options': {'queue': 'periodic'}
         },
         'delete-successful-notifications': {
             'task': 'delete-successful-notifications',
-            'schedule': crontab(minute=0, hour=0),
+            'schedule': crontab(minute=0, hour='0,1,2'),
             'options': {'queue': 'periodic'}
         }
     }


### PR DESCRIPTION
This pr is needed for https://github.com/alphagov/notifications-admin/pull/519

Also added config for deletion task so that it will run at midnight, 1am and 2am to cover utc and utc+1 servers, also clock skew and possibility of servers time zones not being changed in sync. In longer term it might be worth running this job more frequently with a limit on delete in case of lots of records to delete.