### PR TITLE
don't store non-strings to os.environ

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -43,7 +43,7 @@ def extract_notify_config(notify_config):
     os.environ['SECRET_KEY'] = notify_config['credentials']['secret_key']
     os.environ['DANGEROUS_SALT'] = notify_config['credentials']['dangerous_salt']
     os.environ['PERFORMANCE_PLATFORM_TOKEN'] = notify_config['credentials'].get('performance_platform_token', '')
-    os.environ['SMS_INBOUND_WHITELIST'] = notify_config['credentials']['allow_ip_inbound_sms']
+    os.environ['SMS_INBOUND_WHITELIST'] = json.dumps(notify_config['credentials']['allow_ip_inbound_sms'])
 
 
 def extract_notify_aws_config(aws_config):

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 import os
+import json
 
 from celery.schedules import crontab
 from kombu import Exchange, Queue
@@ -262,7 +263,7 @@ class Config(object):
 
     FREE_SMS_TIER_FRAGMENT_COUNT = 250000
 
-    SMS_INBOUND_WHITELIST = os.environ.get('SMS_INBOUND_WHITELIST', [])
+    SMS_INBOUND_WHITELIST = json.loads(os.environ.get('SMS_INBOUND_WHITELIST', '[]'))
 
 
 ######################

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -204,4 +204,4 @@ def test_redis_config():
 def test_sms_inbound_config():
     extract_cloudfoundry_config()
 
-    assert os.environ['SMS_INBOUND_WHITELIST'] == ['111.111.111.111', '100.100.100.100']
+    assert os.environ['SMS_INBOUND_WHITELIST'] == json.dumps(['111.111.111.111', '100.100.100.100'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,13 @@ def os_environ():
     """
     # for use whenever you expect code to edit environment variables
     old_env = os.environ.copy()
-    os.environ = {}
+
+    class EnvironDict(dict):
+        def __setitem__(self, key, value):
+            assert type(value) == str
+            super().__setitem__(key, value)
+
+    os.environ = EnvironDict()
     yield
     os.environ = old_env
 


### PR DESCRIPTION
in tests, we were replacing os.environ with a basic dict so that
we didn't overwrite the contents of the real environment during tests.
However, os.environ doesn't accept non-str values, so this commit
changes the fixture so that it asserts all values set are strings.
We needed to change how we store ip whitelist stuff in the env because
of this.