### PR TITLE
Add endpoints to retrieve billing data

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -100,6 +100,7 @@ def register_blueprint(application):
     from app.notifications.notifications_letter_callback import letter_callback_blueprint
     from app.authentication.auth import requires_admin_auth, requires_auth, requires_no_auth, restrict_ip_sms
     from app.letters.send_letter_jobs import letter_job
+    from app.billing.rest import billing_blueprint
 
     service_blueprint.before_request(requires_admin_auth)
     application.register_blueprint(service_blueprint, url_prefix='/service')
@@ -163,6 +164,9 @@ def register_blueprint(application):
 
     letter_callback_blueprint.before_request(requires_no_auth)
     application.register_blueprint(letter_callback_blueprint)
+
+    billing_blueprint.before_request(requires_admin_auth)
+    application.register_blueprint(billing_blueprint)
 
 
 def register_v2_blueprints(application):

--- a/app/billing/rest.py
+++ b/app/billing/rest.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+import json
+
+from flask import Blueprint, jsonify, request
+
+from app.dao.notification_usage_dao import get_billing_data_for_month
+from app.dao.monthly_billing_dao import get_billing_data_for_financial_year
+from app.dao.date_util import get_financial_year
+from app.errors import register_errors
+from app.models import SMS_TYPE, EMAIL_TYPE
+
+
+billing_blueprint = Blueprint(
+    'billing',
+    __name__,
+    url_prefix='/service/<uuid:service_id>/billing'
+)
+
+
+register_errors(billing_blueprint)
+
+
+@billing_blueprint.route('/monthly-usage')
+def get_yearly_usage_by_month(service_id):
+    try:
+        year = int(request.args.get('year'))
+        start_date, end_date = get_financial_year(year)
+        results = get_billing_data_for_month(service_id, start_date, end_date, SMS_TYPE)
+        json_results = [{
+            "month": datetime.strftime(x[0], "%B"),
+            "billing_units": x[1],
+            "rate_multiplier": x[2],
+            "international": x[3],
+            "notification_type": x[4],
+            "rate": x[5]
+        } for x in results]
+        return json.dumps(json_results)
+    except TypeError:
+        return jsonify(result='error', message='No valid year provided'), 400
+
+
+@billing_blueprint.route('/yearly-usage-summary')
+def get_yearly_billing_usage_summary(service_id):
+    try:
+        year = int(request.args.get('year'))
+        billing_data = get_billing_data_for_financial_year(service_id, year)
+        notification_types = [SMS_TYPE, EMAIL_TYPE]
+        response = [
+            _get_total_billable_units_and_rate_for_notification_type(billing_data, notification_type)
+            for notification_type in notification_types
+        ]
+
+        return json.dumps(response)
+
+    except TypeError:
+        return jsonify(result='error', message='No valid year provided'), 400
+
+
+def _get_total_billable_units_and_rate_for_notification_type(billing_data, noti_type):
+    total_sent = 0
+    rate = 0
+    for entry in billing_data:
+        for monthly_total in entry.monthly_totals:
+            if entry.notification_type == noti_type:
+                total_sent += monthly_total['billing_units'] \
+                    if noti_type == EMAIL_TYPE else (monthly_total['billing_units'] * monthly_total['rate_multiplier'])
+                rate = monthly_total['rate']
+
+    return {
+        "notification_type": noti_type,
+        "billing_units": total_sent,
+        "rate": rate
+    }

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -510,13 +510,14 @@ def get_yearly_billing_usage(service_id):
     try:
         year = int(request.args.get('year'))
         results = notification_usage_dao.get_yearly_billing_data(service_id, year)
-        json_result = [{"credits": x[0],
-                        "billing_units": x[1],
-                        "rate_multiplier": x[2],
-                        "notification_type": x[3],
-                        "international": x[4],
-                        "rate": x[5]
-                        } for x in results]
+        json_result = [{
+            "credits": x[0],
+            "billing_units": x[1],
+            "rate_multiplier": x[2],
+            "notification_type": x[3],
+            "international": x[4],
+            "rate": x[5]
+        } for x in results]
         return json.dumps(json_result)
 
     except TypeError:

