### PR TITLE
bump utils to 13.6.0 - downgrade non-gsm chars on sms send

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@13.5.0#egg=notifications-utils==13.5.0
+git+https://github.com/alphagov/notifications-utils.git@13.6.0#egg=notifications-utils==13.6.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@13.7.0#egg=notifications-utils==13.7.0
+git+https://github.com/alphagov/notifications-utils.git@13.8.0#egg=notifications-utils==13.8.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
also refactor test_send_to_providers to use the shiny new db.py create_*db obj* functions and clean up some of the fixture usage