### PR TITLE
Update Python client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ celery==3.1.23
 monotonic==1.2
 statsd==3.2.1
 
-git+https://github.com/alphagov/notifications-python-client.git@1.2.0#egg=notifications-python-client==1.2.0
+git+https://github.com/alphagov/notifications-python-client.git@1.3.0#egg=notifications-python-client==1.3.0
 
 
 git+https://github.com/alphagov/notifications-utils.git@9.0.1#egg=notifications-utils==9.0.1


### PR DESCRIPTION
Just so that nobody else has to do it.

Implements:
- [x] https://github.com/alphagov/notifications-python-client/pull/29

Which is a breaking change, but the breaking bits don’t seem to affect this app.