### PR TITLE
Return notification content for outbound messages

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -494,7 +494,7 @@ def dao_get_notifications_by_to_field(service_id, search_term, statuses=None):
     if statuses:
         filters.append(Notification.status.in_(statuses))
 
-    results = db.session.query(Notification).filter(*filters).all()
+    results = db.session.query(Notification).filter(*filters).order_by(desc(Notification.created_at)).all()
     return results
 
 

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -11,6 +11,10 @@ from app.dao import (
     templates_dao,
     notifications_dao
 )
+from app.errors import (
+    register_errors,
+    InvalidRequest
+)
 from app.models import KEY_TYPE_TEAM, PRIORITY
 from app.models import SMS_TYPE
 from app.notifications.process_notifications import (
@@ -37,12 +41,6 @@ from app.utils import pagination_links, get_template_instance
 from notifications_utils.recipients import get_international_phone_info
 
 notifications = Blueprint('notifications', __name__)
-
-from app.errors import (
-    register_errors,
-    InvalidRequest
-)
-
 
 register_errors(notifications)
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -59,6 +59,7 @@ from app.schemas import (
     user_schema,
     permission_schema,
     notification_with_template_schema,
+    notification_with_personalisation_schema,
     notifications_filter_schema,
     detailed_service_schema
 )
@@ -303,7 +304,7 @@ def get_all_notifications_for_service(service_id):
 def search_for_notification_by_to_field(service_id, search_term, statuses):
     results = notifications_dao.dao_get_notifications_by_to_field(service_id, search_term, statuses)
     return jsonify(
-        notifications=notification_with_template_schema.dump(results, many=True).data
+        notifications=notification_with_personalisation_schema.dump(results, many=True).data
     ), 200
 
 

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -1903,3 +1903,24 @@ def test_dao_get_notifications_by_to_field_returns_all_if_no_status_filter(sampl
     assert len(notifications) == 2
     assert notification1.id in notification_ids
     assert notification2.id in notification_ids
+
+
+@freeze_time('2016-01-01 11:10:00')
+def test_dao_get_notifications_by_to_field_orders_by_created_at_desc(sample_template):
+    notification = partial(
+        create_notification,
+        template=sample_template,
+        to_field='+447700900855',
+        normalised_to='447700900855'
+    )
+
+    notification_a_minute_ago = notification(created_at=datetime.utcnow() - timedelta(minutes=1))
+    notification = notification(created_at=datetime.utcnow())
+
+    notifications = dao_get_notifications_by_to_field(
+        sample_template.service_id, '+447700900855'
+    )
+
+    assert len(notifications) == 2
+    assert notifications[0].id == notification.id
+    assert notifications[1].id == notification_a_minute_ago.id


### PR DESCRIPTION
This changes `search_for_notification_by_to_field` to return the content of each `Notification`. 

## Summary

Instead of creating a new endpoint for retrieving notification content for outbound messages, this uses the existing endpoint which is used in `get_notifications_for_service`. This returns the notifications in descending order of `created_at`.