### PR TITLE
Fix perf platform stats job

### DIFF
--- a/app/clients/performance_platform/performance_platform_client.py
+++ b/app/clients/performance_platform/performance_platform_client.py
@@ -1,8 +1,7 @@
 import base64
 import json
+import requests
 from datetime import datetime
-from requests import request
-
 from flask import current_app
 
 from app.utils import (
@@ -30,7 +29,7 @@ class PerformancePlatformClient:
     def send_performance_stats(self, date, channel, count, period):
         if self.active:
             payload = {
-                '_timestamp': str(date),
+                '_timestamp': date.isoformat(),
                 'service': 'govuk-notify',
                 'channel': channel,
                 'count': count,
@@ -62,10 +61,9 @@ class PerformancePlatformClient:
             'Content-Type': "application/json",
             'Authorization': 'Bearer {}'.format(self.bearer_token)
         }
-        resp = request(
-            "POST",
+        resp = requests.post(
             self.performance_platform_url,
-            data=json.dumps(payload),
+            json=payload,
             headers=headers
         )
 

--- a/app/config.py
+++ b/app/config.py
@@ -126,7 +126,7 @@ class Config(object):
         },
         'send-daily-performance-platform-stats': {
             'task': 'send-daily-performance-platform-stats',
-            'schedule': crontab(minute=30, hour=0),  # 00:30
+            'schedule': crontab(minute='*/10'),  # Every 10 minutes
             'options': {'queue': 'periodic'}
         },
         'timeout-sending-notifications': {
@@ -156,10 +156,11 @@ class Config(object):
 
     SENDING_NOTIFICATIONS_TIMEOUT_PERIOD = 259200  # 3 days
 
-    SIMULATED_EMAIL_ADDRESSES = ('simulate-delivered@notifications.service.gov.uk',
-                                 'simulate-delivered-2@notifications.service.gov.uk',
-                                 'simulate-delivered-3@notifications.service.gov.uk',
-                                 )
+    SIMULATED_EMAIL_ADDRESSES = (
+        'simulate-delivered@notifications.service.gov.uk',
+        'simulate-delivered-2@notifications.service.gov.uk',
+        'simulate-delivered-3@notifications.service.gov.uk',
+    )
 
     SIMULATED_SMS_NUMBERS = ('+447700900000', '+447700900111', '+447700900222')
 

--- a/tests/app/clients/test_performance_platform.py
+++ b/tests/app/clients/test_performance_platform.py
@@ -28,7 +28,7 @@ def test_should_not_call_if_not_enabled(notify_api, client, mocker):
     mocker.patch.object(client, '_send_stats_to_performance_platform')
     client.active = False
     client.send_performance_stats(
-        date='2016-10-16T00:00:00+00:00',
+        date=datetime(2016, 10, 16, 0, 0, 0),
         channel='sms',
         count=142,
         period='day'

--- a/tests/app/clients/test_performance_platform.py
+++ b/tests/app/clients/test_performance_platform.py
@@ -40,7 +40,7 @@ def test_should_not_call_if_not_enabled(notify_api, client, mocker):
 def test_should_call_if_enabled(notify_api, client, mocker):
     mocker.patch.object(client, '_send_stats_to_performance_platform')
     client.send_performance_stats(
-        date='2016-10-16T00:00:00+00:00',
+        date=datetime(2016, 10, 16, 0, 0, 0),
         channel='sms',
         count=142,
         period='day'
@@ -57,7 +57,7 @@ def test_send_platform_stats_creates_correct_call(notify_api, client):
             status_code=200
         )
         client.send_performance_stats(
-            date='2016-10-16T00:00:00+00:00',
+            date=datetime(2016, 10, 16, 0, 0, 0),
             channel='sms',
             count=142,
             period='day'
@@ -73,9 +73,9 @@ def test_send_platform_stats_creates_correct_call(notify_api, client):
     assert request_args['service'] == 'govuk-notify'
     assert request_args['period'] == 'day'
     assert request_args['channel'] == 'sms'
-    assert request_args['_timestamp'] == '2016-10-16T00:00:00+00:00'
+    assert request_args['_timestamp'] == '2016-10-16T00:00:00'
     assert request_args['count'] == 142
-    expected_base64_id = 'MjAxNi0xMC0xNlQwMDowMDowMCswMDowMGdvdnVrLW5vdGlmeXNtc25vdGlmaWNhdGlvbnNkYXk='
+    expected_base64_id = 'MjAxNi0xMC0xNlQwMDowMDowMGdvdnVrLW5vdGlmeXNtc25vdGlmaWNhdGlvbnNkYXk='
     assert request_args['_id'] == expected_base64_id
 
 


### PR DESCRIPTION
**Issue:**

Timestamp in the payload was being sent in the incorrect format, instead of `2017-02-02 00:00:00` it should have been `2017-02-02T00:00:00`. This caused a 400 to be returned from the performance platform.

This adds a fix to ensure it is formatted correctly.

**Temporary change:** Make this run every 10 minutes for debugging, will be amended in a separate PR.