### PR TITLE
Better error logging

### DIFF
--- a/app/template_statistics/rest.py
+++ b/app/template_statistics/rest.py
@@ -1,8 +1,7 @@
 from flask import (
     Blueprint,
     jsonify,
-    request,
-    current_app
+    request
 )
 
 from app.dao.notifications_dao import (
@@ -16,7 +15,7 @@ template_statistics = Blueprint('template-statistics',
                                 __name__,
                                 url_prefix='/service/<service_id>/template-statistics')
 
-from app.errors import register_errors
+from app.errors import register_errors, InvalidData
 
 register_errors(template_statistics)
 
@@ -28,14 +27,14 @@ def get_template_statistics_for_service(service_id):
             limit_days = int(request.args['limit_days'])
         except ValueError as e:
             error = '{} is not an integer'.format(request.args['limit_days'])
-            current_app.logger.error(error)
-            return jsonify(result="error", message={'limit_days': [error]}), 400
+            message = {'limit_days': [error]}
+            raise InvalidData(message, status_code=400)
     else:
         limit_days = None
     stats = dao_get_template_statistics_for_service(service_id, limit_days=limit_days)
     data, errors = template_statistics_schema.dump(stats, many=True)
     if errors:
-        return jsonify(result="error", message=errors), 400
+        raise InvalidData(errors, status_code=400)
     return jsonify(data=data)
 
 
@@ -44,5 +43,5 @@ def get_template_statistics_for_template_id(service_id, template_id):
     stats = dao_get_template_statistics_for_template(template_id)
     data, errors = template_statistics_schema.dump(stats, many=True)
     if errors:
-        return jsonify(result="error", message=errors), 400
+        raise InvalidData(errors, status_code=400)
     return jsonify(data=data)


### PR DESCRIPTION
Rest methods that explicitly return errors by pass the error handlers as they do not raise exceptions.

Introduced a simple exception that contains error messages and status
code that can be used rather than return json + status code from rest
methods directly.

The handler in errors for this exception can then log the error before
returning json.