### PR TITLE
Process SNS request triggered by a DVLA S3 update

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -4,20 +4,24 @@ from flask import current_app
 FILE_LOCATION_STRUCTURE = 'service-{}-notify/{}.csv'
 
 
-def get_s3_job_object(bucket_name, file_location):
+def get_s3_object(bucket_name, file_location):
     s3 = resource('s3')
-    return s3.Object(bucket_name, file_location)
+    s3_object = s3.Object(bucket_name, file_location)
+    return s3_object.get()['Body'].read()
 
 
 def get_job_from_s3(service_id, job_id):
-    bucket_name = current_app.config['CSV_UPLOAD_BUCKET_NAME']
-    file_location = FILE_LOCATION_STRUCTURE.format(service_id, job_id)
-    obj = get_s3_job_object(bucket_name, file_location)
-    return obj.get()['Body'].read().decode('utf-8')
+    job = _job_from_s3(service_id, job_id)
+    return job
 
 
 def remove_job_from_s3(service_id, job_id):
+    job = _job_from_s3(service_id, job_id)
+    return job.delete()
+
+
+def _job_from_s3():
     bucket_name = current_app.config['CSV_UPLOAD_BUCKET_NAME']
     file_location = FILE_LOCATION_STRUCTURE.format(service_id, job_id)
-    obj = get_s3_job_object(bucket_name, file_location)
-    return obj.delete()
+    obj = get_s3_object(bucket_name, file_location).decode('utf-8')
+    return obj

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -363,7 +363,8 @@ def get_template_class(template_type):
 @notify_celery.task(bind=True, name='update-letter-notifications-statuses')
 @statsd(namespace="tasks")
 def update_letter_notifications_statuses(self, filename):
-    response_file = s3.get_s3_object('development-notifications-csv-upload', filename).decode('utf-8')
+    bucket_location = '{}-ftp'.format(current_app.config['NOTIFY_EMAIL_DOMAIN'])
+    response_file = s3.get_s3_object(bucket_location, filename).decode('utf-8')
     lines = response_file.splitlines()
     notification_updates = []
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -380,7 +380,7 @@ def update_letter_notifications_statuses(self, filename):
     else:
         if notification_updates:
             for update in notification_updates:
-                current_app.logger.error(str(update))
+                current_app.logger.info('DVLA update: {}'.format(str(update)))
                 # TODO: Update notifications with desired status
             return notification_updates
         else:

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -365,16 +365,13 @@ def get_template_class(template_type):
 def update_letter_notifications_statuses(self, filename):
     bucket_location = '{}-ftp'.format(current_app.config['NOTIFY_EMAIL_DOMAIN'])
     response_file = s3.get_s3_object(bucket_location, filename).decode('utf-8')
-    lines = response_file.splitlines()
-    notification_updates = []
 
     try:
         NotificationUpdate = namedtuple('NotificationUpdate', ['reference', 'status', 'page_count', 'cost_threshold'])
-        for line in lines:
-            notification_updates.append(NotificationUpdate(*line.split('|')))
+        notification_updates = [NotificationUpdate(*line.split('|')) for line in response_file.splitlines()]
 
     except TypeError:
-        current_app.logger.exception('DVLA response file has an invalid format')
+        current_app.logger.exception('DVLA response file: {} has an invalid format'.format(filename))
         raise
 
     else:

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -27,7 +27,8 @@ from app.models import (
     NOTIFICATION_PERMANENT_FAILURE,
     KEY_TYPE_NORMAL, KEY_TYPE_TEST,
     LETTER_TYPE,
-    NOTIFICATION_SENT)
+    NOTIFICATION_SENT
+)
 
 from app.dao.dao_utils import transactional
 from app.statsd_decorators import statsd

--- a/app/notifications/notifications_letter_callback.py
+++ b/app/notifications/notifications_letter_callback.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from functools import wraps
 
 from flask import (
     Blueprint,
@@ -11,37 +12,52 @@ from flask import (
 from app import statsd_client
 from app.celery.tasks import update_letter_notifications_statuses
 from app.clients.email.aws_ses import get_aws_responses
-from app.dao import (
-    notifications_dao
-)
-
+from app.dao import notifications_dao
+from app.v2.errors import register_errors
 from app.notifications.process_client_response import validate_callback_data
+from app.notifications.utils import autoconfirm_subscription
+from app.schema_validation import validate
+
 
 letter_callback_blueprint = Blueprint('notifications_letter_callback', __name__)
-
-from app.errors import (
-    register_errors,
-    InvalidRequest
-)
-
 register_errors(letter_callback_blueprint)
 
 
+dvla_sns_callback_schema = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "sns callback received on s3 update",
+    "type": "object",
+    "title": "dvla internal sns callback",
+    "properties": {
+        "Type": {"enum": ["Notification", "SubscriptionConfirmation"]},
+        "MessageId": {"type": "string"},
+        "Message": {"type": ["string", "object"]}
+    },
+    "required": ["Type", "MessageId", "Message"]
+}
+
+
+def validate_schema(schema):
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kw):
+            validate(request.json, schema)
+            return f(*args, **kw)
+        return wrapper
+    return decorator
+
+
 @letter_callback_blueprint.route('/notifications/letter/dvla', methods=['POST'])
