### PR TITLE
Firetext inbound sms

### DIFF
--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -19,7 +19,7 @@ def receive_mmg_sms():
 
 @receive_notifications_blueprint.route('/notifications/sms/receive/firetext', methods=['POST'])
 def receive_firetext_sms():
-    post_data = request.get_json()
+    post_data = request.form
     current_app.logger.info("Received Firetext notification form data: {}".format(post_data))
 
     return jsonify({

--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -1,5 +1,5 @@
 from flask import Blueprint
-from flask import current_app
+from flask import current_app, jsonify
 from flask import request
 
 from app.errors import register_errors
@@ -15,3 +15,13 @@ def receive_mmg_sms():
     current_app.logger.info("Recieve notification form data: {}".format(post_data))
 
     return "RECEIVED"
+
+
+@receive_notifications_blueprint.route('/notifications/sms/receive/firetext', methods=['POST'])
+def receive_firetext_sms():
+    post_data = request.get_json()
+    current_app.logger.info("Received Firetext notification form data: {}".format(post_data))
+
+    return jsonify({
+        "status": "ok"
+    }), 200

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -19,11 +19,12 @@ def test_receive_notification_returns_received_to_mmg(client):
 
 
 def test_receive_notification_returns_received_to_firetext(client):
-    data = {"some": "thing"}
+    data = "source=07999999999&destination=07111111111&message=this is a message&time=2017-01-01 12:00:00"
+
     response = client.post(
         path='/notifications/sms/receive/firetext',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json')])
+        data=data,
+        headers=[('Content-Type', 'application/x-www-form-urlencoded')])
 
     assert response.status_code == 200
     result = json.loads(response.get_data(as_text=True))

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -16,3 +16,16 @@ def test_receive_notification_returns_received_to_mmg(client):
 
     assert response.status_code == 200
     assert response.get_data(as_text=True) == 'RECEIVED'
+
+
+def test_receive_notification_returns_received_to_firetext(client):
+    data = {"some": "thing"}
+    response = client.post(
+        path='/notifications/sms/receive/firetext',
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json')])
+
+    assert response.status_code == 200
+    result = json.loads(response.get_data(as_text=True))
+
+    assert result['status'] == 'ok'


### PR DESCRIPTION
First PR on firetext inbound SMS.

Simply dumps the form data out.

This verifies:
- Content type is url-form-endcoded
- Form body is as expected.

Future PRs will save this to the database.