### PR TITLE
Remove marshmallow schema validation + format error messages

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -8,7 +8,7 @@ from itertools import groupby
 
 from flask import current_app
 from werkzeug.datastructures import MultiDict
-from sqlalchemy import (desc, func, or_, and_, asc, cast, Text)
+from sqlalchemy import (desc, func, or_, and_, asc)
 from sqlalchemy.orm import joinedload
 
 from app import db, create_uuid

--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -42,6 +42,4 @@ def build_error_message(errors):
 
 
 def __format_message(e):
-    s = e.message.split("'")
-    msg = "{}{}".format(s[1], s[2])
-    return msg if not e.cause else "{} {}".format(e.path[0], e.cause.message)
+    return e.message.replace("'", "") if not e.cause else "{} {}".format(e.path[0], e.cause.message)

--- a/app/v2/notifications/get_notifications.py
+++ b/app/v2/notifications/get_notifications.py
@@ -2,8 +2,9 @@ from flask import jsonify, request, url_for
 
 from app import api_user
 from app.dao import notifications_dao
-from app.schemas import notifications_filter_schema
+from app.schema_validation import validate
 from app.v2.notifications import notification_blueprint
+from app.v2.notifications.notification_schemas import get_notifications_request
 
 
 @notification_blueprint.route("/<uuid:id>", methods=['GET'])
@@ -17,7 +18,12 @@ def get_notification_by_id(id):
 
 @notification_blueprint.route("", methods=['GET'])
 def get_notifications():
