### PR TITLE
Fix issue where monthly billing data was not being updated

### DIFF
--- a/app/dao/monthly_billing_dao.py
+++ b/app/dao/monthly_billing_dao.py
@@ -25,18 +25,31 @@ def create_or_update_monthly_billing_sms(service_id, billing_month):
     monthly = get_billing_data_for_month(service_id=service_id, start_date=start_date, end_date=end_date)
     # update monthly
     monthly_totals = _monthly_billing_data_to_json(monthly)
-    row = MonthlyBilling.query.filter_by(start_date=start_date,
-                                         notification_type='sms').first()
+    row = get_monthly_billing_entry(service_id, start_date, SMS_TYPE)
+
     if row:
         row.monthly_totals = monthly_totals
         row.updated_at = datetime.utcnow()
     else:
-        row = MonthlyBilling(service_id=service_id,
-                             notification_type=SMS_TYPE,
-                             monthly_totals=monthly_totals,
-                             start_date=start_date,
-                             end_date=end_date)
+        row = MonthlyBilling(
+            service_id=service_id,
+            notification_type=SMS_TYPE,
+            monthly_totals=monthly_totals,
+            start_date=start_date,
+            end_date=end_date
+        )
+
     db.session.add(row)
+
+
+def get_monthly_billing_entry(service_id, start_date, notification_type):
+    entry = MonthlyBilling.query.filter_by(
+        service_id=service_id,
+        start_date=start_date,
+        notification_type=notification_type
+    ).first()
+
+    return entry
 
 
 @statsd(namespace="dao")

--- a/tests/app/dao/test_monthly_billing.py
+++ b/tests/app/dao/test_monthly_billing.py
@@ -14,13 +14,11 @@ from tests.app.db import create_notification, create_rate, create_service, creat
 
 
 def create_sample_monthly_billing_entry(
-    notify_db,
-    notify_db_session,
     service_id,
-    notification_type,
     monthly_totals,
     start_date,
-    end_date
+    end_date,
+    notification_type=SMS_TYPE
 ):
     entry = MonthlyBilling(
         service_id=service_id,
@@ -38,8 +36,8 @@ def create_sample_monthly_billing_entry(
 def test_add_monthly_billing(sample_template):
     jan = datetime(2017, 1, 1)
     feb = datetime(2017, 2, 15)
-    create_rate(start_date=jan, value=0.0158, notification_type='sms')
-    create_rate(start_date=datetime(2017, 3, 31, 23, 00, 00), value=0.123, notification_type='sms')
+    create_rate(start_date=jan, value=0.0158, notification_type=SMS_TYPE)
+    create_rate(start_date=datetime(2017, 3, 31, 23, 00, 00), value=0.123, notification_type=SMS_TYPE)
     create_notification(template=sample_template, created_at=jan, billable_units=1, status='delivered')
     create_notification(template=sample_template, created_at=feb, billable_units=2, status='delivered')
 
@@ -74,8 +72,8 @@ def test_add_monthly_billing(sample_template):
 def test_add_monthly_billing_multiple_rates_in_a_month(sample_template):
     rate_1 = datetime(2016, 12, 1)
     rate_2 = datetime(2017, 1, 15)
-    create_rate(start_date=rate_1, value=0.0158, notification_type='sms')
-    create_rate(start_date=rate_2, value=0.0124, notification_type='sms')
+    create_rate(start_date=rate_1, value=0.0158, notification_type=SMS_TYPE)
+    create_rate(start_date=rate_2, value=0.0124, notification_type=SMS_TYPE)
 
     create_notification(template=sample_template, created_at=datetime(2017, 1, 1), billable_units=1, status='delivered')
     create_notification(template=sample_template, created_at=datetime(2017, 1, 14, 23, 59), billable_units=1,
@@ -110,7 +108,7 @@ def test_add_monthly_billing_multiple_rates_in_a_month(sample_template):
 
 def test_update_monthly_billing_overwrites_old_totals(sample_template):
     july = datetime(2017, 7, 1)
-    create_rate(july, 0.123, 'sms')
+    create_rate(july, 0.123, SMS_TYPE)
     create_notification(template=sample_template, created_at=datetime(2017, 7, 2), billable_units=1, status='delivered')
     with freeze_time('2017-07-20 02:30:00'):
         create_or_update_monthly_billing_sms(sample_template.service_id, july)
@@ -167,23 +165,17 @@ def test_get_monthly_billing_entry_filters_by_service(notify_db, notify_db_sessi
     now = datetime.utcnow()
 
     create_sample_monthly_billing_entry(
-        notify_db,
-        notify_db_session,
-        service_1.id,
-        'sms',
-        [],
-        now,
-        now + timedelta(days=30)
+        service_id=service_1.id,
+        monthly_totals=[],
+        start_date=now,
+        end_date=now + timedelta(days=30)
     )
 
     create_sample_monthly_billing_entry(
-        notify_db,
-        notify_db_session,
-        service_2.id,
-        'sms',
-        [],
-        now,
-        now + timedelta(days=30)
+        service_id=service_2.id,
+        monthly_totals=[],
+        start_date=now,
+        end_date=now + timedelta(days=30)
     )
 
     entry = get_monthly_billing_entry(service_2.id, now, SMS_TYPE)


### PR DESCRIPTION
This fixes the issue where the monthly billing data was not being updated in some cases when running the db command.

## Issue

`create_or_update_monthly_billing_sms` did not query the `MonthlyBilling` table with the `service_id`. This meant that we would not create a new `MonthlyBilling` entry if one existed already with the same `start date` or `notification_type`.

## Fix

Add the `service_id` in the filter. 