### PR TITLE
Added v2 template get ID endpoint, schema & tests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -110,9 +110,11 @@ def register_blueprint(application):
 def register_v2_blueprints(application):
     from app.v2.notifications.post_notifications import notification_blueprint as post_notifications
     from app.v2.notifications.get_notifications import notification_blueprint as get_notifications
+    from app.v2.template.get_template import template_blueprint
 
     application.register_blueprint(post_notifications)
     application.register_blueprint(get_notifications)
+    application.register_blueprint(template_blueprint)
 
 
 def init_app(app):

--- a/app/models.py
+++ b/app/models.py
@@ -320,6 +320,21 @@ class Template(db.Model):
             _external=True
         )
 
+    def serialize(self):
+
+        serialized = {
+            "id": self.id,
+            "type": self.template_type,
+            "created_at": self.created_at.strftime(DATETIME_FORMAT),
+            "updated_at": self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None,
+            "created_by": self.created_by.email_address,
+            "version": self.version,
+            "body": self.content,
+            "subject": self.subject if self.template_type == EMAIL_TYPE else None
+        }
+
+        return serialized
+
 
 class TemplateHistory(db.Model):
     __tablename__ = 'templates_history'
@@ -342,6 +357,21 @@ class TemplateHistory(db.Model):
                              index=True,
                              nullable=False,
                              default=NORMAL)
+
+    def serialize(self):
+
+        serialized = {
+            "id": self.id,
+            "type": self.template_type,
+            "created_at": self.created_at.strftime(DATETIME_FORMAT),
+            "updated_at": self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None,
+            "created_by": self.created_by.email_address,
+            "version": self.version,
+            "body": self.content,
+            "subject": self.subject if self.template_type == EMAIL_TYPE else None
+        }
+
+        return serialized
 
 
 MMG_PROVIDER = "mmg"

--- a/app/v2/template/__init__.py
+++ b/app/v2/template/__init__.py
@@ -1,0 +1,7 @@
+from flask import Blueprint
+
+from app.v2.errors import register_errors
+
+template_blueprint = Blueprint("v2_template", __name__, url_prefix='/v2/template')
+
+register_errors(template_blueprint)

--- a/app/v2/template/get_template.py
+++ b/app/v2/template/get_template.py
@@ -1,6 +1,7 @@
 import uuid
 
 from flask import jsonify, request
+from jsonschema.exceptions import ValidationError
 from werkzeug.exceptions import abort
 
 from app import api_user
@@ -11,21 +12,19 @@ from app.v2.template.template_schemas import get_template_by_id_request
 
 
 @template_blueprint.route("/<template_id>", methods=['GET'])
-@template_blueprint.route("/<template_id>/version/<version>", methods=['GET'])
+@template_blueprint.route("/<template_id>/version/<int:version>", methods=['GET'])
 def get_template_by_id(template_id, version=None):
     try:
-        casted_id = uuid.UUID(template_id)
-
         _data = {}
         _data['id'] = template_id
         if version:
-            _data['version'] = int(version)
+            _data['version'] = version
 
         data = validate(_data, get_template_by_id_request)
     except ValueError or AttributeError:
         abort(404)
 
     template = templates_dao.dao_get_template_by_id_and_service_id(
-        casted_id, api_user.service_id, data.get('version'))
+        template_id, api_user.service_id, data.get('version'))
 
     return jsonify(template.serialize()), 200

--- a/app/v2/template/get_template.py
+++ b/app/v2/template/get_template.py
@@ -1,0 +1,31 @@
+import uuid
+
+from flask import jsonify, request
+from werkzeug.exceptions import abort
+
+from app import api_user
+from app.dao import templates_dao
+from app.schema_validation import validate
+from app.v2.template import template_blueprint
+from app.v2.template.template_schemas import get_template_by_id_request
+
+
+@template_blueprint.route("/<template_id>", methods=['GET'])
+@template_blueprint.route("/<template_id>/version/<version>", methods=['GET'])
+def get_template_by_id(template_id, version=None):
+    try:
+        casted_id = uuid.UUID(template_id)
+
+        _data = {}
+        _data['id'] = template_id
+        if version:
+            _data['version'] = int(version)
+
+        data = validate(_data, get_template_by_id_request)
+    except ValueError or AttributeError:
+        abort(404)
+
+    template = templates_dao.dao_get_template_by_id_and_service_id(
+        casted_id, api_user.service_id, data.get('version'))
+
+    return jsonify(template.serialize()), 200

--- a/app/v2/template/template_schemas.py
+++ b/app/v2/template/template_schemas.py
@@ -29,7 +29,7 @@ get_template_by_id_response = {
         },
         "updated_at": {
             "format": "date-time",
-            "type": "string",
+            "type": ["string", "null"],
             "description": "Date+time updated"
         },
         "created_by": {"type": "string"},

--- a/app/v2/template/template_schemas.py
+++ b/app/v2/template/template_schemas.py
@@ -4,7 +4,7 @@ from app.schema_validation.definitions import uuid
 
 get_template_by_id_request = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "schema for query parameters allowed when getting list of notifications",
