### PR TITLE
Make bearer prefix on auth header case insensitive

### DIFF
--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -27,7 +27,7 @@ def get_auth_token(req):
     if not auth_header:
         raise AuthError('Unauthorized, authentication token must be provided', 401)
 
-    auth_scheme = auth_header[:7]
+    auth_scheme = auth_header[:7].title()
 
     if auth_scheme != 'Bearer ':
         raise AuthError('Unauthorized, authentication bearer scheme must be used', 401)

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -56,13 +56,14 @@ def test_should_not_allow_invalid_secret(notify_api, sample_api_key):
             assert data['message'] == {"token": ['Invalid token: signature, api token is not valid']}
 
 
-def test_should_allow_valid_token(notify_api, sample_api_key):
+@pytest.mark.parametrize('scheme', ['bearer', 'Bearer'])
+def test_should_allow_valid_token(notify_api, sample_api_key, scheme):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             token = __create_get_token(sample_api_key.service_id)
             response = client.get(
                 '/service/{}'.format(str(sample_api_key.service_id)),
-                headers={'Authorization': 'Bearer {}'.format(token)}
+                headers={'Authorization': '{} {}'.format(scheme, token)}
             )
             assert response.status_code == 200
 


### PR DESCRIPTION
From a support ticket:

> the "Bearer" prefix on the auth header is case sensitive. Can this be made case-insensitive?

Sure can 🙃

https://www.pivotaltracker.com/story/show/133183605