### PR TITLE
Refactor the endpoint to send user email verification when registering

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -18,7 +18,7 @@ from app.dao.users_dao import (
 from app.dao.permissions_dao import permission_dao
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.templates_dao import dao_get_template_by_id
-from app.models import SMS_TYPE, KEY_TYPE_NORMAL
+from app.models import SMS_TYPE, KEY_TYPE_NORMAL, EMAIL_TYPE
 from app.notifications.process_notifications import (
     persist_notification,
     send_notification_to_queue
@@ -203,21 +203,22 @@ def send_user_email_verification(user_id):
     create_user_code(user_to_send_to, secret_code, 'email')
 
     template = dao_get_template_by_id(current_app.config['EMAIL_VERIFY_CODE_TEMPLATE_ID'])
-    message = {
-        'template': str(template.id),
-        'template_version': template.version,
-        'to': user_to_send_to.email_address,
-        'personalisation': {
+
+    saved_notification = persist_notification(
+        template_id=template.id,
+        template_version=template.version,
+        recipient=user_to_send_to.email_address,
+        service_id=current_app.config['NOTIFY_SERVICE_ID'],
+        personalisation={
             'name': user_to_send_to.name,
             'url': _create_verification_url(user_to_send_to, secret_code)
-        }
-    }
-    send_email.apply_async((
-        current_app.config['NOTIFY_SERVICE_ID'],
-        str(uuid.uuid4()),
-        encryption.encrypt(message),
-        datetime.utcnow().strftime(DATETIME_FORMAT)
-    ), queue='notify')
+        },
+        notification_type=EMAIL_TYPE,
+        api_key_id=None,
+        key_type=KEY_TYPE_NORMAL
+    )
+
+    send_notification_to_queue(saved_notification, False, queue="notify")
 
     return jsonify({}), 204
 

--- a/tests/app/user/test_rest_verify.py
+++ b/tests/app/user/test_rest_verify.py
@@ -311,55 +311,35 @@ def test_send_sms_code_returns_404_for_bad_input_data(notify_api, notify_db, not
             assert json.loads(resp.get_data(as_text=True))['message'] == 'No result found'
 
 
-@freeze_time("2016-01-01 11:09:00.061258")
-def test_send_user_email_verification(notify_api,
+def test_send_user_email_verification(client,
                                       sample_user,
                                       mocker,
                                       email_verification_template):
-
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = json.dumps({})
-            mocker.patch('uuid.uuid4', return_value='some_uuid')  # for the notification id
-            mocked = mocker.patch('app.celery.tasks.send_email.apply_async')
-            mocker.patch('notifications_utils.url_safe_token.generate_token', return_value='the-token')
-            auth_header = create_authorization_header()
-            resp = client.post(
-                url_for('user.send_user_email_verification', user_id=str(sample_user.id)),
-                data=data,
-                headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 204
-            assert mocked.call_count == 1
-            message = {
-                'template': str(email_verification_template.id),
-                'template_version': email_verification_template.version,
-                'to': sample_user.email_address,
-                'personalisation': {
-                    'name': sample_user.name,
-                    'url': current_app.config['ADMIN_BASE_URL'] + '/verify-email/' + 'the-token'
-                }
-            }
-            app.celery.tasks.send_email.apply_async.assert_called_once_with(
-                (str(current_app.config['NOTIFY_SERVICE_ID']),
-                 'some_uuid',
-                 encryption.encrypt(message),
-                 "2016-01-01T11:09:00.061258Z"),
-                queue="notify")
+    data = json.dumps({})
+    mocked = mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
+    auth_header = create_authorization_header()
+    resp = client.post(
+        url_for('user.send_user_email_verification', user_id=str(sample_user.id)),
+        data=data,
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert resp.status_code == 204
+    notification = Notification.query.first()
+    mocked.assert_called_once_with(
+        ([str(notification.id)]),
+        queue="notify")
 
 
-def test_send_email_verification_returns_404_for_bad_input_data(notify_api, notify_db, notify_db_session):
+def test_send_email_verification_returns_404_for_bad_input_data(client, notify_db, notify_db_session):
     """
     Tests POST endpoint /user/<user_id>/sms-code return 404 for bad input data
     """
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = json.dumps({})
-            import uuid
-            uuid_ = uuid.uuid4()
-            auth_header = create_authorization_header()
-            resp = client.post(
-                url_for('user.send_user_email_verification', user_id=uuid_),
-                data=data,
-                headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 404
-            assert json.loads(resp.get_data(as_text=True))['message'] == 'No result found'
+    data = json.dumps({})
+    import uuid
+    uuid_ = uuid.uuid4()
+    auth_header = create_authorization_header()
+    resp = client.post(
+        url_for('user.send_user_email_verification', user_id=uuid_),
+        data=data,
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert resp.status_code == 404
+    assert json.loads(resp.get_data(as_text=True))['message'] == 'No result found'


### PR DESCRIPTION
Refactor send_user_email_verification to persist the notification then put on the "notify" queue for delivery.

The reason for doing this is to ensure the tasks performed for the Notify users are not queued behind a large job, a way to
ensure priority for messages.

3rd task for story: https://www.pivotaltracker.com/story/show/135839709