### PR TITLE
Return template name in public API

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -494,7 +494,8 @@ class Template(db.Model):
             "created_by": self.created_by.email_address,
             "version": self.version,
             "body": self.content,
-            "subject": self.subject if self.template_type != SMS_TYPE else None
+            "subject": self.subject if self.template_type != SMS_TYPE else None,
+            "name": self.name,
         }
 
         return serialized

--- a/app/v2/template/template_schemas.py
+++ b/app/v2/template/template_schemas.py
@@ -35,9 +35,10 @@ get_template_by_id_response = {
         "created_by": {"type": "string"},
         "version": {"type": "integer"},
         "body": {"type": "string"},
-        "subject": {"type": ["string", "null"]}
+        "subject": {"type": ["string", "null"]},
+        "name": {"type": "string"},
     },
-    "required": ["id", "type", "created_at", "updated_at", "version", "created_by", "body"]
+    "required": ["id", "type", "created_at", "updated_at", "version", "created_by", "body", "name"],
 }
 
 post_template_preview_request = {

--- a/tests/app/v2/template/test_get_template.py
+++ b/tests/app/v2/template/test_get_template.py
@@ -10,13 +10,13 @@ from tests.app.db import create_template
 valid_version_params = [None, 1]
 
 
-@pytest.mark.parametrize("tmp_type, expected_subject", [
-    (SMS_TYPE, None),
-    (EMAIL_TYPE, 'Template subject'),
-    (LETTER_TYPE, 'Template subject')
+@pytest.mark.parametrize("tmp_type, expected_name, expected_subject", [
+    (SMS_TYPE, 'sms Template Name', None),
+    (EMAIL_TYPE, 'email Template Name', 'Template subject'),
+    (LETTER_TYPE, 'letter Template Name', 'Template subject')
 ])
 @pytest.mark.parametrize("version", valid_version_params)
-def test_get_template_by_id_returns_200(client, sample_service, tmp_type, expected_subject, version):
+def test_get_template_by_id_returns_200(client, sample_service, tmp_type, expected_name, expected_subject, version):
     template = create_template(sample_service, template_type=tmp_type)
     auth_header = create_authorization_header(service_id=sample_service.id)
 
@@ -38,7 +38,8 @@ def test_get_template_by_id_returns_200(client, sample_service, tmp_type, expect
         'version': template.version,
         'created_by': template.created_by.email_address,
         'body': template.content,
-        "subject": expected_subject
+        "subject": expected_subject,
+        'name': expected_name,
     }
 
     assert json_response == expected_response

--- a/tests/app/v2/template/test_template_schemas.py
+++ b/tests/app/v2/template/test_template_schemas.py
@@ -21,7 +21,8 @@ valid_json_get_response = {
     'updated_at': None,
     'version': 1,
     'created_by': 'someone@test.com',
-    'body': 'some body'
+    'body': 'some body',
+    'name': 'some name',
 }
 
 valid_json_get_response_with_optionals = {
@@ -32,7 +33,8 @@ valid_json_get_response_with_optionals = {
     'version': 1,
     'created_by': 'someone',
     'body': 'some body',
-    'subject': "some subject"
+    'subject': "some subject",
+    'name': 'some name',
 }
 
 valid_request_args = [{"id": str(uuid.uuid4()), "version": 1}, {"id": str(uuid.uuid4())}]

--- a/tests/app/v2/templates/test_templates_schemas.py
+++ b/tests/app/v2/templates/test_templates_schemas.py
@@ -22,7 +22,8 @@ valid_json_get_all_response = [
                 'updated_at': None,
                 'version': 1,
                 'created_by': 'someone@test.com',
-                'body': 'some body'
+                'body': 'some body',
+                'name': 'some name',
             },
             {
                 'id': str(uuid.uuid4()),
@@ -32,7 +33,8 @@ valid_json_get_all_response = [
                 'version': 2,
                 'created_by': 'someone@test.com',
                 'subject': 'test subject',
-                'body': 'some body'
+                'body': 'some body',
+                'name': 'some name',
             }
         ]
     },
@@ -45,7 +47,8 @@ valid_json_get_all_response = [
                 'updated_at': None,
                 'version': 2,
                 'created_by': 'someone@test.com',
-                'body': 'some body'
+                'body': 'some body',
+                'name': 'some name',
             }
         ]
     },
@@ -64,7 +67,8 @@ invalid_json_get_all_response = [
                 'updated_at': None,
                 'version': 1,
                 'created_by': 'someone@test.com',
-                'body': 'some body'
+                'body': 'some body',
+                'name': 'some name',
             }
         ]
     }, ['templates is not a valid UUID']),
