### PR TITLE
add junit xml reporting to pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,8 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
+test_results.xml
 *,cover
 
 # Translations

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -30,5 +30,5 @@ fi
 pep8 .
 display_result $? 1 "Code style check"
 
-py.test --cov=app --cov-report=term-missing tests/
+py.test --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml
 display_result $? 2 "Unit tests"


### PR DESCRIPTION
so we can get test stats (including time taken, which i'm most interested in) on jenkins. creates test_results.xml in your project root.