### PR TITLE
Persist international notification fields

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -670,7 +670,7 @@ class Notification(db.Model):
 
     international = db.Column(db.Boolean, nullable=False, default=False)
     phone_prefix = db.Column(db.String, nullable=True)
-    rate_multiplier = db.Column(db.Float(as_decimal=False), nullable=True)
+    rate_multiplier = db.Column(db.Float(), nullable=True)
 
     @property
     def personalisation(self):
@@ -847,7 +847,7 @@ class NotificationHistory(db.Model, HistoryModel):
 
     international = db.Column(db.Boolean, nullable=False, default=False)
     phone_prefix = db.Column(db.String, nullable=True)
-    rate_multiplier = db.Column(db.Float(as_decimal=False), nullable=True)
+    rate_multiplier = db.Column(db.Float(), nullable=True)
 
     @classmethod
     def from_original(cls, notification):

--- a/app/models.py
+++ b/app/models.py
@@ -670,7 +670,7 @@ class Notification(db.Model):
 
     international = db.Column(db.Boolean, nullable=False, default=False)
     phone_prefix = db.Column(db.String, nullable=True)
-    rate_multiplier = db.Column(db.Numeric(), nullable=True)
+    rate_multiplier = db.Column(db.Float(as_decimal=False), nullable=True)
 
     @property
     def personalisation(self):
@@ -847,7 +847,7 @@ class NotificationHistory(db.Model, HistoryModel):
 
     international = db.Column(db.Boolean, nullable=False, default=False)
     phone_prefix = db.Column(db.String, nullable=True)
-    rate_multiplier = db.Column(db.Numeric(), nullable=True)
+    rate_multiplier = db.Column(db.Float(as_decimal=False), nullable=True)
 
     @classmethod
     def from_original(cls, notification):

--- a/tests/app/user/test_rest_verify.py
+++ b/tests/app/user/test_rest_verify.py
@@ -230,7 +230,7 @@ def test_send_user_code_for_sms_with_optional_to_field(client,
     """
     Tests POST endpoint /user/<user_id>/sms-code with optional to field
     """
-    to_number = '+441119876757'
+    to_number = '+447119876757'
     mocked = mocker.patch('app.user.rest.create_secret_code', return_value='11111')
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
     auth_header = create_authorization_header()


### PR DESCRIPTION
This will persist the notification with the international fields to the database. This calls additional validation/formatting in the persist_notification method, given that it will be passed the original recipient entry.

Also, we currently do no validation on send user sms code. For now we rely on the admin validation that only allows UK phone numbers. We'll need to think about supporting verification codes for international numbers in a separate story.