### PR TITLE
Add more organisations for letter branding

### DIFF
--- a/migrations/versions/0104_more_letter_orgs.py
+++ b/migrations/versions/0104_more_letter_orgs.py
@@ -1,0 +1,28 @@
+"""empty message
+
+Revision ID: 0104_more_letter_orgs
+Revises: 0103_add_historical_redact
+Create Date: 2017-06-29 12:44:16.815039
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0104_more_letter_orgs'
+down_revision = '0103_add_historical_redact'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from flask import current_app
+
+def upgrade():
+    op.execute("""
+        INSERT INTO dvla_organisation VALUES
+        ('003', 'Department for Work and Pensions'),
+        ('004', 'Government Equalities Office')
+    """)
+
+
+def downgrade():
+    # data migration, no downloads
+    pass

--- a/tests/app/dvla_organisation/test_rest.py
+++ b/tests/app/dvla_organisation/test_rest.py
@@ -10,4 +10,5 @@ def test_get_dvla_organisations(client):
 
     assert response.status_code == 200
     dvla_organisations = json.loads(response.get_data(as_text=True))
-    assert dvla_organisations == {'001': 'HM Government', '500': 'Land Registry'}
+    assert dvla_organisations['001'] == 'HM Government'
+    assert dvla_organisations['500'] == 'Land Registry'


### PR DESCRIPTION
> The logos are now ready to go on DVLA side- so far we've got:
> 001 = HM Government
> 002 = OPG
> 003 = DWP
> 004 = GEO