### PR TITLE
Make organisation logo nullable

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -135,7 +135,7 @@ class Organisation(db.Model):
     __tablename__ = 'organisation'
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     colour = db.Column(db.String(7), nullable=True)
-    logo = db.Column(db.String(255), nullable=False)
+    logo = db.Column(db.String(255), nullable=True)
     name = db.Column(db.String(255), nullable=True)
 
     def serialize(self):

--- a/app/organisation/organisation_schema.py
+++ b/app/organisation/organisation_schema.py
@@ -7,7 +7,7 @@ post_create_organisation_schema = {
         "name": {"type": ["string", "null"]},
         "logo": {"type": ["string", "null"]}
     },
-    "required": ["logo"]
+    "required": []
 }
 
 post_update_organisation_schema = {

--- a/migrations/versions/0121_nullable_logos.py
+++ b/migrations/versions/0121_nullable_logos.py
@@ -1,0 +1,25 @@
+"""
+
+Revision ID: 0121_nullable_logos
+Revises: 0120_add_org_banner_branding
+Create Date: 2017-09-20 11:00:20.415523
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0121_nullable_logos'
+down_revision = '0120_add_org_banner_branding'
+
+
+def upgrade():
+    op.alter_column(
+        'organisation', 'logo',
+        existing_type=sa.VARCHAR(length=255),
+        nullable=True
+    )
+
+
+def downgrade():
+    pass

--- a/tests/app/dao/test_organisations_dao.py
+++ b/tests/app/dao/test_organisations_dao.py
@@ -21,18 +21,11 @@ def test_create_organisation(notify_db, notify_db_session):
 
 
 def test_create_organisation_without_name_or_colour_is_valid(notify_db, notify_db_session):
-    organisation = create_organisation(name=None, colour=None)
+    organisation = create_organisation(logo=None, name=None, colour=None)
 
     assert Organisation.query.count() == 1
     organisation_from_db = Organisation.query.first()
     assert organisation == organisation_from_db
-
-
-def test_create_organisation_without_logo_raises_error(notify_db, notify_db_session):
-    with pytest.raises(IntegrityError) as excinfo:
-        create_organisation(logo=None)
-    assert 'column "logo" violates not-null constraint' in str(excinfo.value)
-    assert Organisation.query.count() == 0
 
 
 def test_get_organisations_gets_all_organisations(notify_db, notify_db_session):

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -54,7 +54,7 @@ def test_post_create_organisation(admin_request, notify_db_session):
     assert data['logo'] == response['data']['logo']
 
 
-def test_post_create_organisation_without_logo_raises_error(admin_request, notify_db_session):
+def test_post_create_organisation_without_logo_is_ok(admin_request, notify_db_session):
     data = {
         'name': 'test organisation',
         'colour': '#0000ff',
@@ -62,9 +62,8 @@ def test_post_create_organisation_without_logo_raises_error(admin_request, notif
     response = admin_request.post(
         'organisation.create_organisation',
         _data=data,
-        _expected_status=400
+        _expected_status=201,
     )
-    assert response['errors'][0]['message'] == "logo is a required property"
 
 
 def test_post_create_organisation_without_name_or_colour_is_valid(admin_request, notify_db_session):


### PR DESCRIPTION
Now we have the org banner branding, not all organisations need a logo. So it shouldn’t be an error to not provide one.