### PR TITLE
Fix failed login count

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -138,7 +138,6 @@ def verify_user_code(user_id):
         save_model_user(user_to_verify)
 
     use_user_code(code.id)
-    reset_failed_login_count(user_to_verify)
     return jsonify({}), 204
 
 
@@ -331,7 +330,7 @@ def update_password(user_id):
     update_dct, errors = user_update_password_schema_load_json.load(req_json)
     if errors:
         raise InvalidRequest(errors, status_code=400)
-
+    print("reset login count")
     reset_failed_login_count(user)
     update_user_password(user, pwd)
     return jsonify(data=user_schema.dump(user).data), 200

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -505,20 +505,6 @@ def test_update_user_password_saves_correctly(client, sample_service):
     assert resp.status_code == 204
 
 
-def test_update_user_password_resets_failed_login_count(client, sample_service):
-    user = sample_service.users[0]
-    user.failed_login_count = 1
-
-    resp = client.post(
-        url_for('user.update_password', user_id=user.id),
-        data=json.dumps({'_password': 'foo'}),
-        headers=[('Content-Type', 'application/json'), create_authorization_header()]
-    )
-
-    assert resp.status_code == 200
-    assert user.failed_login_count == 0
-
-
 def test_update_user_resets_failed_login_count_if_updating_password(client, sample_service):
     user = sample_service.users[0]
     user.failed_login_count = 1

--- a/tests/app/user/test_rest_verify.py
+++ b/tests/app/user/test_rest_verify.py
@@ -313,7 +313,7 @@ def test_send_email_verification_returns_404_for_bad_input_data(client, notify_d
     assert mocked.call_count == 0
 
 
-def test_user_verify_user_code_valid_code_resets_failed_login_count(client, sample_sms_code):
+def test_user_verify_user_code_valid_code_does_not_reset_failed_login_count(client, sample_sms_code):
     sample_sms_code.user.failed_login_count = 1
     data = json.dumps({
         'code_type': sample_sms_code.code_type,
@@ -323,5 +323,5 @@ def test_user_verify_user_code_valid_code_resets_failed_login_count(client, samp
         data=data,
         headers=[('Content-Type', 'application/json'), create_authorization_header()])
     assert resp.status_code == 204
-    assert sample_sms_code.user.failed_login_count == 0
+    assert sample_sms_code.user.failed_login_count == 1
     assert sample_sms_code.code_used

--- a/tests/app/user/test_rest_verify.py
+++ b/tests/app/user/test_rest_verify.py
@@ -313,7 +313,21 @@ def test_send_email_verification_returns_404_for_bad_input_data(client, notify_d
     assert mocked.call_count == 0
 
 
-def test_user_verify_user_code_valid_code_does_not_reset_failed_login_count(client, sample_sms_code):
+def test_user_verify_user_code_returns_404_when_code_is_right_but_user_account_is_locked(client, sample_sms_code):
+    sample_sms_code.user.failed_login_count = 10
+    data = json.dumps({
+        'code_type': sample_sms_code.code_type,
+        'code': sample_sms_code.txt_code})
+    resp = client.post(
+        url_for('user.verify_user_code', user_id=sample_sms_code.user.id),
+        data=data,
+        headers=[('Content-Type', 'application/json'), create_authorization_header()])
+    assert resp.status_code == 404
+    assert sample_sms_code.user.failed_login_count == 10
+    assert not sample_sms_code.code_used
+
+
+def test_user_verify_user_code_valid_code_resets_failed_login_count(client, sample_sms_code):
     sample_sms_code.user.failed_login_count = 1
     data = json.dumps({
         'code_type': sample_sms_code.code_type,
@@ -323,5 +337,21 @@ def test_user_verify_user_code_valid_code_does_not_reset_failed_login_count(clie
         data=data,
         headers=[('Content-Type', 'application/json'), create_authorization_header()])
     assert resp.status_code == 204
-    assert sample_sms_code.user.failed_login_count == 1
+    assert sample_sms_code.user.failed_login_count == 0
     assert sample_sms_code.code_used
+
+
+def test_user_reset_failed_login_count_returns_200(client, sample_user):
+    sample_user.failed_login_count = 1
+    resp = client.post(url_for("user.user_reset_failed_login_count", user_id=sample_user.id),
+                       data={},
+                       headers=[('Content-Type', 'application/json'), create_authorization_header()])
+    assert resp.status_code == 200
+    assert sample_user.failed_login_count == 0
+
+
+def test_reset_failed_login_count_returns_404_when_user_does_not_exist(client):
+    resp = client.post(url_for("user.user_reset_failed_login_count", user_id=uuid.uuid4()),
+                       data={},
+                       headers=[('Content-Type', 'application/json'), create_authorization_header()])
+    assert resp.status_code == 404


### PR DESCRIPTION
This PR will help to fix the user login flow when the user account becomes locked. However the story is not done until the admin PR is merged as well. 

It is ok to deploy this before the admin app, it will not make the user login flow any worse but it will not be correct until the admin app is deployed as well. Follow up with merging  https://github.com/alphagov/notifications-admin/pull/1162
