### PR TITLE
Add breathing room around GOV.UK logo in emails

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ statsd==3.2.1
 git+https://github.com/alphagov/notifications-python-client.git@1.0.0#egg=notifications-python-client==1.0.0
 
 
-git+https://github.com/alphagov/notifications-utils.git@6.3.1#egg=notifications-utils==6.3.1
+git+https://github.com/alphagov/notifications-utils.git@6.3.2#egg=notifications-utils==6.3.2


### PR DESCRIPTION
Implements and depends on:

- [x] https://github.com/alphagov/notifications-utils/pull/44