### PR TITLE
add statuses filter to GET /service/{}/job

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -27,10 +27,14 @@ def dao_get_job_by_service_id_and_job_id(service_id, job_id):
     return Job.query.filter_by(service_id=service_id, id=job_id).one()
 
 
-def dao_get_jobs_by_service_id(service_id, limit_days=None, page=1, page_size=50):
+def dao_get_jobs_by_service_id(service_id, limit_days=None, page=1, page_size=50, statuses=''):
     query_filter = [Job.service_id == service_id]
     if limit_days is not None:
         query_filter.append(cast(Job.created_at, sql_date) >= days_ago(limit_days))
+    if statuses != ['']:
+        query_filter.append(
+            Job.job_status.in_(statuses)
+        )
     return Job.query \
         .filter(*query_filter) \
         .order_by(desc(Job.created_at)) \

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -27,11 +27,11 @@ def dao_get_job_by_service_id_and_job_id(service_id, job_id):
     return Job.query.filter_by(service_id=service_id, id=job_id).one()
 
 
-def dao_get_jobs_by_service_id(service_id, limit_days=None, page=1, page_size=50, statuses=''):
+def dao_get_jobs_by_service_id(service_id, limit_days=None, page=1, page_size=50, statuses=None):
     query_filter = [Job.service_id == service_id]
     if limit_days is not None:
         query_filter.append(cast(Job.created_at, sql_date) >= days_ago(limit_days))
-    if statuses != ['']:
+    if statuses is not None and statuses != ['']:
         query_filter.append(
             Job.job_status.in_(statuses)
         )

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -102,8 +102,10 @@ def get_jobs_by_service(service_id):
     else:
         limit_days = None
 
+    statuses = [x.strip() for x in request.args.get('statuses', '').split(',')]
+
     page = int(request.args.get('page', 1))
-    return jsonify(**get_paginated_jobs(service_id, limit_days, page))
+    return jsonify(**get_paginated_jobs(service_id, limit_days, statuses, page))
 
 
 @job.route('', methods=['POST'])
@@ -140,14 +142,14 @@ def create_job(service_id):
     return jsonify(data=job_json), 201
 
 
-def get_paginated_jobs(service_id, limit_days, page):
+def get_paginated_jobs(service_id, limit_days, statuses, page):
     pagination = dao_get_jobs_by_service_id(
         service_id,
         limit_days=limit_days,
         page=page,
-        page_size=current_app.config['PAGE_SIZE']
+        page_size=current_app.config['PAGE_SIZE'],
+        statuses=statuses
     )
-
     data = job_schema.dump(pagination.items, many=True).data
     for job_data in data:
         statistics = dao_get_notification_outcomes_for_job(service_id, job_data['id'])

--- a/app/models.py
+++ b/app/models.py
@@ -313,6 +313,7 @@ JOB_STATUS_TYPES = [
     JOB_STATUS_CANCELLED
 ]
 
+
 class JobStatus(db.Model):
     __tablename__ = 'job_status'
 

--- a/app/models.py
+++ b/app/models.py
@@ -304,7 +304,14 @@ JOB_STATUS_FINISHED = 'finished'
 JOB_STATUS_SENDING_LIMITS_EXCEEDED = 'sending limits exceeded'
 JOB_STATUS_SCHEDULED = 'scheduled'
 JOB_STATUS_CANCELLED = 'cancelled'
-
+JOB_STATUS_TYPES = [
+    JOB_STATUS_PENDING,
+    JOB_STATUS_IN_PROGRESS,
+    JOB_STATUS_FINISHED,
+    JOB_STATUS_SENDING_LIMITS_EXCEEDED,
+    JOB_STATUS_SCHEDULED,
+    JOB_STATUS_CANCELLED
+]
 
 class JobStatus(db.Model):
     __tablename__ = 'job_status'


### PR DESCRIPTION
> can now pass in a query string `?statuses=x,y,z` to filter jobs based on `Job.job_status`. Not passing in a status or passing in an empty string is equivalent to selecting every filter type at once.

This is required cos now that jobs are paginated, the front end has to make two separate calls to get jobs - one for scheduled, and one for everything else