### PR TITLE
use freeze_time whenever we mess with dates

### DIFF
--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -459,9 +459,9 @@ def test_fetch_weekly_historical_stats_separates_weeks(notify_db, notify_db_sess
     last_sunday = notification_history(created_at=datetime(2016, 7, 24, 23, 59))
     last_monday_morning = notification_history(created_at=datetime(2016, 7, 25, 0, 0))
     last_monday_evening = notification_history(created_at=datetime(2016, 7, 25, 23, 59))
-    today = notification_history(created_at=datetime.now(), status='delivered')
 
     with freeze_time('Wed 27th July 2016'):
+        today = notification_history(created_at=datetime.now(), status='delivered')
         ret = dao_fetch_weekly_historical_stats_for_service(sample_template.service_id)
 
     assert [(row.week_start, row.status) for row in ret] == [

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1123,18 +1123,19 @@ def test_get_detailed_service(notify_db, notify_db_session, notify_api, sample_s
     assert service['statistics']['sms'] == stats
 
 
-@freeze_time('2016-07-28')
-def test_get_weekly_notification_stats(notify_api, sample_notification):
-    with notify_api.test_request_context(), notify_api.test_client() as client:
+def test_get_weekly_notification_stats(notify_api, notify_db, notify_db_session):
+    with freeze_time('2000-01-01T12:00:00'):
+        noti = create_sample_notification(notify_db, notify_db_session)
+    with notify_api.test_request_context(), notify_api.test_client() as client, freeze_time('2000-01-02T12:00:00'):
         resp = client.get(
-            '/service/{}/notifications/weekly'.format(sample_notification.service_id),
+            '/service/{}/notifications/weekly'.format(noti.service_id),
             headers=[create_authorization_header()]
         )
 
     assert resp.status_code == 200
     data = json.loads(resp.get_data(as_text=True))['data']
     assert data == {
-        '2016-07-25': {
+        '1999-12-27': {
             'sms': {
                 'requested': 1,
                 'delivered': 0,


### PR DESCRIPTION
also fixed a gotcha where an object was created in a fixture, so the freezetime decorator didn't apply