### PR TITLE
Log start of request so requests can be timed

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,10 @@
 import uuid
 import os
-from flask import request, url_for
+from flask import request, url_for, g
 from flask import Flask, _request_ctx_stack
 from flask.ext.sqlalchemy import SQLAlchemy
 from flask_marshmallow import Marshmallow
+from monotonic import monotonic
 from werkzeug.local import LocalProxy
 from notifications_utils import logging
 from app.celery.celery import NotifyCelery
@@ -101,6 +102,10 @@ def init_app(app):
             error = auth.requires_auth()
             if error:
                 return error
+
+    @app.before_request
+    def record_start_time():
+        g.start = monotonic()
 
     @app.after_request
     def after_request(response):

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ monotonic==0.3
 git+https://github.com/alphagov/notifications-python-client.git@1.0.0#egg=notifications-python-client==1.0.0
 
 
-git+https://github.com/alphagov/notifications-utils.git@5.2.0#egg=notifications-utils==5.2.0
+git+https://github.com/alphagov/notifications-utils.git@5.2.3#egg=notifications-utils==5.2.3


### PR DESCRIPTION
Records the start time as a monotic on the global, to be read and used as part of request logging