### PR TITLE
Change to research mode.

### DIFF
--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -15,7 +15,6 @@ perm_fail_email = "perm-fail@simulator.notify"
 temp_fail_email = "temp-fail@simulator.notify"
 
 
-@notify_celery.task(name="send-mmg-response")
 def send_sms_response(provider, reference, to):
     if provider == "mmg":
         body = mmg_callback(reference, to)
@@ -37,7 +36,6 @@ def send_sms_response(provider, reference, to):
     make_request(SMS_TYPE, provider, body, headers)
 
 
-@notify_celery.task(name="send-ses-response")
 def send_email_response(provider, reference, to):
     if to == perm_fail_email:
         body = ses_hard_bounce_callback(reference)


### PR DESCRIPTION
Previously research mode created a task to fake the callback from the providers. This meant there is an extra task for each notification than would be generated in a live situation.

This PR changes that, so that a research mode/test key notification calls the callback API rather than make a task to do that .

This ensures that the flow for research mode more closely mimics that of live, and removes a task from the process so we can more accurately test throughput,