### PR TITLE
Fix perf platform stats job

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -66,6 +66,7 @@ def create_app(app_name=None):
     notify_celery.init_app(application)
     encryption.init_app(application)
     redis_store.init_app(application)
+    performance_platform_client.init_app(application)
     clients.init_app(sms_clients=[firetext_client, mmg_client, loadtest_client], email_clients=[aws_ses_client])
 
     register_blueprint(application)

--- a/tests/app/clients/test_performance_platform.py
+++ b/tests/app/clients/test_performance_platform.py
@@ -17,7 +17,7 @@ def client(mocker):
     client = PerformancePlatformClient()
     current_app = mocker.Mock(config={
         'PERFORMANCE_PLATFORM_ENABLED': True,
-        'PERFORMANCE_PLATFORM_URL': 'performance-platform-url',
+        'PERFORMANCE_PLATFORM_URL': 'https://performance-platform-url/',
         'PERFORMANCE_PLATFORM_TOKEN': 'token'
     })
     client.init_app(current_app)


### PR DESCRIPTION
This fixes the performance platform job that was not being executed.

**Changes:**
- Only execute the task if the client is set as active
- Ensure request JSON is formatted correctly
- Add more logs

