### PR TITLE
Add ‘letter’ as a possible template type

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -212,8 +212,7 @@ class TemplateSchema(BaseTemplateSchema):
 
     @validates_schema
     def validate_type(self, data):
-        template_type = data.get('template_type')
-        if template_type and template_type == models.EMAIL_TYPE:
+        if data.get('template_type') in [models.EMAIL_TYPE, models.LETTER_TYPE]:
             subject = data.get('subject')
             if not subject or subject.strip() == '':
                 raise ValidationError('Invalid template subject', 'subject')

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -213,7 +213,7 @@ class TemplateSchema(BaseTemplateSchema):
     @validates_schema
     def validate_type(self, data):
         template_type = data.get('template_type')
-        if template_type and template_type == 'email':
+        if template_type and template_type == models.EMAIL_TYPE:
             subject = data.get('subject')
             if not subject or subject.strip() == '':
                 raise ValidationError('Invalid template subject', 'subject')

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -180,7 +180,7 @@ def sample_template(notify_db,
         'created_by': created_by,
         'archived': archived
     }
-    if template_type == 'email':
+    if template_type in ['email', 'letter']:
         data.update({
             'subject': subject_line
         })

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -13,6 +13,7 @@ import pytest
 @pytest.mark.parametrize('template_type, subject', [
     ('sms', None),
     ('email', 'subject'),
+    ('letter', 'subject'),
 ])
 def test_create_template(sample_service, sample_user, template_type, subject):
     data = {

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -32,23 +32,6 @@ def test_create_template(sample_service, sample_user, template_type, subject):
     assert dao_get_all_templates_for_service(sample_service.id)[0].name == 'Sample Template'
 
 
-def test_create_email_template(sample_service, sample_user):
-    data = {
-        'name': 'Sample Template',
-        'template_type': "email",
-        'subject': "subject",
-        'content': "Template content",
-        'service': sample_service,
-        'created_by': sample_user
-    }
-    template = Template(**data)
-    dao_create_template(template)
-
-    assert Template.query.count() == 1
-    assert len(dao_get_all_templates_for_service(sample_service.id)) == 1
-    assert dao_get_all_templates_for_service(sample_service.id)[0].name == 'Sample Template'
-
-
 def test_update_template(sample_service, sample_user):
     data = {
         'name': 'Sample Template',

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -10,14 +10,20 @@ from app.models import Template, TemplateHistory
 import pytest
 
 
-def test_create_template(sample_service, sample_user):
+@pytest.mark.parametrize('template_type, subject', [
+    ('sms', None),
+    ('email', 'subject'),
+])
+def test_create_template(sample_service, sample_user, template_type, subject):
     data = {
         'name': 'Sample Template',
-        'template_type': "sms",
+        'template_type': template_type,
         'content': "Template content",
         'service': sample_service,
         'created_by': sample_user
     }
+    if subject:
+        data.update({'subject': subject})
     template = Template(**data)
     dao_create_template(template)
 

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -15,299 +15,281 @@ from app.dao.templates_dao import dao_get_template_by_id
     ('letter', 'subject'),
 ])
 def test_should_create_a_new_template_for_a_service(
-    notify_api, sample_user, sample_service, template_type, subject
+    client, sample_user, sample_service, template_type, subject
 ):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = {
-                'name': 'my template',
-                'template_type': template_type,
-                'content': 'template <b>content</b>',
-                'service': str(sample_service.id),
-                'created_by': str(sample_user.id)
-            }
-            if subject:
-                data.update({'subject': subject})
-            data = json.dumps(data)
-            auth_header = create_authorization_header()
+    data = {
+        'name': 'my template',
+        'template_type': template_type,
+        'content': 'template <b>content</b>',
+        'service': str(sample_service.id),
+        'created_by': str(sample_user.id)
+    }
+    if subject:
+        data.update({'subject': subject})
+    data = json.dumps(data)
+    auth_header = create_authorization_header()
 
