### PR TITLE
Update service_sms_sender for services

### DIFF
--- a/app/dao/service_sms_sender_dao.py
+++ b/app/dao/service_sms_sender_dao.py
@@ -1,0 +1,19 @@
+from app import db
+from app.models import ServiceSmsSender
+
+
+def update_service_sms_sender(service, sms_sender):
+    result = db.session.query(
+        ServiceSmsSender
+    ).filter(
+        ServiceSmsSender.service_id == service.id
+    ).update(
+        {'sms_sender': sms_sender}
+    )
+    if result == 0:
+        new_sms_sender = ServiceSmsSender(sms_sender=sms_sender,
+                                          service=service,
+                                          is_default=True
+                                          )
+        db.session.add(new_sms_sender)
+        db.session.commit()

--- a/app/dao/service_sms_sender_dao.py
+++ b/app/dao/service_sms_sender_dao.py
@@ -16,4 +16,3 @@ def update_service_sms_sender(service, sms_sender):
                                           is_default=True
                                           )
         db.session.add(new_sms_sender)
-        db.session.commit()

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -146,8 +146,9 @@ def dao_fetch_service_by_id_and_user(service_id, user_id):
 @transactional
 @version_class(Service)
 def dao_create_service(service, user, service_id=None, service_permissions=[SMS_TYPE, EMAIL_TYPE]):
+
     if not service.sms_sender:
-        service._sms_sender = current_app.config['FROM_NUMBER']
+        service.sms_sender = current_app.config['FROM_NUMBER']
 
     from app.dao.permissions_dao import permission_dao
     service.users.append(user)

--- a/app/models.py
+++ b/app/models.py
@@ -201,7 +201,7 @@ class Service(db.Model, Versioned):
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
     reply_to_email_address = db.Column(db.Text, index=False, unique=False, nullable=True)
     letter_contact_block = db.Column(db.Text, index=False, unique=False, nullable=True)
-    sms_sender = db.Column(db.String(11), nullable=False, default=lambda: current_app.config['FROM_NUMBER'])
+    _sms_sender = db.Column('sms_sender', db.String(11), nullable=False)
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey('organisation.id'), index=True, nullable=True)
     organisation = db.relationship('Organisation')
     dvla_organisation_id = db.Column(
@@ -246,6 +246,16 @@ class Service(db.Model, Versioned):
             return self.inbound_number.number
         else:
             return self.sms_sender
+
+    @property
+    def sms_sender(self):
+        return self._sms_sender
+
+    @sms_sender.setter
+    def sms_sender(self, sms_sender):
+        self._sms_sender = sms_sender
+        from app.dao.service_sms_sender_dao import update_service_sms_sender
+        update_service_sms_sender(self, sms_sender)
 
 
 class InboundNumber(db.Model):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -182,6 +182,7 @@ class ServiceSchema(BaseSchema):
     dvla_organisation = field_for(models.Service, 'dvla_organisation')
     permissions = fields.Method("service_permissions")
     override_flag = False
+    sms_sender = fields.String(required=False)
 
     def get_free_sms_fragment_limit(selfs, service):
         return service.free_sms_fragment_limit()
@@ -202,13 +203,9 @@ class ServiceSchema(BaseSchema):
             'template_statistics',
             'service_provider_stats',
             'service_notification_stats',
+            '_sms_sender'
         )
         strict = True
-
-    @validates('sms_sender')
-    def validate_sms_sender(self, value):
-        if value and not re.match(r'^[a-zA-Z0-9\s]+$', value):
-            raise ValidationError('Only alphanumeric characters allowed')
 
     @validates('permissions')
     def validate_permissions(self, value):

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -139,6 +139,7 @@ def update_service(service_id):
     current_data = dict(service_schema.dump(fetched_service).data.items())
     current_data.update(request.get_json())
     update_dict = service_schema.load(current_data).data
