### PR TITLE
bump notification-utils to 9.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ statsd==3.2.1
 git+https://github.com/alphagov/notifications-python-client.git@1.3.0#egg=notifications-python-client==1.3.0
 
 
-git+https://github.com/alphagov/notifications-utils.git@9.0.3#egg=notifications-utils==9.0.3
+git+https://github.com/alphagov/notifications-utils.git@9.0.5#egg=notifications-utils==9.0.5


### PR DESCRIPTION
includes improved email validation regex

had to wait a day after admin to ensure any earlier invalid emails that were still in the queue flush through the system fine