### PR TITLE
Update the valid_from date for the rate

### DIFF
--- a/app/dao/notification_usage_dao.py
+++ b/app/dao/notification_usage_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from sqlalchemy import Float, Integer
 from sqlalchemy import func, case, cast
@@ -27,7 +27,6 @@ def get_yearly_billing_data(service_id, year):
     result = []
     for r, n in zip(rates, rates[1:]):
         result.append(sms_yearly_billing_data_query(r.rate, service_id, get_valid_from(r.valid_from), n.valid_from))
-
     result.append(
         sms_yearly_billing_data_query(rates[-1].rate, service_id, get_valid_from(rates[-1].valid_from), end_date))
     result.append(email_yearly_billing_data_query(service_id, start_date, end_date))
@@ -108,7 +107,7 @@ def get_rates_for_year(start_date, end_date, notification_type):
     results = []
     for current_rate, current_rate_expiry_date in zip(rates, rates[1:]):
         if is_between(current_rate.valid_from, start_date, end_date) or \
-                is_between(current_rate_expiry_date.valid_from, start_date, end_date):
+                is_between(current_rate_expiry_date.valid_from - timedelta(microseconds=1), start_date, end_date):
             results.append(current_rate)
 
     if is_between(rates[-1].valid_from, start_date, end_date):

--- a/migrations/versions/0080_fix_rate_start_date.py
+++ b/migrations/versions/0080_fix_rate_start_date.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: 0080_fix_rate_start_date
+Revises: 0079_update_rates
+Create Date: 2017-05-03 16:50:11.334116
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0080_fix_rate_start_date'
+down_revision = '0079_update_rates'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.get_bind()
+    op.execute("UPDATE RATES SET valid_from = '2017-03-31 23:00:00' WHERE valid_from = '2017-04-01 00:00:00'")
+
+
+def downgrade():
+    op.get_bind()
+    op.execute("UPDATE RATES SET valid_from = '2017-03-31 23:00:00' WHERE valid_from = '2017-04-01 00:00:00'")

--- a/tests/app/dao/test_notification_usage_dao.py
+++ b/tests/app/dao/test_notification_usage_dao.py
@@ -12,7 +12,6 @@ def test_get_rates_for_year(notify_db, notify_db_session):
     set_up_rate(notify_db, datetime(2016, 5, 18), 0.016)
     set_up_rate(notify_db, datetime(2017, 3, 31, 23), 0.0158)
     start_date, end_date = get_financial_year(2017)
-    print(start_date)
     rates = get_rates_for_year(start_date, end_date, 'sms')
     assert len(rates) == 1
     assert datetime.strftime(rates[0].valid_from, '%Y-%m-%d %H:%M:%S') == "2017-03-31 23:00:00"

--- a/tests/app/dao/test_notification_usage_dao.py
+++ b/tests/app/dao/test_notification_usage_dao.py
@@ -9,14 +9,26 @@ from tests.app.db import create_notification
 
 
 def test_get_rates_for_year(notify_db, notify_db_session):
+    set_up_rate(notify_db, datetime(2016, 5, 18), 0.016)
+    set_up_rate(notify_db, datetime(2017, 3, 31, 23), 0.0158)
+    start_date, end_date = get_financial_year(2017)
+    print(start_date)
+    rates = get_rates_for_year(start_date, end_date, 'sms')
+    assert len(rates) == 1
+    assert datetime.strftime(rates[0].valid_from, '%Y-%m-%d %H:%M:%S') == "2017-03-31 23:00:00"
+    assert rates[0].rate == 0.0158
+
+
+def test_get_rates_for_year_multiple_result_per_year(notify_db, notify_db_session):
     set_up_rate(notify_db, datetime(2016, 4, 1), 0.015)
-    set_up_rate(notify_db, datetime(2016, 9, 1), 0.016)
-    set_up_rate(notify_db, datetime(2017, 6, 1), 0.0175)
-    rates = get_rates_for_year(datetime(2016, 3, 31), datetime(2017, 3, 31), 'sms')
+    set_up_rate(notify_db, datetime(2016, 5, 18), 0.016)
+    set_up_rate(notify_db, datetime(2017, 4, 1), 0.0158)
+    start_date, end_date = get_financial_year(2016)
+    rates = get_rates_for_year(start_date, end_date, 'sms')
     assert len(rates) == 2
     assert datetime.strftime(rates[0].valid_from, '%Y-%m-%d %H:%M:%S') == "2016-04-01 00:00:00"
     assert rates[0].rate == 0.015
-    assert datetime.strftime(rates[1].valid_from, '%Y-%m-%d %H:%M:%S') == "2016-09-01 00:00:00"
+    assert datetime.strftime(rates[1].valid_from, '%Y-%m-%d %H:%M:%S') == "2016-05-18 00:00:00"
     assert rates[1].rate == 0.016
 
 


### PR DESCRIPTION
Update the valid_from date for the rate that is intended to start at the beginning of the financial year.

It was the start of the financial year in BST, needed to convert it to UTC.
Small change to the logic to find the rates.