### PR TITLE
Allow filtering of billing info by financial year

### DIFF
--- a/app/dao/provider_statistics_dao.py
+++ b/app/dao/provider_statistics_dao.py
@@ -8,14 +8,20 @@ from app.models import (
     NOTIFICATION_STATUS_TYPES_BILLABLE,
     KEY_TYPE_TEST
 )
+from app.dao.notifications_dao import get_financial_year
 
 
-def get_fragment_count(service_id):
+def get_fragment_count(service_id, year=None):
     shared_filters = [
         NotificationHistory.service_id == service_id,
         NotificationHistory.status.in_(NOTIFICATION_STATUS_TYPES_BILLABLE),
         NotificationHistory.key_type != KEY_TYPE_TEST
     ]
+
+    if year:
+        shared_filters.append(NotificationHistory.created_at.between(
+            *get_financial_year(year)
+        ))
 
     sms_count = db.session.query(
         func.sum(NotificationHistory.billable_units)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -190,7 +190,13 @@ def remove_user_from_service(service_id, user_id):
 
 @service_blueprint.route('/<uuid:service_id>/fragment/aggregate_statistics')
 def get_service_provider_aggregate_statistics(service_id):
-    return jsonify(data=get_fragment_count(service_id))
+    year = request.args.get('year')
+    if year is not None:
+        try:
+            year = int(year)
+        except ValueError:
+            raise InvalidRequest('Year must be a number', status_code=400)
+    return jsonify(data=get_fragment_count(service_id, year=year))
 
 
 # This is placeholder get method until more thought

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1393,3 +1393,23 @@ def test_get_notification_billable_unit_count_missing_year(client, sample_servic
     assert json.loads(response.get_data(as_text=True)) == {
         'message': 'No valid year provided', 'result': 'error'
     }
+
+
+@pytest.mark.parametrize('query_string, expected_status, expected_json', [
+    ('', 200, {'data': {'email_count': 0, 'sms_count': 0}}),
+    ('?year=2000', 200, {'data': {'email_count': 0, 'sms_count': 0}}),
+    ('?year=abcd', 400, {'message': 'Year must be a number', 'result': 'error'}),
+])
+def test_get_service_provider_aggregate_statistics(
+    client,
+    sample_service,
+    query_string,
+    expected_status,
+    expected_json,
+):
+    response = client.get(
+        '/service/{}/fragment/aggregate_statistics{}'.format(sample_service.id, query_string),
+        headers=[create_authorization_header(service_id=sample_service.id)]
+    )
+    assert response.status_code == expected_status
+    assert json.loads(response.get_data(as_text=True)) == expected_json


### PR DESCRIPTION
We already filter the usage-by-month query by financial year. When we show the total usage for a service, we should be able to filter this by financial year.

Then, when the two lots of data are put side by side, it all adds up.