### PR TITLE
Return delivery estimate for letter notifications

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -16,6 +16,7 @@ from notifications_utils.recipients import (
     InvalidPhoneError,
     InvalidEmailError
 )
+from notifications_utils.letter_timings import get_letter_timings
 
 from app.encryption import (
     hashpw,
@@ -1029,6 +1030,10 @@ class Notification(db.Model):
             serialized['line_5'] = self.personalisation.get('address_line_5')
             serialized['line_6'] = self.personalisation.get('address_line_6')
             serialized['postcode'] = self.personalisation['postcode']
+            serialized['estimated_delivery'] = \
+                get_letter_timings(serialized['created_at'])\
+                .earliest_delivery\
+                .strftime(DATETIME_FORMAT)
 
         return serialized
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -568,12 +568,12 @@ def sample_notification(
 @pytest.fixture
 def sample_letter_notification(sample_letter_template):
     address = {
-        'addressline1': 'A1',
-        'addressline2': 'A2',
-        'addressline3': 'A3',
-        'addressline4': 'A4',
-        'addressline5': 'A5',
-        'addressline6': 'A6',
+        'address_line_1': 'A1',
+        'address_line_2': 'A2',
+        'address_line_3': 'A3',
+        'address_line_4': 'A4',
+        'address_line_5': 'A5',
+        'address_line_6': 'A6',
         'postcode': 'A_POST'
     }
     return create_notification(sample_letter_template, personalisation=address)

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -9,6 +9,11 @@ from tests.app.db import (
     create_template,
     create_service)
 
+from tests.app.conftest import (
+    sample_notification,
+    sample_email_notification,
+)
+
 
 @pytest.mark.parametrize('billable_units, provider', [
     (1, 'mmg'),
@@ -231,6 +236,26 @@ def test_get_notification_adds_delivery_estimate_for_letters(
     json_response = json.loads(response.get_data(as_text=True))
     assert response.status_code == 200
     assert json_response['estimated_delivery'] == estimated_delivery
+
+
+@pytest.mark.parametrize('notification_mock', [
+    sample_notification,
+    sample_email_notification,
+])
+def test_get_notification_doesnt_have_delivery_estimate_for_non_letters(
+    client,
+    notify_db,
+    notify_db_session,
+    notification_mock,
+):
+    mocked_notification = notification_mock(notify_db, notify_db_session)
+    auth_header = create_authorization_header(service_id=mocked_notification.service_id)
+    response = client.get(
+        path='/v2/notifications/{}'.format(mocked_notification.id),
+        headers=[('Content-Type', 'application/json'), auth_header]
+    )
+    assert response.status_code == 200
+    assert 'estimated_delivery' not in json.loads(response.get_data(as_text=True))
 
 
 def test_get_all_notifications_returns_200(client, sample_template):


### PR DESCRIPTION
> For get all or get one letter the response needs to be updated so that it looks similar to admin app.
>
> status: created|sending --> received letter
> new column: `estimated delivery date`: derived from created at date. (see how the admin app is doing it)
>

– https://www.pivotaltracker.com/story/show/150512525

This commit implements the date (not status) part of this story.

***

Depends on: 
- [x] https://github.com/alphagov/notifications-utils/pull/221