### PR TITLE
Remove DVLA response files older than 7 days

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -1,5 +1,9 @@
-from boto3 import resource
+from datetime import datetime, timedelta
+
 from flask import current_app
+
+import pytz
+from boto3 import client, resource
 
 FILE_LOCATION_STRUCTURE = 'service-{}-notify/{}.csv'
 
@@ -24,7 +28,46 @@ def get_job_from_s3(service_id, job_id):
 def remove_job_from_s3(service_id, job_id):
     bucket_name = current_app.config['CSV_UPLOAD_BUCKET_NAME']
     file_location = FILE_LOCATION_STRUCTURE.format(service_id, job_id)
-    obj = get_s3_object(bucket_name, file_location)
+    return remove_s3_object(bucket_name, file_location)
+
+
+def get_s3_bucket_objects(bucket_name, subfolder='', older_than=7, limit_days=2):
+    boto_client = client('s3', current_app.config['AWS_REGION'])
+    paginator = boto_client.get_paginator('list_objects_v2')
+    page_iterator = paginator.paginate(
+        Bucket=bucket_name,
+        Prefix=subfolder
+    )
+
+    all_objects_in_bucket = []
+    for page in page_iterator:
+        all_objects_in_bucket.extend(page['Contents'])
+
+    return all_objects_in_bucket
+
+
+def filter_s3_bucket_objects_within_date_range(bucket_objects, older_than=7, limit_days=2):
+    """
+    S3 returns the Object['LastModified'] as an 'offset-aware' timestamp so the
+    date range filter must take this into account.
+
+    Additionally an additional Object is returned by S3 corresponding to the
+    container directory. This is redundant and should be removed.
+
+    """
+    end_date = datetime.now(tz=pytz.utc) - timedelta(days=older_than)
+    start_date = end_date - timedelta(days=limit_days)
+    filtered_items = [item for item in bucket_objects if all([
+        not item['Key'].endswith('/'),
+        item['LastModified'] > start_date,
+        item['LastModified'] < end_date
+    ])]
+
+    return filtered_items
+
+
+def remove_s3_object(bucket_name, object_key):
+    obj = get_s3_object(bucket_name, object_key)
     return obj.delete()
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,8 @@
 from datetime import timedelta
+import os
+
 from celery.schedules import crontab
 from kombu import Exchange, Queue
-import os
 
 from app.models import (
     EMAIL_TYPE, SMS_TYPE, LETTER_TYPE,
@@ -209,6 +210,11 @@ class Config(object):
             'schedule': crontab(minute=40, hour=4),
             'options': {'queue': QueueNames.PERIODIC}
         },
