### PR TITLE
Add multiple reply to email endpoints

### DIFF
--- a/app/dao/service_email_reply_to_dao.py
+++ b/app/dao/service_email_reply_to_dao.py
@@ -75,10 +75,10 @@ def _get_existing_default(service_id):
         if len(old_default) == 1:
             return old_default[0]
         else:
-            # is this check necessary
-            raise InvalidRequest(
+            raise Exception(
                 "There should only be one default reply to email for each service. Service {} has {}".format(
                     service_id, len(old_default)))
+    return None
 
 
 def _reset_old_default_to_false(old_default):

--- a/app/dao/service_email_reply_to_dao.py
+++ b/app/dao/service_email_reply_to_dao.py
@@ -40,7 +40,7 @@ def dao_update_reply_to_email(reply_to):
 
 
 @transactional
-def add_reply_to_email_address_for_service(service_id, email_address, is_default=True):
+def add_reply_to_email_address_for_service(service_id, email_address, is_default):
     old_default = _get_existing_default(service_id)
     if is_default:
         _reset_old_default_to_false(old_default)
@@ -53,7 +53,7 @@ def add_reply_to_email_address_for_service(service_id, email_address, is_default
 
 
 @transactional
-def update_reply_to_email_address(service_id, reply_to_id, email_address, is_default=True):
+def update_reply_to_email_address(service_id, reply_to_id, email_address, is_default):
     old_default = _get_existing_default(service_id)
     if is_default:
         _reset_old_default_to_false(old_default)

--- a/app/dao/service_email_reply_to_dao.py
+++ b/app/dao/service_email_reply_to_dao.py
@@ -9,7 +9,7 @@ def dao_get_reply_to_by_service_id(service_id):
         ServiceEmailReplyTo
     ).filter(
         ServiceEmailReplyTo.service_id == service_id
-    ).all()
+    ).order_by(ServiceEmailReplyTo.created_at).all()
     return reply_to
 
 
@@ -37,3 +37,57 @@ def dao_create_reply_to_email_address(reply_to_email):
 @transactional
 def dao_update_reply_to_email(reply_to):
     db.session.add(reply_to)
+
+
+@transactional
+def add_reply_to_email_address_for_service(service_id, email_address, is_default=True):
+    old_default = _get_existing_default(service_id)
+    if is_default:
+        _reset_old_default_to_false(old_default)
+    else:
+        _raise_when_no_default(old_default)
+
+    new_reply_to = ServiceEmailReplyTo(service_id=service_id, email_address=email_address, is_default=is_default)
+    db.session.add(new_reply_to)
+    return new_reply_to
+
+
+@transactional
+def update_reply_to_email_address(service_id, reply_to_id, email_address, is_default=True):
+    old_default = _get_existing_default(service_id)
+    if is_default:
+        _reset_old_default_to_false(old_default)
+    else:
+        if old_default.id == reply_to_id:
+            raise InvalidRequest("You must have at least one reply to email address as the default.", 400)
+
+    reply_to_update = ServiceEmailReplyTo.query.get(reply_to_id)
+    reply_to_update.email_address = email_address
+    reply_to_update.is_default = is_default
+    db.session.add(reply_to_update)
+    return reply_to_update
+
+
+def _get_existing_default(service_id):
+    existing_reply_to = dao_get_reply_to_by_service_id(service_id=service_id)
+    if existing_reply_to:
+        old_default = [x for x in existing_reply_to if x.is_default]
+        if len(old_default) == 1:
+            return old_default[0]
+        else:
+            # is this check necessary
+            raise InvalidRequest(
+                "There should only be one default reply to email for each service. Service {} has {}".format(
+                    service_id, len(old_default)))
+
+
+def _reset_old_default_to_false(old_default):
+    if old_default:
+        old_default.is_default = False
+        db.session.add(old_default)
+
+
+def _raise_when_no_default(old_default):
+    # check that the update is not updating the only default to false
+    if not old_default:
+        raise InvalidRequest("You must have at least one reply to email address as the default.", 400)

--- a/app/models.py
+++ b/app/models.py
@@ -1348,6 +1348,6 @@ class ServiceEmailReplyTo(db.Model):
         return {
             'email_address': self.email_address,
             'is_default': self.is_default,
-            'created_at': self.created_at,
-            'updated_at': self.updated_at
+            'created_at': self.created_at.strftime(DATETIME_FORMAT),
+            'updated_at': self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None
         }

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -533,6 +533,8 @@ def get_email_reply_to_addresses(service_id):
 
 @service_blueprint.route('/<uuid:service_id>/email-reply-to', methods=['POST'])
 def add_service_reply_to_email_address(service_id):
