### PR TITLE
Send Notify's 2FA codes via only one queue

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -70,19 +70,22 @@ def persist_notification(template_id,
     return notification
 
 
-def send_notification_to_queue(notification, research_mode):
-    try:
-        research_mode = research_mode or notification.key_type == KEY_TYPE_TEST
+def send_notification_to_queue(notification, research_mode, queue=None):
+    if research_mode or notification.key_type == KEY_TYPE_TEST:
+        queue = 'research-mode'
+    elif not queue:
         if notification.notification_type == SMS_TYPE:
-            provider_tasks.deliver_sms.apply_async(
-                [str(notification.id)],
-                queue='send-sms' if not research_mode else 'research-mode'
-            )
+            queue = 'send-sms'
         if notification.notification_type == EMAIL_TYPE:
-            provider_tasks.deliver_email.apply_async(
-                [str(notification.id)],
-                queue='send-email' if not research_mode else 'research-mode'
-            )
+            queue = 'send-email'
+
+    if notification.notification_type == SMS_TYPE:
+        deliver_task = provider_tasks.deliver_sms
+    if notification.notification_type == EMAIL_TYPE:
+        deliver_task = provider_tasks.deliver_email
+
+    try:
+        deliver_task.apply_async([str(notification.id)], queue=queue)
     except Exception as e:
         current_app.logger.exception(e)
         dao_delete_notifications_and_history_by_id(notification.id)


### PR DESCRIPTION
At the moment Notify's 2FA codes and internal emails go first to a `notify` queue, but then are put on the shared `send-sms/email` queues along with all other notifications, and they can take some time to arrive if big jobs are being processed.

This change means that these codes won't be delayed by large jobs going through the `send-sms/email` queues. `send_user_sms_code` now works much more like the endpoints for sending notifications, by persisting the notification and only using the `deliver_sms` task (instead of using `send_sms` as well).

The workers consuming the `notify` queue should be able to handle the deliver task as well, so no change should be needed to the celery workers to support this.

I think there's also a change in behaviour here: previously, if the Notify service was in research mode, 2FA codes would not have been sent out, making it impossible to log into the admin. Now, a call to this endpoint will always send out the notification even if we've put the Notify service into research mode, since we set the notification's key type to `normal` and ignore the service's research mode setting when sending the notification to the queue.

I'm opening this now to get feedback on the approach so far for this one endpoint. If people are happy with this I'd aim to carry on to do similar things to the rest of the API endpoints which use notifications internally:

- [ ] `send_user_confirm_new_email`
- [ ] `send_user_email_verification`
- [ ] `send_already_registered_email`
- [ ] `send_user_reset_password`
- [ ] `create_invited_user`