### PR TITLE
Fix mis-matched database migrations

### DIFF
--- a/migrations/versions/0053_cancelled_job_status.py
+++ b/migrations/versions/0053_cancelled_job_status.py
@@ -1,14 +1,14 @@
 """empty message
 
-Revision ID: 0051_cancelled_job_status
-Revises: 0050_index_for_stats
+Revision ID: 0053_cancelled_job_status
+Revises: 0052_drop_jobs_status
 Create Date: 2016-09-01 14:34:06.839381
 
 """
 
 # revision identifiers, used by Alembic.
-revision = '0051_cancelled_job_status'
-down_revision = '0050_index_for_stats'
+revision = '0053_cancelled_job_status'
+down_revision = '0052_drop_jobs_status'
 
 from alembic import op
 import sqlalchemy as sa


### PR DESCRIPTION
The cancelled job migration originally went in as version `0051`.

But `0051_set_job_status` went in first in e3fa8bffd7dd436a9d3da68058528d3ad1cd2c09

This meant that Alembic couldn’t work out what order to run the migrations in, and blew up.

This commit puts the scheduled job migration after all others.