### PR TITLE
Add capability for simulated numbers and email addresses

### DIFF
--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -210,7 +210,6 @@ def send_notification(notification_type):
         template_id=notification['template'],
         service_id=service_id
     )
-
     errors = unarchived_template_schema.validate({'archived': template.archived})
     if errors:
         raise InvalidRequest(errors, status_code=400)
@@ -261,24 +260,29 @@ def send_notification(notification_type):
             status_code=400
         )
 
-    notification_id = create_uuid()
-    notification.update({"template_version": template.version})
-    persist_notification(
-        service,
-        notification_id,
-        notification,
-        datetime.utcnow().strftime(DATETIME_FORMAT),
-        notification_type,
-        str(api_user.id),
-        api_user.key_type
-    )
-
-    return jsonify(
-        data=get_notification_return_data(
+    if not _simulated_recipient(notification['to'], notification_type):
+        notification_id = create_uuid()
+        notification.update({"template_version": template.version})
+        persist_notification(
+            service,
             notification_id,
             notification,
-            template_object)
-    ), 201
+            datetime.utcnow().strftime(DATETIME_FORMAT),
+            notification_type,
+            str(api_user.id),
+            api_user.key_type
+        )
+
+        return jsonify(
+            data=get_notification_return_data(
+                notification_id,
+                notification,
+                template_object)
+        ), 201
+    else:
+        return jsonify(
+            data=_get_simulated_recipient_response_data(template_object)
+        ), 200
 
 
 def get_notification_return_data(notification_id, notification, template):
@@ -302,6 +306,24 @@ def get_notification_statistics_for_day():
     )
     data, errors = notifications_statistics_schema.dump(statistics, many=True)
     return jsonify(data=data), 200
+
+
+def _simulated_recipient(to_address, notification_type):
+    return (to_address in current_app.config['SIMULATED_SMS_NUMBERS']
+            if notification_type == SMS_TYPE
+            else to_address in current_app.config['SIMULATED_EMAIL_ADDRESSES'])
+
+
+def _get_simulated_recipient_response_data(template_object):
+    response_data = {
+        'body': template_object.replaced,
+        'template_version': template_object._template['version']
+    }
+
+    if template_object._template['template_type'] == 'email':
+        response_data.update({'subject': template_object.replaced_subject})
+
+    return response_data
 
 
 def persist_notification(

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -260,9 +260,10 @@ def send_notification(notification_type):
             status_code=400
         )
 
+    notification_id = create_uuid()
+    notification.update({"template_version": template.version})
+
     if not _simulated_recipient(notification['to'], notification_type):
-        notification_id = create_uuid()
-        notification.update({"template_version": template.version})
         persist_notification(
             service,
             notification_id,
@@ -273,16 +274,12 @@ def send_notification(notification_type):
             api_user.key_type
         )
 
-        return jsonify(
-            data=get_notification_return_data(
-                notification_id,
-                notification,
-                template_object)
-        ), 201
-    else:
-        return jsonify(
-            data=_get_simulated_recipient_response_data(template_object)
-        ), 200
+    return jsonify(
+        data=get_notification_return_data(
+            notification_id,
+            notification,
+            template_object)
+    ), 201
 
 
 def get_notification_return_data(notification_id, notification, template):
@@ -312,18 +309,6 @@ def _simulated_recipient(to_address, notification_type):
     return (to_address in current_app.config['SIMULATED_SMS_NUMBERS']
             if notification_type == SMS_TYPE
             else to_address in current_app.config['SIMULATED_EMAIL_ADDRESSES'])
