### PR TITLE
Fix for simulated notifications.

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime
 
 from flask import current_app
@@ -53,7 +54,8 @@ def persist_notification(
     created_by_id=None
 ):
     notification_created_at = created_at or datetime.utcnow()
-
+    if not notification_id and simulated:
+        notification_id = uuid.uuid4()
     notification = Notification(
         id=notification_id,
         template_id=template_id,

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -201,6 +201,7 @@ def test_should_not_persist_or_send_notification_if_simulated_recipient(
 
     assert response.status_code == 201
     apply_async.assert_not_called()
+    assert json.loads(response.get_data(as_text=True))["id"]
     assert Notification.query.count() == 0
 
 


### PR DESCRIPTION
When a post is made for a simulated number the id is empty in the notificaiton object that we return.
This fixes that.