### PR TITLE
remove `sqs` from region - this is only needed in boto2

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -13,7 +13,7 @@ class CeleryConfig:
         self.broker_url = config.get('BROKER_URL', 'sqs://')
 
     broker_transport_options = {
-        'region': 'sqs.eu-west-1',
+        'region': 'eu-west-1',
         'polling_interval': 1,  # 1 second
         'visibility_timeout': 310,
         'queue_name_prefix': None


### PR DESCRIPTION
We don't use boto2 on the api anymore, not since celery 4.0.2

Note - if you run locally with boto2 still installed you'll see errors that complain about things like:

boto.exception.SQSError: SQSError: 403 Forbidden
<?xml version="1.0"?><ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><Error><Type>Sender</Type><Code>SignatureDoesNotMatch</Code><Message>Credential should be scoped to a valid region, not 'queue'. </Message><Detail/></Error><RequestId>52207ca4-9131-58cb-89ae-2d45f06623a3</RequestId></ErrorResponse>

If so, make sure boto2 is completely uninstalled.