### PR TITLE
Sort jobs by processed time first

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -37,7 +37,7 @@ def dao_get_jobs_by_service_id(service_id, limit_days=None, page=1, page_size=50
         )
     return Job.query \
         .filter(*query_filter) \
-        .order_by(desc(Job.created_at)) \
+        .order_by(Job.processing_started.desc(), Job.created_at.desc()) \
         .paginate(page=page, per_page=page_size)
 
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -264,7 +264,8 @@ def sample_job(notify_db,
                notification_count=1,
                created_at=None,
                job_status='pending',
-               scheduled_for=None):
+               scheduled_for=None,
+               processing_started=None):
     if service is None:
         service = sample_service(notify_db, notify_db_session)
     if template is None:
@@ -281,7 +282,8 @@ def sample_job(notify_db,
         'created_at': created_at or datetime.utcnow(),
         'created_by': service.created_by,
         'job_status': job_status,
-        'scheduled_for': scheduled_for
+        'scheduled_for': scheduled_for,
+        'processing_started': processing_started
     }
     job = Job(**data)
     dao_create_job(job)

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from functools import partial
 import uuid
 
 from freezegun import freeze_time
@@ -192,23 +193,26 @@ def test_get_jobs_for_service_with_limit_days_edge_case(notify_db, notify_db_ses
     assert job_eight_days_old not in jobs_limit_days
 
 
-def test_get_jobs_for_service_in_created_at_order(notify_db, notify_db_session, sample_template):
-    job_1 = create_job(
-        notify_db, notify_db_session, sample_template.service, sample_template, created_at=datetime.utcnow())
-    job_2 = create_job(
-        notify_db, notify_db_session, sample_template.service, sample_template, created_at=datetime.utcnow())
-    job_3 = create_job(
-        notify_db, notify_db_session, sample_template.service, sample_template, created_at=datetime.utcnow())
-    job_4 = create_job(
-        notify_db, notify_db_session, sample_template.service, sample_template, created_at=datetime.utcnow())
+def test_get_jobs_for_service_in_processed_at_then_created_at_order(notify_db, notify_db_session, sample_template):
+    _create_job = partial(create_job, notify_db, notify_db_session, sample_template.service, sample_template)
+    scheduled_jobs, processed_jobs = [], []
+
+    for index in range(0, 4):
+        scheduled_jobs.append(_create_job(
+            created_at=datetime.utcnow() - timedelta(seconds=index)
+        ))
+        processed_jobs.append(_create_job(
+            created_at=datetime.utcnow() - timedelta(minutes=(4 - index)),
+            processing_started=datetime.utcnow() - timedelta(hours=index)
+        ))
 
     jobs = dao_get_jobs_by_service_id(sample_template.service.id).items
 
-    assert len(jobs) == 4
-    assert jobs[0].id == job_4.id
-    assert jobs[1].id == job_3.id
-    assert jobs[2].id == job_2.id
-    assert jobs[3].id == job_1.id
+    assert len(jobs) == 8
+
+    for index in range(0, 4):
+        assert jobs[index].id == scheduled_jobs[index].id
+        assert jobs[index + 4].id == processed_jobs[index].id
 
 
 def test_update_job(sample_job):

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -196,21 +196,13 @@ def test_get_jobs_for_service_with_limit_days_edge_case(notify_db, notify_db_ses
 def test_get_jobs_for_service_in_processed_at_then_created_at_order(notify_db, notify_db_session, sample_template):
 
     _create_job = partial(create_job, notify_db, notify_db_session, sample_template.service, sample_template)
-
-    def _time_from_hour(hour):
-        return datetime(2001, 1, 1, hour) if hour is not None else None
+    from_hour = partial(datetime, 2001, 1, 1)
 
     created_jobs = [
-        _create_job(
-            created_at=_time_from_hour(created_at_hour),
-            processing_started=_time_from_hour(processing_started_hour),
-        )
-        for created_at_hour, processing_started_hour in [
-            (2, None),
-            (1, None),
-            (1, 4),
-            (4, 3),
-        ]
+        _create_job(created_at=from_hour(2), processing_started=None),
+        _create_job(created_at=from_hour(1), processing_started=None),
+        _create_job(created_at=from_hour(1), processing_started=from_hour(4)),
+        _create_job(created_at=from_hour(4), processing_started=from_hour(3)),
     ]
 
     jobs = dao_get_jobs_by_service_id(sample_template.service.id).items

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -202,7 +202,7 @@ def test_get_jobs_for_service_in_processed_at_then_created_at_order(notify_db, n
         _create_job(created_at=from_hour(2), processing_started=None),
         _create_job(created_at=from_hour(1), processing_started=None),
         _create_job(created_at=from_hour(1), processing_started=from_hour(4)),
-        _create_job(created_at=from_hour(4), processing_started=from_hour(3)),
+        _create_job(created_at=from_hour(2), processing_started=from_hour(3)),
     ]
 
     jobs = dao_get_jobs_by_service_id(sample_template.service.id).items


### PR DESCRIPTION
Say you have a dashboard with some jobs you sent. Normally looks like:

job | sent
--- | ---
file.csv | _5pm_
file.csv | 3pm
file.csv | 1pm
file.csv | 11am

However if your 5pm job was scheduled at lunchtime, then it will look like this:

job | sent
--- | ---
file.csv | 3pm
file.csv | 1pm
file.csv | _5pm_
file.csv | 11am

This is because the jobs are sorted by when they were created, not when they were sent. It looks wrong.

**For jobs that have already been sent**

This commit changes the sort order to be based on `processed_at` instead.

**For upcoming jobs**

If a job doesn’t have a `processed_at` time then it’s scheduled, but hasn’t started yet. Only in this case should we still be sorting by`created_at`.