### PR TITLE
notification status as table

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -127,7 +127,8 @@ def dao_update_service(service):
     db.session.add(service)
 
 
-def dao_add_user_to_service(service, user, permissions=[]):
+def dao_add_user_to_service(service, user, permissions=None):
+    permissions = permissions or []
     try:
         from app.dao.permissions_dao import permission_dao
         service.users.append(user)
@@ -214,7 +215,8 @@ def fetch_todays_total_message_count(service_id):
 def _stats_for_service_query(service_id):
     return db.session.query(
         Notification.notification_type,
-        Notification.status,
+        # see dao_fetch_todays_stats_for_all_services for why we have this label
+        Notification.status.label('status'),
         func.count(Notification.id).label('count')
     ).filter(
         Notification.service_id == service_id,
@@ -232,13 +234,13 @@ def dao_fetch_monthly_historical_stats_by_template_for_service(service_id, year)
     start_date, end_date = get_financial_year(year)
     sq = db.session.query(
         NotificationHistory.template_id,
-        NotificationHistory.status,
+        # see dao_fetch_todays_stats_for_all_services for why we have this label
+        NotificationHistory.status.label('status'),
         month.label('month'),
         func.count().label('count')
     ).filter(
         NotificationHistory.service_id == service_id,
         NotificationHistory.created_at.between(start_date, end_date)
-
     ).group_by(
         month,
         NotificationHistory.template_id,
@@ -249,7 +251,7 @@ def dao_fetch_monthly_historical_stats_by_template_for_service(service_id, year)
         Template.id.label('template_id'),
         Template.name,
         Template.template_type,
-        sq.c.status,
+        sq.c.status.label('status'),
         sq.c.count.label('count'),
         sq.c.month
     ).join(
@@ -267,7 +269,8 @@ def dao_fetch_monthly_historical_stats_for_service(service_id, year):
     start_date, end_date = get_financial_year(year)
     rows = db.session.query(
         NotificationHistory.notification_type,
-        NotificationHistory.status,
+        # see dao_fetch_todays_stats_for_all_services for why we have this label
+        NotificationHistory.status.label('status'),
         month,
         func.count(NotificationHistory.id).label('count')
     ).filter(
@@ -306,7 +309,9 @@ def dao_fetch_monthly_historical_stats_for_service(service_id, year):
 def dao_fetch_todays_stats_for_all_services(include_from_test_key=True):
     query = db.session.query(
         Notification.notification_type,
-        Notification.status,
+        # this label is necessary as the column has a different name under the hood (_status_enum / _status_fkey),
+        # if we query the Notification object there is a hybrid property to translate, but here there isn't anything.
+        Notification.status.label('status'),
         Notification.service_id,
         func.count(Notification.id).label('count')
     ).filter(
@@ -336,7 +341,8 @@ def fetch_stats_by_date_range_for_all_services(start_date, end_date, include_fro
 
     query = db.session.query(
         table.notification_type,
-        table.status,
+        # see dao_fetch_todays_stats_for_all_services for why we have this label
+        table.status.label('status'),
         table.service_id,
         func.count(table.id).label('count')
     ).filter(

--- a/app/errors.py
+++ b/app/errors.py
@@ -92,7 +92,7 @@ def register_errors(blueprint):
     @blueprint.errorhandler(SQLAlchemyError)
     def db_error(e):
         current_app.logger.exception(e)
-        if e.orig.pgerror and \
+        if hasattr(e, 'orig') and hasattr(e.orig, 'pgerror') and e.orig.pgerror and \
             ('duplicate key value violates unique constraint "services_name_key"' in e.orig.pgerror or
                 'duplicate key value violates unique constraint "services_email_from_key"' in e.orig.pgerror):
             return jsonify(

--- a/app/models.py
+++ b/app/models.py
@@ -895,6 +895,10 @@ class NotificationHistory(db.Model, HistoryModel):
         history.status = notification.status
         return history
 
+    def update_from_original(self, original):
+        super().update_from_original(original)
+        self.status = original.status
+
     @hybrid_property
     def status(self):
         return self._status_enum

--- a/migrations/versions/0081_noti_status_as_enum.py
+++ b/migrations/versions/0081_noti_status_as_enum.py
@@ -1,0 +1,33 @@
+"""empty message
+
+Revision ID: 0081_noti_status_as_enum
+Revises: 0080_fix_rate_start_date
+Create Date: 2017-05-02 14:50:04.070874
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0081_noti_status_as_enum'
+down_revision = '0080_fix_rate_start_date'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('notification_status',
+        sa.Column('name', sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint('name')
+    )
+
+    op.execute('ALTER TABLE notifications ADD COLUMN notification_status text')
+    op.execute('ALTER TABLE notification_history ADD COLUMN notification_status text')
+
+    op.create_index(op.f('ix_notifications_notification_status'), 'notifications', ['notification_status'])
+    op.create_index(op.f('ix_notification_history_notification_status'), 'notification_history', ['notification_status'])
+
+
+def downgrade():
+    op.execute('ALTER TABLE notifications DROP COLUMN notification_status')
+    op.execute('ALTER TABLE notification_history DROP COLUMN notification_status')
+    op.execute('DROP TABLE notification_status')

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -311,6 +311,8 @@ def test_should_by_able_to_update_status_by_id(sample_template, sample_job, mmg_
         data = _notification_json(sample_template, job_id=sample_job.id, status='sending')
         notification = Notification(**data)
         dao_create_notification(notification)
+        assert notification._status_enum == 'sending'
+        assert notification._status_fkey == 'sending'
 
     assert Notification.query.get(notification.id).status == 'sending'
 
@@ -321,6 +323,8 @@ def test_should_by_able_to_update_status_by_id(sample_template, sample_job, mmg_
     assert updated.updated_at == datetime(2000, 1, 2, 12, 0, 0)
     assert Notification.query.get(notification.id).status == 'delivered'
     assert notification.updated_at == datetime(2000, 1, 2, 12, 0, 0)
+    assert notification._status_enum == 'delivered'
+    assert notification._status_fkey == 'delivered'
 
 
 def test_should_not_update_status_by_id_if_not_sending_and_does_not_update_job(notify_db, notify_db_session):
@@ -825,12 +829,30 @@ def test_get_notification_billable_unit_count_per_month(notify_db, notify_db_ses
         ) == months
 
 
-def test_update_notification(sample_notification, sample_template):
+def test_update_notification(sample_notification):
     assert sample_notification.status == 'created'
     sample_notification.status = 'failed'
     dao_update_notification(sample_notification)
     notification_from_db = Notification.query.get(sample_notification.id)
     assert notification_from_db.status == 'failed'
+
+
+def test_update_notification_with_no_notification_status(sample_notification):
+    # specifically, it has an old enum status, but not a new status (because the upgrade script has just run)
+    sample_notification._status_fkey = None
+    sample_notification._enum_status = 'created'
+    dao_update_notification(sample_notification)
+
+    assert sample_notification.status == 'created'
+    assert sample_notification._enum_status == 'created'
+    assert sample_notification._status_fkey == None
+
+    sample_notification.status = 'failed'
+    dao_update_notification(sample_notification)
+    notification_from_db = Notification.query.get(sample_notification.id)
+    assert notification_from_db.status == 'failed'
+    assert notification_from_db._status_enum == 'failed'
+    assert notification_from_db._status_fkey == 'failed'
 
 
 @freeze_time("2016-01-10 12:00:00.000000")

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -839,20 +839,33 @@ def test_update_notification(sample_notification):
 
 def test_update_notification_with_no_notification_status(sample_notification):
     # specifically, it has an old enum status, but not a new status (because the upgrade script has just run)
-    sample_notification._status_fkey = None
-    sample_notification._enum_status = 'created'
-    dao_update_notification(sample_notification)
+    update_dict = {'_status_enum': 'created', '_status_fkey': None}
+    Notification.query.filter(Notification.id == sample_notification.id).update(update_dict)
 
-    assert sample_notification.status == 'created'
-    assert sample_notification._enum_status == 'created'
-    assert sample_notification._status_fkey == None
-
+    # now lets update the status to failed - both columns should now be populated
     sample_notification.status = 'failed'
     dao_update_notification(sample_notification)
+
     notification_from_db = Notification.query.get(sample_notification.id)
     assert notification_from_db.status == 'failed'
     assert notification_from_db._status_enum == 'failed'
     assert notification_from_db._status_fkey == 'failed'
+
+
+def test_updating_notification_with_no_notification_status_updates_notification_history(sample_notification):
+    # same as above, but with notification history
+    update_dict = {'_status_enum': 'created', '_status_fkey': None}
+    Notification.query.filter(Notification.id == sample_notification.id).update(update_dict)
+    NotificationHistory.query.filter(NotificationHistory.id == sample_notification.id).update(update_dict)
+
+    # now lets update the notification's status to failed - both columns should now be populated on the history object
+    sample_notification.status = 'failed'
+    dao_update_notification(sample_notification)
+
+    hist_from_db = NotificationHistory.query.get(sample_notification.id)
+    assert hist_from_db.status == 'failed'
+    assert hist_from_db._status_enum == 'failed'
+    assert hist_from_db._status_fkey == 'failed'
 
 
 @freeze_time("2016-01-10 12:00:00.000000")

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1240,17 +1240,16 @@ def test_get_monthly_notification_stats(mocker, client, sample_service, url, exp
     assert json.loads(response.get_data(as_text=True)) == expected_json
 
 
-def test_get_services_with_detailed_flag(notify_api, notify_db, notify_db_session):
+def test_get_services_with_detailed_flag(client, notify_db, notify_db_session):
     notifications = [
         create_sample_notification(notify_db, notify_db_session),
         create_sample_notification(notify_db, notify_db_session),
         create_sample_notification(notify_db, notify_db_session, key_type=KEY_TYPE_TEST)
     ]
-    with notify_api.test_request_context(), notify_api.test_client() as client:
-        resp = client.get(
-            '/service?detailed=True',
-            headers=[create_authorization_header()]
-        )
+    resp = client.get(
+        '/service?detailed=True',
+        headers=[create_authorization_header()]
+    )
 
     assert resp.status_code == 200
     data = json.loads(resp.get_data(as_text=True))['data']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,8 @@ def notify_db_session(notify_db):
                             "job_status",
                             "provider_details_history",
                             "template_process_type",
-                            "dvla_organisation"]:
+                            "dvla_organisation",
+                            "notification_status_types"]:
             notify_db.engine.execute(tbl.delete())
     notify_db.session.commit()
 


### PR DESCRIPTION
Adds a new column, `notification_status`, to the notification object. I know the name's a bit confusing, but I didn't want it to have some meta name that referenced the fact it's from a table.

This PR sets up the status table, and the new column as a nullable, foreign keyed table.

I've renamed the cols on the model to `_status_enum` and `_status_fkey` - they should not be interacted with directly. `Notification.status` now refers to a property that *reads from enum* and *updates both* - this way we immediately start populating new data without breaking old data. Then we can look at how to transfer old data across