### PR TITLE
detailed service api endpoint

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -1,15 +1,13 @@
 import uuid
 
-from app import db
-from app.models import Service
-from sqlalchemy import asc
+from sqlalchemy import asc, func
 from sqlalchemy.orm import joinedload
 
+from app import db
 from app.dao.dao_utils import (
     transactional,
     version_class
 )
-
 from app.models import (
     NotificationStatistics,
     TemplateStatistics,
@@ -135,3 +133,16 @@ def delete_service_and_all_associated_db_objects(service):
     db.session.commit()
     list(map(db.session.delete, users))
     db.session.commit()
+
+
+def dao_fetch_stats_for_service(service_id):
+    return db.session.query(
+        Notification.notification_type,
+        Notification.status,
+        func.count(Notification.id).label('count')
+    ).filter(
+        Notification.service_id == service_id
+    ).group_by(
+        Notification.notification_type,
+        Notification.status,
+    ).all()

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -123,6 +123,23 @@ class ServiceSchema(BaseSchema):
             raise ValidationError('Only alphanumeric characters allowed')
 
 
+class DetailedServiceSchema(BaseSchema):
+    statistics = fields.Dict()
+
+    class Meta:
+        model = models.Service
+        exclude = (
+            'api_keys',
+            'templates',
+            'users',
+            'created_by',
+            'jobs',
+            'template_statistics',
+            'service_provider_stats',
+            'service_notification_stats'
+        )
+
+
 class NotificationModelSchema(BaseSchema):
     class Meta:
         model = models.Notification
@@ -486,6 +503,7 @@ user_schema = UserSchema()
 user_schema_load_json = UserSchema(load_json=True)
 service_schema = ServiceSchema()
 service_schema_load_json = ServiceSchema(load_json=True)
+detailed_service_schema = DetailedServiceSchema()
 template_schema = TemplateSchema()
 template_schema_load_json = TemplateSchema(load_json=True)
 api_key_schema = ApiKeySchema()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -14,7 +14,6 @@ from app.dao.api_key_dao import (
     get_unsigned_secret,
     expire_api_key)
 from app.dao.services_dao import (
-    dao_fetch_service_by_id_and_user,
     dao_fetch_service_by_id,
     dao_fetch_all_services,
     dao_create_service,
@@ -58,11 +57,7 @@ def get_services():
 
 @service.route('/<uuid:service_id>', methods=['GET'])
 def get_service_by_id(service_id):
-    user_id = request.args.get('user_id', None)
-    if user_id:
-        fetched = dao_fetch_service_by_id_and_user(service_id, user_id)
-    else:
-        fetched = dao_fetch_service_by_id(service_id)
+    fetched = dao_fetch_service_by_id(service_id)
 
     data = service_schema.dump(fetched).data
     return jsonify(data=data)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -8,6 +8,7 @@ from flask import (
 )
 from sqlalchemy.orm.exc import NoResultFound
 
+from app.models import EMAIL_TYPE, SMS_TYPE
 from app.dao.api_key_dao import (
     save_model_api_key,
     get_model_api_keys,
@@ -20,7 +21,8 @@ from app.dao.services_dao import (
     dao_update_service,
     dao_fetch_all_services_by_user,
     dao_add_user_to_service,
-    dao_remove_user_from_service
+    dao_remove_user_from_service,
+    dao_fetch_stats_for_service
 )
 from app.dao import notifications_dao
 from app.dao.provider_statistics_dao import get_fragment_count
@@ -33,6 +35,7 @@ from app.schemas import (
     permission_schema,
     notification_status_schema,
     notifications_filter_schema,
+    detailed_service_schema
 )
 from app.utils import pagination_links
 from app.errors import (
@@ -57,10 +60,13 @@ def get_services():
 
 @service.route('/<uuid:service_id>', methods=['GET'])
 def get_service_by_id(service_id):
-    fetched = dao_fetch_service_by_id(service_id)
+    if 'detailed' in request.args:
+        return get_detailed_service(service_id)
+    else:
+        fetched = dao_fetch_service_by_id(service_id)
 
-    data = service_schema.dump(fetched).data
-    return jsonify(data=data)
+        data = service_schema.dump(fetched).data
+        return jsonify(data=data)
 
 
 @service.route('', methods=['POST'])
@@ -227,3 +233,30 @@ def get_all_notifications_for_service(service_id):
             **kwargs
         )
     ), 200
+
+
+def get_detailed_service(service_id):
+    service = dao_fetch_service_by_id(service_id)
+    statistics = dao_fetch_stats_for_service(service_id)
+    service.statistics = format_statistics(statistics)
+    data = detailed_service_schema.dump(service).data
+    return jsonify(data=data)
+
+
+def format_statistics(statistics):
+    # statistics come in a named tuple with uniqueness from 'notification_type', 'status' - however missing
+    # statuses/notification types won't be represented and the status types need to be simplified/summed up
+    # so we can return emails/sms * created, sent, and failed
+    counts = {
+        template_type: {
+            status: 0 for status in ('requested', 'delivered', 'failed')
+        } for template_type in (EMAIL_TYPE, SMS_TYPE)
+    }
+    for row in statistics:
+        counts[row.notification_type]['requested'] += row.count
+        if row.status == 'delivered':
+            counts[row.notification_type]['delivered'] += row.count
+        elif row.status in ('failed', 'technical-failure', 'temporary-failure', 'permanent-failure'):
+            counts[row.notification_type]['failed'] += row.count
+
+    return counts

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -3,7 +3,6 @@ import pytest
 import uuid
 from datetime import (datetime, date)
 
-import pytest
 from flask import current_app
 
 from app import db

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -7,7 +7,6 @@ from app.dao.services_dao import (
     dao_fetch_all_services,
     dao_fetch_service_by_id,
     dao_fetch_all_services_by_user,
-    dao_fetch_service_by_id_and_user,
     dao_update_service,
     delete_service_and_all_associated_db_objects
 )
@@ -210,27 +209,6 @@ def test_get_service_by_id_returns_none_if_no_service(notify_db):
 def test_get_service_by_id_returns_service(service_factory):
     service = service_factory.get('testing', email_from='testing')
     assert dao_fetch_service_by_id(service.id).name == 'testing'
-
-
-def test_can_get_service_by_id_and_user(service_factory, sample_user):
-    service = service_factory.get('service 1', sample_user, email_from='service.1')
-    assert dao_fetch_service_by_id_and_user(service.id, sample_user.id).name == 'service 1'
-
-
-def test_cannot_get_service_by_id_and_owned_by_different_user(service_factory, sample_user):
-    service1 = service_factory.get('service 1', sample_user, email_from='service.1')
-    new_user = User(
-        name='Test User',
-        email_address='new_user@digital.cabinet-office.gov.uk',
-        password='password',
-        mobile_number='+447700900986'
-    )
-    save_model_user(new_user)
-    service2 = service_factory.get('service 2', new_user, email_from='service.2')
-    assert dao_fetch_service_by_id_and_user(service1.id, sample_user.id).name == 'service 1'
-    with pytest.raises(NoResultFound) as e:
-        dao_fetch_service_by_id_and_user(service2.id, sample_user.id)
-    assert 'No row was found for one()' in str(e)
 
 
 def test_create_service_creates_a_history_record_with_current_data(sample_user):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,7 @@ def sqs_client_conn(request):
     boto3.setup_default_session(region_name='eu-west-1')
     return boto3.resource('sqs')
 
+
 def pytest_generate_tests(metafunc):
     # Copied from https://gist.github.com/pfctdayelise/5719730
     idparametrize = getattr(metafunc.function, 'idparametrize', None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,3 +68,11 @@ def os_environ(request):
 def sqs_client_conn(request):
     boto3.setup_default_session(region_name='eu-west-1')
     return boto3.resource('sqs')
+
+def pytest_generate_tests(metafunc):
+    # Copied from https://gist.github.com/pfctdayelise/5719730
+    idparametrize = getattr(metafunc.function, 'idparametrize', None)
+    if idparametrize:
+        argnames, testdata = idparametrize.args
+        ids, argvalues = zip(*sorted(testdata.items()))
+        metafunc.parametrize(argnames, argvalues, ids=ids)


### PR DESCRIPTION
new detailed service api endpoint that returns the service information, plus an additional statistics dictionary for use on the frontend.

~~depends on #538~~ 

blocks:
https://github.com/alphagov/notifications-admin/issues/802
https://github.com/alphagov/notifications-admin/issues/803