### PR TITLE
Added a proper error response if the notification type is not supported.

### DIFF
--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -17,8 +17,8 @@ from app.errors import (
 )
 from app.models import (
     EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, SMS_TYPE,
-    KEY_TYPE_TEAM, PRIORITY
-)
+    KEY_TYPE_TEAM, PRIORITY,
+    LETTER_TYPE)
 from app.notifications.process_notifications import (
     persist_notification,
     send_notification_to_queue,
@@ -99,8 +99,10 @@ def get_notification_statistics_for_day():
 @notifications.route('/notifications/<string:notification_type>', methods=['POST'])
 def send_notification(notification_type):
 
-    if notification_type not in ['sms', 'email']:
-        assert False
+    if notification_type not in [SMS_TYPE, EMAIL_TYPE]:
+        msg = "{} notification type is not supported".format(notification_type)
+        msg = msg + ", please use the latest version of the client" if notification_type == LETTER_TYPE else msg
+        raise InvalidRequest(msg, 400)
 
     notification_form, errors = (
         sms_template_notification_schema if notification_type == SMS_TYPE else email_notification_schema

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -1205,3 +1205,17 @@ def test_should_not_allow_notification_if_service_permission_not_set(
 
     assert error_json['result'] == 'error'
     assert error_json['message']['service'][0] == expected_error
+
+
+@pytest.mark.parametrize(
+    "notification_type, err_msg",
+    [("letter", "letter notification type is not supported, please use the latest version of the client"),
+     ("apple", "apple notification type is not supported")])
+def test_should_throw_exception_if_notification_type_is_invalid(client, sample_service, notification_type, err_msg):
+    auth_header = create_authorization_header(service_id=sample_service.id)
+    response = client.post(
+        path='/notifications/{}'.format(notification_type),
+        data={},
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert response.status_code == 400
+    assert json.loads(response.get_data(as_text=True))["message"] == err_msg


### PR DESCRIPTION
If the notification was invalid it would raise an exception with an error message. Now if someone tries to send a letter with the old API they will get a message to try the latest version of the client.