### PR TITLE
Create dvla file for a letter job

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1,3 +1,5 @@
+import random
+
 import botocore
 from boto3 import resource
 from datetime import (datetime)
@@ -266,7 +268,9 @@ def build_dvla_file(self, job_id):
         file = ""
         for n in notifications:
             t = {"content": n.template.content, "subject": n.template.subject}
-            template = LetterDVLATemplate(t, n.personalisation, 1)
+            # This unique id is a 7 digits requested by DVLA, not known if this number needs to be sequential.
+            unique_id = int(''.join(map(str, random.sample(range(9), 7))))
+            template = LetterDVLATemplate(t, n.personalisation, unique_id)
             # print(str(template))
             file = file + str(template) + "\n"
         s3upload(filedata=file,

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -258,7 +258,7 @@ def persist_letter(
         handle_exception(self, notification, notification_id, e)
 
 
-@notify_celery.task(bind=True, name="build-dvla-file", max_retries=5, default_retry_delay=300)
+@notify_celery.task(bind=True, name="build-dvla-file", max_retries=15, default_retry_delay=300)
 @statsd(namespace="tasks")
 def build_dvla_file(self, job_id):
     if all_notifications_are_created_for_job(job_id):

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -271,7 +271,6 @@ def build_dvla_file(self, job_id):
             # This unique id is a 7 digits requested by DVLA, not known if this number needs to be sequential.
             unique_id = int(''.join(map(str, random.sample(range(9), 7))))
             template = LetterDVLATemplate(t, n.personalisation, unique_id)
-            # print(str(template))
             file = file + str(template) + "\n"
         s3upload(filedata=file,
                  region=current_app.config['AWS_REGION'],

--- a/app/config.py
+++ b/app/config.py
@@ -175,6 +175,8 @@ class Config(object):
     FUNCTIONAL_TEST_PROVIDER_SERVICE_ID = None
     FUNCTIONAL_TEST_PROVIDER_SMS_TEMPLATE_ID = None
 
+    DVLA_UPLOAD_BUCKET_NAME = "{}-dvla-file-per-job".format(os.getenv('NOTIFY_ENVIRONMENT'))
+
 
 ######################
 # Config overrides ###

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -36,10 +36,7 @@ def all_notifications_are_created_for_job(job_id):
         .group_by(Job.id)\
         .having(func.count(Notification.id) == Job.notification_count).all()
 
-    if query:
-        return True
-    else:
-        return False
+    return query
 
 
 @statsd(namespace="dao")

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -29,17 +29,22 @@ def dao_get_notification_outcomes_for_job(service_id, job_id):
 
 
 @statsd(namespace="dao")
-def are_all_notifications_created_for_job(job_id):
-    query = db.session.query(func.count(Notification.id))\
+def all_notifications_are_created_for_job(job_id):
+    query = db.session.query(func.count(Notification.id), Job.id)\
         .join(Job)\
         .filter(Job.id == job_id)\
         .group_by(Job.id)\
-        .having(func.count(Notification.id) == Job.notification_count).first()
+        .having(func.count(Notification.id) == Job.notification_count).all()
 
     if query:
         return True
     else:
         return False
+
+
+@statsd(namespace="dao")
+def dao_get_all_notifications_for_job(job_id):
+    return db.session.query(Notification).filter(Notification.job_id == job_id).all()
 
 
 def dao_get_job_by_service_id_and_job_id(service_id, job_id):

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -12,8 +12,8 @@ from app.dao.jobs_dao import (
     dao_set_scheduled_jobs_to_pending,
     dao_get_future_scheduled_job_by_id_and_service_id,
     dao_get_notification_outcomes_for_job,
-    dao_get_jobs_older_than
-)
+    dao_get_jobs_older_than,
+    are_all_notifications_created_for_job)
 from app.models import Job
 
 from tests.app.conftest import sample_notification as create_notification
@@ -314,3 +314,20 @@ def test_get_jobs_for_service_doesnt_return_test_messages(notify_db, notify_db_s
     jobs = dao_get_jobs_by_service_id(sample_job.service_id).items
 
     assert jobs == [sample_job]
+
+
+def test_are_all_notifications_created_for_job_returns_true(notify_db, notify_db_session, sample_job):
+    create_notification(notify_db=notify_db, notify_db_session=notify_db_session, job=sample_job)
+    job_is_complete = are_all_notifications_created_for_job(sample_job.id)
+    assert job_is_complete
+
+
+def test_are_all_notifications_created_for_job_returns_false(notify_db, notify_db_session):
+    job = create_job(notify_db=notify_db, notify_db_session=notify_db_session, notification_count=2)
+    job_is_complete = are_all_notifications_created_for_job(job.id)
+    assert not job_is_complete
+
+
+def test_are_all_notifications_created_for_job_returns_false_when_job_does_not_exist(notify_db, notify_db_session):
+    job_is_complete = are_all_notifications_created_for_job(uuid.uuid4())
+    assert not job_is_complete

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -13,7 +13,8 @@ from app.dao.jobs_dao import (
     dao_get_future_scheduled_job_by_id_and_service_id,
     dao_get_notification_outcomes_for_job,
     dao_get_jobs_older_than,
-    are_all_notifications_created_for_job)
+    all_notifications_are_created_for_job,
+    dao_get_all_notifications_for_job)
 from app.models import Job
 
 from tests.app.conftest import sample_notification as create_notification
@@ -316,18 +317,28 @@ def test_get_jobs_for_service_doesnt_return_test_messages(notify_db, notify_db_s
     assert jobs == [sample_job]
 
 
-def test_are_all_notifications_created_for_job_returns_true(notify_db, notify_db_session, sample_job):
-    create_notification(notify_db=notify_db, notify_db_session=notify_db_session, job=sample_job)
-    job_is_complete = are_all_notifications_created_for_job(sample_job.id)
+def test_all_notifications_are_created_for_job_returns_true(notify_db, notify_db_session):
+    job = create_job(notify_db=notify_db, notify_db_session=notify_db_session, notification_count=2)
+    create_notification(notify_db=notify_db, notify_db_session=notify_db_session, job=job)
+    create_notification(notify_db=notify_db, notify_db_session=notify_db_session, job=job)
+    job_is_complete = all_notifications_are_created_for_job(job.id)
     assert job_is_complete
 
 
-def test_are_all_notifications_created_for_job_returns_false(notify_db, notify_db_session):
+def test_all_notifications_are_created_for_job_returns_false(notify_db, notify_db_session):
     job = create_job(notify_db=notify_db, notify_db_session=notify_db_session, notification_count=2)
-    job_is_complete = are_all_notifications_created_for_job(job.id)
+    job_is_complete = all_notifications_are_created_for_job(job.id)
     assert not job_is_complete
 
 
-def test_are_all_notifications_created_for_job_returns_false_when_job_does_not_exist(notify_db, notify_db_session):
-    job_is_complete = are_all_notifications_created_for_job(uuid.uuid4())
+def test_are_all_notifications_created_for_job_returns_false_when_job_does_not_exist():
+    job_is_complete = all_notifications_are_created_for_job(uuid.uuid4())
     assert not job_is_complete
+
+
+def test_dao_get_all_notifications_for_job(notify_db, notify_db_session, sample_job):
+    create_notification(notify_db=notify_db, notify_db_session=notify_db_session, job=sample_job)
+    create_notification(notify_db=notify_db, notify_db_session=notify_db_session, job=sample_job)
+    create_notification(notify_db=notify_db, notify_db_session=notify_db_session, job=sample_job)
+
+    assert len(dao_get_all_notifications_for_job(sample_job.id)) == 3

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -1,7 +1,8 @@
 from datetime import datetime
 import uuid
 
-from app.models import Service, User, Template, Notification, SMS_TYPE, KEY_TYPE_NORMAL
+from app.dao.jobs_dao import dao_create_job
+from app.models import Service, User, Template, Notification, SMS_TYPE, KEY_TYPE_NORMAL, Job
 from app.dao.users_dao import save_model_user
 from app.dao.notifications_dao import dao_create_notification
 from app.dao.templates_dao import dao_create_template
@@ -105,3 +106,30 @@ def create_notification(
     notification = Notification(**data)
     dao_create_notification(notification)
     return notification
+
+
+def create_job(template,
+               notification_count=1,
+               created_at=None,
+               job_status='pending',
+               scheduled_for=None,
+               processing_started=None,
+               original_file_name='some.csv'):
+
+    data = {
+        'id': uuid.uuid4(),
+        'service_id': template.service_id,
+        'service': template.service,
+        'template_id': template.id,
+        'template_version': template.version,
+        'original_file_name': original_file_name,
+        'notification_count': notification_count,
+        'created_at': created_at or datetime.utcnow(),
+        'created_by': template.created_by,
+        'job_status': job_status,
+        'scheduled_for': scheduled_for,
+        'processing_started': processing_started
+    }
+    job = Job(**data)
+    dao_create_job(job)
+    return job


### PR DESCRIPTION
A new task has been created to build a dvla file from the notifications for a given job for letters.
- If all notifications for the job have been persisted to the database we then create a file to save to S3.
Each notification is transformed to a pipe delimited line that matches the DVLA file format, https://github.com/alphagov/notify-ftp-documentation/tree/master/dvla_documentation.
The notifications-ftp app will then aggregate all the files for the day to then send to DVLA to be posted. 
- Else if all the notifications are not persisted to the database the task goes to the retry queue and is retried in 5 minutes for 15 tries. It is likely a job will complete in about 15 minutes so it is unlikely the task will retry more than a few times. 

TODO: move the s3upload method to the notifications-utils package. This is not done at this time because I have been asked to build a security feature. 
TODO: update the job status to `ready to send` after the s3upload is successfully complete. 


 