+        'delete_dvla_response_files': {
+            'task': 'delete_dvla_response_files',
+            'schedule': crontab(minute=10, hour=5),
+            'options': {'queue': QueueNames.PERIODIC}
+        },
         'timeout-job-statistics': {
             'task': 'timeout-job-statistics',
             'schedule': crontab(minute=0, hour=5),
@@ -265,6 +271,7 @@ class Development(Config):
     SQLALCHEMY_ECHO = False
     NOTIFY_EMAIL_DOMAIN = 'notify.tools'
     CSV_UPLOAD_BUCKET_NAME = 'development-notifications-csv-upload'
+    DVLA_RESPONSE_BUCKET_NAME = 'notify.tools-ftp'
     NOTIFY_ENVIRONMENT = 'development'
     NOTIFICATION_QUEUE_PREFIX = 'development'
     DEBUG = True
@@ -284,6 +291,7 @@ class Test(Config):
     NOTIFY_ENVIRONMENT = 'test'
     DEBUG = True
     CSV_UPLOAD_BUCKET_NAME = 'test-notifications-csv-upload'
+    DVLA_RESPONSE_BUCKET_NAME = 'test.notify.com-ftp'
     STATSD_ENABLED = True
     STATSD_HOST = "localhost"
     STATSD_PORT = 1000
@@ -316,6 +324,7 @@ class Preview(Config):
     NOTIFY_EMAIL_DOMAIN = 'notify.works'
     NOTIFY_ENVIRONMENT = 'preview'
     CSV_UPLOAD_BUCKET_NAME = 'preview-notifications-csv-upload'
+    DVLA_RESPONSE_BUCKET_NAME = 'notify.works-ftp'
     FROM_NUMBER = 'preview'
     API_RATE_LIMIT_ENABLED = True
 
@@ -324,6 +333,7 @@ class Staging(Config):
     NOTIFY_EMAIL_DOMAIN = 'staging-notify.works'
     NOTIFY_ENVIRONMENT = 'staging'
     CSV_UPLOAD_BUCKET_NAME = 'staging-notify-csv-upload'
+    DVLA_RESPONSE_BUCKET_NAME = 'staging-notify.works-ftp'
     STATSD_ENABLED = True
     FROM_NUMBER = 'stage'
     API_RATE_LIMIT_ENABLED = True
@@ -333,6 +343,7 @@ class Live(Config):
     NOTIFY_EMAIL_DOMAIN = 'notifications.service.gov.uk'
     NOTIFY_ENVIRONMENT = 'live'
     CSV_UPLOAD_BUCKET_NAME = 'live-notifications-csv-upload'
+    DVLA_RESPONSE_BUCKET_NAME = 'notifications.service.gov.uk-ftp'
     STATSD_ENABLED = True
     FROM_NUMBER = 'GOVUK'
     FUNCTIONAL_TEST_PROVIDER_SERVICE_ID = '6c1d81bb-dae2-4ee9-80b0-89a4aae9f649'
@@ -350,6 +361,7 @@ class Sandbox(CloudFoundryConfig):
     NOTIFY_EMAIL_DOMAIN = 'notify.works'
     NOTIFY_ENVIRONMENT = 'sandbox'
     CSV_UPLOAD_BUCKET_NAME = 'cf-sandbox-notifications-csv-upload'
+    DVLA_RESPONSE_BUCKET_NAME = 'notify.works-ftp'
     FROM_NUMBER = 'sandbox'
     REDIS_ENABLED = False
 

--- a/tests/app/aws/test_s3.py
+++ b/tests/app/aws/test_s3.py
@@ -1,8 +1,29 @@
 from unittest.mock import call
+from datetime import datetime, timedelta
 
 from flask import current_app
 
-from app.aws.s3 import get_s3_file, remove_transformed_dvla_file
+from freezegun import freeze_time
+import pytz
+
+from app.aws.s3 import (
+    get_s3_bucket_objects,
+    get_s3_file,
+    filter_s3_bucket_objects_within_date_range,
+    remove_transformed_dvla_file
+)
+
+
+def datetime_in_past(days=0, seconds=0):
+    return datetime.now(tz=pytz.utc) - timedelta(days=days, seconds=seconds)
+
+
+def single_s3_object_stub(key='foo', last_modified=datetime.utcnow()):
+    return {
+        'ETag': '"d41d8cd98f00b204e9800998ecf8427e"',
+        'Key': key,
+        'LastModified': last_modified
+    }
 
 
 def test_get_s3_file_makes_correct_call(notify_api, mocker):
@@ -25,3 +46,83 @@ def test_remove_transformed_dvla_file_makes_correct_call(notify_api, mocker):
         call(current_app.config['DVLA_UPLOAD_BUCKET_NAME'], '{}-dvla-job.text'.format(fake_uuid)),
         call().delete()
     ])
