### PR TITLE
fix GET /notifications 500 error

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -357,7 +357,7 @@ def get_notification_with_personalisation(service_id, notification_id, key_type)
     if key_type:
         filter_dict['key_type'] = key_type
 
-    return Notification.query.filter_by(**filter_dict).options(joinedload('actual_template')).one()
+    return Notification.query.filter_by(**filter_dict).options(joinedload('template_history')).one()
 
 
 @statsd(namespace="dao")
@@ -392,7 +392,7 @@ def get_notifications_for_service(service_id,
     query = _filter_query(query, filter_dict)
     if personalisation:
         query = query.options(
-            joinedload('actual_template')
+            joinedload('template_history')
         )
     return query.order_by(desc(Notification.created_at)).paginate(
         page=page,

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -391,7 +391,7 @@ def get_notifications_for_service(service_id,
     query = Notification.query.filter(*filters)
     query = _filter_query(query, filter_dict)
     if personalisation:
-        query.options(
+        query = query.options(
             joinedload('actual_template')
         )
     return query.order_by(desc(Notification.created_at)).paginate(

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -8,6 +8,7 @@ from datetime import (
 from flask import current_app
 from werkzeug.datastructures import MultiDict
 from sqlalchemy import (desc, func, Integer, or_, and_, asc)
+from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.expression import cast
 from notifications_utils.template import get_sms_fragment_count
 
@@ -351,12 +352,12 @@ def get_notifications_for_job(service_id, job_id, filter_dict=None, page=1, page
 
 
 @statsd(namespace="dao")
-def get_notification(service_id, notification_id, key_type=None):
+def get_notification_with_personalisation(service_id, notification_id, key_type):
     filter_dict = {'service_id': service_id, 'id': notification_id}
     if key_type:
         filter_dict['key_type'] = key_type
 
-    return Notification.query.filter_by(**filter_dict).one()
+    return Notification.query.filter_by(**filter_dict).options(joinedload('actual_template')).one()
 
 
 @statsd(namespace="dao")
@@ -374,7 +375,8 @@ def get_notifications_for_service(service_id,
                                   page=1,
                                   page_size=None,
                                   limit_days=None,
-                                  key_type=None):
+                                  key_type=None,
+                                  personalisation=False):
     if page_size is None:
         page_size = current_app.config['PAGE_SIZE']
     filters = [Notification.service_id == service_id]
@@ -388,6 +390,10 @@ def get_notifications_for_service(service_id,
 
     query = Notification.query.filter(*filters)
     query = _filter_query(query, filter_dict)
+    if personalisation:
+        query.options(
+            joinedload('actual_template')
+        )
     return query.order_by(desc(Notification.created_at)).paginate(
         page=page,
         per_page=page_size

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -16,6 +16,7 @@ from app.models import (
     VerifyCode,
     ApiKey,
     Template,
+    TemplateHistory,
     Job,
     NotificationHistory,
     Notification,
@@ -122,7 +123,7 @@ def delete_service_and_all_associated_db_objects(service):
     _delete_commit(Notification.query.filter_by(service=service))
     _delete_commit(Job.query.filter_by(service=service))
     _delete_commit(Template.query.filter_by(service=service))
-    _delete_commit(Template.get_history_model().query.filter_by(service_id=service.id))
+    _delete_commit(TemplateHistory.query.filter_by(service_id=service.id))
 
     verify_codes = VerifyCode.query.join(User).filter(User.id.in_([x.id for x in service.users]))
     list(map(db.session.delete, verify_codes))

--- a/app/history_meta.py
+++ b/app/history_meta.py
@@ -171,17 +171,13 @@ class Versioned(object):
         return history_mapper.class_
 
 
-def versioned_objects(iter):
-    for obj in iter:
-        if hasattr(obj, '__history_mapper__'):
-            yield obj
+def create_history(obj, history_cls=None):
+    if not history_cls:
+        history_mapper = obj.__history_mapper__
+        history_cls = history_mapper.class_
 
-
-def create_history(obj):
-    obj_mapper = object_mapper(obj)
-    history_mapper = obj.__history_mapper__
-    history_cls = history_mapper.class_
     history = history_cls()
+    obj_mapper = object_mapper(obj)
 
     obj_state = attributes.instance_state(obj)
     data = {}

--- a/app/models.py
+++ b/app/models.py
@@ -448,7 +448,7 @@ class Notification(db.Model):
     reference = db.Column(db.String, nullable=True, index=True)
     _personalisation = db.Column(db.String, nullable=True)
 
-    actual_template = db.relationship('TemplateHistory', primaryjoin=and_(
+    template_history = db.relationship('TemplateHistory', primaryjoin=and_(
         foreign(template_id) == remote(TemplateHistory.id),
         foreign(template_version) == remote(TemplateHistory.version)
     ))

--- a/app/models.py
+++ b/app/models.py
@@ -5,7 +5,8 @@ from sqlalchemy.dialects.postgresql import (
     UUID,
     JSON
 )
-from sqlalchemy import UniqueConstraint, text
+from sqlalchemy import UniqueConstraint, text, ForeignKeyConstraint, and_
+from sqlalchemy.orm import foreign, remote
 
 from app.encryption import (
     hashpw,
@@ -446,6 +447,14 @@ class Notification(db.Model):
     status = db.Column(NOTIFICATION_STATUS_TYPES_ENUM, index=True, nullable=False, default='created')
     reference = db.Column(db.String, nullable=True, index=True)
     _personalisation = db.Column(db.String, nullable=True)
+
+    # __table_args__ = (
+    #     ForeignKeyConstraint(['template_id', 'template_version'], ['template_history.id', 'template_history.version']),
+    # )
+    actual_template = db.relationship('TemplateHistory', primaryjoin=and_(
+        foreign(template_id) == remote(TemplateHistory.id),
+        foreign(template_version) == remote(TemplateHistory.version)
+    ))
 
     @property
     def personalisation(self):

--- a/app/models.py
+++ b/app/models.py
@@ -448,9 +448,6 @@ class Notification(db.Model):
     reference = db.Column(db.String, nullable=True, index=True)
     _personalisation = db.Column(db.String, nullable=True)
 
-    # __table_args__ = (
-    #     ForeignKeyConstraint(['template_id', 'template_version'], ['template_history.id', 'template_history.version']),
-    # )
     actual_template = db.relationship('TemplateHistory', primaryjoin=and_(
         foreign(template_id) == remote(TemplateHistory.id),
         foreign(template_version) == remote(TemplateHistory.version)

--- a/app/models.py
+++ b/app/models.py
@@ -249,7 +249,7 @@ class TemplateHistory(db.Model):
     subject = db.Column(db.Text)
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
     created_by = db.relationship('User')
-    version = db.Column(db.Integer)
+    version = db.Column(db.Integer, primary_key=True)
 
 
 MMG_PROVIDER = "mmg"

--- a/app/models.py
+++ b/app/models.py
@@ -206,7 +206,7 @@ TEMPLATE_TYPES = [SMS_TYPE, EMAIL_TYPE, LETTER_TYPE]
 template_types = db.Enum(*TEMPLATE_TYPES, name='template_type')
 
 
-class Template(db.Model, Versioned):
+class Template(db.Model):
     __tablename__ = 'templates'
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -231,6 +231,26 @@ class Template(db.Model, Versioned):
     subject = db.Column(db.Text, index=False, unique=False, nullable=True)
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
     created_by = db.relationship('User')
+    version = db.Column(db.Integer, default=1)
+
+
+class TemplateHistory(db.Model):
+    __tablename__ = 'templates_history'
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True)
+    name = db.Column(db.String(255), nullable=False)
+    template_type = db.Column(template_types, nullable=False)
+    created_at = db.Column(db.DateTime, nullable=False)
+    updated_at = db.Column(db.DateTime)
+    content = db.Column(db.Text, nullable=False)
+    archived = db.Column(db.Boolean, nullable=False, default=False)
+    service_id = db.Column(UUID(as_uuid=True), db.ForeignKey('services.id'), index=True, nullable=False)
+    service = db.relationship('Service')
+    subject = db.Column(db.Text)
+    created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
+    created_by = db.relationship('User')
+    version = db.Column(db.Integer)
+
 
 MMG_PROVIDER = "mmg"
 FIRETEXT_PROVIDER = "firetext"

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import itertools
+
 from flask import (
     Blueprint,
     jsonify,
@@ -7,6 +8,7 @@ from flask import (
     current_app,
     json
 )
+
 from notifications_utils.recipients import allowed_to_send_to, first_column_heading
 from notifications_utils.template import Template
 from notifications_utils.renderers import PassThrough
@@ -170,10 +172,10 @@ def process_firetext_response():
 
 
 @notifications.route('/notifications/<uuid:notification_id>', methods=['GET'])
-def get_notifications(notification_id):
-    notification = notifications_dao.get_notification(str(api_user.service_id),
-                                                      notification_id,
-                                                      key_type=api_user.key_type)
+def get_notification_by_id(notification_id):
+    notification = notifications_dao.get_notification_with_personalisation(str(api_user.service_id),
+                                                                           notification_id,
+                                                                           key_type=api_user.key_type)
     return jsonify(data={"notification": notification_with_personalisation_schema.dump(notification).data}), 200
 
 
@@ -186,6 +188,7 @@ def get_all_notifications():
 
     pagination = notifications_dao.get_notifications_for_service(
         str(api_user.service_id),
+        personalisation=True,
         filter_dict=data,
         page=page,
         page_size=page_size,

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -172,17 +172,11 @@ class TemplateSchema(BaseTemplateSchema):
 
 class TemplateHistorySchema(BaseSchema):
 
-    class Meta:
-        # Use the base model class that the history class is created from
-        model = models.Template
-    # We have to use a method here because the relationship field on the
-    # history object is not created.
-    created_by = fields.Method("populate_created_by", dump_only=True)
+    created_by = fields.Nested(UserSchema, only=['id', 'name', 'email_address'], dump_only=True)
     created_at = field_for(models.Template, 'created_at', format='%Y-%m-%d %H:%M:%S.%f')
 
-    def populate_created_by(self, data):
-        usr = models.User.query.filter_by(id=data.created_by_id).one()
-        return {'id': str(usr.id), 'name': usr.name, 'email_address': usr.email_address}
+    class Meta:
+        model = models.TemplateHistory
 
 
 class NotificationsStatisticsSchema(BaseSchema):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -292,9 +292,9 @@ class NotificationWithTemplateSchema(BaseSchema):
 
 
 class NotificationWithPersonalisationSchema(NotificationWithTemplateSchema):
-    actual_template = fields.Nested(TemplateHistorySchema,
-                                    only=['id', 'name', 'template_type', 'content', 'subject', 'version'],
-                                    dump_only=True)
+    template_history = fields.Nested(TemplateHistorySchema,
+                                     only=['id', 'name', 'template_type', 'content', 'subject', 'version'],
+                                     dump_only=True)
 
     class Meta(NotificationWithTemplateSchema.Meta):
         # mark as many fields as possible as required since this is a public api.
@@ -307,7 +307,7 @@ class NotificationWithPersonalisationSchema(NotificationWithTemplateSchema):
             # computed fields
             'personalisation',
             # relationships
-            'service', 'job', 'api_key', 'actual_template'
+            'service', 'job', 'api_key', 'template_history'
         )
 
     @pre_dump
@@ -317,7 +317,7 @@ class NotificationWithPersonalisationSchema(NotificationWithTemplateSchema):
 
     @post_dump
     def handle_template_merge(self, in_data):
-        in_data['template'] = in_data.pop('actual_template')
+        in_data['template'] = in_data.pop('template_history')
         from notifications_utils.template import Template
         template = Template(
             in_data['template'],

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -189,7 +189,7 @@ def get_service_history(service_id):
     api_key_history = ApiKey.get_history_model().query.filter_by(service_id=service_id).all()
     api_keys_data = api_key_history_schema.dump(api_key_history, many=True).data
 
-    template_history = Template.get_history_model().query.filter_by(service_id=service_id).all()
+    template_history = TemplateHistory.query.filter_by(service_id=service_id).all()
     template_data, errors = template_history_schema.dump(template_history, many=True)
 
     events = Event.query.all()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -176,7 +176,7 @@ def get_service_provider_aggregate_statistics(service_id):
 # tables. This is so product owner can pass stories as done
 @service.route('/<uuid:service_id>/history', methods=['GET'])
 def get_service_history(service_id):
-    from app.models import (Service, ApiKey, Template, Event)
+    from app.models import (Service, ApiKey, Template, TemplateHistory, Event)
     from app.schemas import (
         service_history_schema,
         api_key_history_schema,

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -188,7 +188,7 @@ def test_send_sms_should_use_template_version_from_notification_not_latest(
         sender=None
     )
 
-    persisted_notification = notifications_dao.get_notification(sample_template.service_id, db_notification.id)
+    persisted_notification = notifications_dao.get_notification_by_id(db_notification.id)
     assert persisted_notification.to == db_notification.to
     assert persisted_notification.template_id == sample_template.id
     assert persisted_notification.template_version == version_on_notification
@@ -223,7 +223,7 @@ def test_should_call_send_sms_response_task_if_research_mode(notify_db, sample_s
         ('mmg', str(sample_notification.id), sample_notification.to), queue='research-mode'
     )
 
-    persisted_notification = notifications_dao.get_notification(sample_service.id, sample_notification.id)
+    persisted_notification = notifications_dao.get_notification_by_id(sample_notification.id)
     assert persisted_notification.to == sample_notification.to
     assert persisted_notification.template_id == sample_notification.template_id
     assert persisted_notification.status == 'sending'
@@ -499,7 +499,7 @@ def test_should_not_set_billable_units_if_research_mode(notify_db, sample_servic
         sample_notification.id
     )
 
-    persisted_notification = notifications_dao.get_notification(sample_service.id, sample_notification.id)
+    persisted_notification = notifications_dao.get_notification_by_id(sample_notification.id)
     assert persisted_notification.billable_units == 0
 
 

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -23,7 +23,7 @@ from app.models import (
 from app.dao.notifications_dao import (
     dao_create_notification,
     dao_update_notification,
-    get_notification,
+    get_notification_with_personalisation,
     get_notification_for_job,
     get_notifications_for_job,
     dao_get_notification_statistics_for_service,
@@ -57,7 +57,7 @@ def test_should_have_decorated_notifications_dao_functions():
     assert update_notification_status_by_reference.__wrapped__.__name__ == 'update_notification_status_by_reference'  # noqa
     assert get_notification_for_job.__wrapped__.__name__ == 'get_notification_for_job'  # noqa
     assert get_notifications_for_job.__wrapped__.__name__ == 'get_notifications_for_job'  # noqa
-    assert get_notification.__wrapped__.__name__ == 'get_notification'  # noqa
+    assert get_notification_with_personalisation.__wrapped__.__name__ == 'get_notification_with_personalisation'  # noqa
     assert get_notifications_for_service.__wrapped__.__name__ == 'get_notifications_for_service'  # noqa
     assert get_notification_by_id.__wrapped__.__name__ == 'get_notification_by_id'  # noqa
     assert delete_notifications_created_more_than_a_week_ago.__wrapped__.__name__ == 'delete_notifications_created_more_than_a_week_ago'  # noqa
@@ -637,9 +637,11 @@ def test_save_notification_with_no_job(sample_template, mmg_provider):
 
 
 def test_get_notification(sample_notification):
-    notification_from_db = get_notification(
+    notification_from_db = get_notification_with_personalisation(
         sample_notification.service.id,
-        sample_notification.id)
+        sample_notification.id,
+        key_type=None
+    )
     assert sample_notification == notification_from_db
 
 

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -29,6 +29,7 @@ from app.models import (
     VerifyCode,
     ApiKey,
     Template,
+    TemplateHistory,
     Job,
     Notification,
     NotificationHistory,

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -331,7 +331,7 @@ def test_delete_service_and_associated_objects(notify_db,
     assert ApiKey.query.count() == 0
     assert ApiKey.get_history_model().query.count() == 0
     assert Template.query.count() == 0
-    assert Template.get_history_model().query.count() == 0
+    assert TemplateHistory.query.count() == 0
     assert Job.query.count() == 0
     assert Notification.query.count() == 0
     assert Permission.query.count() == 0

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -185,7 +185,7 @@ def test_get_template_by_id_and_service_returns_none_if_no_template(sample_servi
 
 def test_create_template_creates_a_history_record_with_current_data(sample_service, sample_user):
     assert Template.query.count() == 0
-    assert Template.get_history_model().query.count() == 0
+    assert TemplateHistory.query.count() == 0
     data = {
         'name': 'Sample Template',
         'template_type': "email",
@@ -200,7 +200,7 @@ def test_create_template_creates_a_history_record_with_current_data(sample_servi
     assert Template.query.count() == 1
 
     template_from_db = Template.query.first()
-    template_history = Template.get_history_model().query.first()
+    template_history = TemplateHistory.query.first()
 
     assert template_from_db.id == template_history.id
     assert template_from_db.name == template_history.name
@@ -212,7 +212,7 @@ def test_create_template_creates_a_history_record_with_current_data(sample_servi
 
 def test_update_template_creates_a_history_record_with_current_data(sample_service, sample_user):
     assert Template.query.count() == 0
-    assert Template.get_history_model().query.count() == 0
+    assert TemplateHistory.query.count() == 0
     data = {
         'name': 'Sample Template',
         'template_type': "email",
@@ -228,20 +228,20 @@ def test_update_template_creates_a_history_record_with_current_data(sample_servi
     assert created.name == 'Sample Template'
     assert Template.query.count() == 1
     assert Template.query.first().version == 1
-    assert Template.get_history_model().query.count() == 1
+    assert TemplateHistory.query.count() == 1
 
     created.name = 'new name'
     dao_update_template(created)
 
     assert Template.query.count() == 1
-    assert Template.get_history_model().query.count() == 2
+    assert TemplateHistory.query.count() == 2
 
     template_from_db = Template.query.first()
 
     assert template_from_db.version == 2
 
-    assert Template.get_history_model().query.filter_by(name='Sample Template').one().version == 1
-    assert Template.get_history_model().query.filter_by(name='new name').one().version == 2
+    assert TemplateHistory.query.filter_by(name='Sample Template').one().version == 1
+    assert TemplateHistory.query.filter_by(name='new name').one().version == 2
 
 
 def test_get_template_history_version(sample_user, sample_service, sample_template):

--- a/tests/app/notifications/test_rest.py
+++ b/tests/app/notifications/test_rest.py
@@ -623,7 +623,6 @@ def test_get_notifications_for_service_returns_merged_template_content(notify_ap
             }
 
 
-@pytest.mark.xfail(strict=True, raises=NeededByTemplateError)
 def test_get_notification_selects_correct_template_for_personalisation(notify_api,
                                                                        notify_db,
                                                                        notify_db_session,

--- a/tests/app/notifications/test_rest.py
+++ b/tests/app/notifications/test_rest.py
@@ -640,14 +640,15 @@ def test_get_notification_selects_correct_template_for_personalisation(notify_ap
         auth_header = create_authorization_header(service_id=sample_template.service_id)
 
         response = client.get(path='/notifications', headers=[auth_header])
-        assert response.status_code == 200
 
-        resp = json.loads(response.get_data(as_text=True))
-        assert len(resp['notifications']) == 2
-        assert resp['notifications'][0]['template_version'] == 1
-        assert resp['notifications'][0]['body'] == 'This is a template'
-        assert resp['notifications'][1]['template_version'] == 2
-        assert resp['notifications'][1]['body'] == 'foo'
+    assert response.status_code == 200
+
+    resp = json.loads(response.get_data(as_text=True))
+    assert len(resp['notifications']) == 2
+    assert resp['notifications'][0]['template_version'] == 1
+    assert resp['notifications'][0]['body'] == 'This is a template'
+    assert resp['notifications'][1]['template_version'] == 2
+    assert resp['notifications'][1]['body'] == 'foo'
 
 
 def _create_auth_header_from_key(api_key):


### PR DESCRIPTION
kinda two separate parts to this:

### replacing `Versioned` with `TemplateHistory`

version table is a total pain and doesn't actually give us that much for free - but does block us from constructing sqlalchemy relationships or joining to it in an ORM manner, so remove it. Turns out this is very simple - had to do some small work to the version decorator (used on ORM create/update methods) to support this but that's all)

### notification knows about `TemplateHistory` instead of `Template`

It's not complete in this ticket, but this is the smallest section of work that fixes the 500 errors.

We shouldn't be referring to templates in the notification table - notifications are tied to a template's version at the moment in time that they're created, and if the template changes we shouldn't change that reference.

So for now solve this in a stop-gap method - add a new relationship called `template_history` and specificially reference that in `GET /notifications`, in the dao and schema layers.

A future chore is to move all of the other times we link notification and template to refer to this new relationship, and then switch over the foreign key in the database to be a composite foreign key to `templates_history` instead of `template`