### PR TITLE
Suspend/resume service feature

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -205,7 +205,7 @@ def get_service_provider_aggregate_statistics(service_id):
 # tables. This is so product owner can pass stories as done
 @service_blueprint.route('/<uuid:service_id>/history', methods=['GET'])
 def get_service_history(service_id):
-    from app.models import (Service, ApiKey, Template, TemplateHistory, Event)
+    from app.models import (Service, ApiKey, TemplateHistory, Event)
     from app.schemas import (
         service_history_schema,
         api_key_history_schema,
@@ -330,7 +330,7 @@ def update_whitelist(service_id):
         current_app.logger.exception(e)
         dao_rollback()
         msg = '{} is not a valid email address or phone number'.format(str(e))
-        return jsonify(result='error', message=msg), 400
+        raise InvalidRequest(msg, 400)
     else:
         dao_add_and_commit_whitelisted_contacts(whitelist_objs)
         return '', 204
@@ -360,11 +360,8 @@ def archive_service(service_id):
     """
     service = dao_fetch_service_by_id(service_id)
 
-    if not service.active:
-        # assume already inactive, don't change service name
-        return '', 204
-
-    dao_archive_service(service.id)
+    if service.active:
+        dao_archive_service(service.id)
 
     return '', 204
 
@@ -378,11 +375,8 @@ def suspend_service(service_id):
     """
     service = dao_fetch_service_by_id(service_id)
 
-    if not service.active:
-        # assume already inactive, don't change service name
-        return '', 204
-
-    dao_suspend_service(service.id)
+    if service.active:
+        dao_suspend_service(service.id)
 
     return '', 204
 
@@ -397,11 +391,8 @@ def resume_service(service_id):
     """
     service = dao_fetch_service_by_id(service_id)
 
-    if service.active:
-        # assume already inactive, don't change service name
-        return '', 204
-
-    dao_resume_service(service.id)
+    if not service.active:
+        dao_resume_service(service.id)
 
     return '', 204
 

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -659,6 +659,7 @@ def test_fetch_stats_by_date_range_for_all_services(notify_db, notify_db_session
     assert results[0] == ('sms', 'created', result_one.service_id, 2)
 
 
+@freeze_time('2001-01-01T23:59:00')
 def test_dao_suspend_service_marks_service_as_inactive_and_expires_api_keys(sample_service, sample_api_key):
     dao_suspend_service(sample_service.id)
     service = Service.query.get(sample_service.id)
@@ -666,9 +667,10 @@ def test_dao_suspend_service_marks_service_as_inactive_and_expires_api_keys(samp
     assert service.name == sample_service.name
 
     api_key = ApiKey.query.get(sample_api_key.id)
-    assert api_key.expiry_date.date() == datetime.utcnow().date()
+    assert api_key.expiry_date == datetime(2001, 1, 1, 23, 59, 00)
 
 
+@freeze_time('2001-01-01T23:59:00')
 def test_dao_resume_service_marks_service_as_active_and_api_keys_are_still_revoked(sample_service, sample_api_key):
     dao_suspend_service(sample_service.id)
     service = Service.query.get(sample_service.id)
@@ -678,4 +680,4 @@ def test_dao_resume_service_marks_service_as_active_and_api_keys_are_still_revok
     assert Service.query.get(service.id).active
 
     api_key = ApiKey.query.get(sample_api_key.id)
-    assert api_key.expiry_date.date() == datetime.utcnow().date()
+    assert api_key.expiry_date == datetime(2001, 1, 1, 23, 59, 00)

--- a/tests/app/service/test_archived_service.py
+++ b/tests/app/service/test_archived_service.py
@@ -17,63 +17,63 @@ from tests.app.conftest import (
 )
 
 
-def test_deactivate_only_allows_post(client):
+def test_archive_only_allows_post(client):
     auth_header = create_authorization_header()
-    response = client.get('/service/{}/deactivate'.format(uuid.uuid4()), headers=[auth_header])
+    response = client.get('/service/{}/archive'.format(uuid.uuid4()), headers=[auth_header])
     assert response.status_code == 405
 
 
-def test_deactivate_service_errors_with_bad_service_id(client):
+def test_archive_service_errors_with_bad_service_id(client):
     auth_header = create_authorization_header()
-    response = client.post('/service/{}/deactivate'.format(uuid.uuid4()), headers=[auth_header])
+    response = client.post('/service/{}/archive'.format(uuid.uuid4()), headers=[auth_header])
     assert response.status_code == 404
 
 
 def test_deactivating_inactive_service_does_nothing(client, sample_service):
     auth_header = create_authorization_header()
     sample_service.active = False
-    response = client.post('/service/{}/deactivate'.format(sample_service.id), headers=[auth_header])
+    response = client.post('/service/{}/archive'.format(sample_service.id), headers=[auth_header])
     assert response.status_code == 204
     assert sample_service.name == 'Sample service'
 
 
 @pytest.fixture
-def deactivated_service(client, notify_db, notify_db_session, sample_service):
+def archived_service(client, notify_db, notify_db_session, sample_service):
     create_template(notify_db, notify_db_session, template_name='a')
     create_template(notify_db, notify_db_session, template_name='b')
     create_api_key(notify_db, notify_db_session)
     create_api_key(notify_db, notify_db_session)
 
     auth_header = create_authorization_header()
-    response = client.post('/service/{}/deactivate'.format(sample_service.id), headers=[auth_header])
+    response = client.post('/service/{}/archive'.format(sample_service.id), headers=[auth_header])
     assert response.status_code == 204
     assert response.data == b''
     return sample_service
 
 
-def test_deactivating_service_changes_name_and_email(deactivated_service):
-    assert deactivated_service.name == '_archived_Sample service'
-    assert deactivated_service.email_from == '_archived_sample.service'
+def test_deactivating_service_changes_name_and_email(archived_service):
+    assert archived_service.name == '_archived_Sample service'
+    assert archived_service.email_from == '_archived_sample.service'
 
 
-def test_deactivating_service_revokes_api_keys(deactivated_service):
-    assert len(deactivated_service.api_keys) == 2
-    for key in deactivated_service.api_keys:
+def test_deactivating_service_revokes_api_keys(archived_service):
+    assert len(archived_service.api_keys) == 2
+    for key in archived_service.api_keys:
         assert key.expiry_date is not None
         assert key.version == 2
 
 
-def test_deactivating_service_archives_templates(deactivated_service):
-    assert len(deactivated_service.templates) == 2
-    for template in deactivated_service.templates:
+def test_deactivating_service_archives_templates(archived_service):
+    assert len(archived_service.templates) == 2
+    for template in archived_service.templates:
         assert template.archived is True
         assert template.version == 2
 
 
-def test_deactivating_service_creates_history(deactivated_service):
+def test_deactivating_service_creates_history(archived_service):
     ServiceHistory = Service.get_history_model()
     history = ServiceHistory.query.filter_by(
-        id=deactivated_service.id
+        id=archived_service.id
     ).order_by(
         ServiceHistory.version.desc()
     ).first()
@@ -83,7 +83,7 @@ def test_deactivating_service_creates_history(deactivated_service):
 
 
 @pytest.fixture
-def deactivated_service_with_deleted_stuff(client, notify_db, notify_db_session, sample_service):
+def archived_service_with_deleted_stuff(client, notify_db, notify_db_session, sample_service):
     with freeze_time('2001-01-01'):
         template = create_template(notify_db, notify_db_session, template_name='a')
         api_key = create_api_key(notify_db, notify_db_session)
@@ -95,22 +95,22 @@ def deactivated_service_with_deleted_stuff(client, notify_db, notify_db_session,
 
     with freeze_time('2002-02-02'):
         auth_header = create_authorization_header()
-        response = client.post('/service/{}/deactivate'.format(sample_service.id), headers=[auth_header])
+        response = client.post('/service/{}/archive'.format(sample_service.id), headers=[auth_header])
 
     assert response.status_code == 204
     assert response.data == b''
     return sample_service
 
 
-def test_deactivating_service_doesnt_affect_existing_archived_templates(deactivated_service_with_deleted_stuff):
-    assert deactivated_service_with_deleted_stuff.templates[0].archived is True
-    assert deactivated_service_with_deleted_stuff.templates[0].updated_at == datetime(2001, 1, 1, 0, 0, 0)
-    assert deactivated_service_with_deleted_stuff.templates[0].version == 2
+def test_deactivating_service_doesnt_affect_existing_archived_templates(archived_service_with_deleted_stuff):
+    assert archived_service_with_deleted_stuff.templates[0].archived is True
+    assert archived_service_with_deleted_stuff.templates[0].updated_at == datetime(2001, 1, 1, 0, 0, 0)
+    assert archived_service_with_deleted_stuff.templates[0].version == 2
 
 
-def test_deactivating_service_doesnt_affect_existing_revoked_api_keys(deactivated_service_with_deleted_stuff):
-    assert deactivated_service_with_deleted_stuff.api_keys[0].expiry_date == datetime(2001, 1, 1, 0, 0, 0)
-    assert deactivated_service_with_deleted_stuff.api_keys[0].version == 2
+def test_deactivating_service_doesnt_affect_existing_revoked_api_keys(archived_service_with_deleted_stuff):
+    assert archived_service_with_deleted_stuff.api_keys[0].expiry_date == datetime(2001, 1, 1, 0, 0, 0)
+    assert archived_service_with_deleted_stuff.api_keys[0].version == 2
 
 
 def test_deactivating_service_rolls_back_everything_on_error(sample_service, sample_api_key, sample_template):

--- a/tests/app/service/test_suspend_resume_service.py
+++ b/tests/app/service/test_suspend_resume_service.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+
+import pytest
+
+import uuid
+
+from app.models import Service
+from tests import create_authorization_header
+
+
+@pytest.mark.parametrize("endpoint", ["suspend", "resume"])
+def test_only_allows_post(client, endpoint):
+    auth_header = create_authorization_header()
+    response = client.get("/service/{}/{}".format(uuid.uuid4(), endpoint),
+                          headers=[auth_header])
+    assert response.status_code == 405
+
+
+@pytest.mark.parametrize("endpoint", ["suspend", "resume"])
+def test_returns_404_when_service_does_not_exist(client, endpoint):
+    auth_header = create_authorization_header()
+    response = client.post("/service/{}/{}".format(uuid.uuid4(), endpoint),
+                           headers=[auth_header])
+    assert response.status_code == 404
+
+
+@pytest.mark.parametrize("action, active", [("suspend", False), ("resume", True)])
+def test_has_not_effect_when_service_is_already_that_state(client, sample_service, action, active, mocker):
+    mocked = mocker.patch("app.service.rest.dao_{}_service".format(action))
+    sample_service.active = active
+    auth_header = create_authorization_header()
+    response = client.post("/service/{}/{}".format(sample_service.id, action),
+                           headers=[auth_header])
+    assert response.status_code == 204
+    mocked.assert_not_called()
+    assert mocked.called == 0
+
+
+def test_suspending_service_revokes_api_keys(client, sample_service, sample_api_key):
+    auth_header = create_authorization_header()
+    response = client.post("/service/{}/archive".format(sample_service.id),
+                           headers=[auth_header])
+    assert response.status_code == 204
+    assert sample_api_key.expiry_date.date() == datetime.utcnow().date()
+
+
+def test_resume_service_leaves_api_keys_revokes(client, sample_service, sample_api_key):
+    sample_api_key.expiry_date = datetime.utcnow()
+    sample_service.active = False
+    auth_header = create_authorization_header()
+    response = client.post("/service/{}/archive".format(sample_service.id),
+                           headers=[auth_header])
+    assert response.status_code == 204
+    assert sample_api_key.expiry_date.date() == datetime.utcnow().date()
+
+
+@pytest.mark.parametrize("action, original_state", [("suspend", True), ("resume", False)])
+def test_service_history_is_created(client, sample_service, action, original_state):
+    sample_service.active = original_state
+    auth_header = create_authorization_header()
+    response = client.post("/service/{}/{}".format(sample_service.id, action),
+                           headers=[auth_header])
+    ServiceHistory = Service.get_history_model()
+    history = ServiceHistory.query.filter_by(
+        id=sample_service.id
+    ).order_by(
+        ServiceHistory.version.desc()
+    ).first()
+
+    assert response.status_code == 204
+    assert history.version == 2
+    assert history.active != original_state

--- a/tests/app/service/test_suspend_resume_service.py
+++ b/tests/app/service/test_suspend_resume_service.py
@@ -4,7 +4,9 @@ import pytest
 
 import uuid
 
-from app.models import Service
+from freezegun import freeze_time
+
+from app.models import Service, ApiKey
 from tests import create_authorization_header
 
 
@@ -33,25 +35,31 @@ def test_has_not_effect_when_service_is_already_that_state(client, sample_servic
                            headers=[auth_header])
     assert response.status_code == 204
     mocked.assert_not_called()
-    assert mocked.called == 0
+    assert sample_service.active == active
 
 
+@freeze_time('2001-01-01T23:59:00')
 def test_suspending_service_revokes_api_keys(client, sample_service, sample_api_key):
     auth_header = create_authorization_header()
-    response = client.post("/service/{}/archive".format(sample_service.id),
+    response = client.post("/service/{}/suspend".format(sample_service.id),
                            headers=[auth_header])
     assert response.status_code == 204
-    assert sample_api_key.expiry_date.date() == datetime.utcnow().date()
+    assert sample_api_key.expiry_date == datetime(2001, 1, 1, 23, 59, 00)
 
 
 def test_resume_service_leaves_api_keys_revokes(client, sample_service, sample_api_key):
-    sample_api_key.expiry_date = datetime.utcnow()
-    sample_service.active = False
-    auth_header = create_authorization_header()
-    response = client.post("/service/{}/archive".format(sample_service.id),
-                           headers=[auth_header])
-    assert response.status_code == 204
-    assert sample_api_key.expiry_date.date() == datetime.utcnow().date()
+    with freeze_time('2001-10-22T11:59:00'):
+        sample_api_key.expiry_date = datetime.utcnow()
+        sample_service.active = False
+        auth_header = create_authorization_header()
+        client.post("/service/{}/resume".format(sample_service.id),
+                    headers=[auth_header])
+    with freeze_time('2001-10-22T13:59:00'):
+        auth_header = create_authorization_header()
+        response = client.post("/service/{}/resume".format(sample_service.id),
+                               headers=[auth_header])
+        assert response.status_code == 204
+        assert sample_api_key.expiry_date == datetime(2001, 10, 22, 11, 59, 00)
 
 
 @pytest.mark.parametrize("action, original_state", [("suspend", True), ("resume", False)])

--- a/tests/app/service/test_suspend_resume_service.py
+++ b/tests/app/service/test_suspend_resume_service.py
@@ -49,10 +49,8 @@ def test_suspending_service_revokes_api_keys(client, sample_service, sample_api_
 
 def test_resume_service_leaves_api_keys_revokes(client, sample_service, sample_api_key):
     with freeze_time('2001-10-22T11:59:00'):
-        sample_api_key.expiry_date = datetime.utcnow()
-        sample_service.active = False
         auth_header = create_authorization_header()
-        client.post("/service/{}/resume".format(sample_service.id),
+        client.post("/service/{}/suspend".format(sample_service.id),
                     headers=[auth_header])
     with freeze_time('2001-10-22T13:59:00'):
         auth_header = create_authorization_header()


### PR DESCRIPTION
This is the first PR in the story to create a suspend service feature.
- Renaming /service/<id>/deactivate to /service/<id>/archive to match language on the UI.
  - Will need to update admin before deleting the deactivate service method
- Created dao and endpoint methods to suspend and resume a service.
- I confirm the use of suspend and resume with a couple people on the team, seems to be the right choice.

The idea is that if you archive a service there is no coming back from that.
To suspend a service is marking it as inactive and revoking the api keys. To resume a service is to mark the service as active, the service will need to create new API keys.
It makes sense that if a service is under threat that the API keys should be renewed.

The next PR will update the code to check that the service is active before sending the request or allowing any actions by the service.

https://www.pivotaltracker.com/story/show/138598461