### PR TITLE
Refactor the api_key_dao.

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -14,8 +14,8 @@ from sqlalchemy.orm.exc import NoResultFound
 from app.dao.api_key_dao import (
     save_model_api_key,
     get_model_api_keys,
-    get_unsigned_secret
-)
+    get_unsigned_secret,
+    expire_api_key)
 from app.dao.services_dao import (
     dao_fetch_service_by_id_and_user,
     dao_fetch_service_by_id,
@@ -95,6 +95,7 @@ def update_service(service_id):
     return jsonify(data=service_schema.dump(fetched_service).data), 200
 
 
+# is this used.
 @service.route('/<uuid:service_id>/api-key', methods=['POST'])
 def renew_api_key(service_id=None):
     fetched_service = dao_fetch_service_by_id(service_id=service_id)
@@ -107,8 +108,7 @@ def renew_api_key(service_id=None):
 
 @service.route('/<uuid:service_id>/api-key/revoke/<uuid:api_key_id>', methods=['POST'])
 def revoke_api_key(service_id, api_key_id):
-    service_api_key = get_model_api_keys(service_id=service_id, id=api_key_id)
-    save_model_api_key(service_api_key, update_dict={'expiry_date': datetime.utcnow()})
+    expire_api_key(service_id=service_id, api_key_id=api_key_id)
     return jsonify(), 202
 
 

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timedelta
 from notifications_python_client.authentication import create_jwt_token
 from flask import json, current_app
-from app.dao.api_key_dao import get_unsigned_secrets, save_model_api_key, get_unsigned_secret
+from app.dao.api_key_dao import get_unsigned_secrets, save_model_api_key, get_unsigned_secret, expire_api_key
 from app.models import ApiKey
 
 
@@ -161,13 +161,7 @@ def test_authentication_returns_token_expired_when_service_uses_expired_key_and_
             token = create_jwt_token(
                 secret=get_unsigned_secret(expired_api_key.id),
                 client_id=str(sample_api_key.service_id))
-            # expire the key
-            expire_the_key = {'id': expired_api_key.id,
-                              'service': sample_api_key.service,
-                              'name': 'expired_key',
-                              'expiry_date': datetime.utcnow() + timedelta(hours=-2),
-                              'created_by': sample_api_key.created_by}
-            save_model_api_key(expired_api_key, expire_the_key)
+            expire_api_key(service_id=sample_api_key.service_id, api_key_id=expired_api_key.id)
             response = client.get(
                 '/service',
                 headers={'Authorization': 'Bearer {}'.format(token)})

--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -3,7 +3,7 @@ from datetime import timedelta, datetime
 
 from flask import url_for
 from app.models import ApiKey
-from app.dao.api_key_dao import save_model_api_key
+from app.dao.api_key_dao import save_model_api_key, expire_api_key
 from tests import create_authorization_header
 from tests.app.conftest import sample_api_key as create_sample_api_key
 from tests.app.conftest import sample_service as create_sample_service
@@ -97,7 +97,7 @@ def test_get_api_keys_should_return_all_keys_for_service(notify_api, notify_db,
             # this service already has one key, add two more, one expired
             create_sample_api_key(notify_db, notify_db_session, service=sample_api_key.service)
             one_to_expire = create_sample_api_key(notify_db, notify_db_session, service=sample_api_key.service)
-            save_model_api_key(one_to_expire, update_dict={'expiry_date': datetime.utcnow()})
+            expire_api_key(service_id=one_to_expire.service_id, api_key_id=one_to_expire.id)
 
             assert ApiKey.query.count() == 4
 


### PR DESCRIPTION
The only update we should be doing to an api key is to expire/revoke the api key.
Removed the update_dict from the the save method.
Added an expire_api_key method that only updates the api key with an expiry date.