### PR TITLE
Ignore one-off messages in job list on dashboard

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -107,7 +107,7 @@ class Config(object):
     SMS_CHAR_COUNT_LIMIT = 495
     BRANDING_PATH = '/images/email-template/crests/'
     TEST_MESSAGE_FILENAME = 'Test message'
-    ONE_OFF_MESSAGE_FILENAME = 'One-off message'
+    ONE_OFF_MESSAGE_FILENAME = 'Report'
     MAX_VERIFY_CODE_COUNT = 10
 
     NOTIFY_SERVICE_ID = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'

--- a/app/config.py
+++ b/app/config.py
@@ -107,6 +107,7 @@ class Config(object):
     SMS_CHAR_COUNT_LIMIT = 495
     BRANDING_PATH = '/images/email-template/crests/'
     TEST_MESSAGE_FILENAME = 'Test message'
+    ONE_OFF_MESSAGE_FILENAME = 'One-off message'
     MAX_VERIFY_CODE_COUNT = 10
 
     NOTIFY_SERVICE_ID = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -53,7 +53,8 @@ def dao_get_job_by_service_id_and_job_id(service_id, job_id):
 def dao_get_jobs_by_service_id(service_id, limit_days=None, page=1, page_size=50, statuses=None):
     query_filter = [
         Job.service_id == service_id,
-        Job.original_file_name != current_app.config['TEST_MESSAGE_FILENAME']
+        Job.original_file_name != current_app.config['TEST_MESSAGE_FILENAME'],
+        Job.original_file_name != current_app.config['ONE_OFF_MESSAGE_FILENAME'],
     ]
     if limit_days is not None:
         query_filter.append(cast(Job.created_at, sql_date) >= days_ago(limit_days))

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -337,7 +337,7 @@ def test_get_jobs_for_service_is_paginated(notify_db, notify_db_session, sample_
 
 @pytest.mark.parametrize('file_name', [
     'Test message',
-    'One-off message'
+    'Report',
 ])
 def test_get_jobs_for_service_doesnt_return_test_messages(
     notify_db,

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from functools import partial
+import pytest
 import uuid
 
 from freezegun import freeze_time
@@ -334,13 +335,24 @@ def test_get_jobs_for_service_is_paginated(notify_db, notify_db_session, sample_
     assert res.items[1].created_at == datetime(2015, 1, 1, 7)
 
 
-def test_get_jobs_for_service_doesnt_return_test_messages(notify_db, notify_db_session, sample_template, sample_job):
+@pytest.mark.parametrize('file_name', [
+    'Test message',
+    'One-off message'
+])
+def test_get_jobs_for_service_doesnt_return_test_messages(
+    notify_db,
+    notify_db_session,
+    sample_template,
+    sample_job,
+    file_name,
+):
     test_job = create_job(
         notify_db,
         notify_db_session,
         sample_template.service,
         sample_template,
-        original_file_name='Test message')
+        original_file_name=file_name,
+    )
 
     jobs = dao_get_jobs_by_service_id(sample_job.service_id).items
 


### PR DESCRIPTION
Same as how we ignore ‘send yourself a test’ messages (see: d8467bfc3cdca0f7dcd019f93ca20d981ef28760). The dashboard gets clogged up with one off messages otherwise, which affects:
- performance
- users ability to find their jobs