### PR TITLE
Order templates by newest created first

### DIFF
--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -45,7 +45,7 @@ def dao_get_all_templates_for_service(service_id):
         service_id=service_id,
         archived=False
     ).order_by(
-        asc(Template.updated_at), asc(Template.created_at)
+        desc(Template.created_at)
     ).all()
 
 

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -99,7 +99,7 @@ def test_get_all_templates_for_service(notify_db, notify_db_session, service_fac
     assert len(dao_get_all_templates_for_service(service_2.id)) == 2
 
 
-def test_get_all_templates_for_service_in_created_order(notify_db, notify_db_session, sample_service):
+def test_get_all_templates_for_service_shows_newest_created_first(notify_db, notify_db_session, sample_service):
     template_1 = create_sample_template(
         notify_db,
         notify_db_session,
@@ -126,13 +126,14 @@ def test_get_all_templates_for_service_in_created_order(notify_db, notify_db_ses
     )
 
     assert Template.query.count() == 3
-    assert dao_get_all_templates_for_service(sample_service.id)[0].name == 'Sample Template 1'
+    assert dao_get_all_templates_for_service(sample_service.id)[0].name == 'Sample Template 3'
     assert dao_get_all_templates_for_service(sample_service.id)[1].name == 'Sample Template 2'
-    assert dao_get_all_templates_for_service(sample_service.id)[2].name == 'Sample Template 3'
+    assert dao_get_all_templates_for_service(sample_service.id)[2].name == 'Sample Template 1'
 
     template_2.name = 'Sample Template 2 (updated)'
     dao_update_template(template_2)
-    assert dao_get_all_templates_for_service(sample_service.id)[0].name == 'Sample Template 2 (updated)'
+    assert dao_get_all_templates_for_service(sample_service.id)[0].name == 'Sample Template 3'
+    assert dao_get_all_templates_for_service(sample_service.id)[1].name == 'Sample Template 2 (updated)'
 
 
 def test_get_all_returns_empty_list_if_no_templates(sample_service):

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -250,10 +250,10 @@ def test_should_be_able_to_get_all_templates_for_a_service(notify_api, sample_us
 
             assert response.status_code == 200
             update_json_resp = json.loads(response.get_data(as_text=True))
-            assert update_json_resp['data'][0]['name'] == 'my template 1'
+            assert update_json_resp['data'][0]['name'] == 'my template 2'
             assert update_json_resp['data'][0]['version'] == 1
             assert update_json_resp['data'][0]['created_at']
-            assert update_json_resp['data'][1]['name'] == 'my template 2'
+            assert update_json_resp['data'][1]['name'] == 'my template 1'
             assert update_json_resp['data'][1]['version'] == 1
             assert update_json_resp['data'][1]['created_at']
 


### PR DESCRIPTION
When you add a new template, it’s probably the one that you want to do subsequent stuff with. But it’s also helpful to see the template in context (with its siblings) to understand that there are multiple
templates. So we don’t want to do what we do in https://github.com/alphagov/notifications-admin/pull/648
for adding a new template.

But we _can_ make your brand-new template appear first by always ordering by when the template was created.

This also removes the confusion caused by having `updated_at` affecting order, and causing the templates to move around all the time.