### PR TITLE
Update the timeout_notifications scheduled tasks.

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -7,8 +7,8 @@ from app.aws import s3
 from app import notify_celery
 from app.dao.invited_user_dao import delete_invitations_created_more_than_two_days_ago
 from app.dao.jobs_dao import dao_get_scheduled_jobs, dao_update_job, dao_get_jobs_older_than
-from app.dao.notifications_dao import delete_notifications_created_more_than_a_week_ago, get_notifications, \
-    update_notification_status_by_id
+from app.dao.notifications_dao import (delete_notifications_created_more_than_a_week_ago,
+                                       dao_timeout_notifications)
 from app.dao.users_dao import delete_codes_older_created_more_than_a_day_ago
 from app.statsd_decorators import statsd
 from app.models import JOB_STATUS_PENDING
@@ -111,21 +111,13 @@ def delete_invitations():
 @notify_celery.task(name='timeout-sending-notifications')
 @statsd(namespace="tasks")
 def timeout_notifications():
-    # TODO: optimize the query by adding the date where clause to this query.
-    notifications = get_notifications(filter_dict={'status': 'sending'})
-    now = datetime.utcnow()
-    for noti in notifications:
-        try:
-            if (now - noti.created_at) > timedelta(
-                    seconds=current_app.config.get('SENDING_NOTIFICATIONS_TIMEOUT_PERIOD')
-            ):
-                # TODO: think about making this a bulk update rather than one at a time.
-                updated = update_notification_status_by_id(noti.id, 'temporary-failure')
-                if updated:
-                    current_app.logger.info(
-                        "Timeout period reached for notification ({}), status has been updated.".format(noti.id))
-        except Exception as e:
-            current_app.logger.exception(e)
-            current_app.logger.error(
-                "Exception raised trying to timeout notification ({}) skipping notification update.".format(noti.id)
-            )
+    try:
+        updated = dao_timeout_notifications(current_app.config.get('SENDING_NOTIFICATIONS_TIMEOUT_PERIOD'))
+        if updated:
+            current_app.logger.info(
+                "Timeout period reached for {} notifications, status has been updated.".format(updated))
+    except Exception as e:
+        current_app.logger.exception(e)
+        current_app.logger.error(
+            "Exception raised trying to timeout notification skipping notification update."
+        )

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -111,13 +111,7 @@ def delete_invitations():
 @notify_celery.task(name='timeout-sending-notifications')
 @statsd(namespace="tasks")
 def timeout_notifications():
-    try:
-        updated = dao_timeout_notifications(current_app.config.get('SENDING_NOTIFICATIONS_TIMEOUT_PERIOD'))
-        if updated:
-            current_app.logger.info(
-                "Timeout period reached for {} notifications, status has been updated.".format(updated))
-    except Exception as e:
-        current_app.logger.exception(e)
-        current_app.logger.error(
-            "Exception raised trying to timeout notification skipping notification update."
-        )
+    updated = dao_timeout_notifications(current_app.config.get('SENDING_NOTIFICATIONS_TIMEOUT_PERIOD'))
+    if updated:
+        current_app.logger.info(
+            "Timeout period reached for {} notifications, status has been updated.".format(updated))

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -17,7 +17,11 @@ from app.models import (
     Notification,
     NotificationHistory,
     NotificationStatistics,
-    Template)
+    Template,
+    NOTIFICATION_CREATED,
+    NOTIFICATION_SENDING,
+    NOTIFICATION_PENDING,
+    NOTIFICATION_TEMPORARY_FAILURE)
 
 from app.dao.dao_utils import transactional
 from app.statsd_decorators import statsd
@@ -286,3 +290,18 @@ def dao_delete_notifications_and_history_by_id(notification_id):
     db.session.query(NotificationHistory).filter(
         NotificationHistory.id == notification_id
     ).delete(synchronize_session='fetch')
+
+
+def dao_timeout_notifications(timeout_period_in_seconds):
+    # update all notifications that are older that the timeout_period_in_seconds
+    #  with a status of created|sending|pending
+    updated = db.session.query(Notification). \
+        filter(Notification.created_at < (datetime.utcnow() - timedelta(seconds=timeout_period_in_seconds))). \
+        filter(Notification.status.in_([NOTIFICATION_CREATED, NOTIFICATION_SENDING, NOTIFICATION_PENDING])). \
+        update({'status': NOTIFICATION_TEMPORARY_FAILURE}, synchronize_session=False)
+    db.session.query(NotificationHistory). \
+        filter(NotificationHistory.created_at < (datetime.utcnow() - timedelta(seconds=timeout_period_in_seconds))). \
+        filter(NotificationHistory.status.in_([NOTIFICATION_CREATED, NOTIFICATION_SENDING, NOTIFICATION_PENDING])). \
+        update({'status': NOTIFICATION_TEMPORARY_FAILURE}, synchronize_session=False)
+    db.session.commit()
+    return updated

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -295,13 +295,14 @@ def dao_delete_notifications_and_history_by_id(notification_id):
 def dao_timeout_notifications(timeout_period_in_seconds):
     # update all notifications that are older that the timeout_period_in_seconds
     #  with a status of created|sending|pending
+    update_at = datetime.utcnow()
     updated = db.session.query(Notification). \
         filter(Notification.created_at < (datetime.utcnow() - timedelta(seconds=timeout_period_in_seconds))). \
         filter(Notification.status.in_([NOTIFICATION_CREATED, NOTIFICATION_SENDING, NOTIFICATION_PENDING])). \
-        update({'status': NOTIFICATION_TEMPORARY_FAILURE}, synchronize_session=False)
+        update({'status': NOTIFICATION_TEMPORARY_FAILURE, 'updated_at': update_at}, synchronize_session=False)
     db.session.query(NotificationHistory). \
         filter(NotificationHistory.created_at < (datetime.utcnow() - timedelta(seconds=timeout_period_in_seconds))). \
         filter(NotificationHistory.status.in_([NOTIFICATION_CREATED, NOTIFICATION_SENDING, NOTIFICATION_PENDING])). \
-        update({'status': NOTIFICATION_TEMPORARY_FAILURE}, synchronize_session=False)
+        update({'status': NOTIFICATION_TEMPORARY_FAILURE, 'updated_at': update_at}, synchronize_session=False)
     db.session.commit()
     return updated


### PR DESCRIPTION
We found that if the notifications were in created or pending they are not purged from notifications.
- New bulk update method to set all notificaitons with:
  -  a status = created|sending|pending to temporary-failure
  - and is older then today minus SENDING_NOTIFICATIONS_TIMEOUT_PERIOD (in seconds)
- the scheduled task to timeout notifications use the new bulk update query.
- the task will be more efficient