### PR TITLE
Set the expiry time on a verify code (2fa) to 10 minutes.

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -78,6 +78,7 @@ class Config(object):
     SMS_CHAR_COUNT_LIMIT = 495
     BRANDING_PATH = '/images/email-template/crests/'
     TEST_MESSAGE_FILENAME = 'Test message'
+    MAX_VERIFY_CODE_COUNT = 10
 
     NOTIFY_SERVICE_ID = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'
     INVITATION_EMAIL_TEMPLATE_ID = '4f46df42-f795-4cc4-83bb-65ca312f49cc'

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -1,8 +1,6 @@
 import random
 from datetime import (datetime, timedelta)
-
 from sqlalchemy import func
-
 from app import db
 from app.models import (User, VerifyCode)
 
@@ -48,7 +46,7 @@ def get_user_code(user, code, code_type):
     # time searching for the correct code.
     codes = VerifyCode.query.filter_by(
         user=user, code_type=code_type).order_by(
-            VerifyCode.created_at.desc())
+        VerifyCode.created_at.desc())
     retval = None
     for x in codes:
         if x.check_code(code):
@@ -86,7 +84,8 @@ def count_user_verify_codes(user):
     query = db.session.query(
         func.count().label('count')
     ).filter(VerifyCode.user == user,
-             VerifyCode.expiry_datetime <= datetime.utcnow()).one()
+             VerifyCode.expiry_datetime > datetime.utcnow(),
+             VerifyCode.code_used.is_(False)).one()
     return query.count
 
 

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -82,6 +82,14 @@ def delete_user_verify_codes(user):
     db.session.commit()
 
 
+def count_user_verify_codes(user):
+    query = db.session.query(
+        func.count().label('count')
+    ).filter(VerifyCode.user == user,
+             VerifyCode.expiry_datetime <= datetime.utcnow()).one()
+    return query.count
+
+
 def get_user_by_id(user_id=None):
     if user_id:
         return User.query.filter_by(id=user_id).one()

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -35,7 +35,7 @@ def save_model_user(usr, update_dict={}, pwd=None):
 
 def create_user_code(user, code, code_type):
     verify_code = VerifyCode(code_type=code_type,
-                             expiry_datetime=datetime.utcnow() + timedelta(hours=1),
+                             expiry_datetime=datetime.utcnow() + timedelta(minutes=30),
                              user=user)
     verify_code.code = code
     db.session.add(verify_code)

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -81,12 +81,12 @@ def delete_user_verify_codes(user):
 
 
 def count_user_verify_codes(user):
-    query = db.session.query(
-        func.count().label('count')
-    ).filter(VerifyCode.user == user,
-             VerifyCode.expiry_datetime > datetime.utcnow(),
-             VerifyCode.code_used.is_(False)).one()
-    return query.count
+    query = VerifyCode.query.filter(
+        VerifyCode.user == user,
+        VerifyCode.expiry_datetime > datetime.utcnow(),
+        VerifyCode.code_used.is_(False)
+    )
+    return query.count()
 
 
 def get_user_by_id(user_id=None):

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -12,7 +12,8 @@ from app.dao.users_dao import (
     get_user_by_email,
     create_secret_code,
     save_user_attribute,
-    update_user_password
+    update_user_password,
+    count_user_verify_codes
 )
 from app.dao.permissions_dao import permission_dao
 from app.dao.services_dao import dao_fetch_service_by_id
@@ -136,6 +137,10 @@ def verify_user_code(user_id):
 def send_user_sms_code(user_id):
     user_to_send_to = get_user_by_id(user_id=user_id)
     verify_code, errors = request_verify_code_schema.load(request.get_json())
+
+    if count_user_verify_codes(user_to_send_to) >= current_app.config.get('MAX_VERIFY_CODE_COUNT'):
+        # Prevent more than `MAX_VERIFY_CODE_COUNT` active verify codes at a time
+        return jsonify({}), 204
 
     secret_code = create_secret_code()
     create_user_code(user_to_send_to, secret_code, SMS_TYPE)

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -123,10 +123,13 @@ def verify_user_code(user_id):
 
     code = get_user_code(user_to_verify, txt_code, txt_type)
     if not code:
+        increment_failed_login_count(user_to_verify)
         raise InvalidRequest("Code not found", status_code=404)
     if datetime.utcnow() > code.expiry_datetime or code.code_used:
+        increment_failed_login_count(user_to_verify)
         raise InvalidRequest("Code has expired", status_code=400)
     use_user_code(code.id)
