### PR TITLE
Override postgresc connection for jenkins

### DIFF
--- a/environment_test.sh
+++ b/environment_test.sh
@@ -10,7 +10,7 @@ export INVITATION_EXPIRATION_DAYS=2
 export NOTIFY_JOB_QUEUE='notify-jobs-queue-test'
 export NOTIFICATION_QUEUE_PREFIX='notification_development-test'
 export SECRET_KEY='secret-key'
-export SQLALCHEMY_DATABASE_URI='postgresql://localhost/test_notification_api'
+export SQLALCHEMY_DATABASE_URI=${TEST_DATABASE:='postgresql://localhost/test_notification_api'}
 export VERIFY_CODE_FROM_EMAIL_ADDRESS='no-reply@notify.works'
 export FIRETEXT_API_KEY="Firetext"
 export NOTIFY_EMAIL_DOMAIN="test.notify.com"


### PR DESCRIPTION
If TEST_DATABASE is set then the postgres connection is set to that.
Jenkins sets it to the RDS instance that is in that AWS Account