### PR TITLE
Update inbound_numbers to services that have sms_sender in inbound_numbers

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -157,7 +157,7 @@ class CustomDbScript(Command):
         service_id = services.id,
         updated_at = now()
         FROM services
-        WHERE services.sms_sender = inbound_numbers.number AND 
+        WHERE services.sms_sender = inbound_numbers.number AND
         inbound_numbers.service_id is null
         """
         result = db.session.execute(update)

--- a/app/commands.py
+++ b/app/commands.py
@@ -151,6 +151,19 @@ class CustomDbScript(Command):
             db.session.commit()
             result = db.session.execute(subq_hist).fetchall()
 
+    def link_inbound_numbers_to_service(self):
+        update = """
+        UPDATE inbound_numbers SET
+        service_id = services.id,
+        updated_at = now()
+        FROM services
+        WHERE services.sms_sender = inbound_numbers.number
+        """
+        result = db.session.execute(update)
+        db.session.commit()
+
+        print("Linked {} inbound numbers to service".format(result.rowcount))
+
 
 class PopulateMonthlyBilling(Command):
         option_list = (

--- a/app/commands.py
+++ b/app/commands.py
@@ -157,7 +157,8 @@ class CustomDbScript(Command):
         service_id = services.id,
         updated_at = now()
         FROM services
-        WHERE services.sms_sender = inbound_numbers.number
+        WHERE services.sms_sender = inbound_numbers.number AND 
+        inbound_numbers.service_id is null
         """
         result = db.session.execute(update)
         db.session.commit()


### PR DESCRIPTION
## What -

Update script to link an `inbound_numbers.number` to a `services.sms_sender`.
 
This script should only be run after Admin has been deployed - https://github.com/alphagov/notifications-admin/pull/1429
Part 7 / 8 of https://www.pivotaltracker.com/story/show/146774373

## How to review - 

Execute the command 
`python application.py custom_db_script -n link_inbound_numbers_to_service`

After running the command, check that the service ids are populated correctly in the `inbound_numbers` table by checking that the `services.sms_sender` matches the `inbound_numbers.number`

- [ ] - https://github.com/alphagov/notifications-admin/pull/1429 deployed