-    data = notifications_filter_schema.load(request.args).data
+    _data = request.args.to_dict(flat=False)
+    if 'older_than' in _data:
+        # flat=False makes everything a list, but we only ever allow one value for "older_than"
+        _data['older_than'] = _data['older_than'][0]
+
+    data = validate(_data, get_notifications_request)
 
     paginated_notifications = notifications_dao.get_notifications_for_service(
         str(api_user.service_id),
@@ -29,11 +35,11 @@ def get_notifications():
 
     def _build_links(notifications):
         _links = {
-            'current': url_for(".get_notifications", _external=True, **request.args.to_dict(flat=False)),
+            'current': url_for(".get_notifications", _external=True, **data),
         }
 
         if len(notifications):
-            next_query_params = dict(request.args.to_dict(flat=False), older_than=notifications[-1].id)
+            next_query_params = dict(data, older_than=notifications[-1].id)
             _links['next'] = url_for(".get_notifications", _external=True, **next_query_params)
 
         return _links

--- a/app/v2/notifications/get_notifications.py
+++ b/app/v2/notifications/get_notifications.py
@@ -1,5 +1,4 @@
 from flask import jsonify, request, url_for
-
 from app import api_user
 from app.dao import notifications_dao
 from app.schema_validation import validate

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -1,3 +1,4 @@
+from app.models import NOTIFICATION_STATUS_TYPES, TEMPLATE_TYPES
 from app.schema_validation.definitions import (uuid, personalisation)
 
 # this may belong in a templates module
@@ -70,6 +71,28 @@ get_notification_response = {
         "line_1", "line_2", "line_3", "line_4", "line_5", "line_6", "postcode",
         "type", "status", "template", "created_at", "sent_at", "completed_at"
     ]
+}
+
+get_notifications_request = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "schema for query parameters allowed when getting list of notifications",
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "array",
+            "items": {
+                "enum": NOTIFICATION_STATUS_TYPES
+            }
+        },
+        "template_type": {
+            "type": "array",
+            "items": {
+                "enum": TEMPLATE_TYPES
+            }
+        },
+        "older_than": uuid
+    },
+    "additionalProperties": False,
 }
 
 get_notifications_response = {

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -156,6 +156,40 @@ def test_get_all_notifications_filter_by_single_status(client, notify_db, notify
     assert json_response['notifications'][0]['status'] == "pending"
 
 
+@pytest.mark.parametrize('invalid_statuses, valid_statuses', [
+    # one invalid status
+    (["elephant"], []),
+    # multiple invalid statuses
+    (["elephant", "giraffe", "cheetah"], []),
+    # one bad status and one good status
+    (["elephant"], ["created"]),
+])
+def test_get_all_notifications_filter_by_status_invalid_status(
+        client, notify_db, notify_db_session, invalid_statuses, valid_statuses
+):
+    notification = create_sample_notification(notify_db, notify_db_session, status="pending")
+    create_sample_notification(notify_db, notify_db_session)
+
+    auth_header = create_authorization_header(service_id=notification.service_id)
+    response = client.get(
+        path='/v2/notifications?{}'.format(
+            "&".join(["status={}".format(status) for status in invalid_statuses + valid_statuses])
+        ),
+        headers=[('Content-Type', 'application/json'), auth_header])
+
+    json_response = json.loads(response.get_data(as_text=True))
+    partial_error_message = "is not one of " \
+        "[created, sending, delivered, pending, failed, technical-failure, temporary-failure, permanent-failure]"
+
+    assert response.status_code == 400
+    assert response.headers['Content-type'] == "application/json"
+
+    assert json_response['status_code'] == 400
+    assert len(json_response['errors']) == len(invalid_statuses)
+    for index, invalid_status in enumerate(invalid_statuses):
+        assert json_response['errors'][index]['message'] == "{} {}".format(invalid_status, partial_error_message)
+
+
 def test_get_all_notifications_filter_by_multiple_statuses(client, notify_db, notify_db_session):
     notifications = [
         create_sample_notification(notify_db, notify_db_session, status=_status)

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -60,6 +60,44 @@ def test_get_notification_by_id_returns_200(
     assert json_response == expected_response
 
 
+def test_get_notification_by_id_nonexistent_id(client, sample_notification):
+    auth_header = create_authorization_header(service_id=sample_notification.service_id)
+    response = client.get(
+        path='/v2/notifications/dd4b8b9d-d414-4a83-9256-580046bf18f9',
+        headers=[('Content-Type', 'application/json'), auth_header])
+
+    assert response.status_code == 404
+    assert response.headers['Content-type'] == 'application/json'
+
+    json_response = json.loads(response.get_data(as_text=True))
+    assert json_response == {
+        "errors": [
+            {
+                "error": "NoResultFound",
+                "message": "No result found"
+            }
+        ],
+        "status_code": 404
+    }
+
+
+def test_get_notification_by_id_invalid_id(client, sample_notification):
+    auth_header = create_authorization_header(service_id=sample_notification.service_id)
+    response = client.get(
+        path='/v2/notifications/1234-badly-formatted-id-7890',
+        headers=[('Content-Type', 'application/json'), auth_header])
+
+    assert response.status_code == 404
+    assert response.headers['Content-type'] == 'application/json'
+
+    json_response = json.loads(response.get_data(as_text=True))
+    assert json_response == {
+        "message": "The requested URL was not found on the server.  "
+                   "If you entered the URL manually please check your spelling and try again.",
+        "result": "error"
+    }
+
+
 def test_get_all_notifications_returns_200(client, notify_db, notify_db_session):
     notifications = [create_sample_notification(notify_db, notify_db_session) for _ in range(2)]
     notification = notifications[-1]
@@ -88,7 +126,7 @@ def test_get_all_notifications_returns_200(client, notify_db, notify_db_session)
     assert json_response['notifications'][0]['type'] == "sms"
 
 
-def test_get_all_notifications_no_notifications_if_no_notificatons(client, sample_service):
+def test_get_all_notifications_no_notifications_if_no_notifications(client, sample_service):
     auth_header = create_authorization_header(service_id=sample_service.id)
     response = client.get(
         path='/v2/notifications',
@@ -135,6 +173,22 @@ def test_get_all_notifications_filter_by_template_type(client, notify_db, notify
     assert json_response['notifications'][0]['type'] == "email"
 
 
+def test_get_all_notifications_filter_by_template_type_invalid_template_type(client, sample_notification):
+    auth_header = create_authorization_header(service_id=sample_notification.service_id)
+    response = client.get(
+        path='/v2/notifications?template_type=orange',
+        headers=[('Content-Type', 'application/json'), auth_header])
+
+    json_response = json.loads(response.get_data(as_text=True))
+
+    assert response.status_code == 400
+    assert response.headers['Content-type'] == "application/json"
+
+    assert json_response['status_code'] == 400
+    assert len(json_response['errors']) == 1
+    assert json_response['errors'][0]['message'] == "orange is not one of [sms, email, letter]"
+
+
 def test_get_all_notifications_filter_by_single_status(client, notify_db, notify_db_session):
     notification = create_sample_notification(notify_db, notify_db_session, status="pending")
     create_sample_notification(notify_db, notify_db_session)
@@ -156,11 +210,8 @@ def test_get_all_notifications_filter_by_single_status(client, notify_db, notify
     assert json_response['notifications'][0]['status'] == "pending"
 
 
-def test_get_all_notifications_filter_by_status_invalid_status(client, notify_db, notify_db_session):
-    notification = create_sample_notification(notify_db, notify_db_session, status="pending")
-    create_sample_notification(notify_db, notify_db_session)
-
-    auth_header = create_authorization_header(service_id=notification.service_id)
+def test_get_all_notifications_filter_by_status_invalid_status(client, sample_notification):
+    auth_header = create_authorization_header(service_id=sample_notification.service_id)
     response = client.get(
         path='/v2/notifications?status=elephant',
         headers=[('Content-Type', 'application/json'), auth_header])
@@ -248,6 +299,19 @@ def test_get_all_notifications_filter_by_id(client, notify_db, notify_db_session
     assert len(json_response['notifications']) == 1
 
     assert json_response['notifications'][0]['id'] == str(older_notification.id)
+
+
+def test_get_all_notifications_filter_by_id_invalid_id(client, sample_notification):
+    auth_header = create_authorization_header(service_id=sample_notification.service_id)
+    response = client.get(
+        path='/v2/notifications?older_than=1234-badly-formatted-id-7890',
+        headers=[('Content-Type', 'application/json'), auth_header])
+
+    json_response = json.loads(response.get_data(as_text=True))
+
+    assert json_response['status_code'] == 400
+    assert len(json_response['errors']) == 1
+    assert json_response['errors'][0]['message'] == "older_than is not a valid UUID"
 
 
 def test_get_all_notifications_filter_by_id_no_notifications_if_nonexistent_id(client, notify_db, notify_db_session):


### PR DESCRIPTION
The `get_notifications` route is now using a json schema to validate query parameters rather than the marshmallow thing.
Also changed how error messages are returned from `jsonschema` because the previous way was cutting off our failing `enum` routes.

New tests for: 
- invalid statuses
- invalid template_types
- invalid `older_than` ids
- invalid ids in the route to get a single notification