### PR TITLE
Add a service for Notify to use to send messages

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -47,8 +47,6 @@ def dao_create_service(service, user):
     from app.dao.permissions_dao import permission_dao
     service.users.append(user)
     permission_dao.add_default_service_permissions_for_user(user, service)
-    if not service.id:
-        service.id = uuid.uuid4()  # must be set now so version history model can use same id
     service.id = uuid.uuid4()  # must be set now so version history model can use same id
     service.research_mode = False
     db.session.add(service)

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -47,6 +47,8 @@ def dao_create_service(service, user):
     from app.dao.permissions_dao import permission_dao
     service.users.append(user)
     permission_dao.add_default_service_permissions_for_user(user, service)
+    if not service.id:
+        service.id = uuid.uuid4()  # must be set now so version history model can use same id
     service.id = uuid.uuid4()  # must be set now so version history model can use same id
     service.research_mode = False
     db.session.add(service)

--- a/config.py
+++ b/config.py
@@ -16,7 +16,7 @@ class Config(object):
     NOTIFY_APP_NAME = 'api'
     NOTIFY_LOG_PATH = '/var/log/notify/application.log'
     NOTIFY_JOB_QUEUE = os.environ['NOTIFY_JOB_QUEUE']
-    # Notification Queue names are a combination of a prefx plus a name
+    # Notification Queue names are a combination of a prefix plus a name
     NOTIFICATION_QUEUE_PREFIX = os.environ['NOTIFICATION_QUEUE_PREFIX']
     MMG_FROM_NUMBER = os.environ['MMG_FROM_NUMBER']
     SECRET_KEY = os.environ['SECRET_KEY']
@@ -28,6 +28,12 @@ class Config(object):
     NOTIFY_EMAIL_DOMAIN = os.environ['NOTIFY_EMAIL_DOMAIN']
     PAGE_SIZE = 50
     SMS_CHAR_COUNT_LIMIT = 495
