### PR TITLE
Use new service permissions and allow disabling of email/sms

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -153,17 +153,10 @@ def dao_create_service(service, user, service_id=None, service_permissions=[SMS_
     service.active = True
     service.research_mode = False
 
-    def deprecate_process_service_permissions():
-        for permission in service_permissions:
-            service_permission = ServicePermission(service_id=service.id, permission=permission)
-            service.permissions.append(service_permission)
+    for permission in service_permissions:
+        service_permission = ServicePermission(service_id=service.id, permission=permission)
+        service.permissions.append(service_permission)
 
-            if permission == INTERNATIONAL_SMS_TYPE:
-                service.can_send_international_sms = True
-            if permission == LETTER_TYPE:
-                service.can_send_letters = True
-
-    deprecate_process_service_permissions()
     db.session.add(service)
 
 

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -23,7 +23,7 @@ from app.celery.statistics_tasks import record_initial_job_statistics, create_in
 
 def send_sms_to_provider(notification):
     service = notification.service
-
+    print('send')
     if not service.active:
         technical_failure(notification=notification)
         return

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -23,7 +23,6 @@ from app.celery.statistics_tasks import record_initial_job_statistics, create_in
 
 def send_sms_to_provider(notification):
     service = notification.service
-    print('send')
     if not service.active:
         technical_failure(notification=notification)
         return

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -23,6 +23,7 @@ from app.celery.statistics_tasks import record_initial_job_statistics, create_in
 
 def send_sms_to_provider(notification):
     service = notification.service
+
     if not service.active:
         technical_failure(notification=notification)
         return

--- a/app/models.py
+++ b/app/models.py
@@ -187,8 +187,6 @@ class Service(db.Model, Versioned):
         backref=db.backref('user_to_service', lazy='dynamic'))
     restricted = db.Column(db.Boolean, index=False, unique=False, nullable=False)
     research_mode = db.Column(db.Boolean, index=False, unique=False, nullable=False, default=False)
-    can_send_letters = db.Column(db.Boolean, nullable=False, default=False)
-    can_send_international_sms = db.Column(db.Boolean, nullable=False, default=False)
     email_from = db.Column(db.Text, index=False, unique=True, nullable=False)
     created_by = db.relationship('User')
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
@@ -214,12 +212,6 @@ class Service(db.Model, Versioned):
     )
 
     association_proxy('permissions', 'service_permission_types')
-
-    # This is only for backward compatibility and will be dropped when the columns are removed from the data model
-    def set_permissions(self):
-        if self.permissions:
-            self.can_send_letters = LETTER_TYPE in [p.permission for p in self.permissions]
-            self.can_send_international_sms = INTERNATIONAL_SMS_TYPE in [p.permission for p in self.permissions]
 
     @staticmethod
     def free_sms_fragment_limit():

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -15,8 +15,10 @@ from app.errors import (
     register_errors,
     InvalidRequest
 )
