### PR TITLE
Send one off messages from new admin endpoint

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -297,6 +297,8 @@ class Test(Config):
     STATSD_HOST = "localhost"
     STATSD_PORT = 1000
 
+    BROKER_URL = 'you-forgot-to-mock-celery-in-your-tests://'
+
     for queue in QueueNames.all_queues():
         Config.CELERY_QUEUES.append(
             Queue(queue, Exchange('default'), routing_key=queue)

--- a/app/config.py
+++ b/app/config.py
@@ -290,6 +290,7 @@ class Test(Config):
     FROM_NUMBER = 'testing'
     NOTIFY_ENVIRONMENT = 'test'
     DEBUG = True
+    TESTING = True
     CSV_UPLOAD_BUCKET_NAME = 'test-notifications-csv-upload'
     DVLA_RESPONSE_BUCKET_NAME = 'test.notify.com-ftp'
     STATSD_ENABLED = True

--- a/app/errors.py
+++ b/app/errors.py
@@ -7,7 +7,6 @@ from sqlalchemy.orm.exc import NoResultFound
 from marshmallow import ValidationError
 from jsonschema import ValidationError as JsonSchemaValidationError
 from app.authentication.auth import AuthError
-from app.notifications import SendNotificationToQueueError
 
 
 class InvalidRequest(Exception):
@@ -89,11 +88,6 @@ def register_errors(blueprint):
     def no_result_found(e):
         current_app.logger.exception(e)
         return jsonify(result='error', message="No result found"), 404
-
-    @blueprint.errorhandler(SendNotificationToQueueError)
-    def failed_to_create_notification(e):
-        current_app.logger.exception(e)
-        return jsonify(result='error', message=e.message), 500
 
     @blueprint.errorhandler(SQLAlchemyError)
     def db_error(e):

--- a/app/models.py
+++ b/app/models.py
@@ -95,6 +95,11 @@ class User(db.Model):
     platform_admin = db.Column(db.Boolean, nullable=False, default=False)
     current_session_id = db.Column(UUID(as_uuid=True), nullable=True)
 
+    services = db.relationship(
+        'Service',
+        secondary='user_to_service',
+        backref=db.backref('user_to_service', lazy='dynamic'))
+
     @property
     def password(self):
         raise AttributeError("Password not readable")

--- a/app/models.py
+++ b/app/models.py
@@ -800,6 +800,9 @@ class Notification(db.Model):
     phone_prefix = db.Column(db.String, nullable=True)
     rate_multiplier = db.Column(db.Float(asdecimal=False), nullable=True)
 
+    created_by = db.relationship('User')
+    created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), nullable=True)
+
     @hybrid_property
     def status(self):
         return self._status_enum

--- a/app/notifications/__init__.py
+++ b/app/notifications/__init__.py
@@ -1,7 +1,0 @@
-
-
-class SendNotificationToQueueError(Exception):
-    status_code = 500
-
-    def __init__(self):
-        self.message = "Failed to create the notification"

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -17,7 +17,7 @@ from app.models import SMS_TYPE, Notification, KEY_TYPE_TEST, EMAIL_TYPE, Schedu
 from app.dao.notifications_dao import (dao_create_notification,
                                        dao_delete_notifications_and_history_by_id,
                                        dao_created_scheduled_notification)
-from app.v2.errors import BadRequestError, SendNotificationToQueueError
+from app.v2.errors import BadRequestError
 from app.utils import get_template_instance, cache_key_for_service_template_counter, convert_bst_to_utc
 
 
@@ -110,10 +110,9 @@ def send_notification_to_queue(notification, research_mode, queue=None):
 
     try:
         deliver_task.apply_async([str(notification.id)], queue=queue)
-    except Exception as e:
-        current_app.logger.exception(e)
+    except Exception:
         dao_delete_notifications_and_history_by_id(notification.id)
