### PR TITLE
fix template api tests being inconsistent by adding ordering

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -142,6 +142,8 @@ def dao_get_template_statistics_for_service(service_id, limit_days=None):
 def dao_get_template_statistics_for_template(template_id):
     return TemplateStatistics.query.filter(
         TemplateStatistics.template_id == template_id
+    ).order_by(
+        desc(TemplateStatistics.updated_at)
     ).all()
 
 

--- a/tests/app/template_statistics/test_rest.py
+++ b/tests/app/template_statistics/test_rest.py
@@ -168,7 +168,12 @@ def test_get_template_statistics_for_template_only_returns_for_provided_template
         service_id=sample_service.id,
         day=datetime(2001, 1, 1)
     )
-    db.session.add_all([template_1_stats_1, template_1_stats_2, template_2_stats])
+
+    # separate commit to ensure stats_1 has earlier updated_at time
+    db.session.add(template_1_stats_1)
+    db.session.commit()
+
+    db.session.add_all([template_1_stats_2, template_2_stats])
     db.session.commit()
 
     with notify_api.test_request_context():
@@ -183,8 +188,8 @@ def test_get_template_statistics_for_template_only_returns_for_provided_template
             assert response.status_code == 200
             json_resp = json.loads(response.get_data(as_text=True))
             assert len(json_resp['data']) == 2
-            assert json_resp['data'][0]['id'] == str(template_1_stats_1.id)
-            assert json_resp['data'][1]['id'] == str(template_1_stats_2.id)
+            assert json_resp['data'][0]['id'] == str(template_1_stats_2.id)
+            assert json_resp['data'][1]['id'] == str(template_1_stats_1.id)
 
 
 def test_get_template_statistics_for_template_returns_empty_if_no_statistics(


### PR DESCRIPTION
they were previously returning unordered, which broke the build (once and arbitrarily)

i tried to use freezegun to make the updated_at times predictable but didn't have any luck with that, but separate commits should be enough