### PR TITLE
Process CSV files with column headers of any case

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -156,7 +156,10 @@ def process_job(job_id):
             'template': str(template.id),
             'job': str(job.id),
             'to': recipient,
-            'personalisation': personalisation
+            'personalisation': {
+                key: personalisation.get(key)
+                for key in template.placeholders
+            }
         })
 
         if template.template_type == 'sms':

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ monotonic==0.3
 git+https://github.com/alphagov/notifications-python-client.git@0.5.0#egg=notifications-python-client==0.5.0
 
 
-git+https://github.com/alphagov/notifications-utils.git@5.1.0#egg=notifications-utils==5.1.0
+git+https://github.com/alphagov/notifications-utils.git@5.2.0#egg=notifications-utils==5.2.0

--- a/test_csv_files/email.csv
+++ b/test_csv_files/email.csv
@@ -1,2 +1,2 @@
-email address
+email_address
 test@test.com

--- a/test_csv_files/multiple_email.csv
+++ b/test_csv_files/multiple_email.csv
@@ -1,4 +1,4 @@
-email address
+EMAILADDRESS
 test1@test.com
 test2@test.com
 test3@test.com

--- a/test_csv_files/multiple_sms.csv
+++ b/test_csv_files/multiple_sms.csv
@@ -1,4 +1,4 @@
-phone number,name
+PhoneNumber,Name
 +441234123121,chris
 +441234123122,chris
 +441234123123,chris

--- a/test_csv_files/sms.csv
+++ b/test_csv_files/sms.csv
@@ -1,2 +1,2 @@
-phone number, ignore this column
+PHONE NUMBER, IGNORE THIS COLUMN
 +441234123123, nope


### PR DESCRIPTION
Implements and depends on: https://github.com/alphagov/notifications-utils/pull/27

Should be merged and deployed before the same change in the admin app.

Object passed to Celery tasks must be JSON serialisable, hence the `dict` comprehension to convert from a `Columns` object.