+    reset_failed_login_count(user_to_verify)
     return jsonify({}), 204
 
 

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -140,6 +140,7 @@ def send_user_sms_code(user_id):
 
     if count_user_verify_codes(user_to_send_to) >= current_app.config.get('MAX_VERIFY_CODE_COUNT'):
         # Prevent more than `MAX_VERIFY_CODE_COUNT` active verify codes at a time
+        current_app.logger.warn('Max verify code has exceeded for user {}'.format(user_to_send_to.id))
         return jsonify({}), 204
 
     secret_code = create_secret_code()

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -129,7 +129,6 @@ def verify_user_code(user_id):
         increment_failed_login_count(user_to_verify)
         raise InvalidRequest("Code has expired", status_code=400)
     use_user_code(code.id)
-    reset_failed_login_count(user_to_verify)
     return jsonify({}), 204
 
 

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -14,8 +14,8 @@ from app.dao.users_dao import (
     reset_failed_login_count,
     get_user_by_email,
     delete_codes_older_created_more_than_a_day_ago,
-    update_user_password
-)
+    update_user_password,
+    count_user_verify_codes)
 
 from app.models import User, VerifyCode
 
@@ -140,3 +140,8 @@ def test_update_user_password(notify_api, notify_db, notify_db_session, sample_u
     assert not sample_user.check_password(password)
     update_user_password(sample_user, password)
     assert sample_user.check_password(password)
+
+
+def test_count_user_verify_codes(sample_user):
+    [make_verify_code(sample_user) for i in range(5)]
+    assert count_user_verify_codes(sample_user) == 5

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+from freezegun import freeze_time
 from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
 import pytest
@@ -109,13 +110,14 @@ def test_should_not_delete_verification_codes_less_than_one_day_old(sample_user)
     assert VerifyCode.query.one()._code == "12345"
 
 
-def make_verify_code(user, age=timedelta(hours=0), code="12335"):
+def make_verify_code(user, age=timedelta(hours=0), expiry_age=timedelta(0), code="12335", code_used=False):
     verify_code = VerifyCode(
         code_type='sms',
         _code=code,
         created_at=datetime.utcnow() - age,
-        expiry_datetime=datetime.utcnow(),
-        user=user
+        expiry_datetime=datetime.utcnow() - expiry_age,
+        user=user,
+        code_used=code_used
     )
     db.session.add(verify_code)
     db.session.commit()
@@ -143,5 +145,9 @@ def test_update_user_password(notify_api, notify_db, notify_db_session, sample_u
 
 
 def test_count_user_verify_codes(sample_user):
-    [make_verify_code(sample_user) for i in range(5)]
+    with freeze_time(datetime.utcnow() + timedelta(hours=1)):
+        make_verify_code(sample_user, code_used=True)
+        make_verify_code(sample_user, expiry_age=timedelta(hours=2))
+        [make_verify_code(sample_user) for i in range(5)]
+
     assert count_user_verify_codes(sample_user) == 5

--- a/tests/app/user/test_rest_verify.py
+++ b/tests/app/user/test_rest_verify.py
@@ -67,31 +67,6 @@ def test_user_verify_code_bad_code_and_increments_failed_login_count(client,
     assert User.query.get(sample_sms_code.user.id).failed_login_count == 1
 
 
-def test_user_verify_code_resets_failed_login_count_when_successful(client, sample_sms_code):
-    assert not VerifyCode.query.first().code_used
-    data = json.dumps({
-        'code_type': sample_sms_code.code_type,
-        'code': "blah"})
-    auth_header = create_authorization_header()
-    resp = client.post(
-        url_for('user.verify_user_code', user_id=sample_sms_code.user.id),
-        data=data,
-        headers=[('Content-Type', 'application/json'), auth_header])
-    assert resp.status_code == 404
-    assert not VerifyCode.query.first().code_used
-    assert User.query.get(sample_sms_code.user.id).failed_login_count == 1
-    correct_data = json.dumps({
-        'code_type': sample_sms_code.code_type,
-        'code': sample_sms_code.txt_code})
-    success_response = client.post(
-        url_for('user.verify_user_code', user_id=sample_sms_code.user.id),
-        data=correct_data,
-        headers=[('Content-Type', 'application/json'), auth_header])
-    assert success_response.status_code == 204
-    assert VerifyCode.query.first().code_used
-    assert User.query.get(sample_sms_code.user.id).failed_login_count == 0
-
-
 def test_user_verify_code_expired_code_and_increments_failed_login_count(
         client,
         sample_sms_code):

--- a/tests/app/user/test_rest_verify.py
+++ b/tests/app/user/test_rest_verify.py
@@ -1,5 +1,4 @@
 import json
-import moto
 import pytest
 
 from datetime import (
@@ -15,7 +14,7 @@ from app.models import (
     Notification
 )
 
-from app import db, encryption
+from app import db
 
 from tests import create_authorization_header
 from freezegun import freeze_time
@@ -23,198 +22,167 @@ from freezegun import freeze_time
 import app.celery.tasks
 
 
-def test_user_verify_code_sms(notify_api,
-                              sample_sms_code):
-    """
-    Tests POST endpoint '/<user_id>/verify/code'
-    """
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            assert not VerifyCode.query.first().code_used
-            data = json.dumps({
-                'code_type': sample_sms_code.code_type,
-                'code': sample_sms_code.txt_code})
-            auth_header = create_authorization_header()
-            resp = client.post(
-                url_for('user.verify_user_code', user_id=sample_sms_code.user.id),
-                data=data,
-                headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 204
-            assert VerifyCode.query.first().code_used
+def test_user_verify_code(client,
+                          sample_sms_code):
+    assert not VerifyCode.query.first().code_used
+    data = json.dumps({
+        'code_type': sample_sms_code.code_type,
+        'code': sample_sms_code.txt_code})
+    auth_header = create_authorization_header()
+    resp = client.post(
+        url_for('user.verify_user_code', user_id=sample_sms_code.user.id),
+        data=data,
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert resp.status_code == 204
+    assert VerifyCode.query.first().code_used
 
 
-def test_user_verify_code_sms_missing_code(notify_api,
-                                           sample_sms_code):
-    """
-    Tests POST endpoint '/<user_id>/verify/code'
-    """
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            assert not VerifyCode.query.first().code_used
-            data = json.dumps({'code_type': sample_sms_code.code_type})
-            auth_header = create_authorization_header()
-            resp = client.post(
-                url_for('user.verify_user_code', user_id=sample_sms_code.user.id),
-                data=data,
-                headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 400
-            assert not VerifyCode.query.first().code_used
+def test_user_verify_code_missing_code(client,
+                                       sample_sms_code):
+    assert not VerifyCode.query.first().code_used
+    data = json.dumps({'code_type': sample_sms_code.code_type})
+    auth_header = create_authorization_header()
+    resp = client.post(
+        url_for('user.verify_user_code', user_id=sample_sms_code.user.id),
+        data=data,
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert resp.status_code == 400
+    assert not VerifyCode.query.first().code_used
+    assert User.query.get(sample_sms_code.user.id).failed_login_count == 0
 
 
-@moto.mock_sqs
-def test_user_verify_code_email(notify_api,
-                                sqs_client_conn,
-                                sample_email_code):
-    """
-    Tests POST endpoint '/<user_id>/verify/code'
-    """
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            assert not VerifyCode.query.first().code_used
-            data = json.dumps({
-                'code_type': sample_email_code.code_type,
-                'code': sample_email_code.txt_code})
-            auth_header = create_authorization_header()
-            resp = client.post(
-                url_for('user.verify_user_code', user_id=sample_email_code.user.id),
-                data=data,
-                headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 204
-            assert VerifyCode.query.first().code_used
+def test_user_verify_code_bad_code_and_increments_failed_login_count(client,
+                                                                     sample_sms_code):
+    assert not VerifyCode.query.first().code_used
+    data = json.dumps({
+        'code_type': sample_sms_code.code_type,
+        'code': "blah"})
+    auth_header = create_authorization_header()
+    resp = client.post(
+        url_for('user.verify_user_code', user_id=sample_sms_code.user.id),
+        data=data,
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert resp.status_code == 404
+    assert not VerifyCode.query.first().code_used
+    assert User.query.get(sample_sms_code.user.id).failed_login_count == 1
 
 
-def test_user_verify_code_email_bad_code(notify_api,
-                                         sample_email_code):
-    """
-    Tests POST endpoint '/<user_id>/verify/code'
-    """
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            assert not VerifyCode.query.first().code_used
-            data = json.dumps({
-                'code_type': sample_email_code.code_type,
-                'code': "blah"})
-            auth_header = create_authorization_header()
-            resp = client.post(
-                url_for('user.verify_user_code', user_id=sample_email_code.user.id),
-                data=data,
-                headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 404
-            assert not VerifyCode.query.first().code_used
+def test_user_verify_code_resets_failed_login_count_when_successful(client, sample_sms_code):
+    assert not VerifyCode.query.first().code_used
+    data = json.dumps({
+        'code_type': sample_sms_code.code_type,
+        'code': "blah"})
+    auth_header = create_authorization_header()
+    resp = client.post(
+        url_for('user.verify_user_code', user_id=sample_sms_code.user.id),
+        data=data,
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert resp.status_code == 404
+    assert not VerifyCode.query.first().code_used
+    assert User.query.get(sample_sms_code.user.id).failed_login_count == 1
+    correct_data = json.dumps({
+        'code_type': sample_sms_code.code_type,
+        'code': sample_sms_code.txt_code})
+    success_response = client.post(
+        url_for('user.verify_user_code', user_id=sample_sms_code.user.id),
+        data=correct_data,
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert success_response.status_code == 204
+    assert VerifyCode.query.first().code_used
+    assert User.query.get(sample_sms_code.user.id).failed_login_count == 0
 
 
-def test_user_verify_code_email_expired_code(notify_api,
-                                             sample_email_code):
-    """
-    Tests POST endpoint '/<user_id>/verify/code'
-    """
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            assert not VerifyCode.query.first().code_used
-            sample_email_code.expiry_datetime = (
-                datetime.utcnow() - timedelta(hours=1))
-            db.session.add(sample_email_code)
-            db.session.commit()
-            data = json.dumps({
-                'code_type': sample_email_code.code_type,
-                'code': sample_email_code.txt_code})
-            auth_header = create_authorization_header()
-            resp = client.post(
-                url_for('user.verify_user_code', user_id=sample_email_code.user.id),
-                data=data,
-                headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 400
-            assert not VerifyCode.query.first().code_used
+def test_user_verify_code_expired_code_and_increments_failed_login_count(
+        client,
+        sample_sms_code):
+    assert not VerifyCode.query.first().code_used
+    sample_sms_code.expiry_datetime = (
+        datetime.utcnow() - timedelta(hours=1))
+    db.session.add(sample_sms_code)
+    db.session.commit()
+    data = json.dumps({
+        'code_type': sample_sms_code.code_type,
+        'code': sample_sms_code.txt_code})
+    auth_header = create_authorization_header()
+    resp = client.post(
+        url_for('user.verify_user_code', user_id=sample_sms_code.user.id),
+        data=data,
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert resp.status_code == 400
+    assert not VerifyCode.query.first().code_used
+    assert User.query.get(sample_sms_code.user.id).failed_login_count == 1
 
 
 @freeze_time("2016-01-01 10:00:00.000000")
-def test_user_verify_password(notify_api,
-                              notify_db,
+def test_user_verify_password(client,
                               notify_db_session,
                               sample_user):
-    """
-    Tests POST endpoint '/<user_id>/verify/password'
-    """
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = json.dumps({'password': 'password'})
-            auth_header = create_authorization_header()
-            resp = client.post(
-                url_for('user.verify_user_password', user_id=sample_user.id),
-                data=data,
-                headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 204
-            User.query.get(sample_user.id).logged_in_at == datetime.utcnow()
+    data = json.dumps({'password': 'password'})
+    auth_header = create_authorization_header()
+    resp = client.post(
+        url_for('user.verify_user_password', user_id=sample_user.id),
+        data=data,
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert resp.status_code == 204
+    assert User.query.get(sample_user.id).logged_in_at == datetime.utcnow()
 
 
-def test_user_verify_password_invalid_password(notify_api,
+def test_user_verify_password_invalid_password(client,
                                                sample_user):
-    """
-    Tests POST endpoint '/<user_id>/verify/password' invalid endpoint.
-    """
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = json.dumps({'password': 'bad password'})
-            auth_header = create_authorization_header()
+    data = json.dumps({'password': 'bad password'})
+    auth_header = create_authorization_header()
 
-            assert sample_user.failed_login_count == 0
+    assert sample_user.failed_login_count == 0
 
-            resp = client.post(
-                url_for('user.verify_user_password', user_id=sample_user.id),
-                data=data,
-                headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 400
-            json_resp = json.loads(resp.get_data(as_text=True))
-            assert 'Incorrect password' in json_resp['message']['password']
-            assert sample_user.failed_login_count == 1
+    resp = client.post(
+        url_for('user.verify_user_password', user_id=sample_user.id),
+        data=data,
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert resp.status_code == 400
+    json_resp = json.loads(resp.get_data(as_text=True))
+    assert 'Incorrect password' in json_resp['message']['password']
+    assert sample_user.failed_login_count == 1
 
 
-def test_user_verify_password_valid_password_resets_failed_logins(notify_api,
+def test_user_verify_password_valid_password_resets_failed_logins(client,
                                                                   sample_user):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = json.dumps({'password': 'bad password'})
-            auth_header = create_authorization_header()
+    data = json.dumps({'password': 'bad password'})
+    auth_header = create_authorization_header()
 
-            assert sample_user.failed_login_count == 0
+    assert sample_user.failed_login_count == 0
 
-            resp = client.post(
-                url_for('user.verify_user_password', user_id=sample_user.id),
-                data=data,
-                headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 400
-            json_resp = json.loads(resp.get_data(as_text=True))
-            assert 'Incorrect password' in json_resp['message']['password']
+    resp = client.post(
+        url_for('user.verify_user_password', user_id=sample_user.id),
+        data=data,
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert resp.status_code == 400
+    json_resp = json.loads(resp.get_data(as_text=True))
+    assert 'Incorrect password' in json_resp['message']['password']
 
-            assert sample_user.failed_login_count == 1
+    assert sample_user.failed_login_count == 1
 
-            data = json.dumps({'password': 'password'})
-            auth_header = create_authorization_header()
-            resp = client.post(
-                url_for('user.verify_user_password', user_id=sample_user.id),
-                data=data,
-                headers=[('Content-Type', 'application/json'), auth_header])
+    data = json.dumps({'password': 'password'})
+    auth_header = create_authorization_header()
+    resp = client.post(
+        url_for('user.verify_user_password', user_id=sample_user.id),
+        data=data,
+        headers=[('Content-Type', 'application/json'), auth_header])
 
-            assert resp.status_code == 204
-            assert sample_user.failed_login_count == 0
+    assert resp.status_code == 204
+    assert sample_user.failed_login_count == 0
 
 
-def test_user_verify_password_missing_password(notify_api,
+def test_user_verify_password_missing_password(client,
                                                sample_user):
-    """
-    Tests POST endpoint '/<user_id>/verify/password' missing password.
-    """
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = json.dumps({'bingo': 'bongo'})
-            auth_header = create_authorization_header()
-            resp = client.post(
-                url_for('user.verify_user_password', user_id=sample_user.id),
-                data=data,
-                headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 400
-            json_resp = json.loads(resp.get_data(as_text=True))
-            assert 'Required field missing data' in json_resp['message']['password']
+    data = json.dumps({'bingo': 'bongo'})
+    auth_header = create_authorization_header()
+    resp = client.post(
+        url_for('user.verify_user_password', user_id=sample_user.id),
+        data=data,
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert resp.status_code == 400
+    json_resp = json.loads(resp.get_data(as_text=True))
+    assert 'Required field missing data' in json_resp['message']['password']
 
 
 @pytest.mark.parametrize('research_mode', [True, False])
@@ -293,22 +261,17 @@ def test_send_user_code_for_sms_with_optional_to_field(notify_api,
             )
 
 
-def test_send_sms_code_returns_404_for_bad_input_data(notify_api, notify_db, notify_db_session):
-    """
-    Tests POST endpoint /user/<user_id>/sms-code return 404 for bad input data
-    """
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            data = json.dumps({})
-            import uuid
-            uuid_ = uuid.uuid4()
-            auth_header = create_authorization_header()
-            resp = client.post(
-                url_for('user.send_user_sms_code', user_id=uuid_),
-                data=data,
-                headers=[('Content-Type', 'application/json'), auth_header])
-            assert resp.status_code == 404
-            assert json.loads(resp.get_data(as_text=True))['message'] == 'No result found'
+def test_send_sms_code_returns_404_for_bad_input_data(client):
+    data = json.dumps({})
+    import uuid
+    uuid_ = uuid.uuid4()
+    auth_header = create_authorization_header()
+    resp = client.post(
+        url_for('user.send_user_sms_code', user_id=uuid_),
+        data=data,
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert resp.status_code == 404
+    assert json.loads(resp.get_data(as_text=True))['message'] == 'No result found'
 
 
 def test_send_user_email_verification(client,


### PR DESCRIPTION
When the verify code is wrong or expired increment the failed to login count for the user.
When the verify code is successfully used reset the failed login count to 0.
Added a limit to the number of active verify codes.
I removed the tests for the email verify code, we do not use them anymore. 


Merge https://github.com/alphagov/notifications-admin/pull/1134 after this one.

https://www.pivotaltracker.com/story/show/139184309