### PR TITLE
Daily message limit imposed for service api calls.

### DIFF
--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -221,7 +221,7 @@ def send_notification(notification_type):
         total_sms_count = service_stats.sms_requested
         total_email_count = service_stats.emails_requested
 
-        if (total_email_count + total_sms_count >= service.message_limit) and service.restricted:
+        if (total_email_count + total_sms_count >= service.message_limit):
             error = 'Exceeded send limits ({}) for today'.format(service.message_limit)
             raise InvalidRequest(error, status_code=429)
 


### PR DESCRIPTION
Daily message limits are imposed for csv jobs, but not api calls. This pr brings these into line by respecting limits in api calls. It may be decided later that no limit is the way to go, and if so, this can be reverted and a check for service being restricted can be added to tasks.py -> process_job.

Another pr will be coming on admin side to increase the daily limit that is set when service is un restricted.

Fix for https://www.pivotaltracker.com/story/show/126230157