### PR TITLE
use created_by instead of updated_by

### DIFF
--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -143,12 +143,12 @@ def _template_has_not_changed(current_data, updated_template):
 
 def redact_template(template, data):
     # we also don't need to check what was passed in redact_personalisation - its presence in the dict is enough.
-    if 'updated_by_id' not in data:
+    if 'created_by' not in data:
         message = 'Field is required'
-        errors = {'updated_by_id': [message]}
+        errors = {'created_by': [message]}
         raise InvalidRequest(errors, status_code=400)
 
     # if it's already redacted, then just return 200 straight away.
     if not template.redact_personalisation:
-        dao_redact_template(template, data['updated_by_id'])
+        dao_redact_template(template, data['created_by'])
     return 'null', 200

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -552,7 +552,7 @@ def test_update_redact_template(admin_request, sample_template):
 
     data = {
         'redact_personalisation': True,
-        'updated_by_id': str(sample_template.created_by_id)
+        'created_by': str(sample_template.created_by_id)
     }
 
     dt = datetime.now()
@@ -578,7 +578,7 @@ def test_update_redact_template_ignores_other_properties(admin_request, sample_t
     data = {
         'name': 'Foo',
         'redact_personalisation': True,
-        'updated_by_id': str(sample_template.created_by_id)
+        'created_by': str(sample_template.created_by_id)
     }
 
     admin_request.post(
@@ -599,7 +599,7 @@ def test_update_redact_template_does_nothing_if_already_redacted(admin_request, 
 
     data = {
         'redact_personalisation': True,
-        'updated_by_id': str(sample_template.created_by_id)
+        'created_by': str(sample_template.created_by_id)
     }
 
     with freeze_time(dt + timedelta(days=1)):
@@ -617,7 +617,7 @@ def test_update_redact_template_does_nothing_if_already_redacted(admin_request, 
     assert sample_template.template_redacted.updated_at == dt
 
 
-def test_update_redact_template_400s_if_no_updated_by(admin_request, sample_template):
+def test_update_redact_template_400s_if_no_created_by(admin_request, sample_template):
     original_updated_time = sample_template.template_redacted.updated_at
     resp = admin_request.post(
         'template.update_template',
@@ -629,7 +629,7 @@ def test_update_redact_template_400s_if_no_updated_by(admin_request, sample_temp
 
     assert resp == {
         'result': 'error',
-        'message': {'updated_by_id': ['Field is required']}
+        'message': {'created_by': ['Field is required']}
     }
 
     assert sample_template.redact_personalisation is False


### PR DESCRIPTION
to behave in same way as other endpoints