+@validate_schema(dvla_sns_callback_schema)
 def process_letter_response():
-    try:
-        req_json = json.loads(request.data)
+    req_json = request.json
+    if not autoconfirm_subscription(req_json):
         # The callback should have one record for an S3 Put Event.
         filename = req_json['Message']['Records'][0]['s3']['object']['key']
-
-    except (ValueError, KeyError):
-        error = "DVLA callback failed: Invalid JSON"
-        raise InvalidRequest(error, status_code=400)
-
-    else:
+        current_app.logger.info('Received file from DVLA: {}'.format(filename))
         current_app.logger.info('DVLA callback: Calling task to update letter notifications')
         update_letter_notifications_statuses.apply_async([filename], queue='notify')
 
-        return jsonify(
-            result="success", message="DVLA callback succeeded"
-        ), 200
+    return jsonify(
+        result="success", message="DVLA callback succeeded"
+    ), 200

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -13,9 +13,8 @@ from app.clients.email.aws_ses import get_aws_responses
 from app.dao import (
     notifications_dao
 )
-
 from app.notifications.process_client_response import validate_callback_data
-from app.notifications.utils import confirm_subscription
+from app.notifications.utils import autoconfirm_subscription
 
 ses_callback_blueprint = Blueprint('notifications_ses_callback', __name__)
 
@@ -32,14 +31,12 @@ def process_ses_response():
     try:
         ses_request = json.loads(request.data)
 
-        if ses_request.get('Type') == 'SubscriptionConfirmation':
-            current_app.logger.info("SNS subscription confirmation url: {}".format(ses_request['SubscribeURL']))
-            subscribed_topic = confirm_subscription(ses_request)
-            if subscribed_topic:
-                current_app.logger.info("Automatically subscribed to topic: {}".format(subscribed_topic))
-                return jsonify(
-                    result="success", message="SES callback succeeded"
-                ), 200
+        subscribed_topic = autoconfirm_subscription(ses_request)
+        if subscribed_topic:
+            current_app.logger.info("Automatically subscribed to topic: {}".format(subscribed_topic))
+            return jsonify(
+                result="success", message="SES callback succeeded"
+            ), 200
 
         errors = validate_callback_data(data=ses_request, fields=['Message'], client_name=client_name)
         if errors:

--- a/app/notifications/utils.py
+++ b/app/notifications/utils.py
@@ -16,3 +16,10 @@ def confirm_subscription(confirmation_request):
         raise e
 
     return confirmation_request['TopicArn']
+
+
+def autoconfirm_subscription(req_json):
+    if req_json.get('Type') == 'SubscriptionConfirmation':
+        current_app.logger.info("SNS subscription confirmation url: {}".format(req_json['SubscribeURL']))
+        subscribed_topic = confirm_subscription(req_json)
+        return subscribed_topic

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1087,7 +1087,6 @@ def test_update_letter_notifications_statuses_raises_for_invalid_format(notify_a
 
 
 def test_update_letter_notifications_statuses_calls_with_correct_bucket_location(notify_api, mocker):
-    invalid_file = b'ref-foo|Sent|1|Unsorted\nref-bar|Sent|2'
     s3_mock = mocker.patch('app.celery.tasks.s3.get_s3_object')
 
     with set_config(notify_api, 'NOTIFY_EMAIL_DOMAIN', 'foo.bar'):


### PR DESCRIPTION
This processes the SNS request that is triggered when DVLA return a response file (S3). This will call a task to process the file if the file is in the correct format as we expect.

## Summary 

DVLA will return a response file containing the list of notification references along with their status (Success/Failed). We've setup SNS to trigger a notification which will be sent to our endpoint. 

This pulls the file from S3 and then prepares it for processing. Currently this doesn't actually do anything with each notification to update. We can only do this once we've setup our migration to move away from status enums.

## SNS Response types

We will receive two possible events from SNS, `Notification` for an S3 update or `SubscriptionConfirmation`. Both will have the `Type`, `MessageId` and `Message` hence their inclusion in the schema. If the Type isn't a `SubscriptionConfirmation`, we can safely assume it's a notification indicating an object has been added to S3 by DVLA.

## Additional Notes

1) Added a decorator to do JSON schema validation `validate_schema`, it's in the same file for now but can be moved out if/when used elsewhere.
2) Autoconfirm now added to the endpoint
 