### PR TITLE
Remove unused billing usage code

### DIFF
--- a/app/dao/monthly_billing_dao.py
+++ b/app/dao/monthly_billing_dao.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 
-from sqlalchemy import func
-
 
 from app import db
 from app.dao.dao_utils import transactional

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -458,24 +458,6 @@ def get_monthly_template_stats(service_id):
         raise InvalidRequest('Year must be a number', status_code=400)
 
 
-@service_blueprint.route('/<uuid:service_id>/monthly-usage')
-def get_yearly_monthly_usage(service_id):
-    try:
-        year = int(request.args.get('year'))
-        results = notification_usage_dao.get_monthly_billing_data(service_id, year)
-        json_results = [{
-            "month": x[0],
-            "billing_units": x[1],
-            "rate_multiplier": x[2],
-            "international": x[3],
-            "notification_type": x[4],
-            "rate": x[5]
-        } for x in results]
-        return json.dumps(json_results)
-    except TypeError:
-        return jsonify(result='error', message='No valid year provided'), 400
-
-
 @service_blueprint.route('/<uuid:service_id>/inbound-api', methods=['POST'])
 def create_service_inbound_api(service_id):
     data = request.get_json()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -458,25 +458,6 @@ def get_monthly_template_stats(service_id):
         raise InvalidRequest('Year must be a number', status_code=400)
 
 
-@service_blueprint.route('/<uuid:service_id>/yearly-usage')
-def get_yearly_billing_usage(service_id):
-    try:
-        year = int(request.args.get('year'))
-        results = notification_usage_dao.get_yearly_billing_data(service_id, year)
-        json_result = [{
-            "credits": x[0],
-            "billing_units": x[1],
-            "rate_multiplier": x[2],
-            "notification_type": x[3],
-            "international": x[4],
-            "rate": x[5]
-        } for x in results]
-        return json.dumps(json_result)
-
-    except TypeError:
-        return jsonify(result='error', message='No valid year provided'), 400
-
-
 @service_blueprint.route('/<uuid:service_id>/monthly-usage')
 def get_yearly_monthly_usage(service_id):
     try:

--- a/tests/app/dao/test_monthly_billing.py
+++ b/tests/app/dao/test_monthly_billing.py
@@ -3,7 +3,6 @@ from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 from functools import partial
 
