### PR TITLE
Prevent inbound SMS store if no inbound SMS permissions

### DIFF
--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -67,7 +67,6 @@ def receive_firetext_sms():
         }), 200
 
     service = potential_services[0]
-
     inbound = create_inbound_sms_object(service=service,
                                         content=post_data["message"],
                                         from_number=post_data['source'],

--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -128,13 +128,17 @@ def fetch_potential_services(inbound_number, provider_name):
         statsd_client.incr('inbound.{}.failed'.format(provider_name))
         return False
 
-    str_permissions = [p.permission for p in potential_services[0].permissions]
-    if set([INBOUND_SMS_TYPE, SMS_TYPE]).issubset(set(str_permissions)) is False:
+    if not has_inbound_sms_permissions(potential_services[0].permissions):
         current_app.logger.error(
             'Service "{}" does not allow inbound SMS'.format(potential_services[0].id))
         return False
 
     return potential_services
+
+
+def has_inbound_sms_permissions(permissions):
+    str_permissions = [p.permission for p in permissions]
+    return set([INBOUND_SMS_TYPE, SMS_TYPE]).issubset(set(str_permissions))
 
 
 def strip_leading_forty_four(number):

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -27,7 +27,8 @@ from app.models import (
     NotificationStatistics,
     ServiceWhitelist,
     KEY_TYPE_NORMAL, KEY_TYPE_TEST, KEY_TYPE_TEAM,
-    MOBILE_TYPE, EMAIL_TYPE, SMS_TYPE, LETTER_TYPE, NOTIFICATION_STATUS_TYPES_COMPLETED, ScheduledNotification)
+    MOBILE_TYPE, EMAIL_TYPE, SMS_TYPE, LETTER_TYPE, NOTIFICATION_STATUS_TYPES_COMPLETED, ScheduledNotification,
+    SERVICE_PERMISSION_TYPES)
 from app.dao.users_dao import (create_user_code, create_secret_code)
 from app.dao.services_dao import (dao_create_service, dao_add_user_to_service)
 from app.dao.templates_dao import dao_create_template
