### PR TITLE
Search notifications against normalised address

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -265,8 +265,8 @@ def get_service_history(service_id):
 @service_blueprint.route('/<uuid:service_id>/notifications', methods=['GET'])
 def get_all_notifications_for_service(service_id):
     data = notifications_filter_schema.load(request.args).data
-    if data.get("to", None):
-        return search_for_notification_by_to_field(service_id, request.query_string.decode())
+    if data.get('to'):
+        return search_for_notification_by_to_field(service_id, data['to'], statuses=data.get('status'))
     page = data['page'] if 'page' in data else 1
     page_size = data['page_size'] if 'page_size' in data else current_app.config.get('PAGE_SIZE')
     limit_days = data.get('limit_days')
@@ -296,11 +296,11 @@ def get_all_notifications_for_service(service_id):
     ), 200
 
 
-def search_for_notification_by_to_field(service_id, search_term):
-    search_term = search_term.replace('to=', '')
-    results = notifications_dao.dao_get_notifications_by_to_field(service_id, search_term)
+def search_for_notification_by_to_field(service_id, search_term, statuses):
+    results = notifications_dao.dao_get_notifications_by_to_field(service_id, search_term, statuses)
     return jsonify(
-        notifications=notification_with_template_schema.dump(results, many=True).data), 200
+        notifications=notification_with_template_schema.dump(results, many=True).data
+    ), 200
 
 
 @service_blueprint.route('/<uuid:service_id>/notifications/monthly', methods=['GET'])

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -446,7 +446,8 @@ def sample_notification(
     sent_by=None,
     client_reference=None,
     rate_multiplier=1.0,
-    scheduled_for=None
+    scheduled_for=None,
+    normalised_to=None
 ):
     if created_at is None:
         created_at = datetime.utcnow()
@@ -484,7 +485,8 @@ def sample_notification(
         'sent_by': sent_by,
         'updated_at': created_at if status in NOTIFICATION_STATUS_TYPES_COMPLETED else None,
         'client_reference': client_reference,
-        'rate_multiplier': rate_multiplier
+        'rate_multiplier': rate_multiplier,
+        'normalised_to': normalised_to
     }
     if job_row_number is not None:
         data['job_row_number'] = job_row_number

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -1,9 +1,20 @@
 from datetime import datetime
 import uuid
 
+
 from app.dao.jobs_dao import dao_create_job
-from app.models import (Service, User, Template, Notification, EMAIL_TYPE, LETTER_TYPE,
-                        SMS_TYPE, KEY_TYPE_NORMAL, Job, ServicePermission, ScheduledNotification)
+from app.models import (
+    Service,
+    User,
+    Template,
+    Notification,
+    ScheduledNotification,
+    ServicePermission,
+    Job,
+    EMAIL_TYPE,
+    SMS_TYPE,
+    KEY_TYPE_NORMAL,
+)
 from app.dao.users_dao import save_model_user
 from app.dao.notifications_dao import dao_create_notification, dao_created_scheduled_notification
 from app.dao.templates_dao import dao_create_template
@@ -81,7 +92,8 @@ def create_notification(
     rate_multiplier=None,
     international=False,
     phone_prefix=None,
-    scheduled_for=None
+    scheduled_for=None,
+    normalised_to=None
 ):
     if created_at is None:
         created_at = datetime.utcnow()
@@ -115,7 +127,8 @@ def create_notification(
         'job_row_number': job_row_number,
         'rate_multiplier': rate_multiplier,
         'international': international,
-        'phone_prefix': phone_prefix
+        'phone_prefix': phone_prefix,
+        'normalised_to': normalised_to
     }
     notification = Notification(**data)
     dao_create_notification(notification)

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -383,7 +383,6 @@ def test_persist_sms_notification_stores_normalised_number(
 
     assert persisted_notification.to == recipient
     assert persisted_notification.normalised_to == expected_recipient_normalised
-<<<<<<< HEAD
 
 
 @pytest.mark.parametrize('recipient, expected_recipient_normalised', [
@@ -413,5 +412,3 @@ def test_persist_email_notification_stores_normalised_email(
 
     assert persisted_notification.to == recipient
     assert persisted_notification.normalised_to == expected_recipient_normalised
-=======
->>>>>>> Store the normalised number on the notification

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -383,6 +383,7 @@ def test_persist_sms_notification_stores_normalised_number(
 
     assert persisted_notification.to == recipient
     assert persisted_notification.normalised_to == expected_recipient_normalised
+<<<<<<< HEAD
 
 
 @pytest.mark.parametrize('recipient, expected_recipient_normalised', [
@@ -412,3 +413,5 @@ def test_persist_email_notification_stores_normalised_email(
 
     assert persisted_notification.to == recipient
     assert persisted_notification.normalised_to == expected_recipient_normalised
+=======
+>>>>>>> Store the normalised number on the notification


### PR DESCRIPTION
This adds ability to search notifications against their normalised address.

## Summary

The `dao_get_notifications_by_to_field` normalises the search query and then searches Notifications against `normalised_to`. Additionally a `status` filter has been added that allows filtering by one or more statuses.

## Note
This was branched off #981 and needs to be rebased off master.

## Dependencies

- [x] #981 
- [x] #979 
