### PR TITLE
notification_statistics endpoint

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -51,6 +51,12 @@ def dao_get_notification_statistics_for_service_and_day(service_id, day):
     ).order_by(desc(NotificationStatistics.day)).first()
 
 
+def dao_get_notification_statistics_for_day(day):
+    return NotificationStatistics.query.filter_by(
+        day=day
+    ).all()
+
+
 def dao_get_7_day_agg_notification_statistics_for_service(service_id,
                                                           date_from,
                                                           week_count=52):

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -28,7 +28,8 @@ from app.schemas import (
     sms_template_notification_schema,
     notification_status_schema,
     notifications_filter_schema,
-    notifications_statistics_schema
+    notifications_statistics_schema,
+    day_schema,
 )
 from app.celery.tasks import send_sms, send_email
 
@@ -389,14 +390,12 @@ def send_notification(notification_type):
 
 @notifications.route('/notifications/statistics')
 def get_notification_statistics_for_day():
-    data, errors = notifications_statistics_schema.load(request.args)
+    data, errors = day_schema.load(request.args)
     if errors:
         return jsonify(result='error', message=errors), 400
-    if not data.day:
-        return jsonify(result='error', message='Please provide day as query parameter.'), 400
 
-    statistics = notifications_dao.dao_get_notification_statistics_for_day(
-        day=data.day
+    statistics = notifications_dao.dao_get_potential_notification_statistics_for_day(
+        day=data['day']
     )
 
     data, errors = notifications_statistics_schema.dump(statistics, many=True)

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -388,9 +388,16 @@ def send_notification(notification_type):
 
 
 @notifications.route('/notifications/statistics')
-def get_notification_statistics_for_today():
-    today = date.today()
-    statistics = notifications_dao.dao_get_notification_statistics_for_day(day=today)
+def get_notification_statistics_for_day():
+    data, errors = notifications_statistics_schema.load(request.args)
+    if errors:
+        return jsonify(result='error', message=errors), 400
+    if not data.day:
+        return jsonify(result='error', message='Please provide day as query parameter.'), 400
+
+    statistics = notifications_dao.dao_get_notification_statistics_for_day(
+        day=data.day
+    )
 
     data, errors = notifications_statistics_schema.dump(statistics, many=True)
-    return jsonify(data=data, date=today.isoformat()), 200
+    return jsonify(data=data), 200

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date
 import statsd
 import itertools
 from flask import (
@@ -27,7 +27,8 @@ from app.schemas import (
     email_notification_schema,
     sms_template_notification_schema,
     notification_status_schema,
-    notifications_filter_schema
+    notifications_filter_schema,
+    notifications_statistics_schema
 )
 from app.celery.tasks import send_sms, send_email
 
@@ -384,3 +385,12 @@ def send_notification(notification_type):
 
     statsd_client.incr('notifications.api.{}'.format(notification_type))
     return jsonify(data={"notification": {"id": notification_id}}), 201
+
+
+@notifications.route('/notifications/statistics')
+def get_notification_statistics_for_today():
+    today = date.today()
+    statistics = notifications_dao.dao_get_notification_statistics_for_day(day=today)
+
+    data, errors = notifications_statistics_schema.dump(statistics, many=True)
+    return jsonify(data=data, date=today.isoformat()), 200

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -168,7 +168,6 @@ class RequestVerifyCodeSchema(ma.Schema):
 
 class NotificationSchema(ma.Schema):
     personalisation = fields.Dict(required=False)
-    pass
 
 
 class SmsNotificationSchema(NotificationSchema):
@@ -360,6 +359,14 @@ class FromToDateSchema(ma.Schema):
             raise ValidationError("date_from needs to be greater than date_to")
 
 
+class DaySchema(ma.Schema):
+    day = fields.Date(required=True)
+
+    @validates('day')
+    def validate_day(self, value):
+        _validate_not_in_future(value)
+
+
 class WeekAggregateNotificationStatisticsSchema(ma.Schema):
 
     date_from = fields.Date()
@@ -405,3 +412,4 @@ event_schema = EventSchema()
 from_to_date_schema = FromToDateSchema()
 provider_details_schema = ProviderDetailsSchema()
 week_aggregate_notification_statistics_schema = WeekAggregateNotificationStatisticsSchema()
+day_schema = DaySchema()

--- a/tests/app/notifications/rest/test_notification_statistics.py
+++ b/tests/app/notifications/rest/test_notification_statistics.py
@@ -1,0 +1,68 @@
+from datetime import date, timedelta
+
+from flask import json
+from freezegun import freeze_time
+
+from tests import create_authorization_header
+from tests.app.conftest import sample_notification_statistics as create_sample_notification_statistics
+
+
+def test_get_notification_statistics(notify_api, sample_notification_statistics):
+    with notify_api.test_request_context():
+        with notify_api.test_client() as client:
+            auth_header = create_authorization_header(
+                service_id=sample_notification_statistics.service_id
+            )
+
+            response = client.get(
+                '/notifications/statistics',
+                headers=[auth_header]
+            )
+
+            notifications = json.loads(response.get_data(as_text=True))
+            stats = notifications['data'][0]
+            assert stats['emails_requested'] == 2
+            assert stats['emails_delivered'] == 1
+            assert stats['emails_failed'] == 1
+            assert stats['sms_requested'] == 2
+            assert stats['sms_delivered'] == 1
+            assert stats['service'] == str(sample_notification_statistics.service_id)
+            assert response.status_code == 200
+
+
+@freeze_time('1955-11-05T12:00:00')
+def test_get_notification_statistics_only_returns_today(notify_api, notify_db, notify_db_session, sample_service):
+    with notify_api.test_request_context():
+        with notify_api.test_client() as client:
+            yesterdays_notification_statistics = create_sample_notification_statistics(
+                notify_db,
+                notify_db_session,
+                service=sample_service,
+                day=date.today() - timedelta(days=1)
+            )
+            todays_notification_statistics = create_sample_notification_statistics(
+                notify_db,
+                notify_db_session,
+                service=sample_service,
+                day=date.today()
+            )
+            tomorrows_notification_statistics = create_sample_notification_statistics(
+                notify_db,
+                notify_db_session,
+                service=sample_service,
+                day=date.today() + timedelta(days=1)
+            )
+
+            auth_header = create_authorization_header(
+                service_id=sample_service.id
+            )
+
+            response = client.get(
+                '/notifications/statistics',
+                headers=[auth_header]
+            )
+
+            notifications = json.loads(response.get_data(as_text=True))
+            assert len(notifications['data']) == 1
+            assert notifications['data'][0]['day'] == date.today().isoformat()
+            assert response.status_code == 200

--- a/tests/app/notifications/rest/test_notification_statistics.py
+++ b/tests/app/notifications/rest/test_notification_statistics.py
@@ -4,7 +4,10 @@ from flask import json
 from freezegun import freeze_time
 
 from tests import create_authorization_header
-from tests.app.conftest import sample_notification_statistics as create_sample_notification_statistics
+from tests.app.conftest import (
+    sample_notification_statistics as create_sample_notification_statistics,
+    sample_service as create_sample_service
+)
 
 
 def test_get_notification_statistics(notify_api, sample_notification_statistics):
@@ -28,6 +31,7 @@ def test_get_notification_statistics(notify_api, sample_notification_statistics)
             assert stats['emails_failed'] == 1
             assert stats['sms_requested'] == 2
             assert stats['sms_delivered'] == 1
+            assert stats['sms_failed'] == 1
             assert stats['service'] == str(sample_notification_statistics.service_id)
             assert response.status_code == 200
 
@@ -85,6 +89,7 @@ def test_get_notification_statistics_fails_if_no_date(notify_api, sample_notific
 
             resp = json.loads(response.get_data(as_text=True))
             assert resp['result'] == 'error'
+            assert resp['message'] == {'day': ['Missing data for required field.']}
             assert response.status_code == 400
 
 
@@ -102,4 +107,90 @@ def test_get_notification_statistics_fails_if_invalid_date(notify_api, sample_no
 
             resp = json.loads(response.get_data(as_text=True))
             assert resp['result'] == 'error'
+            assert resp['message'] == {'day': ['Not a valid date.']}
             assert response.status_code == 400
+
+
+def test_get_notification_statistics_returns_zeros_if_not_in_db(notify_api, sample_service):
+    with notify_api.test_request_context():
+        with notify_api.test_client() as client:
+            auth_header = create_authorization_header(
+                service_id=sample_service.id
+            )
+
+            response = client.get(
+                '/notifications/statistics?day={}'.format(date.today().isoformat()),
+                headers=[auth_header]
+            )
+
+            notifications = json.loads(response.get_data(as_text=True))
+
+            assert len(notifications['data']) == 1
+            stats = notifications['data'][0]
+            assert stats['emails_requested'] == 0
+            assert stats['emails_delivered'] == 0
+            assert stats['emails_failed'] == 0
+            assert stats['sms_requested'] == 0
+            assert stats['sms_delivered'] == 0
+            assert stats['sms_failed'] == 0
+            assert stats['service'] == str(sample_service.id)
+            assert response.status_code == 200
+
+
+def test_get_notification_statistics_returns_both_existing_stats_and_generated_zeros(
+    notify_api,
+    notify_db,
+    notify_db_session
+):
+    with notify_api.test_request_context():
+        with notify_api.test_client() as client:
+            service_with_stats = create_sample_service(
+                notify_db,
+                notify_db_session,
+                service_name='service_with_stats',
+                email_from='service_with_stats'
+            )
+            service_without_stats = create_sample_service(
+                notify_db,
+                notify_db_session,
+                service_name='service_without_stats',
+                email_from='service_without_stats'
+            )
+            notification_statistics = create_sample_notification_statistics(
+                notify_db,
+                notify_db_session,
+                service=service_with_stats,
+                day=date.today()
+            )
+            auth_header = create_authorization_header(
+                service_id=service_with_stats.id
+            )
+
+            response = client.get(
+                '/notifications/statistics?day={}'.format(date.today().isoformat()),
+                headers=[auth_header]
+            )
+
+            notifications = json.loads(response.get_data(as_text=True))
+
+            assert len(notifications['data']) == 2
+            retrieved_stats = notifications['data'][0]
+            generated_stats = notifications['data'][1]
+
+            assert retrieved_stats['emails_requested'] == 2
+            assert retrieved_stats['emails_delivered'] == 1
+            assert retrieved_stats['emails_failed'] == 1
+            assert retrieved_stats['sms_requested'] == 2
+            assert retrieved_stats['sms_delivered'] == 1
+            assert retrieved_stats['sms_failed'] == 1
+            assert retrieved_stats['service'] == str(service_with_stats.id)
+
+            assert generated_stats['emails_requested'] == 0
+            assert generated_stats['emails_delivered'] == 0
+            assert generated_stats['emails_failed'] == 0
+            assert generated_stats['sms_requested'] == 0
+            assert generated_stats['sms_delivered'] == 0
+            assert generated_stats['sms_failed'] == 0
+            assert generated_stats['service'] == str(service_without_stats.id)
+
+            assert response.status_code == 200


### PR DESCRIPTION
put the tests inside a new `rest` subfolder as I didn't really want to add them into the 1.8k LOC `test_rest.py`.