### PR TITLE
Add letter to possible template types in DB

### DIFF
--- a/migrations/versions/0059_add_letter_template_type.py
+++ b/migrations/versions/0059_add_letter_template_type.py
@@ -1,0 +1,56 @@
+"""empty message
+
+Revision ID: f266fb67597a
+Revises: 0058_add_letters_flag
+Create Date: 2016-11-07 16:13:18.961527
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0059_add_letter_template_type'
+down_revision = '0058_add_letters_flag'
+
+
+name = 'template_type'
+tmp_name = 'tmp_' + name
+
+old_options = ('sms', 'email')
+new_options = old_options + ('letter',)
+
+new_type = sa.Enum(*new_options, name=name)
+old_type = sa.Enum(*old_options, name=name)
+
+tcr = sa.sql.table(
+    'templates',
+    sa.Column('template_type', new_type, nullable=False)
+)
+
+
+def upgrade():
+    op.execute('ALTER TYPE ' + name + ' RENAME TO ' + tmp_name)
+
+    new_type.create(op.get_bind())
+    op.execute(
+        'ALTER TABLE templates ALTER COLUMN template_type ' +
+        'TYPE ' + name + ' USING template_type::text::' + name
+    )
+    op.execute('DROP TYPE ' + tmp_name)
+
+
+def downgrade():
+    # Convert 'letter' template into 'email'
+    op.execute(
+        tcr.update().where(tcr.c.template_type=='letter').values(template_type='email')
+    )
+
+    op.execute('ALTER TYPE ' + name + ' RENAME TO ' + tmp_name)
+
+    old_type.create(op.get_bind())
+    op.execute(
+        'ALTER TABLE templates ALTER COLUMN template_type ' +
+        'TYPE ' + name + ' USING template_type::text::' + name
+    )
+    op.execute('DROP TYPE ' + tmp_name)


### PR DESCRIPTION
A letter type was added to the `enum` in the `Template` model at the same it was added to the `Notification` model. But the migration was only done for the `notifications` table, not the `templates` table.

See: https://github.com/alphagov/notifications-api/commit/25db1bce#diff-516aab258e161fc65e7564dabd2c625aR19

This commit does the migration to add `letter` as a possible value for the `template_type` column, which is a bit fiddly because `enum`s.

Before:
```
notification_api=# select enum_range(null::template_type);
 enum_range
-------------
 {sms,email}
(1 row)
```

After upgrade:
```
notification_api=# select enum_range(null::template_type);
     enum_range
--------------------
 {sms,email,letter}
(1 row)
```

After downgrade
```
notification_api=# select enum_range(null::template_type);
 enum_range
-------------
 {sms,email}
(1 row)
```