### PR TITLE
Allow Notify service to send international sms

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -318,7 +318,7 @@ class ServiceWhitelist(db.Model):
 
         try:
             if recipient_type == MOBILE_TYPE:
-                validate_phone_number(recipient)
+                validate_phone_number(recipient, international=True)
                 instance.recipient = recipient
             elif recipient_type == EMAIL_TYPE:
                 validate_email_address(recipient)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -130,7 +130,7 @@ class UserUpdateAttributeSchema(BaseSchema):
     @validates('mobile_number')
     def validate_mobile_number(self, value):
         try:
-            validate_phone_number(value)
+            validate_phone_number(value, international=True)
         except InvalidPhoneError as error:
             raise ValidationError('Invalid phone number: {}'.format(error))
 

--- a/migrations/versions/0117_international_sms_notify.py
+++ b/migrations/versions/0117_international_sms_notify.py
@@ -1,0 +1,33 @@
+"""empty message
+
+Revision ID: 0117_international_sms_notify
+Revises: 0116_another_letter_org
+Create Date: 2017-08-29 14:09:41.042061
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0117_international_sms_notify'
+down_revision = '0116_another_letter_org'
+
+from alembic import op
+from datetime import datetime
+
+
+NOTIFY_SERVICE_ID = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'
+
+
+def upgrade():
+    op.execute("""
+        INSERT INTO service_permissions VALUES
+        ('{}', 'international_sms', '{}')
+    """.format(NOTIFY_SERVICE_ID, datetime.utcnow()))
+
+
+def downgrade():
+    op.execute("""
+        DELETE FROM service_permissions
+            WHERE
+                service_id = '{}' AND
+                permission = 'international_sms'
+    """.format(NOTIFY_SERVICE_ID))

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -23,19 +23,24 @@ from app.models import User, VerifyCode
 from tests.app.db import create_user
 
 
-def test_create_user(notify_db_session):
+@pytest.mark.parametrize('phone_number', [
+    '+447700900986',
+    '+1-800-555-5555',
+])
+def test_create_user(notify_db_session, phone_number):
     email = 'notify@digital.cabinet-office.gov.uk'
     data = {
         'name': 'Test User',
         'email_address': email,
         'password': 'password',
-        'mobile_number': '+447700900986'
+        'mobile_number': phone_number
     }
     user = User(**data)
     save_model_user(user)
     assert User.query.count() == 1
     assert User.query.first().email_address == email
     assert User.query.first().id == user.id
+    assert User.query.first().mobile_number == phone_number
     assert not user.platform_admin
 
 

--- a/tests/app/service/test_service_whitelist.py
+++ b/tests/app/service/test_service_whitelist.py
@@ -24,14 +24,15 @@ def test_get_whitelist_returns_data(client, sample_service_whitelist):
 def test_get_whitelist_separates_emails_and_phones(client, sample_service):
     dao_add_and_commit_whitelisted_contacts([
         ServiceWhitelist.from_string(sample_service.id, EMAIL_TYPE, 'service@example.com'),
-        ServiceWhitelist.from_string(sample_service.id, MOBILE_TYPE, '07123456789')
+        ServiceWhitelist.from_string(sample_service.id, MOBILE_TYPE, '07123456789'),
+        ServiceWhitelist.from_string(sample_service.id, MOBILE_TYPE, '+1800-555-555'),
     ])
 
     response = client.get('service/{}/whitelist'.format(sample_service.id), headers=[create_authorization_header()])
     assert response.status_code == 200
     assert json.loads(response.get_data(as_text=True)) == {
         'email_addresses': ['service@example.com'],
-        'phone_numbers': ['07123456789']
+        'phone_numbers': ['+1800-555-555', '07123456789']
     }
 
 


### PR DESCRIPTION
Right now Notify restricts you to registering with a UK mobile number. This is because when we built the user registration stuff we couldn’t send to international mobiles.

However we can send to international mobile numbers, and it’s totally reasonable to expect employees of the UK government to be working abroad, and have a foreign mobile phone – we’ve heard from one such user.

In order for users of Notify to register with an international phone number, the Notify service needs to have the `international_sms` permission set. Which this commit does, as a data migration.

---

Since we’re letting users register with international phone numbers on the frontend, we shouldn’t block users from doing this on the API side.  Same thing for the whitelist, where we’re also allowing international phone numbers now. So this PR also updates the validation to be the same between the API and the frontend.



