### PR TITLE
Fix: Ensure get_current_provider returns an active provider

### DIFF
--- a/app/dao/provider_details_dao.py
+++ b/app/dao/provider_details_dao.py
@@ -36,7 +36,8 @@ def get_alternative_sms_provider(identifier):
 
 def get_current_provider(notification_type):
     return ProviderDetails.query.filter_by(
-        notification_type=notification_type
+        notification_type=notification_type,
+        active=True
     ).order_by(
         asc(ProviderDetails.priority)
     ).first()

--- a/tests/app/dao/test_provider_details_dao.py
+++ b/tests/app/dao/test_provider_details_dao.py
@@ -273,3 +273,12 @@ def test_get_sms_provider_with_equal_priority_returns_provider(
         dao_get_sms_provider_with_equal_priority(current_provider.identifier, current_provider.priority)
 
     assert conflicting_provider
+
+
+def test_get_current_sms_provider_returns_active_only(restore_provider_details):
+    current_provider = get_current_provider('sms')
+    current_provider.active = False
+    dao_update_provider_details(current_provider)
+    new_current_provider = get_current_provider('sms')
+
+    assert current_provider.identifier != new_current_provider.identifier


### PR DESCRIPTION
This fixes the issue where `get_current_provider` returns an inactive provider. This would happen in the case where we have an inactive provider with the lowest priority (compared to others of the same notification type). 

