### PR TITLE
Don’t 500 when searching with bad email address

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -9,7 +9,8 @@ from flask import current_app
 from notifications_utils.recipients import (
     validate_and_format_phone_number,
     validate_and_format_email_address,
-    InvalidPhoneError
+    InvalidPhoneError,
+    InvalidEmailError,
 )
 from werkzeug.datastructures import MultiDict
 from sqlalchemy import (desc, func, or_, and_, asc)
@@ -477,7 +478,10 @@ def dao_get_notifications_by_to_field(service_id, search_term, statuses=None):
     try:
         normalised = validate_and_format_phone_number(search_term)
     except InvalidPhoneError:
-        normalised = validate_and_format_email_address(search_term)
+        try:
+            normalised = validate_and_format_email_address(search_term)
+        except InvalidEmailError:
+            normalised = search_term
 
     filters = [
         Notification.service_id == service_id,

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -1772,6 +1772,20 @@ def test_dao_get_notifications_by_to_field_search_is_not_case_sensitive(sample_t
     assert notification.id in notification_ids
 
 
+@pytest.mark.parametrize('to', [
+    'not@email', '123'
+])
+def test_dao_get_notifications_by_to_field_accepts_invalid_phone_numbers_and_email_addresses(
+    sample_template,
+    to,
+):
+    notification = create_notification(
+        template=sample_template, to_field='test@example.com', normalised_to='test@example.com'
+    )
+    results = dao_get_notifications_by_to_field(notification.service_id, to)
+    assert len(results) == 0
+
+
 def test_dao_get_notifications_by_to_field_search_ignores_spaces(sample_template):
     notification1 = create_notification(
         template=sample_template, to_field='+447700900855', normalised_to='447700900855'


### PR DESCRIPTION
In the future we might want to validate email addresses before attempting to search by them. But for a first pass we can just return no results when a user types in something that isn’t an email address or phone number.

It definitely better than returning a 500.