### PR TITLE
Add private endpoint to get notification by ID

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -300,6 +300,19 @@ def get_all_notifications_for_service(service_id):
     ), 200
 
 
+@service_blueprint.route('/<uuid:service_id>/notifications/<uuid:notification_id>', methods=['GET'])
+def get_notification_for_service(service_id, notification_id):
+
+    notification = notifications_dao.get_notification_with_personalisation(
+        service_id,
+        notification_id,
+        key_type=None,
+    )
+    return jsonify(
+        notification_with_template_schema.dump(notification).data,
+    ), 200
+
+
 def search_for_notification_by_to_field(service_id, search_term, statuses):
     results = notifications_dao.dao_get_notifications_by_to_field(service_id, search_term, statuses)
     return jsonify(

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1248,6 +1248,15 @@ def test_get_all_notifications_for_service_in_order(notify_api, notify_db, notif
         assert response.status_code == 200
 
 
+def test_get_notification_for_service_without_uuid(client, notify_db, notify_db_session):
+    service_1 = create_service(notify_db, notify_db_session, service_name="1", email_from='1')
+    response = client.get(
+        path='/service/{}/notifications/{}'.format(service_1.id, 'foo'),
+        headers=[create_authorization_header()]
+    )
+    assert response.status_code == 404
+
+
 def test_get_notification_for_service(client, notify_db, notify_db_session):
 
     service_1 = create_service(notify_db, notify_db_session, service_name="1", email_from='1')


### PR DESCRIPTION
We need this for the two way stuff in the admin app.

We already have this as a public endpoint, but the admin app can’t use it, because the admin app auths with its own key, not that of the service it’s acting on behalf of.

This endpoint makes sure that a request originating from one service can’t be used to see notifications belonging to another service.