### PR TITLE
Fix miscount with monthly totals

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -267,13 +267,13 @@ def dao_fetch_monthly_historical_stats_for_service(service_id, year):
     )
 
     months = {
-        datetime.strftime(date, '%Y-%m'): dict.fromkeys(
-            TEMPLATE_TYPES,
-            dict.fromkeys(
+        datetime.strftime(date, '%Y-%m'): {
+            template_type: dict.fromkeys(
                 NOTIFICATION_STATUS_TYPES,
                 0
             )
-        )
+            for template_type in TEMPLATE_TYPES
+        }
         for date in [
             datetime(year, month, 1) for month in range(4, 13)
         ] + [

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -545,8 +545,8 @@ def test_fetch_monthly_historical_stats_separates_weeks(notify_db, notify_db_ses
         ('2017-03', 'created', 2),
     ):
         assert result[date]['sms'][status] == count
-        assert result[date]['email'][status] == count
-        assert result[date]['letter'][status] == count
+        assert result[date]['email'][status] == 0
+        assert result[date]['letter'][status] == 0
 
     assert result.keys() == {
         '2016-04', '2016-05', '2016-06',

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -545,6 +545,8 @@ def test_fetch_monthly_historical_stats_separates_weeks(notify_db, notify_db_ses
         ('2017-03', 'created', 2),
     ):
         assert result[date]['sms'][status] == count
+        assert result[date]['email'][status] == count
+        assert result[date]['letter'][status] == count
 
     assert result.keys() == {
         '2016-04', '2016-05', '2016-06',

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -526,23 +526,25 @@ def test_fetch_monthly_historical_stats_separates_weeks(notify_db, notify_db_ses
 
     result = dao_fetch_monthly_historical_stats_for_service(sample_template.service_id, 2016)
 
-    assert result['2016-04']['sms']['created'] == 1
-    assert result['2016-04']['sms']['sending'] == 0
-    assert result['2016-04']['sms']['delivered'] == 0
-    assert result['2016-04']['sms']['pending'] == 0
-    assert result['2016-04']['sms']['failed'] == 0
-    assert result['2016-04']['sms']['technical-failure'] == 0
-    assert result['2016-04']['sms']['temporary-failure'] == 0
-    assert result['2016-04']['sms']['permanent-failure'] == 0
+    for date, status, count in (
+        ('2016-04', 'sending', 0),
+        ('2016-04', 'delivered', 0),
+        ('2016-04', 'pending', 0),
+        ('2016-04', 'failed', 0),
+        ('2016-04', 'technical-failure', 0),
+        ('2016-04', 'temporary-failure', 0),
+        ('2016-04', 'permanent-failure', 0),
 
-    assert result['2016-06']['sms']['created'] == 1
+        ('2016-06', 'created', 1),
 
-    assert result['2016-10']['sms']['created'] == 1
+        ('2016-10', 'created', 1),
 
-    assert result['2016-12']['sms']['created'] == 0
-    assert result['2016-12']['sms']['delivered'] == 1
+        ('2016-12', 'created', 0),
+        ('2016-12', 'delivered', 1),
 
-    assert result['2017-03']['sms']['created'] == 2
+        ('2017-03', 'created', 2),
+    ):
+        assert result[date]['sms'][status] == count
 
     assert result.keys() == {
         '2016-04', '2016-05', '2016-06',


### PR DESCRIPTION
_All meaningful changes in 0dfa4a9_

The counts for emails and letters sent by month should be 0 in the tests, because we’re not creating any fake email or letter notifications. But they were coming out the same as whatever the count for sms was.

The status dictionary was being assigned once, and then subsequent uses of it were by reference. This meant that each template type was pointing at the same dictionary, and updating one meant updating all.

This commit adds a dictionary comprehension, which gets evaluated once for each template type, so each template type has its own `dict` of statuses.

Before
--
```
Email     SMS       Letter
  |        |           |
{'sending':, 'failed', …}
```

After
--
```
Email                SMS                   Letter
   |                  |                      |
{'sending':,      {'sending':,            {'sending':,
'failed',          'failed',               'failed',
…}                 …}                      …}
```