### PR TITLE
Job stats for dashboard

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -8,7 +8,7 @@ from app.dao import days_ago
 from app.models import (
     Job, JobStatistics, Notification, NotificationHistory, Template,
     JOB_STATUS_SCHEDULED, JOB_STATUS_PENDING,
-    EMAIL_TYPE, SMS_TYPE, LETTER_TYPE
+    LETTER_TYPE
 )
 from app.statsd_decorators import statsd
 
@@ -142,3 +142,36 @@ def dao_get_all_letter_jobs():
     return db.session.query(Job).join(Job.template).filter(
         Template.template_type == LETTER_TYPE
     ).order_by(desc(Job.created_at)).all()
+
+
+@statsd(namespace="dao")
+def dao_get_job_statistics_for_job(job_id):
+    query = db.session.query(
+        JobStatistics.job_id,
+        Job.original_file_name,
+        Job.created_at,
+        JobStatistics.sent,
+        JobStatistics.delivered,
+        JobStatistics.failed
+    ).filter(JobStatistics.job_id == job_id).filter(Job.id == JobStatistics.job_id)
+    return query.one()
+
+
+@statsd(namespace="dao")
+def dao_get_job_stats_for_service(service_id, page=1, page_size=50, limit_days=None):
+    query = Job.query.join(
+        JobStatistics, Job.id == JobStatistics.job_id
+    ).filter(
+        Job.service_id == service_id
+    ).add_columns(
+        JobStatistics.job_id,
+        Job.original_file_name,
+        Job.created_at,
+        JobStatistics.sent,
+        JobStatistics.delivered,
+        JobStatistics.failed
+    )
+    if limit_days:
+        query = query.filter(Job.created_at >= days_ago(limit_days))
+    query = query.order_by(Job.created_at.desc())
+    return query.paginate(page=page, per_page=page_size).items

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -159,6 +159,9 @@ def dao_get_job_statistics_for_job(service_id, job_id):
         Job.scheduled_for,
         Job.template_id,
         Job.template_version,
+        Job.job_status,
+        Job.service_id,
+        Job.notification_count,
         JobStatistics.sent,
         JobStatistics.delivered,
         JobStatistics.failed
