### PR TITLE
Give better error messages when using the API to send to recipients not in your team

### DIFF
--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -270,11 +270,15 @@ def send_notification(notification_type):
             [user.mobile_number, user.email_address] for user in service.users
         )
     ):
-        raise InvalidRequest(
-            {'to': [(
+        if (api_user.key_type == KEY_TYPE_TEAM):
+            message = 'Can’t send to this recipient using a team-only API key'
+        else:
+            message = (
                 'Can’t send to this recipient when service is in trial mode '
                 '– see https://www.notifications.service.gov.uk/trial-mode'
-            )]},
+            )
+        raise InvalidRequest(
+            {'to': [message]},
             status_code=400
         )
 

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -270,9 +270,13 @@ def send_notification(notification_type):
             [user.mobile_number, user.email_address] for user in service.users
         )
     ):
-        message = 'Invalid {} for restricted service'.format(first_column_heading[notification_type])
-        errors = {'to': [message]}
-        raise InvalidRequest(errors, status_code=400)
+        raise InvalidRequest(
+            {'to': [(
+                'Can’t send to this recipient when service is in trial mode '
+                '– see https://www.notifications.service.gov.uk/trial-mode'
+            )]},
+            status_code=400
+        )
 
     notification_id = create_uuid()
     notification.update({"template_version": template.version})

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -227,7 +227,10 @@ def test_should_not_send_sms_if_restricted_and_not_a_service_user(notify_api, sa
             app.celery.tasks.send_sms.apply_async.assert_not_called()
 
             assert response.status_code == 400
-            assert 'Invalid phone number for restricted service' in json_resp['message']['to']
+            assert [(
+                'Can’t send to this recipient when service is in trial mode '
+                '– see https://www.notifications.service.gov.uk/trial-mode'
+            )] == json_resp['message']['to']
 
 
 def test_should_send_sms_if_restricted_and_a_service_user(notify_api, sample_template, mocker):
@@ -519,7 +522,10 @@ def test_should_not_send_email_if_restricted_and_not_a_service_user(notify_api, 
             app.celery.tasks.send_email.apply_async.assert_not_called()
 
             assert response.status_code == 400
-            assert 'Invalid email address for restricted service' in json_resp['message']['to']
+            assert [(
+                'Can’t send to this recipient when service is in trial mode – see '
+                'https://www.notifications.service.gov.uk/trial-mode'
+            )] == json_resp['message']['to']
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
@@ -698,7 +704,10 @@ def test_should_not_send_email_if_team_api_key_and_not_a_service_user(notify_api
         app.celery.tasks.send_email.apply_async.assert_not_called()
 
         assert response.status_code == 400
-        assert 'Invalid email address for restricted service' in json_resp['message']['to']
+        assert [(
+            'Can’t send to this recipient when service is in trial mode – see '
+            'https://www.notifications.service.gov.uk/trial-mode'
+        )] == json_resp['message']['to']
 
 
 def test_should_not_send_sms_if_team_api_key_and_not_a_service_user(notify_api, sample_template, mocker):
@@ -721,7 +730,10 @@ def test_should_not_send_sms_if_team_api_key_and_not_a_service_user(notify_api, 
         app.celery.tasks.send_sms.apply_async.assert_not_called()
 
         assert response.status_code == 400
-        assert 'Invalid phone number for restricted service' in json_resp['message']['to']
+        assert [(
+            'Can’t send to this recipient when service is in trial mode – see '
+            'https://www.notifications.service.gov.uk/trial-mode'
+        )] == json_resp['message']['to']
 
 
 def test_should_send_email_if_team_api_key_and_a_service_user(notify_api, sample_email_template, mocker):

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -704,10 +704,9 @@ def test_should_not_send_email_if_team_api_key_and_not_a_service_user(notify_api
         app.celery.tasks.send_email.apply_async.assert_not_called()
 
         assert response.status_code == 400
-        assert [(
-            'Can’t send to this recipient when service is in trial mode – see '
-            'https://www.notifications.service.gov.uk/trial-mode'
-        )] == json_resp['message']['to']
+        assert [
+            'Can’t send to this recipient using a team-only API key'
+        ] == json_resp['message']['to']
 
 
 def test_should_not_send_sms_if_team_api_key_and_not_a_service_user(notify_api, sample_template, mocker):
@@ -730,10 +729,9 @@ def test_should_not_send_sms_if_team_api_key_and_not_a_service_user(notify_api, 
         app.celery.tasks.send_sms.apply_async.assert_not_called()
 
         assert response.status_code == 400
-        assert [(
-            'Can’t send to this recipient when service is in trial mode – see '
-            'https://www.notifications.service.gov.uk/trial-mode'
-        )] == json_resp['message']['to']
+        assert [
+            'Can’t send to this recipient using a team-only API key'
+        ] == json_resp['message']['to']
 
 
 def test_should_send_email_if_team_api_key_and_a_service_user(notify_api, sample_email_template, mocker):


### PR DESCRIPTION
## Give better error when sending to non-team members

Scenario we saw in research:
- trying to send a message to someone outside your team
- service is in trial mode

Result:
- error message was terrible, no-one understood it

Solution:
- better error message


## Show separate error messages for team key

Although using a team key is functionally the same as your service being restricted, conflating the two errors is not helpful. What we typically saw in research was that someone was using a team key, got the error, used a live key and got the _same_ error.

This commit adds a new error message that specifically mentions the type of API key that you’re using.