### PR TITLE
fix firetext research mode requests

### DIFF
--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -19,7 +19,7 @@ def send_sms_response(provider, reference, to):
         body = mmg_callback(reference, to)
         headers = {"Content-type": "application/json"}
     else:
-        headers = {"Content-type": "text/plain"}
+        headers = {"Content-type": "application/x-www-form-urlencoded"}
         body = firetext_callback(reference, to)
     make_request('sms', provider, body, headers)
 
@@ -92,7 +92,12 @@ def firetext_callback(notification_id, to):
         status = "1"
     else:
         status = "0"
-    return 'mobile={}&status={}&time=2016-03-10 14:17:00&reference={}'.format(to, status, notification_id)
+    return {
+        'mobile': to,
+        'status': status,
+        'time': '2016-03-10 14:17:00',
+        'reference': notification_id
+    }
 
 
 def ses_notification_callback(reference):

--- a/tests/app/celery/test_research_mode_tasks.py
+++ b/tests/app/celery/test_research_mode_tasks.py
@@ -20,6 +20,8 @@ def test_make_mmg_callback(notify_api, rmock):
     send_sms_response("mmg", "1234", "07811111111")
 
     assert rmock.called
+    assert rmock.request_history[0].url == endpoint
+    assert json.loads(rmock.request_history[0].text)['MSISDN'] == '07811111111'
 
 
 def test_make_firetext_callback(notify_api, rmock):
@@ -32,6 +34,8 @@ def test_make_firetext_callback(notify_api, rmock):
     send_sms_response("firetext", "1234", "07811111111")
 
     assert rmock.called
+    assert rmock.request_history[0].url == endpoint
+    assert 'mobile=07811111111' in rmock.request_history[0].text
 
 
 def test_make_ses_callback(notify_api, rmock):
@@ -71,11 +75,21 @@ def test_temp_failure_mmg_callback():
 
 
 def test_delivered_firetext_callback():
-    assert firetext_callback("1234", "07811111111") == "mobile=07811111111&status=0&time=2016-03-10 14:17:00&reference=1234"  # noqa
+    assert firetext_callback('1234', '07811111111') == {
+        'mobile': '07811111111',
+        'status': '0',
+        'time': '2016-03-10 14:17:00',
+        'reference': '1234'
+    }
 
 
 def test_failure_firetext_callback():
-    assert firetext_callback("1234", "07822222222") == "mobile=07822222222&status=1&time=2016-03-10 14:17:00&reference=1234"  # noqa
+    assert firetext_callback('1234', '07822222222') == {
+        'mobile': '07822222222',
+        'status': '1',
+        'time': '2016-03-10 14:17:00',
+        'reference': '1234'
+    }
 
 
 def test_delivered_ses_callback():


### PR DESCRIPTION
requests converts dicts into query parameters anyway if you don't specify so dont try and encode the data ourselves, also hardened up tests