### PR TITLE
treat sent as delivered in detailed service api

### DIFF
--- a/app/service/statistics.py
+++ b/app/service/statistics.py
@@ -48,7 +48,7 @@ def create_zeroed_stats_dicts():
 
 def _update_statuses_from_row(update_dict, row):
     update_dict['requested'] += row.count
-    if row.status == 'delivered':
+    if row.status in ('delivered', 'sent'):
         update_dict['delivered'] += row.count
     elif row.status in ('failed', 'technical-failure', 'temporary-failure', 'permanent-failure'):
         update_dict['failed'] += row.count

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -43,6 +43,7 @@ def test_should_get_all_statuses_for_notifications_associated_with_job(
     notification(status='technical-failure')
     notification(status='temporary-failure')
     notification(status='permanent-failure')
+    notification(status='sent')
 
     results = dao_get_notification_outcomes_for_job(sample_service.id, sample_job.id)
     assert [(row.count, row.status) for row in results] == [
@@ -53,7 +54,8 @@ def test_should_get_all_statuses_for_notifications_associated_with_job(
         (1, 'failed'),
         (1, 'technical-failure'),
         (1, 'temporary-failure'),
-        (1, 'permanent-failure')
+        (1, 'permanent-failure'),
+        (1, 'sent')
     ]
 
 

--- a/tests/app/service/test_statistics.py
+++ b/tests/app/service/test_statistics.py
@@ -30,6 +30,11 @@ StatsRow = collections.namedtuple('row', ('notification_type', 'status', 'count'
         StatsRow('email', 'temporary-failure', 1),
         StatsRow('email', 'permanent-failure', 1),
     ], [4, 0, 4], [0, 0, 0], [0, 0, 0]),
+    'convert_sent_to_delivered': ([
+        StatsRow('sms', 'sending', 1),
+        StatsRow('sms', 'delivered', 1),
+        StatsRow('sms', 'sent', 1),
+    ], [0, 0, 0], [3, 2, 0], [0, 0, 0]),
 })
 def test_format_statistics(stats, email_counts, sms_counts, letter_counts):
 


### PR DESCRIPTION
this is for when we fetch the large blue numbers for viewing
notifications for an entire service