### PR TITLE
Update email logo to use logo CDN

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -115,7 +115,6 @@ class Config(object):
     PAGE_SIZE = 50
     API_PAGE_SIZE = 250
     SMS_CHAR_COUNT_LIMIT = 495
-    BRANDING_PATH = '/images/email-template/crests/'
     TEST_MESSAGE_FILENAME = 'Test message'
     ONE_OFF_MESSAGE_FILENAME = 'Report'
     MAX_VERIFY_CODE_COUNT = 10

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -155,11 +155,9 @@ def get_logo_url(base_url, logo_file):
         # strip "www."
         netloc = base_url.netloc[4:]
 
-    netloc = 'static-logos.' + netloc
-
     logo_url = parse.ParseResult(
         scheme=base_url.scheme,
-        netloc=netloc,
+        netloc='static-logos.' + netloc,
         path=logo_file,
         params=base_url.params,
         query=base_url.query,

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -145,34 +145,22 @@ def provider_to_use(notification_type, notification_id, international=False):
     return clients.get_client_by_name_and_type(active_providers_in_order[0].identifier, notification_type)
 
 
-def get_logo_url(base_url, branding_path, logo_file):
-    """
-    Get the complete URL for a given logo.
-
-    We have to convert the base_url into a static url. Our hosted environments all have their own cloudfront instances,
-    found at the static subdomain (eg https://static.notifications.service.gov.uk).
-
-    If running locally (dev environment), don't try and use cloudfront - just stick to the actual underlying source
-    ({URL}/static/{PATH})
-    """
+def get_logo_url(base_url, logo_file):
     base_url = parse.urlparse(base_url)
     netloc = base_url.netloc
 
-    # covers both preview and staging
-    if base_url.netloc.startswith('localhost') or 'notify.works' in base_url.netloc:
-        path = '/static' + branding_path + logo_file
-    else:
-        if base_url.netloc.startswith('www'):
-            # strip "www."
-            netloc = base_url.netloc[4:]
+    if base_url.netloc.startswith('localhost'):
+        netloc = 'notify.tools'
+    elif base_url.netloc.startswith('www'):
+        # strip "www."
+        netloc = base_url.netloc[4:]
 
-        netloc = 'static.' + netloc
-        path = branding_path + logo_file
+    netloc = 'static-logos.' + netloc
 
     logo_url = parse.ParseResult(
         scheme=base_url.scheme,
         netloc=netloc,
-        path=path,
+        path=logo_file,
         params=base_url.params,
         query=base_url.query,
         fragment=base_url.fragment
@@ -185,7 +173,6 @@ def get_html_email_options(service):
     if service.organisation:
         logo_url = get_logo_url(
             current_app.config['ADMIN_BASE_URL'],
-            current_app.config['BRANDING_PATH'],
             service.organisation.logo
         )
 

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -435,29 +435,22 @@ def test_get_html_email_renderer_prepends_logo_path(notify_api):
 
     renderer = send_to_providers.get_html_email_options(service)
 
-    assert renderer['brand_logo'] == 'http://localhost:6012/static/images/email-template/crests/justice-league.png'
+    assert renderer['brand_logo'] == 'http://static-logos.notify.tools/justice-league.png'
 
 
 @pytest.mark.parametrize('base_url, expected_url', [
     # don't change localhost to prevent errors when testing locally
-    ('http://localhost:6012', 'http://localhost:6012/static/sub-path/filename.png'),
-    # on other environments, replace www with staging
-    ('https://www.notifications.service.gov.uk', 'https://static.notifications.service.gov.uk/sub-path/filename.png'),
-
-    # staging and preview do not have cloudfront running, so should act as localhost
-    pytest.mark.xfail(('https://www.notify.works', 'https://static.notify.works/sub-path/filename.png')),
-    pytest.mark.xfail(('https://www.staging-notify.works', 'https://static.notify.works/sub-path/filename.png')),
-    pytest.mark.xfail(('https://notify.works', 'https://static.notify.works/sub-path/filename.png')),
-    pytest.mark.xfail(('https://staging-notify.works', 'https://static.notify.works/sub-path/filename.png')),
-    # these tests should be removed when cloudfront works on staging/preview
-    ('https://www.notify.works', 'https://www.notify.works/static/sub-path/filename.png'),
-    ('https://www.staging-notify.works', 'https://www.staging-notify.works/static/sub-path/filename.png'),
+    ('http://localhost:6012', 'http://static-logos.notify.tools/filename.png'),
+    ('https://www.notifications.service.gov.uk', 'https://static-logos.notifications.service.gov.uk/filename.png'),
+    ('https://notify.works', 'https://static-logos.notify.works/filename.png'),
+    ('https://staging-notify.works', 'https://static-logos.staging-notify.works/filename.png'),
+    ('https://www.notify.works', 'https://static-logos.notify.works/filename.png'),
+    ('https://www.staging-notify.works', 'https://static-logos.staging-notify.works/filename.png'),
 ])
 def test_get_logo_url_works_for_different_environments(base_url, expected_url):
-    branding_path = '/sub-path/'
     logo_file = 'filename.png'
 
-    logo_url = send_to_providers.get_logo_url(base_url, branding_path, logo_file)
+    logo_url = send_to_providers.get_logo_url(base_url, logo_file)
 
     assert logo_url == expected_url
 


### PR DESCRIPTION
## What 

In order to manage organisation logos from Admin, the API has to be updated to deliver images from a CDN which is pointing at the S3 logos bucket. 

In preparation any existing logos in use have been uploaded to the s3 bucket so that any emails sent out via the api will pick them up from the logo CDN and not the static location on the web app folder. 

This should ensure no breaks during the update of the API as the existing logos will still be available in the static web app folder.

Step 3/5 from https://www.pivotaltracker.com/story/show/148289053

## How to review

Send an email to yourself from a template that is using a logo
- check that the logo image can be seen
- right click on the logo to check that the image src is the logo CDN