### PR TITLE
Remove restrictions when using simulate API key

### DIFF
--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -15,7 +15,7 @@ from notifications_utils.renderers import PassThrough
 from app.clients.email.aws_ses import get_aws_responses
 from app import api_user, encryption, create_uuid, DATETIME_FORMAT, DATE_FORMAT, statsd_client
 from app.dao.services_dao import dao_fetch_todays_stats_for_service
-from app.models import KEY_TYPE_TEAM
+from app.models import KEY_TYPE_TEAM, KEY_TYPE_TEST
 from app.dao import (
     templates_dao,
     services_dao,
@@ -259,12 +259,16 @@ def send_notification(notification_type):
         errors = {'content': [message]}
         raise InvalidRequest(errors, status_code=400)
 
-    if (service.restricted or api_user.key_type == KEY_TYPE_TEAM) and not allowed_to_send_to(
-        notification['to'],
-        itertools.chain.from_iterable(
-            [user.mobile_number, user.email_address] for user in service.users
+    if all((
+        api_user.key_type != KEY_TYPE_TEST,
+        service.restricted or api_user.key_type == KEY_TYPE_TEAM,
+        not allowed_to_send_to(
+            notification['to'],
+            itertools.chain.from_iterable(
+                [user.mobile_number, user.email_address] for user in service.users
+            )
         )
-    ):
+    )):
         if (api_user.key_type == KEY_TYPE_TEAM):
             message = 'Can’t send to this recipient using a team-only API key'
         else:

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -215,7 +215,10 @@ def send_notification(notification_type):
 
     service_stats = sum(row.count for row in dao_fetch_todays_stats_for_service(service.id))
 
-    if service_stats >= service.message_limit:
+    if all((
+        api_user.key_type != KEY_TYPE_TEST,
+        service_stats >= service.message_limit
+    )):
         error = 'Exceeded send limits ({}) for today'.format(service.message_limit)
         raise InvalidRequest(error, status_code=429)
 

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -764,7 +764,11 @@ def test_should_send_email_if_team_api_key_and_a_service_user(notify_api, sample
         assert response.status_code == 201
 
 
-def test_should_send_email_to_anyone_with_test_key(notify_api, sample_email_template, mocker):
+@pytest.mark.parametrize('restricted', [True, False])
+@pytest.mark.parametrize('limit', [0, 1])
+def test_should_send_email_to_anyone_with_test_key(
+    notify_api, sample_email_template, mocker, restricted, limit
+):
     with notify_api.test_request_context(), notify_api.test_client() as client:
         mocker.patch('app.celery.tasks.send_email.apply_async')
 
@@ -772,7 +776,8 @@ def test_should_send_email_to_anyone_with_test_key(notify_api, sample_email_temp
             'to': 'anyone123@example.com',
             'template': sample_email_template.id
         }
-        sample_email_template.service.restricted = True
+        sample_email_template.service.restricted = restricted
+        sample_email_template.service.message_limit = limit
         api_key = ApiKey(
             service=sample_email_template.service,
             name='test_key',

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -10,7 +10,7 @@ from notifications_python_client.authentication import create_jwt_token
 
 import app
 from app import encryption
-from app.models import ApiKey, KEY_TYPE_TEAM
+from app.models import ApiKey, KEY_TYPE_TEAM, KEY_TYPE_TEST
 from app.dao.templates_dao import dao_get_all_templates_for_service, dao_update_template
 from app.dao.services_dao import dao_update_service
 from app.dao.api_key_dao import save_model_api_key
@@ -761,6 +761,41 @@ def test_should_send_email_if_team_api_key_and_a_service_user(notify_api, sample
                 'key_type': api_key.key_type
             },
             queue='email')
+        assert response.status_code == 201
+
+
+def test_should_send_email_to_anyone_with_test_key(notify_api, sample_email_template, mocker):
+    with notify_api.test_request_context(), notify_api.test_client() as client:
+        mocker.patch('app.celery.tasks.send_email.apply_async')
+
+        data = {
+            'to': 'anyone123@example.com',
+            'template': sample_email_template.id
+        }
+        sample_email_template.service.restricted = True
+        api_key = ApiKey(
+            service=sample_email_template.service,
+            name='test_key',
+            created_by=sample_email_template.created_by,
+            key_type=KEY_TYPE_TEST
+        )
+        save_model_api_key(api_key)
+        auth_header = create_jwt_token(secret=api_key.unsigned_secret, client_id=str(api_key.service_id))
+
+        response = client.post(
+            path='/notifications/email',
+            data=json.dumps(data),
+            headers=[('Content-Type', 'application/json'), ('Authorization', 'Bearer {}'.format(auth_header))]
+        )
+
+        app.celery.tasks.send_email.apply_async.assert_called_once_with(
+            ANY,
+            kwargs={
+                'api_key_id': str(api_key.id),
+                'key_type': api_key.key_type
+            },
+            queue='email'
+        )
         assert response.status_code == 201
 
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/128136359

When you use a test API key it should behave like a live service, except for actually sending the messages. There should be no limits even if the service is in trial mode.

This pull request removes these restrictions when you use a test key:
- sending messages to people outside your team when you’re in trial mode.
- sending messages when you’ve sent up to your daily limit.