### PR TITLE
Don’t prefix text messages if sender name is set

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -61,7 +61,7 @@ def send_sms_to_provider(self, service_id, notification_id):
         template = Template(
             template_model.__dict__,
             values={} if not notification.personalisation else notification.personalisation,
-            renderer=SMSMessage(prefix=service.name)
+            renderer=SMSMessage(prefix=service.name, sender=service.sms_sender)
         )
         try:
             if service.research_mode or notification.key_type == KEY_TYPE_TEST:

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ statsd==3.2.1
 git+https://github.com/alphagov/notifications-python-client.git@1.0.0#egg=notifications-python-client==1.0.0
 
 
-git+https://github.com/alphagov/notifications-utils.git@8.7.6#egg=notifications-utils==8.7.6
+git+https://github.com/alphagov/notifications-utils.git@9.0.0#egg=notifications-utils==9.0.0

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -357,7 +357,7 @@ def test_should_send_sms_sender_from_service_if_present(
 
     mmg_client.send_sms.assert_called_once_with(
         to=format_phone_number(validate_phone_number("+447234123123")),
-        content="Sample service: This is a template:\nwith a newline",
+        content="This is a template:\nwith a newline",
         reference=str(db_notification.id),
         sender=sample_service.sms_sender
     )


### PR DESCRIPTION
Implements:
- [x] https://github.com/alphagov/notifications-utils/pull/66