@@ -77,7 +81,8 @@ invalid_json_get_all_response = [
                 'updated_at': None,
                 'version': 'invalid_version',
                 'created_by': 'someone@test.com',
-                'body': 'some body'
+                'body': 'some body',
+                'name': 'some name',
             }
         ]
     }, ['templates invalid_version is not of type integer']),
@@ -90,7 +95,8 @@ invalid_json_get_all_response = [
                 'updated_at': None,
                 'version': 1,
                 'created_by': 'someone@test.com',
-                'body': 'some body'
+                'body': 'some body',
+                'name': 'some name',
             }
         ]
     }, ['templates invalid_created_at is not a date-time']),
@@ -103,10 +109,24 @@ invalid_json_get_all_response = [
                 'updated_at': None,
                 'version': 1,
                 'created_by': 'someone@test.com',
-                'body': 'some body'
+                'body': 'some body',
+                'name': 'some name',
             }
         ]
     }, ['templates id is a required property']),
+    ({
+        "templates": [
+            {
+                'id': str(uuid.uuid4()),
+                'type': SMS_TYPE,
+                'created_at': '2017-02-10T18:25:43.511Z',
+                'updated_at': None,
+                'version': 1,
+                'created_by': 'someone@test.com',
+                'body': 'some body',
+            }
+        ]
+    }, ['templates name is a required property']),
     ({
         "templates": [
             {
@@ -115,7 +135,8 @@ invalid_json_get_all_response = [
                 'updated_at': None,
                 'version': 1,
                 'created_by': 'someone@test.com',
-                'body': 'some body'
+                'body': 'some body',
+                'name': 'some name',
             }
         ]
     }, ['templates type is a required property']),
@@ -127,7 +148,8 @@ invalid_json_get_all_response = [
                 'updated_at': None,
                 'version': 1,
                 'created_by': 'someone@test.com',
-                'body': 'some body'
+                'body': 'some body',
+                'name': 'some name',
             }
         ]
     }, ['templates created_at is a required property']),
@@ -139,7 +161,8 @@ invalid_json_get_all_response = [
                 'created_at': '2017-02-10T18:25:43.511Z',
                 'version': 1,
                 'created_by': 'someone@test.com',
-                'body': 'some body'
+                'body': 'some body',
+                'name': 'some name',
             }
         ]
     }, ['templates updated_at is a required property']),
@@ -151,7 +174,8 @@ invalid_json_get_all_response = [
                 'created_at': '2017-02-10T18:25:43.511Z',
                 'updated_at': None,
                 'created_by': 'someone@test.com',
-                'body': 'some body'
+                'body': 'some body',
+                'name': 'some name',
             }
         ]
     }, ['templates version is a required property']),
@@ -163,7 +187,8 @@ invalid_json_get_all_response = [
                 'created_at': '2017-02-10T18:25:43.511Z',
                 'updated_at': None,
                 'version': 1,
-                'body': 'some body'
+                'body': 'some body',
+                'name': 'some name',
             }
         ]
     }, ['templates created_by is a required property']),
@@ -175,7 +200,8 @@ invalid_json_get_all_response = [
                 'created_at': '2017-02-10T18:25:43.511Z',
                 'updated_at': None,
                 'version': 1,
-                'created_by': 'someone@test.com'
+                'created_by': 'someone@test.com',
+                'name': 'some name',
             }
         ]
     }, ['templates body is a required property']),
@@ -186,7 +212,8 @@ invalid_json_get_all_response = [
                 'created_at': '2017-02-10T18:25:43.511Z',
                 'updated_at': None,
                 'created_by': 'someone@test.com',
-                'body': 'some body'
+                'body': 'some body',
+                'name': 'some name',
             }
         ]
     }, ['templates id is a required property', 'templates version is a required property']),


### PR DESCRIPTION
The use for the public template API is for building caseworking systems or similar, where you might need a list of templates to pick from (ie instead of using the Notify web interface to pick from and send a message).

Right now our API isn’t returning the template name as part of the response. The name is a useful, human-friendly way of identifying a template.

This commit changes the response to include the name.

Some clients will need updating before this can be useful.