### PR TITLE
Update boto3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ marshmallow-sqlalchemy==0.8.0
 flask-marshmallow==0.6.2
 Flask-Bcrypt==0.6.2
 credstash==1.8.0
-boto3==1.4.0
+boto3==1.4.4
 celery==3.1.23
 monotonic==1.2
 statsd==3.2.1


### PR DESCRIPTION
`aws-cli` uses a newer version of `botocore` yet `boto3=1.4.0` uses an older version. This conflict causes the installation from wheels to fail. It's better to update `boto3` to `1.4.4` which uses the latest `botocore` version . The changes are fairly minimal (non-breaking).