+    "description": "schema for parameters allowed when getting template by id",
     "type": "object",
     "properties": {
         "id": uuid,

--- a/app/v2/template/template_schemas.py
+++ b/app/v2/template/template_schemas.py
@@ -1,0 +1,41 @@
+from app.models import TEMPLATE_TYPES
+from app.schema_validation.definitions import uuid
+
+
+get_template_by_id_request = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "schema for query parameters allowed when getting list of notifications",
+    "type": "object",
+    "properties": {
+        "id": uuid,
+        "version": {"type": ["integer", "null"], "minimum": 1}
+    },
+    "required": ["id"],
+    "additionalProperties": False,
+}
+
+get_template_by_id_response = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "GET template by id schema response",
+    "type": "object",
+    "title": "reponse v2/template",
+    "properties": {
+        "id": uuid,
+        "type": {"enum": TEMPLATE_TYPES},
+        "created_at": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Date+time created"
+        },
+        "updated_at": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Date+time updated"
+        },
+        "created_by": {"type": "string"},
+        "version": {"type": "integer"},
+        "body": {"type": "string"},
+        "subject": {"type": ["string", "null"]}
+    },
+    "required": ["id", "type", "created_at", "updated_at", "version", "created_by", "body"]
+}

--- a/tests/app/v2/template/test_get_template.py
+++ b/tests/app/v2/template/test_get_template.py
@@ -1,0 +1,93 @@
+import pytest
+
+from flask import json
+
+from app import DATETIME_FORMAT
+from tests import create_authorization_header
+from tests.app.conftest import sample_template as create_sample_template
+
+EMAIL_TYPE = 'email'
+SMS_TYPE = 'sms'
+LETTER_TYPE = 'letter'
+
+template_types = [EMAIL_TYPE, SMS_TYPE, LETTER_TYPE]
+valid_version_params = [None, 1]
+
+
+@pytest.mark.parametrize("tmp_type", template_types)
+@pytest.mark.parametrize("version", valid_version_params)
+def test_get_email_template_by_id_returns_200(client, notify_db, notify_db_session, sample_service, tmp_type, version):
+    template = create_sample_template(notify_db, notify_db_session, template_type=tmp_type)
+    auth_header = create_authorization_header(service_id=sample_service.id)
+
+    version_path = '/version/{}'.format(version) if version else ''
+
+    response = client.get(path='/v2/template/{}{}'.format(template.id, version_path),
+                          headers=[('Content-Type', 'application/json'), auth_header])
+
+    assert response.status_code == 200
+    assert response.headers['Content-type'] == 'application/json'
+
+    json_response = json.loads(response.get_data(as_text=True))
+
+    expected_response = {
+        'id': '{}'.format(template.id),
+        'type': '{}'.format(template.template_type),
+        'created_at': template.created_at.strftime(DATETIME_FORMAT),
+        'updated_at': None,
+        'version': template.version,
+        'created_by': template.created_by.email_address,
+        'body': template.content,
+        "subject": template.subject if tmp_type == EMAIL_TYPE else None
+    }
+
+    assert json_response == expected_response
+
+
+def test_get_template_with_invalid_template_id_returns_404(client, sample_service):
+    auth_header = create_authorization_header(service_id=sample_service.id)
+
+    invalid_template_id = 'some_other_id'
+
+    response = client.get(path='/v2/template/{}'.format(invalid_template_id),
+                          headers=[('Content-Type', 'application/json'), auth_header])
+
+    assert response.status_code == 404
+    assert response.headers['Content-type'] == 'application/json'
+
+    json_response = json.loads(response.get_data(as_text=True))
+
+    assert json_response == {
+        "message": "The requested URL was not found on the server.  "
+                   "If you entered the URL manually please check your spelling and try again.",
+        "result": "error"
+    }
+
+
+@pytest.mark.parametrize("tmp_type", template_types)
+def test_get_template_with_invalid_version_returns_404(client, notify_db, notify_db_session, sample_service, tmp_type):
+    template = create_sample_template(
+        notify_db, notify_db_session, template_type=tmp_type)
+
+    auth_header = create_authorization_header(service_id=sample_service.id)
+
+    # test with version number beyond latest version
+    invalid_version = template.version + 1
+
+    response = client.get(path='/v2/template/{}/version/{}'.format(template.id, invalid_version),
+                          headers=[('Content-Type', 'application/json'), auth_header])
+
+    assert response.status_code == 404
+    assert response.headers['Content-type'] == 'application/json'
+
+    json_response = json.loads(response.get_data(as_text=True))
+
+    assert json_response == {
+        "errors": [
+            {
+                "error": "NoResultFound",
+                "message": "No result found"
+            }
+        ],
+        "status_code": 404
+    }

