### PR TITLE
Fix test to expect correct db queue

### DIFF
--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -799,7 +799,7 @@ def test_should_send_email_to_anyone_with_test_key(
                 'api_key_id': str(api_key.id),
                 'key_type': api_key.key_type
             },
-            queue='email'
+            queue='db-email'
         )
         assert response.status_code == 201
 


### PR DESCRIPTION
Sending emails was moved to a different queue in https://github.com/alphagov/notifications-api/pull/647

At the time that https://github.com/alphagov/notifications-api/pull/645 was written, the previous queues were still being used. So when #645 got merged it was testing for the old queues, which broke the tests.