### PR TITLE
Api user cleanup

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -47,7 +47,6 @@ def create_app(app_name=None):
     init_app(application)
     db.init_app(application)
     ma.init_app(application)
-    init_app(application)
     logging.init_app(application)
     statsd_client.init_app(application)
     firetext_client.init_app(application, statsd_client=statsd_client)

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -1,10 +1,8 @@
 from flask import request, jsonify, _request_ctx_stack, current_app
 from notifications_python_client.authentication import decode_jwt_token, get_token_issuer
 from notifications_python_client.errors import TokenDecodeError, TokenExpiredError
-from werkzeug.exceptions import abort
+
 from app.dao.api_key_dao import get_unsigned_secrets
-from app import api_user
-from functools import wraps
 
 
 def authentication_response(message, code):

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -59,14 +59,3 @@ def fetch_client(client):
             "client": client,
             "secret": get_unsigned_secrets(client)
         }
-
-
-def require_admin():
-    def wrap(func):
-        @wraps(func)
-        def wrap_func(*args, **kwargs):
-            if not api_user['client'] == current_app.config.get('ADMIN_CLIENT_USER_NAME'):
-                abort(403)
-            return func(*args, **kwargs)
-        return wrap_func
-    return wrap

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -5,54 +5,65 @@ from notifications_python_client.errors import TokenDecodeError, TokenExpiredErr
 from app.dao.api_key_dao import get_model_api_keys
 
 
-def authentication_response(message, code):
-    return jsonify(result='error',
-                   message={"token": [message]}
-                   ), code
+class AuthError(Exception):
+    def __init__(self, message, code):
+        self.message = {"token": [message]}
+        self.code = code
 
 
-def requires_auth():
-    auth_header = request.headers.get('Authorization', None)
+def get_auth_token(req):
+    auth_header = req.headers.get('Authorization', None)
     if not auth_header:
-        return authentication_response('Unauthorized, authentication token must be provided', 401)
+        raise AuthError('Unauthorized, authentication token must be provided', 401)
 
     auth_scheme = auth_header[:7]
 
     if auth_scheme != 'Bearer ':
-        return authentication_response('Unauthorized, authentication bearer scheme must be used', 401)
+        raise AuthError('Unauthorized, authentication bearer scheme must be used', 401)
 
-    auth_token = auth_header[7:]
+    return auth_header[7:]
+
+
+def requires_auth():
+    auth_token = get_auth_token(request)
     try:
         client = get_token_issuer(auth_token)
     except TokenDecodeError:
-        return authentication_response("Invalid token: signature", 403)
+        raise AuthError("Invalid token: signature", 403)
 
     if client == current_app.config.get('ADMIN_CLIENT_USER_NAME'):
-        errors_resp = get_decode_errors(auth_token, current_app.config.get('ADMIN_CLIENT_SECRET'), expiry_date=None)
-        return errors_resp
+        return handle_admin_key(auth_token, current_app.config.get('ADMIN_CLIENT_SECRET'))
 
-    secret_keys = get_model_api_keys(client)
-    for api_key in secret_keys:
-        errors_resp = get_decode_errors(auth_token, api_key.unsigned_secret, api_key.expiry_date)
-        if not errors_resp:
-            if api_key.expiry_date:
-                return authentication_response("Invalid token: revoked", 403)
-            else:
-                _request_ctx_stack.top.api_user = api_key
-                return
+    api_keys = get_model_api_keys(client)
 
-    if not secret_keys:
-        errors_resp = authentication_response("Invalid token: no api keys for service", 403)
-    current_app.logger.info(errors_resp)
-    return errors_resp
+    for api_key in api_keys:
+        try:
+            get_decode_errors(auth_token, api_key.unsigned_secret)
+        except TokenDecodeError:
+            continue
+
+        if api_key.expiry_date:
+            raise AuthError("Invalid token: revoked", 403)
+
+        _request_ctx_stack.top.api_user = api_key
+        return
+
+    if not api_keys:
+        raise AuthError("Invalid token: no api keys for service", 403)
+    else:
+        raise AuthError("Invalid token: signature", 403)
 
 
-def get_decode_errors(auth_token, unsigned_secret, expiry_date=None):
+def handle_admin_key(auth_token, secret):
+    try:
+        get_decode_errors(auth_token, secret)
+        return
+    except TokenDecodeError as e:
+        raise AuthError("Invalid token: signature", 403)
+
+
+def get_decode_errors(auth_token, unsigned_secret):
     try:
         decode_jwt_token(auth_token, unsigned_secret)
