### PR TITLE
Add include_from_test_key parameter to /service

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -239,8 +239,8 @@ def dao_fetch_weekly_historical_stats_for_service(service_id):
 
 
 @statsd(namespace='dao')
-def dao_fetch_todays_stats_for_all_services():
-    return db.session.query(
+def dao_fetch_todays_stats_for_all_services(include_from_test_key=True):
+    query = db.session.query(
         Notification.notification_type,
         Notification.status,
         Notification.service_id,
@@ -258,3 +258,8 @@ def dao_fetch_todays_stats_for_all_services():
     ).order_by(
         Notification.service_id
     )
+
+    if not include_from_test_key:
+        query = query.filter(Notification.key_type != KEY_TYPE_TEST)
+
+    return query

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -62,11 +62,12 @@ def get_services():
     only_active = request.args.get('only_active') == 'True'
     detailed = request.args.get('detailed') == 'True'
     user_id = request.args.get('user_id', None)
+    include_from_test_key = request.args.get('include_from_test_key', 'True') != 'False'
 
     if user_id:
         services = dao_fetch_all_services_by_user(user_id, only_active)
     elif detailed:
-        return jsonify(data=get_detailed_services(only_active))
+        return jsonify(data=get_detailed_services(only_active, include_from_test_key=include_from_test_key))
     else:
         services = dao_fetch_all_services(only_active)
     data = service_schema.dump(services, many=True).data
@@ -268,9 +269,9 @@ def get_detailed_service(service_id, today_only=False):
     return detailed_service_schema.dump(service).data
 
 
-def get_detailed_services(only_active=False):
+def get_detailed_services(only_active=False, include_from_test_key=True):
     services = {service.id: service for service in dao_fetch_all_services(only_active)}
-    stats = dao_fetch_todays_stats_for_all_services()
+    stats = dao_fetch_todays_stats_for_all_services(include_from_test_key=include_from_test_key)
 
     for service_id, rows in itertools.groupby(stats, lambda x: x.service_id):
         services[service_id].statistics = statistics.format_statistics(rows)

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -628,3 +628,14 @@ def test_dao_fetch_todays_stats_for_all_services_includes_all_keys_by_default(no
 
     assert len(stats) == 1
     assert stats[0].count == 3
+
+
+def test_dao_fetch_todays_stats_for_all_services_can_exclude_from_test_key(notify_db, notify_db_session):
+    create_notification(notify_db, notify_db_session, key_type=KEY_TYPE_NORMAL)
+    create_notification(notify_db, notify_db_session, key_type=KEY_TYPE_TEAM)
+    create_notification(notify_db, notify_db_session, key_type=KEY_TYPE_TEST)
+
+    stats = dao_fetch_todays_stats_for_all_services(include_from_test_key=False).all()
+
+    assert len(stats) == 1
+    assert stats[0].count == 2


### PR DESCRIPTION
We want to be able to toggle the numbers on the platform admin page between
including and excluding notifications sent using test keys, so that we can see
both real use of the platform and all load on it.

This parameter defaults to `True`, which is the existing behaviour.

Also add tests for the existing query for fetching today's stats for all services.