### PR TITLE
Use notify to send forgot password and invitation emails

### DIFF
--- a/app/invite/rest.py
+++ b/app/invite/rest.py
@@ -1,20 +1,20 @@
-from datetime import timedelta
-
+import uuid
+from datetime import datetime
 from flask import (
     Blueprint,
     request,
     jsonify,
     current_app)
 
-from app import encryption
+from app import encryption, DATETIME_FORMAT
 from app.dao.invited_user_dao import (
     save_invited_user,
     get_invited_user,
     get_invited_users_for_service
 )
-
+from app.dao.templates_dao import dao_get_template_by_id
 from app.schemas import invited_user_schema
-from app.celery.tasks import (email_invited_user)
+from app.celery.tasks import (send_email)
 
 invite = Blueprint('invite', __name__, url_prefix='/service/<service_id>/invite')
 
@@ -27,9 +27,25 @@ register_errors(invite)
 def create_invited_user(service_id):
     invited_user, errors = invited_user_schema.load(request.get_json())
     save_invited_user(invited_user)
-    invitation = _create_invitation(invited_user)
-    encrypted_invitation = encryption.encrypt(invitation)
-    email_invited_user.apply_async([encrypted_invitation], queue='email-invited-user')
+
+    template = dao_get_template_by_id(current_app.config['INVITATION_EMAIL_TEMPLATE_ID'])
+    message = {
+        'template': str(template.id),
+        'template_version': template.version,
+        'to': invited_user.email_address,
+        'personalisation': {
+            'user_name': invited_user.from_user.name,
+            'service_name': invited_user.service.name,
+            'url': invited_user_url(invited_user.id)
+        }
+    }
+    send_email.apply_async((
+        current_app.config['NOTIFY_SERVICE_ID'],
+        str(uuid.uuid4()),
+        encryption.encrypt(message),
+        datetime.utcnow().strftime(DATETIME_FORMAT)
+    ), queue="email-invited-user")
+
     return jsonify(data=invited_user_schema.dump(invited_user).data), 201
 
 
@@ -57,19 +73,8 @@ def update_invited_user(service_id, invited_user_id):
     return jsonify(data=invited_user_schema.dump(fetched).data), 200
 
 
-def _create_invitation(invited_user):
+def invited_user_url(invited_user_id):
     from notifications_utils.url_safe_token import generate_token
-    token = generate_token(str(invited_user.id), current_app.config['SECRET_KEY'], current_app.config['DANGEROUS_SALT'])
-    # TODO: confirm what we want to do for this - the idea is that we say expires tomorrow at midnight
-    # and give 48 hours as the max_age
-    expiration_date = (invited_user.created_at + timedelta(days=current_app.config['INVITATION_EXPIRATION_DAYS'])) \
-        .replace(hour=0, minute=0, second=0, microsecond=0)
+    token = generate_token(str(invited_user_id), current_app.config['SECRET_KEY'], current_app.config['DANGEROUS_SALT'])
 
-    invitation = {'to': invited_user.email_address,
-                  'user_name': invited_user.from_user.name,
-                  'service_id': str(invited_user.service_id),
-                  'service_name': invited_user.service.name,
-                  'token': token,
-                  'expiry_date': str(expiration_date)
-                  }
-    return invitation
+    return '{0}/invitation/{1}'.format(current_app.config['ADMIN_BASE_URL'], token)

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -163,7 +163,6 @@ def send_user_email_verification(user_id):
             'url': _create_verification_url(user_to_send_to, secret_code)
         }
     }
