### PR TITLE
use new send-jobs-to-dvla task instead of send-files-to-dvla

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -314,7 +314,7 @@ def populate_monthly_billing():
 def run_letter_jobs():
     job_ids = dao_get_letter_job_ids_by_status(JOB_STATUS_READY_TO_SEND)
     notify_celery.send_task(
-        name=TaskNames.DVLA_FILES,
+        name=TaskNames.DVLA_JOBS,
         args=(job_ids,),
         queue=QueueNames.PROCESS_FTP
     )

--- a/app/config.py
+++ b/app/config.py
@@ -48,7 +48,8 @@ class QueueNames(object):
 
 
 class TaskNames(object):
-    DVLA_FILES = 'send-files-to-dvla'
+    DVLA_JOBS = 'send-jobs-to-dvla'
+    DVLA_NOTIFICATIONS = 'send-notifications-to-dvla'
 
 
 class Config(object):
@@ -226,7 +227,7 @@ class Config(object):
         },
         'run-letter-jobs': {
             'task': 'run-letter-jobs',
-            'schedule': crontab(minute=30, hour=17),
+            'schedule': crontab(hour=17, minute=30),
             'options': {'queue': QueueNames.PERIODIC}
         }
     }

--- a/app/letters/rest.py
+++ b/app/letters/rest.py
@@ -16,7 +16,7 @@ register_errors(letter_job)
 @letter_job.route('/send-letter-jobs', methods=['POST'])
 def send_letter_jobs():
     job_ids = validate(request.get_json(), letter_job_ids)
-    notify_celery.send_task(name=TaskNames.DVLA_FILES, args=(job_ids['job_ids'],), queue=QueueNames.PROCESS_FTP)
+    notify_celery.send_task(name=TaskNames.DVLA_JOBS, args=(job_ids['job_ids'],), queue=QueueNames.PROCESS_FTP)
 
     return jsonify(data={"response": "Task created to send files to DVLA"}), 201
 

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -151,7 +151,7 @@ def process_letter_notification(*, letter_data, api_key, template):
         raise BadRequestError(message='Cannot send letters with a team api key', status_code=403)
 
     if api_key.service.restricted and api_key.key_type != KEY_TYPE_TEST:
-            raise BadRequestError(message='Cannot send letters when service is in trial mode', status_code=403)
+        raise BadRequestError(message='Cannot send letters when service is in trial mode', status_code=403)
 
     job = create_letter_api_job(template)
     notification = create_letter_notification(letter_data, job, api_key)

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -690,6 +690,6 @@ def test_run_letter_jobs(client, mocker, sample_letter_template):
 
     run_letter_jobs()
 
-    mock_celery.assert_called_once_with(name=TaskNames.DVLA_FILES,
+    mock_celery.assert_called_once_with(name=TaskNames.DVLA_JOBS,
                                         args=(job_ids,),
                                         queue=QueueNames.PROCESS_FTP)

--- a/tests/app/letters/test_send_letter_jobs.py
+++ b/tests/app/letters/test_send_letter_jobs.py
@@ -25,7 +25,7 @@ def test_send_letter_jobs(client, mocker, sample_letter_template):
     assert response.status_code == 201
     assert json.loads(response.get_data())['data'] == {'response': "Task created to send files to DVLA"}
 
-    mock_celery.assert_called_once_with(name="send-files-to-dvla",
+    mock_celery.assert_called_once_with(name="send-jobs-to-dvla",
                                         args=(job_ids['job_ids'],),
                                         queue="process-ftp-tasks")
 


### PR DESCRIPTION
the tasks (on the ftp app) do the same thing, but to improve clarity i've renamed it to jobs, because we'll be adding a notifications one soon

- [ ] https://github.com/alphagov/notifications-ftp/pull/23