### PR TITLE
Refactor inbound numbers

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import date, datetime, timedelta
 
-from sqlalchemy import asc, func, or_
+from sqlalchemy import asc, func
 from sqlalchemy.orm import joinedload
 from flask import current_app
 
@@ -66,24 +66,18 @@ def dao_fetch_service_by_id(service_id, only_active=False):
     return query.one()
 
 
-############
-# refactor this when API only uses inbound_numbers and not sms_sender
-############
-def dao_fetch_services_by_sms_sender(sms_sender):
+def dao_fetch_service_by_inbound_number(number):
     inbound_number = InboundNumber.query.filter(
-        InboundNumber.number == sms_sender,
+        InboundNumber.number == number,
         InboundNumber.active
     ).first()
 
     if not inbound_number:
-        return []
+        return None
 
     return Service.query.filter(
-        or_(
-            Service.sms_sender == sms_sender,
-            Service.id == inbound_number.service_id
-        )
-    ).all()
+        Service.id == inbound_number.service_id
+    ).first()
 
 
 def dao_fetch_service_by_id_with_api_keys(service_id, only_active=False):

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -71,10 +71,10 @@ def create_service(
         sms_sender=sms_sender,
     )
 
+    dao_create_service(service, service.created_by, service_id, service_permissions=service_permissions)
+
     if do_create_inbound_number and INBOUND_SMS_TYPE in service_permissions:
         create_inbound_number(number=sms_sender, service_id=service.id)
-
-    dao_create_service(service, service.created_by, service_id, service_permissions=service_permissions)
 
     service.active = active
     service.research_mode = research_mode


### PR DESCRIPTION
## What -

Final step of the story to use `inbound_numbers` table - https://www.pivotaltracker.com/story/show/146774373

- Refactor out `sms_sender` so that it is not returned when getting a service from an inbound number
- removed unnecessary tests

## How to review -

Tests should still run and admin functionality to turn on and off inbound sms should still work.