### PR TITLE
Fix issue with parsing JSON in SNS callback

### DIFF
--- a/app/notifications/notifications_letter_callback.py
+++ b/app/notifications/notifications_letter_callback.py
@@ -1,3 +1,5 @@
+import json
+
 from functools import wraps
 
 from flask import (
@@ -48,7 +50,8 @@ def process_letter_response():
     current_app.logger.info('Received SNS callback: {}'.format(req_json))
     if not autoconfirm_subscription(req_json):
         # The callback should have one record for an S3 Put Event.
-        filename = req_json['Message']['Records'][0]['s3']['object']['key']
+        message = json.loads(req_json['Message'])
+        filename = message['Records'][0]['s3']['object']['key']
         current_app.logger.info('Received file from DVLA: {}'.format(filename))
         current_app.logger.info('DVLA callback: Calling task to update letter notifications')
         update_letter_notifications_statuses.apply_async([filename], queue='notify')

--- a/tests/app/notifications/rest/test_callbacks.py
+++ b/tests/app/notifications/rest/test_callbacks.py
@@ -531,33 +531,5 @@ def _sample_sns_s3_callback():
         "MessageId": "6adbfe0a-d610-509a-9c47-af894e90d32d",
         "Subject": "Amazon S3 Notification",
         "TopicArn": "sample-topic-arn",
-        "Message": {
-            "Records": [{
-                "eventVersion": "2.0",
-                "eventSource": "aws:s3",
-                "awsRegion": "eu-west-1",
-                "eventTime": "2017-05-03T08:35:12.826Z",
-                "eventName": "ObjectCreated:Put",
-                "userIdentity": {"principalId": "some-p-id"},
-                "requestParameters": {"sourceIPAddress": "8.8.8.8"},
-                "responseElements": {"x-amz-request-id": "some-req-id", "x-amz-id-2": "some-amz-id"},
-                "s3": {
-                    "s3SchemaVersion": "1.0",
-                    "configurationId": "some-config-id",
-                    "bucket": {
-                        "name": "some-bucket",
-                        "ownerIdentity": {"principalId": "some-p-id"},
-                        "arn": "some-bucket-arn"
-                    },
-                    "object": {
-                        "key": "bar.txt",
-                        "size": 200,
-                        "eTag": "some-etag",
-                        "versionId": "some-v-id",
-                        "sequencer": "some-seq"
-                    }
-                }
-            }
-            ]
-        }
+        "Message": '{"Records":[{"eventVersion":"2.0","eventSource":"aws:s3","awsRegion":"eu-west-1","eventTime":"2017-05-16T11:38:41.073Z","eventName":"ObjectCreated:Put","userIdentity":{"principalId":"some-p-id"},"requestParameters":{"sourceIPAddress":"8.8.8.8"},"responseElements":{"x-amz-request-id":"some-r-id","x-amz-id-2":"some-x-am-id"},"s3":{"s3SchemaVersion":"1.0","configurationId":"some-c-id","bucket":{"name":"some-bucket","ownerIdentity":{"principalId":"some-p-id"},"arn":"some-bucket-arn"},"object":{"key":"bar.txt","size":200,"eTag":"some-e-tag","versionId":"some-v-id","sequencer":"some-seq"}}}]}'  # noqa
     })


### PR DESCRIPTION
This fixes the issue where the JSON received from SNS in the DVLA callback was not being parsed correctly.

In short, `request.get_json(force=True)` wasn't enough to parse a nested JSON obj. The test data was incorrect so this wasn't caught by the test initially. The test stub has been fixed and now we additionally use `json.loads(req_json['Message')` to parse the nested JSON properly.

