### PR TITLE
Give a more helpful error when token has expired

### DIFF
--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -94,4 +94,4 @@ def get_decode_errors(auth_token, unsigned_secret):
     try:
         decode_jwt_token(auth_token, unsigned_secret)
     except TokenExpiredError:
-        raise AuthError("Invalid token: expired", 403)
+        raise AuthError("Invalid token: expired, check that your system clock is accurate", 403)

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -320,7 +320,9 @@ def test_should_return_403_when_token_is_expired(notify_api,
                     headers={'Authorization': 'Bearer {}'.format(token)})
             assert response.status_code == 403
             error_message = json.loads(response.get_data())
-            assert error_message['message'] == {'token': ['Invalid token: expired']}
+            assert error_message['message'] == {'token': [
+                'Invalid token: expired, check that your system clock is accurate'
+            ]}
 
 
 def __create_get_token(service_id):


### PR DESCRIPTION
We’ve seen quite a few developers encounter the `Invalid token: expired` error message when they’re getting started using the Notify API. When this happens they either raise a support ticket or ask for help on Slack.

In every case this has been because the clock on their machine/environment/container isn’t accurate. The error message doesn’t help them figure this out.

This commit adds extra detail to the error message so they can fix the problem without having to come to us for help.