### PR TITLE
[1/3] add separate send-sms and send-email queues

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -182,7 +182,7 @@ def send_sms(self,
 
         provider_tasks.deliver_sms.apply_async(
             [str(saved_notification.id)],
-            queue=QueueNames.SEND if not service.research_mode else QueueNames.RESEARCH_MODE
+            queue=QueueNames.SEND_COMBINED if not service.research_mode else QueueNames.RESEARCH_MODE
         )
 
         current_app.logger.info(
@@ -227,7 +227,7 @@ def send_email(self,
 
         provider_tasks.deliver_email.apply_async(
             [str(saved_notification.id)],
-            queue=QueueNames.SEND if not service.research_mode else QueueNames.RESEARCH_MODE
+            queue=QueueNames.SEND_COMBINED if not service.research_mode else QueueNames.RESEARCH_MODE
         )
 
         current_app.logger.info("Email {} created at {}".format(saved_notification.id, created_at))

--- a/app/config.py
+++ b/app/config.py
@@ -22,7 +22,9 @@ class QueueNames(object):
     PERIODIC = 'periodic-tasks'
     PRIORITY = 'priority-tasks'
     DATABASE = 'database-tasks'
-    SEND = 'send-tasks'
+    SEND_COMBINED = 'send-tasks'
+    SEND_SMS = 'send-sms-tasks'
+    SEND_EMAIL = 'send-email-tasks'
     RESEARCH_MODE = 'research-mode-tasks'
     STATISTICS = 'statistics-tasks'
     JOBS = 'job-tasks'
@@ -36,7 +38,9 @@ class QueueNames(object):
             QueueNames.PRIORITY,
             QueueNames.PERIODIC,
             QueueNames.DATABASE,
-            QueueNames.SEND,
+            QueueNames.SEND_COMBINED,
+            QueueNames.SEND_SMS,
+            QueueNames.SEND_EMAIL,
             QueueNames.RESEARCH_MODE,
             QueueNames.STATISTICS,
             QueueNames.JOBS,

--- a/app/delivery/rest.py
+++ b/app/delivery/rest.py
@@ -42,4 +42,4 @@ def send_response(send_call, task_call, notification):
                 notification.id,
                 notification.notification_type),
             e)
-        task_call.apply_async((str(notification.id)), queue=QueueNames.SEND)
+        task_call.apply_async((str(notification.id)), queue=QueueNames.SEND_COMBINED)

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -101,7 +101,7 @@ def send_notification_to_queue(notification, research_mode, queue=None):
     if research_mode or notification.key_type == KEY_TYPE_TEST:
         queue = QueueNames.RESEARCH_MODE
     elif not queue:
-        queue = QueueNames.SEND
+        queue = QueueNames.SEND_COMBINED
 
     if notification.notification_type == SMS_TYPE:
         deliver_task = provider_tasks.deliver_sms

--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -33,7 +33,7 @@ applications:
       NOTIFY_APP_NAME: delivery-worker-research
 
   - name: notify-delivery-worker-sender
-    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q send-tasks
+    command: scripts/run_app_paas.sh celery -A aws_run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q send-tasks,send-sms-tasks,send-email-tasks
     env:
       NOTIFY_APP_NAME: delivery-worker-sender
 


### PR DESCRIPTION
we're reading from those two queues as well as the existing send queue, however for now we don't send anything to them

we don't want to start sending immediately notifications to the new queues or they won't be picked up while the deploy's underway


- [x] read from new and old queues 
- [ ] send to new queues instead of old queue
- [ ] remove old queue