### PR TITLE
Ignore case and whitespace in personalisation keys

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -72,10 +72,7 @@ def process_job(job_id):
             'job': str(job.id),
             'to': recipient,
             'row_number': row_number,
-            'personalisation': {
-                key: personalisation.get(key)
-                for key in template.placeholders
-            }
+            'personalisation': dict(personalisation)
         })
 
         if template.template_type == SMS_TYPE:

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ jsonschema==2.5.1
 
 git+https://github.com/alphagov/notifications-python-client.git@1.3.0#egg=notifications-python-client==1.3.0
 
-git+https://github.com/alphagov/notifications-utils.git@9.1.1#egg=notifications-utils==9.1.1
+git+https://github.com/alphagov/notifications-utils.git@9.2.1#egg=notifications-utils==9.2.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -190,7 +190,8 @@ def sample_template(notify_db,
 
 @pytest.fixture(scope='function')
 def sample_template_with_placeholders(notify_db, notify_db_session):
-    return sample_template(notify_db, notify_db_session, content="Hello ((name))\nYour thing is due soon")
+    # deliberate space and title case in placeholder
+    return sample_template(notify_db, notify_db_session, content="Hello (( Name))\nYour thing is due soon")
 
 
 @pytest.fixture(scope='function')

--- a/tests/app/invite/test_invite_rest.py
+++ b/tests/app/invite/test_invite_rest.py
@@ -85,7 +85,7 @@ def test_create_invited_user_invalid_email(notify_api, sample_service, mocker):
             assert response.status_code == 400
             json_resp = json.loads(response.get_data(as_text=True))
             assert json_resp['result'] == 'error'
-            assert json_resp['message'] == {'email_address': ['Not a valid email address']}
+            assert json_resp['message'] == {'email_address': ['Not a valid email address.']}
             app.celery.tasks.send_email.apply_async.assert_not_called()
 
 

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -306,7 +306,7 @@ def test_should_reject_email_notification_with_bad_email(notify_api, sample_emai
             mocked.apply_async.assert_not_called()
             assert response.status_code == 400
             assert data['result'] == 'error'
-            assert data['message']['to'][0] == 'Not a valid email address'
+            assert data['message']['to'][0] == 'Not a valid email address.'
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
@@ -913,7 +913,7 @@ def test_create_template_raises_invalid_request_exception_with_missing_personali
     from app.notifications.rest import create_template_object_for_notification
     with pytest.raises(InvalidRequest) as e:
         create_template_object_for_notification(template, {})
-    assert {'template': ['Missing personalisation: name']} == e.value.message
+    assert {'template': ['Missing personalisation:  Name']} == e.value.message
 
 
 def test_create_template_raises_invalid_request_exception_with_too_much_personalisation_data(

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -470,7 +470,7 @@ def test_send_user_reset_password_should_return_400_when_data_is_not_email_addre
             headers=[('Content-Type', 'application/json'), auth_header])
 
         assert resp.status_code == 400
-        assert json.loads(resp.get_data(as_text=True))['message'] == {'email': ['Not a valid email address']}
+        assert json.loads(resp.get_data(as_text=True))['message'] == {'email': ['Not a valid email address.']}
 
 
 @freeze_time("2016-01-01 11:09:00.061258")


### PR DESCRIPTION
From a support ticket:

> it's possible to add a personalisation token with trailing whitespace (eg. "key " rather than "key"). Can this be trimmed in the UI to guard against this? (one of our devs copied and pasted it from a document and inadvertently included the space)
> 
> Nothing major but caused a few hours of investigations!

Rather than trim the placeholder in the template, we should treat personalisation in API calls the same way we do with CSV files, ie we ignore case and spacing in the name of the placeholder. So
`(( First Name))` is equivalent to `((first_name))`, and both would be populated with a dictionary like `{'firstName': 'Chris'}`.

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/77
- [x] https://github.com/alphagov/notifications-utils/pull/78