### PR TITLE
Insert or update service sms senders

### DIFF
--- a/app/dao/service_sms_sender_dao.py
+++ b/app/dao/service_sms_sender_dao.py
@@ -4,23 +4,29 @@ from app.models import ServiceSmsSender
 
 
 @transactional
-def insert_or_update_service_sms_sender(service, sms_sender):
+def insert_or_update_service_sms_sender(service, sms_sender, inbound_number_id=None):
     result = db.session.query(
         ServiceSmsSender
     ).filter(
         ServiceSmsSender.service_id == service.id
     ).update(
-        {'sms_sender': sms_sender}
+        {'sms_sender': sms_sender,
+         'inbound_number_id': inbound_number_id
+         }
     )
     if result == 0:
         new_sms_sender = ServiceSmsSender(sms_sender=sms_sender,
                                           service=service,
-                                          is_default=True
+                                          is_default=True,
+                                          inbound_number_id=inbound_number_id
                                           )
         db.session.add(new_sms_sender)
 
 
 def insert_service_sms_sender(service, sms_sender):
+    """
+    This method is called from create_service which is wrapped in a transaction.
+    """
     new_sms_sender = ServiceSmsSender(sms_sender=sms_sender,
                                       service=service,
                                       is_default=True

--- a/app/dao/service_sms_sender_dao.py
+++ b/app/dao/service_sms_sender_dao.py
@@ -1,0 +1,28 @@
+from app import db
+from app.dao.dao_utils import transactional
+from app.models import ServiceSmsSender
+
+
+@transactional
+def insert_or_update_service_sms_sender(service, sms_sender):
+    result = db.session.query(
+        ServiceSmsSender
+    ).filter(
+        ServiceSmsSender.service_id == service.id
+    ).update(
+        {'sms_sender': sms_sender}
+    )
+    if result == 0:
+        new_sms_sender = ServiceSmsSender(sms_sender=sms_sender,
+                                          service=service,
+                                          is_default=True
+                                          )
+        db.session.add(new_sms_sender)
+
+
+def insert_service_sms_sender(service, sms_sender):
+    new_sms_sender = ServiceSmsSender(sms_sender=sms_sender,
+                                      service=service,
+                                      is_default=True
+                                      )
+    db.session.add(new_sms_sender)

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -11,6 +11,7 @@ from app.dao.dao_utils import (
     version_class
 )
 from app.dao.notifications_dao import get_financial_year
+from app.dao.service_sms_sender_dao import insert_service_sms_sender
 from app.models import (
     NotificationStatistics,
     ProviderStatistics,
@@ -33,8 +34,8 @@ from app.models import (
     TEMPLATE_TYPES,
     JobStatistics,
     SMS_TYPE,
-    EMAIL_TYPE
-)
+    EMAIL_TYPE,
+    ServiceSmsSender)
 from app.service.statistics import format_monthly_template_notification_stats
 from app.statsd_decorators import statsd
 from app.utils import get_london_month_from_utc_column, get_london_midnight_in_utc
@@ -163,6 +164,7 @@ def dao_create_service(service, user, service_id=None, service_permissions=[SMS_
         service_permission = ServicePermission(service_id=service.id, permission=permission)
         service.permissions.append(service_permission)
 
+    insert_service_sms_sender(service, service.sms_sender)
     db.session.add(service)
 
 
@@ -212,6 +214,7 @@ def delete_service_and_all_associated_db_objects(service):
     subq = db.session.query(Template.id).filter_by(service=service).subquery()
     _delete_commit(TemplateRedacted.query.filter(TemplateRedacted.template_id.in_(subq)))
 
+    _delete_commit(ServiceSmsSender.query.filter_by(service=service))
     _delete_commit(NotificationStatistics.query.filter_by(service=service))
     _delete_commit(ProviderStatistics.query.filter_by(service=service))
     _delete_commit(InvitedUser.query.filter_by(service=service))

--- a/app/inbound_number/rest.py
+++ b/app/inbound_number/rest.py
@@ -7,6 +7,8 @@ from app.dao.inbound_numbers_dao import (
     dao_set_inbound_number_to_service,
     dao_set_inbound_number_active_flag
 )
+from app.dao.service_sms_sender_dao import insert_or_update_service_sms_sender
+from app.dao.services_dao import dao_fetch_service_by_id
 from app.errors import InvalidRequest, register_errors
 
 inbound_number_blueprint = Blueprint('inbound_number', __name__, url_prefix='/inbound-number')
@@ -42,6 +44,8 @@ def post_allocate_inbound_number(service_id):
 
     if len(available_numbers) > 0:
         dao_set_inbound_number_to_service(service_id, available_numbers[0])
+        service = dao_fetch_service_by_id(service_id)
+        insert_or_update_service_sms_sender(service, available_numbers[0].number, available_numbers[0].id)
         return jsonify(), 204
     else:
         raise InvalidRequest('No available inbound numbers', status_code=400)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -202,6 +202,7 @@ class ServiceSchema(BaseSchema):
             'template_statistics',
             'service_provider_stats',
             'service_notification_stats',
+            'service_sms_senders'
         )
         strict = True
 
@@ -252,7 +253,8 @@ class DetailedServiceSchema(BaseSchema):
             'template_statistics',
             'service_provider_stats',
             'service_notification_stats',
-            'organisation'
+            'organisation',
+            'service_sms_senders'
         )
 
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -202,7 +202,8 @@ class ServiceSchema(BaseSchema):
             'template_statistics',
             'service_provider_stats',
             'service_notification_stats',
-            'service_sms_senders'
+            'service_sms_senders',
+            'monthly_billing'
         )
         strict = True
 
