### PR TITLE
Bump utils to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ statsd==3.2.1
 git+https://github.com/alphagov/notifications-python-client.git@1.0.0#egg=notifications-python-client==1.0.0
 
 
-git+https://github.com/alphagov/notifications-utils.git@5.2.8#egg=notifications-utils==5.2.8
+git+https://github.com/alphagov/notifications-utils.git@6.2.0#egg=notifications-utils==6.2.0


### PR DESCRIPTION
This commit doesn’t introduce any new functionality, just keeps things from getting too far behind.

This is a breaking change in utils, see:
https://github.com/alphagov/notifications-utils/commit/4683922d30704e932e7a49d5c3ab058814ee5356

None of these methods are used by the API, so no API code needs to change, cf:

https://github.com/alphagov/notifications-api/search?utf8=%E2%9C%93&q=rows_with_errors&type=Code

https://github.com/alphagov/notifications-api/search?utf8=%E2%9C%93&q=has_errors&type=Code

https://github.com/alphagov/notifications-api/search?utf8=%E2%9C%93&q=annotated_rows&type=Code

https://github.com/alphagov/notifications-api/search?utf8=%E2%9C%93&q=annotated_rows_with_errors&type=Code