### PR TITLE
log ip address as separate field to allow analysis of messages

### DIFF
--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -59,13 +59,16 @@ def restrict_ip_sms():
     if request.headers.get("X-Custom-forwarder"):
         current_app.logger.info("X-Custom-forwarder {}".format(request.headers.get("X-Custom-forwarder")))
 
-    if ip in current_app.config.get('SMS_INBOUND_WHITELIST'):
-        current_app.logger.info("Inbound sms ip addresses {} passed ".format(ip))
-        return
-    else:
-        current_app.logger.info("Inbound sms ip addresses blocked {}".format(ip))
-        return
-        # raise AuthError('Unknown source IP address from the SMS provider', 403)
+    current_app.logger.info({
+        'message': 'Inbound sms ip address',
+        'log_contents': {
+            'passed': ip in current_app.config.get('SMS_INBOUND_WHITELIST'),
+            'ip_address': ip
+        }
+    })
+
+    return
+    # raise AuthError('Unknown source IP address from the SMS provider', 403)
 
 
 def requires_admin_auth():


### PR DESCRIPTION
if you log a dictionary, python-json-logger will pass that through to the json output. In the ip restriction wrapper, lets log the ip_address and whether it was found in the whitelist, to a nested `log_contents` dict.

when logging json, it looks like this:
`{"name": "app", "levelname": "INFO", "message": "Logging configured", "pathname": "/Users/leohemsted/.virtualenvs/api/lib/python3.5/site-packages/notifications_utils/logging.py", "lineno": 98, "log_contents": {"thing": 1, "foo": "bar"}, "requestId": "no-request-id", "time": "2017-07-31T18:09:39", "application": "api", "logType": "application"}`

when logging via stdout locally, it looks like this:
`2017-07-31T18:11:31 api app INFO no-request-id "{'log_contents': {'foo': 'bar', 'thing': 1}, 'message': 'Logging configured'}" [in /Users/leohemsted/.virtualenvs/api/lib/python3.5/site-packages/notifications_utils`