### PR TITLE
[2/5] Upsert into ServiceReplyToEmail table when updating a service

### DIFF
--- a/app/dao/service_email_reply_to_dao.py
+++ b/app/dao/service_email_reply_to_dao.py
@@ -1,0 +1,32 @@
+from app import db
+from app.dao.dao_utils import transactional
+from app.models import ServiceEmailReplyTo
+
+
+def create_or_update_email_reply_to(service_id, email_address):
+    reply_to = dao_get_reply_to_by_service_id(service_id)
+    if reply_to:
+        reply_to.email_address = email_address
+        dao_update_reply_to_email(reply_to)
+    else:
+        reply_to = ServiceEmailReplyTo(service_id=service_id, email_address=email_address)
+        dao_create_reply_to_email_address(reply_to)
+
+
+@transactional
+def dao_create_reply_to_email_address(reply_to_email):
+    db.session.add(reply_to_email)
+
+
+def dao_get_reply_to_by_service_id(service_id):
+    reply_to = db.session.query(
+        ServiceEmailReplyTo
+    ).filter(
+        ServiceEmailReplyTo.service_id == service_id
+    ).first()
+    return reply_to
+
+
+@transactional
+def dao_update_reply_to_email(reply_to):
+    db.session.add(reply_to)

--- a/tests/app/dao/test_service_email_reply_to_dao.py
+++ b/tests/app/dao/test_service_email_reply_to_dao.py
@@ -1,0 +1,41 @@
+from app.dao.service_email_reply_to_dao import (
+    create_or_update_email_reply_to,
+    dao_get_reply_to_by_service_id
+)
+from app.models import ServiceEmailReplyTo
+from tests.app.db import create_reply_to_email, create_service
+
+
+def test_create_or_update_email_reply_to_does_not_create_another_entry(notify_db_session):
+    service = create_service()
+    create_reply_to_email(service, 'test@mail.com')
+
+    create_or_update_email_reply_to(service.id, 'different@mail.com')
+
+    reply_to = dao_get_reply_to_by_service_id(service.id)
+
+    assert ServiceEmailReplyTo.query.count() == 1
+
+
+def test_create_or_update_email_reply_to_updates_existing_entry(notify_db_session):
+    service = create_service()
+    create_reply_to_email(service, 'test@mail.com')
+
+    create_or_update_email_reply_to(service.id, 'different@mail.com')
+
+    reply_to = dao_get_reply_to_by_service_id(service.id)
+
+    assert reply_to.service.id == service.id
+    assert reply_to.email_address == 'different@mail.com'
+
+
+def test_create_or_update_email_reply_to_creates_new_entry(notify_db_session):
+    service = create_service()
+
+    create_or_update_email_reply_to(service.id, 'test@mail.com')
+
+    reply_to = dao_get_reply_to_by_service_id(service.id)
+
+    assert ServiceEmailReplyTo.query.count() == 1
+    assert reply_to.service.id == service.id
+    assert reply_to.email_address == 'test@mail.com'

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -25,7 +25,9 @@ from app.models import (
     SMS_TYPE,
     INBOUND_SMS_TYPE,
     KEY_TYPE_NORMAL,
-    ServiceInboundApi)
+    ServiceInboundApi,
+    ServiceEmailReplyTo
+)
 from app.dao.users_dao import save_model_user
 from app.dao.notifications_dao import dao_create_notification, dao_created_scheduled_notification
 from app.dao.templates_dao import dao_create_template
@@ -327,3 +329,19 @@ def create_monthly_billing_entry(
     db.session.commit()
 
     return entry
+
+
+def create_reply_to_email(
+    service,
+    email_address
+):
+    data = {
+        'service': service,
+        'email_address': email_address,
+    }
+    reply_to = ServiceEmailReplyTo(**data)
+
+    db.session.add(reply_to)
+    db.session.commit()
+
+    return reply_to

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2123,3 +2123,18 @@ def test_is_service_name_unique_returns_400_when_name_does_not_exist(client):
     json_resp = json.loads(response.get_data(as_text=True))
     assert json_resp["message"][0]["name"] == ["Can't be empty"]
     assert json_resp["message"][1]["email_from"] == ["Can't be empty"]
+
+
+def test_update_service_reply_to_email_address_upserts_email_reply_to(mocker, admin_request, sample_service):
+    update_mock = mocker.patch('app.service.rest.create_or_update_email_reply_to')
+
+    admin_request.post(
+        'service.update_service',
+        service_id=sample_service.id,
+        _data={
+            'reply_to_email_address': 'new@mail.com'
+        },
+        _expected_status=200
+    )
+
+    assert update_mock.called


### PR DESCRIPTION
**Branched off #1233 and will rebase off master once #1233 is merged.**  

## Summary

This will upsert (update or insert) the `service_email_reply_to` table when the `reply_to_email_address` for a service is changed.

**UPDATE: Rebased successfully.**