+    # validate the service exists, throws ResultNotFound exception.
+    dao_fetch_service_by_id(service_id)
     form = validate(request.get_json(), add_service_email_reply_to_request)
     new_reply_to = add_reply_to_email_address_for_service(service_id=service_id,
                                                           email_address=form['email_address'],
@@ -540,11 +542,13 @@ def add_service_reply_to_email_address(service_id):
     return jsonify(data=new_reply_to.serialize()), 201
 
 
-@service_blueprint.route('/<uuid:service_id>/email-reply-to/<uuid:id>', methods=['POST'])
-def update_service_reply_to_email_address(service_id, id):
+@service_blueprint.route('/<uuid:service_id>/email-reply-to/<uuid:reply_to_email_id>', methods=['POST'])
+def update_service_reply_to_email_address(service_id, reply_to_email_id):
+    # validate the service exists, throws ResultNotFound exception.
+    dao_fetch_service_by_id(service_id)
     form = validate(request.get_json(), add_service_email_reply_to_request)
     new_reply_to = update_reply_to_email_address(service_id=service_id,
-                                                 reply_to_id=id,
+                                                 reply_to_id=reply_to_email_id,
                                                  email_address=form['email_address'],
                                                  is_default=form.get('is_default', True))
     return jsonify(data=new_reply_to.serialize()), 200

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -46,7 +46,8 @@ from app.dao.service_whitelist_dao import (
     dao_add_and_commit_whitelisted_contacts,
     dao_remove_service_whitelist
 )
-from app.dao.service_email_reply_to_dao import create_or_update_email_reply_to, dao_get_reply_to_by_service_id
+from app.dao.service_email_reply_to_dao import create_or_update_email_reply_to, dao_get_reply_to_by_service_id, \
+    add_reply_to_email_address_for_service, update_reply_to_email_address
 from app.dao.provider_statistics_dao import get_fragment_count
 from app.dao.users_dao import get_user_by_id
 from app.errors import (
@@ -57,6 +58,7 @@ from app.models import Service, ServiceInboundApi
 from app.schema_validation import validate
 from app.service import statistics
 from app.service.service_inbound_api_schema import service_inbound_api, update_service_inbound_api_schema
+from app.service.service_senders_schema import add_service_email_reply_to_request
 from app.service.utils import get_whitelist_objects
 from app.service.sender import send_notification_to_service_users
 from app.service.send_notification import send_one_off_notification
@@ -527,6 +529,25 @@ def create_one_off_notification(service_id):
 def get_email_reply_to_addresses(service_id):
     result = dao_get_reply_to_by_service_id(service_id)
     return jsonify([i.serialize() for i in result]), 200
+
+
+@service_blueprint.route('/<uuid:service_id>/email-reply-to', methods=['POST'])
+def add_service_reply_to_email_address(service_id):
+    form = validate(request.get_json(), add_service_email_reply_to_request)
+    new_reply_to = add_reply_to_email_address_for_service(service_id=service_id,
+                                                          email_address=form['email_address'],
+                                                          is_default=form.get('is_default', True))
+    return jsonify(data=new_reply_to.serialize()), 201
+
+
+@service_blueprint.route('/<uuid:service_id>/email-reply-to/<uuid:id>', methods=['POST'])
+def update_service_reply_to_email_address(service_id, id):
+    form = validate(request.get_json(), add_service_email_reply_to_request)
+    new_reply_to = update_reply_to_email_address(service_id=service_id,
+                                                 reply_to_id=id,
+                                                 email_address=form['email_address'],
+                                                 is_default=form.get('is_default', True))
+    return jsonify(data=new_reply_to.serialize()), 200
 
 
 @service_blueprint.route('/unique', methods=["GET"])

--- a/app/service/service_senders_schema.py
+++ b/app/service/service_senders_schema.py
@@ -1,0 +1,11 @@
+add_service_email_reply_to_request = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "POST service email reply to address",
+    "type": "object",
+    "title": "Add new email reply to address for service",
+    "properties": {
+        "email_address": {"type": "string", "format": "email_address"},
+        "is_default": {"type": "boolean"}
+    },
+    "required": ["email_address"]
+}

--- a/app/service/service_senders_schema.py
+++ b/app/service/service_senders_schema.py
@@ -7,5 +7,5 @@ add_service_email_reply_to_request = {
         "email_address": {"type": "string", "format": "email_address"},
         "is_default": {"type": "boolean"}
     },
-    "required": ["email_address"]
+    "required": ["email_address", "is_default"]
 }