@@ -149,6 +150,11 @@ def sample_service(
         if user not in service.users:
             dao_add_user_to_service(service, user)
     return service
+
+
+@pytest.fixture(scope='function')
+def sample_service_full_permissions(notify_db, notify_db_session):
+    return sample_service(notify_db, notify_db_session, permissions=SERVICE_PERMISSION_TYPES)
 
 
 @pytest.fixture(scope='function')

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -17,49 +17,88 @@ from tests.app.db import create_service
 from tests.app.conftest import sample_service
 
 
-def test_receive_notification_returns_received_to_mmg(client, mocker, sample_service_full_permissions):
-    mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
-    data = {"ID": "1234",
+@pytest.mark.parametrize('provider,headers,data,expected_response', [
+    (
+        'mmg',
+        [('Content-Type', 'application/json')],
+        json.dumps({
+            "ID": "1234",
             "MSISDN": "447700900855",
             "Message": "Some message to notify",
             "Trigger": "Trigger?",
             "Number": "testing",
             "Channel": "SMS",
             "DateRecieved": "2012-06-27 12:33:00"
-            }
-    response = client.post(path='/notifications/sms/receive/mmg',
-                           data=json.dumps(data),
-                           headers=[('Content-Type', 'application/json')])
+        }),
+        'RECEIVED'
+    ),
+    (
+        'firetext',
+        None,
+        {
+            "Message": "Some message to notify",
+            "source": "Source",
+            "time": "2012-06-27 12:33:00",
+            "destination": "447700900856"
+        },
+        '{\n  "status": "ok"\n}'
+    ),
+])
+def test_receive_notification_returns_received_to_mmg(
+    client, mocker, sample_service_full_permissions, provider, headers, data, expected_response):
+    mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
+    response = client.post(path='/notifications/sms/receive/{}'.format(provider),
+                           data=data,
+                           headers=headers)
 
     assert response.status_code == 200
-    assert response.get_data(as_text=True) == 'RECEIVED'
+    assert response.get_data(as_text=True) == expected_response
     inbound_sms_id = InboundSms.query.all()[0].id
     mocked.assert_called_once_with(
         [str(inbound_sms_id), str(sample_service_full_permissions.id)], queue="notify-internal-tasks")
 
 
-@pytest.mark.parametrize('permissions', [
-    ([SMS_TYPE]),
-    ([INBOUND_SMS_TYPE]),
-])
-def test_receive_notification_without_permissions_does_not_create_inbound(
-        client, mocker, notify_db, notify_db_session, permissions):
-    service = sample_service(notify_db, notify_db_session, permissions=permissions)
-    mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
-    data = {"ID": "1234",
+@pytest.mark.parametrize('provider,headers,data,expected_response', [
+    (
+        'mmg',
+        [('Content-Type', 'application/json')],
+        json.dumps({
+            "ID": "1234",
             "MSISDN": "447700900855",
             "Message": "Some message to notify",
             "Trigger": "Trigger?",
             "Number": "testing",
             "Channel": "SMS",
             "DateRecieved": "2012-06-27 12:33:00"
-            }
-    response = client.post(path='/notifications/sms/receive/mmg',
-                           data=json.dumps(data),
-                           headers=[('Content-Type', 'application/json')])
+        }),
+        'RECEIVED'
+    ),
+    (
+        'firetext',
+        None,
+        {
+            "Message": "Some message to notify",
+            "source": "Source",
+            "time": "2012-06-27 12:33:00",
+            "destination": "447700900856"
+        },
+        '{\n  "status": "ok"\n}'
+    ),
+])
+@pytest.mark.parametrize('permissions', [
+    ([SMS_TYPE]),
+    ([INBOUND_SMS_TYPE]),
+])
+def test_receive_notification_without_permissions_does_not_create_inbound(
+        client, mocker, notify_db, notify_db_session, permissions, provider, headers, data, expected_response):
+    service = sample_service(notify_db, notify_db_session, permissions=permissions)
+    mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
+    response = client.post(path='/notifications/sms/receive/{}'.format(provider),
+                           data=data,
+                           headers=headers)
 
     assert response.status_code == 200
-    assert response.get_data(as_text=True) == 'RECEIVED'
+    assert response.get_data(as_text=True) == expected_response
     assert len(InboundSms.query.all()) == 0
     assert mocked.called is False
 

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -5,6 +5,7 @@ from unittest.mock import call
 import pytest
 from flask import json
 
+from app.dao.services_dao import dao_fetch_services_by_sms_sender
 from app.notifications.receive_notifications import (
     format_mmg_message,
     format_mmg_datetime,
@@ -17,18 +18,17 @@ from tests.app.db import create_service
 from tests.app.conftest import sample_service
 
 
-def test_receive_notification_returns_received_to_mmg(
-        client, mocker, sample_service_full_permissions):
+def test_receive_notification_returns_received_to_mmg(client, mocker, sample_service_full_permissions):
     mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
     data = {
-            "ID": "1234",
-            "MSISDN": "447700900855",
-            "Message": "Some message to notify",
-            "Trigger": "Trigger?",
-            "Number": "testing",
-            "Channel": "SMS",
-            "DateRecieved": "2012-06-27 12:33:00"
-        }
+        "ID": "1234",
+        "MSISDN": "447700900855",
+        "Message": "Some message to notify",
+        "Trigger": "Trigger?",
+        "Number": "testing",
+        "Channel": "SMS",
+        "DateRecieved": "2012-06-27 12:33:00"
+    }
     response = client.post(path='/notifications/sms/receive/mmg',
                            data=json.dumps(data),
                            headers=[('Content-Type', 'application/json')])
@@ -62,7 +62,7 @@ def test_receive_notification_returns_received_to_mmg(
             "Message": "Some message to notify",
             "source": "Source",
             "time": "2012-06-27 12:33:00",
-            "destination": "447700900856"
+            "destination": "447700900855"
         },
         '{\n  "status": "ok"\n}'
     ),
