### PR TITLE
Fix sending emails with no logo

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -179,10 +179,11 @@ def get_html_email_options(service):
     govuk_banner = service.branding not in (BRANDING_ORG, BRANDING_ORG_BANNER)
     brand_banner = service.branding == BRANDING_ORG_BANNER
     if service.organisation and service.branding != BRANDING_GOVUK:
+
         logo_url = get_logo_url(
             current_app.config['ADMIN_BASE_URL'],
             service.organisation.logo
-        )
+        ) if service.organisation.logo else None
 
         branding = {
             'brand_colour': service.organisation.colour,

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -459,6 +459,18 @@ def test_get_html_email_renderer_prepends_logo_path(notify_api):
     assert renderer['brand_logo'] == 'http://static-logos.notify.tools/justice-league.png'
 
 
+def test_get_html_email_renderer_handles_org_without_logo(notify_api):
+    Service = namedtuple('Service', ['branding', 'organisation'])
+    Organisation = namedtuple('Organisation', ['colour', 'name', 'logo'])
+
+    org = Organisation(colour='#000000', logo=None, name='Justice League')
+    service = Service(branding=BRANDING_ORG, organisation=org)
+
+    renderer = send_to_providers.get_html_email_options(service)
+
+    assert renderer['brand_logo'] is None
+
+
 @pytest.mark.parametrize('base_url, expected_url', [
     # don't change localhost to prevent errors when testing locally
     ('http://localhost:6012', 'http://static-logos.notify.tools/filename.png'),


### PR DESCRIPTION
Code was not expecting logo to be `None`, thereby causing the task to throw an exception, and retry until eventually putting the email in technical error (for services with org branding but no logo).