### PR TITLE
Throw exception on long running client call

### DIFF
--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -55,7 +55,8 @@ def make_request(notification_type, provider, data, headers):
             "POST",
             api_call,
             headers=headers,
-            data=data
+            data=data,
+            timeout=5
         )
         response.raise_for_status()
     except RequestException as e:

--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -56,7 +56,7 @@ def make_request(notification_type, provider, data, headers):
             api_call,
             headers=headers,
             data=data,
-            timeout=5
+            timeout=60
         )
         response.raise_for_status()
     except RequestException as e:

--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -42,8 +42,10 @@ def get_firetext_responses(status):
 
 class FiretextClientResponseException(SmsClientResponseException):
     def __init__(self, response, exception):
-        self.status_code = response.status_code
-        self.text = response.text
+        status_code = response.status_code if response is not None else 504
+        text = response.text if response is not None else "Gateway Time-out"
+        self.status_code = status_code
+        self.text = text
         self.exception = exception
 
     def __str__(self):
@@ -68,11 +70,13 @@ class FiretextClient(SmsClient):
         return self.name
 
     def record_outcome(self, success, response):
+        status_code = response.status_code if response else 503
+
         log_message = "API {} request {} on {} response status_code {}".format(
             "POST",
             "succeeded" if success else "failed",
             self.url,
-            response.status_code
+            status_code
         )
 
         if success:

--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -97,7 +97,8 @@ class FiretextClient(SmsClient):
             response = request(
                 "POST",
                 self.url,
-                data=data
+                data=data,
+                timeout=60
             )
             response.raise_for_status()
             try:

--- a/app/notifications/notifications_sms_callback.py
+++ b/app/notifications/notifications_sms_callback.py
@@ -11,8 +11,6 @@ register_errors(sms_callback_blueprint)
 
 @sms_callback_blueprint.route('/mmg', methods=['POST'])
 def process_mmg_response():
-    from time import sleep
-    sleep(20)
     client_name = 'MMG'
     data = json.loads(request.data)
     errors = validate_callback_data(data=data,

--- a/app/notifications/notifications_sms_callback.py
+++ b/app/notifications/notifications_sms_callback.py
@@ -11,6 +11,8 @@ register_errors(sms_callback_blueprint)
 
 @sms_callback_blueprint.route('/mmg', methods=['POST'])
 def process_mmg_response():
+    from time import sleep
+    sleep(20)
     client_name = 'MMG'
     data = json.loads(request.data)
     errors = validate_callback_data(data=data,

--- a/tests/app/clients/test_firetext.py
+++ b/tests/app/clients/test_firetext.py
@@ -129,7 +129,7 @@ def test_send_sms_override_configured_shortcode_with_sender(mocker, mock_firetex
     assert request_args['from'][0] == 'fromservice'
 
 
-def test_send_sms_raises_if_firetext_rejects_with_timeout(rmock, mock_firetext_client):
+def test_send_sms_raises_if_firetext_rejects_with_connect_timeout(rmock, mock_firetext_client):
     to = content = reference = 'foo'
 
     with pytest.raises(FiretextClientResponseException) as exc:
@@ -140,7 +140,7 @@ def test_send_sms_raises_if_firetext_rejects_with_timeout(rmock, mock_firetext_c
     assert exc.value.text == 'Gateway Time-out'
 
 
-def test_send_sms_raises_if_firetext_rejects_with_timeout(rmock, mock_firetext_client):
+def test_send_sms_raises_if_firetext_rejects_with_read_timeout(rmock, mock_firetext_client):
     to = content = reference = 'foo'
 
     with pytest.raises(FiretextClientResponseException) as exc:

--- a/tests/app/clients/test_firetext.py
+++ b/tests/app/clients/test_firetext.py
@@ -1,10 +1,11 @@
 from requests import HTTPError
 from urllib.parse import parse_qs
+from requests.exceptions import ConnectTimeout, ReadTimeout
 
 import pytest
 import requests_mock
 
-from app.clients.sms.firetext import get_firetext_responses, SmsClientResponseException
+from app.clients.sms.firetext import get_firetext_responses, SmsClientResponseException, FiretextClientResponseException
 
 
 def test_should_return_correct_details_for_delivery():
@@ -126,3 +127,25 @@ def test_send_sms_override_configured_shortcode_with_sender(mocker, mock_firetex
 
     request_args = parse_qs(request_mock.request_history[0].text)
     assert request_args['from'][0] == 'fromservice'
+
+
+def test_send_sms_raises_if_firetext_rejects_with_timeout(rmock, mock_firetext_client):
+    to = content = reference = 'foo'
+
+    with pytest.raises(FiretextClientResponseException) as exc:
+        rmock.register_uri('POST', 'https://www.firetext.co.uk/api/sendsms/json', exc=ConnectTimeout)
+        mock_firetext_client.send_sms(to, content, reference)
+
+    assert exc.value.status_code == 504
+    assert exc.value.text == 'Gateway Time-out'
+
+
+def test_send_sms_raises_if_firetext_rejects_with_timeout(rmock, mock_firetext_client):
+    to = content = reference = 'foo'
+
+    with pytest.raises(FiretextClientResponseException) as exc:
+        rmock.register_uri('POST', 'https://www.firetext.co.uk/api/sendsms/json', exc=ReadTimeout)
+        mock_firetext_client.send_sms(to, content, reference)
+
+    assert exc.value.status_code == 504
+    assert exc.value.text == 'Gateway Time-out'

--- a/tests/app/clients/test_mmg.py
+++ b/tests/app/clients/test_mmg.py
@@ -116,7 +116,7 @@ def test_send_sms_raises_if_mmg_fails_to_return_json(notify_api, mocker):
     assert exc.value.text == 'NOT AT ALL VALID JSON {"key" : "value"}}'
 
 
-def test_send_sms_raises_if_mmg_rejects_with_timeout(rmock):
+def test_send_sms_raises_if_mmg_rejects_with_connect_timeout(rmock):
     to = content = reference = 'foo'
 
     with pytest.raises(MMGClientResponseException) as exc:
@@ -127,7 +127,7 @@ def test_send_sms_raises_if_mmg_rejects_with_timeout(rmock):
     assert exc.value.text == 'Gateway Time-out'
 
 
-def test_send_sms_raises_if_firetext_rejects_with_timeout(rmock):
+def test_send_sms_raises_if_mmg_rejects_with_read_timeout(rmock):
     to = content = reference = 'foo'
 
     with pytest.raises(MMGClientResponseException) as exc:


### PR DESCRIPTION
Added a 60 second timeout to the MMG and fire text clients.
- This is a CONNECT and a READ timeout.
- Gets wrapped in the standard client exception, with a status code of 504, message Gateway timeout.
- Is quiet noisy in logs to allow us to see it
- Ensures we flick across the provider.

To test change the timeout to 0 and it will timeout.