### PR TITLE
Return empty stats list for job creation

### DIFF
--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -129,4 +129,7 @@ def create_job(service_id):
     if job.job_status == JOB_STATUS_PENDING:
         process_job.apply_async([str(job.id)], queue="process-job")
 
-    return jsonify(data=job_schema.dump(job).data), 201
+    job_json = job_schema.dump(job).data
+    job_json['statistics'] = []
+
+    return jsonify(data=job_json), 201

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -140,6 +140,7 @@ def test_create_unscheduled_job(notify_api, sample_template, mocker, fake_uuid):
 
             assert resp_json['data']['id'] == fake_uuid
             assert resp_json['data']['status'] == 'pending'
+            assert resp_json['data']['statistics'] == []
             assert not resp_json['data']['scheduled_for']
             assert resp_json['data']['job_status'] == 'pending'
             assert resp_json['data']['template'] == str(sample_template.id)
@@ -176,6 +177,7 @@ def test_create_scheduled_job(notify_api, sample_template, mocker, fake_uuid):
                 resp_json = json.loads(response.get_data(as_text=True))
 
                 assert resp_json['data']['id'] == fake_uuid
+                assert resp_json['data']['statistics'] == []
                 assert resp_json['data']['status'] == 'pending'
                 assert resp_json['data']['scheduled_for'] == datetime(2016, 1, 2, 11, 59, 0,
                                                                       tzinfo=pytz.UTC).isoformat()


### PR DESCRIPTION
FAO @quis 

Should fix issue we saw on preview.

Adds statistics block onto the job when a create-job is called