### PR TITLE
Ken update api service permissions handling

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -138,7 +138,7 @@ def dao_create_service(service, user, service_id=None, service_permissions=[SMS_
     service.active = True
     service.research_mode = False
 
-    def process_deprecated_service_permissions():
+    def deprecate_process_service_permissions():
         for permission in service_permissions:
             service_permission = ServicePermission(service_id=service.id, permission=permission)
             service.permissions.append(service_permission)
@@ -148,7 +148,7 @@ def dao_create_service(service, user, service_id=None, service_permissions=[SMS_
             if permission == LETTER_TYPE:
                 service.can_send_letters = True
 
-        def sync_flags(flag, notify_type):
+        def convert_flags(flag, notify_type):
             if flag and notify_type not in service_permissions:
                 service_permission = ServicePermission(service_id=service.id, permission=notify_type)
                 service.permissions.append(service_permission)
@@ -156,10 +156,10 @@ def dao_create_service(service, user, service_id=None, service_permissions=[SMS_
                 service_permission = ServicePermission(service_id=service.id, permission=notify_type)
                 service.permissions.remove(service_permission)
 
-        sync_flags(service.can_send_international_sms, INTERNATIONAL_SMS_TYPE)
-        sync_flags(service.can_send_letters, LETTER_TYPE)
+        convert_flags(service.can_send_international_sms, INTERNATIONAL_SMS_TYPE)
+        convert_flags(service.can_send_letters, LETTER_TYPE)
 
-    process_deprecated_service_permissions()
+    deprecate_process_service_permissions()
     db.session.add(service)
 
 

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -31,7 +31,9 @@ from app.models import (
     TEMPLATE_TYPES,
     JobStatistics,
     SMS_TYPE,
-    EMAIL_TYPE
+    EMAIL_TYPE,
+    INTERNATIONAL_SMS_TYPE,
+    LETTER_TYPE
 )
 from app.service.statistics import format_monthly_template_notification_stats
 from app.statsd_decorators import statsd
@@ -136,10 +138,28 @@ def dao_create_service(service, user, service_id=None, service_permissions=[SMS_
     service.active = True
     service.research_mode = False
 
-    for permission in service_permissions:
-        service_permission = ServicePermission(service_id=service.id, permission=permission)
-        service.permissions.append(service_permission)
+    def process_deprecated_service_permissions():
+        for permission in service_permissions:
+            service_permission = ServicePermission(service_id=service.id, permission=permission)
+            service.permissions.append(service_permission)
 
+            if permission == INTERNATIONAL_SMS_TYPE:
+                service.can_send_international_sms = True
+            if permission == LETTER_TYPE:
+                service.can_send_letters = True
+
+        def sync_flags(flag, notify_type):
+            if flag and notify_type not in service_permissions:
+                service_permission = ServicePermission(service_id=service.id, permission=notify_type)
+                service.permissions.append(service_permission)
+            elif flag is False and notify_type in service_permissions:
+                service_permission = ServicePermission(service_id=service.id, permission=notify_type)
+                service.permissions.remove(service_permission)
+
+        sync_flags(service.can_send_international_sms, INTERNATIONAL_SMS_TYPE)
+        sync_flags(service.can_send_letters, LETTER_TYPE)
+
+    process_deprecated_service_permissions()
     db.session.add(service)
 
 

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -148,17 +148,6 @@ def dao_create_service(service, user, service_id=None, service_permissions=[SMS_
             if permission == LETTER_TYPE:
                 service.can_send_letters = True
 
-        def convert_flags(flag, notify_type):
-            if flag and notify_type not in service_permissions:
-                service_permission = ServicePermission(service_id=service.id, permission=notify_type)
-                service.permissions.append(service_permission)
-            elif flag is False and notify_type in service_permissions:
-                service_permission = ServicePermission(service_id=service.id, permission=notify_type)
-                service.permissions.remove(service_permission)
-
-        convert_flags(service.can_send_international_sms, INTERNATIONAL_SMS_TYPE)
-        convert_flags(service.can_send_letters, LETTER_TYPE)
-
     deprecate_process_service_permissions()
     db.session.add(service)
 

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -169,16 +169,6 @@ def dao_update_service(service):
     db.session.add(service)
 
 
-@transactional
-@version_class(Service)
-def dao_remove_service_permission(service, permission):
-    for p in service.permissions:
-        if p.permission == permission:
-            service.permissions.remove(p)
-
-    db.session.add(service)
-
-
 def dao_add_user_to_service(service, user, permissions=None):
     permissions = permissions or []
     try:

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -138,7 +138,7 @@ def dao_create_service(service, user, service_id=None, service_permissions=[SMS_
 
     for permission in service_permissions:
         service_permission = ServicePermission(service_id=service.id, permission=permission)
-        db.session.add(service_permission)
+        service.permissions.append(service_permission)
 
     db.session.add(service)
 
@@ -146,6 +146,16 @@ def dao_create_service(service, user, service_id=None, service_permissions=[SMS_
 @transactional
 @version_class(Service)
 def dao_update_service(service):
+    db.session.add(service)
+
+
+@transactional
+@version_class(Service)
+def dao_remove_service_permission(service, permission):
+    for p in service.permissions:
+        if p.permission == permission:
+            service.permissions.remove(p)
+
     db.session.add(service)
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -241,7 +241,8 @@ class ServicePermission(db.Model):
     service = db.relationship("Service")
     created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow, nullable=False)
 
-    service_permission_types = db.relationship(Service, backref=db.backref("permissions"))
+    service_permission_types = db.relationship(
+        Service, backref=db.backref("permissions", cascade="all, delete-orphan"))
 
     def __repr__(self):
         return '<{} has service permission: {}>'.format(self.service_id, self.permission)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -247,7 +247,7 @@ class ServiceSchema(BaseSchema):
 
         if len(set(permissions)) != len(permissions):
             duplicates = list(set([x for x in permissions if permissions.count(x) > 1]))
-            raise ValueError('Service Permission duplicated: {}'.format(duplicates))
+            raise ValidationError('Duplicate Service Permission: {}'.format(duplicates))
 
     @pre_load()
     def format_for_data_model(self, in_data):
@@ -264,7 +264,7 @@ class ServiceSchema(BaseSchema):
                 in_data['can_send_international_sms'] = INTERNATIONAL_SMS_TYPE in [p.permission for p in permissions]
 
             def deprecate_convert_flags_to_permissions():
-                def convert_flag(flag, notify_type):
+                def convert_flags(flag, notify_type):
                     if flag and notify_type not in str_permissions:
                         permission = ServicePermission(service_id=in_data['id'], permission=notify_type)
                         permissions.append(permission)
@@ -273,8 +273,8 @@ class ServiceSchema(BaseSchema):
                             if p.permission == notify_type:
                                 permissions.remove(p)
 
-                convert_flag(in_data["can_send_international_sms"], INTERNATIONAL_SMS_TYPE)
-                convert_flag(in_data["can_send_letters"], LETTER_TYPE)
+                convert_flags(in_data["can_send_international_sms"], INTERNATIONAL_SMS_TYPE)
+                convert_flags(in_data["can_send_letters"], LETTER_TYPE)
 
             if self.override_flag:
                 deprecate_override_flags()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -130,10 +130,7 @@ def update_service(service_id):
     current_data = dict(service_schema.dump(fetched_service).data.items())
     service_schema.set_override_flag(request.get_json().get('permissions') is not None)
     current_data.update(request.get_json())
-    try:
-        update_dict = service_schema.load(current_data).data
-    except ValueError as e:
-        raise InvalidRequest(str(e), status_code=400)
+    update_dict = service_schema.load(current_data).data
     dao_update_service(update_dict)
 
     if service_going_live:

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -95,12 +95,11 @@ def get_services():
 def get_service_by_id(service_id):
     if request.args.get('detailed') == 'True':
         data = get_detailed_service(service_id, today_only=request.args.get('today_only') == 'True')
-        return jsonify(data=data)
     else:
         fetched = dao_fetch_service_by_id(service_id)
 
         data = service_schema.dump(fetched).data
-        return jsonify(data=data)
+    return jsonify(data=data)
 
 
 @service_blueprint.route('', methods=['POST'])

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -128,6 +128,7 @@ def update_service(service_id):
     service_going_live = fetched_service.restricted and not request.get_json().get('restricted', True)
 
     current_data = dict(service_schema.dump(fetched_service).data.items())
+    service_schema.set_override_flag(request.get_json().get('permissions') is not None)
     current_data.update(request.get_json())
     try:
         update_dict = service_schema.load(current_data).data

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -129,7 +129,10 @@ def update_service(service_id):
 
     current_data = dict(service_schema.dump(fetched_service).data.items())
     current_data.update(request.get_json())
-    update_dict = service_schema.load(current_data).data
+    try:
+        update_dict = service_schema.load(current_data).data
+    except ValueError as e:
+        raise InvalidRequest(str(e), status_code=400)
     dao_update_service(update_dict)
 
     if service_going_live:

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -24,7 +24,7 @@ from app.models import (
     NotificationStatistics,
     ServiceWhitelist,
     KEY_TYPE_NORMAL, KEY_TYPE_TEST, KEY_TYPE_TEAM,
-    MOBILE_TYPE, EMAIL_TYPE, LETTER_TYPE, NOTIFICATION_STATUS_TYPES_COMPLETED, ScheduledNotification)
+    MOBILE_TYPE, EMAIL_TYPE, SMS_TYPE, LETTER_TYPE, NOTIFICATION_STATUS_TYPES_COMPLETED, ScheduledNotification)
 from app.dao.users_dao import (create_user_code, create_secret_code)
 from app.dao.services_dao import (dao_create_service, dao_add_user_to_service)
 from app.dao.templates_dao import dao_create_template
@@ -124,7 +124,8 @@ def sample_service(
     restricted=False,
     limit=1000,
     email_from=None,
-    can_send_international_sms=False
+    can_send_international_sms=False,
+    permissions=[SMS_TYPE, EMAIL_TYPE]
 ):
     if user is None:
         user = create_user()
@@ -142,7 +143,7 @@ def sample_service(
     service = Service.query.filter_by(name=service_name).first()
     if not service:
         service = Service(**data)
-        dao_create_service(service, user)
+        dao_create_service(service, user, service_permissions=permissions)
     else:
         if user not in service.users:
             dao_add_user_to_service(service, user)

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -11,7 +11,6 @@ from app.dao.services_dao import (
     dao_create_service,
     dao_add_user_to_service,
     dao_remove_user_from_service,
-    dao_remove_service_permission as dao_services_remove_service_permission,
     dao_fetch_all_services,
     dao_fetch_service_by_id,
     dao_fetch_all_services_by_user,
@@ -46,10 +45,7 @@ from app.models import (
     InvitedUser,
     Service,
     ServicePermission,
-<<<<<<< HEAD
     ServicePermissionTypes,
-=======
->>>>>>> Updated service DAO and API end points
     BRANDING_GOVUK,
     DVLA_ORG_HM_GOVERNMENT,
     KEY_TYPE_NORMAL,
@@ -298,7 +294,7 @@ def test_remove_service_does_not_remove_service_permission_types(sample_service)
 
     services = dao_fetch_all_services()
     assert len(services) == 0
-    assert set([p.name for p in ServicePermissionTypes.query.all()]) & set(SERVICE_PERMISSION_TYPES)
+    assert set([p.name for p in ServicePermissionTypes.query.all()]) == set(SERVICE_PERMISSION_TYPES)
 
 
 def test_create_service_by_id_adding_and_removing_letter_returns_service_without_letter(service_factory):
@@ -397,7 +393,9 @@ def test_update_service_permission_creates_a_history_record_with_current_data(sa
     assert service_from_db.version == 2
     assert LETTER_TYPE in [p.permission for p in service_from_db.permissions]
 
-    dao_services_remove_service_permission(service, permission='sms')
+    permission = [p for p in service.permissions if p.permission == 'sms'][0]
+    service.permissions.remove(permission)
+    dao_update_service(service)
 
     assert Service.query.count() == 1
     assert Service.get_history_model().query.count() == 3

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -501,10 +501,10 @@ def test_update_service_flags_with_service_without_default_service_permissions(c
 def test_update_service_flags_will_remove_service_permissions(client, notify_db, notify_db_session):
     auth_header = create_authorization_header()
 
-    service = create_service(notify_db, notify_db_session, can_send_international_sms=True)
+    service = create_service(
+        notify_db, notify_db_session, permissions=[SMS_TYPE, EMAIL_TYPE, INTERNATIONAL_SMS_TYPE])
 
     assert service.can_send_international_sms is True
-    assert set([p.permission for p in service.permissions]) == set([SMS_TYPE, EMAIL_TYPE, INTERNATIONAL_SMS_TYPE])
 
     data = {
         'can_send_international_sms': False

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -21,7 +21,7 @@ from tests.app.conftest import (
     sample_notification_with_job
 )
 from app.models import (
-    ServicePermission,
+    Service, ServicePermission,
     KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST,
     EMAIL_TYPE, SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INBOUND_SMS_TYPE
 )
@@ -629,7 +629,7 @@ def test_update_permissions_with_duplicate_permissions_will_raise_error(client, 
 
     assert resp.status_code == 400
     assert result['result'] == 'error'
-    assert "Service Permission duplicated: ['{}']".format(LETTER_TYPE) in result['message']
+    assert "Duplicate Service Permission: ['{}']".format(LETTER_TYPE) in result['message']['permissions']
 
 
 def test_update_service_research_mode_throws_validation_error(notify_api, sample_service):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -22,7 +22,8 @@ from tests.app.conftest import (
 )
 from app.models import (
     ServicePermission,
-    KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST, EMAIL_TYPE, SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE
+    KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST, 
+    EMAIL_TYPE, SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INBOUND_SMS_TYPE
 )
 
 from tests.app.db import create_user
@@ -161,7 +162,7 @@ def test_get_service_list_has_default_permissions(client, service_factory):
     assert all([set(json['permissions']) == set([EMAIL_TYPE, SMS_TYPE]) for json in json_resp['data']])
 
 
-def test_get_service_by_id_has_default_permissions(client, sample_service):
+def test_get_service_by_id_has_default_service_permissions(client, sample_service):
     auth_header = create_authorization_header()
     resp = client.get(
         '/service/{}'.format(sample_service.id),
@@ -542,6 +543,24 @@ def test_update_permissions_can_add_service_permissions(client, sample_service):
     assert set(result['data']['permissions']) == set([SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE])
 
 
+def test_add_inbound_permissions_will_add_service_permissions(client, sample_service):
+    auth_header = create_authorization_header()
+
+    data = {
+        'permissions': [EMAIL_TYPE, SMS_TYPE, INBOUND_SMS_TYPE]
+    }
+
+    resp = client.post(
+        '/service/{}'.format(sample_service.id),
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header]
+    )
+    result = json.loads(resp.get_data(as_text=True))
+
+    assert resp.status_code == 200
+    assert set(result['data']['permissions']) == set([SMS_TYPE, EMAIL_TYPE, INBOUND_SMS_TYPE])
+
+
 def test_update_permissions_with_an_invalid_permission_will_raise_error(client, sample_service):
     auth_header = create_authorization_header()
     invalid_permission = 'invalid_permission'
@@ -585,6 +604,7 @@ def test_update_permissions_with_international_sms_without_sms_permissions_will_
     auth_header = create_authorization_header()
 
     data = {
+        'can_send_international_sms': True,
         'permissions': [EMAIL_TYPE, INTERNATIONAL_SMS_TYPE]
     }
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -20,7 +20,9 @@ from tests.app.conftest import (
     sample_notification_history as create_notification_history,
     sample_notification_with_job
 )
-from app.models import KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST, EMAIL_TYPE, SMS_TYPE, LETTER_TYPE
+from app.models import (
+    KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST, EMAIL_TYPE, SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE
+)
 
 from tests.app.db import create_user
 
@@ -155,7 +157,7 @@ def test_get_service_list_has_default_permissions(client, service_factory):
     assert response.status_code == 200
     json_resp = json.loads(response.get_data(as_text=True))
     assert len(json_resp['data']) == 3
-    assert all([set(json['permissions']) == set([EMAIL_TYPE, SMS_TYPE]) for json in json_resp['data']])
+    assert all([set(json['permissions']) & set([EMAIL_TYPE, SMS_TYPE]) for json in json_resp['data']])
 
 
 def test_get_service_by_id_has_default_permissions(client, sample_service):
@@ -488,6 +490,7 @@ def test_update_service_flags_will_add_service_permissions(client, sample_servic
     assert result['data']['research_mode'] is True
     assert result['data']['can_send_letters'] is True
     assert result['data']['can_send_international_sms'] is True
+    assert all(set(result['data']['permissions']) & set([SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE]))
 
 
 def test_update_permissions_can_add_service_permissions(client, sample_service):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -541,6 +541,44 @@ def test_update_permissions_with_an_invalid_permission_will_raise_error(client, 
     assert "Invalid Service Permission: '{}'".format(invalid_permission) in result['message']['permissions']
 
 
+def test_update_permissions_with_duplicate_permissions_will_raise_error(client, sample_service):
+    auth_header = create_authorization_header()
+
+    data = {
+        'permissions': [EMAIL_TYPE, SMS_TYPE, LETTER_TYPE, LETTER_TYPE]
+    }
+
+    resp = client.post(
+        '/service/{}'.format(sample_service.id),
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header]
+    )
+    result = json.loads(resp.get_data(as_text=True))
+
+    assert resp.status_code == 400
+    assert result['result'] == 'error'
+    assert "Service Permission duplicated: ['{}']".format(LETTER_TYPE) in result['message']
+
+
+def test_update_permissions_with_international_sms_without_sms_permissions_will_raise_error(client, sample_service):
+    auth_header = create_authorization_header()
+
+    data = {
+        'permissions': [EMAIL_TYPE, INTERNATIONAL_SMS_TYPE]
+    }
+
+    resp = client.post(
+        '/service/{}'.format(sample_service.id),
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header]
+    )
+    result = json.loads(resp.get_data(as_text=True))
+
+    assert resp.status_code == 400
+    assert result['result'] == 'error'
+    assert "International SMS must have SMS enabled" == result['message']
+
+
 def test_update_service_flags_can_remove_service_permissions(client, sample_service):
     auth_header = create_authorization_header()
     initial_data = {


### PR DESCRIPTION
Enables the API to handle both deprecated service permission `can-send` columns in the `services` table and new permissions in `service_permissions` table.

The new json expected by the API in order to update service permissions will be in the form of - 

```
{
  "permissions": ["email", "sms"]
}
```

The existing flags `can_send_letters` and `can_send_international_sms` will still be supported and will update the service_permissions within this PR.

To add a new permission simply be append a valid permission to the list.
To remove permissions remove it from the list.

This will also update the deprecated flags.

Supported permissions -  `["email", "sms", "letter", "international_sms", "inbound_sms"]`

Duplicate permissions will raise errors.