### PR TITLE
Use reply to email address from new table

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -109,13 +109,14 @@ def send_email_to_provider(notification):
         else:
             from_address = '"{}" <{}@{}>'.format(service.name, service.email_from,
                                                  current_app.config['NOTIFY_EMAIL_DOMAIN'])
+
             reference = provider.send_email(
                 from_address,
                 notification.to,
                 plain_text_email.subject,
                 body=str(plain_text_email),
                 html_body=str(html_email),
-                reply_to_address=service.reply_to_email_address,
+                reply_to_address=service.get_default_reply_to_email_address(),
             )
             notification.reference = reference
             update_notification(notification, provider)

--- a/app/models.py
+++ b/app/models.py
@@ -201,7 +201,7 @@ class Service(db.Model, Versioned):
     email_from = db.Column(db.Text, index=False, unique=True, nullable=False)
     created_by = db.relationship('User')
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
-    reply_to_email_address = db.Column(db.Text, index=False, unique=False, nullable=True)
+    _reply_to_email_address = db.Column("reply_to_email_address", db.Text, index=False, unique=False, nullable=True)
     letter_contact_block = db.Column(db.Text, index=False, unique=False, nullable=True)
     sms_sender = db.Column(db.String(11), nullable=False, default=lambda: current_app.config['FROM_NUMBER'])
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey('organisation.id'), index=True, nullable=True)
@@ -248,6 +248,13 @@ class Service(db.Model, Versioned):
             return self.inbound_number.number
         else:
             return self.sms_sender
+
+    def get_default_reply_to_email_address(self):
+        default_reply_to = [x for x in self.reply_to_email_addresses if x.is_default]
+        if len(default_reply_to) > 1:
+            raise Exception("There should only ever be one default")
+        else:
+            return default_reply_to[0].email_address if default_reply_to else None
 
 
 class InboundNumber(db.Model):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -182,7 +182,7 @@ class ServiceSchema(BaseSchema):
     dvla_organisation = field_for(models.Service, 'dvla_organisation')
     permissions = fields.Method("service_permissions")
     override_flag = False
-    reply_to_email_address = fields.Method("get_reply_to_email_address")
+    reply_to_email_address = fields.Method(method_name="get_reply_to_email_address")
 
     def get_free_sms_fragment_limit(selfs, service):
         return service.free_sms_fragment_limit()
@@ -195,7 +195,7 @@ class ServiceSchema(BaseSchema):
 
     class Meta:
         model = models.Service
-        dump_only = ['free_sms_fragment_limit']
+        dump_only = ['free_sms_fragment_limit', 'reply_to_email_address']
         exclude = (
             'updated_at',
             'created_at',

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -182,12 +182,16 @@ class ServiceSchema(BaseSchema):
     dvla_organisation = field_for(models.Service, 'dvla_organisation')
     permissions = fields.Method("service_permissions")
     override_flag = False
+    reply_to_email_address = fields.Method("get_reply_to_email_address")
 
     def get_free_sms_fragment_limit(selfs, service):
         return service.free_sms_fragment_limit()
 
     def service_permissions(self, service):
         return [p.permission for p in service.permissions]
+
+    def get_reply_to_email_address(self, service):
+        return service.get_default_reply_to_email_address()
 
     class Meta:
         model = models.Service

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -23,7 +23,8 @@ from app.models import (
     BRANDING_BOTH,
     BRANDING_ORG_BANNER)
 
-from tests.app.db import create_service, create_template, create_notification, create_inbound_number
+from tests.app.db import create_service, create_template, create_notification, create_inbound_number, \
+    create_reply_to_email
 
 
 def test_should_return_highest_priority_active_provider(restore_provider_details):
@@ -386,7 +387,7 @@ def test_send_email_should_use_service_reply_to_email(
     mocker.patch('app.delivery.send_to_providers.create_initial_notification_statistic_tasks')
 
     db_notification = create_notification(template=sample_email_template)
-    sample_service.reply_to_email_address = 'foo@bar.com'
+    create_reply_to_email(service=sample_service, email_address='foo@bar.com')
 
     send_to_providers.send_email_to_provider(
         db_notification,
@@ -398,7 +399,7 @@ def test_send_email_should_use_service_reply_to_email(
         ANY,
         body=ANY,
         html_body=ANY,
-        reply_to_address=sample_service.reply_to_email_address
+        reply_to_address=sample_service.get_default_reply_to_email_address()
     )
 
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -213,19 +213,19 @@ def test_get_service_by_id_should_404_if_no_service(notify_api, notify_db):
             assert json_resp['message'] == 'No result found'
 
 
-def test_get_service_by_id_and_user(notify_api, service_factory, sample_user):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            service = service_factory.get('new.service', sample_user)
-            auth_header = create_authorization_header()
-            resp = client.get(
-                '/service/{}?user_id={}'.format(service.id, sample_user.id),
-                headers=[auth_header]
-            )
-            assert resp.status_code == 200
-            json_resp = json.loads(resp.get_data(as_text=True))
-            assert json_resp['data']['name'] == service.name
-            assert json_resp['data']['id'] == str(service.id)
+def test_get_service_by_id_and_user(client, sample_service, sample_user):
+    sample_service.reply_to_email = 'something@service.com'
+    create_reply_to_email(service=sample_service, email_address='new@service.com')
+    auth_header = create_authorization_header()
+    resp = client.get(
+        '/service/{}?user_id={}'.format(sample_service.id, sample_user.id),
+        headers=[auth_header]
+    )
+    assert resp.status_code == 200
+    json_resp = json.loads(resp.get_data(as_text=True))
+    assert json_resp['data']['name'] == sample_service.name
+    assert json_resp['data']['id'] == str(sample_service.id)
+    assert json_resp['data']['reply_to_email_address'] == 'new@service.com'
 
 
 def test_get_service_by_id_should_404_if_no_service_for_user(notify_api, sample_user):
@@ -2161,7 +2161,6 @@ def test_get_email_reply_to_addresses_when_there_are_no_reply_to_email_addresses
 def test_get_email_reply_to_addresses_with_one_email_address(client, notify_db, notify_db_session):
     service = create_service(notify_db=notify_db, notify_db_session=notify_db_session)
     reply_to = create_reply_to_email(service, 'test@mail.com')
-    service.reply_to_email_address = 'test@mail.com'
 
     response = client.get('/service/{}/email-reply-to'.format(service.id),
                           headers=[create_authorization_header()])
@@ -2179,8 +2178,6 @@ def test_get_email_reply_to_addresses_with_multiple_email_addresses(client, noti
     service = create_service(notify_db=notify_db, notify_db_session=notify_db_session)
     reply_to_a = create_reply_to_email(service, 'test_a@mail.com')
     reply_to_b = create_reply_to_email(service, 'test_b@mail.com', False)
-
-    service.reply_to_email_address = 'test_a@mail.com'
 
     response = client.get('/service/{}/email-reply-to'.format(service.id),
                           headers=[create_authorization_header()])

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -19,7 +19,7 @@ from tests.app.conftest import (
     sample_template as create_sample_template,
     sample_notification_with_job as create_sample_notification_with_job
 )
-from tests.app.db import create_notification, create_service, create_inbound_number
+from tests.app.db import create_notification, create_service, create_inbound_number, create_reply_to_email
 from tests.conftest import set_config
 
 
@@ -248,3 +248,9 @@ def test_inbound_number_returns_from_number_config(client, notify_db_session):
         service = create_service(sms_sender=None)
 
     assert service.get_inbound_number() == 'test'
+
+
+def test_service_get_default_reply_to_email_address(sample_service):
+    create_reply_to_email(service=sample_service, email_address="default@email.com")
+
+    assert sample_service.get_default_reply_to_email_address() == 'default@email.com'


### PR DESCRIPTION
Stop using Service.reply_to_email_address, instead use the default reply to email address from the Service_reply_to_email table. 