### PR TITLE
Pass through contact block from service to outputted letter

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -273,7 +273,7 @@ def build_dvla_file(self, job_id):
                     notification.personalisation,
                     # This unique id is a 7 digits requested by DVLA, not known
                     # if this number needs to be sequential.
-                    numeric_id=int(''.join(map(str, random.sample(range(9), 7)))),
+                    numeric_id=random.randint(1, int('9' * 7)),
                 ))
                 for notification in dao_get_all_notifications_for_job(job_id)
             )

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -274,6 +274,7 @@ def build_dvla_file(self, job_id):
                     # This unique id is a 7 digits requested by DVLA, not known
                     # if this number needs to be sequential.
                     numeric_id=random.randint(1, int('9' * 7)),
+                    contact_block=notification.service.letter_contact_block,
                 ))
                 for notification in dao_get_all_notifications_for_job(job_id)
             )

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -267,18 +267,22 @@ def persist_letter(
 def build_dvla_file(self, job_id):
     try:
         if all_notifications_are_created_for_job(job_id):
-            notifications = dao_get_all_notifications_for_job(job_id)
-            file = ""
-            for n in notifications:
-                t = {"content": n.template.content, "subject": n.template.subject}
-                # This unique id is a 7 digits requested by DVLA, not known if this number needs to be sequential.
-                unique_id = int(''.join(map(str, random.sample(range(9), 7))))
-                template = LetterDVLATemplate(t, n.personalisation, unique_id)
-                file = file + str(template) + "\n"
-            s3upload(filedata=file,
-                     region=current_app.config['AWS_REGION'],
-                     bucket_name=current_app.config['DVLA_UPLOAD_BUCKET_NAME'],
-                     file_location="{}-dvla-job.text".format(job_id))
+            file_contents = '\n'.join(
+                str(LetterDVLATemplate(
+                    notification.template.__dict__,
+                    notification.personalisation,
+                    # This unique id is a 7 digits requested by DVLA, not known
+                    # if this number needs to be sequential.
+                    numeric_id=int(''.join(map(str, random.sample(range(9), 7)))),
+                ))
+                for notification in dao_get_all_notifications_for_job(job_id)
+            )
+            s3upload(
+                filedata=file_contents + '\n',
+                region=current_app.config['AWS_REGION'],
+                bucket_name=current_app.config['DVLA_UPLOAD_BUCKET_NAME'],
+                file_location="{}-dvla-job.text".format(job_id)
+            )
         else:
             current_app.logger.info("All notifications for job {} are not persisted".format(job_id))
             self.retry(queue="retry", exc="All notifications for job {} are not persisted".format(job_id))

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -994,6 +994,7 @@ def test_build_dvla_file(sample_letter_template, mocker):
 
     # Named arguments
     assert mocked_letter_template.call_args[1]['numeric_id'] == 999
+    assert mocked_letter_template.call_args[1]['contact_block'] == 'London,\nSW1A 1AA'
 
 
 def test_build_dvla_file_retries_if_all_notifications_are_not_created(sample_letter_template, mocker):

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -971,17 +971,29 @@ def test_build_dvla_file(sample_letter_template, mocker):
     create_notification(template=job.template, job=job)
     create_notification(template=job.template, job=job)
 
-    mocked = mocker.patch("app.celery.tasks.s3upload")
-    mocker.patch("app.celery.tasks.LetterDVLATemplate.__str__", return_value="dvla|string")
+    mocker.patch("app.celery.tasks.random.randint", return_value=999)
+    mocked_upload = mocker.patch("app.celery.tasks.s3upload")
+    mocked_letter_template = mocker.patch("app.celery.tasks.LetterDVLATemplate")
+    mocked_letter_template_instance = mocked_letter_template.return_value
+    mocked_letter_template_instance.__str__.return_value = "dvla|string"
     build_dvla_file(job.id)
 
-    file = "dvla|string\ndvla|string\n"
+    mocked_upload.assert_called_once_with(
+        filedata="dvla|string\ndvla|string\n",
+        region=current_app.config['AWS_REGION'],
+        bucket_name=current_app.config['DVLA_UPLOAD_BUCKET_NAME'],
+        file_location="{}-dvla-job.text".format(job.id)
+    )
 
-    assert mocked.called
-    mocked.assert_called_once_with(filedata=file,
-                                   region=current_app.config['AWS_REGION'],
-                                   bucket_name=current_app.config['DVLA_UPLOAD_BUCKET_NAME'],
-                                   file_location="{}-dvla-job.text".format(job.id))
+    # Template
+    assert mocked_letter_template.call_args[0][0]['subject'] == 'Template subject'
+    assert mocked_letter_template.call_args[0][0]['content'] == 'Dear Sir/Madam, Hello. Yours Truly, The Government.'
+
+    # Personalisation
+    assert mocked_letter_template.call_args[0][1] is None
+
+    # Named arguments
+    assert mocked_letter_template.call_args[1]['numeric_id'] == 999
 
 
 def test_build_dvla_file_retries_if_all_notifications_are_not_created(sample_letter_template, mocker):

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -134,7 +134,8 @@ def sample_service(
         'message_limit': limit,
         'restricted': restricted,
         'email_from': email_from,
-        'created_by': user
+        'created_by': user,
+        'letter_contact_block': 'London,\nSW1A 1AA',
     }
     service = Service.query.filter_by(name=service_name).first()
     if not service:


### PR DESCRIPTION
Whatever a user has entered for their service’s contact block should appear in the right place in the file we give to DVLA.

The work to output in the right fields in the DVLA file has already been done. We just weren’t passing it through. This commit passes it through.

***

This is a very simple change (see e47a008) but there’s a bit more refactoring and adding tests behind it that make this pull request larger.

Specifically on the changed way of generating random numbers, I wanted to make sure that they were still evenly distributed. To check this I generated a list of 1000 using both the old and new methods, then sorted and graphed them. Distribution looks pretty even to me:

![image](https://cloud.githubusercontent.com/assets/355079/24609173/b32250d0-1871-11e7-958a-86d4dfcb05d8.png)