-from app import db
 from app.dao.monthly_billing_dao import (
     create_or_update_monthly_billing,
     get_monthly_billing_entry,

--- a/tests/app/dao/test_notification_usage_dao.py
+++ b/tests/app/dao/test_notification_usage_dao.py
@@ -20,7 +20,7 @@ def test_get_rates_for_daterange(notify_db, notify_db_session):
     set_up_rate(notify_db, datetime(2016, 5, 18), 0.016)
     set_up_rate(notify_db, datetime(2017, 3, 31, 23), 0.0158)
     start_date, end_date = get_financial_year(2017)
-    rates = get_rates_for_daterange(start_date, end_date, 'sms')
+    rates = get_rates_for_daterange(start_date, end_date, SMS_TYPE)
     assert len(rates) == 1
     assert datetime.strftime(rates[0].valid_from, '%Y-%m-%d %H:%M:%S') == "2017-03-31 23:00:00"
     assert rates[0].rate == 0.0158
@@ -31,7 +31,7 @@ def test_get_rates_for_daterange_multiple_result_per_year(notify_db, notify_db_s
     set_up_rate(notify_db, datetime(2016, 5, 18), 0.016)
     set_up_rate(notify_db, datetime(2017, 4, 1), 0.0158)
     start_date, end_date = get_financial_year(2016)
-    rates = get_rates_for_daterange(start_date, end_date, 'sms')
+    rates = get_rates_for_daterange(start_date, end_date, SMS_TYPE)
     assert len(rates) == 2
     assert datetime.strftime(rates[0].valid_from, '%Y-%m-%d %H:%M:%S') == "2016-04-01 00:00:00"
     assert rates[0].rate == 0.015
@@ -44,7 +44,7 @@ def test_get_rates_for_daterange_returns_correct_rates(notify_db, notify_db_sess
     set_up_rate(notify_db, datetime(2016, 9, 1), 0.016)
     set_up_rate(notify_db, datetime(2017, 6, 1), 0.0175)
     start_date, end_date = get_financial_year(2017)
-    rates_2017 = get_rates_for_daterange(start_date, end_date, 'sms')
+    rates_2017 = get_rates_for_daterange(start_date, end_date, SMS_TYPE)
     assert len(rates_2017) == 2
     assert datetime.strftime(rates_2017[0].valid_from, '%Y-%m-%d %H:%M:%S') == "2016-09-01 00:00:00"
     assert rates_2017[0].rate == 0.016
@@ -56,7 +56,7 @@ def test_get_rates_for_daterange_in_the_future(notify_db, notify_db_session):
     set_up_rate(notify_db, datetime(2016, 4, 1), 0.015)
     set_up_rate(notify_db, datetime(2017, 6, 1), 0.0175)
     start_date, end_date = get_financial_year(2018)
-    rates = get_rates_for_daterange(start_date, end_date, 'sms')
+    rates = get_rates_for_daterange(start_date, end_date, SMS_TYPE)
     assert datetime.strftime(rates[0].valid_from, '%Y-%m-%d %H:%M:%S') == "2017-06-01 00:00:00"
     assert rates[0].rate == 0.0175
 
@@ -65,7 +65,7 @@ def test_get_rates_for_daterange_returns_empty_list_if_year_is_before_earliest_r
     set_up_rate(notify_db, datetime(2016, 4, 1), 0.015)
     set_up_rate(notify_db, datetime(2017, 6, 1), 0.0175)
     start_date, end_date = get_financial_year(2015)
-    rates = get_rates_for_daterange(start_date, end_date, 'sms')
+    rates = get_rates_for_daterange(start_date, end_date, SMS_TYPE)
     assert rates == []
 
 
@@ -75,7 +75,7 @@ def test_get_rates_for_daterange_early_rate(notify_db, notify_db_session):
     set_up_rate(notify_db, datetime(2016, 9, 1), 0.016)
     set_up_rate(notify_db, datetime(2017, 6, 1), 0.0175)
     start_date, end_date = get_financial_year(2016)
-    rates = get_rates_for_daterange(start_date, end_date, 'sms')
+    rates = get_rates_for_daterange(start_date, end_date, SMS_TYPE)
     assert len(rates) == 3
 
 
@@ -83,7 +83,7 @@ def test_get_rates_for_daterange_edge_case(notify_db, notify_db_session):
     set_up_rate(notify_db, datetime(2016, 3, 31, 23, 00), 0.015)
     set_up_rate(notify_db, datetime(2017, 3, 31, 23, 00), 0.0175)
     start_date, end_date = get_financial_year(2016)
-    rates = get_rates_for_daterange(start_date, end_date, 'sms')
+    rates = get_rates_for_daterange(start_date, end_date, SMS_TYPE)
     assert len(rates) == 1
     assert datetime.strftime(rates[0].valid_from, '%Y-%m-%d %H:%M:%S') == "2016-03-31 23:00:00"
     assert rates[0].rate == 0.015
@@ -96,7 +96,7 @@ def test_get_rates_for_daterange_where_daterange_is_one_month_that_falls_between
     set_up_rate(notify_db, datetime(2017, 3, 31), 0.123)
     start_date = datetime(2017, 2, 1, 00, 00, 00)
     end_date = datetime(2017, 2, 28, 23, 59, 59, 99999)
-    rates = get_rates_for_daterange(start_date, end_date, 'sms')
+    rates = get_rates_for_daterange(start_date, end_date, SMS_TYPE)
     assert len(rates) == 1
     assert datetime.strftime(rates[0].valid_from, '%Y-%m-%d %H:%M:%S') == "2017-01-01 00:00:00"
     assert rates[0].rate == 0.175
@@ -131,10 +131,10 @@ def test_get_monthly_billing_data(notify_db, notify_db_session, sample_template,
     results = get_monthly_billing_data(sample_template.service_id, 2016)
     assert len(results) == 4
     # (billable_units, rate_multiplier, international, type, rate)
-    assert results[0] == ('April', 1, 1, False, 'sms', 0.014)
-    assert results[1] == ('May', 2, 1, False, 'sms', 0.014)
-    assert results[2] == ('July', 7, 1, False, 'sms', 0.014)
-    assert results[3] == ('July', 6, 2, False, 'sms', 0.014)
+    assert results[0] == ('April', 1, 1, False, SMS_TYPE, 0.014)
+    assert results[1] == ('May', 2, 1, False, SMS_TYPE, 0.014)
+    assert results[2] == ('July', 7, 1, False, SMS_TYPE, 0.014)
+    assert results[3] == ('July', 6, 2, False, SMS_TYPE, 0.014)
 
 
 def test_get_monthly_billing_data_with_multiple_rates(notify_db, notify_db_session, sample_template,
@@ -165,10 +165,10 @@ def test_get_monthly_billing_data_with_multiple_rates(notify_db, notify_db_sessi
                         sent_at=datetime(2017, 3, 31), status='sending', billable_units=6)
     results = get_monthly_billing_data(sample_template.service_id, 2016)
     assert len(results) == 4
-    assert results[0] == ('April', 1, 1, False, 'sms', 0.014)
-    assert results[1] == ('May', 2, 1, False, 'sms', 0.014)
-    assert results[2] == ('June', 3, 1, False, 'sms', 0.014)
-    assert results[3] == ('June', 4, 1, False, 'sms', 0.0175)
+    assert results[0] == ('April', 1, 1, False, SMS_TYPE, 0.014)
+    assert results[1] == ('May', 2, 1, False, SMS_TYPE, 0.014)
+    assert results[2] == ('June', 3, 1, False, SMS_TYPE, 0.014)
+    assert results[3] == ('June', 4, 1, False, SMS_TYPE, 0.0175)
 
 
 def test_get_monthly_billing_data_with_no_notifications_for_daterange(notify_db, notify_db_session, sample_template):
@@ -178,7 +178,7 @@ def test_get_monthly_billing_data_with_no_notifications_for_daterange(notify_db,
 
 
 def set_up_rate(notify_db, start_date, value):
-    rate = Rate(id=uuid.uuid4(), valid_from=start_date, rate=value, notification_type='sms')
+    rate = Rate(id=uuid.uuid4(), valid_from=start_date, rate=value, notification_type=SMS_TYPE)
     notify_db.session.add(rate)
 
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1730,50 +1730,6 @@ def test_get_template_stats_by_month_returns_error_for_incorrect_year(
     assert json.loads(response.get_data(as_text=True)) == expected_json
 
 
-def test_get_yearly_billing_usage(client, notify_db, notify_db_session, sample_service):
-    rate = Rate(id=uuid.uuid4(), valid_from=datetime(2016, 3, 31, 23, 00), rate=0.0158, notification_type=SMS_TYPE)
-    notify_db.session.add(rate)
-    after_rate_created = datetime(2016, 6, 5)
-    notification = create_sample_notification(
-        notify_db,
-        notify_db_session,
-        created_at=after_rate_created,
-        sent_at=after_rate_created,
-        status='sending',
-        service=sample_service
-    )
-    create_or_update_monthly_billing(sample_service.id, after_rate_created)
-    response = client.get(
-        '/service/{}/yearly-usage?year=2016'.format(notification.service_id),
-        headers=[create_authorization_header()]
-    )
-    assert response.status_code == 200
-
-    assert json.loads(response.get_data(as_text=True)) == [{'credits': 1,
-                                                            'billing_units': 1,
-                                                            'rate_multiplier': 1,
-                                                            'notification_type': SMS_TYPE,
-                                                            'international': False,
-                                                            'rate': 0.0158},
-                                                           {'credits': 0,
-                                                            'billing_units': 0,
-                                                            'rate_multiplier': 1,
-                                                            'notification_type': EMAIL_TYPE,
-                                                            'international': False,
-                                                            'rate': 0}]
-
-
-def test_get_yearly_billing_usage_returns_400_if_missing_year(client, sample_service):
-    response = client.get(
-        '/service/{}/yearly-usage'.format(sample_service.id),
-        headers=[create_authorization_header()]
-    )
-    assert response.status_code == 400
-    assert json.loads(response.get_data(as_text=True)) == {
-        'message': 'No valid year provided', 'result': 'error'
-    }
-
-
 def test_get_monthly_billing_usage(client, notify_db, notify_db_session, sample_service):
     rate = Rate(id=uuid.uuid4(), valid_from=datetime(2016, 3, 31, 23, 00), rate=0.0158, notification_type=SMS_TYPE)
     notify_db.session.add(rate)


### PR DESCRIPTION
The removes billing code that was previously used by admin for the usage page. 

## Summary

The yearly and monthly functions that queried the `NotificationHistory` table are no longer used. Instead we now query and do aggregation with results from `MonthlyBilling`.