### PR TITLE
Bump utils to allow lists as placeholder values

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@14.0.0#egg=notifications-utils==14.0.0
+git+https://github.com/alphagov/notifications-utils.git@14.0.1#egg=notifications-utils==14.0.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@13.9.6#egg=notifications-utils==13.9.6
+git+https://github.com/alphagov/notifications-utils.git@14.0.0#egg=notifications-utils==14.0.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/128

Also adds a test to make sure that passing a dictionary as a value in the `personalisation` argument works.

# What it means for users of the API

## With this template:

> Here are some animals:
>
> ((animal))

## …and this API call:
```python
send_email(…, personalisation={
    'animal', ['cat', 'rat', 'gnat']
})
```

## We send this message
> Here are some animals:
>
> * cat
> * rat
> * gnat
