### PR TITLE
upgrade flask-bcrypt to 0.7.1

### DIFF
--- a/app/encryption.py
+++ b/app/encryption.py
@@ -16,7 +16,7 @@ class Encryption:
 
 
 def hashpw(password):
-    return generate_password_hash(password.encode('UTF-8'), 10)
+    return generate_password_hash(password.encode('UTF-8'), 10).decode('utf-8')
 
 
 def check_hash(password, hashed_password):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,7 @@
 boto3==1.4.7
 celery==3.1.25 # pyup: <4
 docopt==0.6.2
-# ignore flask-bcrypt - when upgrading, it installs an invalid version of bcrypt that isn't removed when a different
-# branch runs, so can cause other PR builds to fail on jenkins.
-# TODO: Upgrade flask-bcrypt in a safe way
-Flask-Bcrypt==0.6.2 # pyup: ignore
+Flask-Bcrypt==0.7.1
 Flask-Marshmallow==0.8.0
 Flask-Migrate==2.1.1
 Flask-Script==2.0.5


### PR DESCRIPTION
this uses bcrypt directly rather than using the wrapper python-bcrypt.
WARNING! You'll need to update your local install by running:

```
pip uninstall python-bcrypt
pip install flask-bcrypt==0.7.1
```