### PR TITLE
Update utils to 12.1.1

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 
 from flask import current_app
-from notifications_utils.renderers import PassThrough
-from notifications_utils.template import Template
 
 from app import redis_store
 from app.celery import provider_tasks
@@ -11,14 +9,11 @@ from app.dao.notifications_dao import dao_create_notification, dao_delete_notifi
 from app.models import SMS_TYPE, Notification, KEY_TYPE_TEST, EMAIL_TYPE
 from app.notifications.validators import check_sms_content_char_count
 from app.v2.errors import BadRequestError, SendNotificationToQueueError
+from app.utils import get_template_instance
 
 
 def create_content_for_notification(template, personalisation):
-    template_object = Template(
-        template.__dict__,
-        personalisation,
-        renderer=PassThrough()
-    )
+    template_object = get_template_instance(template.__dict__, personalisation)
     check_placeholders(template_object)
 
     if template_object.template_type == SMS_TYPE:

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,6 @@
 from flask import url_for
+from app.models import SMS_TYPE, EMAIL_TYPE
+from notifications_utils.template import SMSMessageTemplate, PlainTextEmailTemplate
 
 
 def pagination_links(pagination, endpoint, **kwargs):
@@ -18,3 +20,9 @@ def url_with_token(data, url, config):
     token = generate_token(data, config['SECRET_KEY'], config['DANGEROUS_SALT'])
     base_url = config['ADMIN_BASE_URL'] + url
     return base_url + token
+
+
+def get_template_instance(template, values):
+    return {
+        SMS_TYPE: SMSMessageTemplate, EMAIL_TYPE: PlainTextEmailTemplate
+    }[template['template_type']](template, values)

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -42,7 +42,7 @@ def post_sms_notification():
     send_notification_to_queue(notification, service.research_mode)
     sms_sender = service.sms_sender if service.sms_sender else current_app.config.get('FROM_NUMBER')
     resp = create_post_sms_response_from_notification(notification,
-                                                      template_with_content.rendered,
+                                                      str(template_with_content),
                                                       sms_sender,
                                                       request.url_root)
     return jsonify(resp), 201
@@ -70,7 +70,7 @@ def post_email_notification():
     send_notification_to_queue(notification, service.research_mode)
 
     resp = create_post_email_response_from_notification(notification=notification,
-                                                        content=template_with_content.rendered,
+                                                        content=str(template_with_content),
                                                         subject=template_with_content.subject,
                                                         email_from=service.email_from,
                                                         url_root=request.url_root)
@@ -89,5 +89,6 @@ def __validate_template(form, service, notification_type):
     check_template_is_for_notification_type(notification_type, template.template_type)
     check_template_is_active(template)
     template_with_content = create_content_for_notification(template, form.get('personalisation', {}))
-    check_sms_content_char_count(template_with_content.content_count)
+    if template.template_type == SMS_TYPE:
+        check_sms_content_char_count(template_with_content.content_count)
     return template, template_with_content

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,6 @@ Flask-Redis==0.1.0
 
 git+https://github.com/alphagov/notifications-python-client.git@3.0.0#egg=notifications-python-client==3.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@12.0.0#egg=notifications-utils==12.0.0
+git+https://github.com/alphagov/notifications-utils.git@12.1.1#egg=notifications-utils==12.1.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,6 @@ Flask-Redis==0.1.0
 
 git+https://github.com/alphagov/notifications-python-client.git@3.0.0#egg=notifications-python-client==3.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@11.1.1#egg=notifications-utils==11.1.1
+git+https://github.com/alphagov/notifications-utils.git@12.0.0#egg=notifications-utils==12.0.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -42,8 +42,6 @@ from app.dao.notifications_dao import (
     dao_timeout_notifications,
     get_financial_year)
 
-from notifications_utils.template import get_sms_fragment_count
-
 from tests.app.conftest import (sample_notification, sample_template, sample_email_template, sample_service, sample_job,
                                 sample_api_key)
 
