### PR TITLE
Bump utils to turn on Markdown links

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,6 @@ gunicorn==19.6.0
 # pin to minor version 3.1.x
 notifications-python-client>=3.1,<3.2
 
-git+https://github.com/alphagov/notifications-utils.git@13.2.0#egg=notifications-utils==13.2.0
+git+https://github.com/alphagov/notifications-utils.git@13.5.0#egg=notifications-utils==13.5.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/115

Changes:
https://github.com/alphagov/notifications-utils/compare/13.2.0...enable-markdown-links