-
-
-def _get_simulated_recipient_response_data(template_object):
-    response_data = {
-        'body': template_object.replaced,
-        'template_version': template_object._template['version']
-    }
-
-    if template_object._template['template_type'] == 'email':
-        response_data.update({'subject': template_object.replaced_subject})
-
-    return response_data
 
 
 def persist_notification(

--- a/config.py
+++ b/config.py
@@ -142,6 +142,13 @@ class Config(object):
 
     SENDING_NOTIFICATIONS_TIMEOUT_PERIOD = 259200
 
+    SIMULATED_EMAIL_ADDRESSES = ('simulate-delivered@notifications.service.gov.uk',
+                                 'simulate-permanent-failure@notifications.service.gov.uk',
+                                 'simulate-temporary-failure@notifications.service.gov.uk',
+                                 )
+
+    SIMULATED_SMS_NUMBERS = ('+447700900000', '+447700900111', '+447700900222')
+
 
 ######################
 # Config overrides ###

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -952,9 +952,7 @@ def test_should_not_persist_notification_or_send_email_if_simulated_email(
         client,
         to_email,
         sample_email_template,
-        fake_uuid,
         mocker):
-    mocker.patch('app.notifications.rest.create_uuid', return_value=fake_uuid)
     apply_async = mocker.patch('app.celery.provider_tasks.send_email_to_provider.apply_async')
 
     data = {
@@ -970,8 +968,8 @@ def test_should_not_persist_notification_or_send_email_if_simulated_email(
         headers=[('Content-Type', 'application/json'), auth_header])
 
     assert response.status_code == 201
-    assert not notifications_dao.get_notification_by_id(fake_uuid)
     apply_async.assert_not_called()
+    assert Notification.query.count() == 0
 
 
 @pytest.mark.parametrize('to_sms', [
@@ -983,9 +981,7 @@ def test_should_not_persist_notification_or_send_sms_if_simulated_number(
         client,
         to_sms,
         sample_template,
-        fake_uuid,
         mocker):
-    mocker.patch('app.notifications.rest.create_uuid', return_value=fake_uuid)
     apply_async = mocker.patch('app.celery.provider_tasks.send_sms_to_provider.apply_async')
 
     data = {
@@ -1001,5 +997,5 @@ def test_should_not_persist_notification_or_send_sms_if_simulated_number(
         headers=[('Content-Type', 'application/json'), auth_header])
 
     assert response.status_code == 201
-    assert not notifications_dao.get_notification_by_id(fake_uuid)
     apply_async.assert_not_called()
+    assert Notification.query.count() == 0

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -963,7 +963,7 @@ def test_should_not_send_email_if_simulated_email_address(client, to_email, samp
         data=json.dumps(data),
         headers=[('Content-Type', 'application/json'), auth_header])
 
-    assert response.status_code == 200
+    assert response.status_code == 201
     apply_async.assert_not_called()
 
 
@@ -987,5 +987,5 @@ def test_should_not_send_sms_if_simulated_sms_number(client, to_sms, sample_temp
         data=json.dumps(data),
         headers=[('Content-Type', 'application/json'), auth_header])
 
-    assert response.status_code == 200
+    assert response.status_code == 201
     apply_async.assert_not_called()

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -674,14 +674,11 @@ def test_should_not_return_html_in_body(notify_api, notify_db, notify_db_session
 def test_should_not_send_email_if_team_api_key_and_not_a_service_user(notify_api, sample_email_template, mocker):
     with notify_api.test_request_context(), notify_api.test_client() as client:
         mocker.patch('app.celery.provider_tasks.send_email_to_provider.apply_async')
-
         data = {
             'to': "not-someone-we-trust@email-address.com",
             'template': str(sample_email_template.id),
         }
 
-        # import pdb
-        # pdb.set_trace()
         auth_header = create_authorization_header(service_id=sample_email_template.service_id, key_type=KEY_TYPE_TEAM)
 
         response = client.post(
@@ -944,3 +941,51 @@ def test_should_delete_sms_notification_and_return_error_if_sqs_fails(notify_api
         assert response.status_code == 500
         assert not notifications_dao.get_notification_by_id(fake_uuid)
         assert not NotificationHistory.query.get(fake_uuid)
+
+
+@pytest.mark.parametrize('to_email', [
+    'simulate-delivered@notifications.service.gov.uk',
+    'simulate-permanent-failure@notifications.service.gov.uk',
+    'simulate-temporary-failure@notifications.service.gov.uk'
+])
+def test_should_not_send_email_if_simulated_email_address(client, to_email, sample_email_template, mocker):
+    apply_async = mocker.patch('app.celery.provider_tasks.send_email_to_provider.apply_async')
+
+    data = {
+        'to': to_email,
+        'template': sample_email_template.id
+    }
+
+    auth_header = create_authorization_header(service_id=sample_email_template.service_id)
+
+    response = client.post(
+        path='/notifications/email',
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header])
+
+    assert response.status_code == 200
+    apply_async.assert_not_called()
+
+
+@pytest.mark.parametrize('to_sms', [
+    '07700 900000',
+    '07700 900111',
+    '07700 900222'
+])
+def test_should_not_send_sms_if_simulated_sms_number(client, to_sms, sample_template, mocker):
+    apply_async = mocker.patch('app.celery.provider_tasks.send_sms_to_provider.apply_async')
+
+    data = {
+        'to': to_sms,
+        'template': sample_template.id
+    }
+
+    auth_header = create_authorization_header(service_id=sample_template.service_id)
+
+    response = client.post(
+        path='/notifications/sms',
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header])
+
+    assert response.status_code == 200
+    apply_async.assert_not_called()


### PR DESCRIPTION
This provides capability to stop emails/sms messages being sent to a specific set of simulated addresses. This provides a means to test these addresses on live without billing. Once a call is made to send an email or sms with the API a simulated response (message body, template id etc.) is returned.

