### PR TITLE
Add separate endpoint to update a user's password

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -103,3 +103,10 @@ def reset_failed_login_count(user):
         user.failed_login_count = 0
         db.session.add(user)
         db.session.commit()
+
+
+def update_user_password(user, password):
+    user.password = password
+    user.password_changed_at = datetime.utcnow()
+    db.session.add(user)
+    db.session.commit()

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -140,6 +140,20 @@ class UserUpdateAttributeSchema(BaseSchema):
                 raise ValidationError('Unknown field name {}'.format(key))
 
 
+class UserUpdatePasswordSchema(BaseSchema):
+
+    class Meta:
+        model = models.User
+        only = ('password')
+        strict = True
+
+    @validates_schema(pass_original=True)
+    def check_unknown_fields(self, data, original_data):
+        for key in original_data:
+            if key not in self.fields:
+                raise ValidationError('Unknown field name {}'.format(key))
+
+
 class ProviderDetailsSchema(BaseSchema):
     class Meta:
         model = models.ProviderDetails
@@ -560,6 +574,7 @@ class UnarchivedTemplateSchema(BaseSchema):
 user_schema = UserSchema()
 user_schema_load_json = UserSchema(load_json=True)
 user_update_schema_load_json = UserUpdateAttributeSchema(load_json=True, partial=True)
+user_update_password_schema_load_json = UserUpdatePasswordSchema(load_json=True, partial=True)
 service_schema = ServiceSchema()
 service_schema_load_json = ServiceSchema(load_json=True)
 detailed_service_schema = DetailedServiceSchema()

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -14,6 +14,7 @@ from app.dao.users_dao import (
     reset_failed_login_count,
     get_user_by_email,
     delete_codes_older_created_more_than_a_day_ago,
+    update_user_password
 )
 
 from app.models import User, VerifyCode
@@ -132,3 +133,10 @@ def test_update_user_attribute(client, sample_user, user_attribute, user_value):
     }
     save_user_attribute(sample_user, update_dict)
     assert getattr(sample_user, user_attribute) == user_value
+
+
+def test_update_user_password(notify_api, notify_db, notify_db_session, sample_user):
+    password = 'newpassword'
+    assert not sample_user.check_password(password)
+    update_user_password(sample_user, password)
+    assert sample_user.check_password(password)

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -534,7 +534,7 @@ def test_send_user_confirm_new_email_returns_400_when_email_missing(client, samp
     mocked.assert_not_called()
 
 
-def test_post_user_update_password(client, sample_service):
+def test_update_user_password_saves_correctly(client, sample_service):
     assert User.query.count() == 1
     sample_user = sample_service.users[0]
     new_password = '1234567890'

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -117,7 +117,7 @@ def test_post_user_missing_attribute_email(notify_api, notify_db, notify_db_sess
             assert {'email_address': ['Missing data for required field.']} == json_resp['message']
 
 
-def test_post_user_missing_attribute_password(notify_api, notify_db, notify_db_session):
+def test_create_user_missing_attribute_password(notify_api, notify_db, notify_db_session):
     """
     Tests POST endpoint '/' missing attribute password.
     """
@@ -532,3 +532,30 @@ def test_send_user_confirm_new_email_returns_400_when_email_missing(client, samp
     assert resp.status_code == 400
     assert json.loads(resp.get_data(as_text=True))['message'] == {'email': ['Missing data for required field.']}
     mocked.assert_not_called()
+
+
+def test_post_user_update_password(client, sample_service):
+    assert User.query.count() == 1
+    sample_user = sample_service.users[0]
+    new_password = '1234567890'
+    data = {
+        '_password': new_password
+    }
+    auth_header = create_authorization_header()
+    headers = [('Content-Type', 'application/json'), auth_header]
+    resp = client.post(
+        url_for('user.update_password', user_id=sample_user.id),
+        data=json.dumps(data),
+        headers=headers)
+    assert resp.status_code == 200
+    assert User.query.count() == 1
+    json_resp = json.loads(resp.get_data(as_text=True))
+    assert json_resp['data']['password_changed_at'] is not None
+    data = {'password': new_password}
+    auth_header = create_authorization_header()
+    headers = [('Content-Type', 'application/json'), auth_header]
+    resp = client.post(
+        url_for('user.verify_user_password', user_id=str(sample_user.id)),
+        data=json.dumps(data),
+        headers=headers)
+    assert resp.status_code == 204


### PR DESCRIPTION
Currently we change the entire `User` object when we want to update the password. 

This refactors so we can update a user's password with a separate endpoint and without passing through the `User` object.