### PR TITLE
Removed references to old queus

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -25,23 +25,6 @@ class QueueNames(object):
     PROCESS_FTP = 'process-ftp-tasks'
 
     @staticmethod
-    def old_queues():
-        return [
-            'db-sms',
-            'db-email',
-            'db-letter',
-            'priority',
-            'periodic',
-            'send-sms',
-            'send-email',
-            'research-mode',
-            'statistics',
-            'notify',
-            'retry',
-            'process-job'
-        ]
-
-    @staticmethod
     def all_queues():
         return [
             QueueNames.PRIORITY,
@@ -262,8 +245,6 @@ class Development(Config):
     NOTIFICATION_QUEUE_PREFIX = 'development'
     DEBUG = True
 
-    queues = QueueNames.all_queues() + QueueNames.old_queues()
-
     for queue in QueueNames.all_queues():
         Config.CELERY_QUEUES.append(
             Queue(queue, Exchange('default'), routing_key=queue)
@@ -283,9 +264,7 @@ class Test(Config):
     STATSD_HOST = "localhost"
     STATSD_PORT = 1000
 
-    queues = QueueNames.all_queues() + QueueNames.old_queues()
-
-    for queue in queues:
+    for queue in QueueNames.all_queues():
         Config.CELERY_QUEUES.append(
             Queue(queue, Exchange('default'), routing_key=queue)
         )

--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -23,33 +23,33 @@ applications:
       NOTIFY_APP_NAME: delivery-celery-beat
 
   - name: notify-delivery-worker-database
-    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q db-sms,db-email,db-letter,database-tasks
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q database-tasks
     env:
       NOTIFY_APP_NAME: delivery-worker-database
 
   - name: notify-delivery-worker-research
-    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=5 -Q research-mode,research-mode-tasks
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=5 -Q research-mode-tasks
     env:
       NOTIFY_APP_NAME: delivery-worker-research
 
   - name: notify-delivery-worker-sender
-    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q send-sms,send-email,send-tasks
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q send-tasks
     env:
       NOTIFY_APP_NAME: delivery-worker-sender
 
   - name: notify-delivery-worker-periodic
-    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=2 -Q periodic,statistics,periodic-tasks,statistics-tasks
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=2 -Q periodic-tasks,statistics-tasks
     instances: 1
     memory: 2G
     env:
       NOTIFY_APP_NAME: delivery-worker-periodic
 
   - name: notify-delivery-worker-priority
-    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=5 -Q priority,priority-tasks
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=5 -Q priority-tasks
     env:
       NOTIFY_APP_NAME: delivery-worker-priority
 
   - name: notify-delivery-worker
-    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q process-job,notify,retry,job-tasks,retry-tasks,notify-internal-tasks
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q job-tasks,retry-tasks,notify-internal-tasks
     env:
       NOTIFY_APP_NAME: delivery-worker


### PR DESCRIPTION
Now we have new queues with new timeouts, this removes references to the old ones from the code base. It does not delete the queues, we can use @imdadahad script for that later.

CANNOT be shipped until at least 4 hours after https://github.com/alphagov/notifications-api/pull/987 on the offchance something ends up in 'inflight'

I'd ship it tomorrow (wednesday) at earliest