### PR TITLE
add historical redaction data

### DIFF
--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -143,12 +143,12 @@ def _template_has_not_changed(current_data, updated_template):
 
 def redact_template(template, data):
     # we also don't need to check what was passed in redact_personalisation - its presence in the dict is enough.
-    if 'updated_by_id' not in data:
+    if 'created_by' not in data:
         message = 'Field is required'
-        errors = {'updated_by_id': [message]}
+        errors = {'created_by': [message]}
         raise InvalidRequest(errors, status_code=400)
 
     # if it's already redacted, then just return 200 straight away.
     if not template.redact_personalisation:
-        dao_redact_template(template, data['updated_by_id'])
+        dao_redact_template(template, data['created_by'])
     return 'null', 200

--- a/migrations/versions/0103_add_historical_redact.py
+++ b/migrations/versions/0103_add_historical_redact.py
@@ -1,0 +1,43 @@
+"""empty message
+
+Revision ID: 0103_add_historical_redact
+Revises: db6d9d9f06bc
+Create Date: 2017-06-29 12:44:16.815039
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0103_add_historical_redact'
+down_revision = 'db6d9d9f06bc'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from flask import current_app
+
+def upgrade():
+    op.execute(
+        """
+        INSERT INTO template_redacted
+        (
+            template_id,
+            redact_personalisation,
+            updated_at,
+            updated_by_id
+        )
+        SELECT
+            templates.id,
+            false,
+            now(),
+            '{notify_user}'
+        FROM
+            templates
+        LEFT JOIN template_redacted on template_redacted.template_id = templates.id
+        WHERE template_redacted.template_id IS NULL
+        """.format(notify_user=current_app.config['NOTIFY_USER_ID'])
+    )
+
+
+def downgrade():
+    # data migration, no downloads
+    pass

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -552,7 +552,7 @@ def test_update_redact_template(admin_request, sample_template):
 
     data = {
         'redact_personalisation': True,
-        'updated_by_id': str(sample_template.created_by_id)
+        'created_by': str(sample_template.created_by_id)
     }
 
     dt = datetime.now()
@@ -578,7 +578,7 @@ def test_update_redact_template_ignores_other_properties(admin_request, sample_t
     data = {
         'name': 'Foo',
         'redact_personalisation': True,
-        'updated_by_id': str(sample_template.created_by_id)
+        'created_by': str(sample_template.created_by_id)
     }
 
     admin_request.post(
@@ -599,7 +599,7 @@ def test_update_redact_template_does_nothing_if_already_redacted(admin_request, 
 
     data = {
         'redact_personalisation': True,
-        'updated_by_id': str(sample_template.created_by_id)
+        'created_by': str(sample_template.created_by_id)
     }
 
     with freeze_time(dt + timedelta(days=1)):
@@ -617,7 +617,7 @@ def test_update_redact_template_does_nothing_if_already_redacted(admin_request, 
     assert sample_template.template_redacted.updated_at == dt
 
 
-def test_update_redact_template_400s_if_no_updated_by(admin_request, sample_template):
+def test_update_redact_template_400s_if_no_created_by(admin_request, sample_template):
     original_updated_time = sample_template.template_redacted.updated_at
     resp = admin_request.post(
         'template.update_template',
@@ -629,7 +629,7 @@ def test_update_redact_template_400s_if_no_updated_by(admin_request, sample_temp
 
     assert resp == {
         'result': 'error',
-        'message': {'updated_by_id': ['Field is required']}
+        'message': {'created_by': ['Field is required']}
     }
 
     assert sample_template.redact_personalisation is False


### PR DESCRIPTION
every current template gets a row in the template_redacted table - this inserts one for any template that doesn't already have a row, with redact set to false, the user set to NOTIFY_USER since it was just a script, and the updated_at set to the time the script is run