### PR TITLE
Email failures

### DIFF
--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -5,10 +5,16 @@ from app.clients import STATISTICS_DELIVERED, STATISTICS_FAILURE
 from app.clients.email import (EmailClientException, EmailClient)
 
 ses_response_map = {
-    'Bounce': {
-        "message": 'Bounced',
+    'Permanent': {
+        "message": 'Hard bounced',
         "success": False,
-        "notification_status": 'failed',
+        "notification_status": 'permanent-failure',
+        "notification_statistics_status": STATISTICS_FAILURE
+    },
+    'Temporary': {
+        "message": 'Soft bounced',
+        "success": False,
+        "notification_status": 'temporary-failure',
         "notification_statistics_status": STATISTICS_FAILURE
     },
     'Delivery': {

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -1,4 +1,4 @@
-from sqlalchemy import (desc, func, Integer)
+from sqlalchemy import (desc, func, Integer, and_)
 from sqlalchemy.sql.expression import cast
 
 from datetime import (
@@ -188,11 +188,9 @@ def update_notification_status_by_id(notification_id, status, notification_stati
 
 
 def update_notification_status_by_reference(reference, status, notification_statistics_status):
-    count = db.session.query(Notification).filter_by(
-        reference=reference
-    ).update({
-        Notification.status: status
-    })
+    count = db.session.query(Notification).filter(Notification.reference == reference,
+                                                  Notification.status == 'sending').update(
+        {Notification.status: status})
 
     if count == 1:
         notification = Notification.query.filter_by(

--- a/tests/app/clients/test_aws_ses.py
+++ b/tests/app/clients/test_aws_ses.py
@@ -11,10 +11,18 @@ def test_should_return_correct_details_for_delivery():
     assert response_dict['success']
 
 
-def test_should_return_correct_details_for_bounced():
-    response_dict = get_aws_responses('Bounce')
-    assert response_dict['message'] == 'Bounced'
-    assert response_dict['notification_status'] == 'failed'
+def test_should_return_correct_details_for_hard_bounced():
+    response_dict = get_aws_responses('Permanent')
+    assert response_dict['message'] == 'Hard bounced'
+    assert response_dict['notification_status'] == 'permanent-failure'
+    assert response_dict['notification_statistics_status'] == 'failure'
+    assert not response_dict['success']
+
+
+def test_should_return_correct_details_for_soft_bounced():
+    response_dict = get_aws_responses('Temporary')
+    assert response_dict['message'] == 'Soft bounced'
+    assert response_dict['notification_status'] == 'temporary-failure'
     assert response_dict['notification_statistics_status'] == 'failure'
     assert not response_dict['success']
 


### PR DESCRIPTION
Update ses callback to interpret hard and soft bounces.  
If the notification has a status == sending then update the status otherwise do not update the status.
In other words do not change the status more than once.