### PR TITLE
Remove references to old utils code

### DIFF
--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -506,7 +506,7 @@ def test_should_send_sms_to_international_providers(
     )
 
     firetext_client.send_sms.assert_called_once_with(
-        to=format_phone_number(validate_phone_number("+447234123999")),
+        to="447234123999",
         content=ANY,
         reference=str(db_notification_uk.id),
         sender=None
@@ -517,7 +517,7 @@ def test_should_send_sms_to_international_providers(
     )
 
     mmg_client.send_sms.assert_called_once_with(
-        to=format_phone_number(validate_phone_number("+447234123111")),
+        to="447234123111",
         content=ANY,
         reference=str(db_notification_international.id),
         sender=None


### PR DESCRIPTION
These methods don’t exist any more.

Not doing this reformatting in the tests probably makes the tests more
robust too 😬