-        raise SendNotificationToQueueError()
+        raise
 
     current_app.logger.info(
         "{} {} sent to the {} queue for delivery".format(notification.notification_type,

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -49,7 +49,8 @@ def persist_notification(
     reference=None,
     client_reference=None,
     notification_id=None,
-    simulated=False
+    simulated=False,
+    created_by_id=None
 ):
 
     notification_created_at = created_at or datetime.utcnow()

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -444,6 +444,7 @@ class NotificationWithTemplateSchema(BaseSchema):
         dump_only=True
     )
     job = fields.Nested(JobSchema, only=["id", "original_file_name"], dump_only=True)
+    created_by = fields.Nested(UserSchema, only=['id', 'name', 'email_address'], dump_only=True)
     status = fields.String(required=False)
     personalisation = fields.Dict(required=False)
     key_type = field_for(models.Notification, 'key_type', required=True)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -61,6 +61,7 @@ from app.service import statistics
 from app.service.service_inbound_api_schema import service_inbound_api, update_service_inbound_api_schema
 from app.service.utils import get_whitelist_objects
 from app.service.sender import send_notification_to_service_users
+from app.service.send_notification import send_one_off_notification
 from app.schemas import (
     service_schema,
     api_key_schema,
@@ -591,3 +592,9 @@ def handle_sql_errror(e):
         return jsonify(result='error', message="No result found"), 404
     else:
         raise e
+
+
+@service_blueprint.route('/<uuid:service_id>/send-notification', methods=['POST'])
+def post_notification(service_id):
+    resp = send_one_off_notification(service_id, request.get_json())
+    return jsonify(resp), 201

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -595,6 +595,6 @@ def handle_sql_errror(e):
 
 
 @service_blueprint.route('/<uuid:service_id>/send-notification', methods=['POST'])
-def post_notification(service_id):
+def create_one_off_notification(service_id):
     resp = send_one_off_notification(service_id, request.get_json())
     return jsonify(resp), 201

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -1,0 +1,61 @@
+from app.config import QueueNames
+from app.notifications.validators import (
+    check_service_over_daily_message_limit,
+    check_sms_content_char_count,
+    validate_and_format_recipient,
+)
+from app.notifications.process_notifications import (
+    create_content_for_notification,
+    persist_notification,
+    send_notification_to_queue,
+)
+from app.models import (
+    KEY_TYPE_NORMAL,
+    PRIORITY,
+    SMS_TYPE,
+)
+from app.dao.services_dao import dao_fetch_service_by_id
+from app.dao.templates_dao import dao_get_template_by_id_and_service_id
+
+
+def send_one_off_notification(service_id, post_data):
+    service = dao_fetch_service_by_id(service_id)
+    template = dao_get_template_by_id_and_service_id(
+        template_id=post_data['template_id'],
+        service_id=service_id
+    )
+
+    personalisation = post_data.get('personalisation', None)
+
+    if template.template_type == SMS_TYPE:
+        template_with_content = create_content_for_notification(template, personalisation)
+        check_sms_content_char_count(template_with_content.content_count)
+
+    check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
+
+    validate_and_format_recipient(
+        send_to=post_data['to'],
+        key_type=KEY_TYPE_NORMAL,
+        service=service,
+        notification_type=template.template_type
+    )
+
+    notification = persist_notification(
+        template_id=template.id,
+        template_version=template.version,
+        recipient=post_data['to'],
+        service=service,
+        personalisation=personalisation,
+        notification_type=template.template_type,
+        api_key_id=None,
+        key_type=KEY_TYPE_NORMAL
+    )
+
+    queue_name = QueueNames.PRIORITY if template.process_type == PRIORITY else None
+    send_notification_to_queue(
+        notification=notification,
+        research_mode=service.research_mode,
+        queue=queue_name
+    )
+
+    return {'id': str(notification.id)}

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -16,6 +16,18 @@ from app.models import (
 )
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.templates_dao import dao_get_template_by_id_and_service_id
+from app.dao.users_dao import get_user_by_id
+from app.v2.errors import BadRequestError
+
+
+def validate_created_by(service, created_by_id):
+    user = get_user_by_id(created_by_id)
+    if service not in user.services:
+        message = 'Can’t create notification - {} is not part of the "{}" service'.format(
+            user.name,
+            service.name
+        )
+        raise BadRequestError(message=message)
 
 
 def send_one_off_notification(service_id, post_data):
@@ -38,6 +50,8 @@ def send_one_off_notification(service_id, post_data):
         notification_type=template.template_type
     )
 
+    validate_created_by(service, post_data['created_by'])
+
     notification = persist_notification(
         template_id=template.id,
         template_version=template.version,
@@ -46,7 +60,8 @@ def send_one_off_notification(service_id, post_data):
         personalisation=personalisation,
         notification_type=template.template_type,
         api_key_id=None,
-        key_type=KEY_TYPE_NORMAL
+        key_type=KEY_TYPE_NORMAL,
+        created_by_id=post_data['created_by']
     )
 
     queue_name = QueueNames.PRIORITY if template.process_type == PRIORITY else None

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -1,8 +1,8 @@
 from app.config import QueueNames
 from app.notifications.validators import (
     check_service_over_daily_message_limit,
-    check_sms_content_char_count,
     validate_and_format_recipient,
+    validate_template,
 )
 from app.notifications.process_notifications import (
     create_content_for_notification,
@@ -27,9 +27,7 @@ def send_one_off_notification(service_id, post_data):
 
     personalisation = post_data.get('personalisation', None)
 
-    if template.template_type == SMS_TYPE:
-        template_with_content = create_content_for_notification(template, personalisation)
-        check_sms_content_char_count(template_with_content.content_count)
+    validate_template(template.id, personalisation, service, template.template_type)
 
     check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
 

--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -5,7 +5,6 @@ from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
 from app.authentication.auth import AuthError
 from app.errors import InvalidRequest
-from app.notifications import SendNotificationToQueueError
 
 
 class TooManyRequestsError(InvalidRequest):
@@ -60,13 +59,6 @@ def register_errors(blueprint):
     @blueprint.errorhandler(AuthError)
     def auth_error(error):
         return jsonify(error.to_dict_v2()), error.code
-
-    @blueprint.errorhandler(SendNotificationToQueueError)
-    def failed_to_create_notification(error):
-        current_app.logger.exception(error)
-        return jsonify(
-            status_code=500,
-            errors=[{"error": error.__class__.__name__, "message": error.message}]), 500
 
     @blueprint.errorhandler(Exception)
     def internal_server_error(error):

--- a/migrations/versions/0100_notification_created_by.py
+++ b/migrations/versions/0100_notification_created_by.py
@@ -1,0 +1,27 @@
+"""add created_by col to notification
+
+Revision ID: 0100_notification_created_by
+Revises: 0099_tfl_dar
+Create Date: 2017-06-13 10:53:25.032202
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0100_notification_created_by'
+down_revision = '0099_tfl_dar'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+    op.add_column('notifications', sa.Column('created_by_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key(None, 'notifications', 'users', ['created_by_id'], ['id'])
+
+    op.add_column('notification_history', sa.Column('created_by_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key(None, 'notification_history', 'users', ['created_by_id'], ['id'])
+
+
+def downgrade():
+    op.drop_column('notifications', 'created_by_id')
+    op.drop_column('notification_history', 'created_by_id')

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -988,34 +988,34 @@ def admin_request(client):
     class AdminRequest:
 
         @staticmethod
-        def get(endpoint, endpoint_kwargs=None, expected_status=200):
+        def get(endpoint, _expected_status=200, **endpoint_kwargs):
             resp = client.get(
                 url_for(endpoint, **(endpoint_kwargs or {})),
                 headers=[create_authorization_header()]
             )
             json_resp = json.loads(resp.get_data(as_text=True))
-            assert resp.status_code == expected_status
+            assert resp.status_code == _expected_status
             return json_resp
 
         @staticmethod
-        def post(endpoint, endpoint_kwargs=None, data=None, expected_status=200):
+        def post(endpoint, _data=None, _expected_status=200, **endpoint_kwargs):
             resp = client.post(
                 url_for(endpoint, **(endpoint_kwargs or {})),
-                data=json.dumps(data),
+                data=json.dumps(_data),
                 headers=[('Content-Type', 'application/json'), create_authorization_header()]
             )
             json_resp = json.loads(resp.get_data(as_text=True))
-            assert resp.status_code == expected_status
+            assert resp.status_code == _expected_status
             return json_resp
 
         @staticmethod
-        def delete(endpoint, endpoint_kwargs=None, expected_status=204):
+        def delete(endpoint, _expected_status=204, **endpoint_kwargs):
             resp = client.delete(
                 url_for(endpoint, **(endpoint_kwargs or {})),
                 headers=[create_authorization_header()]
             )
             json_resp = json.loads(resp.get_data(as_text=True))
-            assert resp.status_code == expected_status
+            assert resp.status_code == _expected_status
             return json_resp
 
     return AdminRequest

--- a/tests/app/inbound_sms/test_rest.py
+++ b/tests/app/inbound_sms/test_rest.py
@@ -164,7 +164,7 @@ def test_get_inbound_sms(admin_request, sample_service):
 
     json_resp = admin_request.get(
         'inbound_sms.get_inbound_sms_for_service',
-        endpoint_kwargs={'service_id': sample_service.id}
+        service_id=sample_service.id
     )
 
     sms = json_resp['data']
@@ -192,7 +192,8 @@ def test_get_inbound_sms_limits(admin_request, sample_service):
 
     sms = admin_request.get(
         'inbound_sms.get_inbound_sms_for_service',
-        endpoint_kwargs={'service_id': sample_service.id, 'limit': 1}
+        service_id=sample_service.id,
+        limit=1,
     )
 
     assert len(sms['data']) == 1
@@ -211,7 +212,8 @@ def test_get_inbound_sms_filters_user_number(admin_request, sample_service, user
 
     sms = admin_request.get(
         'inbound_sms.get_inbound_sms_for_service',
-        endpoint_kwargs={'service_id': sample_service.id, 'user_number': user_number}
+        service_id=sample_service.id,
+        user_number=user_number,
     )
 
     assert len(sms['data']) == 1
@@ -226,7 +228,8 @@ def test_get_inbound_sms_filters_international_user_number(admin_request, sample
 
     sms = admin_request.get(
         'inbound_sms.get_inbound_sms_for_service',
-        endpoint_kwargs={'service_id': sample_service.id, 'user_number': '+1 (202) 555-0104'}
+        service_id=sample_service.id,
+        user_number='+1 (202) 555-0104',
     )
 
     assert len(sms['data']) == 1
@@ -249,7 +252,7 @@ def test_get_inbound_sms_summary(admin_request, sample_service):
 
     summary = admin_request.get(
         'inbound_sms.get_inbound_sms_summary_for_service',
-        endpoint_kwargs={'service_id': sample_service.id}
+        service_id=sample_service.id
     )
 
     assert summary == {
@@ -261,7 +264,7 @@ def test_get_inbound_sms_summary(admin_request, sample_service):
 def test_get_inbound_sms_summary_with_no_inbound(admin_request, sample_service):
     summary = admin_request.get(
         'inbound_sms.get_inbound_sms_summary_for_service',
-        endpoint_kwargs={'service_id': sample_service.id}
+        service_id=sample_service.id
     )
 
     assert summary == {
@@ -275,10 +278,8 @@ def test_get_inbound_sms_by_id_returns_200(admin_request, sample_service):
 
     response = admin_request.get(
         'inbound_sms.get_inbound_by_id',
-        endpoint_kwargs={
-            'service_id': sample_service.id,
-            'inbound_sms_id': inbound.id
-        }
+        service_id=sample_service.id,
+        inbound_sms_id=inbound.id,
     )
 
     assert response['user_number'] == '447700900001'
@@ -288,20 +289,16 @@ def test_get_inbound_sms_by_id_returns_200(admin_request, sample_service):
 def test_get_inbound_sms_by_id_invalid_id_returns_404(admin_request, sample_service):
     assert admin_request.get(
         'inbound_sms.get_inbound_by_id',
-        endpoint_kwargs={
-            'service_id': sample_service.id,
-            'inbound_sms_id': 'bar'
-        },
-        expected_status=404
+        service_id=sample_service.id,
+        inbound_sms_id='bar',
+        _expected_status=404
     )
 
 
 def test_get_inbound_sms_by_id_with_invalid_service_id_returns_404(admin_request, sample_service):
     assert admin_request.get(
         'inbound_sms.get_inbound_by_id',
-        endpoint_kwargs={
-            'service_id': 'foo',
-            'inbound_sms_id': '2cfbd6a1-1575-4664-8969-f27be0ea40d9'
-        },
-        expected_status=404
+        service_id='foo',
+        inbound_sms_id='2cfbd6a1-1575-4664-8969-f27be0ea40d9',
+        _expected_status=404
     )

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -1095,69 +1095,69 @@ def test_returns_a_429_limit_exceeded_if_rate_limit_exceeded(
 
 
 def test_should_allow_store_original_number_on_sms_notification(client, sample_template, mocker):
-        mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
+    mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
-        data = {
-            'to': '+(44) 7700-900 855',
-            'template': str(sample_template.id)
-        }
+    data = {
+        'to': '+(44) 7700-900 855',
+        'template': str(sample_template.id)
+    }
 
-        auth_header = create_authorization_header(service_id=sample_template.service_id)
+    auth_header = create_authorization_header(service_id=sample_template.service_id)
 
-        response = client.post(
-            path='/notifications/sms',
-            data=json.dumps(data),
-            headers=[('Content-Type', 'application/json'), auth_header])
+    response = client.post(
+        path='/notifications/sms',
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header])
 
-        response_data = json.loads(response.data)['data']
-        notification_id = response_data['notification']['id']
+    response_data = json.loads(response.data)['data']
+    notification_id = response_data['notification']['id']
 
-        mocked.assert_called_once_with([notification_id], queue='send-tasks')
-        assert response.status_code == 201
-        assert notification_id
-        notifications = Notification.query.all()
-        assert len(notifications) == 1
-        assert '+(44) 7700-900 855' == notifications[0].to
+    mocked.assert_called_once_with([notification_id], queue='send-tasks')
+    assert response.status_code == 201
+    assert notification_id
+    notifications = Notification.query.all()
+    assert len(notifications) == 1
+    assert '+(44) 7700-900 855' == notifications[0].to
 
 
 def test_should_not_allow_international_number_on_sms_notification(client, sample_template, mocker):
-        mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
+    mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
-        data = {
-            'to': '20-12-1234-1234',
-            'template': str(sample_template.id)
-        }
+    data = {
+        'to': '20-12-1234-1234',
+        'template': str(sample_template.id)
+    }
 
-        auth_header = create_authorization_header(service_id=sample_template.service_id)
+    auth_header = create_authorization_header(service_id=sample_template.service_id)
 
-        response = client.post(
-            path='/notifications/sms',
-            data=json.dumps(data),
-            headers=[('Content-Type', 'application/json'), auth_header])
+    response = client.post(
+        path='/notifications/sms',
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header])
 
-        assert not mocked.called
-        assert response.status_code == 400
-        error_json = json.loads(response.get_data(as_text=True))
-        assert error_json['result'] == 'error'
-        assert error_json['message']['to'][0] == 'Cannot send to international mobile numbers'
+    assert not mocked.called
+    assert response.status_code == 400
+    error_json = json.loads(response.get_data(as_text=True))
+    assert error_json['result'] == 'error'
+    assert error_json['message']['to'][0] == 'Cannot send to international mobile numbers'
 
 
 def test_should_allow_international_number_on_sms_notification(client, notify_db, notify_db_session, mocker):
-        mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
+    mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
-        service = sample_service(notify_db, notify_db_session, can_send_international_sms=True)
-        template = create_sample_template(notify_db, notify_db_session, service=service)
+    service = sample_service(notify_db, notify_db_session, can_send_international_sms=True)
+    template = create_sample_template(notify_db, notify_db_session, service=service)
 
-        data = {
-            'to': '20-12-1234-1234',
-            'template': str(template.id)
-        }
+    data = {
+        'to': '20-12-1234-1234',
+        'template': str(template.id)
+    }
 
-        auth_header = create_authorization_header(service_id=service.id)
+    auth_header = create_authorization_header(service_id=service.id)
 
-        response = client.post(
-            path='/notifications/sms',
-            data=json.dumps(data),
-            headers=[('Content-Type', 'application/json'), auth_header])
+    response = client.post(
+        path='/notifications/sms',
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header])
 
-        assert response.status_code == 201
+    assert response.status_code == 201

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -8,7 +8,6 @@ from freezegun import freeze_time
 from collections import namedtuple
 
 from app.models import Template, Notification, NotificationHistory, ScheduledNotification
-from app.notifications import SendNotificationToQueueError
 from app.notifications.process_notifications import (
     create_content_for_notification,
     persist_notification,
@@ -238,7 +237,7 @@ def test_send_notification_to_queue(notify_db, notify_db_session,
 
 def test_send_notification_to_queue_throws_exception_deletes_notification(sample_notification, mocker):
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async', side_effect=Boto3Error("EXPECTED"))
-    with pytest.raises(SendNotificationToQueueError):
+    with pytest.raises(Boto3Error):
         send_notification_to_queue(sample_notification, False)
         mocked.assert_called_once_with([(str(sample_notification.id))], queue='send-sms')
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -12,13 +12,14 @@ from app import encryption
 from app.dao.users_dao import save_model_user
 from app.dao.services_dao import dao_remove_user_from_service
 from app.models import (
-    Organisation, Rate, Service, ServicePermission, User,
+    User, Organisation, Rate, Service, ServicePermission,
+    DVLA_ORG_LAND_REGISTRY,
     KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST,
     EMAIL_TYPE, SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INBOUND_SMS_TYPE,
-    DVLA_ORG_LAND_REGISTRY
 )
+
 from tests import create_authorization_header
-from tests.app.db import create_template, create_service_inbound_api
+from tests.app.db import create_template, create_service_inbound_api, create_user
 from tests.app.conftest import (
     sample_service as create_service,
     sample_user_service_permission as create_user_service_permission,
@@ -26,8 +27,6 @@ from tests.app.conftest import (
     sample_notification_history as create_notification_history,
     sample_notification_with_job
 )
-
-from tests.app.db import create_user
 
 
 def test_get_service_list(client, service_factory):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2257,7 +2257,8 @@ def test_send_one_off_notification(admin_request, sample_template):
         },
         data={
             'template_id': str(sample_template.id),
-            'to': '07700900001'
+            'to': '07700900001',
+            'created_by': str(sample_template.service.created_by_id)
         },
         expected_status=201
     )

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2247,7 +2247,9 @@ def test_fetch_service_inbound_api(client, sample_service):
     assert json.loads(response.get_data(as_text=True))["data"] == service_inbound_api.serialize()
 
 
-def test_send_one_off_notification(admin_request, sample_template):
+def test_send_one_off_notification(admin_request, sample_template, mocker):
+    mocker.patch('app.service.send_notification.send_notification_to_queue')
+
     response = admin_request.post(
         'service.create_one_off_notification',
         service_id=sample_template.service_id,

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1316,6 +1316,25 @@ def test_get_notification_for_service(client, notify_db, notify_db_session):
         assert service_2_response == {'message': 'No result found', 'result': 'error'}
 
 
+def test_get_notification_for_service_includes_created_by(admin_request, sample_notification):
+    user = sample_notification.created_by = sample_notification.service.created_by
+
+    resp = admin_request.get(
+        'service.get_notification_for_service',
+        endpoint_kwargs={
+            'service_id': sample_notification.service_id,
+            'notification_id': sample_notification.id
+        }
+    )
+
+    assert resp['id'] == str(sample_notification.id)
+    assert resp['created_by'] == {
+        'id': str(user.id),
+        'name': user.name,
+        'email_address': user.email_address
+    }
+
+
 @pytest.mark.parametrize(
     'include_from_test_key, expected_count_of_notifications',
     [

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1322,10 +1322,8 @@ def test_get_notification_for_service_includes_created_by(admin_request, sample_
 
     resp = admin_request.get(
         'service.get_notification_for_service',
-        endpoint_kwargs={
-            'service_id': sample_notification.service_id,
-            'notification_id': sample_notification.id
-        }
+        service_id=sample_notification.service_id,
+        notification_id=sample_notification.id
     )
 
     assert resp['id'] == str(sample_notification.id)
@@ -2252,15 +2250,13 @@ def test_fetch_service_inbound_api(client, sample_service):
 def test_send_one_off_notification(admin_request, sample_template):
     response = admin_request.post(
         'service.create_one_off_notification',
-        endpoint_kwargs={
-            'service_id': sample_template.service_id
-        },
-        data={
+        service_id=sample_template.service_id,
+        _data={
             'template_id': str(sample_template.id),
             'to': '07700900001',
             'created_by': str(sample_template.service.created_by_id)
         },
-        expected_status=201
+        _expected_status=201
     )
 
     noti = Notification.query.one()

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -1,0 +1,180 @@
+import uuid
+from unittest.mock import Mock
+
+import pytest
+from notifications_utils.recipients import InvalidPhoneError
+
+from app.v2.errors import BadRequestError, TooManyRequestsError
+from app.config import QueueNames
+from app.service.send_notification import send_one_off_notification
+from app.models import KEY_TYPE_NORMAL, PRIORITY, SMS_TYPE
+
+from tests.app.db import create_user
+
+
+@pytest.fixture
+def persist_mock(mocker):
+    noti = Mock(id=uuid.uuid4())
+    return mocker.patch('app.service.send_notification.persist_notification', return_value=noti)
+
+
+@pytest.fixture
+def celery_mock(mocker):
+    return mocker.patch('app.service.send_notification.send_notification_to_queue')
+
+
+def test_send_one_off_notification_calls_celery_correctly(persist_mock, celery_mock, sample_template):
+    service = sample_template.service
+
+    post_data = {
+        'template_id': str(sample_template.id),
+        'to': '07700 900 001',
+        'created_by': str(service.created_by_id)
+    }
+
+    resp = send_one_off_notification(service.id, post_data)
+
+    assert resp == {
+        'id': str(persist_mock.return_value.id)
+    }
+
+    celery_mock.assert_called_once_with(
+        notification=persist_mock.return_value,
+        research_mode=False,
+        queue=None
+    )
+
+
+def test_send_one_off_notification_calls_persist_correctly(
+    persist_mock,
+    celery_mock,
+    sample_template_with_placeholders
+):
+    template = sample_template_with_placeholders
+    service = template.service
+
+    post_data = {
+        'template_id': str(template.id),
+        'to': '07700 900 001',
+        'personalisation': {'name': 'foo'},
+        'created_by': str(service.created_by_id)
+    }
+
+    send_one_off_notification(service.id, post_data)
+
+    persist_mock.assert_called_once_with(
+        template_id=template.id,
+        template_version=template.version,
+        recipient=post_data['to'],
+        service=template.service,
+        personalisation={'name': 'foo'},
+        notification_type=SMS_TYPE,
+        api_key_id=None,
+        key_type=KEY_TYPE_NORMAL,
+        created_by_id=str(service.created_by_id)
+    )
+
+
+def test_send_one_off_notification_honors_research_mode(persist_mock, celery_mock, sample_template):
+    service = sample_template.service
+    service.research_mode = True
+
+    post_data = {
+        'template_id': str(sample_template.id),
+        'to': '07700 900 001',
+        'created_by': str(service.created_by_id)
+    }
+
+    send_one_off_notification(service.id, post_data)
+
+    assert celery_mock.call_args[1]['research_mode'] is True
+
+
+def test_send_one_off_notification_honors_priority(persist_mock, celery_mock, sample_template):
+    service = sample_template.service
+    sample_template.process_type = PRIORITY
+
+    post_data = {
+        'template_id': str(sample_template.id),
+        'to': '07700 900 001',
+        'created_by': str(service.created_by_id)
+    }
+
+    send_one_off_notification(service.id, post_data)
+
+    assert celery_mock.call_args[1]['queue'] == QueueNames.PRIORITY
+
+
+def test_send_one_off_notification_raises_if_invalid_recipient(sample_template):
+    service = sample_template.service
+
+    post_data = {
+        'template_id': str(sample_template.id),
+        'to': 'not a phone number',
+        'created_by': str(service.created_by_id)
+    }
+
+    with pytest.raises(InvalidPhoneError):
+        send_one_off_notification(service.id, post_data)
+
+
+def test_send_one_off_notification_raises_if_cant_send_to_recipient(sample_template):
+    service = sample_template.service
+    service.restricted = True
+
+    post_data = {
+        'template_id': str(sample_template.id),
+        'to': '07700 900 001',
+        'created_by': str(service.created_by_id)
+    }
+
+    with pytest.raises(BadRequestError) as e:
+        send_one_off_notification(service.id, post_data)
+
+    assert 'service is in trial mode' in e.value.message
+
+
+def test_send_one_off_notification_raises_if_over_limit(sample_template):
+    service = sample_template.service
+    service.message_limit = 0
+
+    post_data = {
+        'template_id': str(sample_template.id),
+        'to': '07700 900 001',
+        'created_by': str(service.created_by_id)
+    }
+
+    with pytest.raises(TooManyRequestsError):
+        send_one_off_notification(service.id, post_data)
+
+
+def test_send_one_off_notification_raises_if_message_too_long(persist_mock, sample_template_with_placeholders):
+    template = sample_template_with_placeholders
+    service = template.service
+
+    post_data = {
+        'template_id': str(template.id),
+        'to': '07700 900 001',
+        'personalisation': {'name': '🚫' * 500},
+        'created_by': str(service.created_by_id)
+    }
+
+    with pytest.raises(BadRequestError) as e:
+        send_one_off_notification(service.id, post_data)
+
+    assert e.value.message == 'Content for template has a character count greater than the limit of 495'
+
+
+def test_send_one_off_notification_fails_if_created_by_other_service(sample_template):
+    user_not_in_service = create_user(email='some-other-user@gov.uk')
+
+    post_data = {
+        'template_id': str(sample_template.id),
+        'to': '07700 900 001',
+        'created_by': str(user_not_in_service.id)
+    }
+
+    with pytest.raises(BadRequestError) as e:
+        send_one_off_notification(sample_template.service_id, post_data)
+
+    assert e.value.message == 'Can’t create notification - Test User is not part of the "Sample service" service'


### PR DESCRIPTION
new admin endpoint takes `template_id`, `personalisation`, `to` and `created_by` vals, and, after similar validation to an API call, creates a notification and queues up its sending.

We now track `created_by` on the notification object - although only one-off notifications will have a value for this, since it's not applicable for API, and for jobs it's already stored on `job.created_by`.