@@ -819,22 +817,6 @@ def test_should_limit_notifications_return_by_day_limit_plus_one(notify_db, noti
 
     all_notifications = get_notifications_for_service(sample_service.id, limit_days=1).items
     assert len(all_notifications) == 2
-
-
-@pytest.mark.parametrize(
-    "char_count, expected_sms_fragment_count",
-    [
-        (159, 1),
-        (160, 1),
-        (161, 2),
-        (306, 2),
-        (307, 3),
-        (459, 3),
-        (460, 4),
-        (461, 4)
-    ])
-def test_sms_fragment_count(char_count, expected_sms_fragment_count):
-    assert get_sms_fragment_count(char_count) == expected_sms_fragment_count
 
 
 def test_creating_notification_adds_to_notification_history(sample_template):

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -355,11 +355,11 @@ def test_send_email_should_use_service_reply_to_email(
 
 
 def test_get_html_email_renderer_should_return_for_normal_service(sample_service):
-    renderer = send_to_providers.get_html_email_renderer(sample_service)
-    assert renderer.govuk_banner
-    assert renderer.brand_colour is None
-    assert renderer.brand_logo is None
-    assert renderer.brand_name is None
+    options = send_to_providers.get_html_email_options(sample_service)
+    assert options['govuk_banner']
+    assert 'brand_colour' not in options.keys()
+    assert 'brand_logo' not in options.keys()
+    assert 'brand_name' not in options.keys()
 
 
 @pytest.mark.parametrize('branding_type, govuk_banner', [
@@ -373,11 +373,11 @@ def test_get_html_email_renderer_with_branding_details(branding_type, govuk_bann
     notify_db.session.add_all([sample_service, org])
     notify_db.session.commit()
 
-    renderer = send_to_providers.get_html_email_renderer(sample_service)
+    options = send_to_providers.get_html_email_options(sample_service)
 
-    assert renderer.govuk_banner == govuk_banner
-    assert renderer.brand_colour == '000000'
-    assert renderer.brand_name == 'Justice League'
+    assert options['govuk_banner'] == govuk_banner
+    assert options['brand_colour'] == '#000000'
+    assert options['brand_name'] == 'Justice League'
 
 
 def test_get_html_email_renderer_prepends_logo_path(notify_db, sample_service):
@@ -387,9 +387,9 @@ def test_get_html_email_renderer_prepends_logo_path(notify_db, sample_service):
     notify_db.session.add_all([sample_service, org])
     notify_db.session.commit()
 
-    renderer = send_to_providers.get_html_email_renderer(sample_service)
+    renderer = send_to_providers.get_html_email_options(sample_service)
 
-    assert renderer.brand_logo == 'http://localhost:6012/static/images/email-template/crests/justice-league.png'
+    assert renderer['brand_logo'] == 'http://localhost:6012/static/images/email-template/crests/justice-league.png'
 
 
 def test_should_not_set_billable_units_if_research_mode(notify_db, sample_service, sample_notification, mocker):

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -129,7 +129,7 @@ def test_send_notification_with_placeholders_replaced(notify_api, sample_email_t
                 queue="send-email"
             )
             assert response.status_code == 201
-            assert response_data['body'] == 'Hello Jo\nThis is an email from GOV.UK'
+            assert response_data['body'] == u'Hello Jo\nThis is an email from GOV.\u200BUK'
             assert response_data['subject'] == 'Jo'
 
 

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -18,14 +18,14 @@ from tests.app.conftest import sample_notification, sample_template, sample_emai
 def test_create_content_for_notification_passes(sample_email_template):
     template = Template.query.get(sample_email_template.id)
     content = create_content_for_notification(template, None)
-    assert content.rendered == template.content
+    assert str(content) == template.content
 
 
 def test_create_content_for_notification_with_placeholders_passes(sample_template_with_placeholders):
     template = Template.query.get(sample_template_with_placeholders.id)
     content = create_content_for_notification(template, {'name': 'Bobby'})
     assert content.content == template.content
-    assert 'Bobby' in content.rendered
+    assert 'Bobby' in str(content)
 
 
 def test_create_content_for_notification_fails_with_missing_personalisation(sample_template_with_placeholders):

--- a/tests/app/notifications/test_rest.py
+++ b/tests/app/notifications/test_rest.py
@@ -711,7 +711,7 @@ def test_get_notification_by_id_returns_merged_template_content_for_email(
 
         notification = json.loads(response.get_data(as_text=True))['data']['notification']
         assert response.status_code == 200
-        assert notification['body'] == 'Hello world\nThis is an email from GOV.UK'
+        assert notification['body'] == 'Hello world\nThis is an email from GOV.\u200BUK'
         assert notification['subject'] == 'world'
         assert notification['content_char_count'] is None
 

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -129,8 +129,10 @@ def test_post_email_notification_returns_201(client, sample_email_template_with_
     assert resp_json['id'] == str(notification.id)
     assert resp_json['reference'] == reference
     assert notification.reference is None
-    assert resp_json['content']['body'] == sample_email_template_with_placeholders.content.replace('((name))', 'Bob')
-    assert resp_json['content']['subject'] == sample_email_template_with_placeholders.subject
+    assert resp_json['content']['body'] == sample_email_template_with_placeholders.content\
+        .replace('((name))', 'Bob').replace('GOV.UK', u'GOV.\u200bUK')
+    assert resp_json['content']['subject'] == sample_email_template_with_placeholders.subject\
+        .replace('((name))', 'Bob')
     assert resp_json['content']['from_email'] == sample_email_template_with_placeholders.service.email_from
     assert 'v2/notifications/{}'.format(notification.id) in resp_json['uri']
     assert resp_json['template']['id'] == str(sample_email_template_with_placeholders.id)


### PR DESCRIPTION
Includes:

- [x] https://github.com/alphagov/notifications-utils/pull/94 (breaking changes which are responsible for all the changes to the API in this PR)

The test for `get_sms_fragment_count` has been removed because this method is already tested in utils here: https://github.com/alphagov/notifications-utils/blob/ac20f7e99ece4935fccf39ed9d5c0fb40e45bfbc/tests/test_base_template.py#L140-L159

Also includes this bug fix:
- [x] https://github.com/alphagov/notifications-utils/pull/102