### PR TITLE
Add details of API key to notifications

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -315,6 +315,16 @@ class NotificationWithTemplateSchema(BaseSchema):
     )
     job = fields.Nested(JobSchema, only=["id", "original_file_name"], dump_only=True)
     personalisation = fields.Dict(required=False)
+    key_type = field_for(models.Notification, 'key_type', required=True)
+    key_name = fields.String()
+
+    @pre_dump
+    def add_api_key_name(self, in_data):
+        if in_data.api_key:
+            in_data.key_name = in_data.api_key.name
+        else:
+            in_data.key_name = None
+        return in_data
 
 
 class NotificationWithPersonalisationSchema(NotificationWithTemplateSchema):

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -232,10 +232,11 @@ def sample_email_template_with_placeholders(notify_db, notify_db_session):
 def sample_api_key(notify_db,
                    notify_db_session,
                    service=None,
-                   key_type=KEY_TYPE_NORMAL):
+                   key_type=KEY_TYPE_NORMAL,
+                   name=None):
     if service is None:
         service = sample_service(notify_db, notify_db_session)
-    data = {'service': service, 'name': uuid.uuid4(), 'created_by': service.created_by, 'key_type': key_type}
+    data = {'service': service, 'name': name or uuid.uuid4(), 'created_by': service.created_by, 'key_type': key_type}
     api_key = ApiKey(**data)
     save_model_api_key(api_key)
     return api_key
@@ -438,6 +439,17 @@ def sample_notification(notify_db,
     notification = Notification(**data)
     if create:
         dao_create_notification(notification)
+    return notification
+
+
+@pytest.fixture(scope='function')
+def sample_notification_with_api_key(notify_db, notify_db_session):
+    notification = sample_notification(notify_db, notify_db_session)
+    notification.api_key_id = sample_api_key(
+        notify_db,
+        notify_db_session,
+        name='Test key'
+    ).id
     return notification
 
 

--- a/tests/app/test_schemas.py
+++ b/tests/app/test_schemas.py
@@ -8,3 +8,17 @@ def test_job_schema_doesnt_return_notifications(sample_notification_with_job):
 
     assert not errors
     assert 'notifications' not in data
+
+
+def test_notification_schema_ignores_absent_api_key(sample_notification_with_job):
+    from app.schemas import notification_with_template_schema
+
+    data = notification_with_template_schema.dump(sample_notification_with_job).data
+    assert data['key_name'] is None
+
+
+def test_notification_schema_adds_api_key_name(sample_notification_with_api_key):
+    from app.schemas import notification_with_template_schema
+
+    data = notification_with_template_schema.dump(sample_notification_with_api_key).data
+    assert data['key_name'] == 'Test key'


### PR DESCRIPTION
We want to show developers a log of notifications they’ve sent using the API in the admin app. In order to identify a notification it’s probably helpful to know:

- who the notification was sent to (which we expose)
- when the notification was created (which we expose)
- which key was used to create the notification (which we expose, but only as the `id` of the key)

Developers don’t see the `id` of the API key in the app anywhere, so this isn’t useful information. Much more useful is the `type` and `name` of the key. So this commit changes the schema to also return these.

This commit does some slightly hacky stuff with conftest because it breaks a lot of other tests if the sample notification has a real API key or an API key with a non-unique name.