### PR TITLE
Consider one-off notifications to be jobs

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -339,6 +339,7 @@ def get_notifications_for_service(
 
     if not include_jobs or (key_type and key_type != KEY_TYPE_NORMAL):
         filters.append(Notification.job_id.is_(None))
+        filters.append(Notification.api_key_id.isnot(None))
 
     if key_type is not None:
         filters.append(Notification.key_type == key_type)

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -507,7 +507,7 @@ def sample_notification(
         'billable_units': billable_units,
         'personalisation': personalisation,
         'notification_type': template.template_type,
-        'api_key_id': api_key_id,
+        'api_key_id': api_key_id or sample_api_key(notify_db, notify_db_session).id,
         'key_type': key_type,
         'sent_by': sent_by,
         'updated_at': created_at if status in NOTIFICATION_STATUS_TYPES_COMPLETED else None,

--- a/tests/app/dao/test_notification_dao.py
+++ b/tests/app/dao/test_notification_dao.py
@@ -836,12 +836,12 @@ def test_get_notification_by_id(notify_db, notify_db_session, sample_template):
     assert notification_from_db.scheduled_notification.scheduled_for == datetime(2017, 5, 5, 14, 15)
 
 
-def test_get_notifications_by_reference(notify_db, notify_db_session, sample_service):
+def test_get_notifications_by_reference(notify_db, notify_db_session, sample_service, sample_api_key):
     client_reference = 'some-client-ref'
     assert len(Notification.query.all()) == 0
-    sample_notification(notify_db, notify_db_session, client_reference=client_reference)
-    sample_notification(notify_db, notify_db_session, client_reference=client_reference)
-    sample_notification(notify_db, notify_db_session, client_reference='other-ref')
+    sample_notification(notify_db, notify_db_session, api_key_id=sample_api_key.id, client_reference=client_reference)
+    sample_notification(notify_db, notify_db_session, api_key_id=sample_api_key.id, client_reference=client_reference)
+    sample_notification(notify_db, notify_db_session, api_key_id=sample_api_key.id, client_reference='other-ref')
     all_notifications = get_notifications_for_service(sample_service.id, client_reference=client_reference).items
     assert len(all_notifications) == 2
 
@@ -1066,14 +1066,25 @@ def test_should_not_delete_notification_history(notify_db, notify_db_session, sa
 
 
 @freeze_time("2016-01-10")
-def test_should_limit_notifications_return_by_day_limit_plus_one(notify_db, notify_db_session, sample_service):
+def test_should_limit_notifications_return_by_day_limit_plus_one(
+    notify_db,
+    notify_db_session,
+    sample_service,
+    sample_api_key
+):
     assert len(Notification.query.all()) == 0
 
     # create one notification a day between 1st and 9th
     for i in range(1, 11):
         past_date = '2016-01-{0:02d}'.format(i)
         with freeze_time(past_date):
-            sample_notification(notify_db, notify_db_session, created_at=datetime.utcnow(), status="failed")
+            sample_notification(
+                notify_db,
+                notify_db_session,
+                api_key_id=sample_api_key.id,
+                created_at=datetime.utcnow(),
+                status="failed"
+            )
 
     all_notifications = Notification.query.all()
     assert len(all_notifications) == 10
@@ -1302,15 +1313,20 @@ def test_dao_timeout_notifications_doesnt_affect_letters(sample_letter_template)
     assert updated == 0
 
 
-def test_should_return_notifications_excluding_jobs_by_default(notify_db, notify_db_session, sample_service):
+def test_should_return_notifications_excluding_jobs_by_default(
+    notify_db,
+    notify_db_session,
+    sample_service,
+    sample_api_key,
+):
     assert len(Notification.query.all()) == 0
 
     job = sample_job(notify_db, notify_db_session)
     with_job = sample_notification(
-        notify_db, notify_db_session, created_at=datetime.utcnow(), status="delivered", job=job
+        notify_db, notify_db_session, created_at=datetime.utcnow(), status="delivered", api_key_id=None
     )
     without_job = sample_notification(
-        notify_db, notify_db_session, created_at=datetime.utcnow(), status="delivered"
+        notify_db, notify_db_session, created_at=datetime.utcnow(), status="delivered", api_key_id=sample_api_key.id
     )
 
     all_notifications = Notification.query.all()

--- a/tests/app/notifications/test_rest.py
+++ b/tests/app/notifications/test_rest.py
@@ -263,7 +263,6 @@ def test_no_api_keys_return_job_notifications_by_default(
     job_notification = create_sample_notification(
         notify_db,
         notify_db_session,
-        api_key_id=normal_api_key.id,
         job=sample_job
     )
     normal_notification = create_sample_notification(


### PR DESCRIPTION
When we get back the notifications for a service there is the option to filter out those created by a job.

Previously this excluded one-off notifications, because they created a job. Now that they are created directly by the API they are not getting filtered out.

This commit changes the filter to consider a one-off notification to still be created by a job because:
- it keeps the behaviour the same as before
- it means the API integration page is no longer weirdly showing one-off
  messages