### PR TITLE
make pyup ignore flask-bcrypt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,10 @@ apispec==0.25.0
 boto3==1.4.6
 celery==3.1.25 # pyup: <4
 docopt==0.6.2
-Flask-Bcrypt==0.6.2
+# ignore flask-bcrypt - when upgrading, it installs an invalid version of bcrypt that isn't removed when a different
+# branch runs, so can cause other PR builds to fail on jenkins.
+# TODO: Upgrade flask-bcrypt in a safe way
+Flask-Bcrypt==0.6.2 # pyup: ignore
 Flask-Marshmallow==0.8.0
 Flask-Migrate==2.1.0
 Flask-Script==2.0.5


### PR DESCRIPTION
pyup is trying to upgrade flask-bcrypt, which causes errors in all subsequent PR builds for #reasons. Lets make pyup ignore flask-bcrypt until we figure out why the upgrade doesn't work