@@ -74,7 +74,11 @@ def test_receive_notification_returns_received_to_mmg(
 def test_receive_notification_without_permissions_does_not_create_inbound(
         client, mocker, notify_db, notify_db_session, permissions, provider, headers, data, expected_response):
     service = sample_service(notify_db, notify_db_session, permissions=permissions)
+    mocker.patch("app.notifications.receive_notifications.dao_fetch_services_by_sms_sender",
+                 return_value=[service])
     mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
+    mocked_logger = mocker.patch("flask.current_app.logger.error")
+
     response = client.post(path='/notifications/sms/receive/{}'.format(provider),
                            data=data,
                            headers=headers)
@@ -83,6 +87,7 @@ def test_receive_notification_without_permissions_does_not_create_inbound(
     assert response.get_data(as_text=True) == expected_response
     assert len(InboundSms.query.all()) == 0
     assert mocked.called is False
+    assert mocked_logger.call_args == call('Service "{}" does not allow inbound SMS'.format(service.id))
 
 
 @pytest.mark.parametrize('message, expected_output', [

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -12,11 +12,12 @@ from app.notifications.receive_notifications import (
     strip_leading_forty_four
 )
 
-from app.models import InboundSms
+from app.models import InboundSms, EMAIL_TYPE, SMS_TYPE, INBOUND_SMS_TYPE
 from tests.app.db import create_service
+from tests.app.conftest import sample_service
 
 
-def test_receive_notification_returns_received_to_mmg(client, sample_service, mocker):
+def test_receive_notification_returns_received_to_mmg(client, mocker, sample_service_full_permissions):
     mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
     data = {"ID": "1234",
             "MSISDN": "447700900855",
@@ -33,7 +34,34 @@ def test_receive_notification_returns_received_to_mmg(client, sample_service, mo
     assert response.status_code == 200
     assert response.get_data(as_text=True) == 'RECEIVED'
     inbound_sms_id = InboundSms.query.all()[0].id
-    mocked.assert_called_once_with([str(inbound_sms_id), str(sample_service.id)], queue="notify-internal-tasks")
+    mocked.assert_called_once_with(
+        [str(inbound_sms_id), str(sample_service_full_permissions.id)], queue="notify-internal-tasks")
+
+
+@pytest.mark.parametrize('permissions', [
+    ([SMS_TYPE]),
+    ([INBOUND_SMS_TYPE]),
+])
+def test_receive_notification_without_permissions_does_not_create_inbound(
+        client, mocker, notify_db, notify_db_session, permissions):
+    service = sample_service(notify_db, notify_db_session, permissions=permissions)
+    mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
+    data = {"ID": "1234",
+            "MSISDN": "447700900855",
+            "Message": "Some message to notify",
+            "Trigger": "Trigger?",
+            "Number": "testing",
+            "Channel": "SMS",
+            "DateRecieved": "2012-06-27 12:33:00"
+            }
+    response = client.post(path='/notifications/sms/receive/mmg',
+                           data=json.dumps(data),
+                           headers=[('Content-Type', 'application/json')])
+
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == 'RECEIVED'
+    assert len(InboundSms.query.all()) == 0
+    assert mocked.called is False
 
 
 @pytest.mark.parametrize('message, expected_output', [
@@ -55,8 +83,8 @@ def test_format_mmg_datetime(provider_date, expected_output):
     assert format_mmg_datetime(provider_date) == expected_output
 
 
-def test_create_inbound_mmg_sms_object(sample_service):
-    sample_service.sms_sender = 'foo'
+def test_create_inbound_mmg_sms_object(sample_service_full_permissions):
+    sample_service_full_permissions.sms_sender = 'foo'
     data = {
         'Message': 'hello+there+%F0%9F%93%A9',
         'Number': 'foo',
@@ -65,10 +93,10 @@ def test_create_inbound_mmg_sms_object(sample_service):
         'ID': 'bar',
     }
 
-    inbound_sms = create_inbound_sms_object(sample_service, format_mmg_message(data["Message"]),
+    inbound_sms = create_inbound_sms_object(sample_service_full_permissions, format_mmg_message(data["Message"]),
                                             data["MSISDN"], data["ID"], data["DateRecieved"], "mmg")
 
-    assert inbound_sms.service_id == sample_service.id
+    assert inbound_sms.service_id == sample_service_full_permissions.id
     assert inbound_sms.notify_number == 'foo'
     assert inbound_sms.user_number == '447700900001'
     assert inbound_sms.provider_date == datetime(2017, 1, 2, 3, 4, 5)
@@ -80,8 +108,8 @@ def test_create_inbound_mmg_sms_object(sample_service):
 
 @pytest.mark.parametrize('notify_number', ['foo', 'baz'], ids=['two_matching_services', 'no_matching_services'])
 def test_receive_notification_error_if_not_single_matching_service(client, notify_db_session, notify_number):
-    create_service(service_name='a', sms_sender='foo')
-    create_service(service_name='b', sms_sender='foo')
+    create_service(service_name='a', sms_sender='foo', service_permissions=[EMAIL_TYPE, SMS_TYPE, INBOUND_SMS_TYPE])
+    create_service(service_name='b', sms_sender='foo', service_permissions=[EMAIL_TYPE, SMS_TYPE, INBOUND_SMS_TYPE])
 
     data = {
         'Message': 'hello',
@@ -104,7 +132,8 @@ def test_receive_notification_returns_received_to_firetext(notify_db_session, cl
     mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
     mock = mocker.patch('app.notifications.receive_notifications.statsd_client.incr')
 
-    service = create_service(service_name='b', sms_sender='07111111111')
+    service = create_service(
+        service_name='b', sms_sender='07111111111', service_permissions=[EMAIL_TYPE, SMS_TYPE, INBOUND_SMS_TYPE])
 
     data = "source=07999999999&destination=07111111111&message=this is a message&time=2017-01-01 12:00:00"
 
@@ -127,7 +156,8 @@ def test_receive_notification_from_firetext_persists_message(notify_db_session, 
     mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
     mocker.patch('app.notifications.receive_notifications.statsd_client.incr')
 
-    service = create_service(service_name='b', sms_sender='07111111111')
+    service = create_service(
+        service_name='b', sms_sender='07111111111', service_permissions=[EMAIL_TYPE, SMS_TYPE, INBOUND_SMS_TYPE])
 
     data = "source=07999999999&destination=07111111111&message=this is a message&time=2017-01-01 12:00:00"
 
@@ -155,7 +185,8 @@ def test_receive_notification_from_firetext_persists_message_with_normalized_pho
     mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
     mock = mocker.patch('app.notifications.receive_notifications.statsd_client.incr')
 
-    create_service(service_name='b', sms_sender='07111111111')
+    create_service(
+        service_name='b', sms_sender='07111111111', service_permissions=[EMAIL_TYPE, SMS_TYPE, INBOUND_SMS_TYPE])
 
     data = "source=(+44)7999999999&destination=07111111111&message=this is a message&time=2017-01-01 12:00:00"
 
@@ -177,7 +208,8 @@ def test_returns_ok_to_firetext_if_mismatched_sms_sender(notify_db_session, clie
     mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
     mock = mocker.patch('app.notifications.receive_notifications.statsd_client.incr')
 
-    create_service(service_name='b', sms_sender='07111111199')
+    create_service(
+        service_name='b', sms_sender='07111111199', service_permissions=[EMAIL_TYPE, SMS_TYPE, INBOUND_SMS_TYPE])
 
     data = "source=(+44)7999999999&destination=07111111111&message=this is a message&time=2017-01-01 12:00:00"
 


### PR DESCRIPTION
This update prevents services that do not have inbound SMS and SMS permissions from storing the inbound sms message.