-    print(message)
     send_email.apply_async((
         current_app.config['NOTIFY_SERVICE_ID'],
         str(uuid.uuid4()),

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -27,7 +27,6 @@ from app.schemas import (
 
 from app.celery.tasks import (
     send_sms,
-    email_reset_password,
     send_email
 )
 
@@ -151,8 +150,6 @@ def send_user_sms_code(user_id):
 @user.route('/<uuid:user_id>/email-verification', methods=['POST'])
 def send_user_email_verification(user_id):
     user_to_send_to = get_model_users(user_id=user_id)
-    verify_code, errors = request_verify_code_schema.load(request.get_json())
-
     secret_code = create_secret_code()
     create_user_code(user_to_send_to, secret_code, 'email')
 
@@ -166,6 +163,7 @@ def send_user_email_verification(user_id):
             'url': _create_verification_url(user_to_send_to, secret_code)
         }
     }
+    print(message)
     send_email.apply_async((
         current_app.config['NOTIFY_SERVICE_ID'],
         str(uuid.uuid4()),
@@ -224,7 +222,7 @@ def send_user_reset_password():
         'to': user_to_send_to.email_address,
         'personalisation': {
             'user_name': user_to_send_to.name,
-            'url': _create_verification_url(user_to_send_to, _create_reset_password_url(user_to_send_to.email_address))
+            'url': _create_reset_password_url(user_to_send_to.email_address)
         }
     }
     send_email.apply_async([current_app.config['NOTIFY_SERVICE_ID'],

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -609,13 +609,83 @@ def email_verification_template(notify_db,
         service = Service(**data)
         db.session.add(service)
 
-    template = Template.query.get(current_app.config['SMS_CODE_TEMPLATE_ID'])
+    template = Template.query.get(current_app.config['EMAIL_VERIFY_CODE_TEMPLATE_ID'])
     if not template:
         data = {
             'id': current_app.config['EMAIL_VERIFY_CODE_TEMPLATE_ID'],
             'name': 'Email verification template',
             'template_type': 'email',
             'content': '((user_name)) use ((url)) to complete registration',
+            'service': service,
+            'created_by': user,
+            'archived': False
+        }
+        template = Template(**data)
+        db.session.add(template)
+    return template
+
+
+@pytest.fixture(scope='function')
+def invitation_email_template(notify_db,
+                              notify_db_session):
+    user = sample_user(notify_db, notify_db_session)
+    service = Service.query.get(current_app.config['NOTIFY_SERVICE_ID'])
+    if not service:
+        data = {
+            'id': current_app.config['NOTIFY_SERVICE_ID'],
+            'name': 'Notify Service',
+            'message_limit': 1000,
+            'active': True,
+            'restricted': False,
+            'email_from': 'notify.service',
+            'created_by': user
+        }
+        service = Service(**data)
+        db.session.add(service)
+
+    template = Template.query.get(current_app.config['INVITATION_EMAIL_TEMPLATE_ID'])
+    if not template:
+        data = {
+            'id': current_app.config['INVITATION_EMAIL_TEMPLATE_ID'],
+            'name': 'Invitaion template',
+            'template_type': 'email',
+            'content': '((user_name)) is invited to Notify by ((service_name)) ((url)) to complete registration',
+            'subject': 'Invitation to ((service_name))',
+            'service': service,
+            'created_by': user,
+            'archived': False
+        }
+        template = Template(**data)
+        db.session.add(template)
+    return template
+
+
+@pytest.fixture(scope='function')
+def password_reset_email_template(notify_db,
+                                  notify_db_session):
+    user = sample_user(notify_db, notify_db_session)
+    service = Service.query.get(current_app.config['NOTIFY_SERVICE_ID'])
+    if not service:
+        data = {
+            'id': current_app.config['NOTIFY_SERVICE_ID'],
+            'name': 'Notify Service',
+            'message_limit': 1000,
+            'active': True,
+            'restricted': False,
+            'email_from': 'notify.service',
+            'created_by': user
+        }
+        service = Service(**data)
+        db.session.add(service)
+
+    template = Template.query.get(current_app.config['PASSWORD_RESET_TEMPLATE_ID'])
+    if not template:
+        data = {
+            'id': current_app.config['PASSWORD_RESET_TEMPLATE_ID'],
+            'name': 'Password reset template',
+            'template_type': 'email',
+            'content': '((user_name)) you can reset password by clicking ((url))',
+            'subject': 'Reset your password',
             'service': service,
             'created_by': user,
             'archived': False

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -396,9 +396,10 @@ def test_set_user_permissions_remove_old(notify_api,
 def test_send_user_reset_password_should_send_reset_password_link(notify_api,
                                                                   sample_user,
                                                                   mocker,
-                                                                  mock_encryption):
+                                                                  password_reset_email_template):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
+            mocker.patch('notifications_utils.url_safe_token.generate_token', return_value='the-token')
             mocker.patch('uuid.uuid4', return_value='some_uuid')  # for the notification id
             mocker.patch('app.celery.tasks.send_email.apply_async')
             data = json.dumps({'email': sample_user.email_address})
@@ -408,11 +409,20 @@ def test_send_user_reset_password_should_send_reset_password_link(notify_api,
                 data=data,
                 headers=[('Content-Type', 'application/json'), auth_header])
 
+            message = {
+                'template': str(password_reset_email_template.id),
+                'template_version': password_reset_email_template.version,
+                'to': sample_user.email_address,
+                'personalisation': {
+                    'user_name': sample_user.name,
+                    'url': current_app.config['ADMIN_BASE_URL'] + '/new-password/' + 'the-token'
+                }
+            }
             assert resp.status_code == 204
             app.celery.tasks.send_email.apply_async.assert_called_once_with(
                 [str(current_app.config['NOTIFY_SERVICE_ID']),
                  'some_uuid',
-                 "something_encrypted",
+                 app.encryption.encrypt(message),
                  "2016-01-01T11:09:00.061258"],
                 queue="email-reset-password")
 


### PR DESCRIPTION
This PR uses the GOV.UK Notify service to send the email for password reset and invitation emails.
The templates are managed by the template and the endpoints send the send_email task the personalisation for the templates.