@@ -254,7 +255,8 @@ class DetailedServiceSchema(BaseSchema):
             'service_provider_stats',
             'service_notification_stats',
             'organisation',
-            'service_sms_senders'
+            'service_sms_senders',
+            'monthly_billing'
         )
 
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -22,6 +22,7 @@ from app.dao.service_inbound_api_dao import (
     reset_service_inbound_api,
     get_service_inbound_api
 )
+from app.dao.service_sms_sender_dao import insert_or_update_service_sms_sender
 from app.dao.services_dao import (
     dao_fetch_service_by_id,
     dao_fetch_all_services,
@@ -143,6 +144,8 @@ def update_service(service_id):
     current_data = dict(service_schema.dump(fetched_service).data.items())
     current_data.update(request.get_json())
     update_dict = service_schema.load(current_data).data
+    if 'sms_sender' in req_json:
+        insert_or_update_service_sms_sender(fetched_service, req_json['sms_sender'])
     dao_update_service(update_dict)
 
     if service_going_live:

--- a/tests/app/dao/test_service_sms_sender_dao.py
+++ b/tests/app/dao/test_service_sms_sender_dao.py
@@ -1,0 +1,29 @@
+from app.dao.service_sms_sender_dao import insert_or_update_service_sms_sender
+from app.models import ServiceSmsSender
+from tests.app.db import create_service
+
+
+def test_update_service_sms_sender_updates_existing_row(notify_db_session):
+    service = create_service()
+    insert_or_update_service_sms_sender(service, 'testing')
+    service_sms_senders = ServiceSmsSender.query.filter_by(service_id=service.id).all()
+    assert len(service_sms_senders) == 1
+    assert service_sms_senders[0].sms_sender == service.sms_sender
+
+    insert_or_update_service_sms_sender(service, 'NEW_SMS')
+
+    updated_sms_senders = ServiceSmsSender.query.filter_by(service_id=service.id).all()
+    assert len(updated_sms_senders) == 1
+    assert updated_sms_senders[0].sms_sender == 'NEW_SMS'
+    assert updated_sms_senders[0].is_default
+
+
+def test_create_service_inserts_new_service_sms_sender(notify_db_session):
+    assert ServiceSmsSender.query.count() == 0
+
+    service = create_service(sms_sender='new_sms')
+    insert_or_update_service_sms_sender(service, 'new_sms')
+    service_sms_senders = ServiceSmsSender.query.all()
+    assert len(service_sms_senders) == 1
+    assert service_sms_senders[0].sms_sender == 'new_sms'
+    assert service_sms_senders[0].is_default

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -16,7 +16,7 @@ from app.models import (
     DVLA_ORG_LAND_REGISTRY,
     KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST,
     EMAIL_TYPE, SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INBOUND_SMS_TYPE,
-)
+    ServiceSmsSender)
 from tests import create_authorization_header
 from tests.app.conftest import (
     sample_service as create_service,
@@ -281,6 +281,10 @@ def test_create_service(client, sample_user):
     json_resp = json.loads(resp.get_data(as_text=True))
     assert json_resp['data']['name'] == 'created service'
     assert not json_resp['data']['research_mode']
+
+    service_sms_senders = ServiceSmsSender.query.filter_by(service_id=service_db.id).all()
+    assert len(service_sms_senders) == 1
+    assert service_sms_senders[0].sms_sender == service_db.sms_sender
 
 
 def test_should_not_create_service_with_missing_user_id_field(notify_api, fake_uuid):
@@ -1390,6 +1394,10 @@ def test_set_sms_sender_for_service(client, sample_service):
     result = json.loads(resp.get_data(as_text=True))
     assert resp.status_code == 200
     assert result['data']['sms_sender'] == 'elevenchars'
+    service_sms_senders = ServiceSmsSender.query.filter_by(service_id=sample_service.id).all()
+    assert len(service_sms_senders) == 1
+    assert service_sms_senders[0].sms_sender == 'elevenchars'
+    assert service_sms_senders[0].is_default
 
 
 def test_set_sms_sender_for_service_rejects_invalid_characters(client, sample_service):


### PR DESCRIPTION
In order to allow multiple SMS senders for a service we want to store those numbers in a new table, SERVICE_SMS_SENDERS. Which was created in a previous PR. 

In this PR we are inserting or updating the SMS sender to the new table anytime the Service.sms_sender is updated or inserted and any time the InboundSms is updated or added for a service. This will ensure the data is up to date in both places. 

