### PR TITLE
Add multiple reply to email endpoints

### DIFF
--- a/app/dao/service_email_reply_to_dao.py
+++ b/app/dao/service_email_reply_to_dao.py
@@ -1,6 +1,16 @@
 from app import db
 from app.dao.dao_utils import transactional
+from app.errors import InvalidRequest
 from app.models import ServiceEmailReplyTo
+
+
+def dao_get_reply_to_by_service_id(service_id):
+    reply_to = db.session.query(
+        ServiceEmailReplyTo
+    ).filter(
+        ServiceEmailReplyTo.service_id == service_id
+    ).all()
+    return reply_to
 
 
 def create_or_update_email_reply_to(service_id, email_address):
@@ -12,6 +22,7 @@ def create_or_update_email_reply_to(service_id, email_address):
         reply_to[0].email_address = email_address
         dao_update_reply_to_email(reply_to[0])
     else:
+        # Once we move allowing multiple email address this methods will be removed
         raise InvalidRequest(
             "Multiple reply to email addresses were found, this method should not be used.",
             status_code=500
@@ -21,15 +32,6 @@ def create_or_update_email_reply_to(service_id, email_address):
 @transactional
 def dao_create_reply_to_email_address(reply_to_email):
     db.session.add(reply_to_email)
-
-
-def dao_get_reply_to_by_service_id(service_id):
-    reply_to = db.session.query(
-        ServiceEmailReplyTo
-    ).filter(
-        ServiceEmailReplyTo.service_id == service_id
-    ).all()
-    return reply_to
 
 
 @transactional

--- a/app/dao/service_email_reply_to_dao.py
+++ b/app/dao/service_email_reply_to_dao.py
@@ -5,12 +5,17 @@ from app.models import ServiceEmailReplyTo
 
 def create_or_update_email_reply_to(service_id, email_address):
     reply_to = dao_get_reply_to_by_service_id(service_id)
-    if reply_to:
-        reply_to.email_address = email_address
-        dao_update_reply_to_email(reply_to)
-    else:
+    if len(reply_to) == 0:
         reply_to = ServiceEmailReplyTo(service_id=service_id, email_address=email_address)
         dao_create_reply_to_email_address(reply_to)
+    elif len(reply_to) == 1:
+        reply_to[0].email_address = email_address
+        dao_update_reply_to_email(reply_to[0])
+    else:
+        raise InvalidRequest(
+            "Multiple reply to email addresses were found, this method should not be used.",
+            status_code=500
+        )
 
 
 @transactional
@@ -23,7 +28,7 @@ def dao_get_reply_to_by_service_id(service_id):
         ServiceEmailReplyTo
     ).filter(
         ServiceEmailReplyTo.service_id == service_id
-    ).first()
+    ).all()
     return reply_to
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -1343,3 +1343,11 @@ class ServiceEmailReplyTo(db.Model):
     is_default = db.Column(db.Boolean, nullable=False, default=True)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+
+    def serialize(self):
+        return {
+            'email_address': self.email_address,
+            'is_default': self.is_default,
+            'created_at': self.created_at,
+            'updated_at': self.updated_at
+        }

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -46,7 +46,7 @@ from app.dao.service_whitelist_dao import (
     dao_add_and_commit_whitelisted_contacts,
     dao_remove_service_whitelist
 )
-from app.dao.service_email_reply_to_dao import create_or_update_email_reply_to
+from app.dao.service_email_reply_to_dao import create_or_update_email_reply_to, dao_get_reply_to_by_service_id
 from app.dao.provider_statistics_dao import get_fragment_count
 from app.dao.users_dao import get_user_by_id
 from app.errors import (
@@ -521,6 +521,12 @@ def handle_sql_errror(e):
 def create_one_off_notification(service_id):
     resp = send_one_off_notification(service_id, request.get_json())
     return jsonify(resp), 201
+
+
+@service_blueprint.route('/<uuid:service_id>/email-reply-to', methods=["GET"])
+def get_email_reply_to_addresses(service_id):
+    result = dao_get_reply_to_by_service_id(service_id)
+    return jsonify([i.serialize() for i in result]), 200
 
 
 @service_blueprint.route('/unique', methods=["GET"])

--- a/tests/app/dao/test_service_email_reply_to_dao.py
+++ b/tests/app/dao/test_service_email_reply_to_dao.py
@@ -25,8 +25,9 @@ def test_create_or_update_email_reply_to_updates_existing_entry(notify_db_sessio
 
     reply_to = dao_get_reply_to_by_service_id(service.id)
 
-    assert reply_to.service.id == service.id
-    assert reply_to.email_address == 'different@mail.com'
+    assert len(reply_to) == 1
+    assert reply_to[0].service.id == service.id
+    assert reply_to[0].email_address == 'different@mail.com'
 
 
 def test_create_or_update_email_reply_to_creates_new_entry(notify_db_session):
@@ -37,5 +38,5 @@ def test_create_or_update_email_reply_to_creates_new_entry(notify_db_session):
     reply_to = dao_get_reply_to_by_service_id(service.id)
 
     assert ServiceEmailReplyTo.query.count() == 1
-    assert reply_to.service.id == service.id
-    assert reply_to.email_address == 'test@mail.com'
+    assert reply_to[0].service.id == service.id
+    assert reply_to[0].email_address == 'test@mail.com'

--- a/tests/app/dao/test_service_email_reply_to_dao.py
+++ b/tests/app/dao/test_service_email_reply_to_dao.py
@@ -1,7 +1,10 @@
+import pytest
+
 from app.dao.service_email_reply_to_dao import (
     create_or_update_email_reply_to,
     dao_get_reply_to_by_service_id
 )
+from app.errors import InvalidRequest
 from app.models import ServiceEmailReplyTo
 from tests.app.db import create_reply_to_email, create_service
 
@@ -40,3 +43,25 @@ def test_create_or_update_email_reply_to_creates_new_entry(notify_db_session):
     assert ServiceEmailReplyTo.query.count() == 1
     assert reply_to[0].service.id == service.id
     assert reply_to[0].email_address == 'test@mail.com'
+
+
+def test_create_or_update_email_reply_to_raises_exception_if_multilple_email_addresses_exist(notify_db_session):
+    service = create_service()
+    create_reply_to_email(service=service, email_address='something@email.com')
+    create_reply_to_email(service=service, email_address='another@email.com', is_default=False)
+
+    with pytest.raises(expected_exception=InvalidRequest) as e:
+        create_or_update_email_reply_to(service_id=service.id, email_address='third@email.com')
+    assert e.value.message == "Multiple reply to email addresses were found, this method should not be used."
+
+
+def test_dao_get_reply_to_by_service_id(notify_db_session):
+    service = create_service()
+    default_reply_to = create_reply_to_email(service=service, email_address='something@email.com')
+    another_reply_to = create_reply_to_email(service=service, email_address='another@email.com', is_default=False)
+
+    results = dao_get_reply_to_by_service_id(service_id=service.id)
+
+    assert len(results) == 2
+    assert default_reply_to in results
+    assert another_reply_to in results

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -333,11 +333,13 @@ def create_monthly_billing_entry(
 
 def create_reply_to_email(
     service,
-    email_address
+    email_address,
+    is_default=True
 ):
     data = {
         'service': service,
         'email_address': email_address,
+        'is_default': is_default,
     }
     reply_to = ServiceEmailReplyTo(**data)
 


### PR DESCRIPTION
- Changed the dao_get_reply_to_by_service_id method to return a list of
results.
- Added a GET /service/<service_id>/email-reply-to endpoint