### PR TITLE
add type conversion to report downloads

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -752,7 +752,8 @@ class Notification(db.Model):
                 'permanent-failure': 'Email address doesn’t exist',
                 'delivered': 'Delivered',
                 'sending': 'Sending',
-                'created': 'Sending'
+                'created': 'Sending',
+                'sent': 'Delivered'
             },
             'sms': {
                 'failed': 'Failed',
@@ -761,7 +762,8 @@ class Notification(db.Model):
                 'permanent-failure': 'Phone number doesn’t exist',
                 'delivered': 'Delivered',
                 'sending': 'Sending',
-                'created': 'Sending'
+                'created': 'Sending',
+                'sent': 'Sent internationally'
             },
             'letter': {
                 'failed': 'Failed',
@@ -770,7 +772,8 @@ class Notification(db.Model):
                 'permanent-failure': 'Permanent failure',
                 'delivered': 'Delivered',
                 'sending': 'Sending',
-                'created': 'Sending'
+                'created': 'Sending',
+                'sent': 'Delivered'
             }
         }[self.template.template_type].get(self.status, self.status)
 

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -111,6 +111,7 @@ def test_notification_for_csv_returns_correct_job_row_number(notify_db, notify_d
     ('email', 'permanent-failure', 'Email address doesn’t exist'),
     ('sms', 'temporary-failure', 'Phone not accepting messages right now'),
     ('sms', 'permanent-failure', 'Phone number doesn’t exist'),
+    ('sms', 'sent', 'Sent internationally'),
     ('letter', 'permanent-failure', 'Permanent failure'),
     ('letter', 'delivered', 'Delivered')
 ])


### PR DESCRIPTION
"sent" is fine as an internal marker but not very obvious to the end
user that it specifically refers to international messages. We now
say "Sent internationally" in the CSV