### PR TITLE
Platform admin Timeout problem

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -358,14 +358,19 @@ def dao_fetch_monthly_historical_stats_for_service(service_id, year):
 
 
 @statsd(namespace='dao')
-def dao_fetch_todays_stats_for_all_services(include_from_test_key=True):
+def dao_fetch_todays_stats_for_all_services(include_from_test_key=True, trial_mode_services=True):
+
+    # service_id = db.session.query(Service.id).filter(Service.restricted == True)
+
     query = db.session.query(
         Notification.notification_type,
         Notification.status,
         Notification.service_id,
         func.count(Notification.id).label('count')
+    ).join(Service
     ).filter(
-        func.date(Notification.created_at) == date.today()
+        func.date(Notification.created_at) == date.today(),
+        Service.restricted == trial_mode_services
     ).group_by(
         Notification.notification_type,
         Notification.status,

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -367,7 +367,8 @@ def dao_fetch_todays_stats_for_all_services(include_from_test_key=True, trial_mo
         Notification.status,
         Notification.service_id,
         func.count(Notification.id).label('count')
-    ).join(Service
+    ).join(
+        Service
     ).filter(
         func.date(Notification.created_at) == date.today(),
         Service.restricted == trial_mode_services

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -82,6 +82,7 @@ def get_services():
     detailed = request.args.get('detailed') == 'True'
     user_id = request.args.get('user_id', None)
     include_from_test_key = request.args.get('include_from_test_key', 'True') != 'False'
+    trial_mode_services = request.args.get('trial_mode_services')
 
     # If start and end date are not set, we are expecting today's stats.
     today = str(datetime.utcnow().date())
@@ -92,12 +93,15 @@ def get_services():
     if user_id:
         services = dao_fetch_all_services_by_user(user_id, only_active)
     elif detailed:
-        return jsonify(data=get_detailed_services(start_date=start_date, end_date=end_date,
-                                                  only_active=only_active, include_from_test_key=include_from_test_key
+        result = jsonify(data=get_detailed_services(start_date=start_date, end_date=end_date,
+                                                  only_active=only_active, include_from_test_key=include_from_test_key,
+                                                  trial_mode_services = trial_mode_services
                                                   ))
+        return result
     else:
         services = dao_fetch_all_services(only_active)
     data = service_schema.dump(services, many=True).data
+
     return jsonify(data=data)
 
 
@@ -353,10 +357,11 @@ def get_detailed_service(service_id, today_only=False):
     return detailed_service_schema.dump(service).data
 
 
-def get_detailed_services(start_date, end_date, only_active=False, include_from_test_key=True):
+def get_detailed_services(start_date, end_date, only_active=False, include_from_test_key=True,
+                          trial_mode_services=True):
     services = {service.id: service for service in dao_fetch_all_services(only_active)}
     if start_date == datetime.utcnow().date():
-        stats = dao_fetch_todays_stats_for_all_services(include_from_test_key=include_from_test_key)
+        stats = dao_fetch_todays_stats_for_all_services(include_from_test_key=include_from_test_key, trial_mode_services=trial_mode_services)
     else:
 
         stats = fetch_stats_by_date_range_for_all_services(start_date=start_date,

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -94,9 +94,10 @@ def get_services():
         services = dao_fetch_all_services_by_user(user_id, only_active)
     elif detailed:
         result = jsonify(data=get_detailed_services(start_date=start_date, end_date=end_date,
-                                                  only_active=only_active, include_from_test_key=include_from_test_key,
-                                                  trial_mode_services = trial_mode_services
-                                                  ))
+                                                    only_active=only_active,
+                                                    include_from_test_key=include_from_test_key,
+                                                    trial_mode_services=trial_mode_services
+                                                    ))
         return result
     else:
         services = dao_fetch_all_services(only_active)
@@ -361,7 +362,8 @@ def get_detailed_services(start_date, end_date, only_active=False, include_from_
                           trial_mode_services=True):
     services = {service.id: service for service in dao_fetch_all_services(only_active)}
     if start_date == datetime.utcnow().date():
-        stats = dao_fetch_todays_stats_for_all_services(include_from_test_key=include_from_test_key, trial_mode_services=trial_mode_services)
+        stats = dao_fetch_todays_stats_for_all_services(include_from_test_key=include_from_test_key,
+                                                        trial_mode_services=trial_mode_services)
     else:
 
         stats = fetch_stats_by_date_range_for_all_services(start_date=start_date,


### PR DESCRIPTION
When viewing platform admin services, we do an sql queries and whether it's trial mode or live services is filtered at the admin views. 

This PR pass the filtered live/trial mode service to the query and reduce query time. 

This is in relation to PR https://github.com/alphagov/notifications-admin/pull/1491