### PR TITLE
add template body, version, and subject to send_notification api

### DIFF
--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -392,7 +392,25 @@ def send_notification(notification_type):
         ), queue='email')
 
     statsd_client.incr('notifications.api.{}'.format(notification_type))
-    return jsonify(data={"notification": {"id": notification_id}}), 201
+    return jsonify(
+        data=get_notification_return_data(
+            notification_id,
+            notification,
+            template_object)
+    ), 201
+
+
+def get_notification_return_data(notification_id, notification, template):
+    output = {
+        'body': template.replaced,
+        'template_version': notification['template_version'],
+        'notification': {'id': notification_id}
+    }
+
+    if template.template_type == 'email':
+        output.update({'subject': template.subject})
+
+    return output
 
 
 @notifications.route('/notifications/statistics')


### PR DESCRIPTION
example return value:
```
{'data': {'body': "dear leo\n\nit's currently sunny.\n\nbye!",
          'notification': {'id': '71e377b6-a1fb-495b-ba51-6af4bd7bf7cb'},
          'subject': 'my subject',
          'template_version': 1}}
```

subject only sends for emails