### PR TITLE
Optionally get only notifications created by API

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -213,6 +213,7 @@ def get_all_notifications_for_service(service_id):
     page = data['page'] if 'page' in data else 1
     page_size = data['page_size'] if 'page_size' in data else current_app.config.get('PAGE_SIZE')
     limit_days = data.get('limit_days')
+    include_jobs = data.get('include_jobs', True)
 
     pagination = notifications_dao.get_notifications_for_service(
         service_id,
@@ -220,7 +221,7 @@ def get_all_notifications_for_service(service_id):
         page=page,
         page_size=page_size,
         limit_days=limit_days,
-        include_jobs=True)
+        include_jobs=include_jobs)
     kwargs = request.args.to_dict()
     kwargs['service_id'] = service_id
     return jsonify(

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1059,6 +1059,27 @@ def test_get_all_notifications_for_service_including_ones_made_by_jobs(
         assert response.status_code == 200
 
 
+def test_get_only_api_created_notifications_for_service(
+    client,
+    notify_db,
+    notify_db_session,
+    sample_service
+):
+    with_job = sample_notification_with_job(notify_db, notify_db_session, service=sample_service)
+    without_job = create_sample_notification(notify_db, notify_db_session, service=sample_service)
+
+    auth_header = create_authorization_header()
+
+    response = client.get(
+        path='/service/{}/notifications?include_jobs=false'.format(sample_service.id),
+        headers=[auth_header])
+
+    resp = json.loads(response.get_data(as_text=True))
+    assert len(resp['notifications']) == 1
+    assert resp['notifications'][0]['id'] == str(without_job.id)
+    assert response.status_code == 200
+
+
 def test_set_sms_sender_for_service(notify_api, sample_service):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:


### PR DESCRIPTION
This commit adds the `include_jobs` filter to the `GET /services/…/notifications` endpoint. It defaults to `True` (i.e. show all notifications) but makes it possible to only return notifications
created by _any_ API key.

This is so that we can show a log of all notifications sent through the API in the admin app.

It does not expose this parameter to the public `GET /notifications` endpoint because this would violate our rules about keys only being able to get notifications created with keys of the same type.