### PR TITLE
Statsd counter for user agents.

### DIFF
--- a/tests/app/test_user_agent_processing.py
+++ b/tests/app/test_user_agent_processing.py
@@ -1,0 +1,13 @@
+from app import process_user_agent
+
+
+def test_can_process_notify_api_user_agent():
+    assert "notify-api-python-client.3-0-0" == process_user_agent("NOTIFY-API-PYTHON-CLIENT/3.0.0")
+
+
+def test_can_handle_non_notify_api_user_agent():
+    assert "non-notify-user-agent" == process_user_agent("Mozilla/5.0 (iPad; U; CPU OS 3_2_1 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Mobile/7B405")  # noqa
+
+
+def test_handles_null_user_agent():
+    assert "unknown" == process_user_agent(None)


### PR DESCRIPTION
We want to log the usage of the various API clients we have so that we understand when they can be cycled.

To this end we are going to count usage in statsd.

All notify clients have a suer agent, of the format: NOTIFY-API-{LANGUAGE}-CLIENT/version.number

For example, NOTIFY-API-PYTHON-CLIENT/3.0.0

We convert that into a statsd/graphite friendly string of the format: notify-api-python-client.3-0-0

So we can subdivide on client and client version on our dashboards.

Present but unknown User agents are records as "non-notify-user-agent"

Missing are presented as "unknown"