### PR TITLE
1/3 Make Notification._status_enum and NotificationHistory._status_enum nullable

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -788,7 +788,7 @@ class Notification(db.Model):
         unique=False,
         nullable=True,
         onupdate=datetime.datetime.utcnow)
-    _status_enum = db.Column('status', NOTIFICATION_STATUS_TYPES_ENUM, index=True, nullable=False, default='created')
+    _status_enum = db.Column('status', NOTIFICATION_STATUS_TYPES_ENUM, index=True, nullable=True, default='created')
     _status_fkey = db.Column(
         'notification_status',
         db.String,
@@ -999,7 +999,7 @@ class NotificationHistory(db.Model, HistoryModel):
     sent_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
     sent_by = db.Column(db.String, nullable=True)
     updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
-    _status_enum = db.Column('status', NOTIFICATION_STATUS_TYPES_ENUM, index=True, nullable=False, default='created')
+    _status_enum = db.Column('status', NOTIFICATION_STATUS_TYPES_ENUM, index=True, nullable=True, default='created')
     _status_fkey = db.Column(
         'notification_status',
         db.String,

--- a/migrations/versions/0106_null_noti_status.py
+++ b/migrations/versions/0106_null_noti_status.py
@@ -1,0 +1,55 @@
+"""
+
+Revision ID: 0106_null_noti_status
+Revises: 0105_opg_letter_org
+Create Date: 2017-07-10 11:18:27.267721
+
+"""
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = '0106_null_noti_status'
+down_revision = '0105_opg_letter_org'
+
+
+def upgrade():
+    op.alter_column(
+        'notification_history',
+        'status',
+        existing_type=postgresql.ENUM(
+            'created', 'sending', 'delivered', 'pending', 'failed', 'technical-failure',
+            'temporary-failure', 'permanent-failure', 'sent', name='notify_status_type'
+        ),
+        nullable=True
+    )
+    op.alter_column(
+        'notifications',
+        'status',
+        existing_type=postgresql.ENUM(
+            'created', 'sending', 'delivered', 'pending', 'failed', 'technical-failure',
+            'temporary-failure', 'permanent-failure', 'sent', name='notify_status_type'
+        ),
+        nullable=True
+    )
+
+
+def downgrade():
+    op.alter_column(
+        'notifications',
+        'status',
+        existing_type=postgresql.ENUM(
+            'created', 'sending', 'delivered', 'pending', 'failed', 'technical-failure',
+            'temporary-failure', 'permanent-failure', 'sent', name='notify_status_type'
+        ),
+        nullable=False
+    )
+    op.alter_column(
+        'notification_history',
+        'status',
+        existing_type=postgresql.ENUM(
+            'created', 'sending', 'delivered', 'pending', 'failed', 'technical-failure',
+            'temporary-failure', 'permanent-failure', 'sent', name='notify_status_type'
+        ),
+        nullable=False
+    )


### PR DESCRIPTION
## Summary

Before we can remove `_status_enum` we need to make this column nullable. This will ensure that when we create notifications after removing this, the `status` field in the `Notification` and `NotificationHistory` tables can be set to `null` allowing us to still create notifications despite not populating this field.

I tested this locally with 9m notifications and it ran in a second so no potential issues on that front.

## Next Steps

2/3 - Stop updating old Notification status column
3/3 - Delete the old column