### PR TITLE
Upgrade bleach to fix dodgy html5lib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 apispec==0.12.0
-bleach==1.4.2
+bleach==1.4.3
 Flask==0.10.1
 Flask-Script==2.0.5
 Flask-Migrate==1.3.1


### PR DESCRIPTION
Bleach 1.4.2 installs html5lib version 0.999 or greater.

This was fine, until version 0.999999999 (nine nines) was released, which doesn’t work.

Bleach 1.4.3 pins html5lib to 0.9999999 (seven nines), which stops the bad version getting installed.