### PR TITLE
Remove wheels-ing on deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,5 @@ environment.sh
 
 celerybeat-schedule
 
-wheelhouse/
-
 # CloudFoundry
 .cf

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,7 @@ generate-version-file: ## Generates the app version file
 
 .PHONY: build
 build: dependencies generate-version-file ## Build project
-	rm -rf wheelhouse
-	. venv/bin/activate && PIP_ACCEL_CACHE=${PIP_ACCEL_CACHE} pip-accel wheel --wheel-dir=wheelhouse -r requirements.txt
+	. venv/bin/activate && PIP_ACCEL_CACHE=${PIP_ACCEL_CACHE} pip-accel install -r requirements.txt
 
 .PHONY: cf-build
 cf-build: dependencies generate-version-file ## Build project for PAAS
@@ -260,7 +259,7 @@ clean-docker-containers: ## Clean up any remaining docker containers
 
 .PHONY: clean
 clean:
-	rm -rf node_modules cache target venv .coverage build tests/.cache wheelhouse
+	rm -rf node_modules cache target venv .coverage build tests/.cache
 
 .PHONY: cf-login
 cf-login: ## Log in to Cloud Foundry

--- a/scripts/aws_install_dependencies.sh
+++ b/scripts/aws_install_dependencies.sh
@@ -5,4 +5,4 @@ set -eo pipefail
 echo "Install dependencies"
 
 cd /home/notify-app/notifications-api;
-pip3 install --find-links=wheelhouse -r /home/notify-app/notifications-api/requirements.txt
+pip3 install -r /home/notify-app/notifications-api/requirements.txt


### PR DESCRIPTION
This removes storing wheels for offline installation as we used for AWS.

Will need to manually remove the `wheelhouse` folders on the Jenkins before merging this.