### PR TITLE
Add normalised_to field to notification

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -679,6 +679,7 @@ class Notification(db.Model):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     to = db.Column(db.String, nullable=False)
+    normalised_to = db.Column(db.String, nullable=True)
     job_id = db.Column(UUID(as_uuid=True), db.ForeignKey('jobs.id'), index=True, unique=False)
     job = db.relationship('Job', backref=db.backref('notifications', lazy='dynamic'))
     job_row_number = db.Column(db.Integer, nullable=True)

--- a/migrations/versions/0086_add_norm_to_notification.py
+++ b/migrations/versions/0086_add_norm_to_notification.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 0086_add_norm_to_notification
+Revises: 0085_update_incoming_to_inbound
+Create Date: 2017-05-23 10:37:00.404087
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0086_add_norm_to_notification'
+down_revision = '0085_update_incoming_to_inbound'
+
+
+def upgrade():
+    op.add_column('notifications', sa.Column('normalised_to', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('notifications', 'normalised_to')


### PR DESCRIPTION
This adds `normalised_to` field to the `Notification` which will store the number that we normalise to when sending notifications.