### PR TITLE
Test message filtering

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from flask import current_app
 from sqlalchemy import func, desc, asc, cast, Date as sql_date
 
 from app import db
@@ -28,7 +29,10 @@ def dao_get_job_by_service_id_and_job_id(service_id, job_id):
 
 
 def dao_get_jobs_by_service_id(service_id, limit_days=None, page=1, page_size=50, statuses=None):
-    query_filter = [Job.service_id == service_id]
+    query_filter = [
+        Job.service_id == service_id,
+        Job.original_file_name != current_app.config['TEST_MESSAGE_FILENAME']
+    ]
     if limit_days is not None:
         query_filter.append(cast(Job.created_at, sql_date) >= days_ago(limit_days))
     if statuses is not None and statuses != ['']:

--- a/config.py
+++ b/config.py
@@ -57,6 +57,7 @@ class Config(object):
     PAGE_SIZE = 50
     SMS_CHAR_COUNT_LIMIT = 495
     BRANDING_PATH = '/static/images/email-template/crests/'
+    TEST_MESSAGE_FILENAME = 'Test message'
 
     NOTIFY_SERVICE_ID = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'
     INVITATION_EMAIL_TEMPLATE_ID = '4f46df42-f795-4cc4-83bb-65ca312f49cc'

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -265,7 +265,8 @@ def sample_job(notify_db,
                created_at=None,
                job_status='pending',
                scheduled_for=None,
-               processing_started=None):
+               processing_started=None,
+               original_file_name='some.csv'):
     if service is None:
         service = sample_service(notify_db, notify_db_session)
     if template is None:
@@ -277,7 +278,7 @@ def sample_job(notify_db,
         'service': service,
         'template_id': template.id,
         'template_version': template.version,
-        'original_file_name': 'some.csv',
+        'original_file_name': original_file_name,
         'notification_count': notification_count,
         'created_at': created_at or datetime.utcnow(),
         'created_by': service.created_by,

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -300,3 +300,16 @@ def test_get_jobs_for_service_is_paginated(notify_db, notify_db_session, sample_
     assert len(res.items) == 2
     assert res.items[0].created_at == datetime(2015, 1, 1, 8)
     assert res.items[1].created_at == datetime(2015, 1, 1, 7)
+
+
+def test_get_jobs_for_service_doesnt_return_test_messages(notify_db, notify_db_session, sample_template, sample_job):
+    test_job = create_job(
+        notify_db,
+        notify_db_session,
+        sample_template.service,
+        sample_template,
+        original_file_name='Test message')
+
+    jobs = dao_get_jobs_by_service_id(sample_job.service_id).items
+
+    assert jobs == [sample_job]

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -32,15 +32,15 @@ def test_should_get_all_statuses_for_notifications_associated_with_job(
         notify_db_session,
         sample_service,
         sample_job):
-
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='created')
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='sending')
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='delivered')
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='pending')
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='failed')
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='technical-failure')  # noqa
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='temporary-failure')  # noqa
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='permanent-failure')  # noqa
+    notification = partial(create_notification, notify_db, notify_db_session, service=sample_service, job=sample_job)
+    notification(status='created')
+    notification(status='sending')
+    notification(status='delivered')
+    notification(status='pending')
+    notification(status='failed')
+    notification(status='technical-failure')
+    notification(status='temporary-failure')
+    notification(status='permanent-failure')
 
     results = dao_get_notification_outcomes_for_job(sample_service.id, sample_job.id)
     assert [(row.count, row.status) for row in results] == [
@@ -60,14 +60,15 @@ def test_should_count_of_statuses_for_notifications_associated_with_job(
         notify_db_session,
         sample_service,
         sample_job):
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='created')
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='created')
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='sending')
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='sending')
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='sending')
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='sending')
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='delivered')
-    create_notification(notify_db, notify_db_session, service=sample_service, job=sample_job, status='delivered')
+    notification = partial(create_notification, notify_db, notify_db_session, service=sample_service, job=sample_job)
+    notification(status='created')
+    notification(status='created')
+    notification(status='sending')
+    notification(status='sending')
+    notification(status='sending')
+    notification(status='sending')
+    notification(status='delivered')
+    notification(status='delivered')
 
     results = dao_get_notification_outcomes_for_job(sample_service.id, sample_job.id)
     assert [(row.count, row.status) for row in results] == [


### PR DESCRIPTION
We previously filtered test messages on the front-end - unfortunately this doesn't play well with pagination since if you have a page that only contains jobs - eg:

![image](https://cloud.githubusercontent.com/assets/5020841/19273007/cb7c9cfe-8fc2-11e6-9f90-0dfe4d4f7487.png)

so put this on the API side so its filtered before paginating.