### PR TITLE
Persist letters

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -220,20 +220,24 @@ def persist_letter(
     created_at
 ):
     notification = encryption.decrypt(encrypted_notification)
+
+    # we store the recipient as just the first item of the person's address
+    recipient = notification['personalisation']['addressline1']
+
     service = dao_fetch_service_by_id(service_id)
     try:
         saved_notification = persist_notification(
             template_id=notification['template'],
             template_version=notification['template_version'],
-            recipient=notification['to'],
+            recipient=recipient,
             service=service,
-            personalisation=notification.get('personalisation'),
-            notification_type=EMAIL_TYPE,
+            personalisation=notification['personalisation'],
+            notification_type=LETTER_TYPE,
             api_key_id=None,
             key_type=KEY_TYPE_NORMAL,
             created_at=created_at,
-            job_id=notification.get('job', None),
-            job_row_number=notification.get('row_number', None),
+            job_id=notification['job'],
+            job_row_number=notification['row_number'],
             notification_id=notification_id
         )
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -51,7 +51,7 @@ def process_job(job_id):
 
     db_template = dao_get_template_by_id(job.template_id, job.template_version)
 
-    TemplateClass = get_template_class(db_template)
+    TemplateClass = get_template_class(db_template.template_type)
     template = TemplateClass(db_template.__dict__)
 
     for row_number, recipient, personalisation in RecipientCSV(
@@ -266,10 +266,10 @@ def handle_exception(task, notification, notification_id, exc):
             current_app.logger.exception('Retry' + retry_msg)
 
 
-def get_template_class(template):
-    if template.template_type == SMS_TYPE:
+def get_template_class(template_type):
+    if template_type == SMS_TYPE:
         return SMSMessageTemplate
-    elif template.template_type in (EMAIL_TYPE, LETTER_TYPE):
+    elif template_type in (EMAIL_TYPE, LETTER_TYPE):
         # since we don't need rendering capabilities (we only need to extract placeholders) both email and letter can
         # use the same base template
         return WithSubjectTemplate

--- a/app/config.py
+++ b/app/config.py
@@ -167,8 +167,9 @@ class Development(Config):
     SQLALCHEMY_ECHO = False
     CELERY_QUEUES = Config.CELERY_QUEUES + [
         Queue('db-sms', Exchange('default'), routing_key='db-sms'),
-        Queue('send-sms', Exchange('default'), routing_key='send-sms'),
         Queue('db-email', Exchange('default'), routing_key='db-email'),
+        Queue('db-letter', Exchange('default'), routing_key='db-letter'),
+        Queue('send-sms', Exchange('default'), routing_key='send-sms'),
         Queue('send-email', Exchange('default'), routing_key='send-email'),
         Queue('research-mode', Exchange('default'), routing_key='research-mode')
     ]
@@ -186,8 +187,9 @@ class Test(Config):
     STATSD_PORT = 1000
     CELERY_QUEUES = Config.CELERY_QUEUES + [
         Queue('db-sms', Exchange('default'), routing_key='db-sms'),
-        Queue('send-sms', Exchange('default'), routing_key='send-sms'),
         Queue('db-email', Exchange('default'), routing_key='db-email'),
+        Queue('db-letter', Exchange('default'), routing_key='db-letter'),
+        Queue('send-sms', Exchange('default'), routing_key='send-sms'),
         Queue('send-email', Exchange('default'), routing_key='send-email'),
         Queue('research-mode', Exchange('default'), routing_key='research-mode')
     ]

--- a/manifest-delivery-worker-database.yml
+++ b/manifest-delivery-worker-database.yml
@@ -14,6 +14,6 @@ applications:
       - hosted-graphite
     instances: 2
     memory: 256M
-    command: celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q db-sms,db-email
+    command: celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q db-sms,db-email,db-letter
     env:
       NOTIFY_APP_NAME: delivery-worker-database

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -794,10 +794,6 @@ def test_should_use_email_template_and_persist_without_personalisation(sample_em
                                                                      queue='send-email')
 
 
-class MyException(Exception):
-    pass
-
-
 def test_send_sms_should_go_to_retry_queue_if_database_errors(sample_template, mocker):
     notification = _notification_json(sample_template, "+447234123123")
 
@@ -933,5 +929,4 @@ def test_persist_letter_saves_letter_to_database(sample_letter_job, mocker):
     (LETTER_TYPE, WithSubjectTemplate),
 ])
 def test_get_template_class(template_type, expected_class):