@@ -179,6 +182,11 @@ def dao_get_job_stats_for_service(service_id, page=1, page_size=50, limit_days=N
         Job.original_file_name,
         Job.created_at,
         Job.scheduled_for,
+        Job.template_id,
+        Job.template_version,
+        Job.job_status,
+        Job.service_id,
+        Job.notification_count,
         JobStatistics.sent,
         JobStatistics.delivered,
         JobStatistics.failed

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -149,9 +149,8 @@ def dao_get_job_statistics_for_job(service_id, job_id):
     query = Job.query.join(
         JobStatistics, Job.id == JobStatistics.job_id
     ).filter(
-        Job.id == job_id
-    ).join(
-        Template, Template.id == Job.template_id and Template.version == Job.template_version
+        Job.id == job_id,
+        Job.service_id == service_id
     ).add_columns(
         JobStatistics.job_id,
         Job.original_file_name,
@@ -165,8 +164,6 @@ def dao_get_job_statistics_for_job(service_id, job_id):
         JobStatistics.sent,
         JobStatistics.delivered,
         JobStatistics.failed
-    ).filter(
-        Job.service_id == service_id
     )
     return query.one()
 

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -429,16 +429,16 @@ def test_dao_get_job_statistics_for_job(notify_db, notify_db_session, sample_job
     update_job_stats_outcome_count(notification_delivered)
     update_job_stats_outcome_count(notification_failed)
     result = dao_get_job_statistics_for_job(sample_job.service_id, sample_job.id)
-    assert_job_stat(job=sample_job, result=result, sent=3, delivered=1, failed=1, with_template=True)
+    assert_job_stat(job=sample_job, result=result, sent=3, delivered=1, failed=1)
 
 
 def test_dao_get_job_statistics_for_job(notify_db, notify_db_session, sample_service):
     job_1, job_2 = stats_set_up(notify_db, notify_db_session, sample_service)
     result = dao_get_job_statistics_for_job(sample_service.id, job_1.id)
-    assert_job_stat(job=job_1, result=result, sent=2, delivered=1, failed=0, with_template=True)
+    assert_job_stat(job=job_1, result=result, sent=2, delivered=1, failed=0)
 
     result_2 = dao_get_job_statistics_for_job(sample_service.id, job_2.id)
-    assert_job_stat(job=job_2, result=result_2, sent=1, delivered=0, failed=1, with_template=True)
+    assert_job_stat(job=job_2, result=result_2, sent=1, delivered=0, failed=1)
 
 
 def test_dao_get_job_stats_for_service(notify_db, notify_db_session, sample_service):
@@ -508,17 +508,19 @@ def test_dao_get_job_returns_jobs_for_status(
     assert results_2.total == 2
 
 
-def assert_job_stat(job, result, sent, delivered, failed, with_template=False):
+def assert_job_stat(job, result, sent, delivered, failed):
     assert result.job_id == job.id
     assert result.original_file_name == job.original_file_name
     assert result.created_at == job.created_at
     assert result.scheduled_for == job.scheduled_for
+    assert result.template_id == job.template_id
+    assert result.template_version == job.template_version
+    assert result.job_status == job.job_status
+    assert result.service_id == job.service_id
+    assert result.notification_count == job.notification_count
     assert result.sent == sent
     assert result.delivered == delivered
     assert result.failed == failed
-    if with_template:
-        assert result.template_id == job.template_id
-        assert result.template_version == job.template_version
 
 
 def stats_set_up(notify_db, notify_db_session, service):

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -16,7 +16,10 @@ from app.dao.jobs_dao import (
     all_notifications_are_created_for_job,
     dao_update_job_status,
     dao_get_all_notifications_for_job,
-    dao_get_jobs_older_than_limited_by)
+    dao_get_jobs_older_than_limited_by,
+    dao_get_job_statistics_for_job,
+    dao_get_job_stats_for_service)
+from app.dao.statistics_dao import create_or_update_job_sending_statistics, update_job_stats_outcome_count
 from app.models import (
     Job, JobStatistics,
     EMAIL_TYPE, SMS_TYPE, LETTER_TYPE
@@ -411,3 +414,115 @@ def test_should_get_jobs_seven_days_old_filters_type(notify_db, notify_db_sessio
 
     assert len(jobs) == 2
     assert job_to_remain.id not in [job.id for job in jobs]
+
+
+def test_dao_get_job_statistics_for_job(notify_db, notify_db_session, sample_job):
+    notification = create_notification(notify_db=notify_db, notify_db_session=notify_db_session, job=sample_job)
+    notification_delivered = create_notification(notify_db=notify_db, notify_db_session=notify_db_session,
+                                                 job=sample_job, status='delivered')
+    notification_failed = create_notification(notify_db=notify_db, notify_db_session=notify_db_session, job=sample_job,
+                                              status='permanent-failure')
+
+    create_or_update_job_sending_statistics(notification)
+    create_or_update_job_sending_statistics(notification_delivered)
+    create_or_update_job_sending_statistics(notification_failed)
+    update_job_stats_outcome_count(notification_delivered)
+    update_job_stats_outcome_count(notification_failed)
+    results = dao_get_job_statistics_for_job(sample_job.id)
+    assert results.job_id == sample_job.id
+    assert results.sent == 3
+    assert results.delivered == 1
+    assert results.failed == 1
+
+
+def test_dao_get_job_statistics_for_job(notify_db, notify_db_session, sample_service):
+    job_1, job_2 = stats_set_up(notify_db, notify_db_session, sample_service)
+    results = dao_get_job_statistics_for_job(job_1.id)
+    assert_job_stat(job_1, results, 2, 1, 0)
+
+    results_2 = dao_get_job_statistics_for_job(job_2.id)
+    assert_job_stat(job_2, results_2, 1, 0, 1)
+
+
+def test_dao_get_job_stats_for_service(notify_db, notify_db_session, sample_service):
+    job_1, job_2 = stats_set_up(notify_db, notify_db_session, sample_service)
+
+    results = dao_get_job_stats_for_service(sample_service.id)
+    assert len(results) == 2
+    assert_job_stat(job_2, results[0], 1, 0, 1)
+    assert_job_stat(job_1, results[1], 2, 1, 0)
+
+
+def test_dao_get_job_stats_for_service_only_returns_stats_for_service(notify_db, notify_db_session, sample_service):
+    job_1, job_2 = stats_set_up(notify_db, notify_db_session, sample_service)
+    another_service = create_service(notify_db=notify_db, notify_db_session=notify_db_session,
+                                     service_name='Another Service')
+    job_3, job_4 = stats_set_up(notify_db, notify_db_session, service=another_service)
+
+    results = dao_get_job_stats_for_service(sample_service.id)
+    assert len(results) == 2
+    assert_job_stat(job_2, results[0], 1, 0, 1)
+    assert_job_stat(job_1, results[1], 2, 1, 0)
+
+    results = dao_get_job_stats_for_service(another_service.id)
+    assert len(results) == 2
+    assert_job_stat(job_4, results[0], 1, 0, 1)
+    assert_job_stat(job_3, results[1], 2, 1, 0)
+
+
+def test_dao_get_job_stats_for_service_only_returns_jobs_created_within_limited_days(
+        notify_db, notify_db_session, sample_service):
+    job_1, job_2 = stats_set_up(notify_db, notify_db_session, sample_service)
+
+    results = dao_get_job_stats_for_service(sample_service.id, limit_days=1)
+    assert len(results) == 1
+    assert_job_stat(job_2, results[0], 1, 0, 1)
+
+
+def test_dao_get_job_stats_for_service_only_returns_jobs_created_within_limited_days_inclusive(
+        notify_db, notify_db_session, sample_service):
+    job_1, job_2 = stats_set_up(notify_db, notify_db_session, sample_service)
+
+    results = dao_get_job_stats_for_service(sample_service.id, limit_days=2)
+    assert len(results) == 2
+    assert_job_stat(job_2, results[0], 1, 0, 1)
+    assert_job_stat(job_1, results[1], 2, 1, 0)
+
+
+def test_dao_get_job_stats_paginates_results(
+        notify_db, notify_db_session, sample_service):
+    job_1, job_2 = stats_set_up(notify_db, notify_db_session, sample_service)
+
+    results = dao_get_job_stats_for_service(sample_service.id, page=1, page_size=1)
+    assert len(results) == 1
+    assert_job_stat(job_2, results[0], 1, 0, 1)
+    results_2 = dao_get_job_stats_for_service(sample_service.id, page=2, page_size=1)
+    assert len(results_2) == 1
+    assert_job_stat(job_1, results_2[0], 2, 1, 0)
+
+
+def assert_job_stat(job, result, sent, delivered, failed):
+    assert result.job_id == job.id
+    assert result.original_file_name == job.original_file_name
+    assert result.created_at == job.created_at
+    assert result.sent == sent
+    assert result.delivered == delivered
+    assert result.failed == failed
+
+
+def stats_set_up(notify_db, notify_db_session, service):
+    job_1 = create_job(notify_db=notify_db, notify_db_session=notify_db_session,
+                       service=service, created_at=datetime.utcnow() - timedelta(days=2))
+    job_2 = create_job(notify_db=notify_db, notify_db_session=notify_db_session,
+                       service=service, original_file_name='Another job')
+    notification = create_notification(notify_db=notify_db, notify_db_session=notify_db_session, job=job_1)
+    notification_delivered = create_notification(notify_db=notify_db, notify_db_session=notify_db_session,
+                                                 job=job_1, status='delivered')
+    notification_failed = create_notification(notify_db=notify_db, notify_db_session=notify_db_session, job=job_2,
+                                              status='permanent-failure')
+    create_or_update_job_sending_statistics(notification)
+    create_or_update_job_sending_statistics(notification_delivered)
+    create_or_update_job_sending_statistics(notification_failed)
+    update_job_stats_outcome_count(notification_delivered)
+    update_job_stats_outcome_count(notification_failed)
+    return job_1, job_2

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -428,26 +428,23 @@ def test_dao_get_job_statistics_for_job(notify_db, notify_db_session, sample_job
     create_or_update_job_sending_statistics(notification_failed)
     update_job_stats_outcome_count(notification_delivered)
     update_job_stats_outcome_count(notification_failed)
-    results = dao_get_job_statistics_for_job(sample_job.id)
-    assert results.job_id == sample_job.id
-    assert results.sent == 3
-    assert results.delivered == 1
-    assert results.failed == 1
+    result = dao_get_job_statistics_for_job(sample_job.service_id, sample_job.id)
+    assert_job_stat(job=sample_job, result=result, sent=3, delivered=1, failed=1, with_template=True)
 
 
 def test_dao_get_job_statistics_for_job(notify_db, notify_db_session, sample_service):
     job_1, job_2 = stats_set_up(notify_db, notify_db_session, sample_service)
-    results = dao_get_job_statistics_for_job(job_1.id)
-    assert_job_stat(job_1, results, 2, 1, 0)
+    result = dao_get_job_statistics_for_job(sample_service.id, job_1.id)
+    assert_job_stat(job=job_1, result=result, sent=2, delivered=1, failed=0, with_template=True)
 
-    results_2 = dao_get_job_statistics_for_job(job_2.id)
-    assert_job_stat(job_2, results_2, 1, 0, 1)
+    result_2 = dao_get_job_statistics_for_job(sample_service.id, job_2.id)
+    assert_job_stat(job=job_2, result=result_2, sent=1, delivered=0, failed=1, with_template=True)
 
 
 def test_dao_get_job_stats_for_service(notify_db, notify_db_session, sample_service):
     job_1, job_2 = stats_set_up(notify_db, notify_db_session, sample_service)
 
-    results = dao_get_job_stats_for_service(sample_service.id)
+    results = dao_get_job_stats_for_service(sample_service.id).items
     assert len(results) == 2
     assert_job_stat(job_2, results[0], 1, 0, 1)
     assert_job_stat(job_1, results[1], 2, 1, 0)
@@ -459,12 +456,12 @@ def test_dao_get_job_stats_for_service_only_returns_stats_for_service(notify_db,
                                      service_name='Another Service')
     job_3, job_4 = stats_set_up(notify_db, notify_db_session, service=another_service)
 
-    results = dao_get_job_stats_for_service(sample_service.id)
+    results = dao_get_job_stats_for_service(sample_service.id).items
     assert len(results) == 2
     assert_job_stat(job_2, results[0], 1, 0, 1)
     assert_job_stat(job_1, results[1], 2, 1, 0)
 
-    results = dao_get_job_stats_for_service(another_service.id)
+    results = dao_get_job_stats_for_service(another_service.id).items
     assert len(results) == 2
     assert_job_stat(job_4, results[0], 1, 0, 1)
     assert_job_stat(job_3, results[1], 2, 1, 0)
@@ -475,15 +472,15 @@ def test_dao_get_job_stats_for_service_only_returns_jobs_created_within_limited_
     job_1, job_2 = stats_set_up(notify_db, notify_db_session, sample_service)
 
     results = dao_get_job_stats_for_service(sample_service.id, limit_days=1)
-    assert len(results) == 1
-    assert_job_stat(job_2, results[0], 1, 0, 1)
+    assert results.total == 1
+    assert_job_stat(job_2, results.items[0], 1, 0, 1)
 
 
 def test_dao_get_job_stats_for_service_only_returns_jobs_created_within_limited_days_inclusive(
         notify_db, notify_db_session, sample_service):
     job_1, job_2 = stats_set_up(notify_db, notify_db_session, sample_service)
 
-    results = dao_get_job_stats_for_service(sample_service.id, limit_days=2)
+    results = dao_get_job_stats_for_service(sample_service.id, limit_days=2).items
     assert len(results) == 2
     assert_job_stat(job_2, results[0], 1, 0, 1)
     assert_job_stat(job_1, results[1], 2, 1, 0)
@@ -493,28 +490,42 @@ def test_dao_get_job_stats_paginates_results(
         notify_db, notify_db_session, sample_service):
     job_1, job_2 = stats_set_up(notify_db, notify_db_session, sample_service)
 
-    results = dao_get_job_stats_for_service(sample_service.id, page=1, page_size=1)
+    results = dao_get_job_stats_for_service(sample_service.id, page=1, page_size=1).items
     assert len(results) == 1
     assert_job_stat(job_2, results[0], 1, 0, 1)
-    results_2 = dao_get_job_stats_for_service(sample_service.id, page=2, page_size=1)
+    results_2 = dao_get_job_stats_for_service(sample_service.id, page=2, page_size=1).items
     assert len(results_2) == 1
     assert_job_stat(job_1, results_2[0], 2, 1, 0)
 
 
-def assert_job_stat(job, result, sent, delivered, failed):
+def test_dao_get_job_returns_jobs_for_status(
+        notify_db, notify_db_session, sample_service):
+    stats_set_up(notify_db, notify_db_session, sample_service)
+
+    results = dao_get_job_stats_for_service(sample_service.id, statuses=['pending'])
+    assert results.total == 1
+    results_2 = dao_get_job_stats_for_service(sample_service.id, statuses=['pending', 'finished'])
+    assert results_2.total == 2
+
+
+def assert_job_stat(job, result, sent, delivered, failed, with_template=False):
     assert result.job_id == job.id
     assert result.original_file_name == job.original_file_name
     assert result.created_at == job.created_at
+    assert result.scheduled_for == job.scheduled_for
     assert result.sent == sent
     assert result.delivered == delivered
     assert result.failed == failed
+    if with_template:
+        assert result.template_id == job.template_id
+        assert result.template_version == job.template_version
 
 
 def stats_set_up(notify_db, notify_db_session, service):
     job_1 = create_job(notify_db=notify_db, notify_db_session=notify_db_session,
                        service=service, created_at=datetime.utcnow() - timedelta(days=2))
     job_2 = create_job(notify_db=notify_db, notify_db_session=notify_db_session,
-                       service=service, original_file_name='Another job')
+                       service=service, original_file_name='Another job', job_status='finished')
     notification = create_notification(notify_db=notify_db, notify_db_session=notify_db_session, job=job_1)
     notification_delivered = create_notification(notify_db=notify_db, notify_db_session=notify_db_session,
                                                  job=job_1, status='delivered')

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -796,8 +796,9 @@ def test_get_jobs_raises_for_bad_limit_days(client, sample_service):
                           query_string={'limit_days': 'bad_number'},
                           headers=[auth_header])
     assert response.status_code == 400
-    assert response.get_data(as_text=True) == '{\n  "message": {\n    "limit_days": [\n      ' \
-                                              '"bad_number is not an integer"\n    ]\n  },\n  "result": "error"\n}'
+    resp_json = json.loads(response.get_data(as_text=True))
+    assert resp_json["result"] == "error"
+    assert resp_json["message"] == {'limit_days': ['bad_number is not an integer']}
 
 
 def test_parse_status_turns_comma_sep_strings_into_list():
@@ -831,8 +832,7 @@ def test_get_job_stats_by_service_id_and_job_id(client, sample_job):
 
 
 def test_get_job_stats_with_invalid_job_id_returns404(client, sample_template):
-    service_id = sample_template.service.id
-    path = '/service/{}/job/job-=stats{}'.format(service_id, "bad-id")
+    path = '/service/{}/job/job-stats{}'.format(sample_template.service.id, uuid.uuid4())
     auth_header = create_authorization_header()
     response = client.get(path, headers=[auth_header])
     assert response.status_code == 404
@@ -842,7 +842,7 @@ def test_get_job_stats_with_invalid_job_id_returns404(client, sample_template):
 
 
 def test_get_job_stats_with_invalid_service_id_returns404(client, sample_job):
-    path = '/service/{}/job/job-=stats{}'.format(uuid.uuid4(), sample_job.id)
+    path = '/service/{}/job/job-stats{}'.format(uuid.uuid4(), sample_job.id)
     auth_header = create_authorization_header()
     response = client.get(path, headers=[auth_header])
     assert response.status_code == 404

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -832,7 +832,7 @@ def test_get_job_stats_by_service_id_and_job_id(client, sample_job):
 
 
 def test_get_job_stats_with_invalid_job_id_returns404(client, sample_template):
-    path = '/service/{}/job/job-stats{}'.format(sample_template.service.id, uuid.uuid4())
+    path = '/service/{}/job/job-stats/{}'.format(sample_template.service.id, uuid.uuid4())
     auth_header = create_authorization_header()
     response = client.get(path, headers=[auth_header])
     assert response.status_code == 404
@@ -842,7 +842,7 @@ def test_get_job_stats_with_invalid_job_id_returns404(client, sample_template):
 
 
 def test_get_job_stats_with_invalid_service_id_returns404(client, sample_job):
-    path = '/service/{}/job/job-stats{}'.format(uuid.uuid4(), sample_job.id)
+    path = '/service/{}/job/job-stats/{}'.format(uuid.uuid4(), sample_job.id)
     auth_header = create_authorization_header()
     response = client.get(path, headers=[auth_header])
     assert response.status_code == 404


### PR DESCRIPTION
New endpoints created that use a query that use the job_statistics table rather than the notifications table to aggregate totals. We should see a performance improvement on the dashboard, once integrated into the admin app.