### PR TITLE
Add an endpoint to cancel a job

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -46,8 +46,12 @@ def dao_get_scheduled_jobs():
 
 def dao_get_future_scheduled_job_by_id_and_service_id(job_id, service_id):
     return Job.query \
-        .filter_by(service_id=service_id, id=job_id) \
-        .filter(Job.job_status == 'scheduled', Job.scheduled_for > datetime.utcnow()) \
+        .filter(
+            Job.service_id == service_id,
+            Job.id == job_id,
+            Job.job_status == 'scheduled',
+            Job.scheduled_for > datetime.utcnow()
+        ) \
         .one()
 
 

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -39,7 +39,10 @@ def dao_get_job_by_id(job_id):
 
 def dao_get_scheduled_jobs():
     return Job.query \
-        .filter(Job.job_status == JOB_STATUS_SCHEDULED, Job.scheduled_for < datetime.utcnow()) \
+        .filter(
+            Job.job_status == JOB_STATUS_SCHEDULED,
+            Job.scheduled_for < datetime.utcnow()
+        ) \
         .order_by(asc(Job.scheduled_for)) \
         .all()
 

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -44,6 +44,13 @@ def dao_get_scheduled_jobs():
         .all()
 
 
+def dao_get_future_scheduled_job_by_id_and_service_id(job_id, service_id):
+    return Job.query \
+        .filter_by(service_id=service_id, id=job_id) \
+        .filter(Job.job_status == 'scheduled', Job.scheduled_for > datetime.utcnow()) \
+        .one()
+
+
 def dao_create_job(job):
     db.session.add(job)
     db.session.commit()

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta, datetime
 from sqlalchemy import desc, asc, cast, Date as sql_date
 from app import db
 from app.dao import days_ago
-from app.models import Job, NotificationHistory
+from app.models import Job, NotificationHistory, JOB_STATUS_SCHEDULED
 from app.statsd_decorators import statsd
 from sqlalchemy import func, asc
 
@@ -39,7 +39,7 @@ def dao_get_job_by_id(job_id):
 
 def dao_get_scheduled_jobs():
     return Job.query \
-        .filter(Job.job_status == 'scheduled', Job.scheduled_for < datetime.utcnow()) \
+        .filter(Job.job_status == JOB_STATUS_SCHEDULED, Job.scheduled_for < datetime.utcnow()) \
         .order_by(asc(Job.scheduled_for)) \
         .all()
 
@@ -49,7 +49,7 @@ def dao_get_future_scheduled_job_by_id_and_service_id(job_id, service_id):
         .filter(
             Job.service_id == service_id,
             Job.id == job_id,
-            Job.job_status == 'scheduled',
+            Job.job_status == JOB_STATUS_SCHEDULED,
             Job.scheduled_for > datetime.utcnow()
         ) \
         .one()

--- a/app/models.py
+++ b/app/models.py
@@ -308,6 +308,7 @@ JOB_STATUS_IN_PROGRESS = 'in progress'
 JOB_STATUS_FINISHED = 'finished'
 JOB_STATUS_SENDING_LIMITS_EXCEEDED = 'sending limits exceeded'
 JOB_STATUS_SCHEDULED = 'scheduled'
+JOB_STATUS_CANCELLED = 'cancelled'
 
 
 class JobStatus(db.Model):

