### PR TITLE
Reduced memory footprint of the API apps.

### DIFF
--- a/manifest-api-preview.yml
+++ b/manifest-api-preview.yml
@@ -6,3 +6,6 @@ routes:
   - route: notify-api-preview.cloudapps.digital
   - route: api-paas.notify.works
   - route: api.notify.works
+
+instances: 1
+memory: 256M

--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -24,6 +24,7 @@ applications:
 
   - name: notify-delivery-worker-database
     command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q db-sms,db-email,db-letter,database-tasks
+    memory: 1G
     env:
       NOTIFY_APP_NAME: delivery-worker-database
 
@@ -34,13 +35,13 @@ applications:
 
   - name: notify-delivery-worker-sender
     command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q send-sms,send-email,send-tasks
+    memory: 1G
     env:
       NOTIFY_APP_NAME: delivery-worker-sender
 
   - name: notify-delivery-worker-periodic
     command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=2 -Q periodic,statistics,periodic-tasks,statistics-tasks
     instances: 1
-    memory: 2G
     env:
       NOTIFY_APP_NAME: delivery-worker-periodic
 

--- a/manifest-delivery-preview.yml
+++ b/manifest-delivery-preview.yml
@@ -1,3 +1,4 @@
 ---
 
 inherit: manifest-delivery-base.yml
+memory: 256M

--- a/manifest-delivery-production.yml
+++ b/manifest-delivery-production.yml
@@ -3,4 +3,4 @@
 inherit: manifest-delivery-base.yml
 
 instances: 2
-memory: 1G
+memory: 768M

--- a/manifest-delivery-staging.yml
+++ b/manifest-delivery-staging.yml
@@ -3,4 +3,4 @@
 inherit: manifest-delivery-base.yml
 
 instances: 2
-memory: 1G
+memory: 768M


### PR DESCRIPTION
Staging and prod now default to 768M of RAM, down from a 1G saves 512M per instance type
Preview down to 256M per app