### PR TITLE
Reduce boto logging level.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@15.0.4#egg=notifications-utils==15.0.4
+git+https://github.com/alphagov/notifications-utils.git@15.1.1#egg=notifications-utils==15.1.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
Update notifications-utils to version 15.1.1 in the hopes that the new logging level for s3tranfer will stop the boto logging of the letters body.
But I can only test this on preview.