### PR TITLE
run tests in multiple threads at once

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -3,6 +3,7 @@ pycodestyle==2.3.1
 pytest==3.2.1
 pytest-mock==1.6.2
 pytest-cov==2.5.1
+pytest-xdist==1.20.0
 coveralls==1.2.0
 moto==1.1.1
 freezegun==0.3.9

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -30,6 +30,6 @@ fi
 pycodestyle .
 display_result $? 1 "Code style check"
 
-# run with six concurrent threads
-py.test --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml -n 6
+# run with four concurrent threads
+py.test --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml -n 4
 display_result $? 2 "Unit tests"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -30,5 +30,6 @@ fi
 pycodestyle .
 display_result $? 1 "Code style check"
 
-py.test --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml
+# run with six concurrent threads
+py.test --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml -n 6
 display_result $? 2 "Unit tests"


### PR DESCRIPTION
previously we didn't do this because the tests all used the same DB (test_notifications_api), however @minglis shared a snippet that simply creates one test db per thread. If you run without using `run_tests` (or `py.test -n #`) then it'll create a db `test_notifications_api_master`