### PR TITLE
separate service deserialization from validation

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -188,7 +188,7 @@ class Service(db.Model, Versioned):
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
     reply_to_email_address = db.Column(db.Text, index=False, unique=False, nullable=True)
     letter_contact_block = db.Column(db.Text, index=False, unique=False, nullable=True)
-    sms_sender = db.Column(db.String(11), nullable=True, default=lambda: current_app.config['FROM_NUMBER'])
+    sms_sender = db.Column(db.String(11), nullable=False, default=lambda: current_app.config['FROM_NUMBER'])
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey('organisation.id'), index=True, nullable=True)
     organisation = db.relationship('Organisation')
     dvla_organisation_id = db.Column(
@@ -214,6 +214,21 @@ class Service(db.Model, Versioned):
         if self.permissions:
             self.can_send_letters = LETTER_TYPE in [p.permission for p in self.permissions]
             self.can_send_international_sms = INTERNATIONAL_SMS_TYPE in [p.permission for p in self.permissions]
+
+    @classmethod
+    def from_json(cls, data):
+        """
+        Assumption: data has been validated appropriately.
+
+        Returns a Service object based on the provided data. Deserialises created_by to created_by_id as marshmallow
+        would.
+        """
+        # validate json with marshmallow
+        fields = data.copy()
+
+        fields['created_by_id'] = fields.pop('created_by')
+
+        return cls(**fields)
 
 
 class ServicePermission(db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -188,7 +188,7 @@ class Service(db.Model, Versioned):
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
     reply_to_email_address = db.Column(db.Text, index=False, unique=False, nullable=True)
     letter_contact_block = db.Column(db.Text, index=False, unique=False, nullable=True)
-    sms_sender = db.Column(db.String(11), nullable=False, default=lambda: current_app.config['FROM_NUMBER'])
+    sms_sender = db.Column(db.String(11), nullable=True, default=lambda: current_app.config['FROM_NUMBER'])
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey('organisation.id'), index=True, nullable=True)
     organisation = db.relationship('Organisation')
     dvla_organisation_id = db.Column(

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -20,7 +20,7 @@ from tests.app.conftest import (
     sample_notification_history as create_notification_history,
     sample_notification_with_job
 )
-from app.models import KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST
+from app.models import Service, KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST
 
 from tests.app.db import create_user
 
@@ -215,6 +215,10 @@ def test_create_service(client, sample_user):
     assert not json_resp['data']['research_mode']
     assert json_resp['data']['dvla_organisation'] == '001'
     assert json_resp['data']['sms_sender'] == current_app.config['FROM_NUMBER']
+
+    service_db = Service.query.get(json_resp['data']['id'])
+    assert service_db.name == 'created service'
+    assert service_db.sms_sender == current_app.config['FROM_NUMBER']
 
     auth_header_fetch = create_authorization_header()
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1735,3 +1735,19 @@ def test_update_service_does_not_call_send_notification_when_restricted_not_chan
 
     assert resp.status_code == 200
     assert not send_notification_mock.called
+
+
+def test_update_service_works_when_sms_sender_is_null(sample_service, client, mocker):
+    sample_service.sms_sender = None
+    data = {'name': 'new name'}
+
+    resp = client.post(
+        'service/{}'.format(sample_service.id),
+        data=json.dumps(data),
+        headers=[create_authorization_header()],
+        content_type='application/json'
+    )
+
+    assert resp.status_code == 200
+    # make sure it wasn't changed to not-null under the hood
+    assert sample_service.sms_sender is None


### PR DESCRIPTION
Marshmallow validates and deserialises - BUT, when it deserialises, it explicitly sets 
`sms_sender=None`, even when you haven't passed sms_sender in. This is problematic, because we wanted to take advantage of sqlalchemy's default value to set sms_sender to `GOVUK` when the actual DB commit happens.

Instead, still use marshmallow for validating, but manually carry out the json deserialisation in the model class.

This fixes a bug that only manifested when the database was upgraded, but the code hadn't updated. :tada: