### PR TITLE
Non null sender

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -188,7 +188,7 @@ class Service(db.Model, Versioned):
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
     reply_to_email_address = db.Column(db.Text, index=False, unique=False, nullable=True)
     letter_contact_block = db.Column(db.Text, index=False, unique=False, nullable=True)
-    sms_sender = db.Column(db.String(11), nullable=True, default=lambda: current_app.config['FROM_NUMBER'])
+    sms_sender = db.Column(db.String(11), nullable=False, default=lambda: current_app.config['FROM_NUMBER'])
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey('organisation.id'), index=True, nullable=True)
     organisation = db.relationship('Organisation')
     dvla_organisation_id = db.Column(

--- a/migrations/versions/0085_govuk_sms_sender.py
+++ b/migrations/versions/0085_govuk_sms_sender.py
@@ -1,0 +1,25 @@
+"""empty message
+
+Revision ID: 0085_govuk_sms_sender
+Revises: 0084_add_job_stats
+Create Date: 2017-05-22 13:46:09.584801
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0085_govuk_sms_sender'
+down_revision = '0084_add_job_stats'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("UPDATE services SET sms_sender = 'GOVUK' where sms_sender is null")
+    op.execute("UPDATE services_history SET sms_sender = 'GOVUK' where sms_sender is null")
+    op.alter_column('services', 'sms_sender', nullable=False)
+    op.alter_column('services_history', 'sms_sender', nullable=False)
+
+
+def downgrade():
+    op.alter_column('services_history', 'sms_sender', nullable=True)
+    op.alter_column('services', 'sms_sender', nullable=True)

--- a/migrations/versions/0086_govuk_sms_sender.py
+++ b/migrations/versions/0086_govuk_sms_sender.py
@@ -1,14 +1,14 @@
 """empty message
 
-Revision ID: 0085_govuk_sms_sender
-Revises: 0084_add_job_stats
+Revision ID: 0086_govuk_sms_sender
+Revises: 0085_update_incoming_to_inbound
 Create Date: 2017-05-22 13:46:09.584801
 
 """
 
 # revision identifiers, used by Alembic.
-revision = '0085_govuk_sms_sender'
-down_revision = '0084_add_job_stats'
+revision = '0086_govuk_sms_sender'
+down_revision = '0085_update_incoming_to_inbound'
 
 from alembic import op
 

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -627,7 +627,6 @@ def test_should_set_international_phone_number_to_sent_status(
     # if 40604 is actually in DB then treat that as if entered manually
     ('40604', '40604', 'bar'),
     # 'testing' is the FROM_NUMBER during unit tests
-    (None, 'testing', 'Sample service: bar'),
     ('testing', 'testing', 'Sample service: bar'),
 ])
 def test_should_handle_sms_sender_and_prefix_message(

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -214,11 +214,7 @@ def test_create_service(client, sample_user):
     assert json_resp['data']['email_from'] == 'created.service'
     assert not json_resp['data']['research_mode']
     assert json_resp['data']['dvla_organisation'] == '001'
-<<<<<<< HEAD
     assert json_resp['data']['sms_sender'] == current_app.config['FROM_NUMBER']
-=======
-    assert json_resp['data']['sms_sender'] == 'GOVUK'
->>>>>>> set sms_sender to be 'GOVUK' if not otherwise specified
 
     auth_header_fetch = create_authorization_header()
 
@@ -1184,7 +1180,7 @@ def test_set_sms_sender_for_service_rejects_null(client, sample_service):
     result = json.loads(resp.get_data(as_text=True))
     assert resp.status_code == 400
     assert result['result'] == 'error'
-    assert result['message'] == {'sms_sender': 'Field may not be null.'}
+    assert result['message'] == {'sms_sender': ['Field may not be null.']}
 
 
 @pytest.mark.parametrize('today_only,stats', [

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -214,7 +214,11 @@ def test_create_service(client, sample_user):
     assert json_resp['data']['email_from'] == 'created.service'
     assert not json_resp['data']['research_mode']
     assert json_resp['data']['dvla_organisation'] == '001'
+<<<<<<< HEAD
     assert json_resp['data']['sms_sender'] == current_app.config['FROM_NUMBER']
+=======
+    assert json_resp['data']['sms_sender'] == 'GOVUK'
+>>>>>>> set sms_sender to be 'GOVUK' if not otherwise specified
 
     auth_header_fetch = create_authorization_header()
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1134,61 +1134,57 @@ def test_get_only_api_created_notifications_for_service(
     assert response.status_code == 200
 
 
-def test_set_sms_sender_for_service(notify_api, sample_service):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            auth_header = create_authorization_header()
-            resp = client.get(
-                '/service/{}'.format(sample_service.id),
-                headers=[auth_header]
-            )
-            json_resp = json.loads(resp.get_data(as_text=True))
-            assert resp.status_code == 200
-            assert json_resp['data']['name'] == sample_service.name
+def test_set_sms_sender_for_service(client, sample_service):
+    data = {
+        'sms_sender': 'elevenchars',
+    }
 
-            data = {
-                'sms_sender': 'elevenchars',
-            }
+    auth_header = create_authorization_header()
 
-            auth_header = create_authorization_header()
-
-            resp = client.post(
-                '/service/{}'.format(sample_service.id),
-                data=json.dumps(data),
-                headers=[('Content-Type', 'application/json'), auth_header]
-            )
-            result = json.loads(resp.get_data(as_text=True))
-            assert resp.status_code == 200
-            assert result['data']['sms_sender'] == 'elevenchars'
+    resp = client.post(
+        '/service/{}'.format(sample_service.id),
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header]
+    )
+    result = json.loads(resp.get_data(as_text=True))
+    assert resp.status_code == 200
+    assert result['data']['sms_sender'] == 'elevenchars'
 
 
-def test_set_sms_sender_for_service_rejects_invalid_characters(notify_api, sample_service):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            auth_header = create_authorization_header()
-            resp = client.get(
-                '/service/{}'.format(sample_service.id),
-                headers=[auth_header]
-            )
-            json_resp = json.loads(resp.get_data(as_text=True))
-            assert resp.status_code == 200
-            assert json_resp['data']['name'] == sample_service.name
+def test_set_sms_sender_for_service_rejects_invalid_characters(client, sample_service):
+    data = {
+        'sms_sender': 'invalid####',
+    }
 
-            data = {
-                'sms_sender': 'invalid####',
-            }
+    auth_header = create_authorization_header()
 
-            auth_header = create_authorization_header()
+    resp = client.post(
+        '/service/{}'.format(sample_service.id),
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header]
+    )
+    result = json.loads(resp.get_data(as_text=True))
+    assert resp.status_code == 400
+    assert result['result'] == 'error'
+    assert result['message'] == {'sms_sender': ['Only alphanumeric characters allowed']}
 
-            resp = client.post(
-                '/service/{}'.format(sample_service.id),
-                data=json.dumps(data),
-                headers=[('Content-Type', 'application/json'), auth_header]
-            )
-            result = json.loads(resp.get_data(as_text=True))
-            assert resp.status_code == 400
-            assert result['result'] == 'error'
-            assert result['message'] == {'sms_sender': ['Only alphanumeric characters allowed']}
+
+def test_set_sms_sender_for_service_rejects_null(client, sample_service):
+    data = {
+        'sms_sender': None,
+    }
+
+    auth_header = create_authorization_header()
+
+    resp = client.post(
+        '/service/{}'.format(sample_service.id),
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header]
+    )
+    result = json.loads(resp.get_data(as_text=True))
+    assert resp.status_code == 400
+    assert result['result'] == 'error'
+    assert result['message'] == {'sms_sender': 'Field may not be null.'}
 
 
 @pytest.mark.parametrize('today_only,stats', [


### PR DESCRIPTION
This upgrades the database to enforce a non-null constraint on the database. This requires us to make sure we don't put nulls in the DB, which the following two PRs will do:

- [x] https://github.com/alphagov/notifications-api/pull/973
- [x] https://github.com/alphagov/notifications-admin/pull/1284

Then, this can be run to update all existing nulls to 'GOVUK'.