### PR TITLE
Add data.gov.uk to the list of organisations

### DIFF
--- a/migrations/versions/0092_data_gov_uk.py
+++ b/migrations/versions/0092_data_gov_uk.py
@@ -1,0 +1,31 @@
+"""empty message
+
+Revision ID: 0092_data_gov_uk
+Revises: 0091_letter_billing
+Create Date: 2017-06-05 16:15:17.744908
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0092_data_gov_uk'
+down_revision = '0091_letter_billing'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+DATA_GOV_UK_ID = '123496d4-44cb-4324-8e0a-4187101f4bdc'
+
+def upgrade():
+    op.execute("""INSERT INTO organisation VALUES (
+        '{}',
+        '',
+        'data_gov_uk_x2.png',
+        ''
+    )""".format(DATA_GOV_UK_ID))
+
+
+def downgrade():
+    op.execute("""
+        DELETE FROM organisation WHERE "id" = '{}'
+    """.format(DATA_GOV_UK_ID))


### PR DESCRIPTION
We need to send an email with data.gov.uk branding.

The image for the logo doesn’t exist yet, but doing this migration so we’re ready when it the logo does exist.