### PR TITLE
Update reply to email test

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1337,7 +1337,7 @@ class ServiceEmailReplyTo(db.Model):
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
 
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey('services.id'), unique=False, index=True, nullable=False)
-    service = db.relationship(Service, backref=db.backref("reply_to_email_addresses", uselist=False))
+    service = db.relationship(Service, backref=db.backref("reply_to_email_addresses"))
 
     email_address = db.Column(db.Text, nullable=False, index=False, unique=False)
     is_default = db.Column(db.Boolean, nullable=False, default=True)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -202,6 +202,7 @@ class ServiceSchema(BaseSchema):
             'template_statistics',
             'service_provider_stats',
             'service_notification_stats',
+            'reply_to_email_addresses',
         )
         strict = True
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -12,7 +12,7 @@ from app.dao.services_dao import dao_remove_user_from_service
 from app.dao.templates_dao import dao_redact_template
 from app.dao.users_dao import save_model_user
 from app.models import (
-    User, Organisation, Service, ServicePermission, Notification,
+    User, Organisation, Service, ServicePermission, Notification, ServiceEmailReplyTo,
     DVLA_ORG_LAND_REGISTRY,
     KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST,
     EMAIL_TYPE, SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INBOUND_SMS_TYPE,
@@ -2125,9 +2125,7 @@ def test_is_service_name_unique_returns_400_when_name_does_not_exist(client):
     assert json_resp["message"][1]["email_from"] == ["Can't be empty"]
 
 
-def test_update_service_reply_to_email_address_upserts_email_reply_to(mocker, admin_request, sample_service):
-    update_mock = mocker.patch('app.service.rest.create_or_update_email_reply_to')
-
+def test_update_service_reply_to_email_address_upserts_email_reply_to(admin_request, sample_service):
     admin_request.post(
         'service.update_service',
         service_id=sample_service.id,
@@ -2137,4 +2135,4 @@ def test_update_service_reply_to_email_address_upserts_email_reply_to(mocker, ad
         _expected_status=200
     )
 
-    assert update_mock.called
+    assert len(ServiceEmailReplyTo.query.all()) == 1

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2126,7 +2126,7 @@ def test_is_service_name_unique_returns_400_when_name_does_not_exist(client):
 
 
 def test_update_service_reply_to_email_address_upserts_email_reply_to(admin_request, sample_service):
-    admin_request.post(
+    response = admin_request.post(
         'service.update_service',
         service_id=sample_service.id,
         _data={
@@ -2135,4 +2135,8 @@ def test_update_service_reply_to_email_address_upserts_email_reply_to(admin_requ
         _expected_status=200
     )
 
-    assert len(ServiceEmailReplyTo.query.all()) == 1
+    service_reply_to_emails = ServiceEmailReplyTo.query.all()
+    assert len(service_reply_to_emails) == 1
+    assert service_reply_to_emails[0].email_address == 'new@mail.com'
+    assert service_reply_to_emails[0].is_default
+    assert response['data']['reply_to_email_address'] == 'new@mail.com'


### PR DESCRIPTION
- Updated reply to email test so that the request to create or update
email is not mocked.
- Excluded reply_to_email_addresses from the Service schema