### PR TITLE
Protect send_sms send_email task from being executed twice

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -157,17 +157,21 @@ def send_sms(self,
             # Sometimes, SQS plays the same message twice. We should be able to catch an IntegrityError, but it seems
             # SQLAlchemy is throwing a FlushError. So we check if the notification id already exists then do not
             # send to the retry queue.
-            current_app.logger.exception(
-                "RETRY: send_sms notification for job {} row number {}".format(
+            current_app.logger.error(
+                "RETRY: send_sms notification for job {} row number {} and notification id {}".format(
                     notification.get('job', None),
-                    notification.get('row_number', None)), e)
+                    notification.get('row_number', None),
+                    notification_id))
+            current_app.logger.exception(e)
             try:
                 raise self.retry(queue="retry", exc=e)
             except self.MaxRetriesExceededError:
-                current_app.logger.exception(
-                    "RETRY FAILED: task send_sms failed for notification".format(
+                current_app.logger.error(
+                    "RETRY FAILED: send_sms notification for job {} row number {} and notification id {}".format(
                         notification.get('job', None),
-                        notification.get('row_number', None)), e)
+                        notification.get('row_number', None),
+                        notification_id))
+                current_app.logger.exception(e)
 
 
 @notify_celery.task(bind=True, name="send-email", max_retries=5, default_retry_delay=300)
@@ -212,13 +216,18 @@ def send_email(self, service_id,
             # Sometimes, SQS plays the same message twice. We should be able to catch an IntegrityError, but it seems
             # SQLAlchemy is throwing a FlushError. So we check if the notification id already exists then do not
             # send to the retry queue.
-            current_app.logger.exception("RETRY: send_email notification".format(notification.get('job', None),
-                                                                                 notification.get('row_number', None)),
-                                         e)
+            current_app.logger.error(
+                "RETRY: send_sms notification for job {} row number {} and notification id {}".format(
+                    notification.get('job', None),
+                    notification.get('row_number', None),
+                    notification_id))
+            current_app.logger.exception(e)
             try:
                 raise self.retry(queue="retry", exc=e)
             except self.MaxRetriesExceededError:
                 current_app.logger.error(
-                    "RETRY FAILED: task send_email failed for notification".format(
+                    "RETRY FAILED: send_sms notification for job {} row number {} and notification id {}".format(
                         notification.get('job', None),
-                        notification.get('row_number', None)), e)
+                        notification.get('row_number', None),
+                        notification_id))
+                current_app.logger.exception(e)

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -4,7 +4,7 @@ from flask import current_app
 from notifications_utils.renderers import PassThrough
 from notifications_utils.template import Template
 
-from app import DATETIME_FORMAT, redis_store
+from app import redis_store
 from app.celery import provider_tasks
 from app.clients import redis
 from app.dao.notifications_dao import dao_create_notification, dao_delete_notifications_and_history_by_id
@@ -48,8 +48,10 @@ def persist_notification(template_id,
                          created_at=None,
                          job_id=None,
                          job_row_number=None,
-                         reference=None):
+                         reference=None,
+                         notification_id=None):
     notification = Notification(
+        id=notification_id,
         template_id=template_id,
         template_version=template_version,
         to=recipient,

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import pytest
 from freezegun import freeze_time
 
@@ -21,10 +22,9 @@ from tests.app.conftest import (
 
 
 @pytest.mark.parametrize('key_type', ['team', 'normal'])
-def test_exception_thown_by_redis_store_get_should_not_be_fatal(
+def test_exception_thrown_by_redis_store_get_should_not_be_fatal(
         notify_db,
         notify_db_session,
-        notify_api,
         key_type,
         mocker):
     mocker.patch('app.notifications.validators.redis_store.redis_store.get', side_effect=Exception("broken redis"))
@@ -39,7 +39,8 @@ def test_exception_thown_by_redis_store_get_should_not_be_fatal(
     assert e.value.status_code == 429
     assert e.value.message == 'Exceeded send limits (4) for today'
     assert e.value.fields == []
-    app.notifications.validators.redis_store.set.assert_not_called()
+    app.notifications.validators.redis_store.set\
+        .assert_called_with("{}-{}-count".format(service.id, datetime.utcnow().strftime("%Y-%m-%d")), 5, ex=3600)
 
 
 @pytest.mark.parametrize('key_type', ['test', 'team', 'normal'])


### PR DESCRIPTION
Sometimes a message is picked up twice of the SQS queue, we need to safe guard ourselves for that.

In this PR the id for the notification is passed in and used to created the notification, which causes a integrity error.
Normally when we get a SQLAlchemy error here we send the message to the retry queue, but if the notification already exists
we just ignore it.