### PR TITLE
Delete old wheels on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ generate-version-file: ## Generates the app version file
 
 .PHONY: build
 build: dependencies generate-version-file ## Build project
+	rm -rf wheelhouse
 	. venv/bin/activate && PIP_ACCEL_CACHE=${PIP_ACCEL_CACHE} pip-accel wheel --wheel-dir=wheelhouse -r requirements.txt
 
 .PHONY: cf-build


### PR DESCRIPTION
This removes the old wheelhouse directory (including old wheels) before we build from the potentially _updated_ `requirements.txt`.