### PR TITLE
[3/4] - Populate service_letter_contacts from existing data

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -285,3 +285,23 @@ class PopulateServiceSmsSender(Command):
         print("Populated sms sender {} services from services".format(second_result.rowcount))
         print("{} services in table".format(services_count_query))
         print("{} service_sms_senders".format(service_sms_sender_count_query))
+
+
+class PopulateServiceLetterContact(Command):
+
+    def run(self):
+        services_to_update = """
+            INSERT INTO service_letter_contacts(id, service_id, contact_block, is_default, created_at)
+            SELECT uuid_in(md5(random()::text || now()::text)::cstring), id, letter_contact_block, true, '{}'
+            FROM services
+            WHERE letter_contact_block IS NOT NULL
+            AND id NOT IN(
+                SELECT service_id
+                FROM service_letter_contacts
+            )
+        """.format(datetime.utcnow())
+
+        result = db.session.execute(services_to_update)
+        db.session.commit()
+
+        print("Populated letter contacts for {} services".format(result.rowcount))

--- a/application.py
+++ b/application.py
@@ -20,6 +20,7 @@ manager.add_command('populate_monthly_billing', commands.PopulateMonthlyBilling)
 manager.add_command('backfill_processing_time', commands.BackfillProcessingTime)
 manager.add_command('populate_service_email_reply_to', commands.PopulateServiceEmailReplyTo)
 manager.add_command('populate_service_sms_sender', commands.PopulateServiceSmsSender)
+manager.add_command('populate_service_letter_contact', commands.PopulateServiceLetterContact)
 
 
 @manager.command


### PR DESCRIPTION
This adds a command to populate the new `service_letter_contacts` from existing data pulled from `Service.letter_contact_block` for each service.

Conditions:
1. Only create a record if `Service.letter_contact_block` actually has something
2. service_letter_contacts hasn't already been populated for the service

## Dependencies

- [x] - https://github.com/alphagov/notifications-api/pull/1277
- [x] - https://github.com/alphagov/notifications-admin/pull/1511