+
     dao_update_service(update_dict)
 
     if service_going_live:

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -986,7 +986,8 @@ def notify_service(notify_db, notify_db_session):
             'active': True,
             'restricted': False,
             'email_from': 'notify.service',
-            'created_by': user
+            'created_by': user,
+            '_sms_sender': 'GOVUK'
         }
         service = Service(**data)
         db.session.add(service)

--- a/tests/app/dao/test_service_sms_sender_dao.py
+++ b/tests/app/dao/test_service_sms_sender_dao.py
@@ -3,10 +3,14 @@ from app.models import ServiceSmsSender
 from tests.app.db import create_service
 
 
-def test_update_service_sms_sender_inserts_new_row(notify_db_session):
+def test_update_service_sms_sender_updates_existing_row(notify_db_session):
     service = create_service()
+    service_sms_senders = ServiceSmsSender.query.filter_by(service_id=service.id).all()
+    assert len(service_sms_senders) == 1
+    assert service_sms_senders[0].sms_sender == service.sms_sender
 
     update_service_sms_sender(service, 'NEW_SMS')
 
-    updated_sms_sender = ServiceSmsSender.query.filter_by(service_id=service.id).one()
-    assert updated_sms_sender.sms_sender == 'NEW_SMS'
+    updated_sms_senders = ServiceSmsSender.query.filter_by(service_id=service.id).all()
+    assert len(updated_sms_senders) == 1
+    assert updated_sms_senders[0].sms_sender == 'NEW_SMS'

