### PR TITLE
Fix the from number in the post_sms_response.

### DIFF
--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -148,7 +148,7 @@ sms_content = {
         "body": {"type": "string"},
         "from_number": {"type": "string"}
     },
-    "required": ["body"]
+    "required": ["body", "from_number"]
 }
 
 post_sms_response = {

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -1,4 +1,4 @@
-from flask import request, jsonify
+from flask import request, jsonify, current_app
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import api_user
@@ -40,10 +40,10 @@ def post_sms_notification():
                                         key_type=api_user.key_type,
                                         reference=form.get('reference'))
     send_notification_to_queue(notification, service.research_mode)
-
+    sms_sender = service.sms_sender if service.sms_sender else current_app.config.get('FROM_NUMBER')
     resp = create_post_sms_response_from_notification(notification,
                                                       template_with_content.rendered,
-                                                      service.sms_sender,
+                                                      sms_sender,
                                                       request.url_root)
     return jsonify(resp), 201
 

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -32,7 +32,8 @@ def test_post_sms_notification_returns_201(notify_api, sample_template_with_plac
             assert resp_json['id'] == str(notification_id)
             assert resp_json['reference'] == reference
             assert resp_json['content']['body'] == sample_template_with_placeholders.content.replace("(( Name))", "Jo")
-            assert resp_json['content']['from_number'] == sample_template_with_placeholders.service.sms_sender
+            # conftest fixture service does not have a sms sender, use config default
+            assert resp_json['content']['from_number'] == notify_api.config["FROM_NUMBER"]
             assert 'v2/notifications/{}'.format(notification_id) in resp_json['uri']
             assert resp_json['template']['id'] == str(sample_template_with_placeholders.id)
             assert resp_json['template']['version'] == sample_template_with_placeholders.version


### PR DESCRIPTION
 If the service.sms_sender is not set the FROM_NUMBER from the config is returned, which is the default for the notification.