### PR TITLE
Remove app and py3 packages on codedeploy-ment

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -5,6 +5,10 @@ files:
   - destination: /home/notify-app/notifications-api
     source: /
 hooks:
+  BeforeInstall:
+    - location: scripts/aws_clear_instance.sh
+      runas: root
+      timeout: 1000
   AfterInstall:
     - location: scripts/aws_install_dependencies.sh
       runas: root

--- a/scripts/aws_clear_instance.sh
+++ b/scripts/aws_clear_instance.sh
@@ -5,6 +5,6 @@ echo "Removing application and dependencies"
 if [ -d "/home/notify-app/notifications-api" ]; then
     # Remove and re-create the directory
     rm -rf /home/notify-app/notifications-api
-    mkdir -vp /home/notify-app/notifications-api
+    mkdir -p /home/notify-app/notifications-api
 fi
 

--- a/scripts/aws_clear_instance.sh
+++ b/scripts/aws_clear_instance.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "Removing application and dependencies"
+
+if [ -d "/home/notify-app/notifications-api" ]; then
+    # Remove and re-create the directory
+    rm -rf /home/notify-app/notifications-api
+    mkdir -vp /home/notify-app/notifications-api
+    # Remove installed py3 packages
+    pip3 freeze | xargs pip3 uninstall -y
+else
+    echo "Directory does not exist, something went wrong!"
+fi
+

--- a/scripts/aws_clear_instance.sh
+++ b/scripts/aws_clear_instance.sh
@@ -6,9 +6,5 @@ if [ -d "/home/notify-app/notifications-api" ]; then
     # Remove and re-create the directory
     rm -rf /home/notify-app/notifications-api
     mkdir -vp /home/notify-app/notifications-api
-    # Remove installed py3 packages
-    pip3 freeze | xargs pip3 uninstall -y
-else
-    echo "Directory does not exist, something went wrong!"
 fi
 


### PR DESCRIPTION
This will remove the app and installed python3 packages on the instance before run the deployment scripts.

## How it works

Currently we recycle our instances when we auto-scale. This means that our application files and python packages are installed atop of the existing files during deployment. This will not however take care of removing files that we deleted in the app or packages we removed. 

This taps into the AWS `BeforeInstall` hook which will run specified commands before the app files are copied. At this stage it makes sense to remove all our existing application files `/home/notify-app/notifications-api` and also remove all installed python3 packages. 

Once these actions are complete, we will run the standard deployment steps to copy over the new application files and install requirements according to `requirements.txt`.
