### PR TITLE
Use pycodestyle instead of PEP8

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Then simply run
 make test
 ```
 
-That will run pep8 for code analysis and our unit test suite. If you wish to run our functional tests, instructions can be found in the
+That will run pycodestyle for code analysis and our unit test suite. If you wish to run our functional tests, instructions can be found in the
 [notifications-functional-tests](https://github.com/alphagov/notifications-functional-tests) repository.
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -153,6 +153,7 @@ class Service(db.Model, Versioned):
         default=BRANDING_GOVUK
     )
 
+
 MOBILE_TYPE = 'mobile'
 EMAIL_TYPE = 'email'
 
@@ -339,6 +340,7 @@ class TemplateHistory(db.Model):
                              index=True,
                              nullable=False,
                              default=NORMAL)
+
 
 MMG_PROVIDER = "mmg"
 FIRETEXT_PROVIDER = "firetext"

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pep8==1.7.0
+pycodestyle==2.3.1
 pytest==3.0.1
 pytest-mock==1.2
 pytest-cov==2.3.1

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -27,7 +27,7 @@ function display_result {
 if [[ -z "$VIRTUAL_ENV" ]] && [[ -d venv ]]; then
   source ./venv/bin/activate
 fi
-pep8 .
+pycodestyle .
 display_result $? 1 "Code style check"
 
 py.test --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pep8]
+[pycodestyle]
 max-line-length = 120
-ignore = E402
+ignore = E402, E722
 exclude = ./migrations,./venv,./venv3,./build,./cache


### PR DESCRIPTION
PEP8 was renamed to pycodestyle; this issue explains why: https://github.com/PyCQA/pycodestyle/issues/466

This commit changes our tests to use pycodestyle instead of pep8.

It also means:
- making a couple of whitespace changes to appease the linter
- disabling warnings for bare `Except`s (ie `Except` instead of `Except ValueError`) – this seems like a sensible thing to lint for but I’m not going to make meaningful code changes in this commit