### PR TITLE
Only update status when status is sending.

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -219,8 +219,9 @@ def dao_update_notification(notification):
 
 
 def update_notification_status_by_id(notification_id, status, notification_statistics_status):
-    count = db.session.query(Notification).filter_by(
-        id=notification_id
+    count = db.session.query(Notification).filter(
+        Notification.id == notification_id,
+        Notification.status == 'sending'
     ).update({
         Notification.status: status
     })

--- a/app/notifications/process_client_response.py
+++ b/app/notifications/process_client_response.py
@@ -58,9 +58,10 @@ def process_sms_client_response(status, reference, client_name):
                                                                         notification_status,
                                                                         notification_statistics_status)
     if update_success == 0:
-        status_error = "{} callback failed: notification {} not found. Status {}".format(client_name,
-                                                                                         reference,
-                                                                                         notification_status_message)
+        status_error = "{} callback failed: notification {} either not found or already updated " \
+                       "from sending. Status {}".format(client_name,
+                                                        reference,
+                                                        notification_status_message)
         return success, status_error
 
     if not notification_success:


### PR DESCRIPTION
If the sms client provider sends more than one delivery receipt only take the update for the the first one.

Only update the notification.status if status = sending.

https://www.pivotaltracker.com/story/show/119377985