### PR TITLE
add template_statistics endpoint for specific template

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -139,6 +139,12 @@ def dao_get_template_statistics_for_service(service_id, limit_days=None):
         desc(TemplateStatistics.updated_at)).all()
 
 
+def dao_get_template_statistics_for_template(template_id):
+    return TemplateStatistics.query.filter(
+        TemplateStatistics.template_id == template_id
+    ).all()
+
+
 @transactional
 def dao_create_notification(notification, notification_type, provider_identifier):
     provider = ProviderDetails.query.filter_by(identifier=provider_identifier).one()

--- a/app/template_statistics/rest.py
+++ b/app/template_statistics/rest.py
@@ -5,7 +5,10 @@ from flask import (
     current_app
 )
 
-from app.dao.notifications_dao import dao_get_template_statistics_for_service
+from app.dao.notifications_dao import (
+    dao_get_template_statistics_for_service,
+    dao_get_template_statistics_for_template
+)
 
 from app.schemas import template_statistics_schema
 
@@ -30,6 +33,15 @@ def get_template_statistics_for_service(service_id):
     else:
         limit_days = None
     stats = dao_get_template_statistics_for_service(service_id, limit_days=limit_days)
+    data, errors = template_statistics_schema.dump(stats, many=True)
+    if errors:
+        return jsonify(result="error", message=errors), 400
+    return jsonify(data=data)
+
+
+@template_statistics.route('/<template_id>')
+def get_template_statistics_for_template_id(service_id, template_id):
+    stats = dao_get_template_statistics_for_template(template_id)
     data, errors = template_statistics_schema.dump(stats, many=True)
     if errors:
         return jsonify(result="error", message=errors), 400

--- a/tests/app/template_statistics/test_rest.py
+++ b/tests/app/template_statistics/test_rest.py
@@ -1,10 +1,12 @@
+from datetime import datetime
 import json
+
 from freezegun import freeze_time
 
 from app import db
 from app.models import TemplateStatistics
-
 from tests import create_authorization_header
+from tests.app.conftest import sample_template as create_sample_template
 
 
 @freeze_time('2016-04-09')
@@ -130,3 +132,97 @@ def test_get_all_template_statistics_with_bad_limit_arg_returns_400(notify_api, 
             json_resp = json.loads(response.get_data(as_text=True))
             assert json_resp['result'] == 'error'
             assert json_resp['message'] == {'limit_days': ['blurk is not an integer']}
+
+
+def test_get_template_statistics_for_template_only_returns_for_provided_template(
+        notify_db,
+        notify_db_session,
+        notify_api,
+        sample_service
+):
+    template_1 = create_sample_template(
+        notify_db,
+        notify_db_session,
+        template_name='Sample Template 1',
+        service=sample_service
+    )
+    template_2 = create_sample_template(
+        notify_db,
+        notify_db_session,
+        template_name='Sample Template 2',
+        service=sample_service
+    )
+
+    template_1_stats_1 = TemplateStatistics(
+        template_id=template_1.id,
+        service_id=sample_service.id,
+        day=datetime(2001, 1, 1)
+    )
+    template_1_stats_2 = TemplateStatistics(
+        template_id=template_1.id,
+        service_id=sample_service.id,
+        day=datetime(2001, 1, 2)
+    )
+    template_2_stats = TemplateStatistics(
+        template_id=template_2.id,
+        service_id=sample_service.id,
+        day=datetime(2001, 1, 1)
+    )
+    db.session.add_all([template_1_stats_1, template_1_stats_2, template_2_stats])
+    db.session.commit()
+
+    with notify_api.test_request_context():
+        with notify_api.test_client() as client:
+            auth_header = create_authorization_header()
+
+            response = client.get(
+                '/service/{}/template-statistics/{}'.format(sample_service.id, template_1.id),
+                headers=[('Content-Type', 'application/json'), auth_header],
+            )
+
+            assert response.status_code == 200
+            json_resp = json.loads(response.get_data(as_text=True))
+            assert len(json_resp['data']) == 2
+            assert json_resp['data'][0]['id'] == str(template_1_stats_1.id)
+            assert json_resp['data'][1]['id'] == str(template_1_stats_2.id)
+
+
+def test_get_template_statistics_for_template_returns_empty_if_no_statistics(
+        notify_db,
+        notify_db_session,
+        notify_api,
+        sample_service
+):
+    template_1 = create_sample_template(
+        notify_db,
+        notify_db_session,
+        template_name='Sample Template 1',
+        service=sample_service
+    )
+    template_2 = create_sample_template(
+        notify_db,
+        notify_db_session,
+        template_name='Sample Template 2',
+        service=sample_service
+    )
+
+    template_1_stats = TemplateStatistics(
+        template_id=template_1.id,
+        service_id=sample_service.id,
+        day=datetime(2001, 1, 1)
+    )
+    db.session.add(template_1_stats)
+    db.session.commit()
+
+    with notify_api.test_request_context():
+        with notify_api.test_client() as client:
+            auth_header = create_authorization_header()
+
+            response = client.get(
+                '/service/{}/template-statistics/{}'.format(sample_service.id, template_2.id),
+                headers=[('Content-Type', 'application/json'), auth_header],
+            )
+
+            assert response.status_code == 200
+            json_resp = json.loads(response.get_data(as_text=True))
+            assert json_resp['data'] == []


### PR DESCRIPTION
`/service/<service_id>/template-statistics/<template_id>`
still requires service-id just to try and keep api tree cleaner