### PR TITLE
Add international support flag for providers (migration)

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -443,6 +443,8 @@ class ProviderDetails(db.Model):
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=True)
     created_by = db.relationship('User')
+    supports_international = db.Column(db.Boolean, nullable=False, default=False)
+
 
 
 class ProviderDetailsHistory(db.Model, HistoryModel):
@@ -458,6 +460,7 @@ class ProviderDetailsHistory(db.Model, HistoryModel):
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=True)
     created_by = db.relationship('User')
+    supports_international = db.Column(db.Boolean, nullable=False, default=False)
 
 
 JOB_STATUS_PENDING = 'pending'

--- a/app/models.py
+++ b/app/models.py
@@ -446,7 +446,6 @@ class ProviderDetails(db.Model):
     supports_international = db.Column(db.Boolean, nullable=False, default=False)
 
 
-
 class ProviderDetailsHistory(db.Model, HistoryModel):
     __tablename__ = 'provider_details_history'
 

--- a/migrations/versions/0074_add_intl_flag_to_provider.py
+++ b/migrations/versions/0074_add_intl_flag_to_provider.py
@@ -1,0 +1,27 @@
+"""empty message
+
+Revision ID: 0074_add_intl_flag_to_provider
+Revises: 0073_add_international_sms_flag
+Create Date: 2017-04-25 09:44:13.194164
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0074_add_intl_flag_to_provider'
+down_revision = '0073_add_international_sms_flag'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('provider_details', sa.Column('supports_international', sa.Boolean(), nullable=False, server_default=sa.false()))
+    op.add_column('provider_details_history', sa.Column('supports_international', sa.Boolean(), nullable=False, server_default=sa.false()))
+
+    op.execute("UPDATE provider_details SET supports_international=True WHERE identifier='mmg'")
+    op.execute("UPDATE provider_details_history SET supports_international=True WHERE identifier='mmg'")
+
+
+def downgrade():
+    op.drop_column('provider_details_history', 'supports_international')
+    op.drop_column('provider_details', 'supports_international')

--- a/migrations/versions/0076_add_intl_flag_to_provider.py
+++ b/migrations/versions/0076_add_intl_flag_to_provider.py
@@ -1,14 +1,14 @@
 """empty message
 
-Revision ID: 0074_add_intl_flag_to_provider
+Revision ID: 0076_add_intl_flag_to_provider
 Revises: 0073_add_international_sms_flag
 Create Date: 2017-04-25 09:44:13.194164
 
 """
 
 # revision identifiers, used by Alembic.
-revision = '0074_add_intl_flag_to_provider'
-down_revision = '0073_add_international_sms_flag'
+revision = '0076_add_intl_flag_to_provider'
+down_revision = '0075_create_rates_table'
 
 from alembic import op
 import sqlalchemy as sa

--- a/migrations/versions/0076_add_intl_flag_to_provider.py
+++ b/migrations/versions/0076_add_intl_flag_to_provider.py
@@ -1,7 +1,7 @@
 """empty message
 
 Revision ID: 0076_add_intl_flag_to_provider
-Revises: 0073_add_international_sms_flag
+Revises: 0075_create_rates_table
 Create Date: 2017-04-25 09:44:13.194164
 
 """

--- a/tests/app/provider_details/test_rest.py
+++ b/tests/app/provider_details/test_rest.py
@@ -47,7 +47,7 @@ def test_get_provider_details_contains_correct_fields(client, notify_db):
     allowed_keys = {
         "id", "created_by", "display_name",
         "identifier", "priority", 'notification_type',
-        "active", "version", "updated_at"
+        "active", "version", "updated_at", "supports_international"
     }
     assert allowed_keys == set(json_resp[0].keys())
 
@@ -116,7 +116,7 @@ def test_get_provider_versions_contains_correct_fields(client, notify_db):
     allowed_keys = {
         "id", "created_by", "display_name",
         "identifier", "priority", 'notification_type',
-        "active", "version", "updated_at"
+        "active", "version", "updated_at", "supports_international"
     }
     assert allowed_keys == set(json_resp[0].keys())
 


### PR DESCRIPTION
This adds a `supports_international` flag on the providers and sets MMG as `True` for this.

The story was redefined: we don't need to have another provider, but do need some way of differentiating between `domestic` and `international`.

**Also: I'll update the migration to be up-to with master in a separate commit.** 