### PR TITLE
fix run_scheduled_jobs concurrency bug

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -29,9 +29,7 @@ def run_scheduled_jobs():
     try:
         for job in dao_set_scheduled_jobs_to_pending():
             process_job.apply_async([str(job.id)], queue="process-job")
-            current_app.logger.info(
-            "Job ID {} added to process job queue".format(job.id)
-            )
+            current_app.logger.info("Job ID {} added to process job queue".format(job.id))
     except SQLAlchemyError as e:
         current_app.logger.exception("Failed to run scheduled jobs", e)
         raise

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -36,6 +36,9 @@ def process_job(job_id):
     start = datetime.utcnow()
     job = dao_get_job_by_id(job_id)
 
+    if job.job_status != 'pending':
+        return
+
     service = job.service
 
     total_sent = fetch_todays_total_message_count(service.id)

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -71,7 +71,6 @@ def dao_set_scheduled_jobs_to_pending():
     return jobs
 
 
-
 def dao_get_future_scheduled_job_by_id_and_service_id(job_id, service_id):
     return Job.query \
         .filter(

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -52,6 +52,7 @@ def dao_get_scheduled_jobs():
             Job.scheduled_for < datetime.utcnow()
         ) \
         .order_by(asc(Job.scheduled_for)) \
+        .with_for_update() \
         .all()
 
 

--- a/lambda_function/README.md
+++ b/lambda_function/README.md
@@ -1,0 +1,9 @@
+# Lambda function
+
+This code is used to setup a lambda function to call into our API to deliver messages.
+
+Basic expected flow is that an request to GOV.UK Notify to send a text/email will persist in our DB then invoke an async lambda function. 
+
+This function will call /deliver/notification/{id} which will make the API call to our delivery partners, updating the DB with the response.
+
+## EXPERIMENTAL AT THIS STAGE

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -221,6 +221,18 @@ def test_should_not_process_email_job_if_would_exceed_send_limits(notify_db, not
     assert tasks.send_email.apply_async.called is False
 
 
+def test_should_not_process_job_if_already_pending(notify_db, notify_db_session, mocker):
+    job = sample_job(notify_db, notify_db_session, job_status='scheduled')
+
+    mocker.patch('app.celery.tasks.s3.get_job_from_s3')
+    mocker.patch('app.celery.tasks.send_sms.apply_async')
+
+    process_job(job.id)
+
+    assert s3.get_job_from_s3.called is False
+    assert tasks.send_sms.apply_async.called is False
+
+
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_should_process_email_job_if_exactly_on_send_limits(notify_db,
                                                             notify_db_session,

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -8,7 +8,7 @@ from app.dao.jobs_dao import (
     dao_create_job,
     dao_update_job,
     dao_get_jobs_by_service_id,
-    dao_get_scheduled_jobs,
+    dao_set_scheduled_jobs_to_pending,
     dao_get_future_scheduled_job_by_id_and_service_id,
     dao_get_notification_outcomes_for_job,
     dao_get_jobs_older_than
@@ -223,29 +223,40 @@ def test_update_job(sample_job):
     assert job_from_db.job_status == 'in progress'
 
 
-def test_get_scheduled_jobs_gets_all_jobs_in_scheduled_state_scheduled_before_now(notify_db, notify_db_session):
+def test_set_scheduled_jobs_to_pending_gets_all_jobs_in_scheduled_state_before_now(notify_db, notify_db_session):
     one_minute_ago = datetime.utcnow() - timedelta(minutes=1)
     one_hour_ago = datetime.utcnow() - timedelta(minutes=60)
     job_new = create_job(notify_db, notify_db_session, scheduled_for=one_minute_ago, job_status='scheduled')
     job_old = create_job(notify_db, notify_db_session, scheduled_for=one_hour_ago, job_status='scheduled')
-    jobs = dao_get_scheduled_jobs()
+    jobs = dao_set_scheduled_jobs_to_pending()
     assert len(jobs) == 2
     assert jobs[0].id == job_old.id
     assert jobs[1].id == job_new.id
 
 
-def test_get_scheduled_jobs_gets_ignores_jobs_not_scheduled(notify_db, notify_db_session):
+def test_set_scheduled_jobs_to_pending_gets_ignores_jobs_not_scheduled(notify_db, notify_db_session):
     one_minute_ago = datetime.utcnow() - timedelta(minutes=1)
     create_job(notify_db, notify_db_session)
     job_scheduled = create_job(notify_db, notify_db_session, scheduled_for=one_minute_ago, job_status='scheduled')
-    jobs = dao_get_scheduled_jobs()
+    jobs = dao_set_scheduled_jobs_to_pending()
     assert len(jobs) == 1
     assert jobs[0].id == job_scheduled.id
 
 
-def test_get_scheduled_jobs_gets_ignores_jobs_scheduled_in_the_future(sample_scheduled_job):
-    jobs = dao_get_scheduled_jobs()
+def test_set_scheduled_jobs_to_pending_gets_ignores_jobs_scheduled_in_the_future(sample_scheduled_job):
+    jobs = dao_set_scheduled_jobs_to_pending()
     assert len(jobs) == 0
+
+
+def test_set_scheduled_jobs_to_pending_updates_rows(notify_db, notify_db_session):
+    one_minute_ago = datetime.utcnow() - timedelta(minutes=1)
+    one_hour_ago = datetime.utcnow() - timedelta(minutes=60)
+    create_job(notify_db, notify_db_session, scheduled_for=one_minute_ago, job_status='scheduled')
+    create_job(notify_db, notify_db_session, scheduled_for=one_hour_ago, job_status='scheduled')
+    jobs = dao_set_scheduled_jobs_to_pending()
+    assert len(jobs) == 2
+    assert jobs[0].job_status == 'pending'
+    assert jobs[1].job_status == 'pending'
 
 
 def test_get_future_scheduled_job_gets_a_job_yet_to_send(sample_scheduled_job):


### PR DESCRIPTION
we weren't locking the job table, so if the task runs twice (it in fact runs three times) there is a chance it will pick up the same job to process multiple times. The odds increase as more jobs are scheduled, so this got through to live before we noticed. Bad us.

This PR:
* makes the run_scheduled_jobs lock the job table (only against updates, deletes, and other run_scheduled_jobs tasks) using `FOR UPDATE`
* makes the process_job task check if the job is pending. Note: this is _in no way_ failsafe (as it's not tied using a lock to the update that sets `job_status = 'in progress'` , however it is another line of defence.

### TODO: remember to check concurrency issues on scheduled tasks in future