### PR TITLE
Add intl notification fields

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -662,6 +662,12 @@ class Notification(db.Model):
         foreign(template_version) == remote(TemplateHistory.version)
     ))
 
+    client_reference = db.Column(db.String, index=True, nullable=True)
+
+    international = db.Column(db.Boolean, nullable=False, default=False)
+    phone_prefix = db.Column(db.String, nullable=True)
+    rate_multiplier = db.Column(db.Numeric(), nullable=True)
+
     @property
     def personalisation(self):
         if self._personalisation:
@@ -834,6 +840,10 @@ class NotificationHistory(db.Model, HistoryModel):
     status = db.Column(NOTIFICATION_STATUS_TYPES_ENUM, index=True, nullable=False, default='created')
     reference = db.Column(db.String, nullable=True, index=True)
     client_reference = db.Column(db.String, nullable=True)
+
+    international = db.Column(db.Boolean, nullable=False, default=False)
+    phone_prefix = db.Column(db.String, nullable=True)
+    rate_multiplier = db.Column(db.Numeric(), nullable=True)
 
     @classmethod
     def from_original(cls, notification):

--- a/migrations/versions/0076_add_intl_notification.py
+++ b/migrations/versions/0076_add_intl_notification.py
@@ -1,0 +1,32 @@
+"""empty message
+
+Revision ID: 0076_add_intl_notification
+Revises: 0075_create_rates_table
+Create Date: 2017-04-25 11:34:43.229494
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0076_add_intl_notification'
+down_revision = '0075_create_rates_table'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('notification_history', sa.Column('international', sa.Boolean(), nullable=True))
+    op.add_column('notification_history', sa.Column('phone_prefix', sa.String(), nullable=True))
+    op.add_column('notification_history', sa.Column('rate_multiplier', sa.Numeric(), nullable=True))
+    op.add_column('notifications', sa.Column('international', sa.Boolean(), nullable=True))
+    op.add_column('notifications', sa.Column('phone_prefix', sa.String(), nullable=True))
+    op.add_column('notifications', sa.Column('rate_multiplier', sa.Numeric(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('notifications', 'rate_multiplier')
+    op.drop_column('notifications', 'phone_prefix')
+    op.drop_column('notifications', 'international')
+    op.drop_column('notification_history', 'rate_multiplier')
+    op.drop_column('notification_history', 'phone_prefix')
+    op.drop_column('notification_history', 'international')

--- a/migrations/versions/0077_add_intl_notification.py
+++ b/migrations/versions/0077_add_intl_notification.py
@@ -1,14 +1,14 @@
 """empty message
 
-Revision ID: 0076_add_intl_notification
-Revises: 0075_create_rates_table
+Revision ID: 0077_add_intl_notification
+Revises: 0076_add_intl_flag_to_provider
 Create Date: 2017-04-25 11:34:43.229494
 
 """
 
 # revision identifiers, used by Alembic.
-revision = '0076_add_intl_notification'
-down_revision = '0075_create_rates_table'
+revision = '0077_add_intl_notification'
+down_revision = '0076_add_intl_flag_to_provider'
 
 from alembic import op
 import sqlalchemy as sa

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -170,19 +170,20 @@ def test_persist_notification_with_optionals(sample_job, sample_api_key, mocker)
     n_id = uuid.uuid4()
     created_at = datetime.datetime(2016, 11, 11, 16, 8, 18)
     persist_notification(
-         template_id=sample_job.template.id,
-         template_version=sample_job.template.version,
-         recipient='+447111111111',
-         service=sample_job.service,
-         personalisation=None, notification_type='sms',
-         api_key_id=sample_api_key.id,
-         key_type=sample_api_key.key_type,
-         created_at=created_at,
-         job_id=sample_job.id,
-         job_row_number=10,
-         client_reference="ref from client",
-         notification_id=n_id
-     )
+        template_id=sample_job.template.id,
+        template_version=sample_job.template.version,
+        recipient='+447111111111',
+        service=sample_job.service,
+        personalisation=None,
+        notification_type='sms',
+        api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type,
+        created_at=created_at,
+        job_id=sample_job.id,
+        job_row_number=10,
+        client_reference="ref from client",
+        notification_id=n_id
+    )
     assert Notification.query.count() == 1
     assert NotificationHistory.query.count() == 1
     persisted_notification = Notification.query.all()[0]
@@ -197,7 +198,6 @@ def test_persist_notification_with_optionals(sample_job, sample_api_key, mocker)
     assert persisted_notification.international is False
     assert persisted_notification.phone_prefix is None
     assert persisted_notification.rate_multiplier is None
-
 
 
 @freeze_time("2016-01-01 11:09:00.061258")

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -169,18 +169,20 @@ def test_persist_notification_with_optionals(sample_job, sample_api_key, mocker)
         'app.notifications.process_notifications.redis_store.get_all_from_hash')
     n_id = uuid.uuid4()
     created_at = datetime.datetime(2016, 11, 11, 16, 8, 18)
-    persist_notification(template_id=sample_job.template.id,
-                         template_version=sample_job.template.version,
-                         recipient='+447111111111',
-                         service=sample_job.service,
-                         personalisation=None, notification_type='sms',
-                         api_key_id=sample_api_key.id,
-                         key_type=sample_api_key.key_type,
-                         created_at=created_at,
-                         job_id=sample_job.id,
-                         job_row_number=10,
-                         client_reference="ref from client",
-                         notification_id=n_id)
+    persist_notification(
+         template_id=sample_job.template.id,
+         template_version=sample_job.template.version,
+         recipient='+447111111111',
+         service=sample_job.service,
+         personalisation=None, notification_type='sms',
+         api_key_id=sample_api_key.id,
+         key_type=sample_api_key.key_type,
+         created_at=created_at,
+         job_id=sample_job.id,
+         job_row_number=10,
+         client_reference="ref from client",
+         notification_id=n_id
+     )
     assert Notification.query.count() == 1
     assert NotificationHistory.query.count() == 1
     persisted_notification = Notification.query.all()[0]
@@ -192,6 +194,10 @@ def test_persist_notification_with_optionals(sample_job, sample_api_key, mocker)
     mock_service_template_cache.assert_called_once_with(cache_key_for_service_template_counter(sample_job.service_id))
     assert persisted_notification.client_reference == "ref from client"
     assert persisted_notification.reference is None
+    assert persisted_notification.international is False
+    assert persisted_notification.phone_prefix is None
+    assert persisted_notification.rate_multiplier is None
+
 
 
 @freeze_time("2016-01-01 11:09:00.061258")


### PR DESCRIPTION
This adds three new fields the `Notification` model that will be used to differentiate between domestic and international notifications.

All fields are nullable for now but a default has been set so that any new notification created with have `international` set to `False`.

**Note: Will rebase of master once #918 is in.**