### PR TITLE
Fix issue with search notification 500'ing

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -326,7 +326,7 @@ def get_notification_for_service(service_id, notification_id):
 def search_for_notification_by_to_field(service_id, search_term, statuses):
     results = notifications_dao.dao_get_notifications_by_to_field(service_id, search_term, statuses)
     return jsonify(
-        notifications=notification_with_personalisation_schema.dump(results, many=True).data
+        notifications=notification_with_template_schema.dump(results, many=True).data
     ), 200
 
 


### PR DESCRIPTION
This fixes an issue where the search notification 500's on the dashboard.

## Summary

The admin expects each serialised `Notification` to have  `personalisation` field which is not dumped by the `notification_with_personalisation_schema`. The `notification_with_template_schema` provides this and we use this anyway in the same endpoint `get_all_notifications_for_service::302`. So let's use it here too...