### PR TITLE
Output contact blocks with placeholders replaced

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,6 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@16.1.3#egg=notifications-utils==16.1.3
+git+https://github.com/alphagov/notifications-utils.git@17.1.0#egg=notifications-utils==17.1.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/161

***

Also brings in https://github.com/alphagov/notifications-utils/compare/16.1.3...17.0.2. Breaking change is in https://github.com/alphagov/notifications-utils/commit/06beb23c952c75374d8739cba2ffc3054bed33ef – shouldn’t affect the API.