### PR TITLE
Optionally get notifications created with a test key

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -228,14 +228,16 @@ def get_notifications(filter_dict=None):
 
 
 @statsd(namespace="dao")
-def get_notifications_for_service(service_id,
-                                  filter_dict=None,
-                                  page=1,
-                                  page_size=None,
-                                  limit_days=None,
-                                  key_type=None,
-                                  personalisation=False,
-                                  include_jobs=False):
+def get_notifications_for_service(
+    service_id,
+    filter_dict=None,
+    page=1,
+    page_size=None,
+    limit_days=None,
+    key_type=None,
+    personalisation=False,
+    include_jobs=False
+):
     if page_size is None:
         page_size = current_app.config['PAGE_SIZE']
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -236,7 +236,8 @@ def get_notifications_for_service(
     limit_days=None,
     key_type=None,
     personalisation=False,
-    include_jobs=False
+    include_jobs=False,
+    include_from_test_key=False
 ):
     if page_size is None:
         page_size = current_app.config['PAGE_SIZE']
@@ -252,7 +253,7 @@ def get_notifications_for_service(
 
     if key_type is not None:
         filters.append(Notification.key_type == key_type)
-    else:
+    elif not include_from_test_key:
         filters.append(Notification.key_type != KEY_TYPE_TEST)
 
     query = Notification.query.filter(*filters)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -422,6 +422,7 @@ class NotificationsFilterSchema(ma.Schema):
     page_size = fields.Int(required=False)
     limit_days = fields.Int(required=False)
     include_jobs = fields.Boolean(required=False)
+    include_from_test_key = fields.Boolean(required=False)
 
     @pre_load
     def handle_multidict(self, in_data):

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -214,6 +214,7 @@ def get_all_notifications_for_service(service_id):
     page_size = data['page_size'] if 'page_size' in data else current_app.config.get('PAGE_SIZE')
     limit_days = data.get('limit_days')
     include_jobs = data.get('include_jobs', True)
+    include_from_test_key = data.get('include_from_test_key', False)
 
     pagination = notifications_dao.get_notifications_for_service(
         service_id,
@@ -221,7 +222,9 @@ def get_all_notifications_for_service(service_id):
         page=page,
         page_size=page_size,
         limit_days=limit_days,
-        include_jobs=include_jobs)
+        include_jobs=include_jobs,
+        include_from_test_key=include_from_test_key
+    )
     kwargs = request.args.to_dict()
     kwargs['service_id'] = service_id
     return jsonify(

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -1000,11 +1000,15 @@ def test_get_notifications_created_by_api_or_csv_are_returned_correctly_excludin
     all_notifications = Notification.query.all()
     assert len(all_notifications) == 4
 
-    # returns all API derived notifications
+    # returns all real API derived notifications
     all_notifications = get_notifications_for_service(sample_service.id).items
     assert len(all_notifications) == 2
 
-    # all notifications including jobs
+    # returns all API derived notifications, including those created with test key
+    all_notifications = get_notifications_for_service(sample_service.id, include_from_test_key=True).items
+    assert len(all_notifications) == 3
+
+    # all real notifications including jobs
     all_notifications = get_notifications_for_service(sample_service.id, limit_days=1, include_jobs=True).items
     assert len(all_notifications) == 3
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1046,12 +1046,12 @@ def test_get_all_notifications_for_service_in_order(notify_api, notify_db, notif
     ]
 )
 def test_get_all_notifications_for_service_including_ones_made_by_jobs(
-        notify_api,
-        notify_db,
-        notify_db_session,
-        sample_service,
-        include_from_test_key,
-        expected_count_of_notifications
+    notify_api,
+    notify_db,
+    notify_db_session,
+    sample_service,
+    include_from_test_key,
+    expected_count_of_notifications
 ):
     with notify_api.test_request_context(), notify_api.test_client() as client:
         with_job = sample_notification_with_job(notify_db, notify_db_session, service=sample_service)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1046,34 +1046,33 @@ def test_get_all_notifications_for_service_in_order(notify_api, notify_db, notif
     ]
 )
 def test_get_all_notifications_for_service_including_ones_made_by_jobs(
-    notify_api,
+    client,
     notify_db,
     notify_db_session,
     sample_service,
     include_from_test_key,
     expected_count_of_notifications
 ):
