### PR TITLE
Use type from model

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -54,7 +54,7 @@ def send_sms_to_provider(self, service_id, notification_id, encrypted_notificati
     task_start = monotonic()
 
     service = dao_fetch_service_by_id(service_id)
-    provider = provider_to_use('sms', notification_id)
+    provider = provider_to_use(SMS_TYPE, notification_id)
     notification = get_notification_by_id(notification_id)
     if notification.status == 'created':
         template = Template(

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -181,7 +181,7 @@ def send_email(service_id, notification_id, encrypted_notification, created_at, 
     notification = encryption.decrypt(encrypted_notification)
     service = dao_fetch_service_by_id(service_id)
 
-    provider = provider_to_use('email', notification_id)
+    provider = provider_to_use(EMAIL_TYPE, notification_id)
 
     if not service_allowed_to_send_to(notification['to'], service):
         current_app.logger.info(
@@ -204,7 +204,7 @@ def send_email(service_id, notification_id, encrypted_notification, created_at, 
             sent_at=sent_at,
             sent_by=provider.get_name(),
             personalisation=notification.get('personalisation'),
-            notification_type='email'
+            notification_type=EMAIL_TYPE
         )
 
         dao_create_notification(notification_db_object, EMAIL_TYPE)

--- a/app/models.py
+++ b/app/models.py
@@ -293,7 +293,7 @@ class Job(db.Model):
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
 
 
-VERIFY_CODE_TYPES = ['email', 'sms']
+VERIFY_CODE_TYPES = [EMAIL_TYPE, SMS_TYPE]
 
 
 class VerifyCode(db.Model):

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -18,6 +18,7 @@ from app.dao import (
     services_dao,
     notifications_dao
 )
+from app.models import NOTIFICATION_TYPE, SMS_TYPE
 from app.notifications.process_client_response import (
     validate_callback_data,
     process_sms_client_response
@@ -333,7 +334,7 @@ def send_notification(notification_type):
 
     notification_id = create_uuid()
     notification.update({"template_version": template.version})
-    if notification_type == 'sms':
+    if notification_type == SMS_TYPE:
         send_sms.apply_async((
             service_id,
             notification_id,

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -15,6 +15,7 @@ from app.dao.templates_dao import (
 )
 from notifications_utils.template import Template
 from app.dao.services_dao import dao_fetch_service_by_id
+from app.models import SMS_TYPE
 from app.schemas import (template_schema, template_history_schema)
 
 template = Blueprint('template', __name__, url_prefix='/service/<uuid:service_id>/template')
@@ -29,7 +30,7 @@ register_errors(template)
 
 def _content_count_greater_than_limit(content, template_type):
     template = Template({'content': content, 'template_type': template_type})
-    return template_type == 'sms' and template.content_count > current_app.config.get('SMS_CHAR_COUNT_LIMIT')
+    return template_type == SMS_TYPE and template.content_count > current_app.config.get('SMS_CHAR_COUNT_LIMIT')
 
 
 @template.route('', methods=['POST'])

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -17,6 +17,7 @@ from app.dao.users_dao import (
 from app.dao.permissions_dao import permission_dao
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.templates_dao import dao_get_template_by_id
+from app.models import SMS_TYPE
 from app.schemas import (
     email_data_request_schema,
     user_schema,
@@ -124,7 +125,7 @@ def send_user_sms_code(user_id):
     verify_code, errors = request_verify_code_schema.load(request.get_json())
 
     secret_code = create_secret_code()
-    create_user_code(user_to_send_to, secret_code, 'sms')
+    create_user_code(user_to_send_to, secret_code, SMS_TYPE)
 
     mobile = user_to_send_to.mobile_number if verify_code.get('to', None) is None else verify_code.get('to')
     sms_code_template_id = current_app.config['SMS_CODE_TEMPLATE_ID']


### PR DESCRIPTION
A small refactor to use the SMS_TYPE and EMAIL_TYPE in code rather than 'sms' or 'email'