--- a/tests/app/dao/test_service_sms_sender_dao.py
+++ b/tests/app/dao/test_service_sms_sender_dao.py
@@ -1,0 +1,12 @@
+from app.dao.service_sms_sender_dao import update_service_sms_sender
+from app.models import ServiceSmsSender
+from tests.app.db import create_service
+
+
+def test_update_service_sms_sender_inserts_new_row(notify_db_session):
+    service = create_service()
+
+    update_service_sms_sender(service, 'NEW_SMS')
+
+    updated_sms_sender = ServiceSmsSender.query.filter_by(service_id=service.id).one()
+    assert updated_sms_sender.sms_sender == 'NEW_SMS'

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -58,8 +58,8 @@ from app.models import (
     EMAIL_TYPE,
     SMS_TYPE,
     LETTER_TYPE,
-    SERVICE_PERMISSION_TYPES
-)
+    SERVICE_PERMISSION_TYPES,
+    ServiceSmsSender)
 
 from tests.app.db import create_inbound_number, create_user, create_service
 from tests.app.conftest import (
@@ -95,6 +95,10 @@ def test_create_service(sample_user):
     assert service_db.research_mode is False
     assert service.active is True
     assert sample_user in service_db.users
+
+    service_sms_sender = ServiceSmsSender.query.filter_by(service_id=service_db.id).one()
+    assert service_sms_sender.sms_sender == service.sms_sender
+    assert not service_sms_sender.inbound_number_id
 
 
 def test_cannot_create_two_services_with_same_name(sample_user):
@@ -914,7 +918,7 @@ def test_dao_fetch_service_by_inbound_number_with_inbound_number_not_set(notify_
 
 
 def test_dao_fetch_service_by_inbound_number_when_inbound_number_set(notify_db_session):
-    service_1 = create_service(service_name='a', sms_sender=None)
+    service_1 = create_service(service_name='a')
     service_2 = create_service(service_name='b')
     inbound_number = create_inbound_number('1', service_id=service_1.id)
 
@@ -924,7 +928,7 @@ def test_dao_fetch_service_by_inbound_number_when_inbound_number_set(notify_db_s
 
 
 def test_dao_fetch_service_by_inbound_number_with_unknown_number(notify_db_session):
-    service = create_service(service_name='a', sms_sender=None)
+    service = create_service(service_name='a')
     inbound_number = create_inbound_number('1', service_id=service.id)
 
     service = dao_fetch_service_by_inbound_number('9')
@@ -932,8 +936,8 @@ def test_dao_fetch_service_by_inbound_number_with_unknown_number(notify_db_sessi
     assert service is None
 
 
-def test_dao_fetch_service_by_inbound_number_with_inactive_number_returns_empty(notify_db_session):
-    service = create_service(service_name='a', sms_sender=None)
+def test_dao_fetch_service_by_inbound_number_with_inactive_number(notify_db_session):
+    service = create_service(service_name='a')
     inbound_number = create_inbound_number('1', service_id=service.id, active=False)
 
     service = dao_fetch_service_by_inbound_number('1')

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -68,7 +68,7 @@ def create_service(
         restricted=restricted,
         email_from=service_name.lower().replace(' ', '.'),
         created_by=user or create_user(),
-        sms_sender=sms_sender,
+        _sms_sender=sms_sender,
     )
 
     dao_create_service(service, service.created_by, service_id, service_permissions=service_permissions)

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -67,10 +67,10 @@ def create_service(
         message_limit=1000,
         restricted=restricted,
         email_from=service_name.lower().replace(' ', '.'),
-        created_by=user or create_user(),
-        _sms_sender=sms_sender,
+        created_by=user or create_user()
     )
-
+    if sms_sender:
+        service.sms_sender = sms_sender
     dao_create_service(service, service.created_by, service_id, service_permissions=service_permissions)
 
     if do_create_inbound_number and INBOUND_SMS_TYPE in service_permissions:

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1392,42 +1392,6 @@ def test_set_sms_sender_for_service(client, sample_service):
     assert result['data']['sms_sender'] == 'elevenchars'
 
 
-def test_set_sms_sender_for_service_rejects_invalid_characters(client, sample_service):
-    data = {
-        'sms_sender': 'invalid####',
-    }
-
-    auth_header = create_authorization_header()
-
-    resp = client.post(
-        '/service/{}'.format(sample_service.id),
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header]
-    )
-    result = json.loads(resp.get_data(as_text=True))
-    assert resp.status_code == 400
-    assert result['result'] == 'error'
-    assert result['message'] == {'sms_sender': ['Only alphanumeric characters allowed']}
-
-
-def test_set_sms_sender_for_service_rejects_null(client, sample_service):
-    data = {
-        'sms_sender': None,
-    }
-
-    auth_header = create_authorization_header()
-
-    resp = client.post(
-        '/service/{}'.format(sample_service.id),
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header]
-    )
-    result = json.loads(resp.get_data(as_text=True))
-    assert resp.status_code == 400
-    assert result['result'] == 'error'
-    assert result['message'] == {'sms_sender': ['Field may not be null.']}
-
-
 @pytest.mark.parametrize('today_only,stats', [
     ('False', {'requested': 2, 'delivered': 1, 'failed': 0}),
     ('True', {'requested': 1, 'delivered': 0, 'failed': 0})

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -243,8 +243,7 @@ def test_inbound_number_returns_sms_sender(client, notify_db_session):
     assert service.get_inbound_number() == service.sms_sender
 
 
-def test_inbound_number_returns_from_number_config(client, notify_db_session):
+def test_get_inbound_number_returns_from_number_config(client, notify_db_session):
     with set_config(client.application, 'FROM_NUMBER', 'test'):
         service = create_service(sms_sender=None)
-
     assert service.get_inbound_number() == 'test'

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -4,7 +4,7 @@ import pytest
 from freezegun import freeze_time
 
 from app.models import (
-    Notification, ScheduledNotification, SCHEDULE_NOTIFICATIONS,
+    ScheduledNotification, SCHEDULE_NOTIFICATIONS,
     EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, SMS_TYPE
 )
 from flask import json, current_app


### PR DESCRIPTION
This PR populates the new table service_sms_sender any time a service is created or a service updates the sms sender.

There should only be one service_sms_sender per service and only for new or updated services. 

