### PR TITLE
Small fixes for the V2 post notification endpoints

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -57,7 +57,7 @@ def persist_notification(template_id,
         notification_type=notification_type,
         api_key_id=api_key_id,
         key_type=key_type,
-        created_at=created_at or datetime.utcnow().strftime(DATETIME_FORMAT),
+        created_at=created_at or datetime.utcnow(),
         job_id=job_id,
         job_row_number=job_row_number,
         client_reference=reference

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -47,7 +47,7 @@ post_sms_response = {
     "title": "response v2/notifications/sms",
     "properties": {
         "id": uuid,
-        "reference": {"type": "string"},
+        "reference": {"type": ["string", "null"]},
         "content": sms_content,
         "uri": {"type": "string"},
         "template": template
@@ -90,7 +90,7 @@ post_email_response = {
     "title": "response v2/notifications/email",
     "properties": {
         "id": uuid,
-        "reference": {"type": "string"},
+        "reference": {"type": ["string", "null"]},
         "content": email_content,
         "uri": {"type": "string"},
         "template": template

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -38,7 +38,7 @@ def post_sms_notification():
                                         notification_type=SMS_TYPE,
                                         api_key_id=api_user.id,
                                         key_type=api_user.key_type,
-                                        reference=form['reference'])
+                                        reference=form.get('reference'))
     send_notification_to_queue(notification, service.research_mode)
 
     resp = create_post_sms_response_from_notification(notification,
@@ -65,7 +65,7 @@ def post_email_notification():
                                         notification_type=EMAIL_TYPE,
                                         api_key_id=api_user.id,
                                         key_type=api_user.key_type,
-                                        reference=form['reference'])
+                                        reference=form.get('reference'))
 
     send_notification_to_queue(notification, service.research_mode)
 

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -29,7 +29,7 @@ def test_post_sms_notification_returns_201(notify_api, sample_template, mocker, 
             notifications = Notification.query.all()
             assert len(notifications) == 1
             notification_id = notifications[0].id
-            assert resp_json['id'] == notification_id
+            assert resp_json['id'] == str(notification_id)
             assert resp_json['reference'] == reference
             assert resp_json['content']['body'] == sample_template.content
             assert resp_json['content']['from_number'] == sample_template.service.sms_sender


### PR DESCRIPTION
For the post_sms_response and post_email_response the reference property is always present but the value can be null.

Added a test for an empty reference.
Remove datetime format on the created_at attribute of a notification, it is not needed.