### PR TITLE
Add a process type to templates

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -258,6 +258,11 @@ class NotificationStatistics(db.Model):
     )
 
 
+class TemplateProcessTypes(db.Model):
+    __tablename__ = 'template_process_type'
+    name = db.Column(db.String(255), primary_key=True)
+
+
 SMS_TYPE = 'sms'
 EMAIL_TYPE = 'email'
 LETTER_TYPE = 'letter'
@@ -265,6 +270,10 @@ LETTER_TYPE = 'letter'
 TEMPLATE_TYPES = [SMS_TYPE, EMAIL_TYPE, LETTER_TYPE]
 
 template_types = db.Enum(*TEMPLATE_TYPES, name='template_type')
+
+NORMAL = 'normal'
+PRIORITY = 'priority'
+TEMPLATE_PROCESS_TYPE = [NORMAL, PRIORITY]
 
 
 class Template(db.Model):
@@ -293,6 +302,11 @@ class Template(db.Model):
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
     created_by = db.relationship('User')
     version = db.Column(db.Integer, default=1, nullable=False)
+    process_type = db.Column(db.String(255),
+                             db.ForeignKey('template_process_type.name'),
+                             index=True,
+                             nullable=True,
+                             default=NORMAL)
 
     def get_link(self):
         # TODO: use "/v2/" route once available
@@ -320,7 +334,11 @@ class TemplateHistory(db.Model):
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
     created_by = db.relationship('User')
     version = db.Column(db.Integer, primary_key=True, nullable=False)
-
+    process_type = db.Column(db.String(255),
+                             db.ForeignKey('template_process_type.name'),
+                             index=True,
+                             nullable=True,
+                             default=NORMAL)
 
 MMG_PROVIDER = "mmg"
 FIRETEXT_PROVIDER = "firetext"

--- a/migrations/versions/0063_templates_process_type.py
+++ b/migrations/versions/0063_templates_process_type.py
@@ -1,0 +1,38 @@
+"""empty message
+
+Revision ID: 0063_templates_process_type
+Revises: 0062_provider_details_history
+Create Date: 2017-01-10 15:39:30.909308
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0063_templates_process_type'
+down_revision = '0062_provider_details_history'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('template_process_type',
+    sa.Column('name', sa.String(length=255), nullable=False),
+    sa.PrimaryKeyConstraint('name')
+    )
+    op.execute("INSERT INTO template_process_type VALUES ('normal'), ('priority')")
+    op.add_column('templates', sa.Column('process_type', sa.String(length=255), nullable=True))
+    op.create_index(op.f('ix_templates_process_type'), 'templates', ['process_type'], unique=False)
+    op.create_foreign_key('templates_history_process_type_fkey', 'templates', 'template_process_type', ['process_type'], ['name'])
+    op.add_column('templates_history', sa.Column('process_type', sa.String(length=255), nullable=True))
+    op.create_index(op.f('ix_templates_history_process_type'), 'templates_history', ['process_type'], unique=False)
+    op.create_foreign_key('templates_process_type_fkey', 'templates_history', 'template_process_type', ['process_type'], ['name'])
+
+
+def downgrade():
+    op.drop_constraint('templates_history_process_type_fkey', 'templates_history', type_='foreignkey')
+    op.drop_index(op.f('ix_templates_history_process_type'), table_name='templates_history')
+    op.drop_column('templates_history', 'process_type')
+    op.drop_constraint('templates_process_type_fkey', 'templates', type_='foreignkey')
+    op.drop_index(op.f('ix_templates_process_type'), table_name='templates')
+    op.drop_column('templates', 'process_type')
+    op.drop_table('template_process_type')

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -12,7 +12,6 @@ from app.notifications import SendNotificationToQueueError
 from app.notifications.process_notifications import (create_content_for_notification,
                                                      persist_notification, send_notification_to_queue)
 from app.v2.errors import BadRequestError
-from tests.app.conftest import sample_notification, sample_template, sample_email_template
 
 
 def test_create_content_for_notification_passes(sample_email_template):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,12 @@ def notify_db_session(notify_db):
 
     notify_db.session.remove()
     for tbl in reversed(notify_db.metadata.sorted_tables):
-        if tbl.name not in ["provider_details", "key_types", "branding_type", "job_status", "provider_details_history"]:
+        if tbl.name not in ["provider_details",
+                            "key_types",
+                            "branding_type",
+                            "job_status",
+                            "provider_details_history",
+                            "template_process_type"]:
             notify_db.engine.execute(tbl.delete())
     notify_db.session.commit()
 


### PR DESCRIPTION
This is the first deploy in series of deploys to give certain templates priority in processing. 
Applicable templates would be for two factor auth or one time passwords.

If the template is marked as priority the notification will be sent using the `notify` queue.
The `notify` queue is a low volume queue, messages here will not be queue behind a large job and should be delivered with in a more consistent time frame.

- Added templates.process_type and templates_history.process_type column.
- Added a template_process_type table to handle the enum for templates.process_type, initial values are normal and priority

https://www.pivotaltracker.com/story/show/135429147