### PR TITLE
Add a lockmode for the update_notifications_status_by_id to prevent t…

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -246,7 +246,7 @@ def _update_notification_status(notification, status, notification_statistics_st
 
 @transactional
 def update_notification_status_by_id(notification_id, status, notification_statistics_status=None):
-    notification = Notification.query.filter(
+    notification = Notification.query.with_lockmode("update").filter(
         Notification.id == notification_id,
         or_(Notification.status == 'created',
             Notification.status == 'sending',


### PR DESCRIPTION
…he timeout task from updating the same notification more than once.

This happens because more than one beat process was creating the timeout task, resulting in multiple workers running the same queries at the same time.