### PR TITLE
2/3 Stop updating old Notification status column

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -17,7 +17,7 @@ from app.statsd_decorators import statsd
 def dao_get_notification_outcomes_for_job(service_id, job_id):
     query = db.session.query(
         func.count(NotificationHistory.status).label('count'),
-        NotificationHistory.status.label('status')
+        NotificationHistory.status
     )
 
     return query \

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -411,7 +411,7 @@ def _timeout_notifications(current_statuses, new_status, timeout_start, updated_
             table.notification_type != LETTER_TYPE
         )
         last_update_count = q.update(
-            {'_status_enum': new_status, '_status_fkey': new_status, 'updated_at': updated_at},
+            {'status': new_status, 'updated_at': updated_at},
             synchronize_session=False
         )
     return last_update_count
@@ -432,8 +432,8 @@ def dao_timeout_notifications(timeout_period_in_seconds):
     """
     timeout_start = datetime.utcnow() - timedelta(seconds=timeout_period_in_seconds)
     updated_at = datetime.utcnow()
-
     timeout = functools.partial(_timeout_notifications, timeout_start=timeout_start, updated_at=updated_at)
+
     # Notifications still in created status are marked with a technical-failure:
     updated = timeout([NOTIFICATION_CREATED], NOTIFICATION_TECHNICAL_FAILURE)
 

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -262,8 +262,7 @@ def fetch_todays_total_message_count(service_id):
 def _stats_for_service_query(service_id):
     return db.session.query(
         Notification.notification_type,
-        # see dao_fetch_todays_stats_for_all_services for why we have this label
-        Notification.status.label('status'),
+        Notification.status,
         func.count(Notification.id).label('count')
     ).filter(
         Notification.service_id == service_id,
@@ -281,8 +280,7 @@ def dao_fetch_monthly_historical_stats_by_template_for_service(service_id, year)
     start_date, end_date = get_financial_year(year)
     sq = db.session.query(
         NotificationHistory.template_id,
-        # see dao_fetch_todays_stats_for_all_services for why we have this label
-        NotificationHistory.status.label('status'),
+        NotificationHistory.status,
         month.label('month'),
         func.count().label('count')
     ).filter(
@@ -298,7 +296,7 @@ def dao_fetch_monthly_historical_stats_by_template_for_service(service_id, year)
         Template.id.label('template_id'),
         Template.name,
         Template.template_type,
-        sq.c.status.label('status'),
+        sq.c.status,
         sq.c.count.label('count'),
         sq.c.month
     ).join(
@@ -316,8 +314,7 @@ def dao_fetch_monthly_historical_stats_for_service(service_id, year):
     start_date, end_date = get_financial_year(year)
     rows = db.session.query(
         NotificationHistory.notification_type,
-        # see dao_fetch_todays_stats_for_all_services for why we have this label
-        NotificationHistory.status.label('status'),
+        NotificationHistory.status,
         month,
         func.count(NotificationHistory.id).label('count')
     ).filter(
@@ -356,9 +353,7 @@ def dao_fetch_monthly_historical_stats_for_service(service_id, year):
 def dao_fetch_todays_stats_for_all_services(include_from_test_key=True):
     query = db.session.query(
         Notification.notification_type,
-        # this label is necessary as the column has a different name under the hood (_status_enum / _status_fkey),
-        # if we query the Notification object there is a hybrid property to translate, but here there isn't anything.
-        Notification.status.label('status'),
+        Notification.status,
         Notification.service_id,
         func.count(Notification.id).label('count')
     ).filter(
@@ -388,8 +383,7 @@ def fetch_stats_by_date_range_for_all_services(start_date, end_date, include_fro
 
     query = db.session.query(
         table.notification_type,
-        # see dao_fetch_todays_stats_for_all_services for why we have this label
-        table.status.label('status'),
+        table.status,
         table.service_id,
         func.count(table.id).label('count')
     ).filter(

--- a/app/dao/statistics_dao.py
+++ b/app/dao/statistics_dao.py
@@ -31,7 +31,7 @@ def timeout_job_counts(notifications_type, timeout_start):
     results = db.session.query(
         JobStatistics.job_id.label('job_id'),
         func.count(Notification.status).label('count'),
-        Notification.status.label('status')
+        Notification.status
     ).filter(
         Notification.notification_type == notifications_type,
         JobStatistics.job_id == Notification.job_id,

--- a/app/models.py
+++ b/app/models.py
@@ -788,14 +788,14 @@ class Notification(db.Model):
         unique=False,
         nullable=True,
         onupdate=datetime.datetime.utcnow)
-    _status_enum = db.Column('status', NOTIFICATION_STATUS_TYPES_ENUM, index=True, nullable=True, default='created')
-    _status_fkey = db.Column(
+    status = db.Column(
         'notification_status',
         db.String,
         db.ForeignKey('notification_status_types.name'),
         index=True,
         nullable=True,
-        default='created'
+        default='created',
+        key='status'  # http://docs.sqlalchemy.org/en/latest/core/metadata.html#sqlalchemy.schema.Column
     )
     reference = db.Column(db.String, nullable=True, index=True)
     client_reference = db.Column(db.String, index=True, nullable=True)
@@ -816,14 +816,6 @@ class Notification(db.Model):
 
     created_by = db.relationship('User')
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), nullable=True)
-
-    @hybrid_property
-    def status(self):
-        return self._status_fkey
-
-    @status.setter
-    def status(self, status):
-        self._status_fkey = status
 
     @property
     def personalisation(self):
@@ -998,14 +990,14 @@ class NotificationHistory(db.Model, HistoryModel):
     sent_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
     sent_by = db.Column(db.String, nullable=True)
     updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
-    _status_enum = db.Column('status', NOTIFICATION_STATUS_TYPES_ENUM, index=True, nullable=True, default='created')
-    _status_fkey = db.Column(
+    status = db.Column(
         'notification_status',
         db.String,
         db.ForeignKey('notification_status_types.name'),
         index=True,
         nullable=True,
-        default='created'
+        default='created',
+        key='status'  # http://docs.sqlalchemy.org/en/latest/core/metadata.html#sqlalchemy.schema.Column
     )
     reference = db.Column(db.String, nullable=True, index=True)
     client_reference = db.Column(db.String, nullable=True)
@@ -1026,14 +1018,6 @@ class NotificationHistory(db.Model, HistoryModel):
     def update_from_original(self, original):
         super().update_from_original(original)
         self.status = original.status
-
-    @hybrid_property
-    def status(self):
-        return self._status_fkey
-
-    @status.setter
-    def status(self, status):
-        self._status_fkey = status
 
 
 INVITED_USER_STATUS_TYPES = ['pending', 'accepted', 'cancelled']

--- a/app/models.py
+++ b/app/models.py
@@ -819,12 +819,11 @@ class Notification(db.Model):
 
     @hybrid_property
     def status(self):
-        return self._status_enum
+        return self._status_fkey
 
     @status.setter
     def status(self, status):
         self._status_fkey = status
-        self._status_enum = status
 
     @property
     def personalisation(self):
@@ -1030,12 +1029,11 @@ class NotificationHistory(db.Model, HistoryModel):
 
     @hybrid_property
     def status(self):
-        return self._status_enum
+        return self._status_fkey
 
     @status.setter
     def status(self, status):
         self._status_fkey = status
-        self._status_enum = status
 
 
 INVITED_USER_STATUS_TYPES = ['pending', 'accepted', 'cancelled']

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -260,7 +260,7 @@ class NotificationModelSchema(BaseSchema):
     class Meta:
         model = models.Notification
         strict = True
-        exclude = ('_personalisation', 'job', 'service', 'template', 'api_key', '_status_enum', '_status_fkey')
+        exclude = ('_personalisation', 'job', 'service', 'template', 'api_key',)
 
     status = fields.String(required=False)
 
@@ -416,7 +416,7 @@ class NotificationWithTemplateSchema(BaseSchema):
     class Meta:
         model = models.Notification
         strict = True
-        exclude = ('_personalisation', '_status_enum', '_status_fkey')
+        exclude = ('_personalisation', )
 
     template = fields.Nested(
         TemplateSchema,

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -157,13 +157,8 @@ def test_update_status_of_notifications_after_timeout(notify_api, sample_templat
         timeout_notifications()
 
         assert not1.status == 'temporary-failure'
-        assert not1._status_fkey == 'temporary-failure'
-
         assert not2.status == 'technical-failure'
-        assert not2._status_fkey == 'technical-failure'
-
         assert not3.status == 'temporary-failure'
-        assert not3._status_fkey == 'temporary-failure'
 
 
 def test_not_update_status_of_notification_before_timeout(notify_api, sample_template):

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -40,7 +40,8 @@ def test_should_get_all_statuses_for_notifications_associated_with_job(
         notify_db,
         notify_db_session,
         sample_service,
-        sample_job):
+        sample_job
+):
     notification = partial(create_notification, notify_db, notify_db_session, service=sample_service, job=sample_job)
     notification(status='created')
     notification(status='sending')
@@ -53,7 +54,7 @@ def test_should_get_all_statuses_for_notifications_associated_with_job(
     notification(status='sent')
 
     results = dao_get_notification_outcomes_for_job(sample_service.id, sample_job.id)
-    assert [(row.count, row.status) for row in results] == [
+    assert set([(row.count, row.status) for row in results]) == set([
         (1, 'created'),
         (1, 'sending'),
         (1, 'delivered'),
@@ -63,17 +64,19 @@ def test_should_get_all_statuses_for_notifications_associated_with_job(
         (1, 'temporary-failure'),
         (1, 'permanent-failure'),
         (1, 'sent')
-    ]
+    ])
 
 
 def test_should_count_of_statuses_for_notifications_associated_with_job(
         notify_db,
         notify_db_session,
         sample_service,
-        sample_job):
+        sample_job
+):
     notification = partial(create_notification, notify_db, notify_db_session, service=sample_service, job=sample_job)
     notification(status='created')
     notification(status='created')
+
     notification(status='sending')
     notification(status='sending')
     notification(status='sending')
@@ -82,11 +85,11 @@ def test_should_count_of_statuses_for_notifications_associated_with_job(
     notification(status='delivered')
 
     results = dao_get_notification_outcomes_for_job(sample_service.id, sample_job.id)
-    assert [(row.count, row.status) for row in results] == [
+    assert set([(row.count, row.status) for row in results]) == set([
         (2, 'created'),
         (4, 'sending'),
         (2, 'delivered')
-    ]
+    ])
 
 
 def test_should_return_zero_length_array_if_no_notifications_for_job(sample_service, sample_job):

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -410,7 +410,7 @@ def test_should_by_able_to_update_status_by_id(sample_template, sample_job, mmg_
         data = _notification_json(sample_template, job_id=sample_job.id, status='sending')
         notification = Notification(**data)
         dao_create_notification(notification)
-        assert notification._status_fkey == 'sending'
+        assert notification.status == 'sending'
 
     assert Notification.query.get(notification.id).status == 'sending'
 
@@ -421,7 +421,7 @@ def test_should_by_able_to_update_status_by_id(sample_template, sample_job, mmg_
     assert updated.updated_at == datetime(2000, 1, 2, 12, 0, 0)
     assert Notification.query.get(notification.id).status == 'delivered'
     assert notification.updated_at == datetime(2000, 1, 2, 12, 0, 0)
-    assert notification._status_fkey == 'delivered'
+    assert notification.status == 'delivered'
 
 
 def test_should_not_update_status_by_id_if_not_sending_and_does_not_update_job(notify_db, notify_db_session):

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -410,7 +410,6 @@ def test_should_by_able_to_update_status_by_id(sample_template, sample_job, mmg_
         data = _notification_json(sample_template, job_id=sample_job.id, status='sending')
         notification = Notification(**data)
         dao_create_notification(notification)
-        assert notification._status_enum == 'sending'
         assert notification._status_fkey == 'sending'
 
     assert Notification.query.get(notification.id).status == 'sending'
@@ -422,7 +421,6 @@ def test_should_by_able_to_update_status_by_id(sample_template, sample_job, mmg_
     assert updated.updated_at == datetime(2000, 1, 2, 12, 0, 0)
     assert Notification.query.get(notification.id).status == 'delivered'
     assert notification.updated_at == datetime(2000, 1, 2, 12, 0, 0)
-    assert notification._status_enum == 'delivered'
     assert notification._status_fkey == 'delivered'
 
 
@@ -950,43 +948,12 @@ def test_get_notification_billable_unit_count_per_month(notify_db, notify_db_ses
         ) == months
 
 
-def test_update_notification(sample_notification):
+def test_update_notification_sets_status(sample_notification):
     assert sample_notification.status == 'created'
     sample_notification.status = 'failed'
     dao_update_notification(sample_notification)
     notification_from_db = Notification.query.get(sample_notification.id)
     assert notification_from_db.status == 'failed'
-
-
-def test_update_notification_with_no_notification_status(sample_notification):
-    # specifically, it has an old enum status, but not a new status (because the upgrade script has just run)
-    update_dict = {'_status_enum': 'created', '_status_fkey': None}
-    Notification.query.filter(Notification.id == sample_notification.id).update(update_dict)
-
-    # now lets update the status to failed - both columns should now be populated
-    sample_notification.status = 'failed'
-    dao_update_notification(sample_notification)
-
-    notification_from_db = Notification.query.get(sample_notification.id)
-    assert notification_from_db.status == 'failed'
-    assert notification_from_db._status_enum == 'failed'
-    assert notification_from_db._status_fkey == 'failed'
-
-
-def test_updating_notification_with_no_notification_status_updates_notification_history(sample_notification):
-    # same as above, but with notification history
-    update_dict = {'_status_enum': 'created', '_status_fkey': None}
-    Notification.query.filter(Notification.id == sample_notification.id).update(update_dict)
-    NotificationHistory.query.filter(NotificationHistory.id == sample_notification.id).update(update_dict)
-
-    # now lets update the notification's status to failed - both columns should now be populated on the history object
-    sample_notification.status = 'failed'
-    dao_update_notification(sample_notification)
-
-    hist_from_db = NotificationHistory.query.get(sample_notification.id)
-    assert hist_from_db.status == 'failed'
-    assert hist_from_db._status_enum == 'failed'
-    assert hist_from_db._status_fkey == 'failed'
 
 
 @pytest.mark.parametrize('notification_type, expected_sms_count, expected_email_count, expected_letter_count', [

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -463,8 +463,6 @@ def test_get_all_notifications_for_job_returns_correct_format(
     assert len(resp['notifications']) == 1
     assert resp['notifications'][0]['id'] == str(sample_notification_with_job.id)
     assert resp['notifications'][0]['status'] == sample_notification_with_job.status
-    assert '_status_fkey' not in resp['notifications'][0]
-    assert '_status_enum' not in resp['notifications'][0]
 
 
 def test_get_job_by_id(notify_api, sample_job):

--- a/tests/app/test_schemas.py
+++ b/tests/app/test_schemas.py
@@ -44,8 +44,6 @@ def test_notification_schema_has_correct_status(sample_notification, schema_name
     data = getattr(schemas, schema_name).dump(sample_notification).data
 
     assert data['status'] == sample_notification.status
-    assert '_status_enum' not in data
-    assert '_status_fkey' not in data
 
 
 @pytest.mark.parametrize('user_attribute, user_value', [


### PR DESCRIPTION
This stops updating the old `Notification. _status_enum` and `NotificationHistory. _status_enum` columns and instead will now only update the newer `_status_fkey` column.

## Notes

- Return new column when calling `.status`
- Remove unncessary tests that were checking `._status_enum` was being populated
- Updates some tests which can cause failure if unordered