+
+
+def test_get_s3_bucket_objects_make_correct_pagination_call(notify_api, mocker):
+    paginator_mock = mocker.patch('app.aws.s3.client')
+
+    get_s3_bucket_objects('foo-bucket', subfolder='bar')
+
+    paginator_mock.assert_has_calls([
+        call().get_paginator().paginate(Bucket='foo-bucket', Prefix='bar')
+    ])
+
+
+def test_get_s3_bucket_objects_builds_objects_list_from_paginator(notify_api, mocker):
+    paginator_mock = mocker.patch('app.aws.s3.client')
+    multiple_pages_s3_object = [
+        {
+            "Contents": [
+                single_s3_object_stub('bar/foo.txt', datetime_in_past(days=8)),
+            ]
+        },
+        {
+            "Contents": [
+                single_s3_object_stub('bar/foo1.txt', datetime_in_past(days=8)),
+            ]
+        }
+    ]
+    paginator_mock.return_value.get_paginator.return_value.paginate.return_value = multiple_pages_s3_object
+
+    bucket_objects = get_s3_bucket_objects('foo-bucket', subfolder='bar')
+
+    assert len(bucket_objects) == 2
+    assert set(bucket_objects[0].keys()) == set(['ETag', 'Key', 'LastModified'])
+
+
+@freeze_time("2016-01-01 11:00:00")
+def test_get_s3_bucket_objects_removes_redundant_root_object(notify_api, mocker):
+    s3_objects_stub = [
+        single_s3_object_stub('bar/', datetime_in_past(days=8)),
+        single_s3_object_stub('bar/foo.txt', datetime_in_past(days=8)),
+    ]
+
+    filtered_items = filter_s3_bucket_objects_within_date_range(s3_objects_stub)
+
+    assert len(filtered_items) == 1
+
+    assert filtered_items[0]["Key"] == 'bar/foo.txt'
+    assert filtered_items[0]["LastModified"] == datetime_in_past(days=8)
+
+
+@freeze_time("2016-01-01 11:00:00")
+def test_filter_s3_bucket_objects_within_date_range_filters_by_date_range(notify_api, mocker):
+    s3_objects_stub = [
+        single_s3_object_stub('bar/', datetime_in_past(days=8)),
+        single_s3_object_stub('bar/foo.txt', datetime_in_past(days=8)),
+        single_s3_object_stub('bar/foo1.txt', datetime_in_past(days=8)),
+    ]
+
+    filtered_items = filter_s3_bucket_objects_within_date_range(s3_objects_stub)
+
+    assert len(filtered_items) == 2
+
+    assert filtered_items[0]["Key"] == 'bar/foo.txt'
+    assert filtered_items[0]["LastModified"] == datetime_in_past(days=8)
+
+    assert filtered_items[1]["Key"] == 'bar/foo1.txt'
+    assert filtered_items[1]["LastModified"] == datetime_in_past(days=8)
+
+
+@freeze_time("2016-01-01 11:00:00")
+def test_get_s3_bucket_objects_does_not_return_outside_of_date_range(notify_api, mocker):
+    s3_objects_stub = [
+        single_s3_object_stub('bar/', datetime_in_past(days=7)),
+        single_s3_object_stub('bar/foo.txt', datetime_in_past(days=7)),
+        single_s3_object_stub('bar/foo2.txt', datetime_in_past(days=9)),
+        single_s3_object_stub('bar/foo2.txt', datetime_in_past(days=9, seconds=1)),
+    ]
+
+    filtered_items = filter_s3_bucket_objects_within_date_range(s3_objects_stub)
+
+    assert len(filtered_items) == 0

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1,12 +1,14 @@
+from datetime import (datetime, date, timedelta)
 import json
 import uuid
-from datetime import (datetime, date, timedelta)
 
-import requests_mock
+from flask import current_app, url_for
+
 import pytest
+import pytz
+import requests_mock
 from sqlalchemy import asc
 from sqlalchemy.orm.session import make_transient
-from flask import current_app, url_for
 
 from app import db
 from app.models import (
@@ -35,7 +37,6 @@ from app.dao.notifications_dao import dao_create_notification
 from app.dao.invited_user_dao import save_invited_user
 from app.dao.provider_rates_dao import create_provider_rates
 from app.clients.sms.firetext import FiretextClient
-
 from tests import create_authorization_header
 from tests.app.db import create_user, create_template, create_notification
 
@@ -1018,3 +1019,7 @@ def admin_request(client):
             return json_resp
 
     return AdminRequest
+
+
+def datetime_in_past(days=0, seconds=0):
+    return datetime.now(tz=pytz.utc) - timedelta(days=days, seconds=seconds)


### PR DESCRIPTION
This adds a task (run daily at 5:10AM) to remove DVLA response files older than 7 days.

## Summary

This works by using `boto` to get all s3 objects in the bucket and then, for each object, checking `Object["LastModified"]` to see if it is older than seven days (similar to how we do with other jobs). If so we remove the file.


## Notes

- `boto` annoyingly returns the root directory an `Object`, e.g. if you wanted all files in `somedir/`, it'll return all the files within as objects but additionally an object for `somedir/`. This has to be removed manually.
- the `Object["LastModified"]` is 'offset-aware' and so needs additionally processing to make sure date range filters work as expected.