### PR TITLE
Redo queue visibitlity timeout

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -10,31 +10,7 @@ from app.statsd_decorators import statsd
 from app.delivery import send_to_providers
 
 
-def retry_iteration_to_delay(retry=0):
-    """
-    :param retry times we have performed a retry
-    Given current retry calculate some delay before retrying
-    0: 10 seconds
-    1: 60 seconds (1 minutes)
-    2: 300 seconds (5 minutes)
-    3: 3600 seconds (60 minutes)
-    4: 14400 seconds (4 hours)
-    :param retry (zero indexed):
-    :return length to retry in seconds, default 10 seconds
-    """
-
-    delays = {
-        0: 10,
-        1: 60,
-        2: 300,
-        3: 3600,
-        4: 14400
-    }
-
-    return delays.get(retry, 10)
-
-
-@notify_celery.task(bind=True, name="deliver_sms", max_retries=5, default_retry_delay=5)
+@notify_celery.task(bind=True, name="deliver_sms", max_retries=48, default_retry_delay=300)
 @statsd(namespace="tasks")
 def deliver_sms(self, notification_id):
     try:
@@ -47,7 +23,7 @@ def deliver_sms(self, notification_id):
             current_app.logger.exception(
                 "SMS notification delivery for id: {} failed".format(notification_id)
             )
