### PR TITLE
Use python3 when running migration-check script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,5 +306,5 @@ cf-push:
 
 .PHONY: check-if-migrations-to-run
 check-if-migrations-to-run:
-	@echo $(shell python scripts/check_if_new_migration.py)
+	@echo $(shell python3 scripts/check_if_new_migration.py)
 


### PR DESCRIPTION
This script is run on Jenkins but with `python2`, it needs to run with `python3` otherwise a nasty SSL error occurs.