### PR TITLE
Add celery beat task to switch providers on failure

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -131,7 +131,7 @@ def switch_providers_on_slow_delivery():
 
     if slow_delivery_notifications:
         notification = slow_delivery_notifications[0]
-        current_app.logger.info(
+        current_app.logger.warning(
             'Slow delivery notification found with id: {} created at: {} sent at: {} by: {}'.format(
                 notification.id,
                 notification.created_at,

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -20,6 +20,7 @@ from app.models import (
     NotificationStatistics,
     Template,
     NOTIFICATION_CREATED,
+    NOTIFICATION_DELIVERED,
     NOTIFICATION_SENDING,
     NOTIFICATION_PENDING,
     NOTIFICATION_TECHNICAL_FAILURE,
@@ -324,6 +325,26 @@ def _filter_query(query, filter_dict=None):
         query = query.join(Template).filter(Template.template_type.in_(template_types))
 
     return query
+
+
+@statsd(namespace="dao")
+def dao_provider_notifications_where_delivery_longer_than(
+    starting_from,
+    amount_of_time,
+    service_id,
+    template_id,
+    providers
+):
+    notifications = db.session.query(Notification).filter(
+        Notification.created_at >= starting_from,
+        Notification.service_id == service_id,
+        Notification.template_id == template_id,
+        Notification.status.in_([NOTIFICATION_SENDING, NOTIFICATION_DELIVERED]),
+        Notification.sent_by.in_(providers),
+        (Notification.sent_at - Notification.created_at) >= amount_of_time,
+    ).order_by(desc(Notification.created_at)).all()
+
+    return notifications
 
 
 @statsd(namespace="dao")

--- a/app/dao/provider_details_dao.py
+++ b/app/dao/provider_details_dao.py
@@ -64,7 +64,7 @@ def dao_switch_sms_provider(identifier):
     new_provider = get_alternative_sms_provider(identifier)
 
     if not new_provider.active:
-        current_app.logger.info('Cancelling switch from {} to {} as {} is inactive'.format(
+        current_app.logger.warning('Cancelling switch from {} to {} as {} is inactive'.format(
             current_provider.identifier,
             new_provider.identifier,
             new_provider.identifier
@@ -73,7 +73,7 @@ def dao_switch_sms_provider(identifier):
         return current_provider
 
     if current_provider.identifier == new_provider.identifier:
-        current_app.logger.info('Alternative provider {} is already activated'.format(new_provider.identifier))
+        current_app.logger.warning('Alternative provider {} is already activated'.format(new_provider.identifier))
         return current_provider
 
     else:

--- a/app/dao/provider_details_dao.py
+++ b/app/dao/provider_details_dao.py
@@ -4,6 +4,7 @@ from sqlalchemy import asc
 from app.dao.dao_utils import transactional
 from app.models import ProviderDetails, ProviderDetailsHistory
 from app import db
+from flask import current_app
 
 
 def get_provider_details():
@@ -14,10 +15,38 @@ def get_provider_details_by_id(provider_details_id):
     return ProviderDetails.query.get(provider_details_id)
 
 
+def get_provider_details_by_identifier(identifier):
+    return ProviderDetails.query.filter_by(identifier=identifier).one()
+
+
+def get_alternative_sms_provider(identifier):
+    sms_providers = set(['firetext', 'mmg'])
+    selected_provider = None
+    try:
+        selected_provider = sms_providers.difference([identifier]).pop()
+    except KeyError:
+        current_app.logger.error('Could not get an alternative sms provider from list {} given {}').format(
+            sms_providers,
+            identifier
+        )
+    else:
+        return ProviderDetails.query.filter_by(
+            identifier=selected_provider
+        ).one()
+
+
 def get_provider_details_by_notification_type(notification_type):
     return ProviderDetails.query.filter_by(
         notification_type=notification_type
     ).order_by(asc(ProviderDetails.priority)).all()
+
+
+def get_current_provider(notification_type):
+    return ProviderDetails.query.filter_by(
+        notification_type=notification_type
+    ).order_by(
+        asc(ProviderDetails.priority)
+    ).first()
 
 
 @transactional
@@ -27,3 +56,36 @@ def dao_update_provider_details(provider_details):
     history = ProviderDetailsHistory.from_original(provider_details)
     db.session.add(provider_details)
     db.session.add(history)
+
+
+@transactional
+def dao_switch_sms_provider(identifier):
+    current_provider = get_current_provider('sms')
+    new_provider = get_alternative_sms_provider(identifier)
+
+    if current_provider.identifier != new_provider.identifier:
+        # Swap priority to change primary provider
+        if new_provider.priority > current_provider.priority:
+            new_provider.priority, current_provider.priority = current_provider.priority, new_provider.priority
+
+            current_app.logger.info('Switching provider from {} to {}'.format(
+                current_provider.identifier,
+                new_provider.identifier
+            ))
+
+            current_app.logger.info('Provider {} now updated with priority of {}'.format(
+                current_provider.identifier,
+                current_provider.priority
+            ))
+            current_app.logger.info('Provider {} now updated with priority of {}'.format(
+                new_provider.identifier,
+                new_provider.priority
+            ))
+
+        elif new_provider.priority == current_provider.priority:
+            current_provider.priority += 10
+
+        db.session.add_all([current_provider, new_provider])
+
+    else:
+        current_app.logger.info('Alternative provider {} is already activated'.format(new_provider.identifier))

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -105,11 +105,11 @@ def dao_fetch_service_by_id_and_user(service_id, user_id):
 
 @transactional
 @version_class(Service)
-def dao_create_service(service, user):
+def dao_create_service(service, user, service_id=None):
     from app.dao.permissions_dao import permission_dao
     service.users.append(user)
     permission_dao.add_default_service_permissions_for_user(user, service)
-    service.id = uuid.uuid4()  # must be set now so version history model can use same id
+    service.id = service_id or uuid.uuid4()  # must be set now so version history model can use same id
     service.active = True
     service.research_mode = False
     db.session.add(service)

--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -12,8 +12,8 @@ from app.dao.dao_utils import (
 
 @transactional
 @version_class(Template, TemplateHistory)
-def dao_create_template(template):
-    template.id = uuid.uuid4()  # must be set now so version history model can use same id
+def dao_create_template(template, template_id=None):
+    template.id = template_id or uuid.uuid4()  # must be set now so version history model can use same id
     template.archived = False
     db.session.add(template)
 

--- a/config.py
+++ b/config.py
@@ -43,9 +43,9 @@ class Config(object):
     # URL of redis instance
     REDIS_URL = os.getenv('REDIS_URL')
 
-    # Functional provider tests (auto switching on slow delivery)
-    FUNCTIONAL_TEST_SERVICE_ID = os.getenv('FUNCTIONAL_TEST_SERVICE_ID')
-    FUNCTIONAL_TEST_TEMPLATE_ID = os.getenv('FUNCTIONAL_TEST_TEMPLATE_ID')
+    # Functional provider tests (set below based on environment)
+    FUNCTIONAL_TEST_SERVICE_ID = None
+    FUNCTIONAL_TEST_TEMPLATE_ID = None
 
     ###########################
     # Default config values ###
@@ -193,6 +193,8 @@ class Test(Config):
         Queue('send-email', Exchange('default'), routing_key='send-email'),
         Queue('research-mode', Exchange('default'), routing_key='research-mode')
     ]
+    FUNCTIONAL_TEST_SERVICE_ID = 'ca06f587-fe04-484e-a8c5-de2bd45b0d2a'  # Random uuid's for tests
+    FUNCTIONAL_TEST_TEMPLATE_ID = '2a1d0b10-45c4-4155-8cea-a7b62d5c83c6'
 
 
 class Preview(Config):
@@ -202,6 +204,8 @@ class Preview(Config):
     API_HOST_NAME = 'http://admin-api.internal'
     FROM_NUMBER = 'preview'
     REDIS_ENABLED = True
+    FUNCTIONAL_TEST_SERVICE_ID = '64f8dff2-913d-471f-8793-57b9087b6ef3'
+    FUNCTIONAL_TEST_TEMPLATE_ID = 'fb0ac112-2438-4eac-a21b-acc6da8bc406'
 
 
 class Staging(Config):
@@ -212,6 +216,8 @@ class Staging(Config):
     API_HOST_NAME = 'http://admin-api.internal'
     FROM_NUMBER = 'stage'
     REDIS_ENABLED = True
+    FUNCTIONAL_TEST_SERVICE_ID = '8035fcbf-f064-4dda-b8f7-3fffa3478f30'
+    FUNCTIONAL_TEST_TEMPLATE_ID = 'ea048f03-deee-4bbc-8768-6a76a4861bd4'
 
 
 class Live(Config):
@@ -222,6 +228,8 @@ class Live(Config):
     API_HOST_NAME = 'http://admin-api.internal'
     FROM_NUMBER = '40604'
     REDIS_ENABLED = True
+    FUNCTIONAL_TEST_SERVICE_ID = '6c1d81bb-dae2-4ee9-80b0-89a4aae9f649'
+    FUNCTIONAL_TEST_TEMPLATE_ID = '285bb62d-08e7-414b-b5a3-6372ba320e06'
 
 
 configs = {

--- a/config.py
+++ b/config.py
@@ -43,6 +43,10 @@ class Config(object):
     # URL of redis instance
     REDIS_URL = os.getenv('REDIS_URL')
 
+    # Functional provider tests (auto switching on slow delivery)
+    FUNCTIONAL_TEST_SERVICE_ID = os.getenv('FUNCTIONAL_TEST_SERVICE_ID')
+    FUNCTIONAL_TEST_TEMPLATE_ID = os.getenv('FUNCTIONAL_TEST_TEMPLATE_ID')
+
     ###########################
     # Default config values ###
     ###########################
@@ -106,6 +110,11 @@ class Config(object):
         'delete-successful-notifications': {
             'task': 'delete-successful-notifications',
             'schedule': crontab(minute=0, hour='0,1,2'),
+            'options': {'queue': 'periodic'}
+        },
+        'switch-sms-providers-on-slow-delivery': {
+            'task': 'switch-sms-providers-on-slow-delivery',
+            'schedule': crontab(),  # runs every minute
             'options': {'queue': 'periodic'}
         },
         'timeout-sending-notifications': {

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -216,6 +216,31 @@ def test_will_remove_csv_files_for_jobs_older_than_seven_days(notify_db, notify_
     s3.remove_job_from_s3.assert_called_once_with(job_1.service_id, job_1.id)
 
 
+def test_switch_sms_providers_old_slow_delivery_notifications_does_not_switch(
+    notify_db,
+    notify_db_session,
+    restore_provider_details,
+    mocker
+):
+    set_primary_sms_provider('mmg')
+
+    # Create a notification '10 mins, 1 second ago'
+    create_sample_functional_test_slow_delivery_notification(
+        notify_db,
+        notify_db_session,
+        created_at=datetime.utcnow() - timedelta(minutes=10, seconds=1),
+        sent_at=datetime.utcnow(),
+        sent_by='mmg'
+    )
+
+    # Should not switch providers
+    switch_providers_on_slow_delivery()
+
+    current_provider = get_current_provider('sms')
+
+    assert current_provider.identifier == 'mmg'
+
+
 def test_switch_sms_providers_mmg_slow_delivery_sets_firetext_as_primary(
     notify_db,
     notify_db_session,

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -10,10 +10,67 @@ from app.celery.scheduled_tasks import (delete_verify_codes,
                                         delete_failed_notifications,
                                         delete_invitations,
                                         timeout_notifications,
-                                        run_scheduled_jobs)
+                                        run_scheduled_jobs,
+                                        switch_providers_on_slow_delivery)
 from app.dao.jobs_dao import dao_get_job_by_id
-from tests.app.conftest import sample_notification, sample_job
+from app.dao.provider_details_dao import (
+    dao_update_provider_details,
+    get_provider_details_by_identifier,
+    get_alternative_sms_provider,
+    get_current_provider
+)
+from tests.app.conftest import (
+    sample_notification as create_sample_notification,
+    sample_service as create_sample_service,
+    sample_template as create_sample_template,
+    sample_job,
+    set_primary_sms_provider
+)
 from unittest.mock import call
+
+
+def set_equal_priorities_for_sms_providers():
+    primary_provider = get_provider_details_by_identifier('mmg')
+    secondary_provider = get_alternative_sms_provider('firetext')
+
+    primary_provider.priority = 10
+    secondary_provider.priority = 10
+
+    dao_update_provider_details(primary_provider)
+    dao_update_provider_details(secondary_provider)
+
+
+def create_sample_functional_test_slow_delivery_notification(
+    notify_db,
+    notify_db_session,
+    created_at=None,
+    sent_at=None,
+    sent_by=None
+):
+    service = create_sample_service(
+        notify_db,
+        notify_db_session,
+        service_id=current_app.config.get('FUNCTIONAL_TEST_SERVICE_ID')
+    )
+
+    template = create_sample_template(
+        notify_db,
+        notify_db_session,
+        template_id=current_app.config.get('FUNCTIONAL_TEST_TEMPLATE_ID'),
+        service=service
+    )
+    notification = create_sample_notification(
+        notify_db,
+        notify_db_session,
+        service=service,
+        template=template,
+        created_at=created_at,
+        sent_at=sent_at,
+        sent_by=sent_by,
+        status='sending'
+    )
+
+    return notification
 
 
 def test_should_have_decorated_tasks_functions():
@@ -58,7 +115,7 @@ def test_update_status_of_notifications_after_timeout(notify_api,
                                                       sample_template,
                                                       mmg_provider):
     with notify_api.test_request_context():
-        not1 = sample_notification(
+        not1 = create_sample_notification(
             notify_db,
             notify_db_session,
             service=sample_service,
@@ -66,7 +123,7 @@ def test_update_status_of_notifications_after_timeout(notify_api,
             status='sending',
             created_at=datetime.utcnow() - timedelta(
                 seconds=current_app.config.get('SENDING_NOTIFICATIONS_TIMEOUT_PERIOD') + 10))
-        not2 = sample_notification(
+        not2 = create_sample_notification(
             notify_db,
             notify_db_session,
             service=sample_service,
@@ -74,7 +131,7 @@ def test_update_status_of_notifications_after_timeout(notify_api,
             status='created',
             created_at=datetime.utcnow() - timedelta(
                 seconds=current_app.config.get('SENDING_NOTIFICATIONS_TIMEOUT_PERIOD') + 10))
-        not3 = sample_notification(
+        not3 = create_sample_notification(
             notify_db,
             notify_db_session,
             service=sample_service,
@@ -95,7 +152,7 @@ def test_not_update_status_of_notification_before_timeout(notify_api,
                                                           sample_template,
                                                           mmg_provider):
     with notify_api.test_request_context():
-        not1 = sample_notification(
+        not1 = create_sample_notification(
             notify_db,
             notify_db_session,
             service=sample_service,
@@ -157,3 +214,108 @@ def test_will_remove_csv_files_for_jobs_older_than_seven_days(notify_db, notify_
     with freeze_time('2016-10-17T00:00:00'):
         remove_csv_files()
     s3.remove_job_from_s3.assert_called_once_with(job_1.service_id, job_1.id)
+
+
+def test_switch_sms_providers_mmg_slow_delivery_sets_firetext_as_primary(
+    notify_db,
+    notify_db_session,
+    restore_provider_details,
+    mocker
+):
+    set_primary_sms_provider('mmg')
+
+    create_sample_functional_test_slow_delivery_notification(
+        notify_db,
+        notify_db_session,
+        created_at=datetime.utcnow() - timedelta(minutes=5),
+        sent_at=datetime.utcnow(),
+        sent_by='mmg'
+    )
+
+    # Should attempt switch to firetext
+    switch_providers_on_slow_delivery()
+
+    current_provider = get_current_provider('sms')
+
+    assert current_provider.identifier == 'firetext'
+
+
+def test_switch_sms_providers_firetext_slow_delivery_sets_mmg_as_primary(
+    notify_db,
+    notify_db_session,
+    restore_provider_details,
+    mocker
+):
+    set_primary_sms_provider('firetext')
+
+    # Should attempt switch to mmg
+    create_sample_functional_test_slow_delivery_notification(
+        notify_db,
+        notify_db_session,
+        created_at=datetime.utcnow() - timedelta(minutes=5),
+        sent_at=datetime.utcnow(),
+        sent_by='firetext'
+    )
+
+    switch_providers_on_slow_delivery()
+
+    current_provider = get_current_provider('sms')
+
+    assert current_provider.identifier == 'mmg'
+
+
+def test_switch_sms_providers_with_equal_priorities_sets_firetext_as_primary(
+    notify_db,
+    notify_db_session,
+    restore_provider_details,
+    mocker
+):
+    set_equal_priorities_for_sms_providers()
+
+    create_sample_functional_test_slow_delivery_notification(
+        notify_db,
+        notify_db_session,
+        created_at=datetime.utcnow() - timedelta(minutes=5),
+        sent_at=datetime.utcnow(),
+        sent_by='mmg'
+    )
+
+    # Should attempt switch to firetext
+    switch_providers_on_slow_delivery()
+
+    primary_provider = get_provider_details_by_identifier('firetext')
+    secondary_provider = get_provider_details_by_identifier('mmg')
+
+    assert primary_provider.priority < secondary_provider.priority
+
+
+def test_switch_sms_providers_mmg_already_primary_does_not_update(
+    notify_db,
+    notify_db_session,
+    restore_provider_details,
+    mocker
+):
+    set_primary_sms_provider('mmg')
+
+    provider_mmg_before = get_provider_details_by_identifier('mmg')
+    provider_firetext_before = get_provider_details_by_identifier('firetext')
+
+    create_sample_functional_test_slow_delivery_notification(
+        notify_db,
+        notify_db_session,
+        created_at=datetime.utcnow() - timedelta(minutes=5),
+        sent_at=datetime.utcnow(),
+        sent_by='firetext'
+    )
+
+    # Should attempt switch to mmg
+    switch_providers_on_slow_delivery()
+
+    provider_mmg_after = get_provider_details_by_identifier('mmg')
+    provider_firetext_after = get_provider_details_by_identifier('firetext')
+
+    assert provider_mmg_before.priority == provider_mmg_after.priority
+    assert provider_firetext_before.priority == provider_firetext_after.priority
+
+    assert provider_mmg_before.version == provider_mmg_after.version
+    assert provider_firetext_before.version == provider_firetext_after.version

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import (datetime, date, timedelta)
 
+from sqlalchemy import asc
 from sqlalchemy.orm.session import make_transient
 import requests_mock
 import pytest
@@ -33,6 +34,11 @@ from app.dao.jobs_dao import dao_create_job
 from app.dao.notifications_dao import dao_create_notification
 from app.dao.invited_user_dao import save_invited_user
 from app.dao.provider_rates_dao import create_provider_rates
+from app.dao.provider_details_dao import (
+    dao_update_provider_details,
+    get_provider_details_by_identifier,
+    get_alternative_sms_provider
+)
 from app.clients.sms.firetext import FiretextClient
 
 
@@ -136,7 +142,8 @@ def sample_service(notify_db,
                    active=True,
                    restricted=False,
                    limit=1000,
-                   email_from=None):
+                   email_from=None,
+                   service_id=None):
     if user is None:
         user = sample_user(notify_db, notify_db_session)
     if email_from is None:
@@ -152,7 +159,7 @@ def sample_service(notify_db,
     service = Service.query.filter_by(name=service_name).first()
     if not service:
         service = Service(**data)
-        dao_create_service(service, user)
+        dao_create_service(service, user, service_id)
     else:
         if user not in service.users:
             dao_add_user_to_service(service, user)
@@ -162,6 +169,7 @@ def sample_service(notify_db,
 @pytest.fixture(scope='function')
 def sample_template(notify_db,
                     notify_db_session,
+                    template_id=None,
                     template_name="Template Name",
                     template_type="sms",
                     content="This is a template:\nwith a newline",
@@ -189,7 +197,7 @@ def sample_template(notify_db,
             'subject': subject_line
         })
     template = Template(**data)
-    dao_create_template(template)
+    dao_create_template(template, template_id)
     return template
 
 
@@ -645,13 +653,34 @@ def fake_uuid():
 
 
 @pytest.fixture(scope='function')
+def current_sms_provider():
+    return ProviderDetails.query.filter_by(
+        notification_type='sms'
+    ).order_by(
+        asc(ProviderDetails.priority)
+    ).first()
+
+
+@pytest.fixture(scope='function')
+def set_primary_sms_provider(identifier='mmg'):
+    primary_provider = get_provider_details_by_identifier(identifier)
+    secondary_provider = get_alternative_sms_provider(identifier)
+
+    primary_provider.priority = 10
+    secondary_provider.priority = 20
+
+    dao_update_provider_details(primary_provider)
+    dao_update_provider_details(secondary_provider)
+
+
+@pytest.fixture(scope='function')
 def ses_provider():
     return ProviderDetails.query.filter_by(identifier='ses').one()
 
 
 @pytest.fixture(scope='function')
-def firetext_provider():
-    return ProviderDetails.query.filter_by(identifier='mmg').one()
+def firetext_provider(notify_db, notify_db_session):
+    return ProviderDetails.query.filter_by(identifier='firetext').one()
 
 
 @pytest.fixture(scope='function')

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -26,6 +26,7 @@ from app.dao.notifications_dao import (
     dao_get_last_template_usage,
     dao_get_notification_statistics_for_service_and_day,
     dao_get_potential_notification_statistics_for_day,
+    dao_provider_notifications_where_delivery_longer_than,
     dao_get_template_usage,
     dao_update_notification,
     delete_notifications_created_more_than_a_week_ago,
@@ -816,6 +817,30 @@ def test_should_limit_notifications_return_by_day_limit_plus_one(notify_db, noti
 
     all_notifications = get_notifications_for_service(sample_service.id, limit_days=1).items
     assert len(all_notifications) == 2
+
+
+@freeze_time("2016-01-10 12:00:00.000000")
+def test_get_notifications_with_slow_delivery_time_returns_notifications(notify_db, notify_db_session):
+    # create a notification with a slow delivery time (7 mins)
+    notification = sample_notification(
+        notify_db,
+        notify_db_session,
+        created_at=datetime.utcnow() - timedelta(minutes=7),
+        sent_at=datetime.utcnow(),
+        status='sending',
+        sent_by='mmg'
+    )
+
+    # get notifications that took longer than 5 minutes to deliver
+    slow_delivery_notifications = dao_provider_notifications_where_delivery_longer_than(
+        amount_of_time=timedelta(minutes=4),
+        starting_from=datetime.utcnow() - timedelta(minutes=10),
+        service_id=notification.service_id,
+        template_id=notification.template.id,
+        providers=['firetext', 'mmg']
+    )
+
+    assert len(slow_delivery_notifications) == 1
 
 
 def test_creating_notification_adds_to_notification_history(sample_template):

--- a/tests/app/dao/test_provider_details_dao.py
+++ b/tests/app/dao/test_provider_details_dao.py
@@ -59,6 +59,16 @@ def test_should_not_error_if_any_provider_in_code_not_in_database(restore_provid
     assert clients.get_sms_client('mmg')
 
 
+def test_update_sms_provider_to_inactive_sets_inactive(restore_provider_details):
+    set_primary_sms_provider('mmg')
+    primary_provider = get_current_provider('sms')
+    primary_provider.active = False
+
+    dao_update_provider_details(primary_provider)
+
+    assert not primary_provider.active
+
+
 @freeze_time('2000-01-01T00:00:00')
 def test_update_adds_history(restore_provider_details):
     ses = ProviderDetails.query.filter(ProviderDetails.identifier == 'ses').one()
@@ -129,7 +139,7 @@ def test_switch_sms_provider_switches_on_slow_delivery(
     assert new_provider.priority < old_provider.priority
 
 
-def test_switch_sms_provider_already_activated_does_not_switch(
+def test_switch_sms_provider_to_already_activated_provider_does_not_switch(
     notify_db,
     notify_db_session,
     current_sms_provider,
@@ -137,6 +147,7 @@ def test_switch_sms_provider_already_activated_does_not_switch(
     mocker
 ):
     alternate_sms_provider = get_alternative_sms_provider(current_sms_provider.identifier)
+
     # A notification that has been in sending for 7 mins
     notification = create_sample_notification(
         notify_db,
@@ -146,6 +157,34 @@ def test_switch_sms_provider_already_activated_does_not_switch(
         status='sending',
         sent_by=alternate_sms_provider.identifier  # Must be alternate sms provider (not activated)
     )
+
+    dao_switch_sms_provider(notification.sent_by)
+
+    new_provider = get_current_provider('sms')
+
+    assert current_sms_provider.id == new_provider.id
+    assert current_sms_provider.identifier == new_provider.identifier
+
+
+def test_switch_sms_provider_to_inactive_provider_does_not_switch(
+    notify_db,
+    notify_db_session,
+    current_sms_provider,
+    restore_provider_details,
+    mocker
+):
+    notification = create_sample_notification(
+        notify_db,
+        notify_db_session,
+        created_at=datetime.utcnow() - timedelta(minutes=10),
+        sent_at=datetime.utcnow() - timedelta(minutes=3),
+        status='sending',
+        sent_by=current_sms_provider.identifier
+    )
+
+    alternate_sms_provider = get_alternative_sms_provider(current_sms_provider.identifier)
+    alternate_sms_provider.active = False
+    dao_update_provider_details(alternate_sms_provider)
 
     dao_switch_sms_provider(notification.sent_by)
 

--- a/tests/app/dao/test_provider_details_dao.py
+++ b/tests/app/dao/test_provider_details_dao.py
@@ -1,13 +1,23 @@
-from datetime import datetime
+import pytest
+
+from datetime import datetime, timedelta
 
 from freezegun import freeze_time
 
 from app.models import ProviderDetails, ProviderDetailsHistory
 from app import clients
 from app.dao.provider_details_dao import (
+    dao_switch_sms_provider,
+    get_current_provider,
+    get_alternative_sms_provider,
     get_provider_details,
+    get_provider_details_by_id,
     get_provider_details_by_notification_type,
     dao_update_provider_details
+)
+from tests.app.conftest import (
+    sample_notification as create_sample_notification,
+    set_primary_sms_provider
 )
 
 
@@ -78,3 +88,68 @@ def test_update_adds_history(restore_provider_details):
     assert not ses_history[1].active
     assert ses_history[1].version == 2
     assert ses_history[1].updated_at == datetime(2000, 1, 1, 0, 0, 0)
+
+
+def test_get_current_provider_sms_returns_correct_provider(restore_provider_details):
+    set_primary_sms_provider('mmg')
+
+    provider = get_current_provider('sms')
+
+    assert provider.identifier == 'mmg'
+
+
+@pytest.mark.parametrize('provider_identifier', ['firetext', 'mmg'])
+def test_get_alternative_sms_provider_returns_expected_provider(notify_db, provider_identifier):
+    provider = get_alternative_sms_provider(provider_identifier)
+    assert provider.identifier != provider
+
+
+def test_switch_sms_provider_switches_on_slow_delivery(
+    notify_db,
+    notify_db_session,
+    current_sms_provider,
+    restore_provider_details
+):
+    # A notification that has been in sending for 7 mins
+    notification = create_sample_notification(
+        notify_db,
+        notify_db_session,
+        created_at=datetime.utcnow() - timedelta(minutes=10),
+        sent_at=datetime.utcnow() - timedelta(minutes=3),
+        status='sending',
+        sent_by=current_sms_provider.identifier
+    )
+
+    dao_switch_sms_provider(notification.sent_by)
+
+    old_provider = get_provider_details_by_id(current_sms_provider.id)
+    new_provider = get_current_provider('sms')
+
+    assert current_sms_provider.identifier != new_provider.identifier
+    assert new_provider.priority < old_provider.priority
+
+
+def test_switch_sms_provider_already_activated_does_not_switch(
+    notify_db,
+    notify_db_session,
+    current_sms_provider,
+    restore_provider_details,
+    mocker
+):
+    alternate_sms_provider = get_alternative_sms_provider(current_sms_provider.identifier)
+    # A notification that has been in sending for 7 mins
+    notification = create_sample_notification(
+        notify_db,
+        notify_db_session,
+        created_at=datetime.utcnow() - timedelta(minutes=10),
+        sent_at=datetime.utcnow() - timedelta(minutes=3),
+        status='sending',
+        sent_by=alternate_sms_provider.identifier  # Must be alternate sms provider (not activated)
+    )
+
+    dao_switch_sms_provider(notification.sent_by)
+
+    new_provider = get_current_provider('sms')
+
+    assert current_sms_provider.id == new_provider.id
+    assert current_sms_provider.identifier == new_provider.identifier


### PR DESCRIPTION
This adds a celery beat task (running every minute) to **automatically** switch providers on slow delivery of notifications. 

# **How it works**

There are some assumptions made here regarding how the task will operate and check for notifications:
- only those sent from the functional test service with a specific template id (refer to [config.py](https://github.com/alphagov/notifications-api/blob/c2a62e58f5dea6b28c15d1b09fc54489df261c55/config.py))
- in the last 10 minutes either `sending` or `delivered` where the delivery time is/took longer than four minutes

Currently to make a given provider the primary, we set the priority = x where x < all other provider priorities. The switching mechanism behaves differently depending on the current state of providers:

- Only attempt to switch between firetext and mmg (can be changed in the future)
- If the provider we want to switch to is inactive (`active=False`), we won't attempt the switch
- If the provider priorities are equal, then we will simply increase the priority of the one we want to be secondary.

# **Testing locally**

1. Make sure providers are active 
2. Set the `FUNCTIONAL_TEST_SERVICE_ID` and `FUNCTIONAL_TEST_TEMPLATE_ID` to a valid service and template id (from your local dev service). 
3. Run `scripts/run_celery_beat.sh`
3. Send an sms notification and manually edit the db to change the `sent_at` for that notification. As long as the  `(created_at - sent_at)` is more than 4 minutes it should be picked up as a 'slow delivery notification'
4. Monitor the celery beat deamon and you should see logs indicating that a provider switch is taking place. The switch can also be verified on the admin dashboard. 

Note: You can play around with the priorities and active flags to validate switching is behaving as expected.