### PR TITLE
[3/5] Migrate existing data to new service_email_reply_to table

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -228,3 +228,23 @@ class BackfillProcessingTime(Command):
                 process_end_date.isoformat()
             ))
             send_processing_time_for_start_and_end(process_start_date, process_end_date)
+
+
+class PopulateServiceEmailReplyTo(Command):
+
+    def run(self):
+        services_to_update = """
+            INSERT INTO service_email_reply_to(id, service_id, email_address, is_default, created_at)
+            SELECT '{}', id, reply_to_email_address, true, '{}'
+            FROM services
+            WHERE reply_to_email_address IS NOT NULL
+            AND id NOT IN(
+                SELECT service_id
+                FROM service_email_reply_to
+            )
+        """.format(uuid.uuid4(), datetime.utcnow())
+
+        result = db.session.execute(services_to_update)
+        db.session.commit()
+
+        print("Populated email reply to adderesses for {}".format(result.rowcount))

--- a/app/commands.py
+++ b/app/commands.py
@@ -235,14 +235,14 @@ class PopulateServiceEmailReplyTo(Command):
     def run(self):
         services_to_update = """
             INSERT INTO service_email_reply_to(id, service_id, email_address, is_default, created_at)
-            SELECT '{}', id, reply_to_email_address, true, '{}'
+            SELECT uuid_in(md5(random()::text || now()::text)::cstring), id, reply_to_email_address, true, '{}'
             FROM services
             WHERE reply_to_email_address IS NOT NULL
             AND id NOT IN(
                 SELECT service_id
                 FROM service_email_reply_to
             )
-        """.format(uuid.uuid4(), datetime.utcnow())
+        """.format(datetime.utcnow())
 
         result = db.session.execute(services_to_update)
         db.session.commit()

--- a/application.py
+++ b/application.py
@@ -18,6 +18,7 @@ manager.add_command('purge_functional_test_data', commands.PurgeFunctionalTestDa
 manager.add_command('custom_db_script', commands.CustomDbScript)
 manager.add_command('populate_monthly_billing', commands.PopulateMonthlyBilling)
 manager.add_command('backfill_processing_time', commands.BackfillProcessingTime)
+manager.add_command('populate_service_email_reply_to', commands.PopulateServiceEmailReplyTo)
 
 
 @manager.command


### PR DESCRIPTION
Branched off #1237 and will be rebased once that's merged in.

This adds a command that will migrate all the existing data to the new `service_email_reply_to` table.

## Summary

As it stands, any service that updates their `reply_to_email_address` will have an 'upserted` entry in 
`service_email_reply_to`. However services that do not, still need an entry in this new table if their `reply_to_email_address` has been set. 

This adds a command that will do that. There are two key rules:

1. If the `reply_to_email_address` is `NULL` for a service, we do not want to create an entry
2. If an entry already exists for a service in `service_email_reply_to`, don't populate the new table as  it's already there

**UPDATE: Rebased off master**