### PR TITLE
Stop redis cache from throwing an error

### DIFF
--- a/app/template_statistics/rest.py
+++ b/app/template_statistics/rest.py
@@ -76,7 +76,10 @@ def get_template_statistics_for_7_days(limit_days, service_id):
     if not template_stats_by_id:
         stats = dao_get_template_usage(service_id, limit_days=limit_days)
         cache_values = dict([(x.template_id, x.count) for x in stats])
-        redis_store.set_hash_and_expire(cache_key, cache_values, current_app.config.get('EXPIRE_CACHE_IN_SECONDS', 600))
+        if cache_values:
+            redis_store.set_hash_and_expire(cache_key,
+                                            cache_values,
+                                            current_app.config.get('EXPIRE_CACHE_IN_SECONDS', 600))
     else:
         stats = dao_get_templates_for_cache(template_stats_by_id.items())
     return stats

--- a/tests/app/template_statistics/test_rest.py
+++ b/tests/app/template_statistics/test_rest.py
@@ -182,8 +182,9 @@ def set_up_notifications(notify_db, notify_db_session):
 
 
 @freeze_time('2016-08-18')
-def test_returns_empty_list_if_no_templates_used(client, sample_service):
+def test_returns_empty_list_if_no_templates_used(client, sample_service, mocker):
     auth_header = create_authorization_header()
+    mock_redis = mocker.patch('app.redis_store.set_hash_and_expire')
 
     response = client.get(
         '/service/{}/template-statistics'.format(sample_service.id),
@@ -193,6 +194,7 @@ def test_returns_empty_list_if_no_templates_used(client, sample_service):
     assert response.status_code == 200
     json_resp = json.loads(response.get_data(as_text=True))
     assert len(json_resp['data']) == 0
+    mock_redis.assert_not_called()
 
 
 def test_get_template_statistics_by_id_returns_last_notification(


### PR DESCRIPTION
The logs kept reporting a data error from the redis client. This would happen any time we set the cache with empty cache values.

Added a check for values before setting the cache