### PR TITLE
Added the random string reference to the letter

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,6 @@
 import os
+import random
+import string
 import uuid
 
 from flask import Flask, _request_ctx_stack
@@ -202,6 +204,10 @@ def init_app(app):
 
 def create_uuid():
     return str(uuid.uuid4())
+
+
+def create_random_identifier():
+    return ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(16))
 
 
 def process_user_agent(user_agent_string):

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -10,6 +10,7 @@ from notifications_utils.template import SMSMessageTemplate, WithSubjectTemplate
 from sqlalchemy.exc import SQLAlchemyError
 from app import (
     create_uuid,
+    create_random_identifier,
     DATETIME_FORMAT,
     notify_celery,
     encryption
@@ -262,7 +263,8 @@ def persist_letter(
             created_at=created_at,
             job_id=notification['job'],
             job_row_number=notification['row_number'],
-            notification_id=notification_id
+            notification_id=notification_id,
+            reference=create_random_identifier()
         )
 
         current_app.logger.info("Letter {} created at {}".format(saved_notification.id, created_at))
@@ -311,10 +313,8 @@ def create_dvla_file_contents(job_id):
         str(LetterDVLATemplate(
             notification.template.__dict__,
             notification.personalisation,
-            # This unique id is a 7 digits requested by DVLA, not known
-            # if this number needs to be sequential.
-            numeric_id=random.randint(1, int('9' * 7)),
-            contact_block=notification.service.letter_contact_block,
+            notification_reference=notification.reference,
+            contact_block=notification.service.letter_contact_block
         ))
         for notification in dao_get_all_notifications_for_job(job_id)
     )

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -43,7 +43,7 @@ def all_notifications_are_created_for_job(job_id):
 
 @statsd(namespace="dao")
 def dao_get_all_notifications_for_job(job_id):
-    return db.session.query(Notification).filter(Notification.job_id == job_id).all()
+    return db.session.query(Notification).filter(Notification.job_id == job_id).order_by(Notification.created_at).all()
 
 
 def dao_get_job_by_service_id_and_job_id(service_id, job_id):

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -36,6 +36,7 @@ def persist_notification(template_id,
                          job_id=None,
                          job_row_number=None,
                          reference=None,
+                         client_reference=None,
                          notification_id=None,
                          simulated=False):
     # if simulated create a Notification model to return but do not persist the Notification to the dB
@@ -53,7 +54,8 @@ def persist_notification(template_id,
         created_at=created_at or datetime.utcnow(),
         job_id=job_id,
         job_row_number=job_row_number,
-        client_reference=reference
+        client_reference=client_reference,
+        reference=reference
     )
     if not simulated:
         dao_create_notification(notification)

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -47,7 +47,7 @@ def post_notification(notification_type):
                                         notification_type=notification_type,
                                         api_key_id=api_user.id,
                                         key_type=api_user.key_type,
-                                        reference=form.get('reference', None),
+                                        client_reference=form.get('reference', None),
                                         simulated=simulated)
     if not simulated:
         queue_name = 'priority' if template.process_type == PRIORITY else None

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@15.0.4#egg=notifications-utils==15.0.4
+git+https://github.com/alphagov/notifications-utils.git@15.2.1#egg=notifications-utils==15.2.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1032,6 +1032,7 @@ def test_create_dvla_file_contents(sample_letter_template, mocker):
 
     # Personalisation
     assert not calls[0][0][1]
+    assert not calls[1][0][1]
 
     # Named arguments
     assert calls[1][1]['contact_block'] == 'London,\nSW1A 1AA'

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1045,8 +1045,8 @@ def test_dvla_letter_template(sample_letter_notification):
          "subject": sample_letter_notification.template.subject}
     letter = LetterDVLATemplate(t,
                                 sample_letter_notification.personalisation,
-                                12345)
-    assert str(letter) == "140|500|001||201703230012345|||||||||||||A1||A2|A3|A4|A5|A6|A_POST|||||||||23 March 2017<cr><cr><h1>Template subject<normal><cr><cr>Dear Sir/Madam, Hello. Yours Truly, The Government.<cr><cr>"  # noqa
+                                "random-string")
+    assert str(letter) == "140|500|001||random-string|||||||||||||A1||A2|A3|A4|A5|A6|A_POST|||||||||23 March 2017<cr><cr><h1>Template subject<normal><cr><cr>Dear Sir/Madam, Hello. Yours Truly, The Government.<cr><cr>"  # noqa
 
 
 def test_update_job_to_sent_to_dvla(sample_letter_template, sample_letter_job):

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -179,7 +179,7 @@ def test_persist_notification_with_optionals(sample_job, sample_api_key, mocker)
                          created_at=created_at,
                          job_id=sample_job.id,
                          job_row_number=10,
-                         reference="ref from client",
+                         client_reference="ref from client",
                          notification_id=n_id)
     assert Notification.query.count() == 1
     assert NotificationHistory.query.count() == 1


### PR DESCRIPTION
- uses the reference field on the notifications table to store a 16char random string used to cross reference DVLA letters back to the notification
- used as letter barcode does not have space for a UUID notification id

- [x] Depends on [https://github.com/alphagov/notifications-utils/pull/149](https://github.com/alphagov/notifications-utils/pull/149)

Renamed the numeric_id to notification_reference in utils and changed validation rules to match this

Note also the persist_notification method set "reference" to be "client_reference" which is confusing and they are different things, so fixed this too.