### PR TITLE
Add international sms feature flag in db

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -151,6 +151,7 @@ class Service(db.Model, Versioned):
     restricted = db.Column(db.Boolean, index=False, unique=False, nullable=False)
     research_mode = db.Column(db.Boolean, index=False, unique=False, nullable=False, default=False)
     can_send_letters = db.Column(db.Boolean, nullable=False, default=False)
+    can_send_international_sms = db.Column(db.Boolean, nullable=False, default=False)
     email_from = db.Column(db.Text, index=False, unique=True, nullable=False)
     created_by = db.relationship('User')
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)

--- a/migrations/versions/0073_add_international_sms_flag.py
+++ b/migrations/versions/0073_add_international_sms_flag.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: 0073_add_international_sms_flag
+Revises: 0072_add_dvla_orgs
+Create Date: 2017-10-25 17:37:27.660723
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0073_add_international_sms_flag'
+down_revision = '0072_add_dvla_orgs'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('services', sa.Column('can_send_international_sms', sa.Boolean(), nullable=False, server_default=sa.false()))
+    op.add_column('services_history', sa.Column('can_send_international_sms', sa.Boolean(), nullable=False, server_default=sa.false()))
+
+
+def downgrade():
+    op.drop_column('services_history', 'can_send_international_sms')
+    op.drop_column('services', 'can_send_international_sms')


### PR DESCRIPTION
## What

Add new column in db for international sms feature flag

## How to review

Check that `can_send_international_sms` column is added to the `services` and `services_history` after migration