### PR TITLE
Build DVLA file with blank `TO_NAME_2` field

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@15.0.0#egg=notifications-utils==15.0.0
+git+https://github.com/alphagov/notifications-utils.git@15.0.2#egg=notifications-utils==15.0.2
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1018,4 +1018,4 @@ def test_dvla_letter_template(sample_letter_notification):
     letter = LetterDVLATemplate(t,
                                 sample_letter_notification.personalisation,
                                 12345)
-    assert str(letter) == "140|500|001||201703230012345|||||||||||||A1|A2|A3|A4|A5|A6||A_POST|||||||||23 March 2017<cr><cr><h1>Template subject<normal><cr><cr>Dear Sir/Madam, Hello. Yours Truly, The Government.<cr><cr>"  # noqa
+    assert str(letter) == "140|500|001||201703230012345|||||||||||||A1||A2|A3|A4|A5|A6|A_POST|||||||||23 March 2017<cr><cr><h1>Template subject<normal><cr><cr>Dear Sir/Madam, Hello. Yours Truly, The Government.<cr><cr>"  # noqa


### PR DESCRIPTION
Problem: we were sending the first line of the address in the `TO_NAME_2` field. This meant that they couldn’t do any PAF lookups with it, because it wasn’t where they were expecting.

The first line of the address is the second line of what our users give us. We need to give this to DVLA as the _third_ line of the address output, which they call `TO_ADDRESS_LINE_1`.

Also fixes a problem with line breaks between items in bulleted lists.

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/139
- [x] https://github.com/alphagov/notifications-utils/pull/137