### PR TITLE
Remove explicit api_host_name vars from the envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,7 @@ cf-rollback: ## Rollbacks the app to the previous release
 
 .PHONY: cf-push
 cf-push:
+	$(if ${CF_APP},,$(error Must specify CF_APP))
 	cf push ${CF_APP} -f ${CF_MANIFEST_FILE}
 
 define cf_deploy_with_docker

--- a/app/config.py
+++ b/app/config.py
@@ -214,7 +214,6 @@ class Preview(Config):
     NOTIFY_EMAIL_DOMAIN = 'notify.works'
     NOTIFY_ENVIRONMENT = 'preview'
     CSV_UPLOAD_BUCKET_NAME = 'preview-notifications-csv-upload'
-    API_HOST_NAME = 'http://admin-api.internal'
     FROM_NUMBER = 'preview'
 
 
@@ -223,7 +222,6 @@ class Staging(Config):
     NOTIFY_ENVIRONMENT = 'staging'
     CSV_UPLOAD_BUCKET_NAME = 'staging-notify-csv-upload'
     STATSD_ENABLED = True
-    API_HOST_NAME = 'http://admin-api.internal'
     FROM_NUMBER = 'stage'
 
 
@@ -232,7 +230,6 @@ class Live(Config):
     NOTIFY_ENVIRONMENT = 'live'
     CSV_UPLOAD_BUCKET_NAME = 'live-notifications-csv-upload'
     STATSD_ENABLED = True
-    API_HOST_NAME = 'http://admin-api.internal'
     FROM_NUMBER = '40604'
 
 


### PR DESCRIPTION
The API_HOST_NAME exists in credstash for all existing environments.