### PR TITLE
Add task for ses results queue

### DIFF
--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -15,7 +15,6 @@ from app.dao import (
 )
 from app.celery.statistics_tasks import create_outcome_notification_statistic_tasks
 from app.notifications.process_client_response import validate_callback_data
-from app.notifications.utils import autoconfirm_subscription
 
 ses_callback_blueprint = Blueprint('notifications_ses_callback', __name__)
 
@@ -38,11 +37,6 @@ def sns_callback_handler():
 def process_ses_response(ses_request):
     client_name = 'SES'
     try:
-        subscribed_topic = autoconfirm_subscription(ses_request)
-        if subscribed_topic:
-            current_app.logger.info("Automatically subscribed to topic: {}".format(subscribed_topic))
-            return [], 200, {'result': "success", 'message': "SES callback succeeded"}
-
         errors = validate_callback_data(data=ses_request, fields=['Message'], client_name=client_name)
         if errors:
             return errors, 400, {}

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -37,6 +37,11 @@ def sns_callback_handler():
 def process_ses_response(ses_request):
     client_name = 'SES'
     try:
+
+        # TODO: remove this check once the sns_callback_handler is removed
+        if not isinstance(ses_request, dict):
+            ses_request = json.loads(ses_request)
+
         errors = validate_callback_data(data=ses_request, fields=['Message'], client_name=client_name)
         if errors:
             return errors, 400, {}

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -27,11 +27,13 @@ register_errors(ses_callback_blueprint)
 
 
 @ses_callback_blueprint.route('/notifications/email/ses', methods=['POST'])
-def process_ses_response():
+def sns_callback_handler():
+    process_ses_response(json.loads(request.data))
+
+
+def process_ses_response(ses_request):
     client_name = 'SES'
     try:
-        ses_request = json.loads(request.data)
-
         subscribed_topic = autoconfirm_subscription(ses_request)
         if subscribed_topic:
             current_app.logger.info("Automatically subscribed to topic: {}".format(subscribed_topic))

--- a/tests/app/notifications/test_notifications_ses_callback.py
+++ b/tests/app/notifications/test_notifications_ses_callback.py
@@ -133,9 +133,9 @@ def test_ses_callback_should_update_multiple_notification_status_sent(
         sent_at=datetime.utcnow(),
         status='sending')
 
-    resp1 = process_ses_response(json.loads(data=ses_notification_callback(ref='ref1')))
-    resp2 = process_ses_response(json.loads(data=ses_notification_callback(ref='ref2')))
-    resp3 = process_ses_response(json.loads(data=ses_notification_callback(ref='ref3')))
+    resp1 = process_ses_response(json.loads(ses_notification_callback(ref='ref1')))
+    resp2 = process_ses_response(json.loads(ses_notification_callback(ref='ref2')))
+    resp3 = process_ses_response(json.loads(ses_notification_callback(ref='ref3')))
 
     assert resp1[1] == 200
     assert resp2[1] == 200
@@ -167,7 +167,7 @@ def test_ses_callback_should_set_status_to_temporary_failure(client,
     )
     assert get_notification_by_id(notification.id).status == 'sending'
 
-    _, status, res = process_ses_response(json.loads(data=ses_soft_bounce_callback()))
+    _, status, res = process_ses_response(json.loads(ses_soft_bounce_callback()))
     assert status == 200
     assert res['result'] == 'success'
     assert res['message'] == 'SES callback succeeded'
@@ -195,7 +195,7 @@ def test_ses_callback_should_not_set_status_once_status_is_delivered(client,
 
     assert get_notification_by_id(notification.id).status == 'delivered'
 
-    error, status, _ = process_ses_response(json.loads(data=ses_soft_bounce_callback()))
+    error, status, _ = process_ses_response(json.loads(ses_soft_bounce_callback()))
     assert status == 404
     assert error == 'SES callback failed: notification either not found or already updated from sending. Status temporary-failure for notification reference ref'  # noqa
     assert get_notification_by_id(notification.id).status == 'delivered'
@@ -222,7 +222,7 @@ def test_ses_callback_should_set_status_to_permanent_failure(client,
 
     assert get_notification_by_id(notification.id).status == 'sending'
 
-    _, status, res = process_ses_response(json.loads(data=ses_hard_bounce_callback()))
+    _, status, res = process_ses_response(json.loads(ses_hard_bounce_callback()))
     assert status == 200
     assert res['result'] == 'success'
     assert res['message'] == 'SES callback succeeded'


### PR DESCRIPTION
This abstracts the code that handles the SES callbacks to allow it to be reused from a celery task.

The tests are also updated to reflect this change, calling the process function directly instead of via the endpoint. 

The endpoint is going to be removed in a subsequent PR, once the subscriptions to it have been removed from AWS.