### PR TITLE
[WIP] Permissions being removed

### DIFF
--- a/app/dao/permissions_dao.py
+++ b/app/dao/permissions_dao.py
@@ -32,6 +32,8 @@ class PermissionDAO(DAOClass):
     class Meta:
         model = Permission
 
+    # TODO rework this as last filter wins, whereas what is needed is
+    # append to filter so that semantics are 'and'
     def get_query(self, filter_by_dict=None):
         if filter_by_dict is None:
             filter_by_dict = MultiDict()
@@ -60,13 +62,14 @@ class PermissionDAO(DAOClass):
             self.create_instance(permission, _commit=False)
 
     def remove_user_service_permissions(self, user, service):
-        query = self.get_query(filter_by_dict={'user': user.id, 'service': service.id})
+        query = self.Meta.model.query.filter_by(user=user, service=service)
         query.delete()
 
-    def set_user_service_permission(self, user, service, permissions, _commit=False):
+    def set_user_service_permission(self, user, service, permissions, _commit=False, replace=False):
         try:
-            query = self.get_query(filter_by_dict={'user': user.id, 'service': service.id})
-            query.delete()
+            if replace:
+                query = self.Meta.model.query.filter_by(user=user, service=service)
+                query.delete()
             for p in permissions:
                 p.user = user
                 p.service = service

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1,9 +1,13 @@
-from datetime import (datetime, date)
+from datetime import (
+    datetime,
+    date
+)
 
-from flask import Blueprint
 from flask import (
     jsonify,
-    request
+    request,
+    abort,
+    Blueprint
 )
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -152,6 +156,8 @@ def add_user_to_service(service_id, user_id):
                        message='User id: {} already part of service id: {}'.format(user_id, service_id)), 400
 
     permissions, errors = permission_schema.load(request.get_json(), many=True)
+    if errors:
+        abort(400, errors)
 
     dao_add_user_to_service(service, user, permissions)
     data, errors = service_schema.dump(service)
@@ -172,15 +178,6 @@ def remove_user_from_service(service_id, user_id):
             message='You cannot remove the only user for a service'), 400
     dao_remove_user_from_service(service, user)
     return jsonify({}), 204
-
-
-def _process_permissions(user, service, permission_groups):
-    from app.permissions_utils import get_permissions_by_group
-    permissions = get_permissions_by_group(permission_groups)
-    for permission in permissions:
-        permission.user = user
-        permission.service = service
-    return permissions
 
 
 @service.route('/<uuid:service_id>/fragment/aggregate_statistics')

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -188,7 +188,7 @@ def set_permissions(user_id, service_id):
     for p in permissions:
         p.user = user
         p.service = service
-    permission_dao.set_user_service_permission(user, service, permissions, _commit=True)
+    permission_dao.set_user_service_permission(user, service, permissions, _commit=True, replace=True)
     return jsonify({}), 204
 
 


### PR DESCRIPTION
This is marked as WIP for the bug as I still need to do a migration script for existing broken accounts.

When adding a user new with permissions to a service, the permissions
dao was deleting all permissions for that user (regardless of service
id) as the last filter on the permissions dao get_query method won.

I've added a replace flag to the set_user_service_permission method
so that it can handle adding new users + permissions and editing
of existing users' permissions.

Also by pass the get_query method until it can be refactored to work
correctly.

For now execute the filter query directly on the model.