-    except TokenExpiredError:
-        return authentication_response("Invalid token: expired", 403)
-    except TokenDecodeError:
-        return authentication_response("Invalid token: signature", 403)
-    else:
-        return None
+    except TokenExpiredError as e:
+        raise AuthError("Invalid token: expired")

--- a/app/authentication/utils.py
+++ b/app/authentication/utils.py
@@ -1,0 +1,12 @@
+from flask import current_app
+from itsdangerous import URLSafeSerializer
+
+
+def get_secret(secret):
+    serializer = URLSafeSerializer(current_app.config.get('SECRET_KEY'))
+    return serializer.loads(secret, salt=current_app.config.get('DANGEROUS_SALT'))
+
+
+def generate_secret(token):
+    serializer = URLSafeSerializer(current_app.config.get('SECRET_KEY'))
+    return serializer.dumps(str(token), current_app.config.get('DANGEROUS_SALT'))

--- a/app/errors.py
+++ b/app/errors.py
@@ -5,6 +5,7 @@ from flask import (
 from sqlalchemy.exc import SQLAlchemyError, DataError
 from sqlalchemy.orm.exc import NoResultFound
 from marshmallow import ValidationError
+from app.authentication.auth import AuthError
 
 
 class InvalidRequest(Exception):
@@ -22,6 +23,10 @@ class InvalidRequest(Exception):
 
 
 def register_errors(blueprint):
+
+    @blueprint.app_errorhandler(AuthError)
+    def authentication_error(error):
+        return jsonify(result='error', message=error.message), error.code
 
     @blueprint.app_errorhandler(ValidationError)
     def validation_error(error):

--- a/app/models.py
+++ b/app/models.py
@@ -5,14 +5,13 @@ from sqlalchemy.dialects.postgresql import (
     UUID,
     JSON
 )
-
 from sqlalchemy import UniqueConstraint
 
 from app.encryption import (
     hashpw,
     check_hash
 )
-
+from app.authentication.utils import get_secret
 from app import (
     db,
     encryption
@@ -134,6 +133,10 @@ class ApiKey(db.Model, Versioned):
     __table_args__ = (
         UniqueConstraint('service_id', 'name', name='uix_service_to_key_name'),
     )
+
+    @property
+    def unsigned_secret(self):
+        return get_secret(self.secret)
 
 
 KEY_TYPE_NORMAL = 'normal'

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -169,7 +169,7 @@ def process_firetext_response():
 
 @notifications.route('/notifications/<uuid:notification_id>', methods=['GET'])
 def get_notifications(notification_id):
-    notification = notifications_dao.get_notification(api_user['client'], notification_id)
+    notification = notifications_dao.get_notification(str(api_user.service_id), notification_id)
     return jsonify(data={"notification": notification_status_schema.dump(notification).data}), 200
 
 
@@ -181,7 +181,7 @@ def get_all_notifications():
     limit_days = data.get('limit_days')
 
     pagination = notifications_dao.get_notifications_for_service(
-        api_user['client'],
+        str(api_user.service_id),
         filter_dict=data,
         page=page,
         page_size=page_size,
@@ -203,8 +203,8 @@ def send_notification(notification_type):
     if notification_type not in ['sms', 'email']:
         assert False
 
-    service_id = api_user['client']
-    service = services_dao.dao_fetch_service_by_id(api_user['client'])
+    service_id = str(api_user.service_id)
+    service = services_dao.dao_fetch_service_by_id(service_id)
 
     service_stats = notifications_dao.dao_get_notification_statistics_for_service_and_day(
         service_id,

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -5,14 +5,12 @@ from flask import (
     jsonify,
     request,
     current_app,
-    url_for,
     json
 )
 from notifications_utils.recipients import allowed_to_send_to, first_column_heading
 from notifications_utils.template import Template
 from app.clients.email.aws_ses import get_aws_responses
 from app import api_user, encryption, create_uuid, DATETIME_FORMAT, DATE_FORMAT, statsd_client
-from app.authentication.auth import require_admin
 from app.dao import (
     templates_dao,
     services_dao,
@@ -32,6 +30,7 @@ from app.schemas import (
     unarchived_template_schema
 )
 from app.celery.tasks import send_sms, send_email
+from app.utils import pagination_links
 
 notifications = Blueprint('notifications', __name__)
 
@@ -197,74 +196,6 @@ def get_all_notifications():
             **request.args.to_dict()
         )
     ), 200
-
-
-@notifications.route('/service/<service_id>/notifications', methods=['GET'])
-@require_admin()
-def get_all_notifications_for_service(service_id):
-    data = notifications_filter_schema.load(request.args).data
-    page = data['page'] if 'page' in data else 1
-    page_size = data['page_size'] if 'page_size' in data else current_app.config.get('PAGE_SIZE')
-    limit_days = data.get('limit_days')
-
-    pagination = notifications_dao.get_notifications_for_service(
-        service_id,
-        filter_dict=data,
-        page=page,
-        page_size=page_size,
-        limit_days=limit_days)
-    kwargs = request.args.to_dict()
-    kwargs['service_id'] = service_id
-    return jsonify(
-        notifications=notification_status_schema.dump(pagination.items, many=True).data,
-        page_size=page_size,
-        total=pagination.total,
-        links=pagination_links(
-            pagination,
-            '.get_all_notifications_for_service',
-            **kwargs
-        )
-    ), 200
-
-
-@notifications.route('/service/<service_id>/job/<job_id>/notifications', methods=['GET'])
-@require_admin()
-def get_all_notifications_for_service_job(service_id, job_id):
-    data = notifications_filter_schema.load(request.args).data
-    page = data['page'] if 'page' in data else 1
-    page_size = data['page_size'] if 'page_size' in data else current_app.config.get('PAGE_SIZE')
-
-    pagination = notifications_dao.get_notifications_for_job(
-        service_id,
-        job_id,
-        filter_dict=data,
-        page=page,
-        page_size=page_size)
-    kwargs = request.args.to_dict()
-    kwargs['service_id'] = service_id
-    kwargs['job_id'] = job_id
-    return jsonify(
-        notifications=notification_status_schema.dump(pagination.items, many=True).data,
-        page_size=page_size,
-        total=pagination.total,
-        links=pagination_links(
-            pagination,
-            '.get_all_notifications_for_service_job',
-            **kwargs
-        )
-    ), 200
-
-
-def pagination_links(pagination, endpoint, **kwargs):
-    if 'page' in kwargs:
-        kwargs.pop('page', None)
-    links = dict()
-    if pagination.has_prev:
-        links['prev'] = url_for(endpoint, page=pagination.prev_num, **kwargs)
-    if pagination.has_next:
-        links['next'] = url_for(endpoint, page=pagination.next_num, **kwargs)
-        links['last'] = url_for(endpoint, page=pagination.pages, **kwargs)
-    return links
 
 
 @notifications.route('/notifications/<string:notification_type>', methods=['POST'])

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,13 @@
+from flask import url_for
+
+
+def pagination_links(pagination, endpoint, **kwargs):
+    if 'page' in kwargs:
+        kwargs.pop('page', None)
+    links = dict()
+    if pagination.has_prev:
+        links['prev'] = url_for(endpoint, page=pagination.prev_num, **kwargs)
+    if pagination.has_next:
+        links['next'] = url_for(endpoint, page=pagination.next_num, **kwargs)
+        links['last'] = url_for(endpoint, page=pagination.pages, **kwargs)
+    return links

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -1,9 +1,8 @@
-import uuid
-from datetime import datetime, timedelta
+from datetime import datetime
 from notifications_python_client.authentication import create_jwt_token
 from flask import json, current_app
 from app.dao.api_key_dao import get_unsigned_secrets, save_model_api_key, get_unsigned_secret, expire_api_key
-from app.models import ApiKey, KEY_TYPE_NORMAL
+from app.models import ApiKey, KEY_TYPE_NORMAL, KEY_TYPE_TEAM
 
 
 def test_should_not_allow_request_with_no_token(notify_api):
@@ -88,13 +87,6 @@ def test_should_allow_valid_token_when_service_has_multiple_keys(notify_api, sam
                 '/service/{}'.format(str(sample_api_key.service_id)),
                 headers={'Authorization': 'Bearer {}'.format(token)})
             assert response.status_code == 200
-
-
-JSON_BODY = json.dumps({
-    "key1": "value1",
-    "key2": "value2",
-    "key3": "value3"
-})
 
 
 def test_authentication_passes_admin_client_token(notify_api,

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -171,9 +171,9 @@ def test_authentication_returns_token_expired_when_service_uses_expired_key_and_
             assert data['message'] == {"token": ['Invalid token: revoked']}
 
 
-def test_authentication_returns_error_when_api_client_has_no_secrets(notify_api,
-                                                                     notify_db,
-                                                                     notify_db_session):
+def test_authentication_returns_error_when_admin_client_has_no_secrets(notify_api,
+                                                                       notify_db,
+                                                                       notify_db_session):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             api_secret = notify_api.config.get('ADMIN_CLIENT_SECRET')

--- a/tests/app/authentication/test_utils.py
+++ b/tests/app/authentication/test_utils.py
@@ -1,0 +1,8 @@
+from app.authentication.utils import generate_secret, get_secret
+
+
+def test_secret_is_signed_and_can_be_read_again(notify_api):
+    with notify_api.test_request_context():
+        signed_secret = generate_secret('some_uuid')
+        assert signed_secret != 'some_uuid'
+        assert 'some_uuid' == get_secret(signed_secret)

--- a/tests/app/dao/test_api_key_dao.py
+++ b/tests/app/dao/test_api_key_dao.py
@@ -4,21 +4,13 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
+from app.authentication.utils import get_secret
 from app.dao.api_key_dao import (save_model_api_key,
                                  get_model_api_keys,
                                  get_unsigned_secrets,
                                  get_unsigned_secret,
-                                 _generate_secret,
-                                 _get_secret, expire_api_key)
+                                 expire_api_key)
 from app.models import ApiKey, KEY_TYPE_NORMAL
-
-
-def test_secret_is_signed_and_can_be_read_again(notify_api, mocker):
-    with notify_api.test_request_context():
-        mocker.patch("uuid.uuid4", return_value='some_uuid')
-        signed_secret = _generate_secret()
-        assert 'some_uuid' == _get_secret(signed_secret)
-        assert signed_secret != 'some_uuid'
 
 
 def test_save_api_key_should_create_new_api_key_and_history(sample_service):
@@ -72,13 +64,13 @@ def test_should_return_unsigned_api_keys_for_service_id(sample_api_key):
     unsigned_api_key = get_unsigned_secrets(sample_api_key.service_id)
     assert len(unsigned_api_key) == 1
     assert sample_api_key.secret != unsigned_api_key[0]
-    assert unsigned_api_key[0] == _get_secret(sample_api_key.secret)
+    assert unsigned_api_key[0] == get_secret(sample_api_key.secret)
 
 
 def test_get_unsigned_secret_returns_key(sample_api_key):
     unsigned_api_key = get_unsigned_secret(sample_api_key.id)
     assert sample_api_key.secret != unsigned_api_key
-    assert unsigned_api_key == _get_secret(sample_api_key.secret)
+    assert unsigned_api_key == get_secret(sample_api_key.secret)
 
 
 def test_should_not_allow_duplicate_key_names_per_service(sample_api_key, fake_uuid):

--- a/tests/app/notifications/test_rest.py
+++ b/tests/app/notifications/test_rest.py
@@ -1,15 +1,12 @@
 from datetime import datetime, timedelta
 import uuid
 
-import pytest
 from flask import json
 
 import app.celery.tasks
-from app.models import NOTIFICATION_STATUS_TYPES
 from app.dao.notifications_dao import get_notification_by_id, dao_get_notification_statistics_for_service
 from tests import create_authorization_header
 from tests.app.conftest import sample_notification as create_sample_notification
-from tests.app.conftest import sample_job as create_sample_job
 from tests.app.conftest import sample_service as create_sample_service
 
 
@@ -135,170 +132,6 @@ def test_get_all_notifications_newest_first(notify_api, notify_db, notify_db_ses
             assert notifications['notifications'][1]['to'] == notification_2.to
             assert notifications['notifications'][2]['to'] == notification_1.to
             assert response.status_code == 200
-
-
-def test_get_all_notifications_for_service_in_order(notify_api, notify_db, notify_db_session):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            service_1 = create_sample_service(notify_db, notify_db_session, service_name="1", email_from='1')
-            service_2 = create_sample_service(notify_db, notify_db_session, service_name="2", email_from='2')
-
-            create_sample_notification(notify_db, notify_db_session, service=service_2)
-
-            notification_1 = create_sample_notification(notify_db, notify_db_session, service=service_1)
-            notification_2 = create_sample_notification(notify_db, notify_db_session, service=service_1)
-            notification_3 = create_sample_notification(notify_db, notify_db_session, service=service_1)
-
-            auth_header = create_authorization_header()
-
-            response = client.get(
-                path='/service/{}/notifications'.format(service_1.id),
-                headers=[auth_header])
-
-            resp = json.loads(response.get_data(as_text=True))
-            assert len(resp['notifications']) == 3
-            assert resp['notifications'][0]['to'] == notification_3.to
-            assert resp['notifications'][1]['to'] == notification_2.to
-            assert resp['notifications'][2]['to'] == notification_1.to
-            assert response.status_code == 200
-
-
-def test_get_all_notifications_for_job_in_order_of_job_number(notify_api,
-                                                              notify_db,
-                                                              notify_db_session,
-                                                              sample_service):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            main_job = create_sample_job(notify_db, notify_db_session, service=sample_service)
-            another_job = create_sample_job(notify_db, notify_db_session, service=sample_service)
-
-            notification_1 = create_sample_notification(
-                notify_db,
-                notify_db_session,
-                job=main_job,
-                to_field="1",
-                created_at=datetime.utcnow(),
-                job_row_number=1
-            )
-            notification_2 = create_sample_notification(
-                notify_db,
-                notify_db_session,
-                job=main_job,
-                to_field="2",
-                created_at=datetime.utcnow(),
-                job_row_number=2
-            )
-            notification_3 = create_sample_notification(
-                notify_db,
-                notify_db_session,
-                job=main_job,
-                to_field="3",
-                created_at=datetime.utcnow(),
-                job_row_number=3
-            )
-            create_sample_notification(notify_db, notify_db_session, job=another_job)
-
-            auth_header = create_authorization_header()
-
-            response = client.get(
-                path='/service/{}/job/{}/notifications'.format(sample_service.id, main_job.id),
-                headers=[auth_header])
-
-            resp = json.loads(response.get_data(as_text=True))
-            assert len(resp['notifications']) == 3
-            assert resp['notifications'][0]['to'] == notification_1.to
-            assert resp['notifications'][0]['job_row_number'] == notification_1.job_row_number
-            assert resp['notifications'][1]['to'] == notification_2.to
-            assert resp['notifications'][1]['job_row_number'] == notification_2.job_row_number
-            assert resp['notifications'][2]['to'] == notification_3.to
-            assert resp['notifications'][2]['job_row_number'] == notification_3.job_row_number
-            assert response.status_code == 200
-
-
-@pytest.mark.parametrize(
-    "expected_notification_count, status_args",
-    [
-        (
-            1,
-            '?status={}'.format(NOTIFICATION_STATUS_TYPES[0])
-        ),
-        (
-            0,
-            '?status={}'.format(NOTIFICATION_STATUS_TYPES[1])
-        ),
-        (
-            1,
-            '?status={}&status={}&status={}'.format(
-                *NOTIFICATION_STATUS_TYPES[0:3]
-            )
-        ),
-        (
-            0,
-            '?status={}&status={}&status={}'.format(
-                *NOTIFICATION_STATUS_TYPES[3:6]
-            )
-        ),
-    ]
-)
-def test_get_all_notifications_for_job_filtered_by_status(
-    notify_api,
-    notify_db,
-    notify_db_session,
-    sample_service,
-    expected_notification_count,
-    status_args
-):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            job = create_sample_job(notify_db, notify_db_session, service=sample_service)
-
-            create_sample_notification(
-                notify_db,
-                notify_db_session,
-                job=job,
-                to_field="1",
-                created_at=datetime.utcnow(),
-                status=NOTIFICATION_STATUS_TYPES[0],
-                job_row_number=1
-            )
-
-            response = client.get(
-                path='/service/{}/job/{}/notifications{}'.format(sample_service.id, job.id, status_args),
-                headers=[create_authorization_header()]
-            )
-            resp = json.loads(response.get_data(as_text=True))
-            assert len(resp['notifications']) == expected_notification_count
-            assert response.status_code == 200
-
-
-def test_should_not_get_notifications_by_service_with_client_credentials(notify_api, sample_api_key):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            auth_header = create_authorization_header(service_id=sample_api_key.service.id)
-
-            response = client.get(
-                '/service/{}/notifications'.format(sample_api_key.service.id),
-                headers=[auth_header])
-
-            resp = json.loads(response.get_data(as_text=True))
-            assert response.status_code == 403
-            assert resp['result'] == 'error'
-            assert resp['message'] == 'Forbidden, invalid authentication token provided'
-
-
-def test_should_not_get_notifications_by_job_and_service_with_client_credentials(notify_api, sample_job):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            auth_header = create_authorization_header(service_id=sample_job.service.id)
-
-            response = client.get(
-                '/service/{}/job/{}/notifications'.format(sample_job.service.id, sample_job.id),
-                headers=[auth_header])
-
-            resp = json.loads(response.get_data(as_text=True))
-            assert response.status_code == 403
-            assert resp['result'] == 'error'
-            assert resp['message'] == 'Forbidden, invalid authentication token provided'
 
 
 def test_should_reject_invalid_page_param(notify_api, sample_email_template):


### PR DESCRIPTION
## api_user now contains the relevant ApiKey object

used in notifications/rest.py to get the current API's service id, it previously contained a dict of `{'client': service_id, 'secrets': [ all api_key secrets of that service ]}`. now contains full db object.

the api_key needs to be stored after the requires_auth decorator, for distinguishing between api_key types.

To aid me I attempted a cleanup of auth.py

### require_admin decorator removed.

it's not required - nginx performs all of its functionality
the functions that used it moved from notifications to job/rest.py and service/rest.py with no changes

### api_secret code moved to authentication/utils.py

so that it can be accessed cleanly from a new `unsigned_secret` property on the `ApiKey` model.

### tweaked authentication error messages

ensure consistency and accuracy of error messages - sometimes previously would report wrong error message if there were multiple invalid keys in the database

* **new**: if the token matches but has been revoked, now return `"Invalid token: revoked"` (previously expired)
* if the token matches but has expired (more than 30 sec since it was generated) still return "expired"
* if no token matches, errors with "signature"

### use error handler rather than returning 403

raise AuthError and catch in `errors.py` - I did this because with the code changes that the above introduced, the function was getting ridiculous - whether this has improved code legibility is up for debtate, and am happy to roll back change if people think it hasn't helped. 