+
+    NOTIFY_SERVICE_ID = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'
+    INVITATION_EMAIL_TEMPLATE_ID = '4f46df42-f795-4cc4-83bb-65ca312f49cc'
+    SMS_CODE_TEMPLATE_ID = '36fb0730-6259-4da1-8a80-c8de22ad4246'
+    EMAIL_VERIFY_CODE_TEMPLATE_ID = 'ece42649-22a8-4d06-b87f-d52d5d3f0a27'
+    PASSWORD_RESET_TEMPLATE_ID = '474e9242-823b-4f99-813d-ed392e7f1201'
 
     BROKER_URL = 'sqs://'
     BROKER_TRANSPORT_OPTIONS = {

--- a/migrations/versions/0025_notify_service_data.py
+++ b/migrations/versions/0025_notify_service_data.py
@@ -25,7 +25,7 @@ def upgrade():
     password = hashpw(str(uuid.uuid4()))
     op.get_bind()
     user_insert = """INSERT INTO users (id, name, email_address, created_at, failed_login_count, _password, mobile_number, state, platform_admin)
-                     VALUES ('{}', 'Notify service user', 'this-does-not-work@this.does.not.work.gov.uk', '{}', 0,'{}', '+441234123412', 'active', False)
+                     VALUES ('{}', 'Notify service user', 'notify-service-user@digital.cabinet-office', '{}', 0,'{}', '+441234123412', 'active', False)
                   """
     op.execute(user_insert.format(user_id, datetime.utcnow(), password))
     service_history_insert = """INSERT INTO services_history (id, name, created_at, active, message_limit, restricted, research_mode, email_from, created_by_id, reply_to_email_address, version)
@@ -41,18 +41,6 @@ def upgrade():
     op.execute(service_insert.format(service_id, datetime.utcnow(), user_id))
     user_to_service_insert = """INSERT INTO user_to_service (user_id, service_id) VALUES ('{}', '{}')"""
     op.execute(user_to_service_insert.format(user_id, service_id))
-
-    permission_insert = """INSERT INTO permissions (id, service_id, user_id, permission, created_at)
-                           VALUES ('{}', '{}', '{}', '{}','{}')
-                           """
-    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'manage_users', datetime.utcnow()))
-    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'manage_templates', datetime.utcnow()))
-    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'manage_settings', datetime.utcnow()))
-    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'send_texts', datetime.utcnow()))
-    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'send_emails', datetime.utcnow()))
-    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'send_letters', datetime.utcnow()))
-    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'manage_api_keys', datetime.utcnow()))
-    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'view_activity', datetime.utcnow()))
 
     template_history_insert = """INSERT INTO templates_history (id, name, template_type, created_at,
                                                                 content, archived, service_id,
@@ -111,7 +99,6 @@ def downgrade():
     op.get_bind()
     op.execute("delete from templates where service_id = '{}'".format(service_id))
     op.execute("delete from templates_history where service_id = '{}'".format(service_id))
-    op.execute("delete from permissions where user_id = '{}'".format(user_id))
     op.execute("delete from user_to_service where service_id = '{}'".format(service_id))
     op.execute("delete from services_history where id = '{}'".format(service_id))
     op.execute("delete from services where id = '{}'".format(service_id))

--- a/migrations/versions/0025_notify_service_data.py
+++ b/migrations/versions/0025_notify_service_data.py
@@ -1,0 +1,119 @@
+"""empty message
+
+Revision ID: 0025_notify_service_data
+Revises: 0024_add_research_mode_defaults
+Create Date: 2016-06-01 14:17:01.963181
+
+"""
+
+# revision identifiers, used by Alembic.
+from datetime import datetime
+
+from alembic import op
+
+from app.encryption import hashpw
+import uuid
+revision = '0025_notify_service_data'
+down_revision = '0024_add_research_mode_defaults'
+
+
+user_id= '6af522d0-2915-4e52-83a3-3690455a5fe6'
+service_id = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'
+
+
+def upgrade():
+    password = hashpw(str(uuid.uuid4()))
+    op.get_bind()
+    user_insert = """INSERT INTO users (id, name, email_address, created_at, failed_login_count, _password, mobile_number, state, platform_admin)
+                     VALUES ('{}', 'Notify service user', 'this-does-not-work@this.does.not.work.gov.uk', '{}', 0,'{}', '+441234123412', 'active', False)
+                  """
+    op.execute(user_insert.format(user_id, datetime.utcnow(), password))
+    service_history_insert = """INSERT INTO services_history (id, name, created_at, active, message_limit, restricted, research_mode, email_from, created_by_id, reply_to_email_address, version)
+                        VALUES ('{}', 'Notify service', '{}', True, 1000, False, False, 'notify@digital.cabinet-office.gov.uk',
+                        '{}', 'notify@digital.cabinet-office.gov.uk', 1)
+
+                     """
+    op.execute(service_history_insert.format(service_id, datetime.utcnow(), user_id))
+    service_insert = """INSERT INTO services (id, name, created_at, active, message_limit, restricted, research_mode, email_from, created_by_id, reply_to_email_address, version)
+                        VALUES ('{}', 'Notify service', '{}', True, 1000, False, False, 'notify@digital.cabinet-office.gov.uk',
+                        '{}', 'notify@digital.cabinet-office.gov.uk', 1)
+                    """
+    op.execute(service_insert.format(service_id, datetime.utcnow(), user_id))
+    user_to_service_insert = """INSERT INTO user_to_service (user_id, service_id) VALUES ('{}', '{}')"""
+    op.execute(user_to_service_insert.format(user_id, service_id))
+
+    permission_insert = """INSERT INTO permissions (id, service_id, user_id, permission, created_at)
+                           VALUES ('{}', '{}', '{}', '{}','{}')
+                           """
+    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'manage_users', datetime.utcnow()))
+    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'manage_templates', datetime.utcnow()))
+    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'manage_settings', datetime.utcnow()))
+    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'send_texts', datetime.utcnow()))
+    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'send_emails', datetime.utcnow()))
+    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'send_letters', datetime.utcnow()))
+    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'manage_api_keys', datetime.utcnow()))
+    op.execute(permission_insert.format(uuid.uuid4(), service_id, user_id, 'view_activity', datetime.utcnow()))
+
+    template_history_insert = """INSERT INTO templates_history (id, name, template_type, created_at,
+                                                                content, archived, service_id,
+                                                                subject, created_by_id, version)
+                                 VALUES ('{}', '{}', '{}', '{}', '{}', False, '{}', '{}', '{}', 1)
+                              """
+    template_insert = """INSERT INTO templates (id, name, template_type, created_at,
+                                                content, archived, service_id, subject, created_by_id, version)
+                                 VALUES ('{}', '{}', '{}', '{}', '{}', False, '{}', '{}', '{}', 1)
+                              """
+    email_verification_content = \
+        """Hi ((name)),\n\nTo complete your registration for GOV.UK Notify please click the link below\n\n((url))"""
+    op.execute(template_history_insert.format(uuid.uuid4(), 'Notify email verification code', 'email',
+                                              datetime.utcnow(), email_verification_content, service_id,
+                                              'Confirm GOV.UK Notify registration', user_id))
+    op.execute(template_insert.format('ece42649-22a8-4d06-b87f-d52d5d3f0a27', 'Notify email verification code', 'email',
+                                      datetime.utcnow(), email_verification_content, service_id,
+                                      'Confirm GOV.UK Notify registration', user_id))
+
+    invitation_subject = "((user_name)) has invited you to collaborate on ((service_name)) on GOV.UK Notify"
+    invitation_content = """((user_name)) has invited you to collaborate on ((service_name)) on GOV.UK Notify.\n\n
+        GOV.UK Notify makes it easy to keep people updated by helping you send text messages, emails and letters.\n\n
+        Click this link to create an account on GOV.UK Notify:\n((url))\n\n
+        This invitation will stop working at midnight tomorrow. This is to keep ((service_name)) secure.
+        """
+    op.execute(template_history_insert.format('4f46df42-f795-4cc4-83bb-65ca312f49cc', 'Notify invitation email',
+                                              'email', datetime.utcnow(), invitation_content, service_id,
+                                              invitation_subject, user_id))
+    op.execute(template_insert.format('4f46df42-f795-4cc4-83bb-65ca312f49cc', 'Notify invitation email',
+                                      'email', datetime.utcnow(), invitation_content, service_id,
+                                      invitation_subject, user_id))
+
+    sms_code_content = '((verify_code)) is your Notify authentication code'
+    op.execute(template_history_insert.format('36fb0730-6259-4da1-8a80-c8de22ad4246', 'Notify SMS verify code',
+                                              'sms', datetime.utcnow(), sms_code_content, service_id, None, user_id))
+
+    op.execute(template_insert.format('36fb0730-6259-4da1-8a80-c8de22ad4246', 'Notify SMS verify code',
+                                      'sms', datetime.utcnow(), sms_code_content, service_id, None, user_id))
+
+    password_reset_content = "Hi ((user_name)),\n\n" \
+                             "We received a request to reset your password on GOV.UK Notify.\n\n" \
+                             "If you didn''t request this email, you can ignore it – " \
+                             "your password has not been changed.\n\n" \
+                             "To reset your password, click this link:\n\n" \
+                             "((url))"
+
+    op.execute(template_history_insert.format('474e9242-823b-4f99-813d-ed392e7f1201', 'Notify password reset email',
+                                              'email', datetime.utcnow(), password_reset_content, service_id,
+                                              'Reset your GOV.UK Notify password', user_id))
+    op.execute(template_insert.format('474e9242-823b-4f99-813d-ed392e7f1201', 'Notify password reset email',
+                                      'email', datetime.utcnow(), password_reset_content, service_id,
+                                      'Reset your GOV.UK Notify password', user_id))
+
+
+def downgrade():
+    op.get_bind()
+    op.execute("delete from templates where service_id = '{}'".format(service_id))
+    op.execute("delete from templates_history where service_id = '{}'".format(service_id))
+    op.execute("delete from permissions where user_id = '{}'".format(user_id))
+    op.execute("delete from user_to_service where service_id = '{}'".format(service_id))
+    op.execute("delete from services_history where id = '{}'".format(service_id))
+    op.execute("delete from services where id = '{}'".format(service_id))
+    op.execute("delete from users where id = '{}'".format(user_id))
+


### PR DESCRIPTION
Add a service that will be used to send Notify's messages.
Including sms code, email verification, invitation emails, and password reset emails
Added the service id and template ids to config.
Small change to dao_create_service to use id if set.

First PR for https://www.pivotaltracker.com/story/show/120282429 