### PR TITLE
Small refactor to how notification_schemas are tested.

### DIFF
--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -177,7 +177,7 @@ email_content = {
 
 post_email_response = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "POST sms notification response schema",
+    "description": "POST email notification response schema",
     "type": "object",
     "title": "response v2/notifications/email",
     "properties": {

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -88,7 +88,7 @@ def post_notification(notification_type):
         create_resp_partial = functools.partial(
             create_post_email_response_from_notification,
             subject=template_with_content.subject,
-            email_from=authenticated_service.email_from
+            email_from='{}@{}'.format(authenticated_service.email_from, current_app.config['NOTIFY_EMAIL_DOMAIN'])
         )
     elif notification_type == LETTER_TYPE:
         create_resp_partial = functools.partial(

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -8,4 +8,6 @@ coveralls==1.2.0
 moto==1.1.2
 freezegun==0.3.9
 requests-mock==1.3.0
+# optional requirements for jsonschema
 strict-rfc3339==0.7
+rfc3987==1.3.7

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -12,7 +12,9 @@ from app.models import KEY_TYPE_TEST
 from app.models import LETTER_TYPE
 from app.models import Notification
 from app.models import SMS_TYPE
+from app.schema_validation import validate
 from app.v2.errors import RateLimitError
+from app.v2.notifications.notification_schemas import post_letter_response
 from app.variables import LETTER_TEST_API_FILENAME
 from app.variables import LETTER_API_FILENAME
 
@@ -53,6 +55,7 @@ def test_post_letter_notification_returns_201(client, sample_letter_template, mo
 
     resp_json = letter_request(client, data, service_id=sample_letter_template.service_id)
 
+    assert validate(resp_json, post_letter_response) == resp_json
     job = Job.query.one()
     assert job.original_file_name == LETTER_API_FILENAME
     notification = Notification.query.one()


### PR DESCRIPTION
My local build was not always getting the optional requirement for the jsonschema uri format checker (rfc3987).
The requirement has been added to the requirements_for_test file.
I changed the tests to validate the response schema from the post_notifications tests, this way we can tell if we are breaking the contract.
This showed that the email_from was not returning the entire email address but just the username, that has been corrected here.
Removed the response schema validation tests since they are not being testing in the post notification tests.