### PR TITLE
Add a ‘preview template’ endpoint

### DIFF
--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -108,7 +108,7 @@ def preview_template_by_id_and_service_id(service_id, template_id):
 
     data['subject'], data['content'] = template_object.replaced_subject, template_object.replaced
 
-    return jsonify(data=data)
+    return jsonify(data)
 
 
 @template.route('/<uuid:template_id>/version/<int:version>')

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -86,6 +86,31 @@ def get_template_by_id_and_service_id(service_id, template_id):
     return jsonify(data=data)
 
 
+@template.route('/<uuid:template_id>/preview', methods=['GET'])
+def preview_template_by_id_and_service_id(service_id, template_id):
+    fetched_template = dao_get_template_by_id_and_service_id(template_id=template_id, service_id=service_id)
+    data = template_schema.dump(fetched_template).data
+    template_object = Template(data, values=request.args.to_dict())
+
+    if template_object.missing_data:
+        raise InvalidRequest(
+            {'template': [
+                'Missing personalisation: {}'.format(", ".join(template_object.missing_data))
+            ]}, status_code=400
+        )
+
+    if template_object.additional_data:
+        raise InvalidRequest(
+            {'template': [
+                'Personalisation not needed for template: {}'.format(", ".join(template_object.additional_data))
+            ]}, status_code=400
+        )
+
+    data['subject'], data['content'] = template_object.replaced_subject, template_object.replaced
+
+    return jsonify(data=data)
+
+
 @template.route('/<uuid:template_id>/version/<int:version>')
 def get_template_version(service_id, template_id, version):
     data = template_history_schema.dump(

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1,8 +1,10 @@
 import json
 import random
 import string
+import pytest
 from app.models import Template
 from tests import create_authorization_header
+from tests.app.conftest import sample_template as create_sample_template
 from app.dao.templates_dao import dao_get_template_by_id
 
 
@@ -322,6 +324,82 @@ def test_should_get_only_templates_for_that_service(notify_api, sample_user, ser
 
             assert len(json_resp_3['data']) == 2
             assert len(json_resp_4['data']) == 1
+
+
+@pytest.mark.parametrize(
+    "subject, content, path, expected_subject, expected_content, expected_error", [
+        (
+            'about your ((thing))',
+            'hello ((name)) we’ve received your ((thing))',
+            '/service/{}/template/{}',
+            'about your ((thing))',
+            'hello ((name)) we’ve received your ((thing))',
+            None
+        ),
+        (
+            'about your thing',
+            'hello user we’ve received your thing',
+            '/service/{}/template/{}/preview',
+            'about your thing',
+            'hello user we’ve received your thing',
+            None
+        ),
+        (
+            'about your ((thing))',
+            'hello ((name)) we’ve received your ((thing))',
+            '/service/{}/template/{}/preview?name=Amala&thing=document',
+            'about your document',
+            'hello Amala we’ve received your document',
+            None
+        ),
+        (
+            'about your ((thing))',
+            'hello ((name)) we’ve received your ((thing))',
+            '/service/{}/template/{}/preview?eman=Amala&gniht=document',
+            None, None,
+            'Missing personalisation: thing, name'
+        ),
+        (
+            'about your ((thing))',
+            'hello ((name)) we’ve received your ((thing))',
+            '/service/{}/template/{}/preview?name=Amala&thing=document&foo=bar',
+            None, None,
+            'Personalisation not needed for template: foo'
+        )
+    ]
+)
+def test_should_get_a_single_template(
+    notify_db,
+    notify_api,
+    sample_user,
+    service_factory,
+    subject,
+    content,
+    path,
+    expected_subject,
+    expected_content,
+    expected_error
+):
+    with notify_api.test_request_context(), notify_api.test_client() as client:
+
+        template = create_sample_template(
+            notify_db, notify_db.session, subject_line=subject, content=content, template_type='email'
+        )
+
+        response = client.get(
+            path.format(template.service.id, template.id),
+            headers=[create_authorization_header()]
+        )
+
+        content = json.loads(response.get_data(as_text=True))
+
+        if expected_error:
+            assert response.status_code == 400
+            assert content['message']['template'] == [expected_error]
+        else:
+            assert response.status_code == 200
+            assert content['data']['content'] == expected_content
+            assert content['data']['subject'] == expected_subject
 
 
 def test_should_return_empty_array_if_no_templates_for_service(notify_api, sample_service):


### PR DESCRIPTION
There’s a need for users of the API to be able to take advantage of Notify’s template rendering.

For example, there’s a service that’s building a case management system. Their users are sending emails on a case-by-case basis. Before they send an email, it’s reassuring to double check that the right data is being inserted, that the right template is being used, etc.

This commit:
- adds a separate endpoint for previewing a template, with personalisation taken from the get parameters of the request
- beefs up the tests around getting a template

Not part of this pull request:
- making this endpoint publicly accessible