### PR TITLE
don't use cloudfront on preview or staging

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -135,8 +135,11 @@ def get_logo_url(base_url, branding_path, logo_file):
     base_url = parse.urlparse(base_url)
     netloc = base_url.netloc
 
-    if base_url.netloc.startswith('localhost'):
-        netloc = 'localhost:6012'
+    if (
+        base_url.netloc.startswith('localhost') or
+        # covers both preview and staging
+        'notify.works' in base_url.netloc
+    ):
         path = '/static' + branding_path + logo_file
     else:
         if base_url.netloc.startswith('www'):

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -397,8 +397,15 @@ def test_get_html_email_renderer_prepends_logo_path(notify_api):
     ('http://localhost:6012', 'http://localhost:6012/static/sub-path/filename.png'),
     # on other environments, replace www with staging
     ('https://www.notifications.service.gov.uk', 'https://static.notifications.service.gov.uk/sub-path/filename.png'),
-    ('https://www.notify.works', 'https://static.notify.works/sub-path/filename.png'),
-    ('https://notify.works', 'https://static.notify.works/sub-path/filename.png'),
+
+    # staging and preview do not have cloudfront running, so should act as localhost
+    pytest.mark.xfail(('https://www.notify.works', 'https://static.notify.works/sub-path/filename.png')),
+    pytest.mark.xfail(('https://www.staging-notify.works', 'https://static.notify.works/sub-path/filename.png')),
+    pytest.mark.xfail(('https://notify.works', 'https://static.notify.works/sub-path/filename.png')),
+    pytest.mark.xfail(('https://staging-notify.works', 'https://static.notify.works/sub-path/filename.png')),
+    # these tests should be removed when cloudfront works on staging/preview
+    ('https://www.notify.works', 'https://www.notify.works/static/sub-path/filename.png'),
+    ('https://www.staging-notify.works', 'https://www.staging-notify.works/static/sub-path/filename.png'),
 ])
 def test_get_logo_url_works_for_different_environments(base_url, expected_url):
     branding_path = '/sub-path/'


### PR DESCRIPTION
cloudfront caching isn't set up on those environments yet, so continue
to use flask for now - in the future we'll want to revert this once
those environments are up and running properly