--- a/migrations/versions/0051_cancelled_job_status.py
+++ b/migrations/versions/0051_cancelled_job_status.py
@@ -1,0 +1,22 @@
+"""empty message
+
+Revision ID: 0051_cancelled_job_status
+Revises: 0050_index_for_stats
+Create Date: 2016-09-01 14:34:06.839381
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0051_cancelled_job_status'
+down_revision = '0050_index_for_stats'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+    op.execute("INSERT INTO job_status VALUES ('cancelled')")
+
+def downgrade():
+    op.execute("UPDATE jobs SET job_status = 'finished' WHERE job_status = 'cancelled'")
+    op.execute("DELETE FROM job_status WHERE name = 'cancelled';")

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1,7 +1,7 @@
 import requests_mock
 import pytest
 import uuid
-from datetime import (datetime, date)
+from datetime import (datetime, date, timedelta)
 
 from flask import current_app
 
@@ -285,6 +285,22 @@ def sample_job_with_placeholdered_template(
         notify_db_session,
         service=service,
         template=sample_template_with_placeholders(notify_db, notify_db_session)
+    )
+
+
+@pytest.fixture(scope='function')
+def sample_scheduled_job(
+    notify_db,
+    notify_db_session,
+    service=None
+):
+    return sample_job(
+        notify_db,
+        notify_db_session,
+        service=service,
+        template=sample_template_with_placeholders(notify_db, notify_db_session),
+        scheduled_for=(datetime.utcnow() + timedelta(minutes=60)).isoformat(),
+        job_status='scheduled'
     )
 
 

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -247,15 +247,15 @@ def test_get_scheduled_jobs_gets_ignores_jobs_not_scheduled(notify_db, notify_db
     assert jobs[0].id == job_scheduled.id
 
 
-def test_get_scheduled_jobs_gets_ignores_jobs_scheduled_in_the_future(notify_db, notify_db_session):
-    one_minute_in_the_future = datetime.utcnow() + timedelta(minutes=1)
-    sample_job(notify_db, notify_db_session, scheduled_for=one_minute_in_the_future, job_status='scheduled')
+def test_get_scheduled_jobs_gets_ignores_jobs_scheduled_in_the_future(
+    notify_db, notify_db_session, sample_scheduled_job
+):
     jobs = dao_get_scheduled_jobs()
     assert len(jobs) == 0
 
 
-def test_get_future_scheduled_job_gets_a_job_yet_to_send(notify_db, notify_db_session):
-    one_hour_from_now = datetime.utcnow() + timedelta(minutes=60)
-    job = sample_job(notify_db, notify_db_session, scheduled_for=one_hour_from_now, job_status='scheduled')
-    result = dao_get_future_scheduled_job_by_id_and_service_id(job.id, job.service_id)
-    assert result.id == job.id
+def test_get_future_scheduled_job_gets_a_job_yet_to_send(
+    notify_db, notify_db_session, sample_scheduled_job
+):
+    result = dao_get_future_scheduled_job_by_id_and_service_id(sample_scheduled_job.id, sample_scheduled_job.service_id)
+    assert result.id == sample_scheduled_job.id

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -247,15 +247,11 @@ def test_get_scheduled_jobs_gets_ignores_jobs_not_scheduled(notify_db, notify_db
     assert jobs[0].id == job_scheduled.id
 
 
-def test_get_scheduled_jobs_gets_ignores_jobs_scheduled_in_the_future(
-    notify_db, notify_db_session, sample_scheduled_job
-):
+def test_get_scheduled_jobs_gets_ignores_jobs_scheduled_in_the_future(sample_scheduled_job):
     jobs = dao_get_scheduled_jobs()
     assert len(jobs) == 0
 
 
-def test_get_future_scheduled_job_gets_a_job_yet_to_send(
-    notify_db, notify_db_session, sample_scheduled_job
-):
+def test_get_future_scheduled_job_gets_a_job_yet_to_send(sample_scheduled_job):
     result = dao_get_future_scheduled_job_by_id_and_service_id(sample_scheduled_job.id, sample_scheduled_job.service_id)
     assert result.id == sample_scheduled_job.id

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -7,6 +7,7 @@ from app.dao.jobs_dao import (
     dao_update_job,
     dao_get_jobs_by_service_id,
     dao_get_scheduled_jobs,
+    dao_get_future_scheduled_job_by_id_and_service_id,
     dao_get_notification_outcomes_for_job
 )
 
@@ -251,3 +252,10 @@ def test_get_scheduled_jobs_gets_ignores_jobs_scheduled_in_the_future(notify_db,
     sample_job(notify_db, notify_db_session, scheduled_for=one_minute_in_the_future, job_status='scheduled')
     jobs = dao_get_scheduled_jobs()
     assert len(jobs) == 0
+
+
+def test_get_future_scheduled_job_gets_a_job_yet_to_send(notify_db, notify_db_session):
+    one_hour_from_now = datetime.utcnow() + timedelta(minutes=60)
+    job = sample_job(notify_db, notify_db_session, scheduled_for=one_hour_from_now, job_status='scheduled')
+    result = dao_get_future_scheduled_job_by_id_and_service_id(job.id, job.service_id)
+    assert result.id == job.id


### PR DESCRIPTION
If you schedule a job you might change your mind or circumstances might change. So you need to be able to cancel it. This commit adds a `DELETE` endpoint for individual jobs which sets their status to `cancelled`.

I don’t really know what I’m doing here so someone should probably take a close look at it.