### PR TITLE
Fix syncing issue with Notification statuses

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -410,7 +410,10 @@ def _timeout_notifications(current_statuses, new_status, timeout_start, updated_
             table.status.in_(current_statuses),
             table.notification_type != LETTER_TYPE
         )
-        last_update_count = q.update({'status': new_status, 'updated_at': updated_at}, synchronize_session=False)
+        last_update_count = q.update(
+            {'_status_enum': new_status, '_status_fkey': new_status, 'updated_at': updated_at},
+            synchronize_session=False
+        )
     return last_update_count
 
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -155,9 +155,15 @@ def test_update_status_of_notifications_after_timeout(notify_api, sample_templat
             created_at=datetime.utcnow() - timedelta(
                 seconds=current_app.config.get('SENDING_NOTIFICATIONS_TIMEOUT_PERIOD') + 10))
         timeout_notifications()
+
         assert not1.status == 'temporary-failure'
+        assert not1._status_fkey == 'temporary-failure'
+
         assert not2.status == 'technical-failure'
+        assert not2._status_fkey == 'technical-failure'
+
         assert not3.status == 'temporary-failure'
+        assert not3._status_fkey == 'temporary-failure'
 
 
 def test_not_update_status_of_notification_before_timeout(notify_api, sample_template):


### PR DESCRIPTION
This fixes an issue where the status fields for `Notification` and `NotificationHistory` are not being synced correctly.

## Summary

The scheduled job `timeout_notifications` times out notifications after three days. This results in the statuses in both `[Notification, NotificationHistory]` to be updated based on some rules.

However, this does not correctly update **both** status fields (_status_enum, _status_fkey) correctly to keep them in sync. 

Once this is in place, another DB command will need to be run that clean up the mess.