### PR TITLE
Select an inbound number for a service

### DIFF
--- a/app/dao/inbound_numbers_dao.py
+++ b/app/dao/inbound_numbers_dao.py
@@ -31,3 +31,17 @@ def dao_set_inbound_number_active_flag(service_id, active):
     inbound_number.active = active
 
     db.session.add(inbound_number)
+
+
+@transactional
+def dao_allocate_number_for_service(service_id, inbound_number_id):
+    updated = InboundNumber.query.filter_by(
+        id=inbound_number_id,
+        active=True,
+        service_id=None
+    ).update(
+        {"service_id": service_id}
+    )
+    if not updated:
+        raise Exception("Inbound number: {} is not available".format(inbound_number_id))
+    return InboundNumber.query.get(inbound_number_id)

--- a/app/models.py
+++ b/app/models.py
@@ -204,6 +204,7 @@ class Service(db.Model, Versioned):
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
     _reply_to_email_address = db.Column("reply_to_email_address", db.Text, index=False, unique=False, nullable=True)
     letter_contact_block = db.Column(db.Text, index=False, unique=False, nullable=True)
+    # This column is now deprecated
     sms_sender = db.Column(db.String(11), nullable=False, default=lambda: current_app.config['FROM_NUMBER'])
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey('organisation.id'), index=True, nullable=True)
     organisation = db.relationship('Organisation')

--- a/tests/app/dao/test_inbound_numbers_dao.py
+++ b/tests/app/dao/test_inbound_numbers_dao.py
@@ -6,8 +6,8 @@ from app.dao.inbound_numbers_dao import (
     dao_get_inbound_number_for_service,
     dao_get_available_inbound_numbers,
     dao_set_inbound_number_to_service,
-    dao_set_inbound_number_active_flag
-)
+    dao_set_inbound_number_active_flag,
+    dao_allocate_number_for_service)
 from app.models import InboundNumber
 
 from tests.app.db import create_service, create_inbound_number
@@ -79,3 +79,21 @@ def test_set_inbound_number_active_flag(notify_db, notify_db_session, sample_ser
     inbound_number = dao_get_inbound_number_for_service(sample_service.id)
 
     assert inbound_number.active is active
+
+
+def test_dao_allocate_number_for_service(notify_db_session):
+    number = '078945612'
+    inbound_number = create_inbound_number(number=number)
+    service = create_service()
+
+    updated_inbound_number = dao_allocate_number_for_service(service_id=service.id, inbound_number_id=inbound_number.id)
+    assert service.get_inbound_number() == number
+    assert updated_inbound_number.service_id == service.id
+
+
+def test_dao_allocate_number_for_service(notify_db_session, sample_service):
+    number = '078945612'
+    inbound_number = create_inbound_number(number=number, service_id=sample_service.id)
+    service = create_service(service_name="Service needs an inbound number")
+    with pytest.raises(Exception):
+        dao_allocate_number_for_service(service_id=service.id, inbound_number_id=inbound_number.id)

--- a/tests/app/dao/test_inbound_numbers_dao.py
+++ b/tests/app/dao/test_inbound_numbers_dao.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from sqlalchemy.exc import IntegrityError
 
@@ -97,3 +99,9 @@ def test_dao_allocate_number_for_service(notify_db_session, sample_service):
     service = create_service(service_name="Service needs an inbound number")
     with pytest.raises(Exception):
         dao_allocate_number_for_service(service_id=service.id, inbound_number_id=inbound_number.id)
+
+
+def test_dao_allocate_number_for_service(notify_db_session, sample_service):
+    service = create_service(service_name="Service needs an inbound number")
+    with pytest.raises(Exception):
+        dao_allocate_number_for_service(service_id=service.id, inbound_number_id=uuid.uuid4())

--- a/tests/app/inbound_number/test_rest.py
+++ b/tests/app/inbound_number/test_rest.py
@@ -1,3 +1,5 @@
+import uuid
+
 from app.dao.inbound_numbers_dao import dao_get_inbound_number_for_service
 from app.models import ServiceSmsSender
 
@@ -129,3 +131,59 @@ def test_allocate_inbound_number_insert_update_service_sms_sender(
     assert service_sms_senders[0].sms_sender == inbound_number.number
     assert service_sms_senders[0].inbound_number_id == inbound_number.id
     assert service_sms_senders[0].is_default
+
+
+def test_allocate_inbound_number_to_service(admin_request, notify_db_session):
+    service = create_service()
+    inbound_number = create_inbound_number(number='1235468')
+
+    admin_request.post(
+        'inbound_number.allocate_inbound_number_to_service',
+        _expected_status=204,
+        service_id=service.id,
+        inbound_number_id=inbound_number.id
+    )
+    sms_sender = ServiceSmsSender.query.filter_by(service_id=service.id).first()
+    assert sms_sender.sms_sender == inbound_number.number
+    assert sms_sender.inbound_number_id == inbound_number.id
+
+
+def test_allocate_inbound_number_to_service_returns_404_if_service_does_not_exist(
+        admin_request, notify_db_session
+):
+    inbound_number = create_inbound_number(number='1235468')
+
+    admin_request.post(
+        'inbound_number.allocate_inbound_number_to_service',
+        _expected_status=404,
+        service_id=uuid.uuid4(),
+        inbound_number_id=inbound_number.id
+    )
+
+
+def test_allocate_inbound_number_to_service_returns_500_if_inbound_number_is_assigned(
+        admin_request, notify_db_session
+):
+    service = create_service()
+    inbound_number = create_inbound_number(number='1235468', service_id=service.id)
+
+    admin_request.post(
+        'inbound_number.allocate_inbound_number_to_service',
+        _expected_status=404,
+        service_id=uuid.uuid4(),
+        inbound_number_id=inbound_number.id
+    )
+
+
+def test_get_available_inbound_numbers_returns_empty_list(admin_request):
+    result = admin_request.get('inbound_number.get_available_inbound_numbers')
+
+    assert result['data'] == []
+
+
+def test_get_available_inbound_numbers(admin_request, sample_inbound_numbers):
+    result = admin_request.get('inbound_number.get_available_inbound_numbers')
+
+    assert len(result['data']) == 1
+    assert result['data'] == [i.serialize() for i in sample_inbound_numbers if
+                              i.service_id is None]


### PR DESCRIPTION
- Add new endpoint to get available inbound number.
- Add new endpoint to allocate a specific number to a given service.

This will allow the platform admin user to choose a number when setting the inbound_sms permission for a service.