### PR TITLE
Raise validation errors for empty letter fields

### DIFF
--- a/app/schema_validation/definitions.py
+++ b/app/schema_validation/definitions.py
@@ -19,7 +19,27 @@ personalisation = {
 }
 
 
-letter_personalisation = dict(personalisation, required=["address_line_1", "address_line_2", "postcode"])
+letter_personalisation = dict(
+    personalisation,
+    properties={
+        "address_line_1": {
+            "type": "string",
+            "minLength": 1,
+            "validationMessage": "address_line_1 is required"
+        },
+        "address_line_2": {
+            "type": "string",
+            "minLength": 1,
+            "validationMessage": "address_line_2 is required"
+        },
+        "postcode": {
+            "type": "string",
+            "minLength": 1,
+            "validationMessage": "postcode is required"
+        },
+    },
+    required=["address_line_1", "address_line_2", "postcode"],
+)
 
 
 https_url = {

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -20,6 +20,13 @@ from tests import create_authorization_header
 from tests.app.db import create_service, create_template
 
 
+test_address = {
+    'address_line_1': 'test 1',
+    'address_line_2': 'test 2',
+    'postcode': 'test pc'
+}
+
+
 def letter_request(client, data, service_id, key_type=KEY_TYPE_NORMAL, _expected_status=201):
     resp = client.post(
         url_for('v2_notifications.post_notification', notification_type=LETTER_TYPE),
@@ -81,7 +88,7 @@ def test_post_letter_notification_returns_400_and_missing_template(
 ):
     data = {
         'template_id': str(uuid.uuid4()),
-        'personalisation': {'address_line_1': '', 'address_line_2': '', 'postcode': ''}
+        'personalisation': test_address
     }
 
     error_json = letter_request(client, data, service_id=sample_service_full_permissions.id, _expected_status=400)
@@ -90,12 +97,33 @@ def test_post_letter_notification_returns_400_and_missing_template(
     assert error_json['errors'] == [{'error': 'BadRequestError', 'message': 'Template not found'}]
 
 
+def test_post_letter_notification_returns_400_for_empty_personalisation(
+    client,
+    sample_service_full_permissions,
+    sample_letter_template
+):
+    data = {
+        'template_id': str(sample_letter_template.id),
+        'personalisation': {'address_line_1': '', 'address_line_2': '', 'postcode': ''}
+    }
+
+    error_json = letter_request(client, data, service_id=sample_service_full_permissions.id, _expected_status=400)
+
+    assert error_json['status_code'] == 400
+    assert all([e['error'] == 'ValidationError' for e in error_json['errors']])
+    assert set([e['message'] for e in error_json['errors']]) == set([
+        'personalisation address_line_1 is required',
+        'personalisation address_line_2 is required',
+        'personalisation postcode is required'
+    ])
+
+
 def test_notification_returns_400_for_missing_template_field(
     client,
     sample_service_full_permissions
 ):
     data = {
-        'personalisation': {'address_line_1': '', 'address_line_2': '', 'postcode': ''}
+        'personalisation': test_address
     }
 
     error_json = letter_request(client, data, service_id=sample_service_full_permissions.id, _expected_status=400)
@@ -147,7 +175,7 @@ def test_returns_a_429_limit_exceeded_if_rate_limit_exceeded(
 
     data = {
         'template_id': str(sample_letter_template.id),
-        'personalisation': {'address_line_1': '', 'address_line_2': '', 'postcode': ''}
+        'personalisation': test_address
     }
 
     error_json = letter_request(client, data, service_id=sample_letter_template.service_id, _expected_status=429)
@@ -175,7 +203,7 @@ def test_post_letter_notification_returns_403_if_not_allowed_to_send_notificatio
 
     data = {
         'template_id': str(template.id),
-        'personalisation': {'address_line_1': '', 'address_line_2': '', 'postcode': ''}
+        'personalisation': test_address
     }
 
     error_json = letter_request(client, data, service_id=service.id, _expected_status=400)


### PR DESCRIPTION
## What

Fixes the problem mentioned here https://www.pivotaltracker.com/story/show/150843938 

Currently for letter API calls it throws a `400` on missing required fields but accepts blank ones, which should really also throw a `400` with an appropriate message.

- Updated the JSON schema to check that strings are not empty.
- Refactored letter tests so that they are not broken

