### PR TITLE
Comma-format number when emailing live services

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -132,7 +132,7 @@ def update_service(service_id):
             template_id=current_app.config['SERVICE_NOW_LIVE_TEMPLATE_ID'],
             personalisation={
                 'service_name': current_data['name'],
-                'message_limit': current_data['message_limit']
+                'message_limit': '{:,}'.format(current_data['message_limit'])
             },
             include_user_fields=['name']
         )

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1682,7 +1682,15 @@ def test_update_service_calls_send_notification_as_service_becomes_live(notify_d
     )
 
     assert resp.status_code == 200
-    assert send_notification_mock.called
+    send_notification_mock.assert_called_once_with(
+        service_id=restricted_service.id,
+        template_id='618185c6-3636-49cd-b7d2-6f6f5eb3bdde',
+        personalisation={
+            'service_name': restricted_service.name,
+            'message_limit': '1,000'
+        },
+        include_user_fields=['name']
+    )
 
 
 def test_update_service_does_not_call_send_notification_for_live_service(sample_service, client, mocker):


### PR DESCRIPTION
250,000 is easier to read than 250000.