### PR TITLE
Error handling

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -31,7 +31,7 @@ def run_scheduled_jobs():
             process_job.apply_async([str(job.id)], queue="process-job")
             current_app.logger.info("Job ID {} added to process job queue".format(job.id))
     except SQLAlchemyError as e:
-        current_app.logger.exception("Failed to run scheduled jobs", e)
+        current_app.logger.exception("Failed to run scheduled jobs")
         raise
 
 
@@ -45,7 +45,7 @@ def delete_verify_codes():
             "Delete job started {} finished {} deleted {} verify codes".format(start, datetime.utcnow(), deleted)
         )
     except SQLAlchemyError as e:
-        current_app.logger.exception("Failed to delete verify codes", e)
+        current_app.logger.exception("Failed to delete verify codes")
         raise
 
 
@@ -63,7 +63,7 @@ def delete_successful_notifications():
             )
         )
     except SQLAlchemyError as e:
-        current_app.logger.exception("Failed to delete successful notifications", e)
+        current_app.logger.exception("Failed to delete successful notifications")
         raise
 
 
@@ -84,7 +84,7 @@ def delete_failed_notifications():
             )
         )
     except SQLAlchemyError as e:
-        current_app.logger.exception("Failed to delete failed notifications", e)
+        current_app.logger.exception("Failed to delete failed notifications")
         raise
 
 
@@ -98,7 +98,7 @@ def delete_invitations():
             "Delete job started {} finished {} deleted {} invitations".format(start, datetime.utcnow(), deleted)
         )
     except SQLAlchemyError as e:
-        current_app.logger.exception("Failed to delete invitations", e)
+        current_app.logger.exception("Failed to delete invitations")
         raise
 
 

--- a/app/errors.py
+++ b/app/errors.py
@@ -42,10 +42,7 @@ def register_errors(blueprint):
 
     @blueprint.app_errorhandler(400)
     def bad_request(e):
-        if isinstance(e, str):
-            msg = e
-        else:
-            msg = e.description or "Invalid request parameters"
+        msg = e.description or "Invalid request parameters"
         current_app.logger.exception(msg)
         return jsonify(result='error', message=str(msg)), 400
 
@@ -61,10 +58,7 @@ def register_errors(blueprint):
 
     @blueprint.app_errorhandler(404)
     def page_not_found(e):
-        if isinstance(e, str):
-            msg = e
-        else:
-            msg = e.description or "Not found"
+        msg = e.description or "Not found"
         current_app.logger.exception(msg)
         return jsonify(result='error', message=msg), 404
 
@@ -73,18 +67,9 @@ def register_errors(blueprint):
         current_app.logger.exception(e)
         return jsonify(result='error', message=str(e.description)), 429
 
-    @blueprint.app_errorhandler(500)
-    def internal_server_error(e):
-        current_app.logger.exception(e)
-        return jsonify(result='error', message="Internal server error"), 500
-
     @blueprint.app_errorhandler(NoResultFound)
-    def no_result_found(e):
-        current_app.logger.exception(e)
-        return jsonify(result='error', message="No result found"), 404
-
     @blueprint.app_errorhandler(DataError)
-    def data_error(e):
+    def no_result_found(e):
         current_app.logger.exception(e)
         return jsonify(result='error', message="No result found"), 404
 
@@ -100,4 +85,11 @@ def register_errors(blueprint):
                     e.params.get('name', e.params.get('email_from', ''))
                 )]}
             ), 400
+        return jsonify(result='error', message="Internal server error"), 500
+
+    # this must be defined after all other error handlers since it catches the generic Exception object
+    @blueprint.app_errorhandler(500)
+    @blueprint.app_errorhandler(Exception)
+    def internal_server_error(e):
+        current_app.logger.exception(e)
         return jsonify(result='error', message="Internal server error"), 500

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -309,7 +309,7 @@ def persist_notification(
                 queue='send-email' if not research_mode else 'research-mode'
             )
     except Exception as e:
-        current_app.logger.exception("Failed to send to SQS exception", e)
+        current_app.logger.exception("Failed to send to SQS exception")
         dao_delete_notifications_and_history_by_id(notification_id)
         raise InvalidRequest(message="Internal server error", status_code=500)
 


### PR DESCRIPTION
1. Fix `logger.exception` syntax. log functions (`info`, `error`, etc) take in a msg parameter, the message to display, and any further parameters are assumed to be `%s` style format arguments - if they don't match, then the logger handles this error, however this was not being picked up by our custom handlers for JSON output (for kibana). I've made sure that everywhere where we call `logger.exception` we don't pass in `e` (`logger.exception` simply logs a regular error message, and then includes stack trace from the sys exc_info vars).

2. Clean up errors.py a little bit. Made sure there's a generic Exception handling thing so that if we throw any arbitrary exception it gets handled by our custom loggers and returns proper json, and removed some unused code paths and code duplication