### PR TITLE
Templates can now be [REDACTED] 

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -111,6 +111,7 @@ def dao_archive_service(service_id):
     # to ensure that db.session still contains the models when it comes to creating history objects
     service = Service.query.options(
         joinedload('templates'),
+        joinedload('templates.template_redacted'),
         joinedload('api_keys'),
     ).filter(Service.id == service_id).one()
 

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -19,6 +19,7 @@ from app.models import (
     ApiKey,
     Template,
     TemplateHistory,
+    TemplateRedacted,
     Job,
     NotificationHistory,
     Notification,
@@ -218,6 +219,7 @@ def delete_service_and_all_associated_db_objects(service):
     _delete_commit(Job.query.filter_by(service=service))
     _delete_commit(NotificationHistory.query.filter_by(service=service))
     _delete_commit(Notification.query.filter_by(service=service))
+    _delete_commit(TemplateRedacted.query.filter_by(service=service))
     _delete_commit(Template.query.filter_by(service=service))
     _delete_commit(TemplateHistory.query.filter_by(service_id=service.id))
     _delete_commit(ServicePermission.query.filter_by(service_id=service.id))

--- a/app/models.py
+++ b/app/models.py
@@ -443,6 +443,8 @@ class Template(db.Model):
         default=NORMAL
     )
 
+    redact_personalisation = association_proxy('template_redacted', 'redact_personalisation')
+
     def get_link(self):
         # TODO: use "/v2/" route once available
         return url_for(

--- a/app/models.py
+++ b/app/models.py
@@ -434,12 +434,14 @@ class Template(db.Model):
     subject = db.Column(db.Text, index=False, unique=False, nullable=True)
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
     created_by = db.relationship('User')
-    version = db.Column(db.Integer, default=1, nullable=False)
-    process_type = db.Column(db.String(255),
-                             db.ForeignKey('template_process_type.name'),
-                             index=True,
-                             nullable=False,
-                             default=NORMAL)
+    version = db.Column(db.Integer, default=0, nullable=False)
+    process_type = db.Column(
+        db.String(255),
+        db.ForeignKey('template_process_type.name'),
+        index=True,
+        nullable=False,
+        default=NORMAL
+    )
 
     def get_link(self):
         # TODO: use "/v2/" route once available
@@ -463,6 +465,19 @@ class Template(db.Model):
         }
 
         return serialized
+
+
+class TemplateRedacted(db.Model):
+    __tablename__ = 'template_redacted'
+
+    template_id = db.Column(UUID(as_uuid=True), db.ForeignKey('templates.id'), primary_key=True, nullable=False)
+    redact_personalisation = db.Column(db.Boolean, nullable=False, default=False)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    updated_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), nullable=False)
+    updated_by = db.relationship('User')
+
+    # uselist=False as this is a one-to-one relationship
+    template = db.relationship('Template', uselist=False, backref=db.backref('template_redacted', uselist=False))
 
 
 class TemplateHistory(db.Model):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -297,6 +297,11 @@ class BaseTemplateSchema(BaseSchema):
         strict = True
 
 
+class TemplateRedactedSchema(BaseSchema):
+    class Meta:
+        model = models.TemplateRedacted
+
+
 class TemplateSchema(BaseTemplateSchema):
 
     created_by = field_for(models.Template, 'created_by', required=True)
@@ -440,7 +445,7 @@ class NotificationWithTemplateSchema(BaseSchema):
 
     template = fields.Nested(
         TemplateSchema,
-        only=['id', 'version', 'name', 'template_type', 'content', 'subject'],
+        only=['id', 'version', 'name', 'template_type', 'content', 'subject', 'redact_personalisation'],
         dump_only=True
     )
     job = fields.Nested(JobSchema, only=["id", "original_file_name"], dump_only=True)

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -61,8 +61,10 @@ def update_template(service_id, template_id):
     # if redacting, don't update anything else
     if data.get('redact_personalisation') is True and 'updated_by_id' in data:
         # we also don't need to check what was passed in redact_personalisation - its presence in the dict is enough.
-        dao_redact_template(fetched_template, data['updated_by_id'])
-        return '', 200
+        # also, only
+        if not fetched_template.redact_personalisation:
+            dao_redact_template(fetched_template, data['updated_by_id'])
+        return 'null', 200
 
     current_data = dict(template_schema.dump(fetched_template).data.items())
     updated_template = dict(template_schema.dump(fetched_template).data.items())