--- a/tests/app/v2/template/test_template_schemas.py
+++ b/tests/app/v2/template/test_template_schemas.py
@@ -1,0 +1,67 @@
+import uuid
+
+import pytest
+from flask import json
+
+from app.v2.template.template_schemas import (
+    get_template_by_id_response,
+    get_template_by_id_request
+)
+from app.schema_validation import validate
+from jsonschema.exceptions import ValidationError
+
+
+valid_json = {
+    'id': str(uuid.uuid4()),
+    'type': 'email',
+    'created_at': '2017-01-10T18:25:43.511Z',
+    'updated_at': '2017-04-23T18:25:43.511Z',
+    'version': 1,
+    'created_by': 'someone@test.com',
+    'body': "some body"
+}
+
+valid_json_with_optionals = {
+    'id': str(uuid.uuid4()),
+    'type': 'email',
+    'created_at': '2017-01-10T18:25:43.511Z',
+    'updated_at': '2017-04-23T18:25:43.511Z',
+    'version': 1,
+    'created_by': 'someone',
+    'body': "some body",
+    'subject': "some subject"
+}
+
+valid_request_args = [
+    {"id": str(uuid.uuid4()), "version": 1}, {"id": str(uuid.uuid4())}]
+
+invalid_request_args = [
+    ({"id": str(uuid.uuid4()), "version": "test"}, ["version test is not of type integer, null"]),
+    ({"id": str(uuid.uuid4()), "version": 0}, ["version 0 is less than the minimum of 1"]),
+    ({"version": 1}, ["id is a required property"]),
+    ({"id": "invalid_uuid"}, ["id is not a valid UUID"]),
+    ({"id": "invalid_uuid", "version": 0}, ["version 0 is less than the minimum of 1",
+                                            "id is not a valid UUID"])
+]
+
+
+@pytest.mark.parametrize("args", valid_request_args)
+def test_get_template_request_schema__against_valid_args_is_valid(args):
+    assert validate(args, get_template_by_id_request) == args
+
+
+@pytest.mark.parametrize("args,error_message", invalid_request_args)
+def test_get_template_request_schema_against_invalid_args_is_invalid(args, error_message):
+    with pytest.raises(ValidationError) as e:
+        validate(args, get_template_by_id_request)
+    errors = json.loads(str(e.value))
+
+    assert errors['status_code'] == 400
+
+    for error in errors['errors']:
+        assert error['message'] in error_message
+
+
+@pytest.mark.parametrize("response", [valid_json, valid_json_with_optionals])
+def test_get_template_response_schema_is_valid(response):
+    assert validate(response, get_template_by_id_response) == response

--- a/tests/app/v2/template/test_template_schemas.py
+++ b/tests/app/v2/template/test_template_schemas.py
@@ -40,13 +40,12 @@ invalid_request_args = [
     ({"id": str(uuid.uuid4()), "version": 0}, ["version 0 is less than the minimum of 1"]),
     ({"version": 1}, ["id is a required property"]),
     ({"id": "invalid_uuid"}, ["id is not a valid UUID"]),
-    ({"id": "invalid_uuid", "version": 0}, ["version 0 is less than the minimum of 1",
-                                            "id is not a valid UUID"])
+    ({"id": "invalid_uuid", "version": 0}, ["version 0 is less than the minimum of 1", "id is not a valid UUID"])
 ]
 
 
 @pytest.mark.parametrize("args", valid_request_args)
-def test_get_template_request_schema__against_valid_args_is_valid(args):
+def test_get_template_request_schema_against_valid_args_is_valid(args):
     assert validate(args, get_template_by_id_request) == args
 
 

--- a/tests/app/v2/template/test_template_schemas.py
+++ b/tests/app/v2/template/test_template_schemas.py
@@ -15,7 +15,7 @@ valid_json = {
     'id': str(uuid.uuid4()),
     'type': 'email',
     'created_at': '2017-01-10T18:25:43.511Z',
-    'updated_at': '2017-04-23T18:25:43.511Z',
+    'updated_at': None,
     'version': 1,
     'created_by': 'someone@test.com',
     'body': "some body"
@@ -25,7 +25,7 @@ valid_json_with_optionals = {
     'id': str(uuid.uuid4()),
     'type': 'email',
     'created_at': '2017-01-10T18:25:43.511Z',
-    'updated_at': '2017-04-23T18:25:43.511Z',
+    'updated_at': None,
     'version': 1,
     'created_by': 'someone',
     'body': "some body",
@@ -62,5 +62,9 @@ def test_get_template_request_schema_against_invalid_args_is_invalid(args, error
 
 
 @pytest.mark.parametrize("response", [valid_json, valid_json_with_optionals])
-def test_get_template_response_schema_is_valid(response):
+@pytest.mark.parametrize("updated_datetime", [None, '2017-01-11T18:25:43.511Z'])
+def test_get_template_response_schema_is_valid(response, updated_datetime):
+    if updated_datetime:
+        response['updated_at'] = updated_datetime
+
     assert validate(response, get_template_by_id_response) == response


### PR DESCRIPTION
## What

Added v2/template/{id} endpoint with JSON schema and supporting tests.

Details outlined in this document under `Templates / Get Template by ID` section - [Notify V2 API](https://docs.google.com/document/d/1EuCipShwpZKVPQp3N0j7yRKazS34v5Bj5E9epl89iqY/edit#)

## How to review 

execute `py.test tests/app/v2/template/`

### References

[Pivotal Tracker story] (https://www.pivotaltracker.com/n/projects/1443052/stories/141482957)