### PR TITLE
Delete inbound messages older than seven days

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from app.aws import s3
 from app import notify_celery
 from app import performance_platform_client
+from app.dao.inbound_sms_dao import delete_inbound_sms_created_more_than_a_week_ago
 from app.dao.invited_user_dao import delete_invitations_created_more_than_two_days_ago
 from app.dao.jobs_dao import dao_set_scheduled_jobs_to_pending, dao_get_jobs_older_than_limited_by
 from app.dao.notifications_dao import (
@@ -226,3 +227,21 @@ def timeout_job_statistics():
     if updated:
         current_app.logger.info(
             "Timeout period reached for {} job statistics, failure count has been updated.".format(updated))
+
+
+@notify_celery.task(name="delete-inbound-sms")
+@statsd(namespace="tasks")
+def delete_inbound_sms_older_than_seven_days():
+    try:
+        start = datetime.utcnow()
+        deleted = delete_inbound_sms_created_more_than_a_week_ago()
+        current_app.logger.info(
+            "Delete inbound sms job started {} finished {} deleted {} inbound sms notifications".format(
+                start,
+                datetime.utcnow(),
+                deleted
+            )
+        )
+    except SQLAlchemyError as e:
+        current_app.logger.exception("Failed to delete inbound sms notifications")
+        raise

--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from celery.schedules import crontab
 from kombu import Exchange, Queue
 import os
+
 from app.models import KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST
 
 if os.environ.get('VCAP_SERVICES'):
@@ -166,6 +167,11 @@ class Config(object):
         'delete-letter-notifications': {
             'task': 'delete-letter-notifications',
             'schedule': crontab(minute=40, hour=0),
+            'options': {'queue': QueueNames.PERIODIC}
+        },
+        'delete-inbound-sms': {
+            'task': 'delete-inbound-sms',
+            'schedule': crontab(minute=0, hour=1),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'send-daily-performance-platform-stats': {

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -2,7 +2,8 @@ import functools
 from datetime import (
     datetime,
     timedelta,
-    date)
+    date
+)
 
 from flask import current_app
 
@@ -26,6 +27,7 @@ from app.models import (
     NotificationHistory,
     NotificationStatistics,
     Template,
+    ScheduledNotification,
     NOTIFICATION_CREATED,
     NOTIFICATION_DELIVERED,
     NOTIFICATION_SENDING,
@@ -35,7 +37,8 @@ from app.models import (
     NOTIFICATION_PERMANENT_FAILURE,
     KEY_TYPE_NORMAL, KEY_TYPE_TEST,
     LETTER_TYPE,
-    NOTIFICATION_SENT, ScheduledNotification)
+    NOTIFICATION_SENT,
+)
 
 from app.dao.dao_utils import transactional
 from app.statsd_decorators import statsd

--- a/tests/app/dao/test_inbound_sms_dao.py
+++ b/tests/app/dao/test_inbound_sms_dao.py
@@ -1,10 +1,15 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from freezegun import freeze_time
 
-from app.dao.inbound_sms_dao import dao_get_inbound_sms_for_service, dao_count_inbound_sms_for_service
-
+from app.dao.inbound_sms_dao import (
+    dao_get_inbound_sms_for_service,
+    dao_count_inbound_sms_for_service,
+    delete_inbound_sms_created_more_than_a_week_ago
+)
 from tests.app.db import create_inbound_sms, create_service
+
+from app.models import InboundSms
 
 
 def test_get_all_inbound_sms(sample_service):
@@ -57,3 +62,27 @@ def test_count_inbound_sms_for_service(notify_db_session):
     create_inbound_sms(service_two)
 
     assert dao_count_inbound_sms_for_service(service_one.id) == 2
+
+
+@freeze_time("2017-01-01 12:00:00")
+def test_should_delete_inbound_sms_older_than_seven_days(sample_service):
+    older_than_seven_days = datetime.utcnow() - timedelta(days=7, seconds=1)
+    create_inbound_sms(sample_service, created_at=older_than_seven_days)
+    delete_inbound_sms_created_more_than_a_week_ago()
+
+    assert len(InboundSms.query.all()) == 0
+
+
+@freeze_time("2017-01-01 12:00:00")
+def test_should_not_delete_inbound_sms_before_seven_days(sample_service):
+    yesterday = datetime.utcnow() - timedelta(days=1)
+    just_before_seven_days = datetime.utcnow() - timedelta(days=6, hours=23, minutes=59, seconds=59)
+    older_than_seven_days = datetime.utcnow() - timedelta(days=7, seconds=1)
+
+    create_inbound_sms(sample_service, created_at=yesterday)
+    create_inbound_sms(sample_service, created_at=just_before_seven_days)
+    create_inbound_sms(sample_service, created_at=older_than_seven_days)
+
+    delete_inbound_sms_created_more_than_a_week_ago()
+
+    assert len(InboundSms.query.all()) == 2

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import uuid
 
 
+from app.dao.inbound_sms_dao import dao_create_inbound_sms
 from app.dao.jobs_dao import dao_create_job
 from app.models import (
     InboundSms,
@@ -12,6 +13,7 @@ from app.models import (
     ScheduledNotification,
     ServicePermission,
     Job,
+    InboundSms,
     EMAIL_TYPE,
     SMS_TYPE,
     KEY_TYPE_NORMAL,
@@ -151,14 +153,15 @@ def create_notification(
     return notification
 
 
-def create_job(template,
-               notification_count=1,
-               created_at=None,
-               job_status='pending',
-               scheduled_for=None,
-               processing_started=None,
-               original_file_name='some.csv'):
-
+def create_job(
+    template,
+    notification_count=1,
+    created_at=None,
+    job_status='pending',
+    scheduled_for=None,
+    processing_started=None,
+    original_file_name='some.csv'
+):
     data = {
         'id': uuid.uuid4(),
         'service_id': template.service_id,
@@ -193,11 +196,12 @@ def create_inbound_sms(
     user_number='447700900111',
     provider_date=None,
     provider_reference=None,
-    content='Hello'
+    content='Hello',
+    created_at=None
 ):
     inbound = InboundSms(
         service=service,
-        created_at=datetime.utcnow(),
+        created_at=created_at or datetime.utcnow(),
         notify_number=notify_number or service.sms_sender,
         user_number=user_number,
         provider_date=provider_date or datetime.utcnow(),


### PR DESCRIPTION
This adds a scheduled task that deletes inbound sms older than 7 days. This runs at 1AM every day, similar to other delete jobs which run 20 mins apart.

