### PR TITLE
use cloudfront instead of flask to serve static images

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -1,3 +1,4 @@
+from urllib import parse
 from datetime import datetime
 
 from flask import current_app
@@ -115,17 +116,53 @@ def provider_to_use(notification_type, notification_id):
     return clients.get_client_by_name_and_type(active_providers_in_order[0].identifier, notification_type)
 
 
+def get_logo_url(base_url, branding_path, logo_file):
+    """
+    Get the complete URL for a given logo.
+
+    We have to convert the base_url into a static url. Our hosted environments all have their own cloudfront instances,
+    found at the static subdomain (eg https://static.notifications.service.gov.uk).
+
+    If running locally (dev environment), don't try and use cloudfront - just stick to the actual underlying source
+    ({URL}/static/{PATH})
+    """
+    base_url = parse.urlparse(base_url)
+    netloc = base_url.netloc
+
+    if base_url.netloc.startswith('localhost'):
+        netloc = 'localhost:6012'
+        path = '/static' + branding_path + logo_file
+    else:
+        if base_url.netloc.startswith('www'):
+            # strip "www."
+            netloc = base_url.netloc[4:]
+
+        netloc = 'static.' + netloc
+        path = branding_path + logo_file
+
+    logo_url = parse.ParseResult(
+        scheme=base_url.scheme,
+        netloc=netloc,
+        path=path,
+        params=base_url.params,
+        query=base_url.query,
+        fragment=base_url.fragment
+    )
+    return parse.urlunparse(logo_url)
+
+
 def get_html_email_options(service):
     govuk_banner = service.branding != BRANDING_ORG
     if service.organisation:
-        logo = '{}{}{}'.format(
+        logo_url = get_logo_url(
             current_app.config['ADMIN_BASE_URL'],
             current_app.config['BRANDING_PATH'],
             service.organisation.logo
         )
+
         branding = {
             'brand_colour': service.organisation.colour,
-            'brand_logo': logo,
+            'brand_logo': logo_url,
             'brand_name': service.organisation.name,
         }
     else:

--- a/config.py
+++ b/config.py
@@ -59,7 +59,7 @@ class Config(object):
     SQLALCHEMY_TRACK_MODIFICATIONS = True
     PAGE_SIZE = 50
     SMS_CHAR_COUNT_LIMIT = 495
-    BRANDING_PATH = '/static/images/email-template/crests/'
+    BRANDING_PATH = '/images/email-template/crests/'
     TEST_MESSAGE_FILENAME = 'Test message'
 
     NOTIFY_SERVICE_ID = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,8 @@ statsd==3.2.1
 jsonschema==2.5.1
 Flask-Redis==0.1.0
 
-notifications-python-client==3.0.0
+# pin to minor version 3.1.x
+notifications-python-client>=3.1,<3.2
 
 git+https://github.com/alphagov/notifications-utils.git@12.2.0#egg=notifications-utils==12.2.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,8 @@ statsd==3.2.1
 jsonschema==2.5.1
 Flask-Redis==0.1.0
 
-git+https://github.com/alphagov/notifications-python-client.git@3.0.0#egg=notifications-python-client==3.0.0
+notifications-python-client==3.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@12.1.1#egg=notifications-utils==12.1.1
+git+https://github.com/alphagov/notifications-utils.git@12.2.0#egg=notifications-utils==12.2.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
branding in emails was previously hosted from admin app - this changes the url to be static.{domain}/images instead of {domain}/static/images, which redirects to cloudfront.

some manipulation of the URL was required to make sure it still serves locally rather than returning "static.localhost:6012" for example.

(if ADMIN_BASE_URL is localhost it just returns the old /static/ path)

also was able to remove DB interaction from a test. woo!