### PR TITLE
Update utils to make DAR logo bigger

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@17.1.3#egg=notifications-utils==17.1.3
+git+https://github.com/alphagov/notifications-utils.git@17.4.0#egg=notifications-utils==17.4.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/170

Brings in these changes: https://github.com/alphagov/notifications-utils/compare/17.1.3...17.4.0