### PR TITLE
No jobs on api get

### DIFF
--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -168,6 +168,7 @@ def get_notification_by_id(notification_id):
 @notifications.route('/notifications', methods=['GET'])
 def get_all_notifications():
     data = notifications_filter_schema.load(request.args).data
+    include_jobs = data.get('include_jobs', False)
     page = data['page'] if 'page' in data else 1
     page_size = data['page_size'] if 'page_size' in data else current_app.config.get('PAGE_SIZE')
     limit_days = data.get('limit_days')
@@ -179,7 +180,8 @@ def get_all_notifications():
         page=page,
         page_size=page_size,
         limit_days=limit_days,
-        key_type=api_user.key_type)
+        key_type=api_user.key_type,
+        include_jobs=include_jobs)
     return jsonify(
         notifications=notification_with_personalisation_schema.dump(pagination.items, many=True).data,
         page_size=page_size,

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -421,6 +421,7 @@ class NotificationsFilterSchema(ma.Schema):
     page = fields.Int(required=False)
     page_size = fields.Int(required=False)
     limit_days = fields.Int(required=False)
+    include_jobs = fields.Boolean(required=False)
 
     @pre_load
     def handle_multidict(self, in_data):

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -219,7 +219,8 @@ def get_all_notifications_for_service(service_id):
         filter_dict=data,
         page=page,
         page_size=page_size,
-        limit_days=limit_days)
+        limit_days=limit_days,
+        include_jobs=True)
     kwargs = request.args.to_dict()
     kwargs['service_id'] = service_id
     return jsonify(

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -19,7 +19,7 @@ from app.models import (
     ProviderStatistics,
     ProviderDetails,
     NotificationStatistics,
-    KEY_TYPE_NORMAL)
+    KEY_TYPE_NORMAL, KEY_TYPE_TEST, KEY_TYPE_TEAM)
 from app.dao.users_dao import (save_model_user, create_user_code, create_secret_code)
 from app.dao.services_dao import (dao_create_service, dao_add_user_to_service)
 from app.dao.templates_dao import dao_create_template
