### PR TITLE
fix v2 schema phone/email validation when non-str passed in

### DIFF
--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -10,13 +10,13 @@ def validate(json_to_validate, schema):
 
     @format_checker.checks('phone_number', raises=InvalidPhoneError)
     def validate_schema_phone_number(instance):
-        if instance is not None:
+        if isinstance(instance, str):
             validate_phone_number(instance, international=True)
         return True
 
     @format_checker.checks('email_address', raises=InvalidEmailError)
     def validate_schema_email_address(instance):
-        if instance is not None:
+        if isinstance(instance, str):
             validate_email_address(instance)
         return True
 


### PR DESCRIPTION
jsonschema states:

> A format attribute can generally only validate a given set of instance types. If the type of the instance to validate is not in this set, validation for this format attribute and instance SHOULD succeed.

We were not checking for the type of the input, and our validators were behaving in unexpected manners (throwing TypeErrors etc etc). Despite us declaring that the phone_number field is of type `str`, we still need to make sure the validator passes gracefully, so that the inbuilt type check can be the bit that catches if someone passes in a non-str value. We've seen this with people passing in integers instead of strs for phone numbers. This'll make them receive a nice 400 error (e.g. "phone_number 12345 is not of type string"), rather than us having a 500 internal server error