### PR TITLE
Refactor for code reuse

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -150,12 +150,12 @@ def send_sms(self,
         )
 
     except SQLAlchemyError as e:
-        current_app.logger.exception("RETRY: send_sms notification {}".format(saved_notification.id), e)
+        current_app.logger.exception("RETRY: send_sms notification", e)
         try:
             raise self.retry(queue="retry", exc=e)
         except self.MaxRetriesExceededError:
             current_app.logger.exception(
-                "RETRY FAILED: task send_sms failed for notification {}".format(saved_notification.id),
+                "RETRY FAILED: task send_sms failed for notification",
                 e
             )
 
@@ -198,11 +198,11 @@ def send_email(self, service_id,
 
         current_app.logger.info("Email {} created at {}".format(saved_notification.id, created_at))
     except SQLAlchemyError as e:
-        current_app.logger.exception("RETRY: send_email notification {}".format(saved_notification.id), e)
+        current_app.logger.exception("RETRY: send_email notification", e)
         try:
             raise self.retry(queue="retry", exc=e)
         except self.MaxRetriesExceededError:
             current_app.logger.error(
-                "RETRY FAILED: task send_email failed for notification {}".format(saved_notification.id),
+                "RETRY FAILED: task send_email failed for notification",
                 e
             )

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -130,26 +130,26 @@ def send_sms(self,
         return
 
     try:
-        persist_notification(template_id=notification['template'],
-                             template_version=notification['template_version'],
-                             recipient=notification['to'],
-                             service_id=service.id,
-                             personalisation=notification.get('personalisation'),
-                             notification_type=SMS_TYPE,
-                             api_key_id=api_key_id,
-                             key_type=key_type,
-                             created_at=created_at,
-                             job_id=notification.get('job', None),
-                             job_row_number=notification.get('row_number', None),
-                             )
+        saved_notification = persist_notification(template_id=notification['template'],
+                                                  template_version=notification['template_version'],
+                                                  recipient=notification['to'],
+                                                  service_id=service.id,
+                                                  personalisation=notification.get('personalisation'),
+                                                  notification_type=SMS_TYPE,
+                                                  api_key_id=api_key_id,
+                                                  key_type=key_type,
+                                                  created_at=created_at,
+                                                  job_id=notification.get('job', None),
+                                                  job_row_number=notification.get('row_number', None),
+                                                  )
 
         provider_tasks.deliver_sms.apply_async(
-            [notification_id],
+            [saved_notification.id],
             queue='send-sms' if not service.research_mode else 'research-mode'
         )
 
         current_app.logger.info(
-            "SMS {} created at {} for job {}".format(notification_id, created_at, notification.get('job', None))
+            "SMS {} created at {} for job {}".format(saved_notification.id, created_at, notification.get('job', None))
         )
 
     except SQLAlchemyError as e:
@@ -179,7 +179,7 @@ def send_email(self, service_id,
         return
 
     try:
-        persist_notification(
+        saved_notification = persist_notification(
             template_id=notification['template'],
             template_version=notification['template_version'],
             recipient=notification['to'],
@@ -195,7 +195,7 @@ def send_email(self, service_id,
         )
 
         provider_tasks.deliver_email.apply_async(
-            [notification_id],
+            [saved_notification.id],
             queue='send-email' if not service.research_mode else 'research-mode'
         )
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -153,12 +153,12 @@ def send_sms(self,
         )
 
     except SQLAlchemyError as e:
-        current_app.logger.exception("RETRY: send_sms notification {}".format(notification_id), e)
+        current_app.logger.exception("RETRY: send_sms notification {}".format(saved_notification.id), e)
         try:
             raise self.retry(queue="retry", exc=e)
         except self.MaxRetriesExceededError:
             current_app.logger.exception(
-                "RETRY FAILED: task send_sms failed for notification {}".format(notification.id),
+                "RETRY FAILED: task send_sms failed for notification {}".format(saved_notification.id),
                 e
             )
 
@@ -199,13 +199,13 @@ def send_email(self, service_id,
             queue='send-email' if not service.research_mode else 'research-mode'
         )
 
-        current_app.logger.info("Email {} created at {}".format(notification_id, created_at))
+        current_app.logger.info("Email {} created at {}".format(saved_notification.id, created_at))
     except SQLAlchemyError as e:
-        current_app.logger.exception("RETRY: send_email notification {}".format(notification_id), e)
+        current_app.logger.exception("RETRY: send_email notification {}".format(saved_notification.id), e)
         try:
             raise self.retry(queue="retry", exc=e)
         except self.MaxRetriesExceededError:
             current_app.logger.error(
-                "RETRY FAILED: task send_email failed for notification {}".format(notification.id),
+                "RETRY FAILED: task send_email failed for notification {}".format(saved_notification.id),
                 e
             )

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -17,11 +17,9 @@ from app.dao.jobs_dao import (
     dao_update_job,
     dao_get_job_by_id
 )
-from app.dao.notifications_dao import dao_create_notification
 from app.dao.services_dao import dao_fetch_service_by_id, fetch_todays_total_message_count
 from app.dao.templates_dao import dao_get_template_by_id
 from app.models import (
-    Notification,
     EMAIL_TYPE,
     SMS_TYPE,
     KEY_TYPE_NORMAL
@@ -140,6 +138,7 @@ def send_sms(self,
                              notification_type=SMS_TYPE,
                              api_key_id=api_key_id,
                              key_type=key_type,
+                             created_at=created_at,
                              job_id=notification.get('job', None),
                              job_row_number=notification.get('row_number', None),
                              )
@@ -189,8 +188,10 @@ def send_email(self, service_id,
             notification_type=EMAIL_TYPE,
             api_key_id=api_key_id,
             key_type=key_type,
+            created_at=created_at,
             job_id=notification.get('job', None),
             job_row_number=notification.get('row_number', None),
+
         )
 
         provider_tasks.deliver_email.apply_async(

--- a/app/models.py
+++ b/app/models.py
@@ -572,7 +572,9 @@ class Notification(db.Model):
                             personalisation,
                             notification_type,
                             api_key_id,
-                            key_type):
+                            key_type,
+                            job_id,
+                            job_row_number):
         return cls(
             template_id=template_id,
             template_version=template_version,
@@ -583,7 +585,9 @@ class Notification(db.Model):
             personalisation=personalisation,
             notification_type=notification_type,
             api_key_id=api_key_id,
-            key_type=key_type
+            key_type=key_type,
+            job_id=job_id,
+            job_row_number=job_row_number,
         )
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -537,34 +537,6 @@ class Notification(db.Model):
         if personalisation:
             self._personalisation = encryption.encrypt(personalisation)
 
-    @classmethod
-    def from_request(cls,
-                     template_id,
-                     template_version,
-                     recipient,
-                     service_id,
-                     personalisation,
-                     notification_type,
-                     api_key_id,
-                     key_type,
-                     job_id,
-                     job_row_number,
-                     created_at):
-        return cls(
-            template_id=template_id,
-            template_version=template_version,
-            to=recipient,
-            service_id=service_id,
-            status='created',
-            created_at=created_at,
-            personalisation=personalisation,
-            notification_type=notification_type,
-            api_key_id=api_key_id,
-            key_type=key_type,
-            job_id=job_id,
-            job_row_number=job_row_number
-        )
-
 
 class NotificationHistory(db.Model):
     __tablename__ = 'notification_history'

--- a/app/models.py
+++ b/app/models.py
@@ -538,56 +538,31 @@ class Notification(db.Model):
             self._personalisation = encryption.encrypt(personalisation)
 
     @classmethod
-    def from_api_request(
-            cls,
-            created_at,
-            notification,
-            notification_id,
-            service_id,
-            notification_type,
-            api_key_id,
-            key_type):
-        return cls(
-            id=notification_id,
-            template_id=notification['template'],
-            template_version=notification['template_version'],
-            to=notification['to'],
-            service_id=service_id,
-            job_id=notification.get('job', None),
-            job_row_number=notification.get('row_number', None),
-            status='created',
-            created_at=datetime.datetime.strptime(created_at, DATETIME_FORMAT),
-            personalisation=notification.get('personalisation'),
-            notification_type=notification_type,
-            api_key_id=api_key_id,
-            key_type=key_type
-        )
-
-    @classmethod
-    def from_v2_api_request(cls,
-                            template_id,
-                            template_version,
-                            recipient,
-                            service_id,
-                            personalisation,
-                            notification_type,
-                            api_key_id,
-                            key_type,
-                            job_id,
-                            job_row_number):
+    def from_request(cls,
+                     template_id,
+                     template_version,
+                     recipient,
+                     service_id,
+                     personalisation,
+                     notification_type,
+                     api_key_id,
+                     key_type,
+                     job_id,
+                     job_row_number,
+                     created_at):
         return cls(
             template_id=template_id,
             template_version=template_version,
             to=recipient,
             service_id=service_id,
             status='created',
-            created_at=datetime.datetime.utcnow(),
+            created_at=created_at,
             personalisation=personalisation,
             notification_type=notification_type,
             api_key_id=api_key_id,
             key_type=key_type,
             job_id=job_id,
-            job_row_number=job_row_number,
+            job_row_number=job_row_number
         )
 
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -1,7 +1,10 @@
+from datetime import datetime
+
 from flask import current_app
 from notifications_utils.renderers import PassThrough
 from notifications_utils.template import Template
 
+from app import DATETIME_FORMAT
 from app.celery import provider_tasks
 from app.dao.notifications_dao import dao_create_notification, dao_delete_notifications_and_history_by_id
 from app.models import SMS_TYPE, Notification, KEY_TYPE_TEST, EMAIL_TYPE
@@ -41,19 +44,22 @@ def persist_notification(template_id,
                          notification_type,
                          api_key_id,
                          key_type,
+                         created_at=None,
                          job_id=None,
                          job_row_number=None):
-    notification = Notification.from_v2_api_request(template_id=template_id,
-                                                    template_version=template_version,
-                                                    recipient=recipient,
-                                                    service_id=service_id,
-                                                    personalisation=personalisation,
-                                                    notification_type=notification_type,
-                                                    api_key_id=api_key_id,
-                                                    key_type=key_type,
-                                                    job_id=job_id,
-                                                    job_row_number=job_row_number
-                                                    )
+    notification = Notification.from_request(
+        template_id=template_id,
+        template_version=template_version,
+        recipient=recipient,
+        service_id=service_id,
+        personalisation=personalisation,
+        notification_type=notification_type,
+        api_key_id=api_key_id,
+        key_type=key_type,
+        created_at=created_at if created_at else datetime.utcnow().strftime(DATETIME_FORMAT),
+        job_id=job_id,
+        job_row_number=job_row_number
+    )
     dao_create_notification(notification)
     return notification
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -40,7 +40,9 @@ def persist_notification(template_id,
                          personalisation,
                          notification_type,
                          api_key_id,
-                         key_type):
+                         key_type,
+                         job_id=None,
+                         job_row_number=None):
     notification = Notification.from_v2_api_request(template_id=template_id,
                                                     template_version=template_version,
                                                     recipient=recipient,
@@ -48,7 +50,10 @@ def persist_notification(template_id,
                                                     personalisation=personalisation,
                                                     notification_type=notification_type,
                                                     api_key_id=api_key_id,
-                                                    key_type=key_type)
+                                                    key_type=key_type,
+                                                    job_id=job_id,
+                                                    job_row_number=job_row_number
+                                                    )
     dao_create_notification(notification)
     return notification
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -47,10 +47,10 @@ def persist_notification(template_id,
                          created_at=None,
                          job_id=None,
                          job_row_number=None):
-    notification = Notification.from_request(
+    notification = Notification(
         template_id=template_id,
         template_version=template_version,
-        recipient=recipient,
+        to=recipient,
         service_id=service_id,
         personalisation=personalisation,
         notification_type=notification_type,

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -77,7 +77,7 @@ def send_notification_to_queue(notification, research_mode):
                 [str(notification.id)],
                 queue='send-email' if not research_mode else 'research-mode'
             )
-    except Exception as e:
+    except Exception:
         current_app.logger.exception("Failed to send to SQS exception")
         dao_delete_notifications_and_history_by_id(notification.id)
         raise

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -742,8 +742,7 @@ def test_should_use_email_template_and_persist_without_personalisation(sample_em
         encryption.encrypt(notification),
         now.strftime(DATETIME_FORMAT)
     )
-    assert Notification.query.count() == 1
-    persisted_notification = Notification.query.all()[0]
+    persisted_notification = Notification.query.one()
     assert persisted_notification.to == 'my_email@my_email.com'
     assert persisted_notification.template_id == sample_email_template.id
     assert persisted_notification.created_at == now

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -339,8 +339,7 @@ def test_should_send_template_to_correct_sms_task_and_persist(sample_template_wi
         datetime.utcnow().strftime(DATETIME_FORMAT)
     )
 
-    assert Notification.query.count() == 1
-    persisted_notification = Notification.query.all()[0]
+    persisted_notification = Notification.query.one()
     assert persisted_notification.to == '+447234123123'
     assert persisted_notification.template_id == sample_template_with_placeholders.id
     assert persisted_notification.template_version == sample_template_with_placeholders.version
@@ -377,8 +376,7 @@ def test_should_put_send_sms_task_in_research_mode_queue_if_research_mode_servic
         encryption.encrypt(notification),
         datetime.utcnow().strftime(DATETIME_FORMAT)
     )
-    assert Notification.query.count() == 1
-    persisted_notification = Notification.query.all()[0]
+    persisted_notification = Notification.query.one()
     provider_tasks.deliver_sms.apply_async.assert_called_once_with(
         [persisted_notification.id],
         queue="research-mode"
@@ -392,7 +390,7 @@ def test_should_send_sms_if_restricted_service_and_valid_number(notify_db, notif
     template = sample_template(notify_db, notify_db_session, service=service)
     notification = _notification_json(template, "+447700900890")  # The user’s own number, but in a different format
 
-    mocked_deliver_sms = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
+    mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
     notification_id = uuid.uuid4()
     encrypt_notification = encryption.encrypt(notification)
@@ -403,8 +401,7 @@ def test_should_send_sms_if_restricted_service_and_valid_number(notify_db, notif
         datetime.utcnow().strftime(DATETIME_FORMAT)
     )
 
-    assert Notification.query.count() == 1
-    persisted_notification = Notification.query.all()[0]
+    persisted_notification = Notification.query.one()
     assert persisted_notification.to == '+447700900890'
     assert persisted_notification.template_id == template.id
     assert persisted_notification.template_version == template.version
@@ -440,8 +437,7 @@ def test_should_send_sms_if_restricted_service_and_non_team_number_with_test_key
         key_type=KEY_TYPE_TEST
     )
 
-    assert Notification.query.count() == 1
-    persisted_notification = Notification.query.all()[0]
+    persisted_notification = Notification.query.one()
     mocked_deliver_sms.assert_called_once_with(
         [persisted_notification.id],
         queue="send-sms"
@@ -469,8 +465,7 @@ def test_should_send_email_if_restricted_service_and_non_team_email_address_with
         key_type=KEY_TYPE_TEST
     )
 
-    assert Notification.query.count() == 1
-    persisted_notification = Notification.query.all()[0]
+    persisted_notification = Notification.query.one()
     mocked_deliver_email.assert_called_once_with(
         [persisted_notification.id],
         queue="send-email"
@@ -537,8 +532,7 @@ def test_should_put_send_email_task_in_research_mode_queue_if_research_mode_serv
         datetime.utcnow().strftime(DATETIME_FORMAT)
     )
 
-    assert Notification.query.count() == 1
-    persisted_notification = Notification.query.all()[0]
+    persisted_notification = Notification.query.one()
     provider_tasks.deliver_email.apply_async.assert_called_once_with(
         [persisted_notification.id],
         queue="research-mode"
@@ -563,8 +557,7 @@ def test_should_send_sms_template_to_and_persist_with_job_id(sample_job, sample_
         api_key_id=str(sample_api_key.id),
         key_type=KEY_TYPE_NORMAL
     )
-    assert Notification.query.count() == 1
-    persisted_notification = Notification.query.all()[0]
+    persisted_notification = Notification.query.one()
     assert persisted_notification.to == '+447234123123'
     assert persisted_notification.job_id == sample_job.id
     assert persisted_notification.template_id == sample_job.template.id
@@ -660,8 +653,7 @@ def test_should_use_email_template_and_persist(sample_email_template_with_placeh
             key_type=sample_api_key.key_type
         )
 
-    assert Notification.query.count() == 1
-    persisted_notification = Notification.query.all()[0]
+    persisted_notification = Notification.query.one()
     assert persisted_notification.to == 'my_email@my_email.com'
     assert persisted_notification.template_id == sample_email_template_with_placeholders.id
     assert persisted_notification.template_version == sample_email_template_with_placeholders.version
@@ -698,8 +690,7 @@ def test_send_email_should_use_template_version_from_job_not_latest(sample_email
         now.strftime(DATETIME_FORMAT)
     )
 
-    assert Notification.query.count() == 1
-    persisted_notification = Notification.query.all()[0]
+    persisted_notification = Notification.query.one()
     assert persisted_notification.to == 'my_email@my_email.com'
     assert persisted_notification.template_id == sample_email_template.id
     assert persisted_notification.template_version == version_on_notification
@@ -724,8 +715,7 @@ def test_should_use_email_template_subject_placeholders(sample_email_template_wi
         encryption.encrypt(notification),
         now.strftime(DATETIME_FORMAT)
     )
-    assert Notification.query.count() == 1
-    persisted_notification = Notification.query.all()[0]
+    persisted_notification = Notification.query.one()
     assert persisted_notification.to == 'my_email@my_email.com'
     assert persisted_notification.template_id == sample_email_template_with_placeholders.id
     assert persisted_notification.status == 'created'
@@ -742,8 +732,6 @@ def test_should_use_email_template_subject_placeholders(sample_email_template_wi
 def test_should_use_email_template_and_persist_without_personalisation(sample_email_template, mocker):
     notification = _notification_json(sample_email_template, "my_email@my_email.com")
     mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
-
-    assert Notification.query.count() == 0
 
     notification_id = uuid.uuid4()
 

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime
 
 import pytest
@@ -12,23 +13,20 @@ from app.models import (
 def test_should_build_notification_from_minimal_set_of_api_derived_params(notify_api):
     now = datetime.utcnow()
 
-    notification = {
-        'template': 'template',
-        'template_version': '1',
-        'to': 'someone',
-        'personalisation': {}
-    }
-    notification = Notification.from_api_request(
-        created_at=now.strftime(DATETIME_FORMAT),
-        notification=notification,
-        notification_id="notification_id",
-        service_id="service_id",
+    notification = Notification.from_request(
+        template_id='template',
+        template_version='1',
+        recipient='someone',
+        service_id='service_id',
         notification_type='SMS',
+        created_at=now,
         api_key_id='api_key_id',
-        key_type='key_type'
+        key_type='key_type',
+        personalisation={},
+        job_id=None,
+        job_row_number=None
     )
     assert notification.created_at == now
-    assert notification.id == "notification_id"
     assert notification.template_id == 'template'
     assert notification.template_version == '1'
     assert not notification.job_row_number
@@ -44,28 +42,22 @@ def test_should_build_notification_from_minimal_set_of_api_derived_params(notify
 
 def test_should_build_notification_from_full_set_of_api_derived_params(notify_api):
     now = datetime.utcnow()
-
-    notification = {
-        'template': 'template',
-        'template_version': '1',
-        'to': 'someone',
-        'personalisation': {'key': 'value'},
-        'job': 'job_id',
-        'row_number': 100
-    }
-    notification = Notification.from_api_request(
-        created_at=now.strftime(DATETIME_FORMAT),
-        notification=notification,
-        notification_id="notification_id",
-        service_id="service_id",
-        notification_type='SMS',
-        api_key_id='api_key_id',
-        key_type='key_type'
-    )
+    notification = Notification.from_request(template_id='template',
+                                             template_version=1,
+                                             recipient='someone',
+                                             service_id='service_id',
+                                             personalisation={'key': 'value'},
+                                             notification_type='SMS',
+                                             api_key_id='api_key_id',
+                                             key_type='key_type',
+                                             job_id='job_id',
+                                             job_row_number=100,
+                                             created_at=now
+                                             )
     assert notification.created_at == now
-    assert notification.id == "notification_id"
+    assert notification.id is None
     assert notification.template_id == 'template'
-    assert notification.template_version == '1'
+    assert notification.template_version == 1
     assert notification.job_row_number == 100
     assert notification.job_id == 'job_id'
     assert notification.to == 'someone'

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -10,65 +10,6 @@ from app.models import (
     MOBILE_TYPE, EMAIL_TYPE)
 
 
-def test_should_build_notification_from_minimal_set_of_api_derived_params(notify_api):
-    now = datetime.utcnow()
-
-    notification = Notification.from_request(
-        template_id='template',
-        template_version='1',
-        recipient='someone',
-        service_id='service_id',
-        notification_type='SMS',
-        created_at=now,
-        api_key_id='api_key_id',
-        key_type='key_type',
-        personalisation={},
-        job_id=None,
-        job_row_number=None
-    )
-    assert notification.created_at == now
-    assert notification.template_id == 'template'
-    assert notification.template_version == '1'
-    assert not notification.job_row_number
-    assert not notification.job_id
-    assert notification.to == 'someone'
-    assert notification.service_id == 'service_id'
-    assert notification.status == 'created'
-    assert not notification.personalisation
-    assert notification.notification_type == 'SMS'
-    assert notification.api_key_id == 'api_key_id'
-    assert notification.key_type == 'key_type'
-
-
-def test_should_build_notification_from_full_set_of_api_derived_params(notify_api):
-    now = datetime.utcnow()
-    notification = Notification.from_request(template_id='template',
-                                             template_version=1,
-                                             recipient='someone',
-                                             service_id='service_id',
-                                             personalisation={'key': 'value'},
-                                             notification_type='SMS',
-                                             api_key_id='api_key_id',
-                                             key_type='key_type',
-                                             job_id='job_id',
-                                             job_row_number=100,
-                                             created_at=now
-                                             )
-    assert notification.created_at == now
-    assert notification.id is None
-    assert notification.template_id == 'template'
-    assert notification.template_version == 1
-    assert notification.job_row_number == 100
-    assert notification.job_id == 'job_id'
-    assert notification.to == 'someone'
-    assert notification.service_id == 'service_id'
-    assert notification.status == 'created'
-    assert notification.personalisation == {'key': 'value'}
-    assert notification.notification_type == 'SMS'
-    assert notification.api_key_id == 'api_key_id'
-    assert notification.key_type == 'key_type'
-
-
 @pytest.mark.parametrize('mobile_number', [
     '07700 900678',
     '+44 7700 900678'


### PR DESCRIPTION
- Refactor send_sms and send_email to use common code to persist the notificaiton.
- Use the same method to persist a notification.
- Refactored the send_sms task to use this method.
- Fix the send_sms and send_email code to send the notification id that has been persisted.
- Fix logging in send_sms and send_email