### PR TITLE
Missing the name on the aws start celery command

### DIFF
--- a/aws_run_celery.py
+++ b/aws_run_celery.py
@@ -6,5 +6,5 @@ import os
 # on aws get secrets and export to env
 os.environ.update(getAllSecrets(region="eu-west-1"))
 
-application = create_app()
+application = create_app("delivery")
 application.app_context().push()


### PR DESCRIPTION
- means that logs are branded as application:api not delivery.