### PR TITLE
Loosen key restriction on get notification

### DIFF
--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -159,7 +159,7 @@ def process_firetext_response():
 def get_notification_by_id(notification_id):
     notification = notifications_dao.get_notification_with_personalisation(str(api_user.service_id),
                                                                            notification_id,
-                                                                           key_type=api_user.key_type)
+                                                                           key_type=None)
     return jsonify(data={"notification": notification_with_personalisation_schema.dump(notification).data}), 200
 
 

--- a/tests/app/notifications/test_rest.py
+++ b/tests/app/notifications/test_rest.py
@@ -93,7 +93,7 @@ def test_get_notifications_empty_result(notify_api, sample_api_key):
     (KEY_TYPE_TEAM, KEY_TYPE_NORMAL),
     (KEY_TYPE_TEAM, KEY_TYPE_TEST),
 ])
-def test_get_notification_from_different_api_key_fails(
+def test_get_notification_from_different_api_key_works(
     notify_api,
     sample_notification,
     api_key_type,
@@ -110,10 +110,7 @@ def test_get_notification_from_different_api_key_fails(
         response = client.get(
             path='/notifications/{}'.format(sample_notification.id),
             headers=_create_auth_header_from_key(api_key))
-        notification = json.loads(response.get_data(as_text=True))
-        assert response.status_code == 404
-        assert notification['result'] == "error"
-        assert notification['message'] == "No result found"
+        assert response.status_code == 200
 
 
 @pytest.mark.parametrize('key_type', [KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST])


### PR DESCRIPTION
Currently getting a single notification by ID is restricted to notifications created with the same key type.

This makes things awkward for the functional tests now we’ve removed the ability to create live keys in trial mode. So this commit removes the restriction, so that any key can get any notification, no matter how it was created.

And you’re never going to guess a UUID, so the chances of this giving you privileged access to someone’s personal information is none.

This does not change the get all notifications endpoint, which absolutely should be restricted by key type.