### PR TITLE
only send to team emails/phones if POST /notification/<type> with team api_key

### DIFF
--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -11,6 +11,7 @@ from notifications_utils.recipients import allowed_to_send_to, first_column_head
 from notifications_utils.template import Template
 from app.clients.email.aws_ses import get_aws_responses
 from app import api_user, encryption, create_uuid, DATETIME_FORMAT, DATE_FORMAT, statsd_client
+from app.models import KEY_TYPE_TEAM
 from app.dao import (
     templates_dao,
     services_dao,
@@ -253,7 +254,7 @@ def send_notification(notification_type):
         errors = {'content': [message]}
         raise InvalidRequest(errors, status_code=400)
 
-    if service.restricted and not allowed_to_send_to(
+    if (service.restricted or api_user.key_type == KEY_TYPE_TEAM) and not allowed_to_send_to(
         notification['to'],
         itertools.chain.from_iterable(
             [user.mobile_number, user.email_address] for user in service.users

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,27 +2,27 @@ import uuid
 from flask import current_app
 from notifications_python_client.authentication import create_jwt_token
 from app.models import ApiKey, KEY_TYPE_NORMAL
-from app.dao.api_key_dao import (get_unsigned_secrets, save_model_api_key)
+from app.dao.api_key_dao import save_model_api_key
 from app.dao.services_dao import dao_fetch_service_by_id
 
 
-def create_authorization_header(service_id=None):
+def create_authorization_header(service_id=None, key_type=KEY_TYPE_NORMAL):
     if service_id:
         client_id = str(service_id)
-        secrets = get_unsigned_secrets(service_id)
+        secrets = ApiKey.query.filter_by(service_id=service_id, key_type=key_type).all()
         if secrets:
-            secret = secrets[0]
+            secret = secrets[0].unsigned_secret
         else:
             service = dao_fetch_service_by_id(service_id)
             data = {
                 'service': service,
                 'name': uuid.uuid4(),
                 'created_by': service.created_by,
-                'key_type': KEY_TYPE_NORMAL
+                'key_type': key_type
             }
             api_key = ApiKey(**data)
             save_model_api_key(api_key)
-            secret = get_unsigned_secrets(service_id)[0]
+            secret = api_key.unsigned_secret
 
     else:
         client_id = current_app.config.get('ADMIN_CLIENT_USER_NAME')


### PR DESCRIPTION
uses same restriction as a service in trial mode