### PR TITLE
Request id logging

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,7 @@ from flask import request, url_for, g, jsonify
 from flask.ext.sqlalchemy import SQLAlchemy
 from flask_marshmallow import Marshmallow
 from monotonic import monotonic
-from notifications_utils import logging
+from notifications_utils import logging, request_id
 from werkzeug.local import LocalProxy
 
 from app.celery.celery import NotifyCelery
@@ -48,6 +48,7 @@ def create_app(app_name=None):
         application.config['NOTIFY_APP_NAME'] = app_name
 
     init_app(application)
+    request_id.init_app(application)
     db.init_app(application)
     ma.init_app(application)
     statsd_client.init_app(application)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,6 @@ Flask-Redis==0.1.0
 
 git+https://github.com/alphagov/notifications-python-client.git@3.0.0#egg=notifications-python-client==3.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@9.2.1#egg=notifications-utils==9.2.1
+git+https://github.com/alphagov/notifications-utils.git@10.3.0#egg=notifications-utils==10.3.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -70,7 +70,7 @@ def test_should_process_sms_job(sample_job, mocker):
     assert encryption.encrypt.call_args[0][0]['to'] == '+441234123123'
     assert encryption.encrypt.call_args[0][0]['template'] == str(sample_job.template.id)
     assert encryption.encrypt.call_args[0][0]['template_version'] == sample_job.template.version
-    assert encryption.encrypt.call_args[0][0]['personalisation'] == {}
+    assert encryption.encrypt.call_args[0][0]['personalisation'] == {'phonenumber': '+441234123123'}
     assert encryption.encrypt.call_args[0][0]['row_number'] == 0
     tasks.send_sms.apply_async.assert_called_once_with(
         (str(sample_job.service_id),
@@ -288,7 +288,7 @@ def test_should_process_email_job(sample_email_job, mocker):
     assert encryption.encrypt.call_args[0][0]['to'] == 'test@test.com'
     assert encryption.encrypt.call_args[0][0]['template'] == str(sample_email_job.template.id)
     assert encryption.encrypt.call_args[0][0]['template_version'] == sample_email_job.template.version
-    assert encryption.encrypt.call_args[0][0]['personalisation'] == {}
+    assert encryption.encrypt.call_args[0][0]['personalisation'] == {'emailaddress': 'test@test.com'}
     tasks.send_email.apply_async.assert_called_once_with(
         (
             str(sample_email_job.service_id),
@@ -320,7 +320,7 @@ def test_should_process_all_sms_job(sample_job,
     assert encryption.encrypt.call_args[0][0]['template'] == str(sample_job_with_placeholdered_template.template.id)
     assert encryption.encrypt.call_args[0][0][
                'template_version'] == sample_job_with_placeholdered_template.template.version  # noqa
-    assert encryption.encrypt.call_args[0][0]['personalisation'] == {'name': 'chris'}
+    assert encryption.encrypt.call_args[0][0]['personalisation'] == {'phonenumber': '+441234123120', 'name': 'chris'}
     tasks.send_sms.apply_async.call_count == 10
     job = jobs_dao.dao_get_job_by_id(sample_job_with_placeholdered_template.id)
     assert job.job_status == 'finished'


### PR DESCRIPTION
depends on

- [ ] https://github.com/alphagov/notifications-utils/pull/89

Enables request id logging on the API.
- request ids if not present are generated by the utils code and attached to all log events in a request
- request ids present on an API call are respected and attached to all log events in a request