### PR TITLE
Records the service ID if present in the request

### DIFF
--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -36,8 +36,6 @@ from app.schemas import (
 )
 from app.service.utils import service_allowed_to_send_to
 from app.utils import pagination_links
-from app import redis_store
-from app.clients import redis
 
 notifications = Blueprint('notifications', __name__)
 


### PR DESCRIPTION
this is used later in logging of requests

- if a client call the service id is stored
- if an admin app call the string "admin-app" is recorded.

depends on 

- [ ] https://github.com/alphagov/notifications-utils/pull/88