### PR TITLE
Removed the oneOf validation in the get_notification_response schema.

### DIFF
--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -187,17 +187,19 @@ post_email_response = {
 }
 
 
-def create_post_sms_response_from_notification(notification, body, from_number, url_root):
+def create_post_sms_response_from_notification(notification, body, from_number, url_root, service_id):
     return {"id": notification.id,
             "reference": notification.client_reference,
             "content": {'body': body,
                         'from_number': from_number},
             "uri": "{}v2/notifications/{}".format(url_root, str(notification.id)),
-            "template": __create_template_from_notification(notification=notification, url_root=url_root)
+            "template": __create_template_from_notification(notification=notification,
+                                                            url_root=url_root,
+                                                            service_id=service_id)
             }
 
 
-def create_post_email_response_from_notification(notification, content, subject, email_from, url_root):
+def create_post_email_response_from_notification(notification, content, subject, email_from, url_root, service_id):
     return {
         "id": notification.id,
         "reference": notification.client_reference,
@@ -207,13 +209,15 @@ def create_post_email_response_from_notification(notification, content, subject,
             "subject": subject
         },
         "uri": "{}v2/notifications/{}".format(url_root, str(notification.id)),
-        "template": __create_template_from_notification(notification=notification, url_root=url_root)
+        "template": __create_template_from_notification(notification=notification,
+                                                        url_root=url_root,
+                                                        service_id=service_id)
     }
 
 
-def __create_template_from_notification(notification, url_root):
+def __create_template_from_notification(notification, url_root, service_id):
     return {
         "id": notification.template_id,
         "version": notification.template_version,
-        "uri": "{}v2/templates/{}".format(url_root, str(notification.template_id))
+        "uri": "{}services/{}/templates/{}".format(url_root, str(service_id), str(notification.template_id))
     }

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -20,32 +20,6 @@ get_notification_response = {
     "description": "GET notification response schema",
     "type": "object",
     "title": "response v2/notification",
-    "oneOf": [
-        {"properties": {
-            "email_address": {"type": "string", "format": "email_address"},
-            "type": {"enum": ["email"]},
-
-            "phone_number": {"type": "null"},
-            "line_1": {"type": "null"},
-            "postcode": {"type": "null"}
-        }},
-        {"properties": {
-            "phone_number": {"type": "string", "format": "phone_number"},
-            "type": {"enum": ["sms"]},
-
-            "email_address": {"type": "null"},
-            "line_1": {"type": "null"},
-            "postcode": {"type": "null"}
-        }},
-        {"properties": {
-            "line_1": {"type": "string", "minLength": 1},
-            "postcode": {"type": "string", "minLength": 1},
-            "type": {"enum": ["letter"]},
-
-            "email_address": {"type": "null"},
-            "phone_number": {"type": "null"}
-        }}
-    ],
     "properties": {
         "id": uuid,
         "reference": {"type": ["string", "null"]},

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -41,10 +41,11 @@ def post_sms_notification():
                                         reference=form.get('reference'))
     send_notification_to_queue(notification, service.research_mode)
     sms_sender = service.sms_sender if service.sms_sender else current_app.config.get('FROM_NUMBER')
-    resp = create_post_sms_response_from_notification(notification,
-                                                      str(template_with_content),
-                                                      sms_sender,
-                                                      request.url_root)
+    resp = create_post_sms_response_from_notification(notification=notification,
+                                                      body=str(template_with_content),
+                                                      from_number=sms_sender,
+                                                      url_root=request.url_root,
+                                                      service_id=service.id)
     return jsonify(resp), 201
 
 
@@ -73,7 +74,8 @@ def post_email_notification():
                                                         content=str(template_with_content),
                                                         subject=template_with_content.subject,
                                                         email_from=service.email_from,
-                                                        url_root=request.url_root)
+                                                        url_root=request.url_root,
+                                                        service_id=service.id)
     return jsonify(resp), 201
 
 

--- a/tests/app/v2/notifications/test_notification_schemas.py
+++ b/tests/app/v2/notifications/test_notification_schemas.py
@@ -6,6 +6,7 @@ from jsonschema import ValidationError
 
 from app.v2.notifications.notification_schemas import (
     get_notifications_request,
+    get_notification_response,
     post_sms_request as post_sms_request_schema,
     post_sms_response as post_sms_response_schema,
     post_email_request as post_email_request_schema,
@@ -309,3 +310,28 @@ def test_post_sms_response_schema_invalid_template_uri_raises_validation_error(r
     assert error['status_code'] == 400
     assert error['errors'] == [{'error': 'ValidationError',
                                'message': "template invalid-uri is not a uri"}]
+
+
+def test_get_notifications_response_with_email_and_phone_number():
+    response = {"id": str(uuid.uuid4()),
+                "reference": "something",
+                "email_address": None,
+                "phone_number": "+447115411111",
+                "line_1": None,
+                "line_2": None,
+                "line_3": None,
+                "line_4": None,
+                "line_5": None,
+                "line_6": None,
+                "postcode": None,
+                "type": "email",
+                "status": "delivered",
+                "template": {"id": str(uuid.uuid4()), "version": 1, "uri": "http://template/id"},
+                "body": "some body",
+                "subject": "some subject",
+                "created_at": "2016-01-01",
+                "sent_at": "2016-01-01",
+                "completed_at": "2016-01-01"
+                }
+
+    assert validate(response, get_notification_response) == response

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -37,7 +37,9 @@ def test_post_sms_notification_returns_201(notify_api, sample_template_with_plac
             assert 'v2/notifications/{}'.format(notification_id) in resp_json['uri']
             assert resp_json['template']['id'] == str(sample_template_with_placeholders.id)
             assert resp_json['template']['version'] == sample_template_with_placeholders.version
-            assert 'v2/templates/{}'.format(sample_template_with_placeholders.id) in resp_json['template']['uri']
+            assert 'services/{}/templates/{}'.format(sample_template_with_placeholders.service_id,
+                                                     sample_template_with_placeholders.id) \
+                   in resp_json['template']['uri']
             assert mocked.called
 
 
@@ -137,7 +139,9 @@ def test_post_email_notification_returns_201(client, sample_email_template_with_
     assert 'v2/notifications/{}'.format(notification.id) in resp_json['uri']
     assert resp_json['template']['id'] == str(sample_email_template_with_placeholders.id)
     assert resp_json['template']['version'] == sample_email_template_with_placeholders.version
-    assert 'v2/templates/{}'.format(sample_email_template_with_placeholders.id) in resp_json['template']['uri']
+    assert 'services/{}/templates/{}'.format(str(sample_email_template_with_placeholders.service_id),
+                                             str(sample_email_template_with_placeholders.id)) \
+           in resp_json['template']['uri']
     assert mocked.called
 
 


### PR DESCRIPTION
Small PR to remove the oneOf validation in the v2 get_notification_response schema. It doesn't work properly with the required element of the schema.