### PR TITLE
Update schema to validate contents of GET notifications

### DIFF
--- a/tests/app/notifications/rest/test_callbacks.py
+++ b/tests/app/notifications/rest/test_callbacks.py
@@ -3,7 +3,7 @@ import uuid
 from datetime import datetime
 from flask import json
 from freezegun import freeze_time
-from mock import call
+from unittest.mock import call
 
 import app.celery.tasks
 from app.dao.notifications_dao import (

--- a/tests/app/public_contracts/schemas/GET_notifications_return.json
+++ b/tests/app/public_contracts/schemas/GET_notifications_return.json
@@ -20,6 +20,9 @@
         },
         "next" : {
           "type" : "string"
+        },
+        "prev" : {
+          "type" : "string"
         }
       }
     },

--- a/tests/app/public_contracts/schemas/GET_notifications_return.json
+++ b/tests/app/public_contracts/schemas/GET_notifications_return.json
@@ -15,16 +15,17 @@
     "links": {
       "type": "object",
       "properties" : {
-        "last": {
+        "prev" : {
           "type" : "string"
         },
         "next" : {
           "type" : "string"
         },
-        "prev" : {
+        "last": {
           "type" : "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "page_size": {"type": "number"},
     "total": {"type": "number"}

--- a/tests/app/public_contracts/schemas/GET_notifications_return.json
+++ b/tests/app/public_contracts/schemas/GET_notifications_return.json
@@ -14,7 +14,14 @@
     },
     "links": {
       "type": "object",
-      "additionalProperties": false
+      "properties" : {
+        "last": {
+          "type" : "string"
+        },
+        "next" : {
+          "type" : "string"
+        }
+      }
     },
     "page_size": {"type": "number"},
     "total": {"type": "number"}


### PR DESCRIPTION
The current schema disallows the links' object within the returned response to have any properties despite being contained in the response (as expected). This removes the aforementioned constraint and implements a check to ensure the link's object contains the expected properties.