### PR TITLE
Add endpoint to get inbound sms by id

### DIFF
--- a/app/dao/inbound_sms_dao.py
+++ b/app/dao/inbound_sms_dao.py
@@ -49,5 +49,8 @@ def delete_inbound_sms_created_more_than_a_week_ago():
     return deleted
 
 
-def dao_get_inbound_sms_by_id(inbound_id):
-    return InboundSms.query.filter_by(id=inbound_id).one()
+def dao_get_inbound_sms_by_id(service_id, inbound_id):
+    return InboundSms.query.filter_by(
+        id=inbound_id,
+        service_id=service_id
+    ).one()

--- a/app/dao/inbound_sms_dao.py
+++ b/app/dao/inbound_sms_dao.py
@@ -47,3 +47,7 @@ def delete_inbound_sms_created_more_than_a_week_ago():
     ).delete(synchronize_session='fetch')
 
     return deleted
+
+
+def dao_get_inbound_sms_by_id(inbound_id):
+    return InboundSms.query.filter_by(id=inbound_id).one()

--- a/app/inbound_sms/rest.py
+++ b/app/inbound_sms/rest.py
@@ -1,11 +1,19 @@
+import uuid
+
 from flask import (
     Blueprint,
     jsonify,
     request
 )
+from werkzeug.exceptions import abort
+
 from notifications_utils.recipients import validate_and_format_phone_number
 
-from app.dao.inbound_sms_dao import dao_get_inbound_sms_for_service, dao_count_inbound_sms_for_service
+from app.dao.inbound_sms_dao import (
+    dao_get_inbound_sms_for_service,
+    dao_count_inbound_sms_for_service,
+    dao_get_inbound_sms_by_id
+)
 from app.errors import register_errors
 
 inbound_sms = Blueprint(
@@ -40,3 +48,16 @@ def get_inbound_sms_summary_for_service(service_id):
         count=count,
         most_recent=most_recent[0].created_at.isoformat() if most_recent else None
     )
+
+
+@inbound_sms.route('/<inbound_sms_id>', methods=['GET'])
+def get_inbound_by_id(service_id, inbound_sms_id):
+    # TODO: Add JSON Schema here
+    try:
+        validated_uuid = uuid.UUID(inbound_sms_id)
+    except (ValueError, AttributeError):
+        abort(400)
+
+    inbound_sms = dao_get_inbound_sms_by_id(validated_uuid)
+
+    return jsonify(inbound_sms.serialize()), 200

--- a/app/inbound_sms/rest.py
+++ b/app/inbound_sms/rest.py
@@ -1,11 +1,8 @@
-import uuid
-
 from flask import (
     Blueprint,
     jsonify,
     request
 )
-from werkzeug.exceptions import abort
 
 from notifications_utils.recipients import validate_and_format_phone_number
 
@@ -19,7 +16,7 @@ from app.errors import register_errors
 inbound_sms = Blueprint(
     'inbound_sms',
     __name__,
-    url_prefix='/service/<service_id>/inbound-sms'
+    url_prefix='/service/<uuid:service_id>/inbound-sms'
 )
 
 register_errors(inbound_sms)
@@ -50,14 +47,8 @@ def get_inbound_sms_summary_for_service(service_id):
     )
 
 
-@inbound_sms.route('/<inbound_sms_id>', methods=['GET'])
+@inbound_sms.route('/<uuid:inbound_sms_id>', methods=['GET'])
 def get_inbound_by_id(service_id, inbound_sms_id):
-    # TODO: Add JSON Schema here
-    try:
-        validated_uuid = uuid.UUID(inbound_sms_id)
-    except (ValueError, AttributeError):
-        abort(400)
-
-    inbound_sms = dao_get_inbound_sms_by_id(validated_uuid)
+    inbound_sms = dao_get_inbound_sms_by_id(service_id, inbound_sms_id)
 
     return jsonify(inbound_sms.serialize()), 200

