### PR TITLE
Replaced subjects

### DIFF
--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -365,7 +365,7 @@ def get_notification_return_data(notification_id, notification, template):
     }
 
     if template.template_type == 'email':
-        output.update({'subject': template.subject})
+        output.update({'subject': template.replaced_subject})
 
     return output
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -248,7 +248,7 @@ class SmsAdminNotificationSchema(SmsNotificationSchema):
 
 class NotificationStatusSchema(BaseSchema):
 
-    template = fields.Nested(TemplateSchema, only=["id", "name", "template_type", "content"], dump_only=True)
+    template = fields.Nested(TemplateSchema, only=["id", "name", "template_type", "content", "subject"], dump_only=True)
     job = fields.Nested(JobSchema, only=["id", "original_file_name"], dump_only=True)
     personalisation = fields.Dict(required=False)
 
@@ -267,10 +267,13 @@ class NotificationStatusSchema(BaseSchema):
     def handle_template_merge(self, in_data):
         if in_data.get('personalisation'):
             from notifications_utils.template import Template
-            merged = Template(in_data['template'], in_data['personalisation']).replaced
-            in_data['body'] = merged
+            template = Template(in_data['template'], in_data['personalisation'])
+            in_data['body'] = template.replaced
+            if in_data['template']['template_type'] == 'email':
+                in_data['subject'] = template.replaced_subject
             in_data.pop('personalisation', None)
         in_data['template'].pop('content', None)
+        in_data['template'].pop('subject', None)
         return in_data
 
 


### PR DESCRIPTION
In the two new tickets to add the final compiled message body to the `POST /notifications/_ _ _ _`  and  `GET /notifications[/ _ _ _ _]` responses, we neglected to convert email subjects with placeholders in them

Tests and code for that.