### PR TITLE
Extra logging for delivery receipts

### DIFF
--- a/app/notifications/notifications_sms_callback.py
+++ b/app/notifications/notifications_sms_callback.py
@@ -1,4 +1,5 @@
 from flask import Blueprint
+from flask import current_app
 from flask import json
 from flask import request, jsonify
 
@@ -22,6 +23,10 @@ def process_mmg_response():
     success, errors = process_sms_client_response(status=str(data.get('status')),
                                                   reference=data.get('CID'),
                                                   client_name=client_name)
+
+    current_app.logger.info(
+        "Full delivery response from {} for notification: {}\n{}".format(client_name, request.form.get('reference'),
+                                                                         request.form))
     if errors:
         raise InvalidRequest(errors, status_code=400)
     else:
@@ -38,6 +43,9 @@ def process_firetext_response():
         raise InvalidRequest(errors, status_code=400)
 
     status = request.form.get('status')
+    current_app.logger.info(
+        "Full delivery response from {} for notification: {}\n{}".format(client_name, request.form.get('reference'),
+                                                                         request.form))
     success, errors = process_sms_client_response(status=status,
                                                   reference=request.form.get('reference'),
                                                   client_name=client_name)


### PR DESCRIPTION
Added logging to show the entire form posted to us by the SMS client providers.

This can be useful information when debugging what happened to a notification.
Recently there was a discrepancy between the failure type used by each provider for a particular number, this logging would have helped.