### PR TITLE
Fix a bug in the accept invitation that was throwing a 500.

### DIFF
--- a/app/accept_invite/rest.py
+++ b/app/accept_invite/rest.py
@@ -33,8 +33,7 @@ def get_invited_user_by_token(token):
                                       current_app.config['DANGEROUS_SALT'],
                                       max_age_seconds)
     except SignatureExpired:
-        message = 'Invitation with id {} expired'.format(invited_user_id)
-        errors = {'invitation': [message]}
+        errors = {'invitation': ['Invitation has expired']}
         raise InvalidRequest(errors, status_code=400)
 
     invited_user = get_invited_user_by_id(invited_user_id)

--- a/tests/app/accept_invite/test_accept_invite_rest.py
+++ b/tests/app/accept_invite/test_accept_invite_rest.py
@@ -1,0 +1,59 @@
+import uuid
+
+import pytest
+from flask import json
+from freezegun import freeze_time
+from notifications_utils.url_safe_token import generate_token
+
+from tests import create_authorization_header
+
+
+def test_accept_invite_for_expired_token_returns_400(notify_api, sample_invited_user):
+    with notify_api.test_request_context():
+        with notify_api.test_client() as client:
+            with freeze_time('2016-01-01T12:00:00'):
+                token = generate_token(str(sample_invited_user.id), notify_api.config['SECRET_KEY'],
+                                       notify_api.config['DANGEROUS_SALT'])
+        url = '/invite/{}'.format(token)
+        auth_header = create_authorization_header()
+        response = client.get(url, headers=[('Content-Type', 'application/json'), auth_header])
+
+        assert response.status_code == 400
+        json_resp = json.loads(response.get_data(as_text=True))
+        assert json_resp['result'] == 'error'
+        assert json_resp['message'] == {'invitation': ['Invitation has expired']}
+
+
+def test_accept_invite_returns_200_when_token_valid(notify_api, sample_invited_user):
+    with notify_api.test_request_context():
+        with notify_api.test_client() as client:
+            token = generate_token(str(sample_invited_user.id), notify_api.config['SECRET_KEY'],
+                                       notify_api.config['DANGEROUS_SALT'])
+            url = '/invite/{}'.format(token)
+            auth_header = create_authorization_header()
+            response = client.get(url, headers=[('Content-Type', 'application/json'), auth_header])
+
+            assert response.status_code == 200
+            json_resp = json.loads(response.get_data(as_text=True))
+            assert json_resp['data']['id'] == str(sample_invited_user.id)
+            assert json_resp['data']['email_address'] == sample_invited_user.email_address
+            assert json_resp['data']['from_user'] == str(sample_invited_user.user_id)
+            assert json_resp['data']['service']== str(sample_invited_user.service_id)
+            assert json_resp['data']['status'] == sample_invited_user.status
+            assert json_resp['data']['permissions'] == sample_invited_user.permissions
+
+
+
+def test_accept_invite_returns_200_when_token_valid(notify_api):
+    with notify_api.test_request_context():
+        with notify_api.test_client() as client:
+            token = generate_token(str(uuid.uuid4()), notify_api.config['SECRET_KEY'],
+                                       notify_api.config['DANGEROUS_SALT'])
+            url = '/invite/{}'.format(token)
+            auth_header = create_authorization_header()
+            response = client.get(url, headers=[('Content-Type', 'application/json'), auth_header])
+
+            assert response.status_code == 404
+            json_resp = json.loads(response.get_data(as_text=True))
+            assert json_resp['result'] == 'error'
+            assert json_resp['message'] == 'No result found'

--- a/tests/app/accept_invite/test_accept_invite_rest.py
+++ b/tests/app/accept_invite/test_accept_invite_rest.py
@@ -4,7 +4,6 @@ import pytest
 from flask import json
 from freezegun import freeze_time
 from notifications_utils.url_safe_token import generate_token
-
 from tests import create_authorization_header
 
 
@@ -28,7 +27,7 @@ def test_accept_invite_returns_200_when_token_valid(notify_api, sample_invited_u
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             token = generate_token(str(sample_invited_user.id), notify_api.config['SECRET_KEY'],
-                                       notify_api.config['DANGEROUS_SALT'])
+                                   notify_api.config['DANGEROUS_SALT'])
             url = '/invite/{}'.format(token)
             auth_header = create_authorization_header()
             response = client.get(url, headers=[('Content-Type', 'application/json'), auth_header])
@@ -38,17 +37,16 @@ def test_accept_invite_returns_200_when_token_valid(notify_api, sample_invited_u
             assert json_resp['data']['id'] == str(sample_invited_user.id)
             assert json_resp['data']['email_address'] == sample_invited_user.email_address
             assert json_resp['data']['from_user'] == str(sample_invited_user.user_id)
-            assert json_resp['data']['service']== str(sample_invited_user.service_id)
+            assert json_resp['data']['service'] == str(sample_invited_user.service_id)
             assert json_resp['data']['status'] == sample_invited_user.status
             assert json_resp['data']['permissions'] == sample_invited_user.permissions
 
 
-
-def test_accept_invite_returns_200_when_token_valid(notify_api):
+def test_accept_invite_returns_400_when_invited_user_does_not_exist(notify_api):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             token = generate_token(str(uuid.uuid4()), notify_api.config['SECRET_KEY'],
-                                       notify_api.config['DANGEROUS_SALT'])
+                                   notify_api.config['DANGEROUS_SALT'])
             url = '/invite/{}'.format(token)
             auth_header = create_authorization_header()
             response = client.get(url, headers=[('Content-Type', 'application/json'), auth_header])


### PR DESCRIPTION
- If the token for invitation was expired, the method would throw a 500 while creating the erorr message.
- Added unit tests.