### PR TITLE
Speed up GET services endpoints

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -3,6 +3,7 @@ import uuid
 from app import db
 from app.models import Service
 from sqlalchemy import asc
+from sqlalchemy.orm import joinedload
 
 from app.dao.dao_utils import (
     transactional,
@@ -27,19 +28,38 @@ from app.models import (
 
 
 def dao_fetch_all_services():
-    return Service.query.order_by(asc(Service.created_at)).all()
+    return Service.query.order_by(
+        asc(Service.created_at)
+    ).options(
+        joinedload('users')
+    ).all()
 
 
 def dao_fetch_service_by_id(service_id):
-    return Service.query.filter_by(id=service_id).one()
+    return Service.query.filter_by(
+        id=service_id
+    ).options(
+        joinedload('users')
+    ).one()
 
 
 def dao_fetch_all_services_by_user(user_id):
-    return Service.query.filter(Service.users.any(id=user_id)).order_by(asc(Service.created_at)).all()
+    return Service.query.filter(
+        Service.users.any(id=user_id)
+    ).order_by(
+        asc(Service.created_at)
+    ).options(
+        joinedload('users')
+    ).all()
 
 
 def dao_fetch_service_by_id_and_user(service_id, user_id):
-    return Service.query.filter(Service.users.any(id=user_id)).filter_by(id=service_id).one()
+    return Service.query.filter(
+        Service.users.any(id=user_id),
+        Service.id == service_id
+    ).options(
+        joinedload('users')
+    ).one()
 
 
 @transactional

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -106,7 +106,15 @@ class ServiceSchema(BaseSchema):
 
     class Meta:
         model = models.Service
-        exclude = ("updated_at", "created_at", "api_keys", "templates", "jobs", 'old_id')
+        exclude = ('updated_at',
+                   'created_at',
+                   'api_keys',
+                   'templates',
+                   'jobs',
+                   'old_id',
+                   'template_statistics',
+                   'service_provider_stats',
+                   'service_notification_stats')
         strict = True
 
     @validates('sms_sender')


### PR DESCRIPTION
Speed up GET services:

### before
![image](https://cloud.githubusercontent.com/assets/5020841/16872439/b92f20ea-4a84-11e6-922a-d643908b0037.png)

### after
![image](https://cloud.githubusercontent.com/assets/5020841/16872457/d3d4776a-4a84-11e6-995a-9750849b760e.png)

Joined loads are almost always better than lazily loading - we know we need users, so load them when we grab the service, rather than when we dump the schema.

No loads are better than both, so exclude stats tables.
