### PR TITLE
Force parse JSON received from SNS

### DIFF
--- a/app/notifications/notifications_letter_callback.py
+++ b/app/notifications/notifications_letter_callback.py
@@ -35,7 +35,7 @@ def validate_schema(schema):
     def decorator(f):
         @wraps(f)
         def wrapper(*args, **kw):
-            validate(request.json, schema)
+            validate(request.get_json(force=True), schema)
             return f(*args, **kw)
         return wrapper
     return decorator
@@ -44,7 +44,8 @@ def validate_schema(schema):
 @letter_callback_blueprint.route('/notifications/letter/dvla', methods=['POST'])
 @validate_schema(dvla_sns_callback_schema)
 def process_letter_response():
-    req_json = request.json
+    req_json = request.get_json(force=True)
+    current_app.logger.info('Received SNS callback: {}'.format(req_json))
     if not autoconfirm_subscription(req_json):
         # The callback should have one record for an S3 Put Event.
         filename = req_json['Message']['Records'][0]['s3']['object']['key']

--- a/tests/app/notifications/rest/test_callbacks.py
+++ b/tests/app/notifications/rest/test_callbacks.py
@@ -71,6 +71,18 @@ def test_dvla_callback_calls_update_letter_notifications_task(client, mocker):
     update_task.assert_called_with(['bar.txt'], queue='notify')
 
 
+def test_dvla_callback_does_not_raise_error_parsing_json_for_plaintext_header(client, mocker):
+    mocker.patch('app.notifications.notifications_letter_callback.update_letter_notifications_statuses.apply_async')
+    data = _sample_sns_s3_callback()
+    response = client.post(
+        path='/notifications/letter/dvla',
+        data=data,
+        headers=[('Content-Type', 'text/plain')]
+    )
+
+    assert response.status_code == 200
+
+
 def test_firetext_callback_should_not_need_auth(client, mocker):
     mocker.patch('app.statsd_client.incr')
     response = client.post(


### PR DESCRIPTION
This fixes an issue where the JSON is not being parsed properly in the DVLA callback. 

## Why

An SNS callback with a JSON body has the header set to `text/plain` (http://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.html). Flask's `request.get_json()` returns None if header is not set to `application/json`. This can be overridden by passing in the `force` parameter with a `True` value.

We haven't faced this behaviour with our SES callbacks as in there we call `json.loads(request.body)` which doesn't look at the header. This solution is less `flasky`, however. 