### PR TITLE
Remove drop updated_at column from db script

### DIFF
--- a/migrations/versions/0085_update_incoming_to_inbound.py
+++ b/migrations/versions/0085_update_incoming_to_inbound.py
@@ -1,0 +1,22 @@
+"""empty message
+
+Revision ID: 0085_update_incoming_to_inbound
+Revises: 0084_add_job_stats
+Create Date: 2017-05-22 10:23:43.939050
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0085_update_incoming_to_inbound'
+down_revision = '0084_add_job_stats'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+    op.execute("UPDATE service_permission_types SET name='inbound_sms' WHERE name='incoming_sms'")
+
+
+def downgrade():
+    op.execute("UPDATE service_permission_types SET name='incoming_sms' WHERE name='inbound_sms'")


### PR DESCRIPTION
Updated the script so that it doesn't drop any columns from the service_permissions table