--- a/tests/app/dao/test_service_email_reply_to_dao.py
+++ b/tests/app/dao/test_service_email_reply_to_dao.py
@@ -138,6 +138,15 @@ def test_add_reply_to_email_address_ensures_first_reply_to_is_default(sample_ser
                                                email_address="first@address.com", is_default=False)
 
 
+def test_add_reply_to_email_address_ensure_there_is_not_more_than_one_default(sample_service):
+    create_reply_to_email(service=sample_service, email_address='first@email.com', is_default=True)
+    create_reply_to_email(service=sample_service, email_address='second@email.com', is_default=True)
+    with pytest.raises(Exception):
+        add_reply_to_email_address_for_service(service_id=sample_service.id,
+                                               email_address='third_email@address.com',
+                                               is_default=False)
+
+
 def test_update_reply_to_email_address(sample_service):
     first_reply_to = create_reply_to_email(service=sample_service, email_address="first@address.com")
     update_reply_to_email_address(service_id=sample_service.id, reply_to_id=first_reply_to.id,

--- a/tests/app/dao/test_service_email_reply_to_dao.py
+++ b/tests/app/dao/test_service_email_reply_to_dao.py
@@ -69,7 +69,9 @@ def test_dao_get_reply_to_by_service_id(notify_db_session):
 
 def test_add_reply_to_email_address_for_service_creates_first_email_for_service(notify_db_session):
     service = create_service()
-    add_reply_to_email_address_for_service(service_id=service.id, email_address='new@address.com')
+    add_reply_to_email_address_for_service(service_id=service.id,
+                                           email_address='new@address.com',
+                                           is_default=True)
 
     results = dao_get_reply_to_by_service_id(service_id=service.id)
     assert len(results) == 1
@@ -112,7 +114,8 @@ def test_add_reply_to_email_address_new_reply_to_is_default_existing_reply_to_is
 
 def test_add_reply_to_email_address_can_add_a_third_reply_to_address(sample_service):
     add_reply_to_email_address_for_service(service_id=sample_service.id,
-                                           email_address="first@address.com")
+                                           email_address="first@address.com",
+                                           is_default=True)
     add_reply_to_email_address_for_service(service_id=sample_service.id, email_address='second@address.com',
                                            is_default=False)
     add_reply_to_email_address_for_service(service_id=sample_service.id, email_address='third@address.com',
@@ -150,7 +153,8 @@ def test_add_reply_to_email_address_ensure_there_is_not_more_than_one_default(sa
 def test_update_reply_to_email_address(sample_service):
     first_reply_to = create_reply_to_email(service=sample_service, email_address="first@address.com")
     update_reply_to_email_address(service_id=sample_service.id, reply_to_id=first_reply_to.id,
-                                  email_address='change_address@email.com')
+                                  email_address='change_address@email.com',
+                                  is_default=True)
     updated_reply_to = ServiceEmailReplyTo.query.get(first_reply_to.id)
 
     assert updated_reply_to.email_address == 'change_address@email.com'

--- a/tests/app/dao/test_service_email_reply_to_dao.py
+++ b/tests/app/dao/test_service_email_reply_to_dao.py
@@ -2,8 +2,8 @@ import pytest
 
 from app.dao.service_email_reply_to_dao import (
     create_or_update_email_reply_to,
-    dao_get_reply_to_by_service_id
-)
+    dao_get_reply_to_by_service_id,
+    add_reply_to_email_address_for_service, update_reply_to_email_address)
 from app.errors import InvalidRequest
 from app.models import ServiceEmailReplyTo
 from tests.app.db import create_reply_to_email, create_service
@@ -65,3 +65,116 @@ def test_dao_get_reply_to_by_service_id(notify_db_session):
     assert len(results) == 2
     assert default_reply_to in results
     assert another_reply_to in results
