### PR TITLE
Template useage per

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -39,11 +39,9 @@ def dao_get_notification_statistics_for_service(service_id, limit_days=None):
     query_filter = [NotificationStatistics.service_id == service_id]
     if limit_days is not None:
         query_filter.append(NotificationStatistics.day >= days_ago(limit_days))
-    return NotificationStatistics.query.filter(
-        *query_filter
-    ).order_by(
-        desc(NotificationStatistics.day)
-    ).all()
+    return NotificationStatistics.query.filter(*query_filter)\
+        .order_by(desc(NotificationStatistics.day))\
+        .all()
 
 
 @statsd(namespace="dao")
@@ -162,9 +160,8 @@ def dao_get_template_usage(service_id, limit_days=None):
 
 @statsd(namespace="dao")
 def dao_get_last_template_usage(template_id):
-    return NotificationHistory.query.filter(
-        NotificationHistory.template_id == template_id
-    ).join(Template) \
+    return NotificationHistory.query.filter(NotificationHistory.template_id == template_id)\
+        .join(Template) \
         .order_by(desc(NotificationHistory.created_at)) \
         .first()
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -137,7 +137,6 @@ def dao_get_7_day_agg_notification_statistics_for_service(service_id,
 
 @statsd(namespace="dao")
 def dao_get_template_usage(service_id, limit_days=None):
-
     table = NotificationHistory
 
     if limit_days and limit_days <= 7:  # can get this data from notifications table
@@ -155,28 +154,19 @@ def dao_get_template_usage(service_id, limit_days=None):
         query_filter.append(table.created_at >= days_ago(limit_days))
 
     return query.filter(*query_filter) \
-        .join(Template)\
-        .group_by(table.template_id, Template.name, Template.template_type)\
-        .order_by(asc(Template.name))\
+        .join(Template) \
+        .group_by(table.template_id, Template.name, Template.template_type) \
+        .order_by(asc(Template.name)) \
         .all()
 
 
 @statsd(namespace="dao")
-def dao_get_template_statistics_for_service(service_id, limit_days=None):
-    query_filter = [TemplateStatistics.service_id == service_id]
-    if limit_days is not None:
-        query_filter.append(TemplateStatistics.day >= days_ago(limit_days))
-    return TemplateStatistics.query.filter(*query_filter).order_by(
-        desc(TemplateStatistics.updated_at)).all()
-
-
-@statsd(namespace="dao")
-def dao_get_template_statistics_for_template(template_id):
-    return TemplateStatistics.query.filter(
-        TemplateStatistics.template_id == template_id
-    ).order_by(
-        desc(TemplateStatistics.updated_at)
-    ).all()
+def dao_get_last_template_usage(template_id):
+    return NotificationHistory.query.filter(
+        NotificationHistory.template_id == template_id
+    ).join(Template) \
+        .order_by(desc(NotificationHistory.created_at)) \
+        .first()
 
 
 @statsd(namespace="dao")

--- a/app/template_statistics/rest.py
+++ b/app/template_statistics/rest.py
@@ -6,11 +6,9 @@ from flask import (
 
 from app.dao.notifications_dao import (
     dao_get_template_usage,
-    dao_get_template_statistics_for_service,
-    dao_get_template_statistics_for_template
-)
+    dao_get_last_template_usage)
 
-from app.schemas import template_statistics_schema
+from app.schemas import notifications_filter_schema, NotificationWithTemplateSchema, notification_with_template_schema
 
 template_statistics = Blueprint('template-statistics',
                                 __name__,
@@ -47,6 +45,10 @@ def get_template_statistics_for_service_by_day(service_id):
 
 @template_statistics.route('/<template_id>')
 def get_template_statistics_for_template_id(service_id, template_id):
-    stats = dao_get_template_statistics_for_template(template_id)
-    data = template_statistics_schema.dump(stats, many=True).data
+    notification = dao_get_last_template_usage(template_id)
+    if not notification:
+        message = 'No template found for id {}'.format(template_id)
+        errors = {'template_id': [message]}
+        raise InvalidRequest(errors, status_code=404)
+    data = notification_with_template_schema.dump(notification).data
     return jsonify(data=data)

--- a/tests/app/template_statistics/test_rest.py
+++ b/tests/app/template_statistics/test_rest.py
@@ -193,7 +193,6 @@ def test_get_template_statistics_by_id_returns_last_notification(
 
             assert response.status_code == 200
             json_resp = json.loads(response.get_data(as_text=True))['data']
-            print(json_resp)
             assert json_resp['id'] == str(notification_3.id)
 
 


### PR DESCRIPTION
Requires https://github.com/alphagov/notifications-api/pull/610

Is a breaking ADMIN change.

Changes last template usage query to be based on history table and gets last row for that template to allow us to work out what the last use for that template was.