### PR TITLE
Get service with stats for today

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import date
 
 from sqlalchemy import asc, func
 from sqlalchemy.orm import joinedload
@@ -136,6 +137,16 @@ def delete_service_and_all_associated_db_objects(service):
 
 
 def dao_fetch_stats_for_service(service_id):
+    return _stats_for_service_query(service_id).all()
+
+
+def dao_fetch_todays_stats_for_service(service_id):
+    return _stats_for_service_query(service_id).filter(
+        func.date(Notification.created_at) == date.today()
+    ).all()
+
+
+def _stats_for_service_query(service_id):
     return db.session.query(
         Notification.notification_type,
         Notification.status,
@@ -145,4 +156,4 @@ def dao_fetch_stats_for_service(service_id):
     ).group_by(
         Notification.notification_type,
         Notification.status,
-    ).all()
+    )

--- a/migrations/versions/0043_notification_indexes.py
+++ b/migrations/versions/0043_notification_indexes.py
@@ -1,0 +1,44 @@
+"""empty message
+
+Revision ID: 0043_notification_indexes
+Revises: 0042_notification_history
+Create Date: 2016-08-01 10:37:41.198070
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0043_notification_indexes'
+down_revision = '0042_notification_history'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_index(op.f('ix_notifications_created_at'), 'notifications', ['created_at'])
+    op.create_index(op.f('ix_notification_history_created_at'), 'notification_history', ['created_at'])
+
+    op.create_index(op.f('ix_notifications_status'), 'notifications', ['status'])
+    op.create_index(op.f('ix_notification_history_status'), 'notification_history', ['status'])
+
+    op.create_index(op.f('ix_notifications_notification_type'), 'notifications', ['notification_type'])
+    op.create_index(op.f('ix_notification_history_notification_type'), 'notification_history', ['notification_type'])
+
+    op.create_index(
+        'ix_notification_history_week_created',
+        'notification_history',
+        [sa.text("date_trunc('week', created_at)")]
+    )
+
+
+def downgrade():
+    op.drop_index(op.f('ix_notifications_created_at'), table_name='notifications')
+    op.drop_index(op.f('ix_notification_history_created_at'), table_name='notification_history')
+
+    op.drop_index(op.f('ix_notifications_status'), table_name='notifications')
+    op.drop_index(op.f('ix_notification_history_status'), table_name='notification_history')
+
+    op.drop_index(op.f('ix_notifications_notification_type'), table_name='notifications')
+    op.drop_index(op.f('ix_notification_history_notification_type'), table_name='notification_history')
+
+    op.drop_index(op.f('ix_notification_history_week_created'), table_name='notification_history')

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -319,12 +319,14 @@ def sample_notification(notify_db,
                         to_field=None,
                         status='created',
                         reference=None,
-                        created_at=datetime.utcnow(),
+                        created_at=None,
                         content_char_count=160,
                         create=True,
                         personalisation=None,
                         api_key_id=None,
                         key_type=KEY_TYPE_NORMAL):
+    if created_at is None:
+        created_at = datetime.utcnow()
     if service is None:
         service = sample_service(notify_db, notify_db_session)
     if template is None:


### PR DESCRIPTION
This endpoint is needed by the send page, which checks to see how many messages you've sent today compared to your daily limit

blocks https://github.com/alphagov/notifications-admin/pull/809

~~blocked by #557~~