### PR TITLE
Stringify the cost before passing to jsonify as it complains otherwise

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -557,7 +557,7 @@ class Notification(db.Model):
             desc(ProviderRates.valid_from)
         ).limit(1).one()
 
-        return provider_rate.rate * self.billable_units
+        return float(provider_rate.rate * self.billable_units)
 
     def completed_at(self):
         if self.status in [

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -1,12 +1,24 @@
 import json
+import pytest
 
 from app import DATETIME_FORMAT
 from tests import create_authorization_header
+from tests.app.conftest import sample_notification as create_sample_notification
 
 
-def test_get_notification_by_id_returns_200(client, sample_notification):
+@pytest.mark.parametrize('billable_units, provider', [
+    (1, 'mmg'),
+    (0, 'mmg'),
+    (1, None)
+])
+def test_get_notification_by_id_returns_200(
+        client, notify_db, notify_db_session, sample_provider_rate, billable_units, provider
+):
+    sample_notification = create_sample_notification(
+        notify_db, notify_db_session, billable_units=billable_units, sent_by=provider
+    )
+
     auth_header = create_authorization_header(service_id=sample_notification.service_id)
-
     response = client.get(
         path='/v2/notifications/{}'.format(sample_notification.id),
         headers=[('Content-Type', 'application/json'), auth_header])


### PR DESCRIPTION
When trying to call getNotificationById a 500 occurred. 

Essentially it complained at the point we we're trying jsonify the notification response (without having str'd the cost). This seems to fix the issue after testing on the NET client.