### PR TITLE
Fix: Update history when auto switching provider

### DIFF
--- a/app/dao/provider_details_dao.py
+++ b/app/dao/provider_details_dao.py
@@ -59,7 +59,8 @@ def dao_switch_sms_provider_to_provider_with_identifier(identifier):
 
     if not provider_is_already_primary_or_inactive(current_provider, new_provider, identifier):
         update_provider_priorities(current_provider, new_provider)
-        db.session.add_all([current_provider, new_provider])
+        dao_update_provider_details(current_provider)
+        dao_update_provider_details(new_provider)
 
 
 def get_provider_details_by_notification_type(notification_type):

--- a/tests/app/dao/test_provider_details_dao.py
+++ b/tests/app/dao/test_provider_details_dao.py
@@ -122,8 +122,7 @@ def test_get_alternative_sms_provider_returns_expected_provider(notify_db, provi
 
 def test_switch_sms_provider_to_current_provider_does_not_switch(
     restore_provider_details,
-    current_sms_provider,
-    mocker
+    current_sms_provider
 ):
     dao_switch_sms_provider_to_provider_with_identifier(current_sms_provider.identifier)
     new_provider = get_current_provider('sms')
@@ -134,8 +133,7 @@ def test_switch_sms_provider_to_current_provider_does_not_switch(
 
 def test_switch_sms_provider_to_inactive_provider_does_not_switch(
     restore_provider_details,
-    current_sms_provider,
-    mocker
+    current_sms_provider
 ):
     alternative_sms_provider = get_alternative_sms_provider(current_sms_provider.identifier)
     alternative_sms_provider.active = False
@@ -150,8 +148,7 @@ def test_switch_sms_provider_to_inactive_provider_does_not_switch(
 
 def test_toggle_sms_provider_switches_provider(
     restore_provider_details,
-    current_sms_provider,
-    mocker
+    current_sms_provider
 ):
     dao_toggle_sms_provider(current_sms_provider.identifier)
     new_provider = get_current_provider('sms')
@@ -161,8 +158,7 @@ def test_toggle_sms_provider_switches_provider(
 
 def test_toggle_sms_provider_switches_when_provider_priorities_are_equal(
     restore_provider_details,
-    current_sms_provider,
-    mocker
+    current_sms_provider
 ):
     new_provider = get_alternative_sms_provider(current_sms_provider.identifier)
     current_sms_provider.priority = new_provider.priority

--- a/tests/app/dao/test_provider_details_dao.py
+++ b/tests/app/dao/test_provider_details_dao.py
@@ -168,3 +168,14 @@ def test_toggle_sms_provider_switches_when_provider_priorities_are_equal(
 
     assert new_provider.identifier != current_sms_provider.identifier
     assert new_provider.priority < current_sms_provider.priority
+
+
+def test_toggle_sms_provider_updates_version(
+    restore_provider_details,
+    current_sms_provider
+):
+    version_before = current_sms_provider.version
+    dao_toggle_sms_provider(current_sms_provider.identifier)
+    version_after = current_sms_provider.version
+
+    assert version_after - version_before == 1


### PR DESCRIPTION
This is a small fix that ensures the provider history table is updated when switching providers.

Originally the priorities were being updated only.