### PR TITLE
Add DAO and endpoint for getting billable units/financial year

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -225,7 +225,7 @@ def get_notification_billable_unit_count_per_month(service_id, year):
         NotificationHistory.service_id == service_id,
         NotificationHistory.created_at >= start,
         NotificationHistory.created_at < end
-    ).all()
+    )
 
     return [
         (month, sum(count for _, count in row))

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -359,6 +359,6 @@ def get_april_fools(year):
 
 
 def get_bst_month(datetime):
-    return pytz.utc.localize(datetime).replace(
-        tzinfo=pytz.timezone("Europe/London")
+    return pytz.utc.localize(datetime).astimezone(
+        pytz.timezone("Europe/London")
     ).strftime('%B')

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -221,6 +221,7 @@ def get_notification_billable_unit_count_per_month(service_id, year):
     ).order_by(
         NotificationHistory.created_at
     ).filter(
+        NotificationHistory.billable_units != 0,
         NotificationHistory.service_id == service_id,
         NotificationHistory.created_at >= start,
         NotificationHistory.created_at < end

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -348,7 +348,7 @@ def dao_timeout_notifications(timeout_period_in_seconds):
 
 
 def get_financial_year(year):
-    return (get_april_fools(year), get_april_fools(year + 1))
+    return get_april_fools(year), get_april_fools(year + 1)
 
 
 def get_april_fools(year):

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -310,3 +310,13 @@ def update_whitelist(service_id):
     else:
         dao_add_and_commit_whitelisted_contacts(whitelist_objs)
         return '', 204
+
+
+@service_blueprint.route('/<uuid:service_id>/billable-units')
+def get_billable_unit_count(service_id):
+    try:
+        return jsonify(notifications_dao.get_notification_billable_unit_count_per_month(
+            service_id, int(request.args.get('year'))
+        ))
+    except TypeError:
+        return jsonify(result='error', message='No valid year provided'), 400

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -716,6 +716,10 @@ def test_get_notification_billable_unit_count_per_month(notify_db, notify_db_ses
         (
             2015,
             [('January', 1), ('March', 1)]
+        ),
+        (
+            2014,
+            []
         )
     ):
         assert get_notification_billable_unit_count_per_month(

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, date
+import pytz
 import uuid
 from functools import partial
 
@@ -690,18 +691,21 @@ def test_get_all_notifications_for_job_by_status(notify_db, notify_db_session, s
 def test_get_notification_billable_unit_count_per_month(notify_db, notify_db_session, sample_service):
 
     for year, month, day in (
-        (2017, 1, 1),
+        (2017, 1, 1),  # ↓ 2016 financial year
         (2016, 8, 1),
         (2016, 7, 31),
         (2016, 4, 6),
         (2016, 4, 6),
-        (2016, 4, 1),
+        (2016, 4, 1),  # ↓ 2015 financial year
         (2016, 3, 31),
         (2016, 1, 1)
     ):
         sample_notification(
             notify_db, notify_db_session, service=sample_service,
-            created_at=date(year, month, day)
+            created_at=datetime(
+                year, month, day, 0, 0, 0, 0,
+                tzinfo=pytz.utc
+            )
         )
 
     for financial_year, months in (
@@ -711,11 +715,11 @@ def test_get_notification_billable_unit_count_per_month(notify_db, notify_db_ses
         ),
         (
             2016,
-            [('April', 3), ('July', 1), ('August', 1), ('January', 1)]
+            [('April', 2), ('July', 1), ('August', 1), ('January', 1)]
         ),
         (
             2015,
-            [('January', 1), ('March', 1)]
+            [('January', 1), ('March', 1), ('April', 1)]
         ),
         (
             2014,
@@ -1204,5 +1208,7 @@ def test_should_exclude_test_key_notifications_by_default(
 
 def test_get_financial_year():
     start, end = get_financial_year(2000)
-    assert start == date(2000, 4, 1)
-    assert end == date(2001, 4, 1)
+    assert start.tzinfo == pytz.utc
+    assert start.isoformat() == '2000-04-01T00:01:00+00:00'
+    assert end.tzinfo == pytz.utc
+    assert end.isoformat() == '2001-04-01T00:01:00+00:00'

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -691,21 +691,20 @@ def test_get_all_notifications_for_job_by_status(notify_db, notify_db_session, s
 def test_get_notification_billable_unit_count_per_month(notify_db, notify_db_session, sample_service):
 
     for year, month, day in (
-        (2017, 1, 1),  # ↓ 2016 financial year
+        (2017, 1, 15),  # ↓ 2016 financial year
         (2016, 8, 1),
-        (2016, 7, 31),
-        (2016, 4, 6),
-        (2016, 4, 6),
+        (2016, 7, 15),
+        (2016, 4, 15),
+        (2016, 4, 15),
         (2016, 4, 1),  # ↓ 2015 financial year
         (2016, 3, 31),
-        (2016, 1, 1)
+        (2016, 1, 15)
     ):
         sample_notification(
             notify_db, notify_db_session, service=sample_service,
             created_at=datetime(
-                year, month, day, 0, 0, 0, 0,
-                tzinfo=pytz.utc
-            )
+                year, month, day, 0, 0, 0, 0
+            ) - timedelta(hours=1, seconds=1)  # one second before midnight
         )
 
     for financial_year, months in (
@@ -715,11 +714,11 @@ def test_get_notification_billable_unit_count_per_month(notify_db, notify_db_ses
         ),
         (
             2016,
-            [('April', 2), ('July', 1), ('August', 1), ('January', 1)]
+            [('April', 2), ('July', 2), ('January', 1)]
         ),
         (
             2015,
-            [('January', 1), ('March', 1), ('April', 1)]
+            [('January', 1), ('March', 2)]
         ),
         (
             2014,

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -31,13 +31,15 @@ from app.dao.notifications_dao import (
     delete_notifications_created_more_than_a_week_ago,
     get_notification_by_id,
     get_notification_for_job,
+    get_notification_billable_unit_count_per_month,
     get_notification_with_personalisation,
     get_notifications_for_job,
     get_notifications_for_service,
     update_notification_status_by_id,
     update_notification_status_by_reference,
     dao_delete_notifications_and_history_by_id,
-    dao_timeout_notifications)
+    dao_timeout_notifications,
+    get_financial_year)
 
 from notifications_utils.template import get_sms_fragment_count
 
@@ -685,6 +687,42 @@ def test_get_all_notifications_for_job_by_status(notify_db, notify_db_session, s
     assert len(notifications(filter_dict={'status': NOTIFICATION_STATUS_TYPES[:3]}).items) == 3
 
 
+def test_get_notification_billable_unit_count_per_month(notify_db, notify_db_session, sample_service):
+
+    for year, month, day in (
+        (2017, 1, 1),
+        (2016, 8, 1),
+        (2016, 7, 31),
+        (2016, 4, 6),
+        (2016, 4, 6),
+        (2016, 4, 1),
+        (2016, 3, 31),
+        (2016, 1, 1)
+    ):
+        sample_notification(
+            notify_db, notify_db_session, service=sample_service,
+            created_at=date(year, month, day)
+        )
+
+    for financial_year, months in (
+        (
+            2017,
+            []
+        ),
+        (
+            2016,
+            [('April', 3), ('July', 1), ('August', 1), ('January', 1)]
+        ),
+        (
+            2015,
+            [('January', 1), ('March', 1)]
+        )
+    ):
+        assert get_notification_billable_unit_count_per_month(
+            sample_service.id, financial_year
+        ) == months
+
+
 def test_update_notification(sample_notification, sample_template):
     assert sample_notification.status == 'created'
     sample_notification.status = 'failed'
@@ -1158,3 +1196,9 @@ def test_should_exclude_test_key_notifications_by_default(
 
     all_notifications = get_notifications_for_service(sample_service.id, limit_days=1, key_type=KEY_TYPE_TEST).items
     assert len(all_notifications) == 1
+
+
+def test_get_financial_year():
+    start, end = get_financial_year(2000)
+    assert start == date(2000, 4, 1)
+    assert end == date(2001, 4, 1)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1300,3 +1300,27 @@ def test_get_detailed_services_only_includes_todays_notifications(notify_db, not
         'email': {'delivered': 0, 'failed': 0, 'requested': 0},
         'sms': {'delivered': 0, 'failed': 0, 'requested': 2}
     }
+
+
+@freeze_time('2012-12-12T12:00:01')
+def test_get_notification_billable_unit_count(client, notify_db, notify_db_session):
+    notification = create_sample_notification(notify_db, notify_db_session)
+    response = client.get(
+        '/service/{}/billable-units?year=2012'.format(notification.service_id),
+        headers=[create_authorization_header(service_id=notification.service_id)]
+    )
+    assert response.status_code == 200
+    assert json.loads(response.get_data(as_text=True)) == {
+        'December': 1
+    }
+
+
+def test_get_notification_billable_unit_count_missing_year(client, sample_service):
+    response = client.get(
+        '/service/{}/billable-units'.format(sample_service.id),
+        headers=[create_authorization_header(service_id=sample_service.id)]
+    )
+    assert response.status_code == 400
+    assert json.loads(response.get_data(as_text=True)) == {
+        'message': 'No valid year provided', 'result': 'error'
+    }


### PR DESCRIPTION
In order to invoice people we need to know how many text message fragments they’ve sent per month.

This should be per (government) financial year, ie April 1<sup>st</sup> to April 1<sup>st</sup> because we’ll only ever show a page for one year (because the 250,000 allowance is topped up at the start of every financial year).

**Exposed at**
`/services/ef7a665d-11a4-425a-a180-a67ca00b69d7/billable-units?year=2016`

**Returns**
```python
{
    'April': 3,
    'July': 1,
    'August': 1,
    'January': 1
}
```