--- a/tests/app/dao/test_inbound_sms_dao.py
+++ b/tests/app/dao/test_inbound_sms_dao.py
@@ -5,7 +5,8 @@ from freezegun import freeze_time
 from app.dao.inbound_sms_dao import (
     dao_get_inbound_sms_for_service,
     dao_count_inbound_sms_for_service,
-    delete_inbound_sms_created_more_than_a_week_ago
+    delete_inbound_sms_created_more_than_a_week_ago,
+    dao_get_inbound_sms_by_id
 )
 from tests.app.db import create_inbound_sms, create_service
 
@@ -86,3 +87,11 @@ def test_should_not_delete_inbound_sms_before_seven_days(sample_service):
     delete_inbound_sms_created_more_than_a_week_ago()
 
     assert len(InboundSms.query.all()) == 2
+
+
+def test_get_inbound_sms_by_id_returns(sample_service):
+    inbound = create_inbound_sms(sample_service)
+
+    inbound_from_db = dao_get_inbound_sms_by_id(inbound.id)
+
+    assert inbound == inbound_from_db

--- a/tests/app/dao/test_inbound_sms_dao.py
+++ b/tests/app/dao/test_inbound_sms_dao.py
@@ -92,6 +92,6 @@ def test_should_not_delete_inbound_sms_before_seven_days(sample_service):
 def test_get_inbound_sms_by_id_returns(sample_service):
     inbound = create_inbound_sms(sample_service)
 
-    inbound_from_db = dao_get_inbound_sms_by_id(inbound.id)
+    inbound_from_db = dao_get_inbound_sms_by_id(sample_service.id, inbound.id)
 
     assert inbound == inbound_from_db

--- a/tests/app/inbound_sms/test_rest.py
+++ b/tests/app/inbound_sms/test_rest.py
@@ -112,3 +112,29 @@ def test_get_inbound_sms_summary_with_no_inbound(admin_request, sample_service):
         'count': 0,
         'most_recent': None
     }
+
+
+def test_get_inbound_sms_by_id_returns_200(admin_request, sample_service):
+    inbound = create_inbound_sms(sample_service, user_number='447700900001')
+
+    response = admin_request.get(
+        'inbound_sms.get_inbound_by_id',
+        endpoint_kwargs={
+            'service_id': sample_service.id,
+            'inbound_sms_id': inbound.id
+        }
+    )
+
+    assert response['user_number'] == '447700900001'
+    assert response['service_id'] == str(sample_service.id)
+
+
+def test_get_inbound_sms_by_id_invalid_id_returns_400(admin_request, sample_service):
+    assert admin_request.get(
+        'inbound_sms.get_inbound_by_id',
+        endpoint_kwargs={
+            'service_id': sample_service.id,
+            'inbound_sms_id': 'dsadsda'
+        },
+        expected_status=400
+    )

--- a/tests/app/inbound_sms/test_rest.py
+++ b/tests/app/inbound_sms/test_rest.py
@@ -129,12 +129,23 @@ def test_get_inbound_sms_by_id_returns_200(admin_request, sample_service):
     assert response['service_id'] == str(sample_service.id)
 
 
-def test_get_inbound_sms_by_id_invalid_id_returns_400(admin_request, sample_service):
+def test_get_inbound_sms_by_id_invalid_id_returns_404(admin_request, sample_service):
     assert admin_request.get(
         'inbound_sms.get_inbound_by_id',
         endpoint_kwargs={
             'service_id': sample_service.id,
-            'inbound_sms_id': 'dsadsda'
+            'inbound_sms_id': 'bar'
         },
-        expected_status=400
+        expected_status=404
+    )
+
+
+def test_get_inbound_sms_by_id_with_invalid_service_id_returns_404(admin_request, sample_service):
+    assert admin_request.get(
+        'inbound_sms.get_inbound_by_id',
+        endpoint_kwargs={
+            'service_id': 'foo',
+            'inbound_sms_id': '2cfbd6a1-1575-4664-8969-f27be0ea40d9'
+        },
+        expected_status=404
     )


### PR DESCRIPTION
This adds a new endpoint to get an inbound message by id (to be used by admin).

## Notes:

1. URL: `/service/<id>/inbound-sms/<id>`
2. Added basic validation for now (similar to how we do in v2), will need to add a JSON schema at some point but may possible be an overkill to just validate a single `uuid`...