-from app.models import KEY_TYPE_TEAM, PRIORITY
-from app.models import INTERNATIONAL_SMS_TYPE, SMS_TYPE, INBOUND_SMS_TYPE, EMAIL_TYPE
+from app.models import (
+    EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, SMS_TYPE,
+    KEY_TYPE_TEAM, PRIORITY
+)
 from app.notifications.process_notifications import (
     persist_notification,
     send_notification_to_queue,
@@ -168,14 +170,11 @@ def get_notification_return_data(notification_id, notification, template):
 def _service_has_permission(service, notify_type):
     if notify_type not in [p.permission for p in service.permissions]:
         notify_type_text = notify_type + 's'
-        action = 'send'
-        if notify_type in [SMS_TYPE, INBOUND_SMS_TYPE]:
+        if notify_type == SMS_TYPE:
             notify_type_text = 'text messages'
-            if notify_type == INBOUND_SMS_TYPE:
-                action = 'receive'
 
         raise InvalidRequest(
-            {'to': ["Cannot {action} {type}".format(action=action, type=notify_type_text)]},
+            {'to': ["Cannot send {}".format(notify_type_text)]},
             status_code=400
         )
 

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -169,7 +169,7 @@ def _service_has_permission(service, notify_type):
     if notify_type not in [p.permission for p in service.permissions]:
         notify_type_text = notify_type + 's'
         action = 'send'
-        if notify_type == SMS_TYPE or notify_type == INBOUND_SMS_TYPE:
+        if notify_type in [SMS_TYPE, INBOUND_SMS_TYPE]:
             notify_type_text = 'text messages'
             if notify_type == INBOUND_SMS_TYPE:
                 action = 'receive'

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -122,7 +122,6 @@ def send_notification(notification_type):
         _service_has_permission(authenticated_service, SMS_TYPE)
         _service_can_send_internationally(authenticated_service, notification_form['to'])
     elif notification_type == EMAIL_TYPE:
-        print('email')
         _service_has_permission(authenticated_service, EMAIL_TYPE)
 
     # Do not persist or send notification to the queue if it is a simulated recipient
@@ -167,7 +166,6 @@ def get_notification_return_data(notification_id, notification, template):
 
 
 def _service_has_permission(service, notify_type):
-    print(service.permissions)
     if notify_type not in [p.permission for p in service.permissions]:
         notify_type_text = notify_type + 's'
         action = 'send'

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -165,7 +165,7 @@ def get_notification_return_data(notification_id, notification, template):
 def _service_can_send_internationally(service, number):
     international_phone_info = get_international_phone_info(number)
 
-    if international_phone_info.international and not service.can_send_international_sms:
+    if international_phone_info.international and 'international_sms' not in service.permissions:
         raise InvalidRequest(
             {'to': ["Cannot send to international mobile numbers"]},
             status_code=400

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -16,7 +16,7 @@ from app.errors import (
     InvalidRequest
 )
 from app.models import KEY_TYPE_TEAM, PRIORITY
-from app.models import SMS_TYPE
+from app.models import INTERNATIONAL_SMS_TYPE, SMS_TYPE
 from app.notifications.process_notifications import (
     persist_notification,
     send_notification_to_queue,
@@ -165,7 +165,8 @@ def get_notification_return_data(notification_id, notification, template):
 def _service_can_send_internationally(service, number):
     international_phone_info = get_international_phone_info(number)
 
-    if international_phone_info.international and 'international_sms' not in service.permissions:
+    if international_phone_info.international and \
+            INTERNATIONAL_SMS_TYPE not in [p.permission for p in service.permissions]:
         raise InvalidRequest(
             {'to': ["Cannot send to international mobile numbers"]},
             status_code=400

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -8,7 +8,10 @@ from notifications_utils.recipients import (
 from notifications_utils.clients.redis import rate_limit_cache_key, daily_limit_cache_key
 
 from app.dao import services_dao, templates_dao
-from app.models import INTERNATIONAL_SMS_TYPE, KEY_TYPE_TEST, KEY_TYPE_TEAM, SMS_TYPE, SCHEDULE_NOTIFICATIONS
+from app.models import (
+    INTERNATIONAL_SMS_TYPE, SMS_TYPE,
+    KEY_TYPE_TEST, KEY_TYPE_TEAM, SCHEDULE_NOTIFICATIONS
+)
 from app.service.utils import service_allowed_to_send_to
 from app.v2.errors import TooManyRequestsError, BadRequestError, RateLimitError
 from app import redis_store

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -73,17 +73,8 @@ def service_can_send_to_recipient(send_to, key_type, service):
         raise BadRequestError(message=message)
 
 
-def service_has_permission(service, permission):
-    if permission not in [p.permission for p in service.permissions]:
-        action = 'send'
-        permission_text = permission + 's'
-        if permission == SMS_TYPE:
-            permission_text = 'text messages'
-        elif permission == SCHEDULE_NOTIFICATIONS:
-            action = 'schedule'
-            permission_text = "notifications (this feature is invite-only)"
-
-        raise BadRequestError(message="Cannot {} {}".format(action, permission_text))
+def service_has_permission(notify_type, permissions):
+    return notify_type in [p.permission for p in permissions]
 
 
 def validate_and_format_recipient(send_to, key_type, service, notification_type):

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -8,7 +8,7 @@ from notifications_utils.recipients import (
 from notifications_utils.clients.redis import rate_limit_cache_key, daily_limit_cache_key
 
 from app.dao import services_dao, templates_dao
-from app.models import KEY_TYPE_TEST, KEY_TYPE_TEAM, SMS_TYPE, SCHEDULE_NOTIFICATIONS
+from app.models import INTERNATIONAL_SMS_TYPE, KEY_TYPE_TEST, KEY_TYPE_TEAM, SMS_TYPE, SCHEDULE_NOTIFICATIONS
 from app.service.utils import service_allowed_to_send_to
 from app.v2.errors import TooManyRequestsError, BadRequestError, RateLimitError
 from app import redis_store
@@ -76,7 +76,8 @@ def validate_and_format_recipient(send_to, key_type, service, notification_type)
     if notification_type == SMS_TYPE:
         international_phone_info = get_international_phone_info(send_to)
 
-        if international_phone_info.international and 'international_sms' not in service.permissions:
+        if international_phone_info.international and \
+                INTERNATIONAL_SMS_TYPE not in [p.permission for p in service.permissions]:
             raise BadRequestError(message="Cannot send to international mobile numbers")
 
         return validate_and_format_phone_number(

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -76,7 +76,7 @@ def validate_and_format_recipient(send_to, key_type, service, notification_type)
     if notification_type == SMS_TYPE:
         international_phone_info = get_international_phone_info(send_to)
 
-        if international_phone_info.international and not service.can_send_international_sms:
+        if international_phone_info.international and 'international_sms' not in service.permissions:
             raise BadRequestError(message="Cannot send to international mobile numbers")
 
         return validate_and_format_phone_number(

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -73,6 +73,19 @@ def service_can_send_to_recipient(send_to, key_type, service):
         raise BadRequestError(message=message)
 
 
+def service_has_permission(service, permission):
+    if permission not in [p.permission for p in service.permissions]:
+        action = 'send'
+        permission_text = permission + 's'
+        if permission == SMS_TYPE:
+            permission_text = 'text messages'
+        elif permission == SCHEDULE_NOTIFICATIONS:
+            action = 'schedule'
+            permission_text = "notifications (this feature is invite-only)"
+
+        raise BadRequestError(message="Cannot {} {}".format(action, permission_text))
+
+
 def validate_and_format_recipient(send_to, key_type, service, notification_type):
     service_can_send_to_recipient(send_to, key_type, service)
 
@@ -96,12 +109,6 @@ def check_sms_content_char_count(content_count):
     if content_count > char_count_limit:
         message = 'Content for template has a character count greater than the limit of {}'.format(char_count_limit)
         raise BadRequestError(message=message)
-
-
-def service_can_schedule_notification(service, scheduled_for):
-    if scheduled_for:
-        if SCHEDULE_NOTIFICATIONS not in [p.permission for p in service.permissions]:
-            raise BadRequestError(message="Cannot schedule notifications (this feature is invite-only)")
 
 
 def validate_template(template_id, personalisation, service, notification_type):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -230,31 +230,7 @@ class ServiceSchema(BaseSchema):
                 permission = ServicePermission(service_id=in_data["id"], permission=p)
                 permissions.append(permission)
 
-            def deprecate_override_flags():
-                in_data['can_send_letters'] = LETTER_TYPE in str_permissions
-                in_data['can_send_international_sms'] = INTERNATIONAL_SMS_TYPE in str_permissions
-
-            def deprecate_convert_flags_to_permissions():
-                def convert_flags(flag, notify_type):
-                    if flag and notify_type not in str_permissions:
-                        permission = ServicePermission(service_id=in_data['id'], permission=notify_type)
-                        permissions.append(permission)
-                    elif flag is False and notify_type in str_permissions:
-                        for p in permissions:
-                            if p.permission == notify_type:
-                                permissions.remove(p)
-
-                convert_flags(in_data["can_send_international_sms"], INTERNATIONAL_SMS_TYPE)
-                convert_flags(in_data["can_send_letters"], LETTER_TYPE)
-
-            if self.override_flag:
-                deprecate_override_flags()
-            else:
-                deprecate_convert_flags_to_permissions()
             in_data['permissions'] = permissions
-
-    def set_override_flag(self, flag):
-        self.override_flag = flag
 
 
 class DetailedServiceSchema(BaseSchema):

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -142,7 +142,6 @@ def update_service(service_id):
     service_going_live = fetched_service.restricted and not request.get_json().get('restricted', True)
 
     current_data = dict(service_schema.dump(fetched_service).data.items())
-    service_schema.set_override_flag(request.get_json().get('permissions') is not None)
     current_data.update(request.get_json())
     update_dict = service_schema.load(current_data).data
     dao_update_service(update_dict)

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -45,10 +45,11 @@ def create_template(service_id):
     permissions = fetched_service.permissions
     new_template = template_schema.load(request.get_json()).data
 
-    if service_has_permission(new_template.template_type, permissions) is False:
-        raise InvalidRequest(
-            "Creating {} templates is not allowed".format(
-                get_public_notify_type_text(new_template.template_type)), 403)
+    if not service_has_permission(new_template.template_type, permissions):
+        message = "Creating {} templates is not allowed".format(
+            get_public_notify_type_text(new_template.template_type))
+        errors = {'template_type': [message]}
+        raise InvalidRequest(errors, 403)
 
     new_template.service = fetched_service
     over_limit = _content_count_greater_than_limit(new_template.content, new_template.template_type)
@@ -66,10 +67,12 @@ def create_template(service_id):
 def update_template(service_id, template_id):
     fetched_template = dao_get_template_by_id_and_service_id(template_id=template_id, service_id=service_id)
 
-    if service_has_permission(fetched_template.template_type, fetched_template.service.permissions) is False:
-        raise InvalidRequest(
-            "Updating {} templates is not allowed".format(
-                get_public_notify_type_text(fetched_template.template_type)), 403)
+    if not service_has_permission(fetched_template.template_type, fetched_template.service.permissions):
+        message = "Updating {} templates is not allowed".format(
+            get_public_notify_type_text(fetched_template.template_type))
+        errors = {'template_type': [message]}
+
+        raise InvalidRequest(errors, 403)
 
     data = request.get_json()
 

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -15,7 +15,8 @@ from app.dao.templates_dao import (
 )
 from notifications_utils.template import SMSMessageTemplate
 from app.dao.services_dao import dao_fetch_service_by_id
-from app.models import SMS_TYPE
+from app.dao.service_permissions_dao import dao_fetch_service_permissions
+from app.models import SMS_TYPE, EMAIL_TYPE
 from app.schemas import (template_schema, template_history_schema)
 
 template_blueprint = Blueprint('template', __name__, url_prefix='/service/<uuid:service_id>/template')
@@ -36,10 +37,26 @@ def _content_count_greater_than_limit(content, template_type):
     return template.content_count > current_app.config.get('SMS_CHAR_COUNT_LIMIT')
 
 
+def _has_service_permission(template_type, action, permissions):
+    if template_type not in [p.permission for p in permissions]:
+        template_type_text = template_type
+        if template_type == SMS_TYPE:
+            template_type_text = 'text message'
+        message = 'Cannot {action} {type} templates'.format(
+            action=action, type=template_type_text)
+        errors = {'content': [message]}
+        raise InvalidRequest(errors, status_code=400)
+
+
 @template_blueprint.route('', methods=['POST'])
 def create_template(service_id):
     fetched_service = dao_fetch_service_by_id(service_id=service_id)
+    # permissions needs to be placed here otherwise marshmallow will intefere with versioning
+    permissions = fetched_service.permissions
     new_template = template_schema.load(request.get_json()).data
+
+    _has_service_permission(new_template.template_type, 'create', permissions)
+
     new_template.service = fetched_service
     over_limit = _content_count_greater_than_limit(new_template.content, new_template.template_type)
     if over_limit:
@@ -55,6 +72,8 @@ def create_template(service_id):
 @template_blueprint.route('/<uuid:template_id>', methods=['POST'])
 def update_template(service_id, template_id):
     fetched_template = dao_get_template_by_id_and_service_id(template_id=template_id, service_id=service_id)
+
+    _has_service_permission(fetched_template.template_type, 'update', fetched_template.service.permissions)
 
     data = request.get_json()
 

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -37,7 +37,7 @@ def _content_count_greater_than_limit(content, template_type):
     return template.content_count > current_app.config.get('SMS_CHAR_COUNT_LIMIT')
 
 
-def _has_service_permission(template_type, action, permissions):
+def _service_has_permission(template_type, action, permissions):
     if template_type not in [p.permission for p in permissions]:
         template_type_text = template_type
         if template_type == SMS_TYPE:
@@ -53,7 +53,7 @@ def create_template(service_id):
     permissions = fetched_service.permissions
     new_template = template_schema.load(request.get_json()).data
 
-    _has_service_permission(new_template.template_type, 'Create', permissions)
+    _service_has_permission(new_template.template_type, 'Create', permissions)
 
     new_template.service = fetched_service
     over_limit = _content_count_greater_than_limit(new_template.content, new_template.template_type)
@@ -71,7 +71,7 @@ def create_template(service_id):
 def update_template(service_id, template_id):
     fetched_template = dao_get_template_by_id_and_service_id(template_id=template_id, service_id=service_id)
 
-    _has_service_permission(fetched_template.template_type, 'Update', fetched_template.service.permissions)
+    _service_has_permission(fetched_template.template_type, 'Update', fetched_template.service.permissions)
 
     data = request.get_json()
 

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -42,10 +42,8 @@ def _has_service_permission(template_type, action, permissions):
         template_type_text = template_type
         if template_type == SMS_TYPE:
             template_type_text = 'text message'
-        message = 'Cannot {action} {type} templates'.format(
-            action=action, type=template_type_text)
-        errors = {'content': [message]}
-        raise InvalidRequest(errors, status_code=400)
+        raise InvalidRequest("{action} {type} template is not allowed".format(
+            action=action, type=template_type_text), 403)
 
 
 @template_blueprint.route('', methods=['POST'])
@@ -55,7 +53,7 @@ def create_template(service_id):
     permissions = fetched_service.permissions
     new_template = template_schema.load(request.get_json()).data
 
-    _has_service_permission(new_template.template_type, 'create', permissions)
+    _has_service_permission(new_template.template_type, 'Create', permissions)
 
     new_template.service = fetched_service
     over_limit = _content_count_greater_than_limit(new_template.content, new_template.template_type)
@@ -73,7 +71,7 @@ def create_template(service_id):
 def update_template(service_id, template_id):
     fetched_template = dao_get_template_by_id_and_service_id(template_id=template_id, service_id=service_id)
 
-    _has_service_permission(fetched_template.template_type, 'update', fetched_template.service.permissions)
+    _has_service_permission(fetched_template.template_type, 'Update', fetched_template.service.permissions)
 
     data = request.get_json()
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -77,3 +77,12 @@ def get_london_month_from_utc_column(column):
 
 def cache_key_for_service_template_counter(service_id, limit_days=7):
     return "{}-template-counter-limit-{}-days".format(service_id, limit_days)
+
+
+def get_public_notify_type_text(notify_type, plural=False):
+    from app.models import SMS_TYPE
+    notify_type_text = notify_type
+    if notify_type == SMS_TYPE:
+        notify_type_text = 'text message'
+
+    return '{}{}'.format(notify_type_text, 's' if plural else '')

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -32,13 +32,13 @@ def post_notification(notification_type):
     else:
         form = validate(request.get_json(), post_sms_request)
 
-    if service_has_permission(notification_type, authenticated_service.permissions) is False:
+    if not service_has_permission(notification_type, authenticated_service.permissions):
         raise BadRequestError(message="Cannot send {}".format(
             get_public_notify_type_text(notification_type, plural=True)))
 
     scheduled_for = form.get("scheduled_for", None)
     if scheduled_for:
-        if service_has_permission(SCHEDULE_NOTIFICATIONS, authenticated_service.permissions) is False:
+        if not service_has_permission(SCHEDULE_NOTIFICATIONS, authenticated_service.permissions):
             raise BadRequestError(message="Cannot schedule notifications (this feature is invite-only)")
 
     check_rate_limiting(authenticated_service, api_user)

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -163,12 +163,13 @@ def sample_template(
     user=None,
     service=None,
     created_by=None,
-    process_type='normal'
+    process_type='normal',
+    permissions=[EMAIL_TYPE, SMS_TYPE]
 ):
     if user is None:
         user = create_user()
     if service is None:
-        service = sample_service(notify_db, notify_db_session)
+        service = sample_service(notify_db, notify_db_session, permissions=permissions)
     if created_by is None:
         created_by = create_user()
 
@@ -188,6 +189,11 @@ def sample_template(
     template = Template(**data)
     dao_create_template(template)
     return template
+
+
+@pytest.fixture(scope='function')
+def sample_template_without_sms_permission(notify_db, notify_db_session):
+    return sample_template(notify_db, notify_db_session, permissions=[EMAIL_TYPE])
 
 
 @pytest.fixture(scope='function')
@@ -213,11 +219,12 @@ def sample_email_template(
         user=None,
         content="This is a template",
         subject_line='Email Subject',
-        service=None):
+        service=None,
+        permissions=[EMAIL_TYPE, SMS_TYPE]):
     if user is None:
         user = create_user()
     if service is None:
-        service = sample_service(notify_db, notify_db_session)
+        service = sample_service(notify_db, notify_db_session, permissions=permissions)
     data = {
         'name': template_name,
         'template_type': template_type,
@@ -229,6 +236,11 @@ def sample_email_template(
     template = Template(**data)
     dao_create_template(template)
     return template
+
+
+@pytest.fixture(scope='function')
+def sample_template_without_email_permission(notify_db, notify_db_session):
+    return sample_email_template(notify_db, notify_db_session, permissions=[SMS_TYPE])
 
 
 @pytest.fixture

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -127,7 +127,6 @@ def sample_service(
     restricted=False,
     limit=1000,
     email_from=None,
-    can_send_international_sms=False,
     permissions=[SMS_TYPE, EMAIL_TYPE]
 ):
     if user is None:
@@ -141,7 +140,6 @@ def sample_service(
         'email_from': email_from,
         'created_by': user,
         'letter_contact_block': 'London,\nSW1A 1AA',
-        'can_send_international_sms': can_send_international_sms
     }
     service = Service.query.filter_by(name=service_name).first()
     if not service:

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -197,6 +197,11 @@ def sample_template_without_sms_permission(notify_db, notify_db_session):
 
 
 @pytest.fixture(scope='function')
+def sample_template_without_letter_permission(notify_db, notify_db_session):
+    return sample_template(notify_db, notify_db_session, template_type="letter", permissions=[EMAIL_TYPE])
+
+
+@pytest.fixture(scope='function')
 def sample_template_with_placeholders(notify_db, notify_db_session):
     # deliberate space and title case in placeholder
     return sample_template(notify_db, notify_db_session, content="Hello (( Name))\nYour thing is due soon")

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -297,14 +297,13 @@ def test_create_service_by_id_adding_and_removing_letter_returns_service_without
 
     service = dao_fetch_service_by_id(service.id)
     assert len(service.permissions) == 3
-    assert set([SMS_TYPE, EMAIL_TYPE, LETTER_TYPE]) == set(service.permissions)
+    assert set([SMS_TYPE, EMAIL_TYPE, LETTER_TYPE]) == set([p.permission for p in service.permissions])
 
     dao_remove_service_permission(service_id=service.id, permission=LETTER_TYPE)
-    service.set_permissions()
     service = dao_fetch_service_by_id(service.id)
 
     assert len(service.permissions) == 2
-    assert set([SMS_TYPE, EMAIL_TYPE]) == set(service.permissions)
+    assert set([SMS_TYPE, EMAIL_TYPE]) == set([p.permission for p in service.permissions])
 
 
 def test_create_service_creates_a_history_record_with_current_data(sample_user):

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -9,7 +9,8 @@ from notifications_python_client.authentication import create_jwt_token
 
 import app
 from app.dao import notifications_dao
-from app.models import ApiKey, KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST, Notification, NotificationHistory
+from app.models import (
+    ApiKey, INTERNATIONAL_SMS_TYPE, KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST, Notification, NotificationHistory)
 from app.dao.templates_dao import dao_get_all_templates_for_service, dao_update_template
 from app.dao.services_dao import dao_update_service
 from app.dao.api_key_dao import save_model_api_key
@@ -1147,7 +1148,7 @@ def test_should_not_allow_international_number_on_sms_notification(client, sampl
 def test_should_allow_international_number_on_sms_notification(client, notify_db, notify_db_session, mocker):
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
-    service = sample_service(notify_db, notify_db_session, permissions=['international_sms'])
+    service = sample_service(notify_db, notify_db_session, permissions=[INTERNATIONAL_SMS_TYPE, 'sms'])
     template = create_sample_template(notify_db, notify_db_session, service=service)
 
     data = {

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -1198,4 +1198,4 @@ def test_should_not_allow_notification_if_service_permission_not_set(
     error_json = json.loads(response.get_data(as_text=True))
 
     assert error_json['result'] == 'error'
-    assert error_json['message']['to'][0] == expected_error
+    assert error_json['message']['service'][0] == expected_error

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -10,8 +10,9 @@ from notifications_python_client.authentication import create_jwt_token
 import app
 from app.dao import notifications_dao
 from app.models import (
-    ApiKey, INTERNATIONAL_SMS_TYPE, SMS_TYPE, EMAIL_TYPE,
-    KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST, Notification, NotificationHistory)
+    INTERNATIONAL_SMS_TYPE, SMS_TYPE, EMAIL_TYPE,
+    ApiKey, KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST, Notification, NotificationHistory
+)
 from app.dao.templates_dao import dao_get_all_templates_for_service, dao_update_template
 from app.dao.services_dao import dao_update_service
 from app.dao.api_key_dao import save_model_api_key

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -1147,7 +1147,7 @@ def test_should_not_allow_international_number_on_sms_notification(client, sampl
 def test_should_allow_international_number_on_sms_notification(client, notify_db, notify_db_session, mocker):
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
-    service = sample_service(notify_db, notify_db_session, can_send_international_sms=True)
+    service = sample_service(notify_db, notify_db_session, permissions=['international_sms'])
     template = create_sample_template(notify_db, notify_db_session, service=service)
 
     data = {

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -317,6 +317,6 @@ def test_rejects_api_calls_with_international_numbers_if_service_does_not_allow_
 
 @pytest.mark.parametrize('key_type', ['test', 'normal'])
 def test_allows_api_calls_with_international_numbers_if_service_does_allow_int_sms(sample_service, key_type):
-    sample_service.can_send_international_sms = True
+    sample_service.permissions = ['international_sms']
     result = validate_and_format_recipient('20-12-1234-1234', key_type, sample_service, 'sms')
     assert result == '201212341234'

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -316,7 +316,8 @@ def test_rejects_api_calls_with_international_numbers_if_service_does_not_allow_
 
 
 @pytest.mark.parametrize('key_type', ['test', 'normal'])
-def test_allows_api_calls_with_international_numbers_if_service_does_allow_int_sms(sample_service, key_type):
-    sample_service.permissions = ['international_sms']
-    result = validate_and_format_recipient('20-12-1234-1234', key_type, sample_service, 'sms')
+def test_allows_api_calls_with_international_numbers_if_service_does_allow_int_sms(
+        key_type, notify_db, notify_db_session):
+    service = create_service(notify_db, notify_db_session, permissions=['sms', 'international_sms'])
+    result = validate_and_format_recipient('20-12-1234-1234', key_type, service, 'sms')
     assert result == '201212341234'

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -523,7 +523,7 @@ def test_update_service_flags_will_remove_service_permissions(client, notify_db,
     service = create_service(
         notify_db, notify_db_session, permissions=[SMS_TYPE, EMAIL_TYPE, INTERNATIONAL_SMS_TYPE])
 
-    assert INTERNATIONAL_SMS_TYPE in service.permissions
+    assert INTERNATIONAL_SMS_TYPE in [p.permission for p in service.permissions]
 
     data = {
         'permissions': [SMS_TYPE, EMAIL_TYPE]

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -479,7 +479,7 @@ def test_update_service_flags(client, sample_service):
 
     data = {
         'research_mode': True,
-        'permissions': ['letter', 'international_sms']
+        'permissions': [LETTER_TYPE, INTERNATIONAL_SMS_TYPE]
     }
 
     auth_header = create_authorization_header()
@@ -492,7 +492,7 @@ def test_update_service_flags(client, sample_service):
     result = json.loads(resp.get_data(as_text=True))
     assert resp.status_code == 200
     assert result['data']['research_mode'] is True
-    assert set(result['data']['permissions']) == set(['letter', 'international_sms'])
+    assert set(result['data']['permissions']) == set([LETTER_TYPE, INTERNATIONAL_SMS_TYPE])
 
 
 @pytest.fixture(scope='function')
@@ -503,7 +503,7 @@ def service_with_no_permissions(notify_db, notify_db_session):
 def test_update_service_flags_with_service_without_default_service_permissions(client, service_with_no_permissions):
     auth_header = create_authorization_header()
     data = {
-        'permissions': ['letter', 'international_sms'],
+        'permissions': [LETTER_TYPE, INTERNATIONAL_SMS_TYPE],
     }
 
     resp = client.post(
@@ -537,7 +537,7 @@ def test_update_service_flags_will_remove_service_permissions(client, notify_db,
     result = json.loads(resp.get_data(as_text=True))
 
     assert resp.status_code == 200
-    assert 'international_sms' not in result['data']['permissions']
+    assert INTERNATIONAL_SMS_TYPE not in result['data']['permissions']
 
     permissions = ServicePermission.query.filter_by(service_id=service.id).all()
     assert set([p.permission for p in permissions]) == set([SMS_TYPE, EMAIL_TYPE])
@@ -1454,8 +1454,8 @@ def test_get_detailed_service(notify_db, notify_db_session, notify_api, sample_s
     service = json.loads(resp.get_data(as_text=True))['data']
     assert service['id'] == str(sample_service.id)
     assert 'statistics' in service.keys()
-    assert set(service['statistics'].keys()) == {'sms', 'email', 'letter'}
-    assert service['statistics']['sms'] == stats
+    assert set(service['statistics'].keys()) == {SMS_TYPE, EMAIL_TYPE, LETTER_TYPE}
+    assert service['statistics'][SMS_TYPE] == stats
 
 
 @pytest.mark.parametrize(
@@ -1507,9 +1507,9 @@ def test_get_services_with_detailed_flag(client, notify_db, notify_db_session):
     assert data[0]['name'] == 'Sample service'
     assert data[0]['id'] == str(notifications[0].service_id)
     assert data[0]['statistics'] == {
-        'email': {'delivered': 0, 'failed': 0, 'requested': 0},
-        'sms': {'delivered': 0, 'failed': 0, 'requested': 3},
-        'letter': {'delivered': 0, 'failed': 0, 'requested': 0}
+        EMAIL_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0},
+        SMS_TYPE: {'delivered': 0, 'failed': 0, 'requested': 3},
+        LETTER_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0}
     }
 
 
@@ -1530,9 +1530,9 @@ def test_get_services_with_detailed_flag_excluding_from_test_key(notify_api, not
     data = json.loads(resp.get_data(as_text=True))['data']
     assert len(data) == 1
     assert data[0]['statistics'] == {
-        'email': {'delivered': 0, 'failed': 0, 'requested': 0},
-        'sms': {'delivered': 0, 'failed': 0, 'requested': 2},
-        'letter': {'delivered': 0, 'failed': 0, 'requested': 0}
+        EMAIL_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0},
+        SMS_TYPE: {'delivered': 0, 'failed': 0, 'requested': 2},
+        LETTER_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0}
     }
 
 
@@ -1586,15 +1586,15 @@ def test_get_detailed_services_groups_by_service(notify_db, notify_db_session):
     assert len(data) == 2
     assert data[0]['id'] == str(service_1.id)
     assert data[0]['statistics'] == {
-        'email': {'delivered': 0, 'failed': 0, 'requested': 0},
-        'sms': {'delivered': 1, 'failed': 0, 'requested': 3},
-        'letter': {'delivered': 0, 'failed': 0, 'requested': 0}
+        EMAIL_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0},
+        SMS_TYPE: {'delivered': 1, 'failed': 0, 'requested': 3},
+        LETTER_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0}
     }
     assert data[1]['id'] == str(service_2.id)
     assert data[1]['statistics'] == {
-        'email': {'delivered': 0, 'failed': 0, 'requested': 0},
-        'sms': {'delivered': 0, 'failed': 0, 'requested': 1},
-        'letter': {'delivered': 0, 'failed': 0, 'requested': 0}
+        EMAIL_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0},
+        SMS_TYPE: {'delivered': 0, 'failed': 0, 'requested': 1},
+        LETTER_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0}
     }
 
 
@@ -1613,15 +1613,15 @@ def test_get_detailed_services_includes_services_with_no_notifications(notify_db
     assert len(data) == 2
     assert data[0]['id'] == str(service_1.id)
     assert data[0]['statistics'] == {
-        'email': {'delivered': 0, 'failed': 0, 'requested': 0},
-        'sms': {'delivered': 0, 'failed': 0, 'requested': 1},
-        'letter': {'delivered': 0, 'failed': 0, 'requested': 0}
+        EMAIL_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0},
+        SMS_TYPE: {'delivered': 0, 'failed': 0, 'requested': 1},
+        LETTER_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0}
     }
     assert data[1]['id'] == str(service_2.id)
     assert data[1]['statistics'] == {
-        'email': {'delivered': 0, 'failed': 0, 'requested': 0},
-        'sms': {'delivered': 0, 'failed': 0, 'requested': 0},
-        'letter': {'delivered': 0, 'failed': 0, 'requested': 0}
+        EMAIL_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0},
+        SMS_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0},
+        LETTER_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0}
     }
 
 
@@ -1638,9 +1638,9 @@ def test_get_detailed_services_only_includes_todays_notifications(notify_db, not
 
     assert len(data) == 1
     assert data[0]['statistics'] == {
-        'email': {'delivered': 0, 'failed': 0, 'requested': 0},
-        'sms': {'delivered': 0, 'failed': 0, 'requested': 2},
-        'letter': {'delivered': 0, 'failed': 0, 'requested': 0}
+        EMAIL_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0},
+        SMS_TYPE: {'delivered': 0, 'failed': 0, 'requested': 2},
+        LETTER_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0}
     }
 
 
@@ -1665,9 +1665,9 @@ def test_get_detailed_services_for_date_range(notify_db, notify_db_session, set_
 
     assert len(data) == 1
     assert data[0]['statistics'] == {
-        'email': {'delivered': 0, 'failed': 0, 'requested': 0},
-        'sms': {'delivered': 0, 'failed': 0, 'requested': 2},
-        'letter': {'delivered': 0, 'failed': 0, 'requested': 0}
+        EMAIL_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0},
+        SMS_TYPE: {'delivered': 0, 'failed': 0, 'requested': 2},
+        LETTER_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0}
     }
 
 
@@ -1761,7 +1761,7 @@ def test_get_template_stats_by_month_returns_error_for_incorrect_year(
 
 
 def test_get_yearly_billing_usage(client, notify_db, notify_db_session):
-    rate = Rate(id=uuid.uuid4(), valid_from=datetime(2016, 3, 31, 23, 00), rate=0.0158, notification_type='sms')
+    rate = Rate(id=uuid.uuid4(), valid_from=datetime(2016, 3, 31, 23, 00), rate=0.0158, notification_type=SMS_TYPE)
     notify_db.session.add(rate)
     notification = create_sample_notification(notify_db, notify_db_session, created_at=datetime(2016, 6, 5),
                                               sent_at=datetime(2016, 6, 5),
@@ -1775,13 +1775,13 @@ def test_get_yearly_billing_usage(client, notify_db, notify_db_session):
     assert json.loads(response.get_data(as_text=True)) == [{'credits': 1,
                                                             'billing_units': 1,
                                                             'rate_multiplier': 1,
-                                                            'notification_type': 'sms',
+                                                            'notification_type': SMS_TYPE,
                                                             'international': False,
                                                             'rate': 0.0158},
                                                            {'credits': 0,
                                                             'billing_units': 0,
                                                             'rate_multiplier': 1,
-                                                            'notification_type': 'email',
+                                                            'notification_type': EMAIL_TYPE,
                                                             'international': False,
                                                             'rate': 0}]
 
@@ -1798,7 +1798,7 @@ def test_get_yearly_billing_usage_returns_400_if_missing_year(client, sample_ser
 
 
 def test_get_monthly_billing_usage(client, notify_db, notify_db_session, sample_service):
-    rate = Rate(id=uuid.uuid4(), valid_from=datetime(2016, 3, 31, 23, 00), rate=0.0158, notification_type='sms')
+    rate = Rate(id=uuid.uuid4(), valid_from=datetime(2016, 3, 31, 23, 00), rate=0.0158, notification_type=SMS_TYPE)
     notify_db.session.add(rate)
     notification = create_sample_notification(notify_db, notify_db_session, created_at=datetime(2016, 6, 5),
                                               sent_at=datetime(2016, 6, 5),
@@ -1810,7 +1810,7 @@ def test_get_monthly_billing_usage(client, notify_db, notify_db_session, sample_
                                sent_at=datetime(2016, 7, 5),
                                status='sending')
 
-    template = create_template(sample_service, template_type='email')
+    template = create_template(sample_service, template_type=EMAIL_TYPE)
     create_sample_notification(notify_db, notify_db_session, created_at=datetime(2016, 6, 5),
                                sent_at=datetime(2016, 6, 5),
                                status='sending',
@@ -1825,19 +1825,19 @@ def test_get_monthly_billing_usage(client, notify_db, notify_db_session, sample_
     assert actual == [{'month': 'June',
                        'international': False,
                        'rate_multiplier': 1,
-                       'notification_type': 'sms',
+                       'notification_type': SMS_TYPE,
                        'rate': 0.0158,
                        'billing_units': 1},
                       {'month': 'June',
                        'international': False,
                        'rate_multiplier': 2,
-                       'notification_type': 'sms',
+                       'notification_type': SMS_TYPE,
                        'rate': 0.0158,
                        'billing_units': 1},
                       {'month': 'July',
                        'international': False,
                        'rate_multiplier': 1,
-                       'notification_type': 'sms',
+                       'notification_type': SMS_TYPE,
                        'rate': 0.0158,
                        'billing_units': 1}]
 
@@ -1854,7 +1854,7 @@ def test_get_monthly_billing_usage_returns_400_if_missing_year(client, sample_se
 
 
 def test_get_monthly_billing_usage_returns_empty_list_if_no_notifications(client, notify_db, sample_service):
-    rate = Rate(id=uuid.uuid4(), valid_from=datetime(2016, 3, 31, 23, 00), rate=0.0158, notification_type='sms')
+    rate = Rate(id=uuid.uuid4(), valid_from=datetime(2016, 3, 31, 23, 00), rate=0.0158, notification_type=SMS_TYPE)
     notify_db.session.add(rate)
     response = client.get(
         '/service/{}/monthly-usage?year=2016'.format(sample_service.id),

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -91,9 +91,9 @@ def test_should_raise_error_if_service_does_not_exist_on_create(client, sample_u
 
 
 @pytest.mark.parametrize('permissions, template_type, subject, expected_error', [
-    ([EMAIL_TYPE], SMS_TYPE, None, 'Create text message template is not allowed'),
-    ([SMS_TYPE], EMAIL_TYPE, 'subject', 'Create email template is not allowed'),
-    ([SMS_TYPE], LETTER_TYPE, 'subject', 'Create letter template is not allowed'),
+    ([EMAIL_TYPE], SMS_TYPE, None, 'Creating text message templates is not allowed'),
+    ([SMS_TYPE], EMAIL_TYPE, 'subject', 'Creating email templates is not allowed'),
+    ([SMS_TYPE], LETTER_TYPE, 'subject', 'Creating letter templates is not allowed'),
 ])
 def test_should_raise_error_on_create_if_no_permission(
         client, sample_user, permissions, template_type, subject, expected_error):
@@ -123,9 +123,9 @@ def test_should_raise_error_on_create_if_no_permission(
 
 
 @pytest.mark.parametrize('template_factory, expected_error', [
-    (sample_template_without_sms_permission, 'Update text message template is not allowed'),
-    (sample_template_without_email_permission, 'Update email template is not allowed'),
-    (sample_template_without_letter_permission, 'Update letter template is not allowed')
+    (sample_template_without_sms_permission, 'Updating text message templates is not allowed'),
+    (sample_template_without_email_permission, 'Updating email templates is not allowed'),
+    (sample_template_without_letter_permission, 'Updating letter templates is not allowed')
 ])
 def test_should_be_error_on_update_if_no_permission(
         client, sample_user, template_factory, expected_error, notify_db, notify_db_session):

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -91,9 +91,9 @@ def test_should_raise_error_if_service_does_not_exist_on_create(client, sample_u
 
 
 @pytest.mark.parametrize('permissions, template_type, subject, expected_error', [
-    ([EMAIL_TYPE], SMS_TYPE, None, 'Creating text message templates is not allowed'),
-    ([SMS_TYPE], EMAIL_TYPE, 'subject', 'Creating email templates is not allowed'),
-    ([SMS_TYPE], LETTER_TYPE, 'subject', 'Creating letter templates is not allowed'),
+    ([EMAIL_TYPE], SMS_TYPE, None, {'template_type': ['Creating text message templates is not allowed']}),
+    ([SMS_TYPE], EMAIL_TYPE, 'subject', {'template_type': ['Creating email templates is not allowed']}),
+    ([SMS_TYPE], LETTER_TYPE, 'subject', {'template_type': ['Creating letter templates is not allowed']}),
 ])
 def test_should_raise_error_on_create_if_no_permission(
         client, sample_user, permissions, template_type, subject, expected_error):
@@ -123,9 +123,9 @@ def test_should_raise_error_on_create_if_no_permission(
 
 
 @pytest.mark.parametrize('template_factory, expected_error', [
-    (sample_template_without_sms_permission, 'Updating text message templates is not allowed'),
-    (sample_template_without_email_permission, 'Updating email templates is not allowed'),
-    (sample_template_without_letter_permission, 'Updating letter templates is not allowed')
+    (sample_template_without_sms_permission, {'template_type': ['Updating text message templates is not allowed']}),
+    (sample_template_without_email_permission, {'template_type': ['Updating email templates is not allowed']}),
+    (sample_template_without_letter_permission, {'template_type': ['Updating letter templates is not allowed']})
 ])
 def test_should_be_error_on_update_if_no_permission(
         client, sample_user, template_factory, expected_error, notify_db, notify_db_session):

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -7,26 +7,34 @@ from datetime import datetime, timedelta
 import pytest
 from freezegun import freeze_time
 
-from app.models import Template
+from app.models import Template, SMS_TYPE, EMAIL_TYPE, LETTER_TYPE
 from app.dao.templates_dao import dao_get_template_by_id, dao_redact_template
 
 from tests import create_authorization_header
-from tests.app.conftest import sample_template as create_sample_template
+from tests.app.conftest import (
+    sample_template as create_sample_template,
+    sample_template_without_sms_permission,
+    sample_template_without_email_permission
+)
+from tests.app.db import create_service
+
+from app.dao.templates_dao import dao_get_template_by_id
 
 
 @pytest.mark.parametrize('template_type, subject', [
-    ('sms', None),
-    ('email', 'subject'),
-    ('letter', 'subject'),
+    (SMS_TYPE, None),
+    (EMAIL_TYPE, 'subject'),
+    (LETTER_TYPE, 'subject'),
 ])
 def test_should_create_a_new_template_for_a_service(
-    client, sample_user, sample_service, template_type, subject
+    client, sample_user, template_type, subject
 ):
+    service = create_service(service_permissions=[template_type])
     data = {
         'name': 'my template',
         'template_type': template_type,
         'content': 'template <b>content</b>',
-        'service': str(sample_service.id),
+        'service': str(service.id),
         'created_by': str(sample_user.id)
     }
     if subject:
@@ -35,7 +43,7 @@ def test_should_create_a_new_template_for_a_service(
     auth_header = create_authorization_header()
 
     response = client.post(
-        '/service/{}/template'.format(sample_service.id),
+        '/service/{}/template'.format(service.id),
         headers=[('Content-Type', 'application/json'), auth_header],
         data=data
     )
@@ -44,7 +52,7 @@ def test_should_create_a_new_template_for_a_service(
     assert json_resp['data']['name'] == 'my template'
     assert json_resp['data']['template_type'] == template_type
     assert json_resp['data']['content'] == 'template <b>content</b>'
-    assert json_resp['data']['service'] == str(sample_service.id)
+    assert json_resp['data']['service'] == str(service.id)
     assert json_resp['data']['id']
     assert json_resp['data']['version'] == 1
     assert json_resp['data']['process_type'] == 'normal'
@@ -59,10 +67,10 @@ def test_should_create_a_new_template_for_a_service(
     assert sorted(json_resp['data']) == sorted(template_schema.dump(template).data)
 
 
-def test_should_be_error_if_service_does_not_exist_on_create(client, sample_user, fake_uuid):
+def test_should_raise_error_if_service_does_not_exist_on_create(client, sample_user, fake_uuid):
     data = {
         'name': 'my template',
-        'template_type': 'sms',
+        'template_type': SMS_TYPE,
         'content': 'template content',
         'service': fake_uuid,
         'created_by': str(sample_user.id)
@@ -81,11 +89,70 @@ def test_should_be_error_if_service_does_not_exist_on_create(client, sample_user
     assert json_resp['message'] == 'No result found'
 
 
+@pytest.mark.parametrize('permissions, template_type, subject, expected_error', [
+    ([EMAIL_TYPE], SMS_TYPE, None, 'Cannot create text message templates'),
+    ([SMS_TYPE], EMAIL_TYPE, 'subject', 'Cannot create email templates'),
+])
+def test_should_raise_error_on_create_if_no_permission(
+        client, sample_user, permissions, template_type, subject, expected_error):
+    service = create_service(service_permissions=permissions)
+    data = {
+        'name': 'my template',
+        'template_type': template_type,
+        'content': 'template content',
+        'service': str(service.id),
+        'created_by': str(sample_user.id)
+    }
+    if subject:
+        data.update({'subject': subject})
+
+    data = json.dumps(data)
+    auth_header = create_authorization_header()
+
+    response = client.post(
+        '/service/{}/template'.format(service.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=data
+    )
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert response.status_code == 400
+    assert json_resp['result'] == 'error'
+    assert json_resp['message'] == {'content': [expected_error]}
+
+
+@pytest.mark.parametrize('template_factory, expected_error', [
+    (sample_template_without_sms_permission, 'Cannot update text message templates'),
+    (sample_template_without_email_permission, 'Cannot update email templates'),
+])
+def test_should_be_error_on_update_if_no_permission(
+        client, sample_user, template_factory, expected_error, notify_db, notify_db_session):
+    template_without_permission = template_factory(notify_db, notify_db_session)
+    data = {
+        'content': 'new template content',
+        'created_by': str(sample_user.id)
+    }
+
+    data = json.dumps(data)
+    auth_header = create_authorization_header()
+
+    update_response = client.post(
+        '/service/{}/template/{}'.format(
+            template_without_permission.service_id, template_without_permission.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=data
+    )
+
+    json_resp = json.loads(update_response.get_data(as_text=True))
+    assert update_response.status_code == 400
+    assert json_resp['result'] == 'error'
+    assert json_resp['message'] == {'content': [expected_error]}
+
+
 def test_should_error_if_created_by_missing(client, sample_user, sample_service):
     service_id = str(sample_service.id)
     data = {
         'name': 'my template',
-        'template_type': 'sms',
+        'template_type': SMS_TYPE,
         'content': 'template content',
         'service': service_id
     }
@@ -120,7 +187,7 @@ def test_should_be_error_if_service_does_not_exist_on_update(client, fake_uuid):
     assert json_resp['message'] == 'No result found'
 
 
-@pytest.mark.parametrize('template_type', ['email', 'letter'])
+@pytest.mark.parametrize('template_type', [EMAIL_TYPE, LETTER_TYPE])
 def test_must_have_a_subject_on_an_email_or_letter_template(client, sample_user, sample_service, template_type):
     data = {
         'name': 'my template',
@@ -194,7 +261,7 @@ def test_should_be_able_to_archive_template(client, sample_template):
 def test_should_be_able_to_get_all_templates_for_a_service(client, sample_user, sample_service):
     data = {
         'name': 'my template 1',
-        'template_type': 'email',
+        'template_type': EMAIL_TYPE,
         'subject': 'subject 1',
         'content': 'template content',
         'service': str(sample_service.id),
@@ -203,7 +270,7 @@ def test_should_be_able_to_get_all_templates_for_a_service(client, sample_user, 
     data_1 = json.dumps(data)
     data = {
         'name': 'my template 2',
-        'template_type': 'email',
+        'template_type': EMAIL_TYPE,
         'subject': 'subject 2',
         'content': 'template content',
         'service': str(sample_service.id),
@@ -271,7 +338,7 @@ def test_should_get_only_templates_for_that_service(client, sample_user, service
 
     data = {
         'name': 'my template 2',
-        'template_type': 'email',
+        'template_type': EMAIL_TYPE,
         'subject': 'subject 2',
         'content': 'template content',
         'service': str(service_1.id),
@@ -310,17 +377,17 @@ def test_should_get_only_templates_for_that_service(client, sample_user, service
         (
             'about your ((thing))',
             'hello ((name)) we’ve received your ((thing))',
-            'email'
+            EMAIL_TYPE
         ),
         (
             None,
             'hello ((name)) we’ve received your ((thing))',
-            'sms'
+            SMS_TYPE
         ),
         (
             'about your ((thing))',
             'hello ((name)) we’ve received your ((thing))',
-            'letter'
+            LETTER_TYPE
         )
     ]
 )
@@ -400,7 +467,7 @@ def test_should_preview_a_single_template(
 ):
 
     template = create_sample_template(
-        notify_db, notify_db.session, subject_line=subject, content=content, template_type='email'
+        notify_db, notify_db.session, subject_line=subject, content=content, template_type=EMAIL_TYPE
     )
 
     response = client.get(
@@ -454,7 +521,7 @@ def test_create_400_for_over_limit_content(client, notify_api, sample_user, samp
     content = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(limit + 1))
     data = {
         'name': 'too big template',
-        'template_type': 'sms',
+        'template_type': SMS_TYPE,
         'content': content,
         'service': str(sample_service.id),
         'created_by': str(sample_user.id)

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -12,7 +12,11 @@ from flask import json, current_app
 from app.models import Notification
 from app.v2.errors import RateLimitError
 from tests import create_authorization_header
-from tests.app.conftest import sample_template as create_sample_template, sample_service
+from tests.app.conftest import (
+    sample_template as create_sample_template, sample_service,
+    sample_template_without_sms_permission, sample_template_without_email_permission
+)
+
 from tests.app.db import create_service, create_template
 
 
@@ -54,7 +58,7 @@ def test_post_sms_notification_returns_201(client, sample_template_with_placehol
 @pytest.mark.parametrize("notification_type, key_send_to, send_to",
                          [("sms", "phone_number", "+447700900855"),
                           ("email", "email_address", "sample@email.com")])
-def test_post_sms_notification_returns_404_and_missing_template(client, sample_service,
+def test_post_sms_notification_returns_400_and_missing_template(client, sample_service,
                                                                 notification_type, key_send_to, send_to):
     data = {
         key_send_to: send_to,
@@ -308,9 +312,37 @@ def test_post_sms_notification_returns_400_if_not_allowed_to_send_int_sms(client
     ]
 
 
+@pytest.mark.parametrize('template_factory,expected_error', [
+    (sample_template_without_sms_permission, 'Cannot send text messages'),
+    (sample_template_without_email_permission, 'Cannot send emails')])
+def test_post_sms_notification_returns_400_if_not_allowed_to_send_notification(
+        client, template_factory, expected_error, notify_db, notify_db_session):
+    sample_template_without_permission = template_factory(notify_db, notify_db_session)
+    data = {
+        'phone_number': '07700 900000',
+        'email_address': 'someone@test.com',
+        'template_id': sample_template_without_permission.id
+    }
+    auth_header = create_authorization_header(service_id=sample_template_without_permission.service.id)
+
+    response = client.post(
+        path='/v2/notifications/{}'.format(sample_template_without_permission.template_type),
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header])
+
+    assert response.status_code == 400
+    assert response.headers['Content-type'] == 'application/json'
+
+    error_json = json.loads(response.get_data(as_text=True))
+    assert error_json['status_code'] == 400
+    assert error_json['errors'] == [
+        {"error": "BadRequestError", "message": expected_error}
+    ]
+
+
 def test_post_sms_notification_returns_201_if_allowed_to_send_int_sms(notify_db, notify_db_session, client, mocker):
 
-    service = sample_service(notify_db, notify_db_session, permissions=[INTERNATIONAL_SMS_TYPE])
+    service = sample_service(notify_db, notify_db_session, permissions=[SMS_TYPE, INTERNATIONAL_SMS_TYPE])
     template = create_sample_template(notify_db, notify_db_session, service=service)
 
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -307,7 +307,7 @@ def test_post_sms_notification_returns_400_if_not_allowed_to_send_int_sms(client
 
 def test_post_sms_notification_returns_201_if_allowed_to_send_int_sms(notify_db, notify_db_session, client, mocker):
 
-    service = sample_service(notify_db, notify_db_session, can_send_international_sms=True)
+    service = sample_service(notify_db, notify_db_session, permissions=["international_sms"])
     template = create_sample_template(notify_db, notify_db_session, service=service)
 
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')


### PR DESCRIPTION
Refactored the code to remove references to permission flags in service and use service permissions instead.

Also updated code to ensure that email / sms permission settings are honoured for sending, and creating / updating templates.

If the notification is already scheduled or in a queue then honour sending it.