### PR TITLE
Let team key send to whitelist

### DIFF
--- a/app/service/utils.py
+++ b/app/service/utils.py
@@ -34,16 +34,16 @@ def service_allowed_to_send_to(recipient, service, key_type):
         return True
 
     team_members = itertools.chain.from_iterable(
-        [user.mobile_number, user.email_address] for user in service.users)
+        [user.mobile_number, user.email_address] for user in service.users
+    )
+    whitelist_members = [
+        member.recipient for member in service.whitelist
+    ]
 
-    if key_type == KEY_TYPE_TEAM:
-        return allowed_to_send_to(
-            recipient,
-            team_members
-        )
-
-    if key_type == KEY_TYPE_NORMAL and service.restricted:
-        whitelist_members = [member.recipient for member in service.whitelist]
+    if (
+        (key_type == KEY_TYPE_NORMAL and service.restricted) or
+        (key_type == KEY_TYPE_TEAM)
+    ):
         return allowed_to_send_to(
             recipient,
             itertools.chain(

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -783,7 +783,8 @@ def test_should_not_send_notification_to_non_whitelist_recipient_in_trial_mode(
     to,
     _create_sample_template,
     key_type,
-    mocker):
+    mocker
+):
     service = create_sample_service(notify_db, notify_db_session, limit=2, restricted=True)
     service_whitelist = create_sample_service_whitelist(notify_db, notify_db_session, service=service)
 


### PR DESCRIPTION
There is an overlap between team key/trial mode/whitelist. But it’s not a complete overlap. So it’s hard to understand all the different permutations of which key lets you send to which people when.

This commit tries to reduce the differences between these concepts. So for a user of the API

**In trial mode**

- You can send to anyone in your team or whitelist, using the team key
- You can simulate sending to anyone, using the simulate key

**When you’re live**

- You can send to anyone in your team or whitelist, using the team key
- You can simulate sending to anyone, using the simulate key
- You can send to anyone with the live key

So doing a `diff` on that list, the only change when you go live mode is:

`+ You can send to anyone with the live key`

***

**(How trial mode used to work)**

- You can send to anyone in your team or whitelist, using the normal key
- You can simulate sending to anyone, using the simulate key
- You can send to _just_ people in your team using the team key