-    with notify_api.test_request_context(), notify_api.test_client() as client:
-        with_job = sample_notification_with_job(notify_db, notify_db_session, service=sample_service)
-        without_job = create_sample_notification(notify_db, notify_db_session, service=sample_service)
-        from_test_api_key = create_sample_notification(
-            notify_db, notify_db_session, service=sample_service, key_type=KEY_TYPE_TEST
-        )
+    with_job = sample_notification_with_job(notify_db, notify_db_session, service=sample_service)
+    without_job = create_sample_notification(notify_db, notify_db_session, service=sample_service)
+    from_test_api_key = create_sample_notification(
+        notify_db, notify_db_session, service=sample_service, key_type=KEY_TYPE_TEST
+    )
 
-        auth_header = create_authorization_header()
+    auth_header = create_authorization_header()
 
-        response = client.get(
-            path='/service/{}/notifications?include_from_test_key={}'.format(
-                sample_service.id, include_from_test_key
-            ),
-            headers=[auth_header]
-        )
+    response = client.get(
+        path='/service/{}/notifications?include_from_test_key={}'.format(
+            sample_service.id, include_from_test_key
+        ),
+        headers=[auth_header]
+    )
 
-        resp = json.loads(response.get_data(as_text=True))
-        assert len(resp['notifications']) == expected_count_of_notifications
-        assert resp['notifications'][0]['to'] == with_job.to
-        assert resp['notifications'][1]['to'] == without_job.to
-        assert response.status_code == 200
+    resp = json.loads(response.get_data(as_text=True))
+    assert len(resp['notifications']) == expected_count_of_notifications
+    assert resp['notifications'][0]['to'] == with_job.to
+    assert resp['notifications'][1]['to'] == without_job.to
+    assert response.status_code == 200
 
 
 def test_get_only_api_created_notifications_for_service(

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -16,6 +16,7 @@ from tests.app.conftest import (
     sample_user as create_sample_user,
     sample_notification as create_sample_notification,
     sample_notification_with_job)
+from app.models import KEY_TYPE_TEST
 
 
 def test_get_service_list(notify_api, service_factory):
@@ -1037,23 +1038,39 @@ def test_get_all_notifications_for_service_in_order(notify_api, notify_db, notif
         assert response.status_code == 200
 
 
+@pytest.mark.parametrize(
+    'include_from_test_key, expected_count_of_notifications',
+    [
+        (False, 2),
+        (True, 3)
+    ]
+)
 def test_get_all_notifications_for_service_including_ones_made_by_jobs(
         notify_api,
         notify_db,
         notify_db_session,
-        sample_service):
+        sample_service,
+        include_from_test_key,
+        expected_count_of_notifications
+):
     with notify_api.test_request_context(), notify_api.test_client() as client:
         with_job = sample_notification_with_job(notify_db, notify_db_session, service=sample_service)
         without_job = create_sample_notification(notify_db, notify_db_session, service=sample_service)
+        from_test_api_key = create_sample_notification(
+            notify_db, notify_db_session, service=sample_service, key_type=KEY_TYPE_TEST
+        )
 
         auth_header = create_authorization_header()
 
         response = client.get(
-            path='/service/{}/notifications'.format(sample_service.id),
-            headers=[auth_header])
+            path='/service/{}/notifications?include_from_test_key={}'.format(
+                sample_service.id, include_from_test_key
+            ),
+            headers=[auth_header]
+        )
 
         resp = json.loads(response.get_data(as_text=True))
-        assert len(resp['notifications']) == 2
+        assert len(resp['notifications']) == expected_count_of_notifications
         assert resp['notifications'][0]['to'] == with_job.to
         assert resp['notifications'][1]['to'] == without_job.to
         assert response.status_code == 200


### PR DESCRIPTION
_Reviewers: There are quite a lot of whitespace changes in this PR. The meat of the changes are in f9f3bb8 and d7bb83f._

***

Developers need visibility of what their integration is doing within the app. This includes notifications sent with a test key.

This PR adds an optional, defaults-to-false parameter to include notifications sent from a test API key when getting notifications.

This is only for the method that the admin app uses; it doesn’t affect the public get notifications endpoint.