### PR TITLE
notification.personalisation now always returns an empty dict

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -838,12 +838,11 @@ class Notification(db.Model):
     def personalisation(self):
         if self._personalisation:
             return encryption.decrypt(self._personalisation)
-        return None
+        return {}
 
     @personalisation.setter
     def personalisation(self, personalisation):
-        if personalisation:
-            self._personalisation = encryption.encrypt(personalisation)
+        self._personalisation = encryption.encrypt(personalisation or {})
 
     def completed_at(self):
         if self.status in NOTIFICATION_STATUS_TYPES_COMPLETED:

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -2,6 +2,7 @@ import pytest
 
 from freezegun import freeze_time
 
+from app import encryption
 from app.models import (
     ServiceWhitelist,
     Notification,
@@ -145,3 +146,23 @@ def test_notification_for_csv_returns_bst_correctly(notify_db, notify_db_session
 
     serialized = notification.serialize_for_csv()
     assert serialized['created_at'] == 'Monday 27 March 2017 at 00:01'
+
+
+def test_notification_personalisation_getter_returns_empty_dict_from_None(sample_notification):
+    sample_notification._personalisation = None
+    assert sample_notification.personalisation == {}
+
+
+def test_notification_personalisation_getter_always_returns_empty_dict(sample_notification):
+    sample_notification._personalisation = encryption.encrypt({})
+    assert sample_notification.personalisation == {}
+
+
+@pytest.mark.parametrize('input_value', [
+    None,
+    {}
+])
+def test_notification_personalisation_setter_always_sets_empty_dict(sample_notification, input_value):
+    sample_notification.personalisation = input_value
+
+    assert sample_notification._personalisation == encryption.encrypt({})


### PR DESCRIPTION
There are a variety of ways a notification can be created - via the API, via CSV, via one-off messages, via the same but sent as a test - the point is, there are lots of entry points, and lots of inconsistency about how personalisation may be sent in. If there are no personalisation options in the template, we may get either `None` or `{}` - if the value is None, to avoid an error in our encryption lib, we just store None in the database.

THIS ENDS NOW!

We've had some problems on the front-end that is caused by notifications having the `None` value. This commit changes the personalisation property getter and setter to store/return `{}` rather than None.