### PR TITLE
dont pass reply-to-addresses about

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -148,7 +148,7 @@ def send_email_to_provider(self, service_id, notification_id, reply_to_addresses
                     template.replaced_subject,
                     body=template.replaced_govuk_escaped,
                     html_body=template.as_HTML_email,
-                    reply_to_addresses=reply_to_addresses,
+                    reply_to_address=service.reply_to_email_address,
                 )
 
                 update_provider_stats(

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -106,7 +106,6 @@ def process_job(job_id):
                 create_uuid(),
                 encrypted,
                 datetime.utcnow().strftime(DATETIME_FORMAT)),
-                {'reply_to_addresses': service.reply_to_email_address},
                 queue='bulk-email')
 
     finished = datetime.utcnow()
@@ -182,8 +181,7 @@ def send_email(self, service_id,
     try:
         _save_notification(created_at, notification, notification_id, service_id, EMAIL_TYPE, api_key_id, key_type)
 
-        send_email_to_provider.apply_async((service_id, notification_id, reply_to_addresses),
-                                           queue='email')
+        send_email_to_provider.apply_async((service_id, notification_id), queue='email')
 
         current_app.logger.info("Email {} created at {}".format(notification_id, created_at))
         statsd_client.incr("notifications.tasks.send-email")

--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -60,14 +60,12 @@ class AwsSesClient(EmailClient):
                    subject,
                    body,
                    html_body='',
-                   reply_to_addresses=None):
+                   reply_to_address=None):
         try:
             if isinstance(to_addresses, str):
                 to_addresses = [to_addresses]
-            if reply_to_addresses and isinstance(reply_to_addresses, str):
-                reply_to_addresses = [reply_to_addresses]
-            elif reply_to_addresses is None:
-                reply_to_addresses = []
+
+            reply_to_addresses = [reply_to_address] if reply_to_address else []
 
             body = {
                 'Text': {'Data': body}


### PR DESCRIPTION
dont send reply_to_addresses around from process_job and send_email - take it from the service in send_email_to_provider. also clean up the kwarg in aws_ses.send_email to more accurately reflect what we might pass in


this is the first of two PRs - next PR will remove kwargs from celery tasks