### PR TITLE
Ensure all wheels are installed offline from the wheelhouse directory

### DIFF
--- a/scripts/aws_install_dependencies.sh
+++ b/scripts/aws_install_dependencies.sh
@@ -5,4 +5,4 @@ set -eo pipefail
 echo "Install dependencies"
 
 cd /home/notify-app/notifications-api;
-pip3 install --find-links=wheelhouse -r /home/notify-app/notifications-api/requirements.txt
+pip3 install --no-index --find-links=wheelhouse wheelhouse/*


### PR DESCRIPTION
This installs all wheels from the `wheelhouse` directory instead of resolving each requirement in `requirements.txt`.

## Dependencies

- [x] #836 

## Why

Currently if any VCS link exists in `requirements.txt`, pip will attempt to resolve the package by going online. This introduces issues during our deployment process, particularly when Github is down - as we have two VCS dependencies (`boto` and `notifications-utils`). 

## How

In #825, changes were introduced to delete the old app directory (include the leftover wheels) during deployment on recycled instances. This instills confidence that the latest wheelhouse directory will not contain any duplicate wheels (from a previous deployment) but instead have the latest up-to date wheels generated during our build process. This will install all of the wheels in the wheelhouse directory without going online at all(`--no-index`).
