### PR TITLE
Removed slash from v2 get all templates route

### DIFF
--- a/app/v2/templates/get_templates.py
+++ b/app/v2/templates/get_templates.py
@@ -8,7 +8,7 @@ from app.v2.templates import v2_templates_blueprint
 from app.v2.templates.templates_schemas import get_all_template_request
 
 
-@v2_templates_blueprint.route("/", methods=['GET'])
+@v2_templates_blueprint.route("", methods=['GET'])
 def get_templates():
     data = validate(request.args.to_dict(), get_all_template_request)
 

--- a/tests/app/v2/templates/test_get_templates.py
+++ b/tests/app/v2/templates/test_get_templates.py
@@ -17,7 +17,7 @@ def test_get_all_templates_returns_200(client, sample_service):
 
     auth_header = create_authorization_header(service_id=sample_service.id)
 
-    response = client.get(path='/v2/templates/',
+    response = client.get(path='/v2/templates',
                           headers=[('Content-Type', 'application/json'), auth_header])
 
     assert response.status_code == 200
@@ -47,7 +47,7 @@ def test_get_all_templates_for_valid_type_returns_200(client, sample_service, tm
 
     auth_header = create_authorization_header(service_id=sample_service.id)
 
-    response = client.get(path='/v2/templates/?type={}'.format(tmp_type),
+    response = client.get(path='/v2/templates?type={}'.format(tmp_type),
                           headers=[('Content-Type', 'application/json'), auth_header])
 
     assert response.status_code == 200
@@ -81,7 +81,7 @@ def test_get_correct_num_templates_for_valid_type_returns_200(client, sample_ser
 
     auth_header = create_authorization_header(service_id=sample_service.id)
 
-    response = client.get(path='/v2/templates/?type={}'.format(tmp_type),
+    response = client.get(path='/v2/templates?type={}'.format(tmp_type),
                           headers=[('Content-Type', 'application/json'), auth_header])
 
     assert response.status_code == 200
@@ -96,7 +96,7 @@ def test_get_all_templates_for_invalid_type_returns_400(client, sample_service):
 
     invalid_type = 'coconut'
 
-    response = client.get(path='/v2/templates/?type={}'.format(invalid_type),
+    response = client.get(path='/v2/templates?type={}'.format(invalid_type),
                           headers=[('Content-Type', 'application/json'), auth_header])
 
     assert response.status_code == 400


### PR DESCRIPTION
Route doesn't need a trailing slash for v2 get templates, so have removed it and updated the tests.