-    template = Mock(template_type=template_type)
-    assert get_template_class(template) == expected_class
+    assert get_template_class(template_type) == expected_class

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -1,5 +1,10 @@
-from app.models import User
+from datetime import datetime
+import uuid
+
+from app.models import User, Template, Notification, SMS_TYPE, KEY_TYPE_NORMAL
 from app.dao.users_dao import save_model_user
+from app.dao.notifications_dao import dao_create_notification
+from app.dao.templates_dao import dao_create_template
 
 
 def create_user(mobile_number="+447700900986", email="notify@digital.cabinet-office.gov.uk"):
@@ -15,3 +20,64 @@ def create_user(mobile_number="+447700900986", email="notify@digital.cabinet-off
         user = User(**data)
     save_model_user(user)
     return user
+
+
+def create_template(service, user=None, template_type=SMS_TYPE):
+    data = {
+        'name': '{} Template Name'.format(template_type),
+        'template_type': template_type,
+        'content': 'Dear Sir/Madam, Hello. Yours Truly, The Government.',
+        'service': service,
+        'created_by': service.created_by,
+    }
+    if template_type != SMS_TYPE:
+        data['subject'] = 'Template subject'
+    template = Template(**data)
+    dao_create_template(template)
+    return template
+
+
+def create_notification(
+    template,
+    job=None,
+    job_row_number=None,
+    to_field='+447700900855',
+    status='created',
+    reference=None,
+    created_at=None,
+    sent_at=None,
+    billable_units=1,
+    personalisation=None,
+    api_key_id=None,
+    key_type=KEY_TYPE_NORMAL,
+    sent_by=None,
+    client_reference=None
+):
+    if created_at is None:
+        created_at = datetime.utcnow()
+    data = {
+        'id': uuid.uuid4(),
+        'to': to_field,
+        'job_id': job.id if job else None,
+        'job': job,
+        'service_id': template.service_id,
+        'template_id': template.id if template else None,
+        'template': template,
+        'template_version': template.version,
+        'status': status,
+        'reference': reference,
+        'created_at': created_at,
+        'sent_at': sent_at,
+        'billable_units': billable_units,
+        'personalisation': personalisation,
+        'notification_type': template.template_type,
+        'api_key_id': api_key_id,
+        'key_type': key_type,
+        'sent_by': sent_by,
+        'updated_at': None,
+        'client_reference': client_reference,
+        'job_row_number': None
+    }
+    notification = Notification(**data)
+    dao_create_notification(notification)
+    return notification


### PR DESCRIPTION
### Refactor tasks code

I pulled out the per-row handling from process_job into a separate function for readability/testability. I also pulled the exception handling stuff from send_sms and send_email out because it's literally identical.

### Refactor tasks tests

I tried not to do too much, but moved a couple of tests around so they're in logical sections within the file, and changed a couple of mock points. I also created some new functions in `tests/db.py` to create templates and notifications - these don't require `notify_db`/`notify_db_session` so can be used anywhere cleanly - though you'll need to take care to ensure your test cleans up after itself.

### New letter stuff

Added new task `persist_letter` - I know it's not named at all related to the `send_sms` and `send_email` tasks it mimics, but those tasks aren't really fair - those tasks persist to the database, and then queue up the `provider_tasks.deliver_xxx` tasks - if renaming celery tasks wasn't such a bother i'd rename those to persist_sms and persist_email too.

The task itself is super straightforward - the only thing of note it does is set the `to` field to equal `personalisation['addressline1']`, which is a required field, and will hopefully generally be a person's name or company name.

also, I didn't include the api_key and key_type params from send_xxx tasks - they're not used cos we don't use this task for api calls


todo:

- [x] test using front end. some front end work required first but it should work, so i'm happy for people to start reviewing before i've finished admin work
- [x] https://github.com/alphagov/notifications-aws/pull/118