### PR TITLE
2/3 Make older Notification enum status fields nullable

### DIFF
--- a/migrations/versions/0106_noti_status_null.py
+++ b/migrations/versions/0106_noti_status_null.py
@@ -1,0 +1,56 @@
+"""empty message
+
+Revision ID: 0106_noti_status_null
+Revises: 0105_opg_letter_org
+Create Date: 2017-07-03 16:58:38.650154
+
+"""
+
+# revision identifiers, used by Alembic.
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = '0106_noti_status_null'
+down_revision = '0105_opg_letter_org'
+
+
+def upgrade():
+    op.alter_column(
+        'notification_history',
+        'status',
+        existing_type=postgresql.ENUM(
+            'created', 'sending', 'delivered', 'pending', 'failed', 'technical-failure',
+            'temporary-failure', 'permanent-failure', 'sent', name='notify_status_type'
+        ),
+        nullable=True
+    )
+    op.alter_column(
+        'notifications',
+        'status',
+        existing_type=postgresql.ENUM(
+            'created', 'sending', 'delivered', 'pending', 'failed', 'technical-failure',
+            'temporary-failure', 'permanent-failure', 'sent', name='notify_status_type'
+        ),
+        nullable=True
+    )
+
+
+def downgrade():
+    op.alter_column(
+        'notifications',
+        'status',
+        existing_type=postgresql.ENUM(
+            'created', 'sending', 'delivered', 'pending', 'failed', 'technical-failure',
+            'temporary-failure', 'permanent-failure', 'sent', name='notify_status_type'
+        ),
+        nullable=False
+    )
+    op.alter_column(
+        'notification_history',
+        'status',
+        existing_type=postgresql.ENUM(
+            'created', 'sending', 'delivered', 'pending', 'failed', 'technical-failure',
+            'temporary-failure', 'permanent-failure', 'sent', name='notify_status_type'
+        ),
+        nullable=False
+    )


### PR DESCRIPTION
This makes `Notification.status` and `NotificationHistory.status` nullable in the DB. 

**Note: This was branched off and also depends on #1057. Will rebase off master once that's merged.**

## Summary

Before we can remove `_status_enum` we need to make this column nullable. This will ensure that when we create notifications after removing this, the `status` field in the `Notification` and `NotificationHistory` tables can be set to `null` allowing us to still create notifications despite not populating this field.

I tested this locally with 9m notifications and it ran in a second so no potential issues on that front.

## Next Steps

3/3 - Drop the `_status_enum` column from the DB