--- a/tests/app/billing/test_billing.py
+++ b/tests/app/billing/test_billing.py
@@ -1,0 +1,130 @@
+from datetime import datetime, timedelta
+import json
+
+from app.dao.monthly_billing_dao import create_or_update_monthly_billing
+from app.models import SMS_TYPE, EMAIL_TYPE
+from tests.app.db import (
+    create_notification,
+    create_rate
+)
+from tests import create_authorization_header
+
+IN_MAY_2016 = datetime(2016, 5, 10, 23, 00, 00)
+IN_JUN_2016 = datetime(2016, 6, 3, 23, 00, 00)
+
+
+def _assert_dict_equals(actual, expected_dict):
+    assert set(actual.keys()) == set(expected_dict.keys())
+    assert set(actual.values()) == set(expected_dict.values())
+
+
+def test_get_yearly_billing_summary_returns_correct_breakdown(client, sample_template):
+    create_rate(start_date=IN_MAY_2016 - timedelta(days=1), value=0.12, notification_type=SMS_TYPE)
+    create_notification(
+        template=sample_template, created_at=IN_MAY_2016,
+        billable_units=1, rate_multiplier=2, status='delivered'
+    )
+    create_notification(
+        template=sample_template, created_at=IN_JUN_2016,
+        billable_units=2, rate_multiplier=3, status='delivered'
+    )
+
+    create_or_update_monthly_billing(service_id=sample_template.service_id, billing_month=IN_MAY_2016)
+    create_or_update_monthly_billing(service_id=sample_template.service_id, billing_month=IN_JUN_2016)
+
+    response = client.get(
+        '/service/{}/billing/yearly-usage-summary?year=2016'.format(sample_template.service.id),
+        headers=[create_authorization_header()]
+    )
+    assert response.status_code == 200
+
+    resp_json = json.loads(response.get_data(as_text=True))
+    assert len(resp_json) == 2
+
+    _assert_dict_equals(resp_json[0], {
+        'notification_type': SMS_TYPE,
+        'billing_units': 8,
+        'rate': 0.12
+    })
+
+    _assert_dict_equals(resp_json[1], {
+        'notification_type': EMAIL_TYPE,
+        'billing_units': 0,
+        'rate': 0
+    })
+
+
+def test_get_yearly_billing_usage_breakdown_returns_400_if_missing_year(client, sample_service):
+    response = client.get(
+        '/service/{}/billing/yearly-usage-summary'.format(sample_service.id),
+        headers=[create_authorization_header()]
+    )
+    assert response.status_code == 400
+    assert json.loads(response.get_data(as_text=True)) == {
+        'message': 'No valid year provided', 'result': 'error'
+    }
+
+
+def test_get_yearly_usage_by_month_returns_400_if_missing_year(client, sample_service):
+    response = client.get(
+        '/service/{}/billing/monthly-usage'.format(sample_service.id),
+        headers=[create_authorization_header()]
+    )
+    assert response.status_code == 400
+    assert json.loads(response.get_data(as_text=True)) == {
+        'message': 'No valid year provided', 'result': 'error'
+    }
+
+
+def test_get_yearly_usage_by_month_returns_empty_list_if_no_notifications(client, sample_template):
+    create_rate(start_date=IN_MAY_2016 - timedelta(days=1), value=0.12, notification_type=SMS_TYPE)
+    response = client.get(
+        '/service/{}/billing/monthly-usage?year=2016'.format(sample_template.service.id),
+        headers=[create_authorization_header()]
+    )
+    assert response.status_code == 200
+
+    results = json.loads(response.get_data(as_text=True))
+    assert results == []
+
+
+def test_get_yearly_usage_by_month_returns_correctly(client, sample_template):
+    create_rate(start_date=IN_MAY_2016 - timedelta(days=1), value=0.12, notification_type=SMS_TYPE)
+    create_notification(
+        template=sample_template, created_at=IN_MAY_2016,
+        billable_units=1, rate_multiplier=2, status='delivered'
+    )
+    create_notification(
+        template=sample_template, created_at=IN_JUN_2016,
+        billable_units=2, rate_multiplier=3, status='delivered'
+    )
+
+    create_or_update_monthly_billing(service_id=sample_template.service_id, billing_month=IN_MAY_2016)
+    create_or_update_monthly_billing(service_id=sample_template.service_id, billing_month=IN_JUN_2016)
+
+    response = client.get(
+        '/service/{}/billing/monthly-usage?year=2016'.format(sample_template.service.id),
+        headers=[create_authorization_header()]
+    )
+
+    assert response.status_code == 200
+
+    resp_json = json.loads(response.get_data(as_text=True))
+
+    _assert_dict_equals(resp_json[0], {
+        'billing_units': 1,
+        'international': False,
+        'month': 'May',
+        'notification_type': SMS_TYPE,
+        'rate': 0.12,
+        'rate_multiplier': 2
+    })
+
+    _assert_dict_equals(resp_json[1], {
+        'billing_units': 2,
+        'international': False,
+        'month': 'June',
+        'notification_type': SMS_TYPE,
+        'rate': 0.12,
+        'rate_multiplier': 3
+    })


### PR DESCRIPTION
This adds two new endpoints to retrieve billing data from the new table.

## Summary

A new `billing_blueprint` has been added to keep this nice and separate.

For the monthly breakdown endpoint, it returns the same response as we did before. 
For the yearly endpoint, the response is slightly different. This is because admin only makes use of `rate`, `notification_type` and `billing_units`, hence why only these are returned.

Additionally it's worth noting that currently we are making a strong assumption that we will only have a single rate per year (not a new thing in this pr). As discussed, we will have to refactor etc. as and when that day comes. For now it returns the rate corresponding to that year.

## Dependencies

- [x] - #1172 