### PR TITLE
DO NOT MERGE: Revert timezone accuracy on usage

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -391,6 +391,6 @@ def get_april_fools(year):
 
 
 def get_bst_month(datetime):
-    return pytz.utc.localize(datetime).astimezone(
-        pytz.timezone("Europe/London")
+    return pytz.utc.localize(datetime).replace(
+        tzinfo=pytz.timezone("Europe/London")
     ).strftime('%B')

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -1,10 +1,10 @@
+import uuid
 import pytz
 from datetime import (
     datetime,
     timedelta,
     date
 )
-from itertools import groupby
 
 from flask import current_app
 from werkzeug.datastructures import MultiDict
@@ -215,25 +215,20 @@ def get_notifications_for_job(service_id, job_id, filter_dict=None, page=1, page
 @statsd(namespace="dao")
 def get_notification_billable_unit_count_per_month(service_id, year):
     start, end = get_financial_year(year)
-
-    notifications = db.session.query(
-        NotificationHistory.created_at,
-        NotificationHistory.billable_units
+    return db.session.query(
+        func.to_char(NotificationHistory.created_at, "FMMonth"),
+        func.sum(NotificationHistory.billable_units)
+    ).group_by(
+        func.to_char(NotificationHistory.created_at, "FMMonth"),
+        func.to_char(NotificationHistory.created_at, "YYYY-MM")
     ).order_by(
-        NotificationHistory.created_at
+        func.to_char(NotificationHistory.created_at, "YYYY-MM")
     ).filter(
         NotificationHistory.billable_units != 0,
         NotificationHistory.service_id == service_id,
         NotificationHistory.created_at >= start,
         NotificationHistory.created_at < end
     ).all()
-
-    return [
-        (month, sum(count for _, count in row))
-        for month, row in groupby(
-            notifications, lambda row: get_bst_month(row[0])
-        )
-    ]
 
 
 @statsd(namespace="dao")
@@ -380,17 +375,7 @@ def dao_timeout_notifications(timeout_period_in_seconds):
 
 
 def get_financial_year(year):
-    return get_april_fools(year), get_april_fools(year + 1)
-
-
-def get_april_fools(year):
-    return datetime(
-        year, 4, 1, 0, 0, 0, 0,
-        pytz.timezone("Europe/London")
-    ).astimezone(pytz.utc)
-
-
-def get_bst_month(datetime):
-    return pytz.utc.localize(datetime).replace(
-        tzinfo=pytz.timezone("Europe/London")
-    ).strftime('%B')
+    return (
+        date(year, 4, 1),
+        date(year + 1, 4, 1)
+    )

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -226,7 +226,7 @@ def get_notification_billable_unit_count_per_month(service_id, year):
         NotificationHistory.service_id == service_id,
         NotificationHistory.created_at >= start,
         NotificationHistory.created_at < end
-    )
+    ).all()
 
     return [
         (month, sum(count for _, count in row))

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -701,20 +701,21 @@ def test_get_all_notifications_for_job_by_status(notify_db, notify_db_session, s
 def test_get_notification_billable_unit_count_per_month(notify_db, notify_db_session, sample_service):
 
     for year, month, day in (
-        (2017, 1, 15),  # ↓ 2016 financial year
+        (2017, 1, 1),  # ↓ 2016 financial year
         (2016, 8, 1),
-        (2016, 7, 15),
-        (2016, 4, 15),
-        (2016, 4, 15),
+        (2016, 7, 31),
+        (2016, 4, 6),
+        (2016, 4, 6),
         (2016, 4, 1),  # ↓ 2015 financial year
         (2016, 3, 31),
-        (2016, 1, 15)
+        (2016, 1, 1)
     ):
         sample_notification(
             notify_db, notify_db_session, service=sample_service,
             created_at=datetime(
-                year, month, day, 0, 0, 0, 0
-            ) - timedelta(hours=1, seconds=1)  # one second before midnight
+                year, month, day, 0, 0, 0, 0,
+                tzinfo=pytz.utc
+            )
         )
 
     for financial_year, months in (
@@ -724,11 +725,11 @@ def test_get_notification_billable_unit_count_per_month(notify_db, notify_db_ses
         ),
         (
             2016,
-            [('April', 2), ('July', 2), ('January', 1)]
+            [('April', 2), ('July', 1), ('August', 1), ('January', 1)]
         ),
         (
             2015,
-            [('January', 1), ('March', 2)]
+            [('January', 1), ('March', 1), ('April', 1)]
         ),
         (
             2014,

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta, date
-import pytz
 import uuid
 from functools import partial
 
@@ -701,21 +700,18 @@ def test_get_all_notifications_for_job_by_status(notify_db, notify_db_session, s
 def test_get_notification_billable_unit_count_per_month(notify_db, notify_db_session, sample_service):
 
     for year, month, day in (
-        (2017, 1, 1),  # ↓ 2016 financial year
+        (2017, 1, 1),
         (2016, 8, 1),
         (2016, 7, 31),
         (2016, 4, 6),
         (2016, 4, 6),
-        (2016, 4, 1),  # ↓ 2015 financial year
+        (2016, 4, 1),
         (2016, 3, 31),
         (2016, 1, 1)
     ):
         sample_notification(
             notify_db, notify_db_session, service=sample_service,
-            created_at=datetime(
-                year, month, day, 0, 0, 0, 0,
-                tzinfo=pytz.utc
-            )
+            created_at=date(year, month, day)
         )
 
     for financial_year, months in (
@@ -725,11 +721,11 @@ def test_get_notification_billable_unit_count_per_month(notify_db, notify_db_ses
         ),
         (
             2016,
-            [('April', 2), ('July', 1), ('August', 1), ('January', 1)]
+            [('April', 3), ('July', 1), ('August', 1), ('January', 1)]
         ),
         (
             2015,
-            [('January', 1), ('March', 1), ('April', 1)]
+            [('January', 1), ('March', 1)]
         ),
         (
             2014,
@@ -1202,7 +1198,5 @@ def test_should_exclude_test_key_notifications_by_default(
 
 def test_get_financial_year():
     start, end = get_financial_year(2000)
-    assert start.tzinfo == pytz.utc
-    assert start.isoformat() == '2000-04-01T00:01:00+00:00'
-    assert end.tzinfo == pytz.utc
-    assert end.isoformat() == '2001-04-01T00:01:00+00:00'
+    assert start == date(2000, 4, 1)
+    assert end == date(2001, 4, 1)


### PR DESCRIPTION
Doing the grouping in Python is waaaaay too slow and is causing pages to timeout. If we don’t need complete accuracy we can make this query a lot faster, by doing it in pure SQL.