### PR TITLE
Fix version 2 of post notification, return placeholders

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -42,7 +42,7 @@ def post_sms_notification():
     send_notification_to_queue(notification, service.research_mode)
 
     resp = create_post_sms_response_from_notification(notification,
-                                                      template_with_content.content,
+                                                      template_with_content.replaced,
                                                       service.sms_sender,
                                                       request.url_root)
     return jsonify(resp), 201
@@ -70,7 +70,7 @@ def post_email_notification():
     send_notification_to_queue(notification, service.research_mode)
 
     resp = create_post_email_response_from_notification(notification=notification,
-                                                        content=template_with_content.content,
+                                                        content=template_with_content.replaced,
                                                         subject=template_with_content.subject,
                                                         email_from=service.email_from,
                                                         url_root=request.url_root)

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -39,7 +39,7 @@ def test_exception_thown_by_redis_store_get_should_not_be_fatal(
     assert e.value.status_code == 429
     assert e.value.message == 'Exceeded send limits (4) for today'
     assert e.value.fields == []
-    app.notifications.validators.redis_store.set.assert_not_called()
+    assert app.notifications.validators.redis_store.set.called
 
 
 @pytest.mark.parametrize('key_type', ['test', 'team', 'normal'])
@@ -61,7 +61,7 @@ def test_check_service_message_limit_in_cache_with_unrestricted_service_passes(
     mocker.patch('app.notifications.validators.redis_store.set')
     mocker.patch('app.notifications.validators.services_dao')
     assert not check_service_message_limit(key_type, sample_service)
-    app.notifications.validators.redis_store.set.assert_not_called()
+    assert not app.notifications.validators.redis_store.set.called
     assert not app.notifications.validators.services_dao.mock_calls
 
 


### PR DESCRIPTION
The body of the content in the response to a POST v2/notifications was not replacing the placeholders.

This PR fixes that and adds a test for it.

I am confused as to why I had to change the test_validators test that is checking if the mock is called.
Why did this code pass on preview?