### PR TITLE
Update billing data to handle future dates

### DIFF
--- a/app/dao/notification_usage_dao.py
+++ b/app/dao/notification_usage_dao.py
@@ -21,13 +21,15 @@ def get_yearly_billing_data(service_id, year):
     start_date, end_date = get_financial_year(year)
     rates = get_rates_for_year(start_date, end_date, SMS_TYPE)
 
+    def get_valid_from(valid_from):
+        return start_date if valid_from < start_date else valid_from
+
     result = []
     for r, n in zip(rates, rates[1:]):
-        result.append(
-            sms_yearly_billing_data_query(r.rate, service_id, r.valid_from, n.valid_from))
+        result.append(sms_yearly_billing_data_query(r.rate, service_id, get_valid_from(r.valid_from), n.valid_from))
 
-    result.append(sms_yearly_billing_data_query(rates[-1].rate, service_id, rates[-1].valid_from, end_date))
-
+    result.append(
+        sms_yearly_billing_data_query(rates[-1].rate, service_id, get_valid_from(rates[-1].valid_from), end_date))
     result.append(email_yearly_billing_data_query(service_id, start_date, end_date))
 
     return sum(result, [])

--- a/tests/app/dao/test_notification_usage_dao.py
+++ b/tests/app/dao/test_notification_usage_dao.py
@@ -103,6 +103,21 @@ def test_get_yearly_billing_data(notify_db, notify_db_session, sample_template, 
     assert results[3] == (2, 2, 1, 'email', False, 0)
 
 
+def test_get_future_yearly_billing_data(notify_db, notify_db_session, sample_template, sample_email_template):
+    set_up_rate(notify_db, datetime(2017, 4, 1), 1.58)
+
+    create_notification(template=sample_template, created_at=datetime(2017, 3, 30), sent_at=datetime(2017, 3, 30),
+                        status='sending', billable_units=1)
+    create_notification(template=sample_template, created_at=datetime(2017, 4, 6), sent_at=datetime(2017, 4, 6),
+                        status='sending', billable_units=1)
+    create_notification(template=sample_template, created_at=datetime(2017, 4, 6), sent_at=datetime(2017, 4, 6),
+                        status='sending', billable_units=1)
+
+    results = get_yearly_billing_data(sample_template.service_id, 2018)
+    assert len(results) == 2
+    assert results[0] == (0, 0, 1, 'sms', False, 1.58)
+
+
 def test_get_yearly_billing_data_with_one_rate(notify_db, notify_db_session, sample_template):
     set_up_rate(notify_db, datetime(2016, 4, 1), 1.40)
     # previous year


### PR DESCRIPTION
get_yearly_billing_data function was making queries based on the valid_from rate date for the last rate object passed to the query, I've now updated this to use the start_date of the financial year rather than the rate valid_from date and have created a test to check that it is working as expected.

This only affects future usage dates, current year dates are correct.