### PR TITLE
Rename the task so that it is the name we want to use.

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -287,13 +287,13 @@ def send_sms(service_id, notification_id, encrypted_notification, created_at):
         current_app.logger.exception(e)
 
 
-@notify_celery.task(name="send-email")
-def send_email_v1(service_id, notification_id, from_address,
+@notify_celery.task(name="send-email-v2")
+def send_email_v2(service_id, notification_id,
                   encrypted_notification, created_at, reply_to_addresses=None):
     send_email(service_id, notification_id, encrypted_notification, created_at, reply_to_addresses=None)
 
 
-@notify_celery.task(name="send-email-v2")
+@notify_celery.task(name="send-email")
 def send_email(service_id, notification_id, encrypted_notification, created_at, reply_to_addresses=None):
     task_start = monotonic()
     notification = encryption.decrypt(encrypted_notification)


### PR DESCRIPTION
Next deploy will remove the extra task.