### PR TITLE
add pip-accel to travis to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 sudo: false
 language: python
-cache: pip
+cache:
+  pip: true
+  directories:
+    - ~/.pip-accel
 python:
 - '3.4'
 addons:
   postgresql: '9.3'
 install:
-- pip install -r requirements_for_test.txt
+- pip install pip-accel
+- pip-accel install -r requirements_for_test.txt
 before_script:
 - psql -c 'create database test_notification_api;' -U postgres
 script:


### PR DESCRIPTION
* our travis builds spend several minutes building python dependencies.
* pip rebuilds dependencies, even if the version hasn't changed.
* many of our dependencies are c-compiled, and take a long time to build.
* [pip-accel](https://github.com/paylogic/pip-accel) is a library that locally caches built python libraries
* we can use travis' built-in caching system to cache that pip-accel directory, and hopefully as a result can reduce build times (after the initial build)

from ~100s down to ~25 seconds on this branch