### PR TITLE
Fix test that doesn't account for notifications being created in a di…

### DIFF
--- a/tests/app/service/test_sender.py
+++ b/tests/app/service/test_sender.py
@@ -106,7 +106,9 @@ def test_send_notification_to_service_users_sends_to_active_users_only(
 
     send_notification_to_service_users(service_id=service.id, template_id=template.id)
     notifications = Notification.query.all()
+    notifications_recipients = [notification.to for notification in notifications]
 
     assert Notification.query.count() == 2
-
-    assert pending_user.email_address not in [n.to for n in notifications]
+    assert pending_user.email_address not in notifications_recipients
+    assert first_active_user.email_address in notifications_recipients
+    assert second_active_user.email_address in notifications_recipients


### PR DESCRIPTION
This fixes the issue where this test can fail (and did in a build) if the notifications are created in an unexpected order. 