### PR TITLE
remove default key_type

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -165,7 +165,7 @@ class NotificationsStatisticsSchema(BaseSchema):
 class ApiKeySchema(BaseSchema):
 
     created_by = field_for(models.ApiKey, 'created_by', required=True)
-    key_type = field_for(models.ApiKey, 'key_type', required=True, missing=models.KEY_TYPE_NORMAL)
+    key_type = field_for(models.ApiKey, 'key_type', required=True)
 
     class Meta:
         model = models.ApiKey


### PR DESCRIPTION
depends on https://github.com/alphagov/notifications-admin/pull/730

remove the default key_type - given that we only have one route for creating API keys, which will imminently let the user choose key_type, it makes no sense to provide this default, it's just extra unwelcome logic that we have to remember/support