--- a/migrations/versions/0102_template_redacted.py
+++ b/migrations/versions/0102_template_redacted.py
@@ -1,0 +1,31 @@
+"""empty message
+
+Revision ID: db6d9d9f06bc
+Revises: 0101_een_logo
+Create Date: 2017-06-27 15:37:28.878359
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'db6d9d9f06bc'
+down_revision = '0101_een_logo'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+    op.create_table('template_redacted',
+        sa.Column('template_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('redact_personalisation', sa.Boolean(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_by_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(['template_id'], ['templates.id'], ),
+        sa.ForeignKeyConstraint(['updated_by_id'], ['users.id'], ),
+        sa.PrimaryKeyConstraint('template_id')
+    )
+    op.create_index(op.f('ix_template_redacted_updated_by_id'), 'template_redacted', ['updated_by_id'], unique=False)
+
+
+def downgrade():
+    op.drop_table('template_redacted')

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1,11 +1,17 @@
+import uuid
 import json
 import random
 import string
+from datetime import datetime, timedelta
+
 import pytest
+from freezegun import freeze_time
+
 from app.models import Template
+from app.dao.templates_dao import dao_get_template_by_id, dao_redact_template
+
 from tests import create_authorization_header
 from tests.app.conftest import sample_template as create_sample_template
-from app.dao.templates_dao import dao_get_template_by_id
 
 
 @pytest.mark.parametrize('template_type, subject', [
@@ -539,3 +545,87 @@ def test_update_set_process_type_on_template(client, sample_template):
 
     template = dao_get_template_by_id(sample_template.id)
     assert template.process_type == 'priority'
+
+
+def test_update_redact_template(admin_request, sample_template):
+    assert sample_template.redact_personalisation is False
+
+    data = {
+        'redact_personalisation': True,
+        'updated_by_id': str(sample_template.created_by_id)
+    }
+
+    dt = datetime.now()
+
+    with freeze_time(dt):
+        resp = admin_request.post(
+            'template.update_template',
+            service_id=sample_template.service_id,
+            template_id=sample_template.id,
+            _data=data
+        )
+
+    assert resp is None
+
+    assert sample_template.redact_personalisation is True
+    assert sample_template.template_redacted.updated_by_id == sample_template.created_by_id
+    assert sample_template.template_redacted.updated_at == dt
+
+    assert sample_template.version == 1
+
+
+def test_update_redact_template_ignores_other_properties(admin_request, sample_template):
+    data = {
+        'name': 'Foo',
+        'redact_personalisation': True,
+        'updated_by_id': str(sample_template.created_by_id)
+    }
+
+    admin_request.post(
+        'template.update_template',
+        service_id=sample_template.service_id,
+        template_id=sample_template.id,
+        _data=data
+    )
+
+    assert sample_template.redact_personalisation is True
+    assert sample_template.name != 'Foo'
+
+
+def test_update_redact_template_does_nothing_if_already_redacted(admin_request, sample_template):
+    dt = datetime.now()
+    with freeze_time(dt):
+        dao_redact_template(sample_template, sample_template.created_by_id)
+
+    data = {
+        'redact_personalisation': True,
+        'updated_by_id': str(sample_template.created_by_id)
+    }
+
+    with freeze_time(dt + timedelta(days=1)):
+        resp = admin_request.post(
+            'template.update_template',
+            service_id=sample_template.service_id,
+            template_id=sample_template.id,
+            _data=data
+        )
+
+    assert resp is None
+
+    assert sample_template.redact_personalisation is True
+    # make sure that it hasn't been updated
+    assert sample_template.template_redacted.updated_at == dt
+
+
+
+def test_update_redact_template_does_nothing_if_no_updated_by(admin_request, sample_template):
+    original_updated_time = sample_template.template_redacted.updated_at
+    admin_request.post(
+        'template.update_template',
+        service_id=sample_template.service_id,
+        template_id=sample_template.id,
+        _data={'redact_personalisation': True}
+    )
+
+    assert sample_template.redact_personalisation is False
+    assert sample_template.template_redacted.updated_at == original_updated_time

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -617,15 +617,20 @@ def test_update_redact_template_does_nothing_if_already_redacted(admin_request, 
     assert sample_template.template_redacted.updated_at == dt
 
 
-
-def test_update_redact_template_does_nothing_if_no_updated_by(admin_request, sample_template):
+def test_update_redact_template_400s_if_no_updated_by(admin_request, sample_template):
     original_updated_time = sample_template.template_redacted.updated_at
-    admin_request.post(
+    resp = admin_request.post(
         'template.update_template',
         service_id=sample_template.service_id,
         template_id=sample_template.id,
-        _data={'redact_personalisation': True}
+        _data={'redact_personalisation': True},
+        _expected_status=400
     )
+
+    assert resp == {
+        'result': 'error',
+        'message': {'updated_by_id': ['Field is required']}
+    }
 
     assert sample_template.redact_personalisation is False
     assert sample_template.template_redacted.updated_at == original_updated_time


### PR DESCRIPTION
If you make an update_template post containing `{"redact_personalisation": true, "updated_by_id": "..."}`, then we store a `redact_personalisation` marker in a new database table - TemplateRedacted.

This table just contains that boolean, and who and when updated it.