-            self.retry(queue=QueueNames.RETRY, countdown=retry_iteration_to_delay(self.request.retries))
+            self.retry(queue=QueueNames.RETRY)
         except self.MaxRetriesExceededError:
             current_app.logger.exception(
                 "RETRY FAILED: task send_sms_to_provider failed for notification {}".format(notification_id),
@@ -55,7 +31,7 @@ def deliver_sms(self, notification_id):
             update_notification_status_by_id(notification_id, 'technical-failure')
 
 
-@notify_celery.task(bind=True, name="deliver_email", max_retries=5, default_retry_delay=5)
+@notify_celery.task(bind=True, name="deliver_email", max_retries=48, default_retry_delay=300)
 @statsd(namespace="tasks")
 def deliver_email(self, notification_id):
     try:
@@ -71,7 +47,7 @@ def deliver_email(self, notification_id):
             current_app.logger.exception(
                 "RETRY: Email notification {} failed".format(notification_id)
             )
-            self.retry(queue=QueueNames.RETRY, countdown=retry_iteration_to_delay(self.request.retries))
+            self.retry(queue=QueueNames.RETRY)
         except self.MaxRetriesExceededError:
             current_app.logger.error(
                 "RETRY FAILED: task send_email_to_provider failed for notification {}".format(notification_id)

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -3,6 +3,7 @@ from notifications_utils.recipients import InvalidEmailError
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import notify_celery
+from app.config import QueueNames
 from app.dao import notifications_dao
 from app.dao.notifications_dao import update_notification_status_by_id
 from app.statsd_decorators import statsd
@@ -46,7 +47,7 @@ def deliver_sms(self, notification_id):
             current_app.logger.exception(
                 "SMS notification delivery for id: {} failed".format(notification_id)
             )
-            self.retry(queue="retry", countdown=retry_iteration_to_delay(self.request.retries))
+            self.retry(queue=QueueNames.RETRY, countdown=retry_iteration_to_delay(self.request.retries))
         except self.MaxRetriesExceededError:
             current_app.logger.exception(
                 "RETRY FAILED: task send_sms_to_provider failed for notification {}".format(notification_id),
@@ -70,7 +71,7 @@ def deliver_email(self, notification_id):
             current_app.logger.exception(
                 "RETRY: Email notification {} failed".format(notification_id)
             )
-            self.retry(queue="retry", countdown=retry_iteration_to_delay(self.request.retries))
+            self.retry(queue=QueueNames.RETRY, countdown=retry_iteration_to_delay(self.request.retries))
         except self.MaxRetriesExceededError:
             current_app.logger.error(
                 "RETRY FAILED: task send_email_to_provider failed for notification {}".format(notification_id)

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -23,6 +23,7 @@ from app.dao.provider_details_dao import (
 from app.dao.users_dao import delete_codes_older_created_more_than_a_day_ago
 from app.statsd_decorators import statsd
 from app.celery.tasks import process_job
+from app.config import QueueNames
 
 
 @notify_celery.task(name="remove_csv_files")
@@ -39,7 +40,7 @@ def remove_csv_files():
 def run_scheduled_jobs():
     try:
         for job in dao_set_scheduled_jobs_to_pending():
-            process_job.apply_async([str(job.id)], queue="process-job")
+            process_job.apply_async([str(job.id)], queue=QueueNames.JOBS)
             current_app.logger.info("Job ID {} added to process job queue".format(job.id))
     except SQLAlchemyError as e:
         current_app.logger.exception("Failed to run scheduled jobs")

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -16,6 +16,7 @@ from app import (
 )
 from app.aws import s3
 from app.celery import provider_tasks
+from app.config import QueueNames
 from app.dao.jobs_dao import (
     dao_update_job,
     dao_get_job_by_id,
@@ -80,7 +81,7 @@ def process_job(job_id):
         process_row(row_number, recipient, personalisation, template, job, service)
 
     if template.template_type == LETTER_TYPE:
-        build_dvla_file.apply_async([str(job.id)], queue='process-job')
+        build_dvla_file.apply_async([str(job.id)], queue=QueueNames.JOBS)
         # temporary logging
         current_app.logger.info("send job {} to build-dvla-file in the process-job queue".format(job_id))
     else:
@@ -112,12 +113,6 @@ def process_row(row_number, recipient, personalisation, template, job, service):
         LETTER_TYPE: persist_letter
     }
 
-    queues = {
-        SMS_TYPE: 'db-sms',
-        EMAIL_TYPE: 'db-email',
-        LETTER_TYPE: 'db-letter',
-    }
-
     send_fn = send_fns[template_type]
 
     send_fn.apply_async(
@@ -127,7 +122,7 @@ def process_row(row_number, recipient, personalisation, template, job, service):
             encrypted,
             datetime.utcnow().strftime(DATETIME_FORMAT)
         ),
-        queue=queues[template_type] if not service.research_mode else 'research-mode'
+        queue=QueueNames.DATABASE if not service.research_mode else QueueNames.RESEARCH_MODE
     )
 
 
@@ -181,7 +176,7 @@ def send_sms(self,
 
         provider_tasks.deliver_sms.apply_async(
             [str(saved_notification.id)],
-            queue='send-sms' if not service.research_mode else 'research-mode'
+            queue=QueueNames.SEND if not service.research_mode else QueueNames.RESEARCH_MODE
         )
 
         current_app.logger.info(
@@ -226,7 +221,7 @@ def send_email(self,
 
         provider_tasks.deliver_email.apply_async(
             [str(saved_notification.id)],
-            queue='send-email' if not service.research_mode else 'research-mode'
+            queue=QueueNames.SEND if not service.research_mode else QueueNames.RESEARCH_MODE
         )
 
         current_app.logger.info("Email {} created at {}".format(saved_notification.id, created_at))
@@ -284,10 +279,9 @@ def build_dvla_file(self, job_id):
                 file_location="{}-dvla-job.text".format(job_id)
             )
             dao_update_job_status(job_id, JOB_STATUS_READY_TO_SEND)
-            notify_celery.send_task("aggregrate-dvla-files", ([str(job_id)], ), queue='aggregate-dvla-files')
         else:
             current_app.logger.info("All notifications for job {} are not persisted".format(job_id))
-            self.retry(queue="retry", exc="All notifications for job {} are not persisted".format(job_id))
+            self.retry(queue=QueueNames.RETRY, exc="All notifications for job {} are not persisted".format(job_id))
     except Exception as e:
         current_app.logger.exception("build_dvla_file threw exception")
         raise e
@@ -341,7 +335,7 @@ def handle_exception(task, notification, notification_id, exc):
         # send to the retry queue.
         current_app.logger.exception('Retry' + retry_msg)
         try:
-            task.retry(queue="retry", exc=exc)
+            task.retry(queue=QueueNames.RETRY, exc=exc)
         except task.MaxRetriesExceededError:
             current_app.logger.exception('Retry' + retry_msg)
 

--- a/app/config.py
+++ b/app/config.py
@@ -25,6 +25,23 @@ class QueueNames(object):
     PROCESS_FTP = 'process-ftp-tasks'
 
     @staticmethod
+    def old_queues():
+        return [
+            'db-sms',
+            'db-email',
+            'db-letter',
+            'priority',
+            'periodic',
+            'send-sms',
+            'send-email',
+            'research-mode',
+            'statistics',
+            'notify',
+            'retry',
+            'process-job'
+        ]
+
+    @staticmethod
     def all_queues():
         return [
             QueueNames.PRIORITY,
@@ -240,6 +257,8 @@ class Development(Config):
     NOTIFICATION_QUEUE_PREFIX = 'development'
     DEBUG = True
 
+    queues = QueueNames.all_queues() + QueueNames.old_queues()
+
     for queue in QueueNames.all_queues():
         Config.CELERY_QUEUES.append(
             Queue(queue, Exchange('default'), routing_key=queue)
@@ -259,7 +278,9 @@ class Test(Config):
     STATSD_HOST = "localhost"
     STATSD_PORT = 1000
 
-    for queue in QueueNames.all_queues():
+    queues = QueueNames.all_queues() + QueueNames.old_queues()
+
+    for queue in queues:
         Config.CELERY_QUEUES.append(
             Queue(queue, Exchange('default'), routing_key=queue)
         )

--- a/app/config.py
+++ b/app/config.py
@@ -123,7 +123,7 @@ class Config(object):
     BROKER_TRANSPORT_OPTIONS = {
         'region': AWS_REGION,
         'polling_interval': 1,  # 1 second
-        'visibility_timeout': 300,
+        'visibility_timeout': 310,
         'queue_name_prefix': NOTIFICATION_QUEUE_PREFIX
     }
     CELERY_ENABLE_UTC = True,

--- a/app/config.py
+++ b/app/config.py
@@ -160,11 +160,7 @@ class Config(object):
             'options': {'queue': 'periodic'}
         }
     }
-    CELERY_QUEUES = [
-        Queue('process-job', Exchange('default'), routing_key='process-job'),
-        Queue('retry', Exchange('default'), routing_key='retry'),
-        Queue('notify', Exchange('default'), routing_key='notify')
-    ]
+    CELERY_QUEUES = []
 
     NOTIFICATIONS_ALERT = 5  # five mins
     FROM_NUMBER = 'development'
@@ -224,7 +220,10 @@ class Development(Config):
         Queue('send-sms', Exchange('default'), routing_key='send-sms'),
         Queue('send-email', Exchange('default'), routing_key='send-email'),
         Queue('research-mode', Exchange('default'), routing_key='research-mode'),
-        Queue('statistics', Exchange('default'), routing_key='statistics')
+        Queue('statistics', Exchange('default'), routing_key='statistics'),
+        Queue('process-job', Exchange('default'), routing_key='process-job'),
+        Queue('retry', Exchange('default'), routing_key='retry'),
+        Queue('notify', Exchange('default'), routing_key='notify')
     ]
     API_HOST_NAME = "http://localhost:6011"
     API_RATE_LIMIT_ENABLED = True
@@ -248,7 +247,10 @@ class Test(Config):
         Queue('send-sms', Exchange('default'), routing_key='send-sms'),
         Queue('send-email', Exchange('default'), routing_key='send-email'),
         Queue('research-mode', Exchange('default'), routing_key='research-mode'),
-        Queue('statistics', Exchange('default'), routing_key='statistics')
+        Queue('statistics', Exchange('default'), routing_key='statistics'),
+        Queue('process-job', Exchange('default'), routing_key='process-job'),
+        Queue('retry', Exchange('default'), routing_key='retry'),
+        Queue('notify', Exchange('default'), routing_key='notify')
     ]
 
     API_RATE_LIMIT_ENABLED = True

--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,34 @@ if os.environ.get('VCAP_SERVICES'):
     extract_cloudfoundry_config()
 
 
+class QueueNames(object):
+    PERIODIC = 'periodic-tasks'
+    PRIORITY = 'priority-tasks'
+    DATABASE = 'database-tasks'
+    SEND = 'send-tasks'
+    RESEARCH_MODE = 'research-mode-tasks'
+    STATISTICS = 'statistics-tasks'
+    JOBS = 'job-tasks'
+    RETRY = 'retry-tasks'
+    NOTIFY = 'notify-internal-tasks'
+    PROCESS_FTP = 'process-ftp-tasks'
+
+    @staticmethod
+    def all_queues():
+        return [
+            QueueNames.PRIORITY,
+            QueueNames.PERIODIC,
+            QueueNames.DATABASE,
+            QueueNames.SEND,
+            QueueNames.RESEARCH_MODE,
+            QueueNames.STATISTICS,
+            QueueNames.JOBS,
+            QueueNames.RETRY,
+            QueueNames.NOTIFY,
+            QueueNames.PROCESS_FTP
+        ]
+
+
 class Config(object):
     # URL of admin app
     ADMIN_BASE_URL = os.environ['ADMIN_BASE_URL']
@@ -95,7 +123,7 @@ class Config(object):
     BROKER_TRANSPORT_OPTIONS = {
         'region': AWS_REGION,
         'polling_interval': 1,  # 1 second
-        'visibility_timeout': 14410,  # 4 hours 10 seconds. 10 seconds longer than max retry
+        'visibility_timeout': 300,
         'queue_name_prefix': NOTIFICATION_QUEUE_PREFIX
     }
     CELERY_ENABLE_UTC = True,
@@ -107,57 +135,57 @@ class Config(object):
         'run-scheduled-jobs': {
             'task': 'run-scheduled-jobs',
             'schedule': crontab(minute=1),
-            'options': {'queue': 'periodic'}
+            'options': {'queue': QueueNames.PERIODIC}
         },
         'delete-verify-codes': {
             'task': 'delete-verify-codes',
             'schedule': timedelta(minutes=63),
-            'options': {'queue': 'periodic'}
+            'options': {'queue': QueueNames.PERIODIC}
         },
         'delete-invitations': {
             'task': 'delete-invitations',
             'schedule': timedelta(minutes=66),
-            'options': {'queue': 'periodic'}
+            'options': {'queue': QueueNames.PERIODIC}
         },
         'delete-sms-notifications': {
             'task': 'delete-sms-notifications',
             'schedule': crontab(minute=0, hour=0),
-            'options': {'queue': 'periodic'}
+            'options': {'queue': QueueNames.PERIODIC}
         },
         'delete-email-notifications': {
             'task': 'delete-email-notifications',
             'schedule': crontab(minute=20, hour=0),
-            'options': {'queue': 'periodic'}
+            'options': {'queue': QueueNames.PERIODIC}
         },
         'delete-letter-notifications': {
             'task': 'delete-letter-notifications',
             'schedule': crontab(minute=40, hour=0),
-            'options': {'queue': 'periodic'}
+            'options': {'queue': QueueNames.PERIODIC}
         },
         'send-daily-performance-platform-stats': {
             'task': 'send-daily-performance-platform-stats',
             'schedule': crontab(minute=0, hour=2),
-            'options': {'queue': 'periodic'}
+            'options': {'queue': QueueNames.PERIODIC}
         },
         'switch-current-sms-provider-on-slow-delivery': {
             'task': 'switch-current-sms-provider-on-slow-delivery',
             'schedule': crontab(),  # Every minute
-            'options': {'queue': 'periodic'}
+            'options': {'queue': QueueNames.PERIODIC}
         },
         'timeout-sending-notifications': {
             'task': 'timeout-sending-notifications',
             'schedule': crontab(minute=0, hour=3),
-            'options': {'queue': 'periodic'}
+            'options': {'queue': QueueNames.PERIODIC}
         },
         'remove_csv_files': {
             'task': 'remove_csv_files',
             'schedule': crontab(minute=0, hour=4),
-            'options': {'queue': 'periodic'}
+            'options': {'queue': QueueNames.PERIODIC}
         },
         'timeout-job-statistics': {
             'task': 'timeout-job-statistics',
             'schedule': crontab(minute=0, hour=5),
-            'options': {'queue': 'periodic'}
+            'options': {'queue': QueueNames.PERIODIC}
         }
     }
     CELERY_QUEUES = []
@@ -211,20 +239,12 @@ class Development(Config):
     NOTIFY_ENVIRONMENT = 'development'
     NOTIFICATION_QUEUE_PREFIX = 'development'
     DEBUG = True
-    CELERY_QUEUES = Config.CELERY_QUEUES + [
-        Queue('db-sms', Exchange('default'), routing_key='db-sms'),
-        Queue('priority', Exchange('default'), routing_key='priority'),
-        Queue('periodic', Exchange('default'), routing_key='periodic'),
-        Queue('db-email', Exchange('default'), routing_key='db-email'),
-        Queue('db-letter', Exchange('default'), routing_key='db-letter'),
-        Queue('send-sms', Exchange('default'), routing_key='send-sms'),
-        Queue('send-email', Exchange('default'), routing_key='send-email'),
-        Queue('research-mode', Exchange('default'), routing_key='research-mode'),
-        Queue('statistics', Exchange('default'), routing_key='statistics'),
-        Queue('process-job', Exchange('default'), routing_key='process-job'),
-        Queue('retry', Exchange('default'), routing_key='retry'),
-        Queue('notify', Exchange('default'), routing_key='notify')
-    ]
+
+    for queue in QueueNames.all_queues():
+        Config.CELERY_QUEUES.append(
+            Queue(queue, Exchange('default'), routing_key=queue)
+        )
+
     API_HOST_NAME = "http://localhost:6011"
     API_RATE_LIMIT_ENABLED = True
 
@@ -238,20 +258,11 @@ class Test(Config):
     STATSD_ENABLED = True
     STATSD_HOST = "localhost"
     STATSD_PORT = 1000
-    CELERY_QUEUES = Config.CELERY_QUEUES + [
-        Queue('periodic', Exchange('default'), routing_key='periodic'),
-        Queue('priority', Exchange('default'), routing_key='priority'),
-        Queue('db-sms', Exchange('default'), routing_key='db-sms'),
-        Queue('db-email', Exchange('default'), routing_key='db-email'),
-        Queue('db-letter', Exchange('default'), routing_key='db-letter'),
-        Queue('send-sms', Exchange('default'), routing_key='send-sms'),
-        Queue('send-email', Exchange('default'), routing_key='send-email'),
-        Queue('research-mode', Exchange('default'), routing_key='research-mode'),
-        Queue('statistics', Exchange('default'), routing_key='statistics'),
-        Queue('process-job', Exchange('default'), routing_key='process-job'),
-        Queue('retry', Exchange('default'), routing_key='retry'),
-        Queue('notify', Exchange('default'), routing_key='notify')
-    ]
+
+    for queue in QueueNames.all_queues():
+        Config.CELERY_QUEUES.append(
+            Queue(queue, Exchange('default'), routing_key=queue)
+        )
 
     API_RATE_LIMIT_ENABLED = True
     API_HOST_NAME = "http://localhost:6011"

--- a/app/invite/rest.py
+++ b/app/invite/rest.py
@@ -4,6 +4,7 @@ from flask import (
     jsonify,
     current_app)
 
+from app.config import QueueNames
 from app.dao.invited_user_dao import (
     save_invited_user,
     get_invited_user,
@@ -44,7 +45,7 @@ def create_invited_user(service_id):
         key_type=KEY_TYPE_NORMAL
     )
 
-    send_notification_to_queue(saved_notification, False, queue="notify")
+    send_notification_to_queue(saved_notification, False, queue=QueueNames.NOTIFY)
 
     return jsonify(data=invited_user_schema.dump(invited_user).data), 201
 

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -34,6 +34,8 @@ from app.models import JOB_STATUS_SCHEDULED, JOB_STATUS_PENDING, JOB_STATUS_CANC
 
 from app.utils import pagination_links
 
+from app.config import QueueNames
+
 job_blueprint = Blueprint('job', __name__, url_prefix='/service/<uuid:service_id>/job')
 
 from app.errors import (
@@ -143,7 +145,7 @@ def create_job(service_id):
     dao_create_job(job)
 
     if job.job_status == JOB_STATUS_PENDING:
-        process_job.apply_async([str(job.id)], queue="process-job")
+        process_job.apply_async([str(job.id)], queue=QueueNames.JOBS)
 
     job_json = job_schema.dump(job).data
     job_json['statistics'] = []

--- a/app/letters/send_letter_jobs.py
+++ b/app/letters/send_letter_jobs.py
@@ -2,6 +2,7 @@ from flask import Blueprint, jsonify
 from flask import request
 
 from app import notify_celery
+from app.config import QueueNames
 from app.dao.jobs_dao import dao_get_all_letter_jobs
 from app.schemas import job_schema
 from app.v2.errors import register_errors
@@ -15,7 +16,7 @@ register_errors(letter_job)
 @letter_job.route('/send-letter-jobs', methods=['POST'])
 def send_letter_jobs():
     job_ids = validate(request.get_json(), letter_job_ids)
-    notify_celery.send_task(name="send-files-to-dvla", args=(job_ids['job_ids'],), queue="process-ftp")
+    notify_celery.send_task(name="send-files-to-dvla", args=(job_ids['job_ids'],), queue=QueueNames.PROCESS_FTP)
 
     return jsonify(data={"response": "Task created to send files to DVLA"}), 201
 

--- a/app/notifications/notifications_letter_callback.py
+++ b/app/notifications/notifications_letter_callback.py
@@ -13,7 +13,7 @@ from app.celery.tasks import update_letter_notifications_statuses
 from app.v2.errors import register_errors
 from app.notifications.utils import autoconfirm_subscription
 from app.schema_validation import validate
-
+from app.config import QueueNames
 
 letter_callback_blueprint = Blueprint('notifications_letter_callback', __name__)
 register_errors(letter_callback_blueprint)
@@ -54,7 +54,7 @@ def process_letter_response():
         filename = message['Records'][0]['s3']['object']['key']
         current_app.logger.info('Received file from DVLA: {}'.format(filename))
         current_app.logger.info('DVLA callback: Calling task to update letter notifications')
-        update_letter_notifications_statuses.apply_async([filename], queue='notify')
+        update_letter_notifications_statuses.apply_async([filename], queue=QueueNames.NOTIFY)
 
     return jsonify(
         result="success", message="DVLA callback succeeded"

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -10,6 +10,8 @@ from notifications_utils.recipients import (
 from app import redis_store
 from app.celery import provider_tasks
 from notifications_utils.clients import redis
+
+from app.config import QueueNames
 from app.dao.notifications_dao import dao_create_notification, dao_delete_notifications_and_history_by_id
 from app.models import SMS_TYPE, Notification, KEY_TYPE_TEST, EMAIL_TYPE
 from app.v2.errors import BadRequestError, SendNotificationToQueueError
@@ -90,12 +92,9 @@ def persist_notification(
 
 def send_notification_to_queue(notification, research_mode, queue=None):
     if research_mode or notification.key_type == KEY_TYPE_TEST:
-        queue = 'research-mode'
+        queue = QueueNames.RESEARCH_MODE
     elif not queue:
-        if notification.notification_type == SMS_TYPE:
-            queue = 'send-sms'
-        if notification.notification_type == EMAIL_TYPE:
-            queue = 'send-email'
+        queue = QueueNames.SEND
 
     if notification.notification_type == SMS_TYPE:
         deliver_task = provider_tasks.deliver_sms

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -6,6 +6,7 @@ from flask import (
 )
 
 from app import api_user, authenticated_service
+from app.config import QueueNames
 from app.dao import (
     templates_dao,
     notifications_dao
@@ -134,7 +135,7 @@ def send_notification(notification_type):
                                               key_type=api_user.key_type,
                                               simulated=simulated)
     if not simulated:
-        queue_name = 'priority' if template.process_type == PRIORITY else None
+        queue_name = QueueNames.PRIORITY if template.process_type == PRIORITY else None
         send_notification_to_queue(notification=notification_model,
                                    research_mode=authenticated_service.research_mode,
                                    queue=queue_name)

--- a/app/service/sender.py
+++ b/app/service/sender.py
@@ -1,5 +1,6 @@
 from flask import current_app
 
+from app.config import QueueNames
 from app.dao.services_dao import dao_fetch_service_by_id, dao_fetch_active_users_for_service
 from app.dao.templates_dao import dao_get_template_by_id
 from app.models import EMAIL_TYPE, KEY_TYPE_NORMAL
@@ -24,7 +25,7 @@ def send_notification_to_service_users(service_id, template_id, personalisation=
             api_key_id=None,
             key_type=KEY_TYPE_NORMAL
         )
-        send_notification_to_queue(notification, False, queue='notify')
+        send_notification_to_queue(notification, False, queue=QueueNames.NOTIFY)
 
 
 def _add_user_fields(user, personalisation, fields):

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from flask import (jsonify, request, Blueprint, current_app)
 
+from app.config import QueueNames
 from app.dao.users_dao import (
     get_user_by_id,
     save_model_user,
@@ -182,7 +183,7 @@ def send_user_sms_code(user_id):
     # Assume that we never want to observe the Notify service's research mode
     # setting for this notification - we still need to be able to log into the
     # admin even if we're doing user research using this service:
-    send_notification_to_queue(saved_notification, False, queue='notify')
+    send_notification_to_queue(saved_notification, False, queue=QueueNames.NOTIFY)
 
     return jsonify({}), 204
 
@@ -212,7 +213,7 @@ def send_user_confirm_new_email(user_id):
         key_type=KEY_TYPE_NORMAL
     )
 
-    send_notification_to_queue(saved_notification, False, queue='notify')
+    send_notification_to_queue(saved_notification, False, queue=QueueNames.NOTIFY)
     return jsonify({}), 204
 
 
@@ -239,7 +240,7 @@ def send_user_email_verification(user_id):
         key_type=KEY_TYPE_NORMAL
     )
 
-    send_notification_to_queue(saved_notification, False, queue="notify")
+    send_notification_to_queue(saved_notification, False, queue=QueueNames.NOTIFY)
 
     return jsonify({}), 204
 
@@ -265,7 +266,7 @@ def send_already_registered_email(user_id):
         key_type=KEY_TYPE_NORMAL
     )
 
-    send_notification_to_queue(saved_notification, False, queue="notify")
+    send_notification_to_queue(saved_notification, False, queue=QueueNames.NOTIFY)
 
     return jsonify({}), 204
 
@@ -327,7 +328,7 @@ def send_user_reset_password():
         key_type=KEY_TYPE_NORMAL
     )
 
-    send_notification_to_queue(saved_notification, False, queue="notify")
+    send_notification_to_queue(saved_notification, False, queue=QueueNames.NOTIFY)
 
     return jsonify({}), 204
 

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -2,6 +2,7 @@ from flask import request, jsonify, current_app
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import api_user, authenticated_service
+from app.config import QueueNames
 from app.dao import services_dao, templates_dao
 from app.models import SMS_TYPE, EMAIL_TYPE, PRIORITY
 from app.notifications.process_notifications import (
@@ -57,7 +58,7 @@ def post_notification(notification_type):
                                         simulated=simulated)
 
     if not simulated:
-        queue_name = 'priority' if template.process_type == PRIORITY else None
+        queue_name = QueueNames.PRIORITY if template.process_type == PRIORITY else None
         send_notification_to_queue(
             notification=notification,
             research_mode=authenticated_service.research_mode,

--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -23,33 +23,33 @@ applications:
       NOTIFY_APP_NAME: delivery-celery-beat
 
   - name: notify-delivery-worker-database
-    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q db-sms,db-email,db-letter
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q db-sms,db-email,db-letter,database-tasks
     env:
       NOTIFY_APP_NAME: delivery-worker-database
 
   - name: notify-delivery-worker-research
-    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=5 -Q research-mode
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=5 -Q research-mode,research-mode-tasks
     env:
       NOTIFY_APP_NAME: delivery-worker-research
 
   - name: notify-delivery-worker-sender
-    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q send-sms,send-email
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q send-sms,send-email,send-tasks
     env:
       NOTIFY_APP_NAME: delivery-worker-sender
 
   - name: notify-delivery-worker-periodic
-    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=2 -Q periodic,statistics
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=2 -Q periodic,statistics,periodic-tasks,statistics-tasks
     instances: 1
     memory: 2G
     env:
       NOTIFY_APP_NAME: delivery-worker-periodic
 
   - name: notify-delivery-worker-priority
-    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=5 -Q priority
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=5 -Q priority,priority-tasks
     env:
       NOTIFY_APP_NAME: delivery-worker-priority
 
   - name: notify-delivery-worker
-    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q process-job,notify,retry
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q process-job,notify,retry,job-tasks,retry-tasks,notify-internal-tasks
     env:
       NOTIFY_APP_NAME: delivery-worker

--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -50,6 +50,6 @@ applications:
       NOTIFY_APP_NAME: delivery-worker-priority
 
   - name: notify-delivery-worker
-    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q process-job,notify,retry
     env:
       NOTIFY_APP_NAME: delivery-worker

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -11,34 +11,6 @@ def test_should_have_decorated_tasks_functions():
     assert deliver_email.__wrapped__.__name__ == 'deliver_email'
 
 
-def test_should_by_10_second_delay_as_default():
-    assert provider_tasks.retry_iteration_to_delay() == 10
-
-
-def test_should_by_10_second_delay_on_unmapped_retry_iteration():
-    assert provider_tasks.retry_iteration_to_delay(99) == 10
-
-
-def test_should_by_10_second_delay_on_retry_one():
-    assert provider_tasks.retry_iteration_to_delay(0) == 10
-
-
-def test_should_by_1_minute_delay_on_retry_two():
-    assert provider_tasks.retry_iteration_to_delay(1) == 60
-
-
-def test_should_by_5_minute_delay_on_retry_two():
-    assert provider_tasks.retry_iteration_to_delay(2) == 300
-
-
-def test_should_by_60_minute_delay_on_retry_two():
-    assert provider_tasks.retry_iteration_to_delay(3) == 3600
-
-
-def test_should_by_240_minute_delay_on_retry_two():
-    assert provider_tasks.retry_iteration_to_delay(4) == 14400
-
-
 def test_should_call_send_sms_to_provider_from_deliver_sms_task(
         notify_db,
         notify_db_session,
@@ -61,7 +33,7 @@ def test_should_add_to_retry_queue_if_notification_not_found_in_deliver_sms_task
 
     deliver_sms(notification_id)
     app.delivery.send_to_providers.send_sms_to_provider.assert_not_called()
-    app.celery.provider_tasks.deliver_sms.retry.assert_called_with(queue="retry-tasks", countdown=10)
+    app.celery.provider_tasks.deliver_sms.retry.assert_called_with(queue="retry-tasks")
 
 
 def test_should_call_send_email_to_provider_from_deliver_email_task(
@@ -83,7 +55,7 @@ def test_should_add_to_retry_queue_if_notification_not_found_in_deliver_email_ta
 
     deliver_email(notification_id)
     app.delivery.send_to_providers.send_email_to_provider.assert_not_called()
-    app.celery.provider_tasks.deliver_email.retry.assert_called_with(queue="retry-tasks", countdown=10)
+    app.celery.provider_tasks.deliver_email.retry.assert_called_with(queue="retry-tasks")
 
 
 # DO THESE FOR THE 4 TYPES OF TASK
@@ -94,7 +66,7 @@ def test_should_go_into_technical_error_if_exceeds_retries_on_deliver_sms_task(s
 
     deliver_sms(sample_notification.id)
 
-    provider_tasks.deliver_sms.retry.assert_called_with(queue="retry-tasks", countdown=10)
+    provider_tasks.deliver_sms.retry.assert_called_with(queue="retry-tasks")
 
     assert sample_notification.status == 'technical-failure'
 
@@ -105,7 +77,7 @@ def test_should_go_into_technical_error_if_exceeds_retries_on_deliver_email_task
 
     deliver_email(sample_notification.id)
 
-    provider_tasks.deliver_email.retry.assert_called_with(queue="retry-tasks", countdown=10)
+    provider_tasks.deliver_email.retry.assert_called_with(queue="retry-tasks")
     assert sample_notification.status == 'technical-failure'
 
 

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -61,7 +61,7 @@ def test_should_add_to_retry_queue_if_notification_not_found_in_deliver_sms_task
 
     deliver_sms(notification_id)
     app.delivery.send_to_providers.send_sms_to_provider.assert_not_called()
-    app.celery.provider_tasks.deliver_sms.retry.assert_called_with(queue="retry", countdown=10)
+    app.celery.provider_tasks.deliver_sms.retry.assert_called_with(queue="retry-tasks", countdown=10)
 
 
 def test_should_call_send_email_to_provider_from_deliver_email_task(
@@ -83,7 +83,7 @@ def test_should_add_to_retry_queue_if_notification_not_found_in_deliver_email_ta
 
     deliver_email(notification_id)
     app.delivery.send_to_providers.send_email_to_provider.assert_not_called()
-    app.celery.provider_tasks.deliver_email.retry.assert_called_with(queue="retry", countdown=10)
+    app.celery.provider_tasks.deliver_email.retry.assert_called_with(queue="retry-tasks", countdown=10)
 
 
 # DO THESE FOR THE 4 TYPES OF TASK
@@ -94,7 +94,7 @@ def test_should_go_into_technical_error_if_exceeds_retries_on_deliver_sms_task(s
 
     deliver_sms(sample_notification.id)
 
-    provider_tasks.deliver_sms.retry.assert_called_with(queue='retry', countdown=10)
+    provider_tasks.deliver_sms.retry.assert_called_with(queue="retry-tasks", countdown=10)
 
     assert sample_notification.status == 'technical-failure'
 
@@ -105,7 +105,7 @@ def test_should_go_into_technical_error_if_exceeds_retries_on_deliver_email_task
 
     deliver_email(sample_notification.id)
 
-    provider_tasks.deliver_email.retry.assert_called_with(queue='retry', countdown=10)
+    provider_tasks.deliver_email.retry.assert_called_with(queue="retry-tasks", countdown=10)
     assert sample_notification.status == 'technical-failure'
 
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -165,7 +165,7 @@ def test_should_update_scheduled_jobs_and_put_on_queue(notify_db, notify_db_sess
 
     updated_job = dao_get_job_by_id(job.id)
     assert updated_job.job_status == 'pending'
-    mocked.assert_called_with([str(job.id)], queue='process-job')
+    mocked.assert_called_with([str(job.id)], queue="job-tasks")
 
 
 def test_should_update_all_scheduled_jobs_and_put_on_queue(notify_db, notify_db_session, mocker):
@@ -200,9 +200,9 @@ def test_should_update_all_scheduled_jobs_and_put_on_queue(notify_db, notify_db_
     assert dao_get_job_by_id(job_2.id).job_status == 'pending'
 
     mocked.assert_has_calls([
-        call([str(job_3.id)], queue='process-job'),
-        call([str(job_2.id)], queue='process-job'),
-        call([str(job_1.id)], queue='process-job')
+        call([str(job_3.id)], queue="job-tasks"),
+        call([str(job_2.id)], queue="job-tasks"),
+        call([str(job_1.id)], queue="job-tasks")
     ])
 
 

--- a/tests/app/celery/test_statistics_tasks.py
+++ b/tests/app/celery/test_statistics_tasks.py
@@ -17,7 +17,7 @@ def test_should_create_initial_job_task_if_notification_is_related_to_a_job(
     mock = mocker.patch("app.celery.statistics_tasks.record_initial_job_statistics.apply_async")
     notification = sample_notification(notify_db, notify_db_session, job=sample_job)
     create_initial_notification_statistic_tasks(notification)
-    mock.assert_called_once_with((str(notification.id), ), queue="statistics")
+    mock.assert_called_once_with((str(notification.id), ), queue="statistics-tasks")
 
 
 @pytest.mark.parametrize('status', [
@@ -29,7 +29,7 @@ def test_should_create_intial_job_task_if_notification_is_not_in_completed_state
     mock = mocker.patch("app.celery.statistics_tasks.record_initial_job_statistics.apply_async")
     notification = sample_notification(notify_db, notify_db_session, job=sample_job, status=status)
     create_initial_notification_statistic_tasks(notification)
-    mock.assert_called_once_with((str(notification.id), ), queue="statistics")
+    mock.assert_called_once_with((str(notification.id), ), queue="statistics-tasks")
 
 
 def test_should_not_create_initial_job_task_if_notification_is_not_related_to_a_job(
@@ -47,7 +47,7 @@ def test_should_create_outcome_job_task_if_notification_is_related_to_a_job(
     mock = mocker.patch("app.celery.statistics_tasks.record_outcome_job_statistics.apply_async")
     notification = sample_notification(notify_db, notify_db_session, job=sample_job, status=NOTIFICATION_DELIVERED)
     create_outcome_notification_statistic_tasks(notification)
-    mock.assert_called_once_with((str(notification.id), ), queue="statistics")
+    mock.assert_called_once_with((str(notification.id), ), queue="statistics-tasks")
 
 
 @pytest.mark.parametrize('status', NOTIFICATION_STATUS_TYPES_COMPLETED)
@@ -57,7 +57,7 @@ def test_should_create_outcome_job_task_if_notification_is_in_completed_state(
     mock = mocker.patch("app.celery.statistics_tasks.record_outcome_job_statistics.apply_async")
     notification = sample_notification(notify_db, notify_db_session, job=sample_job, status=status)
     create_outcome_notification_statistic_tasks(notification)
-    mock.assert_called_once_with((str(notification.id), ), queue='statistics')
+    mock.assert_called_once_with((str(notification.id), ), queue="statistics-tasks")
 
 
 @pytest.mark.parametrize('status', [
@@ -100,7 +100,7 @@ def test_should_retry_if_persisting_the_job_stats_has_a_sql_alchemy_exception(
 
     record_initial_job_statistics(str(sample_notification.id))
     dao_mock.assert_called_once_with(sample_notification)
-    retry_mock.assert_called_with(queue="retry")
+    retry_mock.assert_called_with(queue="retry-tasks")
 
 
 def test_should_call_update_job_stats_dao_outcome_methods(notify_db, notify_db_session, sample_notification, mocker):
@@ -123,7 +123,7 @@ def test_should_retry_if_persisting_the_job_outcome_stats_has_a_sql_alchemy_exce
 
     record_outcome_job_statistics(str(sample_notification.id))
     dao_mock.assert_called_once_with(sample_notification)
-    retry_mock.assert_called_with(queue="retry")
+    retry_mock.assert_called_with(queue="retry-tasks")
 
 
 def test_should_retry_if_persisting_the_job_outcome_stats_updates_zero_rows(
@@ -136,7 +136,7 @@ def test_should_retry_if_persisting_the_job_outcome_stats_updates_zero_rows(
 
     record_outcome_job_statistics(str(sample_notification.id))
     dao_mock.assert_called_once_with(sample_notification)
-    retry_mock.assert_called_with(queue="retry")
+    retry_mock.assert_called_with(queue="retry-tasks")
 
 
 def test_should_retry_if_persisting_the_job_stats_creation_cant_find_notification_by_id(
@@ -148,7 +148,7 @@ def test_should_retry_if_persisting_the_job_stats_creation_cant_find_notificatio
 
     record_initial_job_statistics(str(create_uuid()))
     dao_mock.assert_not_called()
-    retry_mock.assert_called_with(queue="retry")
+    retry_mock.assert_called_with(queue="retry-tasks")
 
 
 def test_should_retry_if_persisting_the_job_stats_outcome_cant_find_notification_by_id(
@@ -161,4 +161,4 @@ def test_should_retry_if_persisting_the_job_stats_outcome_cant_find_notification
 
     record_outcome_job_statistics(str(create_uuid()))
     dao_mock.assert_not_called()
-    retry_mock.assert_called_with(queue="retry")
+    retry_mock.assert_called_with(queue="retry-tasks")

--- a/tests/app/delivery/test_rest.py
+++ b/tests/app/delivery/test_rest.py
@@ -78,7 +78,7 @@ def test_should_call_deliver_sms_task_if_send_sms_to_provider_fails(notify_api, 
             )
         app.delivery.send_to_providers.send_sms_to_provider.assert_called_with(sample_notification)
         app.celery.provider_tasks.deliver_sms.apply_async.assert_called_with(
-            (str(sample_notification.id)), queue='send-sms'
+            (str(sample_notification.id)), queue='send-tasks'
         )
         assert response.status_code == 204
 
@@ -100,6 +100,6 @@ def test_should_call_deliver_email_task_if_send_email_to_provider_fails(
             )
         app.delivery.send_to_providers.send_email_to_provider.assert_called_with(sample_email_notification)
         app.celery.provider_tasks.deliver_email.apply_async.assert_called_with(
-            (str(sample_email_notification.id)), queue='send-email'
+            (str(sample_email_notification.id)), queue='send-tasks'
         )
         assert response.status_code == 204

--- a/tests/app/invite/test_invite_rest.py
+++ b/tests/app/invite/test_invite_rest.py
@@ -33,7 +33,7 @@ def test_create_invited_user(client, sample_service, mocker, invitation_email_te
     assert json_resp['data']['id']
 
     notification = Notification.query.first()
-    mocked.assert_called_once_with([(str(notification.id))], queue="notify")
+    mocked.assert_called_once_with([(str(notification.id))], queue="notify-internal-tasks")
 
 
 def test_create_invited_user_invalid_email(client, sample_service, mocker):

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -119,7 +119,7 @@ def test_create_unscheduled_job(notify_api, sample_template, mocker, fake_uuid):
 
             app.celery.tasks.process_job.apply_async.assert_called_once_with(
                 ([str(fake_uuid)]),
-                queue="process-job"
+                queue="job-tasks"
             )
 
             resp_json = json.loads(response.get_data(as_text=True))

--- a/tests/app/letters/test_send_letter_jobs.py
+++ b/tests/app/letters/test_send_letter_jobs.py
@@ -21,7 +21,7 @@ def test_send_letter_jobs(client, mocker):
 
     mock_celery.assert_called_once_with(name="send-files-to-dvla",
                                         args=(job_ids['job_ids'],),
-                                        queue="process-ftp")
+                                        queue="process-ftp-tasks")
 
 
 def test_send_letter_jobs_throws_validation_error(client, mocker):

--- a/tests/app/notifications/rest/test_callbacks.py
+++ b/tests/app/notifications/rest/test_callbacks.py
@@ -68,7 +68,7 @@ def test_dvla_callback_calls_update_letter_notifications_task(client, mocker):
 
     assert response.status_code == 200
     assert update_task.called
-    update_task.assert_called_with(['bar.txt'], queue='notify')
+    update_task.assert_called_with(['bar.txt'], queue='notify-internal-tasks')
 
 
 def test_dvla_callback_does_not_raise_error_parsing_json_for_plaintext_header(client, mocker):

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -207,17 +207,17 @@ def test_persist_notification_increments_cache_if_key_exists(sample_template, sa
 
 
 @pytest.mark.parametrize('research_mode, requested_queue, expected_queue, notification_type, key_type',
-                         [(True, None, 'research-mode', 'sms', 'normal'),
-                          (True, None, 'research-mode', 'email', 'normal'),
-                          (True, None, 'research-mode', 'email', 'team'),
-                          (False, None, 'send-sms', 'sms', 'normal'),
-                          (False, None, 'send-email', 'email', 'normal'),
-                          (False, None, 'send-sms', 'sms', 'team'),
-                          (False, None, 'research-mode', 'sms', 'test'),
-                          (True, 'notify', 'research-mode', 'email', 'normal'),
-                          (False, 'notify', 'notify', 'sms', 'normal'),
-                          (False, 'notify', 'notify', 'email', 'normal'),
-                          (False, 'notify', 'research-mode', 'sms', 'test')])
+                         [(True, None, 'research-mode-tasks', 'sms', 'normal'),
+                          (True, None, 'research-mode-tasks', 'email', 'normal'),
+                          (True, None, 'research-mode-tasks', 'email', 'team'),
+                          (False, None, 'send-tasks', 'sms', 'normal'),
+                          (False, None, 'send-tasks', 'email', 'normal'),
+                          (False, None, 'send-tasks', 'sms', 'team'),
+                          (False, None, 'research-mode-tasks', 'sms', 'test'),
+                          (True, 'notify-internal-tasks', 'research-mode-tasks', 'email', 'normal'),
+                          (False, 'notify-internal-tasks', 'notify-internal-tasks', 'sms', 'normal'),
+                          (False, 'notify-internal-tasks', 'notify-internal-tasks', 'email', 'normal'),
+                          (False, 'notify-internal-tasks', 'research-mode-tasks', 'sms', 'test')])
 def test_send_notification_to_queue(notify_db, notify_db_session,
                                     research_mode, requested_queue, expected_queue,
                                     notification_type, key_type, mocker):

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -374,7 +374,7 @@ def test_send_user_reset_password_should_send_reset_password_link(client,
 
     assert resp.status_code == 204
     notification = Notification.query.first()
-    mocked.assert_called_once_with([str(notification.id)], queue="notify")
+    mocked.assert_called_once_with([str(notification.id)], queue="notify-internal-tasks")
 
 
 def test_send_user_reset_password_should_return_400_when_email_is_missing(client, mocker):
@@ -436,7 +436,7 @@ def test_send_already_registered_email(client, sample_user, already_registered_t
     assert resp.status_code == 204
 
     notification = Notification.query.first()
-    mocked.assert_called_once_with(([str(notification.id)]), queue="notify")
+    mocked.assert_called_once_with(([str(notification.id)]), queue="notify-internal-tasks")
 
 
 def test_send_already_registered_email_returns_400_when_data_is_missing(client, sample_user):
@@ -464,7 +464,7 @@ def test_send_user_confirm_new_email_returns_204(client, sample_user, change_ema
     notification = Notification.query.first()
     mocked.assert_called_once_with(
         ([str(notification.id)]),
-        queue="notify")
+        queue="notify-internal-tasks")
 
 
 def test_send_user_confirm_new_email_returns_400_when_email_missing(client, sample_user, mocker):

--- a/tests/app/user/test_rest_verify.py
+++ b/tests/app/user/test_rest_verify.py
@@ -218,7 +218,7 @@ def test_send_user_sms_code(client,
 
     app.celery.provider_tasks.deliver_sms.apply_async.assert_called_once_with(
         ([str(notification.id)]),
-        queue="notify"
+        queue="notify-internal-tasks"
     )
 
 
@@ -246,7 +246,7 @@ def test_send_user_code_for_sms_with_optional_to_field(client,
     assert notification.to == to_number
     app.celery.provider_tasks.deliver_sms.apply_async.assert_called_once_with(
         ([str(notification.id)]),
-        queue="notify"
+        queue="notify-internal-tasks"
     )
 
 
@@ -294,7 +294,7 @@ def test_send_user_email_verification(client,
         headers=[('Content-Type', 'application/json'), auth_header])
     assert resp.status_code == 204
     notification = Notification.query.first()
-    mocked.assert_called_once_with(([str(notification.id)]), queue="notify")
+    mocked.assert_called_once_with(([str(notification.id)]), queue="notify-internal-tasks")
 
 
 def test_send_email_verification_returns_404_for_bad_input_data(client, notify_db_session, mocker):

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -228,7 +228,7 @@ def test_send_notification_uses_priority_queue_when_template_is_marked_as_priori
     notification_id = json.loads(response.data)['id']
 
     assert response.status_code == 201
-    mocked.assert_called_once_with([notification_id], queue='priority')
+    mocked.assert_called_once_with([notification_id], queue='priority-tasks')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Change retries policy. 
Before we had a long back off, now we have more, but shorter back offs.

- PREVIOUS
When we had an error talking to a provider we retried quickly and if we still got errors we backed off more and more. Maximum attempts was 5, max delay 4hours. This was to allow us time to ship a build if that was required.

- NOW
Backing off 48 times of 5 minutes each. This gives us the same total back off, but many more tries in that period.

- WHY
Having the long back off meant messages could be delayed 4 hours. This was happening more and more, as PaaS deploys can place things into the "inflight" state in SQS. The inflight state MUST have an expiry time LONGER than the maximum retry back off. This meant that messages would be delayed 4 hours, even when there was no app error.

By doing this we can reduce this delay to 5 minutes. Whilst still giving us time to fix issues.

- RELEASING

- [ ] Update autoscaling app to look at new queues (https://github.com/alphagov/notifications-paas-autoscaler/pull/3)

- [ ] Update FTP app to look in new queue and have same visibility time out

- [ ] Validate that renaming queues and new timeouts isn't an issue. Using a different visibility timeout with the same queue CAN cause an issue when celery looks to make the queue (this is confusing celery behaviour where it tries to make queues it hasn't cached, and the queue signature is a combination of name and timeout). Given we don't write to these queues now, only read it *should* be OK. need to test on preview during the deploy.