### PR TITLE
Revert db tasks from api

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -144,6 +144,7 @@ def send_notification_to_persist_queue(
         queue_name = "notify"
     else:
         queue_name = queues[template_type]
+
     send_fn.apply_async(
         (
             str(service.id),

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -123,39 +123,6 @@ def process_row(row_number, recipient, personalisation, template, job, service):
     )
 
 
-def send_notification_to_persist_queue(
-        notification_id, service, template_type, encrypted, priority=False, research_mode=False
-):
-    queues = {
-        SMS_TYPE: 'db-sms',
-        EMAIL_TYPE: 'db-email'
-    }
-
-    send_fns = {
-        SMS_TYPE: send_sms,
-        EMAIL_TYPE: send_email
-    }
-
-    send_fn = send_fns[template_type]
-
-    if research_mode:
-        queue_name = "research-mode"
-    elif priority:
-        queue_name = "notify"
-    else:
-        queue_name = queues[template_type]
-
-    send_fn.apply_async(
-        (
-            str(service.id),
-            notification_id,
-            encrypted,
-            datetime.utcnow().strftime(DATETIME_FORMAT)
-        ),
-        queue=queue_name
-    )
-
-
 def __sending_limits_for_job_exceeded(service, job, job_id):
     total_sent = fetch_todays_total_message_count(service.id)
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -124,14 +124,7 @@ def process_row(row_number, recipient, personalisation, template, job, service):
 
 
 def send_notification_to_persist_queue(
-        notification_id,
-        service,
-        template_type,
-        encrypted,
-        api_key_id,
-        key_type,
-        priority=False,
-        research_mode=False
+        notification_id, service, template_type, encrypted, priority=False, research_mode=False
 ):
     queues = {
         SMS_TYPE: 'db-sms',
@@ -156,12 +149,8 @@ def send_notification_to_persist_queue(
             str(service.id),
             notification_id,
             encrypted,
-            datetime.utcnow().strftime(DATETIME_FORMAT),
+            datetime.utcnow().strftime(DATETIME_FORMAT)
         ),
-        kwargs={
-            'api_key_id': api_key_id,
-            'key_type': key_type
-        },
         queue=queue_name
     )
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -5,7 +5,6 @@ from flask import current_app
 from app import redis_store
 from app.celery import provider_tasks
 from notifications_utils.clients import redis
-
 from app.dao.notifications_dao import dao_create_notification, dao_delete_notifications_and_history_by_id
 from app.models import SMS_TYPE, Notification, KEY_TYPE_TEST, EMAIL_TYPE
 from app.v2.errors import BadRequestError, SendNotificationToQueueError
@@ -38,9 +37,7 @@ def persist_notification(template_id,
                          job_row_number=None,
                          reference=None,
                          notification_id=None,
-                         simulated=False,
-                         persist=True):
-
+                         simulated=False):
     # if simulated create a Notification model to return but do not persist the Notification to the dB
     notification = Notification(
         id=notification_id,
@@ -59,8 +56,7 @@ def persist_notification(template_id,
         client_reference=reference
     )
     if not simulated:
-        if persist:
-            dao_create_notification(notification)
+        dao_create_notification(notification)
         if redis_store.get(redis.daily_limit_cache_key(service.id)):
             redis_store.incr(redis.daily_limit_cache_key(service.id))
         if redis_store.get_all_from_hash(cache_key_for_service_template_counter(service.id)):

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -147,14 +147,12 @@ def send_notification(notification_type):
 
     if not simulated:
         tasks.send_notification_to_persist_queue(
-            notification_id=notification_model.id,
-            service=service,
-            template_type=template.template_type,
-            encrypted=encrypted,
-            api_key_id=str(notification_model.api_key_id),
-            key_type=api_user.key_type,
-            priority=template.process_type == PRIORITY,
-            research_mode=service.research_mode or api_user.key_type == KEY_TYPE_TEST
+            notification_model.id,
+            service,
+            template.template_type,
+            encrypted,
+            template.process_type == PRIORITY,
+            service.research_mode or api_user.key_type == KEY_TYPE_TEST
         )
         # queue_name = 'notify' if template.process_type == PRIORITY else None
         # send_notification_to_queue(notification=notification_model,

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -68,14 +68,12 @@ def post_notification(notification_type):
 
     if not simulated:
         tasks.send_notification_to_persist_queue(
-            notification_id=notification.id,
-            service=service,
-            template_type=template.template_type,
-            encrypted=encrypted,
-            api_key_id=str(notification.api_key_id),
-            key_type=api_user.key_type,
-            priority=template.process_type == PRIORITY,
-            research_mode=service.research_mode or api_user.key_type == KEY_TYPE_TEST
+            notification.id,
+            service,
+            template.template_type,
+            encrypted,
+            template.process_type == PRIORITY,
+            service.research_mode or api_user.key_type == KEY_TYPE_TEST
         )
         # not doing this during paas migration
         # queue_name = 'notify' if template.process_type == PRIORITY else None

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -1,10 +1,9 @@
 from flask import request, jsonify, current_app
 from sqlalchemy.orm.exc import NoResultFound
 
-from app import api_user, encryption, create_uuid
-from app.celery import tasks
+from app import api_user
 from app.dao import services_dao, templates_dao
-from app.models import SMS_TYPE, EMAIL_TYPE, PRIORITY, KEY_TYPE_TEST
+from app.models import SMS_TYPE, EMAIL_TYPE, PRIORITY
 from app.notifications.process_notifications import (create_content_for_notification,
                                                      persist_notification,
                                                      send_notification_to_queue,
@@ -40,44 +39,19 @@ def post_notification(notification_type):
 
     # Do not persist or send notification to the queue if it is a simulated recipient
     simulated = simulated_recipient(send_to, notification_type)
-    notification = persist_notification(
-        notification_id=create_uuid(),
-        template_id=template.id,
-        template_version=template.version,
-        recipient=send_to,
-        service=service,
-        personalisation=form.get('personalisation', {}),
-        notification_type=notification_type,
-        api_key_id=api_user.id,
-        key_type=api_user.key_type,
-        reference=form.get('reference', None),
-        simulated=simulated,
-        persist=False)
-
-    notification_data = {
-        'template': str(template.id),
-        'template_version': template.version,
-        'to': send_to
-    }
-    if notification.personalisation:
-        notification_data.update({
-            'personalisation': dict(notification.personalisation)
-        })
-
-    encrypted = encryption.encrypt(notification_data)
-
+    notification = persist_notification(template_id=template.id,
+                                        template_version=template.version,
+                                        recipient=send_to,
+                                        service=service,
+                                        personalisation=form.get('personalisation', None),
+                                        notification_type=notification_type,
+                                        api_key_id=api_user.id,
+                                        key_type=api_user.key_type,
+                                        reference=form.get('reference', None),
+                                        simulated=simulated)
     if not simulated:
-        tasks.send_notification_to_persist_queue(
-            notification.id,
-            service,
-            template.template_type,
-            encrypted,
-            template.process_type == PRIORITY,
-            service.research_mode or api_user.key_type == KEY_TYPE_TEST
-        )
-        # not doing this during paas migration
-        # queue_name = 'notify' if template.process_type == PRIORITY else None
-        # send_notification_to_queue(notification=notification, research_mode=service.research_mode, queue=queue_name)
+        queue_name = 'notify' if template.process_type == PRIORITY else None
+        send_notification_to_queue(notification=notification, research_mode=service.research_mode, queue=queue_name)
     else:
         current_app.logger.info("POST simulated notification for id: {}".format(notification.id))
     if notification_type == SMS_TYPE:

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -104,9 +104,7 @@ def test_send_notification_invalid_template_id(notify_api, sample_template, mock
 def test_send_notification_with_placeholders_replaced(notify_api, sample_email_template_with_placeholders, mocker):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
-            mocked = mocker.patch('app.celery.tasks.send_email.apply_async')
-            mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
-            mocker.patch('app.encryption.decrypt', return_value={"key": "something_encrypted"})
+            mocked = mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
 
             data = {
                 'to': 'ok@ok.com',
@@ -127,13 +125,8 @@ def test_send_notification_with_placeholders_replaced(notify_api, sample_email_t
             data.update({"template_version": sample_email_template_with_placeholders.version})
 
             mocked.assert_called_once_with(
-                (
-                    str(sample_email_template_with_placeholders.service.id),
-                    notification_id,
-                    "something_encrypted",
-                    '2016-01-01T11:09:00.061258Z'
-                ),
-                queue="db-email"
+                [notification_id],
+                queue="send-email"
             )
             assert response.status_code == 201
             assert response_data['body'] == u'Hello Jo\nThis is an email from GOV.\u200BUK'
@@ -206,7 +199,7 @@ def test_should_send_notification_if_restricted_and_a_service_user(notify_api,
                                                                    mocker):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
-            mocked = mocker.patch('app.celery.tasks.send_{}.apply_async'.format(template_type))
+            mocked = mocker.patch('app.celery.provider_tasks.deliver_{}.apply_async'.format(template_type))
 
             template = sample_template if template_type == 'sms' else sample_email_template
             to = template.service.created_by.mobile_number if template_type == 'sms' \
@@ -267,7 +260,7 @@ def test_should_not_allow_template_from_another_service(notify_api,
 def test_should_allow_valid_sms_notification(notify_api, sample_template, mocker):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
-            mocked = mocker.patch('app.celery.tasks.send_sms.apply_async')
+            mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
             mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
 
             data = {
@@ -285,12 +278,7 @@ def test_should_allow_valid_sms_notification(notify_api, sample_template, mocker
             response_data = json.loads(response.data)['data']
             notification_id = response_data['notification']['id']
 
-            mocked.assert_called_once_with(
-                (str(sample_template.service.id),
-                 notification_id,
-                 "something_encrypted",
-                 '2016-01-01T11:09:00.061258Z'),
-                queue='db-sms')
+            mocked.assert_called_once_with([notification_id], queue='send-sms')
             assert response.status_code == 201
             assert notification_id
             assert 'subject' not in response_data
@@ -321,11 +309,11 @@ def test_should_reject_email_notification_with_bad_email(notify_api, sample_emai
             assert data['message']['to'][0] == 'Not a valid email address'
 
 
-@freeze_time("2016-01-01 11:00:00.000000")
+@freeze_time("2016-01-01 11:09:00.061258")
 def test_should_allow_valid_email_notification(notify_api, sample_email_template, mocker):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
-            mocker.patch('app.celery.tasks.send_email.apply_async')
+            mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
             mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
 
             data = {
@@ -342,15 +330,9 @@ def test_should_allow_valid_email_notification(notify_api, sample_email_template
             assert response.status_code == 201
             response_data = json.loads(response.get_data(as_text=True))['data']
             notification_id = response_data['notification']['id']
-            app.celery.tasks.send_email.apply_async.assert_called_once_with(
-                (
-                    str(sample_email_template.service.id),
-                    notification_id,
-                    "something_encrypted",
-                    '2016-01-01T11:00:00.000000Z'
-
-                ),
-                queue="db-email"
+            app.celery.provider_tasks.deliver_email.apply_async.assert_called_once_with(
+                [notification_id],
+                queue="send-email"
             )
 
             assert response.status_code == 201
@@ -436,7 +418,7 @@ def test_should_allow_api_call_if_under_day_limit_regardless_of_type(
         restricted):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
-            mocker.patch('app.celery.tasks.send_sms.apply_async')
+            mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
             mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
 
             service = create_sample_service(notify_db, notify_db_session, limit=2, restricted=restricted)
@@ -462,7 +444,7 @@ def test_should_allow_api_call_if_under_day_limit_regardless_of_type(
 def test_should_not_return_html_in_body(notify_api, notify_db, notify_db_session, mocker):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
-            mocker.patch('app.celery.tasks.send_email.apply_async')
+            mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
             email_template = create_sample_email_template(notify_db, notify_db_session, content='hello\nthere')
 
             data = {
@@ -482,7 +464,7 @@ def test_should_not_return_html_in_body(notify_api, notify_db, notify_db_session
 
 def test_should_not_send_email_if_team_api_key_and_not_a_service_user(notify_api, sample_email_template, mocker):
     with notify_api.test_request_context(), notify_api.test_client() as client:
-        mocker.patch('app.celery.tasks.send_email.apply_async')
+        mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
         data = {
             'to': "not-someone-we-trust@email-address.com",
             'template': str(sample_email_template.id),
@@ -497,15 +479,17 @@ def test_should_not_send_email_if_team_api_key_and_not_a_service_user(notify_api
 
         json_resp = json.loads(response.get_data(as_text=True))
 
-        app.celery.tasks.send_email.apply_async.assert_not_called()
+        app.celery.provider_tasks.deliver_email.apply_async.assert_not_called()
 
         assert response.status_code == 400
-        assert ['Can’t send to this recipient using a team-only API key'] == json_resp['message']['to']
+        assert [
+            'Can’t send to this recipient using a team-only API key'
+        ] == json_resp['message']['to']
 
 
 def test_should_not_send_sms_if_team_api_key_and_not_a_service_user(notify_api, sample_template, mocker):
     with notify_api.test_request_context(), notify_api.test_client() as client:
-        mocker.patch('app.celery.tasks.send_sms.apply_async')
+        mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
         data = {
             'to': '07123123123',
@@ -520,18 +504,18 @@ def test_should_not_send_sms_if_team_api_key_and_not_a_service_user(notify_api, 
             headers=[('Content-Type', 'application/json'), auth_header])
 
         json_resp = json.loads(response.get_data(as_text=True))
-        app.celery.tasks.send_sms.apply_async.assert_not_called()
+        app.celery.provider_tasks.deliver_sms.apply_async.assert_not_called()
 
         assert response.status_code == 400
-        assert ['Can’t send to this recipient using a team-only API key'] == json_resp['message']['to']
+        assert [
+            'Can’t send to this recipient using a team-only API key'
+        ] == json_resp['message']['to']
 
 
-@freeze_time("2016-01-01 11:00:00.000000")
 def test_should_send_email_if_team_api_key_and_a_service_user(notify_api, sample_email_template, fake_uuid, mocker):
     with notify_api.test_request_context(), notify_api.test_client() as client:
-        mocker.patch('app.celery.tasks.send_email.apply_async')
+        mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
         mocker.patch('app.dao.notifications_dao.create_uuid', return_value=fake_uuid)
-        mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
 
         data = {
             'to': sample_email_template.service.created_by.email_address,
@@ -548,27 +532,18 @@ def test_should_send_email_if_team_api_key_and_a_service_user(notify_api, sample
             path='/notifications/email',
             data=json.dumps(data),
             headers=[('Content-Type', 'application/json'), ('Authorization', 'Bearer {}'.format(auth_header))])
-        notification_id = json.loads(response.data)['data']['notification']['id']
 
-        app.celery.tasks.send_email.apply_async.assert_called_once_with(
-            (str(sample_email_template.service.id),
-             notification_id,
-             "something_encrypted",
-             "2016-01-01T11:00:00.000000Z"),
-            queue='db-email'
-        )
+        app.celery.provider_tasks.deliver_email.apply_async.assert_called_once_with([fake_uuid], queue='send-email')
         assert response.status_code == 201
 
 
 @pytest.mark.parametrize('restricted', [True, False])
 @pytest.mark.parametrize('limit', [0, 1])
-@freeze_time("2016-01-01 11:00:00.000000")
 def test_should_send_sms_to_anyone_with_test_key(
-        notify_api, sample_template, mocker, restricted, limit, fake_uuid
+    notify_api, sample_template, mocker, restricted, limit, fake_uuid
 ):
     with notify_api.test_request_context(), notify_api.test_client() as client:
-        mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
-        mocker.patch('app.celery.tasks.send_sms.apply_async')
+        mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
         mocker.patch('app.dao.notifications_dao.create_uuid', return_value=fake_uuid)
 
         data = {
@@ -591,23 +566,18 @@ def test_should_send_sms_to_anyone_with_test_key(
             data=json.dumps(data),
             headers=[('Content-Type', 'application/json'), ('Authorization', 'Bearer {}'.format(auth_header))]
         )
-        notification_id = json.loads(response.data)['data']['notification']['id']
-        app.celery.tasks.send_sms.apply_async.assert_called_once_with(
-            (str(sample_template.service.id), notification_id, "something_encrypted", "2016-01-01T11:00:00.000000Z"),
-            queue='research-mode'
-        )
+        app.celery.provider_tasks.deliver_sms.apply_async.assert_called_once_with([fake_uuid], queue='research-mode')
         assert response.status_code == 201
 
 
 @pytest.mark.parametrize('restricted', [True, False])
 @pytest.mark.parametrize('limit', [0, 1])
-@freeze_time("2016-01-01 11:00:00.000000")
 def test_should_send_email_to_anyone_with_test_key(
-        notify_api, sample_email_template, mocker, restricted, limit, fake_uuid
+    notify_api, sample_email_template, mocker, restricted, limit, fake_uuid
 ):
     with notify_api.test_request_context(), notify_api.test_client() as client:
-        mocker.patch('app.celery.tasks.send_email.apply_async')
-        mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
+        mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
+        mocker.patch('app.dao.notifications_dao.create_uuid', return_value=fake_uuid)
 
         data = {
             'to': 'anyone123@example.com',
@@ -629,23 +599,15 @@ def test_should_send_email_to_anyone_with_test_key(
             data=json.dumps(data),
             headers=[('Content-Type', 'application/json'), ('Authorization', 'Bearer {}'.format(auth_header))]
         )
-        notification_id = json.loads(response.data)['data']['notification']['id']
-        app.celery.tasks.send_email.apply_async.assert_called_once_with(
-            (str(sample_email_template.service.id),
-             notification_id,
-             "something_encrypted",
-             "2016-01-01T11:00:00.000000Z"),
-            queue='research-mode'
-        )
+
+        app.celery.provider_tasks.deliver_email.apply_async.assert_called_once_with([fake_uuid], queue='research-mode')
         assert response.status_code == 201
 
 
-@freeze_time("2016-01-01 11:00:00.000000")
 def test_should_send_sms_if_team_api_key_and_a_service_user(notify_api, sample_template, fake_uuid, mocker):
     with notify_api.test_request_context(), notify_api.test_client() as client:
-        mocker.patch('app.celery.tasks.send_sms.apply_async')
+        mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
         mocker.patch('app.dao.notifications_dao.create_uuid', return_value=fake_uuid)
-        mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
 
         data = {
             'to': sample_template.service.created_by.mobile_number,
@@ -663,28 +625,18 @@ def test_should_send_sms_if_team_api_key_and_a_service_user(notify_api, sample_t
             data=json.dumps(data),
             headers=[('Content-Type', 'application/json'), ('Authorization', 'Bearer {}'.format(auth_header))])
 
-        notification_id = json.loads(response.data)['data']['notification']['id']
-        app.celery.tasks.send_sms.apply_async.assert_called_once_with(
-            (str(sample_template.service.id),
-             notification_id,
-             "something_encrypted",
-             "2016-01-01T11:00:00.000000Z"),
-            queue='db-sms'
-        )
+        app.celery.provider_tasks.deliver_sms.apply_async.assert_called_once_with([fake_uuid], queue='send-sms')
         assert response.status_code == 201
 
 
 @pytest.mark.parametrize('template_type',
                          ['sms', 'email'])
-@freeze_time("2016-01-01 11:00:00.000000")
 def test_should_persist_notification(notify_api, sample_template,
                                      sample_email_template,
                                      template_type,
                                      fake_uuid, mocker):
     with notify_api.test_request_context(), notify_api.test_client() as client:
-        mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
-
-        mocked = mocker.patch('app.celery.tasks.send_{}.apply_async'.format(template_type))
+        mocked = mocker.patch('app.celery.provider_tasks.deliver_{}.apply_async'.format(template_type))
         mocker.patch('app.dao.notifications_dao.create_uuid', return_value=fake_uuid)
         template = sample_template if template_type == 'sms' else sample_email_template
         to = sample_template.service.created_by.mobile_number if template_type == 'sms' \
@@ -706,19 +658,17 @@ def test_should_persist_notification(notify_api, sample_template,
             data=json.dumps(data),
             headers=[('Content-Type', 'application/json'), ('Authorization', 'Bearer {}'.format(auth_header))])
 
-        notification_id = json.loads(response.data)['data']['notification']['id']
-
-        mocked.assert_called_once_with(
-            (str(template.service.id), notification_id, "something_encrypted", '2016-01-01T11:00:00.000000Z'),
-            queue='db-{}'.format(template_type))
+        mocked.assert_called_once_with([fake_uuid], queue='send-{}'.format(template_type))
         assert response.status_code == 201
 
-        assert not notifications_dao.get_notification_by_id(fake_uuid)
+        notification = notifications_dao.get_notification_by_id(fake_uuid)
+        assert notification.to == to
+        assert notification.template_id == template.id
+        assert notification.notification_type == template_type
 
 
 @pytest.mark.parametrize('template_type',
                          ['sms', 'email'])
-@pytest.mark.skip(reason="This is not required for the duration of PaaS migration")
 def test_should_delete_notification_and_return_error_if_sqs_fails(
         client,
         sample_email_template,
@@ -820,7 +770,8 @@ def test_should_not_persist_notification_or_send_sms_if_simulated_number(
 ])
 @pytest.mark.parametrize('notification_type, to, _create_sample_template', [
     ('sms', '07827992635', create_sample_template),
-    ('email', 'non_whitelist_recipient@mail.com', create_sample_email_template)])
+    ('email', 'non_whitelist_recipient@mail.com', create_sample_email_template)]
+)
 def test_should_not_send_notification_to_non_whitelist_recipient_in_trial_mode(
     client,
     notify_db,
@@ -874,20 +825,21 @@ def test_should_not_send_notification_to_non_whitelist_recipient_in_trial_mode(
 ])
 @pytest.mark.parametrize('notification_type, to, _create_sample_template', [
     ('sms', '07123123123', create_sample_template),
-    ('email', 'whitelist_recipient@mail.com', create_sample_email_template)])
+    ('email', 'whitelist_recipient@mail.com', create_sample_email_template)]
+)
 def test_should_send_notification_to_whitelist_recipient(
-        client,
-        notify_db,
-        notify_db_session,
-        notification_type,
-        to,
-        _create_sample_template,
-        key_type,
-        service_restricted,
-        mocker
+    client,
+    notify_db,
+    notify_db_session,
+    notification_type,
+    to,
+    _create_sample_template,
+    key_type,
+    service_restricted,
+    mocker
 ):
     service = create_sample_service(notify_db, notify_db_session, limit=2, restricted=service_restricted)
-    apply_async = mocker.patch('app.celery.tasks.send_{}.apply_async'.format(notification_type))
+    apply_async = mocker.patch('app.celery.provider_tasks.deliver_{}.apply_async'.format(notification_type))
     template = _create_sample_template(notify_db, notify_db_session, service=service)
     if notification_type == 'sms':
         service_whitelist = create_sample_service_whitelist(notify_db, notify_db_session,
@@ -1007,7 +959,6 @@ def test_create_template_raises_invalid_request_when_content_too_large(
 @pytest.mark.parametrize("notification_type, send_to",
                          [("sms", "07700 900 855"),
                           ("email", "sample@email.com")])
-@freeze_time("2016-01-01 11:00:00.000000")
 def test_send_notification_uses_priority_queue_when_template_is_marked_as_priority(client, notify_db,
                                                                                    notify_db_session, mocker,
                                                                                    notification_type, send_to):
@@ -1017,8 +968,7 @@ def test_send_notification_uses_priority_queue_when_template_is_marked_as_priori
         template_type=notification_type,
         process_type='priority'
     )
-    mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
-    mocked = mocker.patch('app.celery.tasks.send_{}.apply_async'.format(notification_type))
+    mocked = mocker.patch('app.celery.provider_tasks.deliver_{}.apply_async'.format(notification_type))
 
     data = {
         'to': send_to,
@@ -1036,6 +986,4 @@ def test_send_notification_uses_priority_queue_when_template_is_marked_as_priori
     notification_id = response_data['notification']['id']
 
     assert response.status_code == 201
-    mocked.assert_called_once_with(
-        (str(sample.service_id), notification_id, "something_encrypted", '2016-01-01T11:00:00.000000Z'), queue='notify'
-    )
+    mocked.assert_called_once_with([notification_id], queue='notify')

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -1,9 +1,8 @@
 import random
 import string
-from datetime import datetime
-from unittest.mock import ANY
-
 import pytest
+from datetime import datetime
+
 from flask import (json, current_app)
 from freezegun import freeze_time
 from notifications_python_client.authentication import create_jwt_token
@@ -134,7 +133,6 @@ def test_send_notification_with_placeholders_replaced(notify_api, sample_email_t
                     "something_encrypted",
                     '2016-01-01T11:09:00.061258Z'
                 ),
-                kwargs=ANY,
                 queue="db-email"
             )
             assert response.status_code == 201
@@ -292,7 +290,6 @@ def test_should_allow_valid_sms_notification(notify_api, sample_template, mocker
                  notification_id,
                  "something_encrypted",
                  '2016-01-01T11:09:00.061258Z'),
-                kwargs=ANY,
                 queue='db-sms')
             assert response.status_code == 201
             assert notification_id
@@ -351,8 +348,8 @@ def test_should_allow_valid_email_notification(notify_api, sample_email_template
                     notification_id,
                     "something_encrypted",
                     '2016-01-01T11:00:00.000000Z'
+
                 ),
-                kwargs=ANY,
                 queue="db-email"
             )
 
@@ -558,10 +555,6 @@ def test_should_send_email_if_team_api_key_and_a_service_user(notify_api, sample
              notification_id,
              "something_encrypted",
              "2016-01-01T11:00:00.000000Z"),
-            kwargs={
-                'api_key_id': str(api_key.id),
-                'key_type': KEY_TYPE_TEAM
-            },
             queue='db-email'
         )
         assert response.status_code == 201
@@ -601,10 +594,6 @@ def test_should_send_sms_to_anyone_with_test_key(
         notification_id = json.loads(response.data)['data']['notification']['id']
         app.celery.tasks.send_sms.apply_async.assert_called_once_with(
             (str(sample_template.service.id), notification_id, "something_encrypted", "2016-01-01T11:00:00.000000Z"),
-            kwargs={
-                'api_key_id': str(api_key.id),
-                'key_type': KEY_TYPE_TEST
-            },
             queue='research-mode'
         )
         assert response.status_code == 201
@@ -646,10 +635,6 @@ def test_should_send_email_to_anyone_with_test_key(
              notification_id,
              "something_encrypted",
              "2016-01-01T11:00:00.000000Z"),
-            kwargs={
-                'api_key_id': str(api_key.id),
-                'key_type': KEY_TYPE_TEST
-            },
             queue='research-mode'
         )
         assert response.status_code == 201
@@ -684,10 +669,6 @@ def test_should_send_sms_if_team_api_key_and_a_service_user(notify_api, sample_t
              notification_id,
              "something_encrypted",
              "2016-01-01T11:00:00.000000Z"),
-            kwargs={
-                'api_key_id': str(api_key.id),
-                'key_type': KEY_TYPE_TEAM
-            },
             queue='db-sms'
         )
         assert response.status_code == 201
@@ -729,7 +710,6 @@ def test_should_persist_notification(notify_api, sample_template,
 
         mocked.assert_called_once_with(
             (str(template.service.id), notification_id, "something_encrypted", '2016-01-01T11:00:00.000000Z'),
-            kwargs=ANY,
             queue='db-{}'.format(template_type))
         assert response.status_code == 201
 
@@ -1057,7 +1037,5 @@ def test_send_notification_uses_priority_queue_when_template_is_marked_as_priori
 
     assert response.status_code == 201
     mocked.assert_called_once_with(
-        (str(sample.service_id), notification_id, "something_encrypted", '2016-01-01T11:00:00.000000Z'),
-        kwargs=ANY,
-        queue='notify'
+        (str(sample.service_id), notification_id, "something_encrypted", '2016-01-01T11:00:00.000000Z'), queue='notify'
     )

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -77,34 +77,6 @@ def test_persist_notification_creates_and_save_to_db(sample_template, sample_api
     mocked_redis.assert_called_once_with(str(sample_template.service_id) + "-2016-01-01-count")
 
 
-@freeze_time("2016-01-01 11:09:00.061258")
-def test_persist_notification_does_not_create_and_save_to_db_if_persist_is_false(
-        sample_template, sample_api_key, sample_job, mocker
-):
-    mocked_redis = mocker.patch('app.notifications.process_notifications.redis_store.get')
-
-    assert Notification.query.count() == 0
-    assert NotificationHistory.query.count() == 0
-    persist_notification(
-        sample_template.id,
-        sample_template.version,
-        '+447111111111',
-        sample_template.service,
-        {},
-        'sms',
-        sample_api_key.id,
-        sample_api_key.key_type,
-        job_id=sample_job.id,
-        job_row_number=100,
-        reference="ref",
-        persist=False)
-
-    assert Notification.query.count() == 0
-    assert NotificationHistory.query.count() == 0
-
-    mocked_redis.assert_called_once_with(str(sample_template.service_id) + "-2016-01-01-count")
-
-
 def test_persist_notification_throws_exception_when_missing_template(sample_api_key):
     assert Notification.query.count() == 0
     assert NotificationHistory.query.count() == 0

--- a/tests/app/public_contracts/test_POST_notification.py
+++ b/tests/app/public_contracts/test_POST_notification.py
@@ -20,7 +20,7 @@ def _post_notification(client, template, url, to):
 
 
 def test_post_sms_contract(client, mocker, sample_template):
-    mocker.patch('app.celery.tasks.send_sms.apply_async')
+    mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
     mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
 
     response_json = return_json_from_response(_post_notification(
@@ -30,7 +30,7 @@ def test_post_sms_contract(client, mocker, sample_template):
 
 
 def test_post_email_contract(client, mocker, sample_email_template):
-    mocker.patch('app.celery.tasks.send_email.apply_async')
+    mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
     mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
 
     response_json = return_json_from_response(_post_notification(

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1,14 +1,10 @@
 import uuid
-from unittest.mock import ANY
-
 import pytest
 from flask import json
-from freezegun import freeze_time
-
 from app.models import Notification
-
 from tests import create_authorization_header
 from tests.app.conftest import sample_template as create_sample_template
+from freezegun import freeze_time
 
 
 @pytest.mark.parametrize("reference", [None, "reference_from_client"])
@@ -224,7 +220,5 @@ def test_send_notification_uses_priority_queue_when_template_is_marked_as_priori
     print(response.data)
     assert response.status_code == 201
     mocked.assert_called_once_with(
-        (str(sample.service_id), notification_id, 'something_encrypted', '2016-01-01T11:00:00.000000Z'),
-        kwargs=ANY,
-        queue='notify'
+        (str(sample.service_id), notification_id, 'something_encrypted', '2016-01-01T11:00:00.000000Z'), queue='notify'
     )


### PR DESCRIPTION
[DO NOT MERGE - going to do some testing. Review welcome though]

This removes 2 pull requests

1) the code that places an API notification in the DB task queue prior to persistance. This was needed for a no-downtime deploy of the new hosting platform.

2) the api key bug fix that patched an error in (1) that caused an issue in sending test messages.