+
+
+def test_add_reply_to_email_address_for_service_creates_first_email_for_service(notify_db_session):
+    service = create_service()
+    add_reply_to_email_address_for_service(service_id=service.id, email_address='new@address.com')
+
+    results = dao_get_reply_to_by_service_id(service_id=service.id)
+    assert len(results) == 1
+    assert results[0].email_address == 'new@address.com'
+    assert results[0].is_default
+
+
+def test_add_reply_to_email_address_for_service_creates_another_email_for_service(notify_db_session):
+    service = create_service()
+    first_reply_to = create_reply_to_email(service=service, email_address="first@address.com")
+
+    add_reply_to_email_address_for_service(service_id=service.id, email_address='second@address.com', is_default=False)
+
+    results = dao_get_reply_to_by_service_id(service_id=service.id)
+    assert len(results) == 2
+    for x in results:
+        if x.email_address == 'first@address.com':
+            assert x.is_default
+        elif x.email_address == 'second@address.com':
+            assert not x.is_default
+        else:
+            assert False
+
+
+def test_add_reply_to_email_address_new_reply_to_is_default_existing_reply_to_is_not(notify_db_session):
+    service = create_service()
+    first_reply_to = create_reply_to_email(service=service, email_address="first@address.com", is_default=True)
+    add_reply_to_email_address_for_service(service_id=service.id, email_address='second@address.com', is_default=True)
+
+    results = dao_get_reply_to_by_service_id(service_id=service.id)
+    assert len(results) == 2
+    for x in results:
+        if x.email_address == 'first@address.com':
+            assert not x.is_default
+        elif x.email_address == 'second@address.com':
+            assert x.is_default
+        else:
+            assert False
+
+
+def test_add_reply_to_email_address_can_add_a_third_reply_to_address(sample_service):
+    add_reply_to_email_address_for_service(service_id=sample_service.id,
+                                           email_address="first@address.com")
+    add_reply_to_email_address_for_service(service_id=sample_service.id, email_address='second@address.com',
+                                           is_default=False)
+    add_reply_to_email_address_for_service(service_id=sample_service.id, email_address='third@address.com',
+                                           is_default=False)
+
+    results = dao_get_reply_to_by_service_id(service_id=sample_service.id)
+    assert len(results) == 3
+
+    for x in results:
+        if x.email_address == 'first@address.com':
+            assert x.is_default
+        elif x.email_address == 'second@address.com':
+            assert not x.is_default
+        elif x.email_address == 'third@address.com':
+            assert not x.is_default
+        else:
+            assert False
+
+
+def test_add_reply_to_email_address_ensures_first_reply_to_is_default(sample_service):
+    with pytest.raises(expected_exception=InvalidRequest):
+        add_reply_to_email_address_for_service(service_id=sample_service.id,
+                                               email_address="first@address.com", is_default=False)
+
+
+def test_update_reply_to_email_address(sample_service):
+    first_reply_to = create_reply_to_email(service=sample_service, email_address="first@address.com")
+    update_reply_to_email_address(service_id=sample_service.id, reply_to_id=first_reply_to.id,
+                                  email_address='change_address@email.com')
+    updated_reply_to = ServiceEmailReplyTo.query.get(first_reply_to.id)
+
+    assert updated_reply_to.email_address == 'change_address@email.com'
+    assert updated_reply_to.updated_at
+    assert updated_reply_to.is_default
+
+
+def test_update_reply_to_email_address_set_updated_to_default(sample_service):
+    first_reply_to = create_reply_to_email(service=sample_service, email_address="first@address.com")
+    second_reply_to = create_reply_to_email(service=sample_service,
+                                            email_address="second@address.com",
+                                            is_default=False)
+
+    update_reply_to_email_address(service_id=sample_service.id,
+                                  reply_to_id=second_reply_to.id,
+                                  email_address='change_address@email.com',
+                                  is_default=True)
+
+    results = ServiceEmailReplyTo.query.all()
+    assert len(results) == 2
+    for x in results:
+        if x.email_address == 'change_address@email.com':
+            assert x.is_default
+        elif x.email_address == 'first@address.com':
+            assert not x.is_default
+        else:
+            assert False
+
+
+def test_update_reply_to_email_address_raises_exception_if_single_reply_to_and_setting_default_to_false(sample_service):
+    first_reply_to = create_reply_to_email(service=sample_service, email_address="first@address.com")
+    with pytest.raises(expected_exception=InvalidRequest):
+        update_reply_to_email_address(service_id=sample_service.id,
+                                      reply_to_id=first_reply_to.id,
+                                      email_address='should@fail.com',
+                                      is_default=False)


### PR DESCRIPTION
This PR introduces new endpoints to insert multiple reply to email addresses for a service and update a single reply to email address for a service.

Note to the reviewer: there is some complexity around making sure there is always at least one default. Any suggestions to reduce the complexity is welcome.  
