### PR TITLE
Fix uri validation in v2 responses

### DIFF
--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -45,7 +45,9 @@ def __format_message(e):
     def get_path(e):
         error_path = None
         try:
-            error_path = e.path[0]
+            error_path = e.path.popleft()
+            # no need to catch IndexError exception explicity as
+            # error_path is None if e.path has no items
         finally:
             return error_path
 

--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -42,4 +42,25 @@ def build_error_message(errors):
 
 
 def __format_message(e):
-    return e.message.replace("'", "") if not e.cause else "{} {}".format(e.path[0], e.cause.message)
+    def get_path(e):
+        error_path = None
+        try:
+            error_path = e.path[0]
+        finally:
+            return error_path
+
+    def get_error_message(e):
+        error_message = None
+        try:
+            error_message = e.cause.message
+        except AttributeError:
+            error_message = e.message
+        finally:
+            return error_message.replace("'", '')
+
+    path = get_path(e)
+    message = get_error_message(e)
+    if path:
+        return "{} {}".format(path, message)
+    else:
+        return "{}".format(message)

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -10,7 +10,7 @@ template = {
     "properties": {
         "id": uuid,
         "version": {"type": "integer"},
-        "uri": {"type": "string"}
+        "uri": {"type": "string", "format": "uri"}
     },
     "required": ["id", "version", "uri"]
 }
@@ -161,7 +161,7 @@ post_sms_response = {
         "id": uuid,
         "reference": {"type": ["string", "null"]},
         "content": sms_content,
-        "uri": {"type": "string"},
+        "uri": {"type": "string", "format": "uri"},
         "template": template
     },
     "required": ["id", "content", "uri", "template"]
@@ -204,7 +204,7 @@ post_email_response = {
         "id": uuid,
         "reference": {"type": ["string", "null"]},
         "content": email_content,
-        "uri": {"type": "string"},
+        "uri": {"type": "string", "format": "uri"},
         "template": template
     },
     "required": ["id", "content", "uri", "template"]
@@ -216,7 +216,7 @@ def create_post_sms_response_from_notification(notification, body, from_number, 
             "reference": notification.client_reference,
             "content": {'body': body,
                         'from_number': from_number},
-            "uri": "{}/v2/notifications/{}".format(url_root, str(notification.id)),
+            "uri": "{}v2/notifications/{}".format(url_root, str(notification.id)),
             "template": __create_template_from_notification(notification=notification, url_root=url_root)
             }
 
@@ -230,7 +230,7 @@ def create_post_email_response_from_notification(notification, content, subject,
             "body": content,
             "subject": subject
         },
-        "uri": "{}/v2/notifications/{}".format(url_root, str(notification.id)),
+        "uri": "{}v2/notifications/{}".format(url_root, str(notification.id)),
         "template": __create_template_from_notification(notification=notification, url_root=url_root)
     }
 
@@ -239,5 +239,5 @@ def __create_template_from_notification(notification, url_root):
     return {
         "id": notification.template_id,
         "version": notification.template_version,
-        "uri": "{}/v2/templates/{}".format(url_root, str(notification.template_id))
+        "uri": "{}v2/templates/{}".format(url_root, str(notification.template_id))
     }

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -109,7 +109,6 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
     assert '<!DOCTYPE html' in app.aws_ses_client.send_email.call_args[1]['html_body']
 
     notification = Notification.query.filter_by(id=db_notification.id).one()
-
     assert notification.status == 'sending'
     assert notification.sent_at <= datetime.utcnow()
     assert notification.sent_by == 'ses'

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -218,7 +218,7 @@ def test_get_all_notifications_filter_by_template_type_invalid_template_type(cli
 
     assert json_response['status_code'] == 400
     assert len(json_response['errors']) == 1
-    assert json_response['errors'][0]['message'] == "orange is not one of [sms, email, letter]"
+    assert json_response['errors'][0]['message'] == "template_type orange is not one of [sms, email, letter]"
 
 
 def test_get_all_notifications_filter_by_single_status(client, notify_db, notify_db_session):
@@ -255,7 +255,7 @@ def test_get_all_notifications_filter_by_status_invalid_status(client, sample_no
 
     assert json_response['status_code'] == 400
     assert len(json_response['errors']) == 1
-    assert json_response['errors'][0]['message'] == "elephant is not one of [created, sending, delivered, " \
+    assert json_response['errors'][0]['message'] == "status elephant is not one of [created, sending, delivered, " \
         "pending, failed, technical-failure, temporary-failure, permanent-failure]"
 
 


### PR DESCRIPTION
In our v2 notification responses the URI's are returned with an invalid format. An example is `"http://api.url:6011//v2/templates/be35a391-e912-42e9-82e6-3f4953f6cbb0"` where `//` appears twice. 

This pull request rectifies the responses to ensure the URIs are returned in the correct format. Additionally the JSON schemas have been updated to reflect this and tests have been added. 
These tests exposed issues in our error handling, particularly where we build an array of schema validation errors. This function has also been modified to be more bulletproof to ensure we can build this array properly and not break whilst doing so.

Existing tests have also been refactored to check that we now receive the field name as well as the value that failed validation.

