### PR TITLE
[1/5] Create new ServiceEmailReplyTo table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1329,3 +1329,17 @@ class MonthlyBilling(db.Model):
 
     def __repr__(self):
         return str(self.serialized())
+
+
+class ServiceEmailReplyTo(db.Model):
+    __tablename__ = "service_email_reply_to"
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    service_id = db.Column(UUID(as_uuid=True), db.ForeignKey('services.id'), unique=False, index=True, nullable=False)
+    service = db.relationship(Service, backref=db.backref("reply_to_email_addresses", uselist=False))
+
+    email_address = db.Column(db.Text, nullable=False, index=False, unique=False)
+    is_default = db.Column(db.Boolean, nullable=False, default=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,18 +1,17 @@
-"""${message}
+"""
 
 Revision ID: ${up_revision}
 Revises: ${down_revision}
 Create Date: ${create_date}
 
 """
-
-# revision identifiers, used by Alembic.
-revision = ${repr(up_revision)}
-down_revision = ${repr(down_revision)}
-
 from alembic import op
 import sqlalchemy as sa
 ${imports if imports else ""}
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+
 
 def upgrade():
     ${upgrades if upgrades else "pass"}

--- a/migrations/versions/0119_add_email_reply_to.py
+++ b/migrations/versions/0119_add_email_reply_to.py
@@ -1,0 +1,34 @@
+"""
+
+Revision ID: 0119_add_email_reply_to
+Revises: 0118_service_sms_senders
+Create Date: 2017-09-07 15:29:49.087143
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0119_add_email_reply_to'
+down_revision = '0118_service_sms_senders'
+
+
+def upgrade():
+    op.create_table('service_email_reply_to',
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('service_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('email_address', sa.Text(), nullable=False),
+        sa.Column('is_default', sa.Boolean(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['service_id'], ['services.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(
+        op.f('ix_service_email_reply_to_service_id'), 'service_email_reply_to', ['service_id'], unique=False
+    )
+
+
+def downgrade():
+    op.drop_index(op.f('ix_service_email_reply_to_service_id'), table_name='service_email_reply_to')
+    op.drop_table('service_email_reply_to')


### PR DESCRIPTION
This adds a migration that creates the `service_email_reply_to` table that will facilitate having multiple from-email addresses for a service.

## Notes

`email_address` cannot be `null` which means for services that have no `reply_to_email_address` will not have an entry in the table. 

The alembic template used to generate migration scripts was also changed which resolves some PEP errors.