### PR TITLE
manually set sms_sender when creating service

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, timedelta
 
 from sqlalchemy import asc, func
 from sqlalchemy.orm import joinedload
+from flask import current_app
 
 from app import db
 from app.dao.dao_utils import (
@@ -131,6 +132,12 @@ def dao_fetch_service_by_id_and_user(service_id, user_id):
 @transactional
 @version_class(Service)
 def dao_create_service(service, user, service_id=None, service_permissions=[SMS_TYPE, EMAIL_TYPE]):
+    # the default property does not appear to work when there is a difference between the sqlalchemy schema and the
+    # db schema (ie: during a migration), so we have to set sms_sender manually here. After the GOVUK sms_sender
+    # migration is completed, this code should be able to be removed.
+    if not service.sms_sender:
+        service.sms_sender = current_app.config['FROM_NUMBER']
+
     from app.dao.permissions_dao import permission_dao
     service.users.append(user)
     permission_dao.add_default_service_permissions_for_user(user, service)


### PR DESCRIPTION
sqlalchemy default doesn't appear to work correctly when there is a difference between the DB schema and the code (ie: during a migration) in this case, lets just set sms_sender ourselves.

we can't write unit tests for this because this only happens when the db is in an inconsistent state :weary:


(i've actually tested this).

Once this is deployed, I'll re-re-re-re-revert the db migration