### PR TITLE
Remove six dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ marshmallow==2.13.6
 monotonic==1.3
 psycopg2==2.7.3.1
 PyJWT==1.5.2
-six==1.10.0
 SQLAlchemy-Utils==0.32.14
 SQLAlchemy==1.1.14
 statsd==3.2.1


### PR DESCRIPTION
six is used for Python 2/3 compatibility. We never run under Python 2.

Closes #1260 