### PR TITLE
fix placeholders not appearing in email subject

### DIFF
--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -218,12 +218,9 @@ def sample_email_template(
         'template_type': template_type,
         'content': content,
         'service': service,
-        'created_by': user
+        'created_by': user,
+        'subject': subject_line
     }
-    if subject_line:
-        data.update({
-            'subject': subject_line
-        })
     template = Template(**data)
     dao_create_template(template)
     return template


### PR DESCRIPTION
it now switches utils.template.Template type, since the base Template type now no longer has a subject attribute.

updated test case to use `sample_email_template_with_placeholders` instead of `sample_email_template`