### PR TITLE
Change the job_statistics table structure

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1122,6 +1122,9 @@ class JobStatistics(db.Model):
     sms_failed = db.Column(db.BigInteger, index=False, unique=False, nullable=False, default=0)
     letters_sent = db.Column(db.BigInteger, index=False, unique=False, nullable=False, default=0)
     letters_failed = db.Column(db.BigInteger, index=False, unique=False, nullable=False, default=0)
+    sent = db.Column(db.BigInteger, index=False, unique=False, nullable=True, default=0)
+    delivered = db.Column(db.BigInteger, index=False, unique=False, nullable=True, default=0)
+    failed = db.Column(db.BigInteger, index=False, unique=False, nullable=True, default=0)
     created_at = db.Column(
         db.DateTime,
         index=False,

--- a/migrations/versions/0094_job_stats_update.py
+++ b/migrations/versions/0094_job_stats_update.py
@@ -1,0 +1,25 @@
+"""empty message
+
+Revision ID: 0094_job_stats_update
+Revises: 0093_data_gov_uk
+Create Date: 2017-06-06 14:37:30.051647
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0094_job_stats_update'
+down_revision = '0093_data_gov_uk'
+
+
+def upgrade():
+    op.add_column('job_statistics', sa.Column('sent', sa.BigInteger(), nullable=True))
+    op.add_column('job_statistics', sa.Column('delivered', sa.BigInteger(), nullable=True))
+    op.add_column('job_statistics', sa.Column('failed', sa.BigInteger(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('job_statistics', 'sent')
+    op.drop_column('job_statistics', 'failed')
+    op.drop_column('job_statistics', 'delivered')


### PR DESCRIPTION
Add three new columns to job_statistics for sent, delivered and failed.
A job only ever has one notification type.
This is the first deploy, where the columns are added and populated.

Next a data migration will happen to populate these new columns for the older jobs that do not have the values set.
Then we stop populating the old columns and remove them.
This refactoring of the table structure will make the queries to the table much easier to handle.