### PR TITLE
Persist normalised recipient to `Notification`

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -165,19 +165,20 @@ def send_sms(self,
         return
 
     try:
-        saved_notification = persist_notification(template_id=notification['template'],
-                                                  template_version=notification['template_version'],
-                                                  recipient=notification['to'],
-                                                  service=service,
-                                                  personalisation=notification.get('personalisation'),
-                                                  notification_type=SMS_TYPE,
-                                                  api_key_id=api_key_id,
-                                                  key_type=key_type,
-                                                  created_at=created_at,
-                                                  job_id=notification.get('job', None),
-                                                  job_row_number=notification.get('row_number', None),
-                                                  notification_id=notification_id
-                                                  )
+        saved_notification = persist_notification(
+            template_id=notification['template'],
+            template_version=notification['template_version'],
+            recipient=notification['to'],
+            service=service,
+            personalisation=notification.get('personalisation'),
+            notification_type=SMS_TYPE,
+            api_key_id=api_key_id,
+            key_type=key_type,
+            created_at=created_at,
+            job_id=notification.get('job', None),
+            job_row_number=notification.get('row_number', None),
+            notification_id=notification_id
+        )
 
         provider_tasks.deliver_sms.apply_async(
             [str(saved_notification.id)],

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -72,6 +72,7 @@ def persist_notification(
     if notification_type == SMS_TYPE:
         formatted_recipient = validate_and_format_phone_number(recipient, international=True)
         recipient_info = get_international_phone_info(formatted_recipient)
+        notification.normalised_to = formatted_recipient
         notification.international = recipient_info.international
         notification.phone_prefix = recipient_info.country_prefix
         notification.rate_multiplier = recipient_info.billable_units

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -4,7 +4,8 @@ from flask import current_app
 
 from notifications_utils.recipients import (
     get_international_phone_info,
-    validate_and_format_phone_number
+    validate_and_format_phone_number,
+    format_email_address
 )
 
 from app import redis_store
@@ -76,6 +77,8 @@ def persist_notification(
         notification.international = recipient_info.international
         notification.phone_prefix = recipient_info.country_prefix
         notification.rate_multiplier = recipient_info.billable_units
+    elif notification_type == EMAIL_TYPE:
+        notification.normalised_to = format_email_address(notification.to)
 
     # if simulated create a Notification model to return but do not persist the Notification to the dB
     if not simulated:

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -348,3 +348,38 @@ def test_persist_scheduled_notification(sample_notification):
     assert len(scheduled_notification) == 1
     assert scheduled_notification[0].notification_id == sample_notification.id
     assert scheduled_notification[0].scheduled_for == datetime.datetime(2017, 5, 12, 13, 15)
+
+
+@pytest.mark.parametrize('recipient, expected_recipient_normalised', [
+    ('7900900123', '447900900123'),
+    ('+447900   900 123', '447900900123'),
+    ('  07700900222', '447700900222'),
+    ('07700900222', '447700900222'),
+    (' 73122345678', '73122345678'),
+    ('360623400400', '360623400400'),
+    ('-077-00900222-', '447700900222'),
+    ('(360623(400400)', '360623400400')
+
+])
+def test_persist_sms_notification_stores_normalised_number(
+    sample_job,
+    sample_api_key,
+    mocker,
+    recipient,
+    expected_recipient_normalised
+):
+    persist_notification(
+        template_id=sample_job.template.id,
+        template_version=sample_job.template.version,
+        recipient=recipient,
+        service=sample_job.service,
+        personalisation=None,
+        notification_type='sms',
+        api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type,
+        job_id=sample_job.id,
+    )
+    persisted_notification = Notification.query.all()[0]
+
+    assert persisted_notification.to == recipient
+    assert persisted_notification.normalised_to == expected_recipient_normalised

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -383,3 +383,32 @@ def test_persist_sms_notification_stores_normalised_number(
 
     assert persisted_notification.to == recipient
     assert persisted_notification.normalised_to == expected_recipient_normalised
+
+
+@pytest.mark.parametrize('recipient, expected_recipient_normalised', [
+    ('FOO@bar.com', 'foo@bar.com'),
+    ('BAR@foo.com', 'bar@foo.com')
+
+])
+def test_persist_email_notification_stores_normalised_email(
+    sample_job,
+    sample_api_key,
+    mocker,
+    recipient,
+    expected_recipient_normalised
+):
+    persist_notification(
+        template_id=sample_job.template.id,
+        template_version=sample_job.template.version,
+        recipient=recipient,
+        service=sample_job.service,
+        personalisation=None,
+        notification_type='email',
+        api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type,
+        job_id=sample_job.id,
+    )
+    persisted_notification = Notification.query.all()[0]
+
+    assert persisted_notification.to == recipient
+    assert persisted_notification.normalised_to == expected_recipient_normalised


### PR DESCRIPTION
This persists the normalised recipient to the `Notification` for sms and email.

This paves way for searching for notifications (needed for two-way) as we can query against this. 

This was branched off #979 so will be rebased off `master` once that's merged in.

## Dependencies:

- [x] #979 