### PR TITLE
Update scheduled jobs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -190,6 +190,7 @@ class Development(Config):
     SQLALCHEMY_ECHO = False
     CELERY_QUEUES = Config.CELERY_QUEUES + [
         Queue('db-sms', Exchange('default'), routing_key='db-sms'),
+        Queue('priority', Exchange('default'), routing_key='priority'),
         Queue('periodic', Exchange('default'), routing_key='periodic'),
         Queue('db-email', Exchange('default'), routing_key='db-email'),
         Queue('db-letter', Exchange('default'), routing_key='db-letter'),
@@ -211,6 +212,7 @@ class Test(Config):
     STATSD_PORT = 1000
     CELERY_QUEUES = Config.CELERY_QUEUES + [
         Queue('periodic', Exchange('default'), routing_key='periodic'),
+        Queue('priority', Exchange('default'), routing_key='priority'),
         Queue('db-sms', Exchange('default'), routing_key='db-sms'),
         Queue('db-email', Exchange('default'), routing_key='db-email'),
         Queue('db-letter', Exchange('default'), routing_key='db-letter'),

--- a/app/config.py
+++ b/app/config.py
@@ -119,17 +119,17 @@ class Config(object):
         },
         'delete-failed-notifications': {
             'task': 'delete-failed-notifications',
-            'schedule': crontab(minute=15, hour='0,1,2'),
+            'schedule': crontab(minute=0, hour=0),
             'options': {'queue': 'periodic'}
         },
         'delete-successful-notifications': {
             'task': 'delete-successful-notifications',
-            'schedule': crontab(minute=0, hour='0,1,2'),
+            'schedule': crontab(minute=0, hour=1),
             'options': {'queue': 'periodic'}
         },
         'send-daily-performance-platform-stats': {
             'task': 'send-daily-performance-platform-stats',
-            'schedule': crontab(minute=0, hour=4),  # 04:00
+            'schedule': crontab(minute=0, hour=2),
             'options': {'queue': 'periodic'}
         },
         'switch-current-sms-provider-on-slow-delivery': {
@@ -139,17 +139,16 @@ class Config(object):
         },
         'timeout-sending-notifications': {
             'task': 'timeout-sending-notifications',
-            'schedule': crontab(minute=30, hour='0,1,2'),
+            'schedule': crontab(minute=0, hour=3),
             'options': {'queue': 'periodic'}
         },
         'remove_csv_files': {
             'task': 'remove_csv_files',
-            'schedule': crontab(minute=45, hour='0,1,2'),
+            'schedule': crontab(minute=0, hour=4),
             'options': {'queue': 'periodic'}
         }
     }
     CELERY_QUEUES = [
-        Queue('periodic', Exchange('default'), routing_key='periodic'),
         Queue('process-job', Exchange('default'), routing_key='process-job'),
         Queue('retry', Exchange('default'), routing_key='retry'),
         Queue('notify', Exchange('default'), routing_key='notify')
@@ -191,6 +190,7 @@ class Development(Config):
     SQLALCHEMY_ECHO = False
     CELERY_QUEUES = Config.CELERY_QUEUES + [
         Queue('db-sms', Exchange('default'), routing_key='db-sms'),
+        Queue('periodic', Exchange('default'), routing_key='periodic'),
         Queue('db-email', Exchange('default'), routing_key='db-email'),
         Queue('db-letter', Exchange('default'), routing_key='db-letter'),
         Queue('send-sms', Exchange('default'), routing_key='send-sms'),
@@ -210,6 +210,7 @@ class Test(Config):
     STATSD_HOST = "localhost"
     STATSD_PORT = 1000
     CELERY_QUEUES = Config.CELERY_QUEUES + [
+        Queue('periodic', Exchange('default'), routing_key='periodic'),
         Queue('db-sms', Exchange('default'), routing_key='db-sms'),
         Queue('db-email', Exchange('default'), routing_key='db-email'),
         Queue('db-letter', Exchange('default'), routing_key='db-letter'),

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -131,7 +131,7 @@ def send_notification(notification_type):
                                               key_type=api_user.key_type,
                                               simulated=simulated)
     if not simulated:
-        queue_name = 'notify' if template.process_type == PRIORITY else None
+        queue_name = 'priority' if template.process_type == PRIORITY else None
         send_notification_to_queue(notification=notification_model,
                                    research_mode=service.research_mode,
                                    queue=queue_name)

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -50,7 +50,7 @@ def post_notification(notification_type):
                                         reference=form.get('reference', None),
                                         simulated=simulated)
     if not simulated:
-        queue_name = 'notify' if template.process_type == PRIORITY else None
+        queue_name = 'priority' if template.process_type == PRIORITY else None
         send_notification_to_queue(notification=notification, research_mode=service.research_mode, queue=queue_name)
     else:
         current_app.logger.info("POST simulated notification for id: {}".format(notification.id))

--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -17,6 +17,8 @@ memory: 1G
 applications:
   - name: notify-delivery-celery-beat
     command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery beat --loglevel=INFO
+    instances: 1
+    memory: 128M
     env:
       NOTIFY_APP_NAME: delivery-celery-beat
 
@@ -37,8 +39,15 @@ applications:
 
   - name: notify-delivery-worker-periodic
     command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=2 -Q periodic
+    instances: 1
+    memory: 2G
     env:
-      NOTIFY_APP_NAME: delivery-worker
+      NOTIFY_APP_NAME: delivery-worker-periodic
+
+  - name: notify-delivery-worker-priority
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=5 -Q priority
+    env:
+      NOTIFY_APP_NAME: delivery-worker-priority
 
   - name: notify-delivery-worker
     command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11

--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -35,6 +35,11 @@ applications:
     env:
       NOTIFY_APP_NAME: delivery-worker-sender
 
+  - name: notify-delivery-worker-periodic
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=2 -Q periodic
+    env:
+      NOTIFY_APP_NAME: delivery-worker
+
   - name: notify-delivery-worker
     command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11
     env:

--- a/manifest-delivery-production.yml
+++ b/manifest-delivery-production.yml
@@ -3,4 +3,4 @@
 inherit: manifest-delivery-base.yml
 
 instances: 2
-memory: 2G
+memory: 1G

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -1022,4 +1022,4 @@ def test_send_notification_uses_priority_queue_when_template_is_marked_as_priori
     notification_id = response_data['notification']['id']
 
     assert response.status_code == 201
-    mocked.assert_called_once_with([notification_id], queue='notify')
+    mocked.assert_called_once_with([notification_id], queue='priority')

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -223,4 +223,4 @@ def test_send_notification_uses_priority_queue_when_template_is_marked_as_priori
     notification_id = json.loads(response.data)['id']
 
     assert response.status_code == 201
-    mocked.assert_called_once_with([notification_id], queue='notify')
+    mocked.assert_called_once_with([notification_id], queue='priority')


### PR DESCRIPTION
[DO NOT MERGE - Depends on an update to the jenkins build pipeline to ship the new workers that are defined here in the delivery manifests]

Couple of changes to the workers:

1) Celery beat reduced in memory and instance count. (128M and single instance)
2) New workers added for the periodic and priority queues
3) Priority templates now written to the priority queues
4) Priority and periodic queues now no longer read by default. Have specific workers.