### PR TITLE
Update notification international

### DIFF
--- a/migrations/versions/0082_set_international.py
+++ b/migrations/versions/0082_set_international.py
@@ -1,39 +1,44 @@
 """empty message
 
 Revision ID: 0082_set_international
-Revises: 0080_fix_rate_start_date
+Revises: 0081_noti_status_as_enum
 Create Date: 2017-05-05 15:26:34.621670
 
 """
+from datetime import datetime
+from alembic import op
 
 # revision identifiers, used by Alembic.
-from datetime import datetime
-
 revision = '0082_set_international'
-down_revision = '0080_fix_rate_start_date'
-
-from alembic import op
-import sqlalchemy as sa
+down_revision = '0081_noti_status_as_enum'
 
 
 def upgrade():
     conn = op.get_bind()
     start = datetime.utcnow()
-    all_notifications = "select id from notification_history where international is null limit 10000"
+    notification_history = "select id from notification_history where international is null limit 10000"
 
-    results = conn.execute(all_notifications)
+    results = conn.execute(notification_history)
     res = results.fetchall()
 
-    conn.execute("update notifications set international = False where id in ({})".format(all_notifications))
-    conn.execute("update notification_history set international = False where id in ({})".format(all_notifications))
-
     while len(res) > 0:
-        conn.execute("update notifications set international = False where id in ({})".format(all_notifications))
-        conn.execute("update notification_history set international = False where id in ({})".format(all_notifications))
-        results = conn.execute(all_notifications)
+        conn.execute("update notification_history set international = False where id in ({})".format(
+            notification_history))
+        results = conn.execute(notification_history)
         res = results.fetchall()
+
+    notifications = "select id from notifications where international is null limit 10000"
+    results2 = conn.execute(notifications)
+    res2 = results2.fetchall()
+    while len(res2) > 0:
+        conn.execute("update notifications set international = False where id in ({})".format(notifications))
+
+        results2 = conn.execute(notifications)
+        res2 = results2.fetchall()
+
     end = datetime.utcnow()
     print("Started at: {}   ended at: {}".format(start, end))
+
 
 def downgrade():
     # There is no way to downgrade this update.

--- a/migrations/versions/0082_set_international.py
+++ b/migrations/versions/0082_set_international.py
@@ -1,6 +1,6 @@
 """empty message
 
-Revision ID: set_notifications_international
+Revision ID: 0082_set_international
 Revises: 0080_fix_rate_start_date
 Create Date: 2017-05-05 15:26:34.621670
 
@@ -9,7 +9,7 @@ Create Date: 2017-05-05 15:26:34.621670
 # revision identifiers, used by Alembic.
 from datetime import datetime
 
-revision = 'set_notifications_international'
+revision = '0082_set_international'
 down_revision = '0080_fix_rate_start_date'
 
 from alembic import op
@@ -19,14 +19,17 @@ import sqlalchemy as sa
 def upgrade():
     conn = op.get_bind()
     start = datetime.utcnow()
-    all_notifications = "select id from notifications where international is null limit 1000"
+    all_notifications = "select id from notification_history where international is null limit 10000"
 
     results = conn.execute(all_notifications)
     res = results.fetchall()
+
+    conn.execute("update notifications set international = False where id in ({})".format(all_notifications))
+    conn.execute("update notification_history set international = False where id in ({})".format(all_notifications))
+
     while len(res) > 0:
         conn.execute("update notifications set international = False where id in ({})".format(all_notifications))
         conn.execute("update notification_history set international = False where id in ({})".format(all_notifications))
-        conn.commit()
         results = conn.execute(all_notifications)
         res = results.fetchall()
     end = datetime.utcnow()

--- a/migrations/versions/0083_set_international_not_null.py
+++ b/migrations/versions/0083_set_international_not_null.py
@@ -1,0 +1,31 @@
+"""empty message
+
+Revision ID: 0083_set_international_not_null
+Revises: 0082_set_international
+Create Date: 2017-05-10 14:08:51.067762
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0083_set_international_not_null'
+down_revision = '0082_set_international'
+
+
+def upgrade():
+    op.alter_column('notification_history', 'international',
+                    existing_type=sa.BOOLEAN(),
+                    nullable=False)
+    op.alter_column('notifications', 'international',
+                    existing_type=sa.BOOLEAN(),
+                    nullable=False)
+
+
+def downgrade():
+    op.alter_column('notifications', 'international',
+                    existing_type=sa.BOOLEAN(),
+                    nullable=True)
+    op.alter_column('notification_history', 'international',
+                    existing_type=sa.BOOLEAN(),
+                    nullable=True)

--- a/migrations/versions/set_notifications_international.py
+++ b/migrations/versions/set_notifications_international.py
@@ -1,0 +1,37 @@
+"""empty message
+
+Revision ID: set_notifications_international
+Revises: 0080_fix_rate_start_date
+Create Date: 2017-05-05 15:26:34.621670
+
+"""
+
+# revision identifiers, used by Alembic.
+from datetime import datetime
+
+revision = 'set_notifications_international'
+down_revision = '0080_fix_rate_start_date'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    conn = op.get_bind()
+    start = datetime.utcnow()
+    all_notifications = "select id from notifications where international is null limit 1000"
+
+    results = conn.execute(all_notifications)
+    res = results.fetchall()
+    while len(res) > 0:
+        conn.execute("update notifications set international = False where id in ({})".format(all_notifications))
+        conn.execute("update notification_history set international = False where id in ({})".format(all_notifications))
+        conn.commit()
+        results = conn.execute(all_notifications)
+        res = results.fetchall()
+    end = datetime.utcnow()
+    print("Started at: {}   ended at: {}".format(start, end))
+
+def downgrade():
+    # There is no way to downgrade this update.
+    pass


### PR DESCRIPTION
Update the script to set the international flag False where the value is null in the  notifications and notification_history, these updates are done in separate loops.

It takes about 1.5 minutes to update 27,000 notifications and 27,000 notification_history. 

The update is a row level lock so will only affect updates to the same row.
This is unlikely as the data being updated should be older than 3 days.
The second scripts updates the table to set international as not null, to make the model.