-            response = client.post(
-                '/service/{}/template'.format(sample_service.id),
-                headers=[('Content-Type', 'application/json'), auth_header],
-                data=data
-            )
-            assert response.status_code == 201
-            json_resp = json.loads(response.get_data(as_text=True))
-            assert json_resp['data']['name'] == 'my template'
-            assert json_resp['data']['template_type'] == template_type
-            assert json_resp['data']['content'] == 'template content'
-            assert json_resp['data']['service'] == str(sample_service.id)
-            assert json_resp['data']['id']
-            assert json_resp['data']['version'] == 1
-            if subject:
-                assert json_resp['data']['subject'] == 'subject'
-            else:
-                assert not json_resp['data']['subject']
+    response = client.post(
+        '/service/{}/template'.format(sample_service.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=data
+    )
+    assert response.status_code == 201
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert json_resp['data']['name'] == 'my template'
+    assert json_resp['data']['template_type'] == template_type
+    assert json_resp['data']['content'] == 'template content'
+    assert json_resp['data']['service'] == str(sample_service.id)
+    assert json_resp['data']['id']
+    assert json_resp['data']['version'] == 1
+    if subject:
+        assert json_resp['data']['subject'] == 'subject'
+    else:
+        assert not json_resp['data']['subject']
 
 
-def test_should_be_error_if_service_does_not_exist_on_create(notify_api, sample_user, fake_uuid):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = {
-                'name': 'my template',
-                'template_type': 'sms',
-                'content': 'template content',
-                'service': fake_uuid,
-                'created_by': str(sample_user.id)
-            }
-            data = json.dumps(data)
-            auth_header = create_authorization_header()
+def test_should_be_error_if_service_does_not_exist_on_create(client, sample_user, fake_uuid):
+    data = {
+        'name': 'my template',
+        'template_type': 'sms',
+        'content': 'template content',
+        'service': fake_uuid,
+        'created_by': str(sample_user.id)
+    }
+    data = json.dumps(data)
+    auth_header = create_authorization_header()
 
-            response = client.post(
-                '/service/{}/template'.format(fake_uuid),
-                headers=[('Content-Type', 'application/json'), auth_header],
-                data=data
-            )
-            json_resp = json.loads(response.get_data(as_text=True))
-            assert response.status_code == 404
-            assert json_resp['result'] == 'error'
-            assert json_resp['message'] == 'No result found'
+    response = client.post(
+        '/service/{}/template'.format(fake_uuid),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=data
+    )
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert response.status_code == 404
+    assert json_resp['result'] == 'error'
+    assert json_resp['message'] == 'No result found'
 
 
-def test_should_error_if_created_by_missing(notify_api, sample_user, sample_service):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            service_id = str(sample_service.id)
-            data = {
-                'name': 'my template',
-                'template_type': 'sms',
-                'content': 'template content',
-                'service': service_id
-            }
-            data = json.dumps(data)
-            auth_header = create_authorization_header()
+def test_should_error_if_created_by_missing(client, sample_user, sample_service):
+    service_id = str(sample_service.id)
+    data = {
+        'name': 'my template',
+        'template_type': 'sms',
+        'content': 'template content',
+        'service': service_id
+    }
+    data = json.dumps(data)
+    auth_header = create_authorization_header()
 
-            response = client.post(
-                '/service/{}/template'.format(service_id),
-                headers=[('Content-Type', 'application/json'), auth_header],
-                data=data
-            )
-            json_resp = json.loads(response.get_data(as_text=True))
-            assert response.status_code == 400
-            assert json_resp['result'] == 'error'
+    response = client.post(
+        '/service/{}/template'.format(service_id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=data
+    )
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert response.status_code == 400
+    assert json_resp['result'] == 'error'
 
 
-def test_should_be_error_if_service_does_not_exist_on_update(notify_api, fake_uuid):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = {
-                'name': 'my template'
-            }
-            data = json.dumps(data)
-            auth_header = create_authorization_header()
+def test_should_be_error_if_service_does_not_exist_on_update(client, fake_uuid):
+    data = {
+        'name': 'my template'
+    }
+    data = json.dumps(data)
+    auth_header = create_authorization_header()
 
-            response = client.post(
-                '/service/{}/template/{}'.format(fake_uuid, fake_uuid),
-                headers=[('Content-Type', 'application/json'), auth_header],
-                data=data
-            )
-            json_resp = json.loads(response.get_data(as_text=True))
-            assert response.status_code == 404
-            assert json_resp['result'] == 'error'
-            assert json_resp['message'] == 'No result found'
+    response = client.post(
+        '/service/{}/template/{}'.format(fake_uuid, fake_uuid),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=data
+    )
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert response.status_code == 404
+    assert json_resp['result'] == 'error'
+    assert json_resp['message'] == 'No result found'
 
 
 @pytest.mark.parametrize('template_type', ['email', 'letter'])
-def test_must_have_a_subject_on_an_email_or_letter_template(notify_api, sample_user, sample_service, template_type):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = {
-                'name': 'my template',
-                'template_type': template_type,
-                'content': 'template content',
-                'service': str(sample_service.id),
-                'created_by': str(sample_user.id)
-            }
-            data = json.dumps(data)
-            auth_header = create_authorization_header()
+def test_must_have_a_subject_on_an_email_or_letter_template(client, sample_user, sample_service, template_type):
+    data = {
+        'name': 'my template',
+        'template_type': template_type,
+        'content': 'template content',
+        'service': str(sample_service.id),
+        'created_by': str(sample_user.id)
+    }
+    data = json.dumps(data)
+    auth_header = create_authorization_header()
 
-            response = client.post(
-                '/service/{}/template'.format(sample_service.id),
-                headers=[('Content-Type', 'application/json'), auth_header],
-                data=data
-            )
-            json_resp = json.loads(response.get_data(as_text=True))
-            assert response.status_code == 400
-            assert json_resp['result'] == 'error'
-            assert json_resp['message'] == {'subject': ['Invalid template subject']}
+    response = client.post(
+        '/service/{}/template'.format(sample_service.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=data
+    )
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert response.status_code == 400
+    assert json_resp['result'] == 'error'
+    assert json_resp['message'] == {'subject': ['Invalid template subject']}
 
 
-def test_update_should_update_a_template(notify_api, sample_user, sample_template):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = {
-                'content': 'my template has new content <script type="text/javascript">alert("foo")</script>',
-                'created_by': str(sample_user.id)
-            }
-            data = json.dumps(data)
-            auth_header = create_authorization_header()
+def test_update_should_update_a_template(client, sample_user, sample_template):
+    data = {
+        'content': 'my template has new content <script type="text/javascript">alert("foo")</script>',
+        'created_by': str(sample_user.id)
+    }
+    data = json.dumps(data)
+    auth_header = create_authorization_header()
 
-            update_response = client.post(
-                '/service/{}/template/{}'.format(sample_template.service_id, sample_template.id),
-                headers=[('Content-Type', 'application/json'), auth_header],
-                data=data
-            )
+    update_response = client.post(
+        '/service/{}/template/{}'.format(sample_template.service_id, sample_template.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=data
+    )
 
-            assert update_response.status_code == 200
-            update_json_resp = json.loads(update_response.get_data(as_text=True))
-            assert update_json_resp['data']['content'] == 'my template has new content alert("foo")'
-            assert update_json_resp['data']['name'] == sample_template.name
-            assert update_json_resp['data']['template_type'] == sample_template.template_type
-            assert update_json_resp['data']['version'] == 2
+    assert update_response.status_code == 200
+    update_json_resp = json.loads(update_response.get_data(as_text=True))
+    assert update_json_resp['data']['content'] == 'my template has new content alert("foo")'
+    assert update_json_resp['data']['name'] == sample_template.name
+    assert update_json_resp['data']['template_type'] == sample_template.template_type
+    assert update_json_resp['data']['version'] == 2
 
 
-def test_should_be_able_to_archive_template(notify_api, sample_template):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = {
-                'name': sample_template.name,
-                'template_type': sample_template.template_type,
-                'content': sample_template.content,
-                'archived': True,
-                'service': str(sample_template.service.id),
-                'created_by': str(sample_template.created_by.id)
-            }
+def test_should_be_able_to_archive_template(client, sample_template):
+    data = {
+        'name': sample_template.name,
+        'template_type': sample_template.template_type,
+        'content': sample_template.content,
+        'archived': True,
+        'service': str(sample_template.service.id),
+        'created_by': str(sample_template.created_by.id)
+    }
 
-            json_data = json.dumps(data)
+    json_data = json.dumps(data)
 
-            auth_header = create_authorization_header()
+    auth_header = create_authorization_header()
 
-            resp = client.post(
-                '/service/{}/template/{}'.format(sample_template.service.id, sample_template.id),
-                headers=[('Content-Type', 'application/json'), auth_header],
-                data=json_data
-            )
+    resp = client.post(
+        '/service/{}/template/{}'.format(sample_template.service.id, sample_template.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=json_data
+    )
 
-            assert resp.status_code == 200
-            assert Template.query.first().archived
+    assert resp.status_code == 200
+    assert Template.query.first().archived
 
 
-def test_should_be_able_to_get_all_templates_for_a_service(notify_api, sample_user, sample_service):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = {
-                'name': 'my template 1',
-                'template_type': 'email',
-                'subject': 'subject 1',
-                'content': 'template content',
-                'service': str(sample_service.id),
-                'created_by': str(sample_user.id)
-            }
-            data_1 = json.dumps(data)
-            data = {
-                'name': 'my template 2',
-                'template_type': 'email',
-                'subject': 'subject 2',
-                'content': 'template content',
-                'service': str(sample_service.id),
-                'created_by': str(sample_user.id)
-            }
-            data_2 = json.dumps(data)
-            auth_header = create_authorization_header()
-            client.post(
-                '/service/{}/template'.format(sample_service.id),
-                headers=[('Content-Type', 'application/json'), auth_header],
-                data=data_1
-            )
-            auth_header = create_authorization_header()
+def test_should_be_able_to_get_all_templates_for_a_service(client, sample_user, sample_service):
+    data = {
+        'name': 'my template 1',
+        'template_type': 'email',
+        'subject': 'subject 1',
+        'content': 'template content',
+        'service': str(sample_service.id),
+        'created_by': str(sample_user.id)
+    }
+    data_1 = json.dumps(data)
+    data = {
+        'name': 'my template 2',
+        'template_type': 'email',
+        'subject': 'subject 2',
+        'content': 'template content',
+        'service': str(sample_service.id),
+        'created_by': str(sample_user.id)
+    }
+    data_2 = json.dumps(data)
+    auth_header = create_authorization_header()
+    client.post(
+        '/service/{}/template'.format(sample_service.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=data_1
+    )
+    auth_header = create_authorization_header()
 
-            client.post(
-                '/service/{}/template'.format(sample_service.id),
-                headers=[('Content-Type', 'application/json'), auth_header],
-                data=data_2
-            )
+    client.post(
+        '/service/{}/template'.format(sample_service.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=data_2
+    )
 
-            auth_header = create_authorization_header()
+    auth_header = create_authorization_header()
 
-            response = client.get(
-                '/service/{}/template'.format(sample_service.id),
-                headers=[auth_header]
-            )
+    response = client.get(
+        '/service/{}/template'.format(sample_service.id),
+        headers=[auth_header]
+    )
 
-            assert response.status_code == 200
-            update_json_resp = json.loads(response.get_data(as_text=True))
-            assert update_json_resp['data'][0]['name'] == 'my template 2'
-            assert update_json_resp['data'][0]['version'] == 1
-            assert update_json_resp['data'][0]['created_at']
-            assert update_json_resp['data'][1]['name'] == 'my template 1'
-            assert update_json_resp['data'][1]['version'] == 1
-            assert update_json_resp['data'][1]['created_at']
+    assert response.status_code == 200
+    update_json_resp = json.loads(response.get_data(as_text=True))
+    assert update_json_resp['data'][0]['name'] == 'my template 2'
+    assert update_json_resp['data'][0]['version'] == 1
+    assert update_json_resp['data'][0]['created_at']
+    assert update_json_resp['data'][1]['name'] == 'my template 1'
+    assert update_json_resp['data'][1]['version'] == 1
+    assert update_json_resp['data'][1]['created_at']
 
 
-def test_should_get_only_templates_for_that_service(notify_api, sample_user, service_factory):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
+def test_should_get_only_templates_for_that_service(client, sample_user, service_factory):
 
-            service_1 = service_factory.get('service 1', email_from='service.1')
-            service_2 = service_factory.get('service 2', email_from='service.2')
+    service_1 = service_factory.get('service 1', email_from='service.1')
+    service_2 = service_factory.get('service 2', email_from='service.2')
 
-            auth_header_1 = create_authorization_header()
+    auth_header_1 = create_authorization_header()
 
-            response_1 = client.get(
-                '/service/{}/template'.format(service_1.id),
-                headers=[auth_header_1]
-            )
+    response_1 = client.get(
+        '/service/{}/template'.format(service_1.id),
+        headers=[auth_header_1]
+    )
 
-            auth_header_2 = create_authorization_header()
+    auth_header_2 = create_authorization_header()
 
-            response_2 = client.get(
-                '/service/{}/template'.format(service_2.id),
-                headers=[auth_header_2]
-            )
+    response_2 = client.get(
+        '/service/{}/template'.format(service_2.id),
+        headers=[auth_header_2]
+    )
 
-            assert response_1.status_code == 200
-            assert response_2.status_code == 200
+    assert response_1.status_code == 200
+    assert response_2.status_code == 200
 
-            json_resp_1 = json.loads(response_1.get_data(as_text=True))
-            json_resp_2 = json.loads(response_2.get_data(as_text=True))
+    json_resp_1 = json.loads(response_1.get_data(as_text=True))
+    json_resp_2 = json.loads(response_2.get_data(as_text=True))
 
-            assert len(json_resp_1['data']) == 1
-            assert len(json_resp_2['data']) == 1
+    assert len(json_resp_1['data']) == 1
+    assert len(json_resp_2['data']) == 1
 
-            data = {
-                'name': 'my template 2',
-                'template_type': 'email',
-                'subject': 'subject 2',
-                'content': 'template content',
-                'service': str(service_1.id),
-                'created_by': str(sample_user.id)
-            }
-            data = json.dumps(data)
-            create_auth_header = create_authorization_header()
-            resp = client.post(
-                '/service/{}/template'.format(service_1.id),
-                headers=[('Content-Type', 'application/json'), create_auth_header],
-                data=data
-            )
+    data = {
+        'name': 'my template 2',
+        'template_type': 'email',
+        'subject': 'subject 2',
+        'content': 'template content',
+        'service': str(service_1.id),
+        'created_by': str(sample_user.id)
+    }
+    data = json.dumps(data)
+    create_auth_header = create_authorization_header()
+    resp = client.post(
+        '/service/{}/template'.format(service_1.id),
+        headers=[('Content-Type', 'application/json'), create_auth_header],
+        data=data
+    )
 
-            response_3 = client.get(
-                '/service/{}/template'.format(service_1.id),
-                headers=[auth_header_1]
-            )
+    response_3 = client.get(
+        '/service/{}/template'.format(service_1.id),
+        headers=[auth_header_1]
+    )
 
-            response_4 = client.get(
-                '/service/{}/template'.format(service_2.id),
-                headers=[auth_header_2]
-            )
+    response_4 = client.get(
+        '/service/{}/template'.format(service_2.id),
+        headers=[auth_header_2]
+    )
 
-            assert response_3.status_code == 200
-            assert response_4.status_code == 200
+    assert response_3.status_code == 200
+    assert response_4.status_code == 200
 
-            json_resp_3 = json.loads(response_3.get_data(as_text=True))
-            json_resp_4 = json.loads(response_4.get_data(as_text=True))
+    json_resp_3 = json.loads(response_3.get_data(as_text=True))
+    json_resp_4 = json.loads(response_4.get_data(as_text=True))
 
-            assert len(json_resp_3['data']) == 2
-            assert len(json_resp_4['data']) == 1
+    assert len(json_resp_3['data']) == 2
+    assert len(json_resp_4['data']) == 1
 
 
 @pytest.mark.parametrize(
@@ -331,29 +313,28 @@ def test_should_get_only_templates_for_that_service(notify_api, sample_user, ser
 )
 def test_should_get_a_single_template(
     notify_db,
-    notify_api,
+    client,
     sample_user,
     service_factory,
     subject,
     content,
     template_type
 ):
-    with notify_api.test_request_context(), notify_api.test_client() as client:
 
-        template = create_sample_template(
-            notify_db, notify_db.session, subject_line=subject, content=content, template_type=template_type
-        )
+    template = create_sample_template(
+        notify_db, notify_db.session, subject_line=subject, content=content, template_type=template_type
+    )
 
-        response = client.get(
-            '/service/{}/template/{}'.format(template.service.id, template.id),
-            headers=[create_authorization_header()]
-        )
+    response = client.get(
+        '/service/{}/template/{}'.format(template.service.id, template.id),
+        headers=[create_authorization_header()]
+    )
 
-        data = json.loads(response.get_data(as_text=True))['data']
+    data = json.loads(response.get_data(as_text=True))['data']
 
-        assert response.status_code == 200
-        assert data['content'] == content
-        assert data['subject'] == subject
+    assert response.status_code == 200
+    assert data['content'] == content
+    assert data['subject'] == subject
 
 
 @pytest.mark.parametrize(
@@ -392,7 +373,7 @@ def test_should_get_a_single_template(
 )
 def test_should_preview_a_single_template(
     notify_db,
-    notify_api,
+    client,
     sample_user,
     service_factory,
     subject,
@@ -402,144 +383,136 @@ def test_should_preview_a_single_template(
     expected_content,
     expected_error
 ):
-    with notify_api.test_request_context(), notify_api.test_client() as client:
 
-        template = create_sample_template(
-            notify_db, notify_db.session, subject_line=subject, content=content, template_type='email'
-        )
+    template = create_sample_template(
+        notify_db, notify_db.session, subject_line=subject, content=content, template_type='email'
+    )
 
-        response = client.get(
-            path.format(template.service.id, template.id),
-            headers=[create_authorization_header()]
-        )
+    response = client.get(
+        path.format(template.service.id, template.id),
+        headers=[create_authorization_header()]
+    )
 
-        content = json.loads(response.get_data(as_text=True))
+    content = json.loads(response.get_data(as_text=True))
 
-        if expected_error:
-            assert response.status_code == 400
-            assert content['message']['template'] == [expected_error]
-        else:
-            assert response.status_code == 200
-            assert content['content'] == expected_content
-            assert content['subject'] == expected_subject
-
-
-def test_should_return_empty_array_if_no_templates_for_service(notify_api, sample_service):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-
-            auth_header = create_authorization_header()
-
-            response = client.get(
-                '/service/{}/template'.format(sample_service.id),
-                headers=[auth_header]
-            )
-
-            assert response.status_code == 200
-            json_resp = json.loads(response.get_data(as_text=True))
-            assert len(json_resp['data']) == 0
+    if expected_error:
+        assert response.status_code == 400
+        assert content['message']['template'] == [expected_error]
+    else:
+        assert response.status_code == 200
+        assert content['content'] == expected_content
+        assert content['subject'] == expected_subject
 
 
-def test_should_return_404_if_no_templates_for_service_with_id(notify_api, sample_service, fake_uuid):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
+def test_should_return_empty_array_if_no_templates_for_service(client, sample_service):
 
-            auth_header = create_authorization_header()
+    auth_header = create_authorization_header()
 
-            response = client.get(
-                '/service/{}/template/{}'.format(sample_service.id, fake_uuid),
-                headers=[auth_header]
-            )
+    response = client.get(
+        '/service/{}/template'.format(sample_service.id),
+        headers=[auth_header]
+    )
 
-            assert response.status_code == 404
-            json_resp = json.loads(response.get_data(as_text=True))
-            assert json_resp['result'] == 'error'
-            assert json_resp['message'] == 'No result found'
+    assert response.status_code == 200
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert len(json_resp['data']) == 0
 
 
-def test_create_400_for_over_limit_content(notify_api, sample_user, sample_service, fake_uuid):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            limit = notify_api.config.get('SMS_CHAR_COUNT_LIMIT')
-            content = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(limit + 1))
-            data = {
-                'name': 'too big template',
-                'template_type': 'sms',
-                'content': content,
-                'service': str(sample_service.id),
-                'created_by': str(sample_user.id)
-            }
-            data = json.dumps(data)
-            auth_header = create_authorization_header()
+def test_should_return_404_if_no_templates_for_service_with_id(client, sample_service, fake_uuid):
 
-            response = client.post(
-                '/service/{}/template'.format(sample_service.id),
-                headers=[('Content-Type', 'application/json'), auth_header],
-                data=data
-            )
-            assert response.status_code == 400
-            json_resp = json.loads(response.get_data(as_text=True))
-            assert (
-                'Content has a character count greater than the limit of {}'
-            ).format(limit) in json_resp['message']['content']
+    auth_header = create_authorization_header()
+
+    response = client.get(
+        '/service/{}/template/{}'.format(sample_service.id, fake_uuid),
+        headers=[auth_header]
+    )
+
+    assert response.status_code == 404
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert json_resp['result'] == 'error'
+    assert json_resp['message'] == 'No result found'
 
 
-def test_update_400_for_over_limit_content(notify_api, sample_user, sample_template):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            limit = notify_api.config.get('SMS_CHAR_COUNT_LIMIT')
-            json_data = json.dumps({
-                'content': ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(limit + 1)),
-                'created_by': str(sample_user.id)
-            })
-            auth_header = create_authorization_header()
-            resp = client.post(
-                '/service/{}/template/{}'.format(sample_template.service.id, sample_template.id),
-                headers=[('Content-Type', 'application/json'), auth_header],
-                data=json_data
-            )
-            assert resp.status_code == 400
-            json_resp = json.loads(resp.get_data(as_text=True))
-            assert (
-                'Content has a character count greater than the limit of {}'
-            ).format(limit) in json_resp['message']['content']
+def test_create_400_for_over_limit_content(client, notify_api, sample_user, sample_service, fake_uuid):
+
+    limit = notify_api.config.get('SMS_CHAR_COUNT_LIMIT')
+    content = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(limit + 1))
+    data = {
+        'name': 'too big template',
+        'template_type': 'sms',
+        'content': content,
+        'service': str(sample_service.id),
+        'created_by': str(sample_user.id)
+    }
+    data = json.dumps(data)
+    auth_header = create_authorization_header()
+
+    response = client.post(
+        '/service/{}/template'.format(sample_service.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=data
+    )
+    assert response.status_code == 400
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert (
+        'Content has a character count greater than the limit of {}'
+    ).format(limit) in json_resp['message']['content']
 
 
-def test_should_return_all_template_versions_for_service_and_template_id(notify_api, sample_template):
+def test_update_400_for_over_limit_content(client, notify_api, sample_user, sample_template):
+
+    limit = notify_api.config.get('SMS_CHAR_COUNT_LIMIT')
+    json_data = json.dumps({
+        'content': ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(limit + 1)),
+        'created_by': str(sample_user.id)
+    })
+    auth_header = create_authorization_header()
+    resp = client.post(
+        '/service/{}/template/{}'.format(sample_template.service.id, sample_template.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=json_data
+    )
+    assert resp.status_code == 400
+    json_resp = json.loads(resp.get_data(as_text=True))
+    assert (
+        'Content has a character count greater than the limit of {}'
+    ).format(limit) in json_resp['message']['content']
+
+
+def test_should_return_all_template_versions_for_service_and_template_id(client, sample_template):
     original_content = sample_template.content
     from app.dao.templates_dao import dao_update_template
     sample_template.content = original_content + '1'
     dao_update_template(sample_template)
     sample_template.content = original_content + '2'
     dao_update_template(sample_template)
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            auth_header = create_authorization_header()
-            resp = client.get('/service/{}/template/{}/versions'.format(sample_template.service_id, sample_template.id),
-                              headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 200
-            resp_json = json.loads(resp.get_data(as_text=True))['data']
-            assert len(resp_json) == 3
-            for x in resp_json:
-                if x['version'] == 1:
-                    assert x['content'] == original_content
-                elif x['version'] == 2:
-                    assert x['content'] == original_content + '1'
-                else:
-                    assert x['content'] == original_content + '2'
+
+    auth_header = create_authorization_header()
+    resp = client.get('/service/{}/template/{}/versions'.format(sample_template.service_id, sample_template.id),
+                      headers=[('Content-Type', 'application/json'), auth_header])
+    assert resp.status_code == 200
+    resp_json = json.loads(resp.get_data(as_text=True))['data']
+    assert len(resp_json) == 3
+    for x in resp_json:
+        if x['version'] == 1:
+            assert x['content'] == original_content
+        elif x['version'] == 2:
+            assert x['content'] == original_content + '1'
+        else:
+            assert x['content'] == original_content + '2'
 
 
-def test_update_does_not_create_new_version_when_there_is_no_change(notify_api, sample_template):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            auth_header = create_authorization_header()
-            data = {
-                'template_type': sample_template.template_type,
-                'content': sample_template.content,
-            }
-            resp = client.post('/service/{}/template/{}'.format(sample_template.service_id, sample_template.id),
-                               data=json.dumps(data),
-                               headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 200
+def test_update_does_not_create_new_version_when_there_is_no_change(client, sample_template):
+
+    auth_header = create_authorization_header()
+    data = {
+        'template_type': sample_template.template_type,
+        'content': sample_template.content,
+    }
+    resp = client.post('/service/{}/template/{}'.format(sample_template.service_id, sample_template.id),
+                       data=json.dumps(data),
+                       headers=[('Content-Type', 'application/json'), auth_header])
+    assert resp.status_code == 200
+
     template = dao_get_template_by_id(sample_template.id)
     assert template.version == 1

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -321,6 +321,11 @@ def test_should_get_only_templates_for_that_service(notify_api, sample_user, ser
             None,
             'hello ((name)) we’ve received your ((thing))',
             'sms'
+        ),
+        (
+            'about your ((thing))',
+            'hello ((name)) we’ve received your ((thing))',
+            'letter'
         )
     ]
 )

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -49,36 +49,6 @@ def test_should_create_a_new_template_for_a_service(
                 assert not json_resp['data']['subject']
 
 
-def test_should_create_a_new_email_template_for_a_service(notify_api, sample_user, sample_service):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = {
-                'name': 'my template',
-                'template_type': 'email',
-                'subject': 'subject',
-                'content': 'template <b>content</b>',
-                'service': str(sample_service.id),
-                'created_by': str(sample_user.id)
-            }
-            data = json.dumps(data)
-            auth_header = create_authorization_header()
-
-            response = client.post(
-                '/service/{}/template'.format(sample_service.id),
-                headers=[('Content-Type', 'application/json'), auth_header],
-                data=data
-            )
-            assert response.status_code == 201
-            json_resp = json.loads(response.get_data(as_text=True))
-            assert json_resp['data']['name'] == 'my template'
-            assert json_resp['data']['template_type'] == 'email'
-            assert json_resp['data']['content'] == 'template content'
-            assert json_resp['data']['service'] == str(sample_service.id)
-            assert json_resp['data']['subject'] == 'subject'
-            assert json_resp['data']['version'] == 1
-            assert json_resp['data']['id']
-
-
 def test_should_be_error_if_service_does_not_exist_on_create(notify_api, sample_user, fake_uuid):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -12,6 +12,7 @@ from app.dao.templates_dao import dao_get_template_by_id
 @pytest.mark.parametrize('template_type, subject', [
     ('sms', None),
     ('email', 'subject'),
+    ('letter', 'subject'),
 ])
 def test_should_create_a_new_template_for_a_service(
     notify_api, sample_user, sample_service, template_type, subject
@@ -116,12 +117,13 @@ def test_should_be_error_if_service_does_not_exist_on_update(notify_api, fake_uu
             assert json_resp['message'] == 'No result found'
 
 
-def test_must_have_a_subject_on_an_email_template(notify_api, sample_user, sample_service):
+@pytest.mark.parametrize('template_type', ['email', 'letter'])
+def test_must_have_a_subject_on_an_email_or_letter_template(notify_api, sample_user, sample_service, template_type):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             data = {
                 'name': 'my template',
-                'template_type': 'email',
+                'template_type': template_type,
                 'content': 'template content',
                 'service': str(sample_service.id),
                 'created_by': str(sample_user.id)


### PR DESCRIPTION
Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/731

So that you can create and get letter templates.

Fairly straightforward with few changes, apart from loads of whitespace-only changes in 1cda00b

Best to look at the commits in isolation because of that last one.