### PR TITLE
Let jobs be scheduled up to 96 hours in the future

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -39,8 +39,8 @@ def _validate_positive_number(value, msg="Not a positive integer"):
         raise ValidationError(msg)
 
 
-def _validate_datetime_not_more_than_24_hours_in_future(dte, msg="Date cannot be more than 24hrs in the future"):
-    if dte > datetime.utcnow() + timedelta(hours=24):
+def _validate_datetime_not_more_than_96_hours_in_future(dte, msg="Date cannot be more than 96hrs in the future"):
+    if dte > datetime.utcnow() + timedelta(hours=96):
         raise ValidationError(msg)
 
 
@@ -227,7 +227,7 @@ class JobSchema(BaseSchema):
     @validates('scheduled_for')
     def validate_scheduled_for(self, value):
         _validate_datetime_not_in_past(value)
-        _validate_datetime_not_more_than_24_hours_in_future(value)
+        _validate_datetime_not_more_than_96_hours_in_future(value)
 
     class Meta:
         model = models.Job

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -137,7 +137,7 @@ def test_create_scheduled_job(notify_api, sample_template, mocker, fake_uuid):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             with freeze_time("2016-01-01 12:00:00.000000"):
-                scheduled_date = (datetime.utcnow() + timedelta(hours=23, minutes=59)).isoformat()
+                scheduled_date = (datetime.utcnow() + timedelta(hours=95, minutes=59)).isoformat()
                 mocker.patch('app.celery.tasks.process_job.apply_async')
                 data = {
                     'id': fake_uuid,
@@ -163,7 +163,7 @@ def test_create_scheduled_job(notify_api, sample_template, mocker, fake_uuid):
                 resp_json = json.loads(response.get_data(as_text=True))
 
                 assert resp_json['data']['id'] == fake_uuid
-                assert resp_json['data']['scheduled_for'] == datetime(2016, 1, 2, 11, 59, 0,
+                assert resp_json['data']['scheduled_for'] == datetime(2016, 1, 5, 11, 59, 0,
                                                                       tzinfo=pytz.UTC).isoformat()
                 assert resp_json['data']['job_status'] == 'scheduled'
                 assert resp_json['data']['template'] == str(sample_template.id)
@@ -174,7 +174,7 @@ def test_should_not_create_scheduled_job_more_then_24_hours_hence(notify_api, sa
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             with freeze_time("2016-01-01 11:09:00.061258"):
-                scheduled_date = (datetime.utcnow() + timedelta(hours=24, minutes=1)).isoformat()
+                scheduled_date = (datetime.utcnow() + timedelta(hours=96, minutes=1)).isoformat()
 
                 mocker.patch('app.celery.tasks.process_job.apply_async')
                 data = {
@@ -202,7 +202,7 @@ def test_should_not_create_scheduled_job_more_then_24_hours_hence(notify_api, sa
                 resp_json = json.loads(response.get_data(as_text=True))
                 assert resp_json['result'] == 'error'
                 assert 'scheduled_for' in resp_json['message']
-                assert resp_json['message']['scheduled_for'] == ['Date cannot be more than 24hrs in the future']
+                assert resp_json['message']['scheduled_for'] == ['Date cannot be more than 96hrs in the future']
 
 
 def test_should_not_create_scheduled_job_in_the_past(notify_api, sample_template, mocker, fake_uuid):


### PR DESCRIPTION
If you want to send a job on Monday morning, you should be able to schedule it on Friday. You shouldn’t need to work on the weekend.

96 hours is a full 4 days, so you can schedule a job at any time on Friday for any time on Monday.

We’ve checked with the information assurance people, and they’re OK with us holding the data for this extra amount of time.