### PR TITLE
Add fix for bst

### DIFF
--- a/app/clients/performance_platform/performance_platform_client.py
+++ b/app/clients/performance_platform/performance_platform_client.py
@@ -1,13 +1,11 @@
 import base64
 import json
+from datetime import datetime, timedelta
+
 import requests
-from datetime import datetime
 from flask import current_app
 
-from app.utils import (
-    get_midnight_for_day_before,
-    get_london_midnight_in_utc
-)
+from app.utils import get_midnight_for_day_before, get_london_midnight_in_utc, get_utc_time_in_bst
 
 
 class PerformancePlatformClient:
@@ -29,7 +27,7 @@ class PerformancePlatformClient:
     def send_performance_stats(self, date, channel, count, period):
         if self.active:
             payload = {
-                '_timestamp': date.isoformat(),
+                '_timestamp': get_utc_time_in_bst(date).isoformat(),
                 'service': 'govuk-notify',
                 'channel': channel,
                 'count': count,
@@ -45,14 +43,16 @@ class PerformancePlatformClient:
         end_date = get_london_midnight_in_utc(today)
 
         from app.dao.notifications_dao import get_total_sent_notifications_in_date_range
+        email_count = get_total_sent_notifications_in_date_range(start_date, end_date, 'email')
+        sms_count = get_total_sent_notifications_in_date_range(start_date, end_date, 'sms')
+
         return {
             "start_date": start_date,
-            "end_date": end_date,
             "email": {
-                "count": get_total_sent_notifications_in_date_range(start_date, end_date, 'email')
+                "count": email_count
             },
             "sms": {
-                "count": get_total_sent_notifications_in_date_range(start_date, end_date, 'sms')
+                "count": sms_count
             }
         }
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -5,6 +5,8 @@ from flask import url_for
 from sqlalchemy import func
 from notifications_utils.template import SMSMessageTemplate, PlainTextEmailTemplate, LetterPreviewTemplate
 
+local_timezone = pytz.timezone("Europe/London")
+
 
 def pagination_links(pagination, endpoint, **kwargs):
     if 'page' in kwargs:
@@ -39,7 +41,7 @@ def get_london_midnight_in_utc(date):
      :param date: the day to calculate the London midnight in UTC for
      :return: the datetime of London midnight in UTC, for example 2016-06-17 = 2016-06-17 23:00:00
     """
-    return pytz.timezone('Europe/London').localize(datetime.combine(date, datetime.min.time())).astimezone(
+    return local_timezone.localize(datetime.combine(date, datetime.min.time())).astimezone(
         pytz.UTC).replace(
         tzinfo=None)
 
@@ -47,6 +49,10 @@ def get_london_midnight_in_utc(date):
 def get_midnight_for_day_before(date):
     day_before = date - timedelta(1)
     return get_london_midnight_in_utc(day_before)
+
+
+def get_utc_time_in_bst(utc_dt):
+    return utc_dt.replace(tzinfo=pytz.utc).astimezone(local_timezone).replace(tzinfo=None)
 
 
 def get_london_month_from_utc_column(column):

--- a/app/utils.py
+++ b/app/utils.py
@@ -52,7 +52,7 @@ def get_midnight_for_day_before(date):
 
 
 def get_utc_time_in_bst(utc_dt):
-    return utc_dt.replace(tzinfo=pytz.utc).astimezone(local_timezone).replace(tzinfo=None)
+    return pytz.utc.localize(utc_dt).astimezone(local_timezone).replace(tzinfo=None)
 
 
 def get_london_month_from_utc_column(column):

--- a/tests/app/clients/test_performance_platform.py
+++ b/tests/app/clients/test_performance_platform.py
@@ -57,7 +57,7 @@ def test_send_platform_stats_creates_correct_call(notify_api, client):
             status_code=200
         )
         client.send_performance_stats(
-            date=datetime(2016, 10, 16, 0, 0, 0),
+            date=datetime(2016, 10, 15, 23, 0, 0),
             channel='sms',
             count=142,
             period='day'

--- a/tests/app/clients/test_performance_platform.py
+++ b/tests/app/clients/test_performance_platform.py
@@ -110,7 +110,6 @@ def test_get_total_sent_notifications_yesterday_returns_expected_totals_dict(
 
     assert total_count_dict == {
         "start_date": get_midnight_for_day_before(datetime.utcnow()),
-        "end_date": get_london_midnight_in_utc(datetime.utcnow()),
         "email": {
             "count": 3
         },

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -3,7 +3,8 @@ import pytest
 
 from app.utils import (
     get_london_midnight_in_utc,
-    get_midnight_for_day_before
+    get_midnight_for_day_before,
+    get_utc_time_in_bst
 )
 
 
@@ -23,3 +24,15 @@ def test_get_london_midnight_in_utc_returns_expected_date(date, expected_date):
 ])
 def test_get_midnight_for_day_before_returns_expected_date(date, expected_date):
     assert get_midnight_for_day_before(date) == expected_date
+
+
+@pytest.mark.parametrize('date, expected_date', [
+    (datetime(2017, 3, 26, 23, 0), datetime(2017, 3, 27, 0, 0)),    # 2017 BST switchover
+    (datetime(2017, 3, 20, 23, 0), datetime(2017, 3, 20, 23, 0)),
+    (datetime(2017, 3, 28, 10, 0), datetime(2017, 3, 28, 11, 0)),
+    (datetime(2017, 10, 28, 1, 0), datetime(2017, 10, 28, 2, 0)),
+    (datetime(2017, 10, 29, 1, 0), datetime(2017, 10, 29, 1, 0)),
+])
+def test_get_utc_in_bst_returns_expected_date(date, expected_date):
+    ret_date = get_utc_time_in_bst(date)
+    assert ret_date == expected_date


### PR DESCRIPTION
## What

Problem after BST time change, this fix will ensure that the performance platform will get the correct stats as the performance platform doesn't change UTC to BST.

## How to review

Tests have been added to handle conversion from UTC to BST for performance platform POSTs

py.test -k test_get_utc_in_bst_returns_expected_date /tests
