### PR TITLE
V2 get notification by reference

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -248,6 +248,15 @@ def get_notification_by_id(notification_id):
     return Notification.query.filter_by(id=notification_id).first()
 
 
+@statsd(namespace="dao")
+def get_notification_by_reference(service_id, reference, key_type):
+    filter_dict = {'service_id': service_id, 'client_reference': reference}
+    if key_type:
+        filter_dict['key_type'] = key_type
+
+    return Notification.query.filter_by(**filter_dict).options(joinedload('template_history')).one()
+
+
 def get_notifications(filter_dict=None):
     return _filter_query(Notification.query, filter_dict=filter_dict)
 

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -78,6 +78,7 @@ get_notifications_request = {
     "description": "schema for query parameters allowed when getting list of notifications",
     "type": "object",
     "properties": {
+        "client_reference": {"type": "string"},
         "status": {
             "type": "array",
             "items": {

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -411,7 +411,8 @@ def sample_notification(notify_db,
                         personalisation=None,
                         api_key_id=None,
                         key_type=KEY_TYPE_NORMAL,
-                        sent_by=None):
+                        sent_by=None,
+                        client_reference=None):
     if created_at is None:
         created_at = datetime.utcnow()
     if service is None:
@@ -445,7 +446,8 @@ def sample_notification(notify_db,
         'api_key_id': api_key_id,
         'key_type': key_type,
         'sent_by': sent_by,
-        'updated_at': created_at if status in NOTIFICATION_STATUS_TYPES_COMPLETED else None
+        'updated_at': created_at if status in NOTIFICATION_STATUS_TYPES_COMPLETED else None,
+        'client_reference': client_reference
     }
     if job_row_number:
         data['job_row_number'] = job_row_number

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -30,6 +30,7 @@ from app.dao.notifications_dao import (
     dao_update_notification,
     delete_notifications_created_more_than_a_week_ago,
     get_notification_by_id,
+    get_notification_by_reference,
     get_notification_for_job,
     get_notification_billable_unit_count_per_month,
     get_notification_with_personalisation,
@@ -616,13 +617,23 @@ def test_save_notification_with_no_job(sample_template, mmg_provider):
     assert notification_from_db.status == 'created'
 
 
-def test_get_notification(sample_notification):
+def test_get_notification_by_id(sample_notification):
     notification_from_db = get_notification_with_personalisation(
         sample_notification.service.id,
         sample_notification.id,
         key_type=None
     )
     assert sample_notification == notification_from_db
+
+
+def test_get_notification_by_reference(notify_db, notify_db_session):
+    notification = sample_notification(notify_db, notify_db_session, client_reference="some-client-ref")
+    notification_from_db = get_notification_by_reference(
+        notification.service.id,
+        notification.client_reference,
+        key_type=None
+    )
+    assert notification == notification_from_db
 
 
 def test_save_notification_no_job_id(sample_template, mmg_provider):


### PR DESCRIPTION
This will allow an end user to get a notification by reference. Instead of creating a new endpoint, the get all notifications was modified to allow passing in the client reference as a query param e.g. `/v2/notifications?client_reference=someref.` 

The reference is unique so we will only ever return one (if it exists) and the response will be in the same format as when retrieving a single notification. 
