### PR TITLE
Fix daterange in service DAO to work with BST

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -31,7 +31,7 @@ from app.models import (
 )
 from app.service.statistics import format_monthly_template_notification_stats
 from app.statsd_decorators import statsd
-from app.utils import get_london_month_from_utc_column
+from app.utils import get_london_month_from_utc_column, get_london_midnight_in_utc
 
 
 def dao_fetch_all_services(only_active=False):
@@ -324,9 +324,8 @@ def dao_fetch_todays_stats_for_all_services(include_from_test_key=True):
 
 @statsd(namespace='dao')
 def fetch_stats_by_date_range_for_all_services(start_date, end_date, include_from_test_key=True):
-    if not isinstance(end_date, datetime):
-        end_date = datetime.combine(end_date, datetime.min.time())
-
+    start_date = get_london_midnight_in_utc(start_date)
+    end_date = get_london_midnight_in_utc(end_date)
     end_date += timedelta(hours=23, minutes=59, seconds=59)
 
     query = db.session.query(

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1,5 +1,5 @@
 import itertools
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from flask import (
     jsonify,

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -53,7 +53,7 @@ from app.schemas import (
     notifications_filter_schema,
     detailed_service_schema
 )
-from app.utils import pagination_links, get_london_midnight_in_utc
+from app.utils import pagination_links
 from flask import Blueprint
 
 service_blueprint = Blueprint('service', __name__)
@@ -297,8 +297,8 @@ def get_detailed_services(start_date, end_date, only_active=False, include_from_
         stats = dao_fetch_todays_stats_for_all_services(include_from_test_key=include_from_test_key)
     else:
 
-        stats = fetch_stats_by_date_range_for_all_services(start_date=get_london_midnight_in_utc(start_date),
-                                                           end_date=get_london_midnight_in_utc(end_date),
+        stats = fetch_stats_by_date_range_for_all_services(start_date=start_date,
+                                                           end_date=end_date,
                                                            include_from_test_key=include_from_test_key)
 
     for service_id, rows in itertools.groupby(stats, lambda x: x.service_id):

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1,5 +1,5 @@
 import itertools
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from flask import (
     jsonify,

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1393,19 +1393,25 @@ def test_get_detailed_services_only_includes_todays_notifications(notify_db, not
     }
 
 
-@pytest.mark.xfail
-def test_get_detailed_services_for_date_range(notify_db, notify_db_session):
+@pytest.mark.parametrize(
+    'set_time',
+    ['2017-03-28T12:00:00', '2017-01-28T12:00:00', '2017-01-02T12:00:00', '2017-10-31T12:00:00']
+)
+def test_get_detailed_services_for_date_range(notify_db, notify_db_session, set_time):
     from app.service.rest import get_detailed_services
-    create_sample_notification(notify_db, notify_db_session, created_at=datetime.now() - timedelta(days=3))
-    create_sample_notification(notify_db, notify_db_session, created_at=datetime.now() - timedelta(days=2))
-    create_sample_notification(notify_db, notify_db_session, created_at=datetime.now() - timedelta(days=1))
-    create_sample_notification(notify_db, notify_db_session, created_at=datetime.now())
 
-    start_date = (datetime.utcnow() - timedelta(days=2)).date()
-    end_date = (datetime.utcnow() - timedelta(days=1)).date()
+    with freeze_time(set_time):
+        create_sample_notification(notify_db, notify_db_session, created_at=datetime.now() - timedelta(days=3))
+        create_sample_notification(notify_db, notify_db_session, created_at=datetime.now() - timedelta(days=2))
+        create_sample_notification(notify_db, notify_db_session, created_at=datetime.now() - timedelta(days=1))
+        create_sample_notification(notify_db, notify_db_session, created_at=datetime.now())
+
+        start_date = (datetime.utcnow() - timedelta(days=2)).date()
+        end_date = (datetime.utcnow() - timedelta(days=1)).date()
 
     data = get_detailed_services(only_active=False, include_from_test_key=True,
                                  start_date=start_date, end_date=end_date)
+
     assert len(data) == 1
     assert data[0]['statistics'] == {
         'email': {'delivered': 0, 'failed': 0, 'requested': 0},

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1401,10 +1401,10 @@ def test_get_detailed_services_for_date_range(notify_db, notify_db_session, set_
     from app.service.rest import get_detailed_services
 
     with freeze_time(set_time):
-        create_sample_notification(notify_db, notify_db_session, created_at=datetime.now() - timedelta(days=3))
-        create_sample_notification(notify_db, notify_db_session, created_at=datetime.now() - timedelta(days=2))
-        create_sample_notification(notify_db, notify_db_session, created_at=datetime.now() - timedelta(days=1))
-        create_sample_notification(notify_db, notify_db_session, created_at=datetime.now())
+        create_sample_notification(notify_db, notify_db_session, created_at=datetime.utcnow() - timedelta(days=3))
+        create_sample_notification(notify_db, notify_db_session, created_at=datetime.utcnow() - timedelta(days=2))
+        create_sample_notification(notify_db, notify_db_session, created_at=datetime.utcnow() - timedelta(days=1))
+        create_sample_notification(notify_db, notify_db_session, created_at=datetime.utcnow())
 
         start_date = (datetime.utcnow() - timedelta(days=2)).date()
         end_date = (datetime.utcnow() - timedelta(days=1)).date()


### PR DESCRIPTION
## What 

Problem after setting time to BST in get_detailed_services detected by test test_get_detailed_services_for_date_range which was failing. 
After setting the time to a datetime object the query on the DB would search for a precise datetime range rather than a date range.
Fixed in the service DAO by setting the end_date to the end of the day by adding 23 hours, 59 minutes and 59 seconds and filtering on the query based on datetime and not date.

## How to review

execute py.test tests/app/service/test_rest.py::test_get_detailed_services_for_date_range

test has been updated with a range of datetimes for various states
