### PR TITLE
Update the last template usage query to check Notification table

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -149,11 +149,11 @@ def dao_get_template_usage(service_id, limit_days=None):
 
 @statsd(namespace="dao")
 def dao_get_last_template_usage(template_id):
-    return NotificationHistory.query.filter(
-        NotificationHistory.template_id == template_id,
-        NotificationHistory.key_type != KEY_TYPE_TEST
+    return Notification.query.filter(
+        Notification.template_id == template_id,
+        Notification.key_type != KEY_TYPE_TEST
     ).order_by(
-        desc(NotificationHistory.created_at)
+        desc(Notification.created_at)
     ).first()
 
 

--- a/tests/app/template_statistics/test_rest.py
+++ b/tests/app/template_statistics/test_rest.py
@@ -211,8 +211,8 @@ def test_get_template_statistics_by_id_returns_last_notification(
 
 
 def test_get_template_statistics_for_template_returns_empty_if_no_statistics(
-        client,
-        sample_template,
+    client,
+    sample_template,
 ):
     auth_header = create_authorization_header()
 
@@ -221,7 +221,24 @@ def test_get_template_statistics_for_template_returns_empty_if_no_statistics(
         headers=[('Content-Type', 'application/json'), auth_header],
     )
 
+    assert response.status_code == 200
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert json_resp['data'] == {}
+
+
+def test_get_template_statistics_raises_error_for_nonexistent_template(
+    client,
+    sample_service,
+    fake_uuid
+):
+    auth_header = create_authorization_header()
+
+    response = client.get(
+        '/service/{}/template-statistics/{}'.format(sample_service.id, fake_uuid),
+        headers=[('Content-Type', 'application/json'), auth_header],
+    )
+
     assert response.status_code == 404
     json_resp = json.loads(response.get_data(as_text=True))
+    assert json_resp['message'] == 'No result found'
     assert json_resp['result'] == 'error'
-    assert json_resp['message']['template_id'] == ['No template found for id {}'.format(sample_template.id)]

--- a/tests/app/template_statistics/test_rest.py
+++ b/tests/app/template_statistics/test_rest.py
@@ -5,7 +5,12 @@ import pytest
 from freezegun import freeze_time
 
 from tests import create_authorization_header
-from tests.app.conftest import (sample_template as create_sample_template, sample_notification, sample_email_template)
+from tests.app.conftest import (
+    sample_template as create_sample_template,
+    sample_notification,
+    sample_notification_history,
+    sample_email_template
+)
 
 
 def test_get_all_template_statistics_with_bad_arg_returns_400(client, sample_service):
@@ -223,7 +228,7 @@ def test_get_template_statistics_for_template_returns_empty_if_no_statistics(
 
     assert response.status_code == 200
     json_resp = json.loads(response.get_data(as_text=True))
-    assert json_resp['data'] == {}
+    assert not json_resp['data']
 
 
 def test_get_template_statistics_raises_error_for_nonexistent_template(
@@ -242,3 +247,23 @@ def test_get_template_statistics_raises_error_for_nonexistent_template(
     json_resp = json.loads(response.get_data(as_text=True))
     assert json_resp['message'] == 'No result found'
     assert json_resp['result'] == 'error'
+
+
+def test_get_template_statistics_by_id_returns_empty_for_old_notification(
+    notify_db,
+    notify_db_session,
+    client,
+    sample_template
+):
+    sample_notification_history(notify_db, notify_db_session, sample_template)
+
+    auth_header = create_authorization_header()
+
+    response = client.get(
+        '/service/{}/template-statistics/{}'.format(sample_template.service.id, sample_template.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+    )
+
+    assert response.status_code == 200
+    json_resp = json.loads(response.get_data(as_text=True))['data']
+    assert not json_resp


### PR DESCRIPTION
This removes querying from the `NotificationHistory` to check last usage of a given template.

Querying from the `NotificationHistory` table has caused timeouts in multiple places. Let's remove that from here as it's good enough to know (on the admin) that a given template hasn't been used for more than seven days, as opposed to the actual time after seven days.

## Dependencies

- [x] https://github.com/alphagov/notifications-admin/pull/1389