### PR TITLE
Feat use intl provider send sms

### DIFF
--- a/app/dao/provider_details_dao.py
+++ b/app/dao/provider_details_dao.py
@@ -60,6 +60,7 @@ def dao_toggle_sms_provider(identifier):
 @transactional
 def dao_switch_sms_provider_to_provider_with_identifier(identifier):
     new_provider = get_provider_details_by_identifier(identifier)
+
     if provider_is_inactive(new_provider):
         return
 
@@ -69,7 +70,7 @@ def dao_switch_sms_provider_to_provider_with_identifier(identifier):
     providers_to_update = []
 
     if conflicting_provider:
-        providers_to_update = switch_providers(conflicting_provider, new_provider)
+        switch_providers(conflicting_provider, new_provider)
     else:
         current_provider = get_current_provider('sms')
         if not provider_is_primary(current_provider, new_provider, identifier):
@@ -79,10 +80,14 @@ def dao_switch_sms_provider_to_provider_with_identifier(identifier):
             dao_update_provider_details(provider)
 
 
-def get_provider_details_by_notification_type(notification_type):
-    return ProviderDetails.query.filter_by(
-        notification_type=notification_type
-    ).order_by(asc(ProviderDetails.priority)).all()
+def get_provider_details_by_notification_type(notification_type, supports_international=False):
+
+    filters = [ProviderDetails.notification_type == notification_type]
+
+    if supports_international:
+        filters.append(ProviderDetails.supports_international == supports_international)
+
+    return ProviderDetails.query.filter(*filters).order_by(asc(ProviderDetails.priority)).all()
 
 
 @transactional

--- a/tests/app/dao/test_provider_details_dao.py
+++ b/tests/app/dao/test_provider_details_dao.py
@@ -35,16 +35,24 @@ def test_can_get_all_providers(restore_provider_details):
     assert len(get_provider_details()) == 5
 
 
-def test_can_get_sms_providers(restore_provider_details):
+def test_can_get_sms_non_international_providers(restore_provider_details):
     sms_providers = get_provider_details_by_notification_type('sms')
     assert len(sms_providers) == 3
     assert all('sms' == prov.notification_type for prov in sms_providers)
+    assert all(not prov.supports_international for prov in sms_providers)
+
+
+def test_can_get_sms_international_providers(restore_provider_details):
+    sms_providers = get_provider_details_by_notification_type('sms', True)
+    assert len(sms_providers) == 1
+    assert all('sms' == prov.notification_type for prov in sms_providers)
+    assert all(prov.supports_international for prov in sms_providers)
 
 
 def test_can_get_sms_providers_in_order_of_priority(restore_provider_details):
-    providers = get_provider_details_by_notification_type('sms')
+    providers = get_provider_details_by_notification_type('sms', False)
 
-    assert providers[0].priority < providers[1].priority < providers[2].priority
+    assert providers[0].priority < providers[1].priority
 
 
 def test_can_get_email_providers_in_order_of_priority(restore_provider_details):

--- a/tests/app/dao/test_provider_details_dao.py
+++ b/tests/app/dao/test_provider_details_dao.py
@@ -39,7 +39,6 @@ def test_can_get_sms_non_international_providers(restore_provider_details):
     sms_providers = get_provider_details_by_notification_type('sms')
     assert len(sms_providers) == 3
     assert all('sms' == prov.notification_type for prov in sms_providers)
-    assert all(not prov.supports_international for prov in sms_providers)
 
 
 def test_can_get_sms_international_providers(restore_provider_details):

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -72,7 +72,8 @@ def create_notification(
     api_key_id=None,
     key_type=KEY_TYPE_NORMAL,
     sent_by=None,
-    client_reference=None
+    client_reference=None,
+    international=False
 ):
     if created_at is None:
         created_at = datetime.utcnow()
@@ -103,7 +104,8 @@ def create_notification(
         'sent_by': sent_by,
         'updated_at': updated_at,
         'client_reference': client_reference,
-        'job_row_number': job_row_number
+        'job_row_number': job_row_number,
+        'international': international
     }
     notification = Notification(**data)
     dao_create_notification(notification)


### PR DESCRIPTION
when sending international notifications, try and use the international providers.

uses the flag on the notification to pass an additional param to the get providers DAO calls.

This allows us to bring back:
- All providers by default
- Int ones if requested