### PR TITLE
Bump utils to turn off Markdown links

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@13.5.0#egg=notifications-utils==13.5.0
+git+https://github.com/alphagov/notifications-utils.git@13.7.0#egg=notifications-utils==13.7.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/118

Changes: https://github.com/alphagov/notifications-utils/compare/13.5.0...remove-markdown-links