### PR TITLE
update python client to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ monotonic==1.2
 statsd==3.2.1
 jsonschema==2.5.1
 
-git+https://github.com/alphagov/notifications-python-client.git@1.3.0#egg=notifications-python-client==1.3.0
+git+https://github.com/alphagov/notifications-python-client.git@2.0.0#egg=notifications-python-client==2.0.0
 
 git+https://github.com/alphagov/notifications-utils.git@9.1.1#egg=notifications-utils==9.1.1
 


### PR DESCRIPTION
this is to prevent 500 errors because <2.0.0 raised AssertionError if supplied JWT tokens were incorrectly formatted

tests added

- [x] https://github.com/alphagov/notifications-python-client/pull/40