@@ -242,6 +242,16 @@ def sample_api_key(notify_db,
 
 
 @pytest.fixture(scope='function')
+def sample_test_api_key(notify_db, notify_db_session, service=None):
+    return sample_api_key(notify_db, notify_db_session, service, KEY_TYPE_TEST)
+
+
+@pytest.fixture(scope='function')
+def sample_team_api_key(notify_db, notify_db_session, service=None):
+    return sample_api_key(notify_db, notify_db_session, service, KEY_TYPE_TEAM)
+
+
+@pytest.fixture(scope='function')
 def sample_job(notify_db,
                notify_db_session,
                service=None,
@@ -332,6 +342,48 @@ def sample_email_job(notify_db,
 
 
 @pytest.fixture(scope='function')
+def sample_notification_with_job(
+        notify_db,
+        notify_db_session,
+        service=None,
+        template=None,
+        job=None,
+        job_row_number=None,
+        to_field=None,
+        status='created',
+        reference=None,
+        created_at=None,
+        sent_at=None,
+        billable_units=1,
+        create=True,
+        personalisation=None,
+        api_key_id=None,
+        key_type=KEY_TYPE_NORMAL
+):
+    if job is None:
+        job = sample_job(notify_db, notify_db_session, service=service, template=template)
+
+    return sample_notification(
+        notify_db,
+        notify_db_session,
+        service,
+        template,
+        job=job,
+        job_row_number=job_row_number if job_row_number else None,
+        to_field=to_field,
+        status=status,
+        reference=reference,
+        created_at=created_at,
+        sent_at=sent_at,
+        billable_units=billable_units,
+        create=create,
+        personalisation=personalisation,
+        api_key_id=api_key_id,
+        key_type=key_type
+    )
+
+
+@pytest.fixture(scope='function')
 def sample_notification(notify_db,
                         notify_db_session,
                         service=None,
@@ -354,8 +406,6 @@ def sample_notification(notify_db,
         service = sample_service(notify_db, notify_db_session)
     if template is None:
         template = sample_template(notify_db, notify_db_session, service=service)
-    if job is None:
-        job = sample_job(notify_db, notify_db_session, service=service, template=template)
 
     notification_id = uuid.uuid4()
 
@@ -367,7 +417,7 @@ def sample_notification(notify_db,
     data = {
         'id': notification_id,
         'to': to,
-        'job_id': job.id,
+        'job_id': job.id if job else None,
         'job': job,
         'service_id': service.id,
         'service': service,

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -16,7 +16,9 @@ from app.models import (
     NotificationStatistics,
     TemplateStatistics,
     NOTIFICATION_STATUS_TYPES,
-    KEY_TYPE_NORMAL
+    KEY_TYPE_NORMAL,
+    KEY_TYPE_TEAM,
+    KEY_TYPE_TEST
 )
 
 from app.dao.notifications_dao import (
@@ -39,7 +41,8 @@ from app.dao.notifications_dao import (
 
 from notifications_utils.template import get_sms_fragment_count
 
-from tests.app.conftest import (sample_notification, sample_template, sample_email_template, sample_service)
+from tests.app.conftest import (sample_notification, sample_template, sample_email_template, sample_service, sample_job,
+                                sample_api_key)
 
 
 def test_should_have_decorated_notifications_dao_functions():
@@ -259,8 +262,8 @@ def test_should_by_able_to_update_status_by_id(sample_template, sample_job, mmg_
 
 
 def test_should_not_update_status_by_id_if_not_sending_and_does_not_update_job(notify_db, notify_db_session):
-    notification = sample_notification(notify_db, notify_db_session, status='delivered')
-    job = Job.query.get(notification.job_id)
+    job = sample_job(notify_db, notify_db_session)
+    notification = sample_notification(notify_db, notify_db_session, status='delivered', job=job)
     assert Notification.query.get(notification.id).status == 'delivered'
     assert not update_notification_status_by_id(notification.id, 'failed')
     assert Notification.query.get(notification.id).status == 'delivered'
@@ -268,8 +271,8 @@ def test_should_not_update_status_by_id_if_not_sending_and_does_not_update_job(n
 
 
 def test_should_not_update_status_by_reference_if_not_sending_and_does_not_update_job(notify_db, notify_db_session):
-    notification = sample_notification(notify_db, notify_db_session, status='delivered', reference='reference')
-    job = Job.query.get(notification.job_id)
+    job = sample_job(notify_db, notify_db_session)
+    notification = sample_notification(notify_db, notify_db_session, status='delivered', reference='reference', job=job)
     assert Notification.query.get(notification.id).status == 'delivered'
     assert not update_notification_status_by_reference('reference', 'failed')
     assert Notification.query.get(notification.id).status == 'delivered'
@@ -834,7 +837,7 @@ def _notification_json(sample_template, job_id=None, id=None, status=None):
     return data
 
 
-def test_dao_timeout_notifications(notify_db, notify_db_session,):
+def test_dao_timeout_notifications(notify_db, notify_db_session, ):
     with freeze_time(datetime.utcnow() - timedelta(minutes=1)):
         created = sample_notification(notify_db, notify_db_session)
         sending = sample_notification(notify_db, notify_db_session, status='sending')
@@ -874,3 +877,187 @@ def test_dao_timeout_notifications_only_updates_for_older_notifications(notify_d
     assert NotificationHistory.query.get(pending.id).status == 'pending'
     assert NotificationHistory.query.get(delivered.id).status == 'delivered'
     assert updated == 0
+
+
+def test_should_return_notifications_excluding_jobs_by_default(notify_db, notify_db_session, sample_service):
+    assert len(Notification.query.all()) == 0
+
+    job = sample_job(notify_db, notify_db_session)
+    with_job = sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), status="delivered", job=job
+    )
+    without_job = sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), status="delivered"
+    )
+
+    all_notifications = Notification.query.all()
+    assert len(all_notifications) == 2
+
+    all_notifications = get_notifications_for_service(sample_service.id).items
+    assert len(all_notifications) == 1
+    assert all_notifications[0].id == without_job.id
+
+
+def test_should_return_notifications_including_jobs(notify_db, notify_db_session, sample_service):
+    assert len(Notification.query.all()) == 0
+
+    job = sample_job(notify_db, notify_db_session)
+    with_job = sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), status="delivered", job=job
+    )
+
+    all_notifications = Notification.query.all()
+    assert len(all_notifications) == 1
+
+    all_notifications = get_notifications_for_service(sample_service.id).items
+    assert len(all_notifications) == 0
+
+    all_notifications = get_notifications_for_service(sample_service.id, limit_days=1, include_jobs=True).items
+    assert len(all_notifications) == 1
+    assert all_notifications[0].id == with_job.id
+
+
+def test_get_notifications_created_by_api_or_csv_are_returned_correctly(
+        notify_db,
+        notify_db_session,
+        sample_service,
+        sample_job,
+        sample_api_key,
+        sample_team_api_key,
+        sample_test_api_key
+):
+
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), job=sample_job
+    )
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type
+    )
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), api_key_id=sample_team_api_key.id,
+        key_type=sample_team_api_key.key_type
+    )
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), api_key_id=sample_test_api_key.id,
+        key_type=sample_test_api_key.key_type
+    )
+
+    all_notifications = Notification.query.all()
+    assert len(all_notifications) == 4
+
+    # returns all API derived notifications
+    all_notifications = get_notifications_for_service(sample_service.id).items
+    assert len(all_notifications) == 3
+
+    # all notifications including jobs
+    all_notifications = get_notifications_for_service(sample_service.id, limit_days=1, include_jobs=True).items
+    assert len(all_notifications) == 4
+
+
+def test_get_notifications_with_a_live_api_key_type(
+        notify_db,
+        notify_db_session,
+        sample_service,
+        sample_job,
+        sample_api_key,
+        sample_team_api_key,
+        sample_test_api_key
+):
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), job=sample_job
+    )
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type
+    )
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), api_key_id=sample_team_api_key.id,
+        key_type=sample_team_api_key.key_type
+    )
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), api_key_id=sample_test_api_key.id,
+        key_type=sample_test_api_key.key_type
+    )
+
+    all_notifications = Notification.query.all()
+    assert len(all_notifications) == 4
+
+    # only those created with normal API key, no jobs
+    all_notifications = get_notifications_for_service(sample_service.id, limit_days=1, key_type=KEY_TYPE_NORMAL).items
+    assert len(all_notifications) == 1
+
+    # only those created with normal API key, with jobs
+    all_notifications = get_notifications_for_service(sample_service.id, limit_days=1, include_jobs=True,
+                                                      key_type=KEY_TYPE_NORMAL).items
+    assert len(all_notifications) == 2
+
+
+def test_get_notifications_with_a_test_api_key_type(
+        notify_db,
+        notify_db_session,
+        sample_service,
+        sample_job,
+        sample_api_key,
+        sample_team_api_key,
+        sample_test_api_key
+):
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), job=sample_job
+    )
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type
+    )
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), api_key_id=sample_team_api_key.id,
+        key_type=sample_team_api_key.key_type
+    )
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), api_key_id=sample_test_api_key.id,
+        key_type=sample_test_api_key.key_type
+    )
+
+    # only those created with test API key, no jobs
+    all_notifications = get_notifications_for_service(sample_service.id, limit_days=1, key_type=KEY_TYPE_TEST).items
+    assert len(all_notifications) == 1
+
+    # only those created with test API key, no jobs, even when requested
+    all_notifications = get_notifications_for_service(sample_service.id, limit_days=1, include_jobs=True,
+                                                      key_type=KEY_TYPE_TEST).items
+    assert len(all_notifications) == 1
+
+
+def test_get_notifications_with_a_team_api_key_type(
+        notify_db,
+        notify_db_session,
+        sample_service,
+        sample_job,
+        sample_api_key,
+        sample_team_api_key,
+        sample_test_api_key
+):
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), job=sample_job
+    )
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type
+    )
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), api_key_id=sample_team_api_key.id,
+        key_type=sample_team_api_key.key_type
+    )
+    sample_notification(
+        notify_db, notify_db_session, created_at=datetime.utcnow(), api_key_id=sample_test_api_key.id,
+        key_type=sample_test_api_key.key_type
+    )
+
+    # only those created with team API key, no jobs
+    all_notifications = get_notifications_for_service(sample_service.id, limit_days=1, key_type=KEY_TYPE_TEAM).items
+    assert len(all_notifications) == 1
+
+    # only those created with team API key, no jobs, even when requested
+    all_notifications = get_notifications_for_service(sample_service.id, limit_days=1, include_jobs=True,
+                                                      key_type=KEY_TYPE_TEAM).items
+    assert len(all_notifications) == 1

--- a/tests/app/test_schemas.py
+++ b/tests/app/test_schemas.py
@@ -1,7 +1,7 @@
-def test_job_schema_doesnt_return_notifications(sample_notification):
+def test_job_schema_doesnt_return_notifications(sample_notification_with_job):
     from app.schemas import job_schema
 
-    job = sample_notification.job
+    job = sample_notification_with_job.job
     assert job.notifications.count() == 1
 
     data, errors = job_schema.dump(job)


### PR DESCRIPTION
Ensure that we do not return JOB created notifications in the API calls.

Unless:

It is a LIVE key and the include_jobs param is set to TRUE

Other key types CANNOT retrieve JOB created notifications from the API.

Note:
API calls made by the Admin app ALWAYS return ALL notifications (JOB|API) - this may need to change to create flexibility the in the dashboards, but this is like for like functionality for now.