### PR TITLE
Remove db.drop_all from notify_db session fixture to speed up tests

### DIFF
--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -641,7 +641,7 @@ def test_update_notification(sample_notification, sample_template):
 def test_should_delete_notifications_after_seven_days(notify_db, notify_db_session):
     assert len(Notification.query.all()) == 0
 
-    # create one notification a day between 1st and 9th from 11:00 to 19:00
+    # create one notification a day between 1st and 10th from 11:00 to 19:00
     for i in range(1, 11):
         past_date = '2016-01-{0:02d}  {0:02d}:00:00.000000'.format(i, i)
         with freeze_time(past_date):
@@ -654,7 +654,8 @@ def test_should_delete_notifications_after_seven_days(notify_db, notify_db_sessi
     delete_notifications_created_more_than_a_week_ago('failed')
     remaining_notifications = Notification.query.all()
     assert len(remaining_notifications) == 8
-    assert remaining_notifications[0].created_at.date() == date(2016, 1, 3)
+    for notification in remaining_notifications:
+        assert notification.created_at.date() >= date(2016, 1, 3)
 
 
 def test_should_not_delete_failed_notifications_before_seven_days(notify_db, notify_db_session):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,6 @@ def notify_db(notify_api, request):
 
     def teardown():
         db.session.remove()
-        db.drop_all()
         db.get_engine(notify_api).dispose()
 
     request.addfinalizer(teardown)
@@ -47,15 +46,14 @@ def notify_db(notify_api, request):
 
 
 @pytest.fixture(scope='function')
-def notify_db_session(request):
+def notify_db_session(request, notify_db):
     def teardown():
-        db.session.remove()
-        for tbl in reversed(meta.sorted_tables):
+        notify_db.session.remove()
+        for tbl in reversed(notify_db.metadata.sorted_tables):
             if tbl.name not in ["provider_details"]:
-                db.engine.execute(tbl.delete())
-        db.session.commit()
+                notify_db.engine.execute(tbl.delete())
+        notify_db.session.commit()
 
-    meta = MetaData(bind=db.engine, reflect=True)
     request.addfinalizer(teardown)
 
 


### PR DESCRIPTION
We were dropping all tables at the end of the test run, however the alembic_version table is not part of the metadata so was being persisted. Alembic then doesn't upgrade the database next test run, since the version appears up to date, so we were, in the notify_db_session fixture, recreating from MetaData (sqlalchemy models). This involves quite a costly comparison of the postgres system tables and the tables in models.py, which was adding half a second to each test that uses the notify_db_session fixture (virtually all of them).