### PR TITLE
Don’t strip HTML when saving templates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 apispec==0.14.0
-bleach==1.4.3
 Flask==0.10.1
 Flask-Script==2.0.5
 Flask-Migrate==1.3.1
@@ -24,6 +23,6 @@ gunicorn==19.6.0
 # pin to minor version 3.1.x
 notifications-python-client>=3.1,<3.2
 
-git+https://github.com/alphagov/notifications-utils.git@13.1.0#egg=notifications-utils==13.1.0
+git+https://github.com/alphagov/notifications-utils.git@13.2.0#egg=notifications-utils==13.2.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -189,6 +189,14 @@ def sample_template_with_placeholders(notify_db, notify_db_session):
 
 
 @pytest.fixture(scope='function')
+def sample_sms_template_with_html(notify_db, notify_db_session):
+    # deliberate space and title case in placeholder
+    return sample_template(notify_db, notify_db_session, content=(
+        "Hello (( Name))\nHere is <em>some HTML</em> & entities"
+    ))
+
+
+@pytest.fixture(scope='function')
 def sample_email_template(
         notify_db,
         notify_db_session,
@@ -222,6 +230,15 @@ def sample_email_template_with_placeholders(notify_db, notify_db_session):
         notify_db_session,
         content="Hello ((name))\nThis is an email from GOV.UK",
         subject_line="((name))")
+
+
+@pytest.fixture(scope='function')
+def sample_email_template_with_html(notify_db, notify_db_session):
+    return sample_email_template(
+        notify_db,
+        notify_db_session,
+        content="Hello ((name))\nThis is an email from GOV.UK with <em>some HTML</em>",
+        subject_line="((name)) <em>some HTML</em>")
 
 
 @pytest.fixture(scope='function')

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -37,7 +37,7 @@ def test_should_create_a_new_template_for_a_service(
     json_resp = json.loads(response.get_data(as_text=True))
     assert json_resp['data']['name'] == 'my template'
     assert json_resp['data']['template_type'] == template_type
-    assert json_resp['data']['content'] == 'template content'
+    assert json_resp['data']['content'] == 'template <b>content</b>'
     assert json_resp['data']['service'] == str(sample_service.id)
     assert json_resp['data']['id']
     assert json_resp['data']['version'] == 1
@@ -153,7 +153,9 @@ def test_update_should_update_a_template(client, sample_user, sample_template):
 
     assert update_response.status_code == 200
     update_json_resp = json.loads(update_response.get_data(as_text=True))
-    assert update_json_resp['data']['content'] == 'my template has new content alert("foo")'
+    assert update_json_resp['data']['content'] == (
+        'my template has new content <script type="text/javascript">alert("foo")</script>'
+    )
     assert update_json_resp['data']['name'] == sample_template.name
     assert update_json_resp['data']['template_type'] == sample_template.template_type
     assert update_json_resp['data']['version'] == 2


### PR DESCRIPTION
Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/109
- [x] https://github.com/alphagov/notifications-admin/pull/1078

***

Right now we strip HTML from templates at the point of saving them. This also converts stuff like ampersands to their entity form (eg &amp;) and this is what we save in the database.

This is a bad idea when you’re sending a text message or a letter, in which an HTML entity makes no sense. But we still need to encode HTML in the body of HTML emails.

The right place to do this is when rendering the templates. The code to do this is now in utils. So this commit:
- pull in this new utils code
- removes the old
- adds some integration tests to make sure that everything is working as expected (more thorough unit tests are happening in utils)