### PR TITLE
Letter api not by job

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -72,7 +72,7 @@ def remove_s3_object(bucket_name, object_key):
 
 
 def remove_transformed_dvla_file(job_id):
-    bucket_name = current_app.config['DVLA_UPLOAD_BUCKET_NAME']
+    bucket_name = current_app.config['DVLA_BUCKETS']['job']
     file_location = '{}-dvla-job.text'.format(job_id)
     obj = get_s3_object(bucket_name, file_location)
     return obj.delete()

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -325,9 +325,9 @@ def run_letter_jobs():
         current_app.logger.info("Queued {} ready letter job ids onto {}".format(len(job_ids), QueueNames.PROCESS_FTP))
 
 
-@notify_celery.task(name="run-letter-notifications")
+@notify_celery.task(name="run-letter-api-notifications")
 @statsd(namespace="tasks")
-def run_letter_notifications():
+def run_letter_api_notifications():
     current_time = datetime.utcnow().isoformat()
 
     notifications = dao_set_created_live_letter_api_notifications_to_pending()

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -335,17 +335,17 @@ def run_letter_notifications():
     if notifications:
         file_contents = create_dvla_file_contents_for_notifications(notifications)
 
-        file_location = '{}-dvla-notifications.txt'.format(current_time)
+        filename = '{}-dvla-notifications.txt'.format(current_time)
         s3upload(
             filedata=file_contents + '\n',
             region=current_app.config['AWS_REGION'],
             bucket_name=current_app.config['DVLA_BUCKETS']['notification'],
-            file_location=file_location
+            file_location=filename
         )
 
         notify_celery.send_task(
             name=TaskNames.DVLA_NOTIFICATIONS,
-            kwargs={'filename': file_location},
+            kwargs={'filename': filename},
             queue=QueueNames.PROCESS_FTP
         )
         current_app.logger.info(

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -27,7 +27,7 @@ from app.dao.jobs_dao import (
     all_notifications_are_created_for_job,
     dao_get_all_notifications_for_job,
     dao_update_job_status)
-from app.dao.notifications_dao import get_notification_by_id, dao_update_notifications_sent_to_dvla
+from app.dao.notifications_dao import get_notification_by_id, dao_update_notifications_for_job_to_sent_to_dvla
 from app.dao.provider_details_dao import get_current_provider
 from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
 from app.dao.services_dao import dao_fetch_service_by_id, fetch_todays_total_message_count
@@ -279,11 +279,11 @@ def persist_letter(
 def build_dvla_file(self, job_id):
     try:
         if all_notifications_are_created_for_job(job_id):
-            file_contents = create_dvla_file_contents(job_id)
+            file_contents = create_dvla_file_contents_for_job(job_id)
             s3upload(
                 filedata=file_contents + '\n',
                 region=current_app.config['AWS_REGION'],
-                bucket_name=current_app.config['DVLA_UPLOAD_BUCKET_NAME'],
+                bucket_name=current_app.config['DVLA_BUCKETS']['job'],
                 file_location="{}-dvla-job.text".format(job_id)
             )
             dao_update_job_status(job_id, JOB_STATUS_READY_TO_SEND)
@@ -302,15 +302,22 @@ def update_job_to_sent_to_dvla(self, job_id):
     # and update all notifications for this job to sending, provider = DVLA
     provider = get_current_provider(LETTER_TYPE)
 
-    updated_count = dao_update_notifications_sent_to_dvla(job_id, provider.identifier)
+    updated_count = dao_update_notifications_for_job_to_sent_to_dvla(job_id, provider.identifier)
     dao_update_job_status(job_id, JOB_STATUS_SENT_TO_DVLA)
 
     current_app.logger.info("Updated {} letter notifications to sending. "
                             "Updated {} job to {}".format(updated_count, job_id, JOB_STATUS_SENT_TO_DVLA))
 
 
+@notify_celery.task(bind=True, name='update-notifications-to-sent')
+@statsd(namespace="tasks")
 def update_notifications_to_sent_to_dvla(self, notification_references):
+    # This task will be called by the FTP app to update notifications as sent to DVLA
+    provider = get_current_provider(LETTER_TYPE)
 
+    updated_count = dao_update_notifications_for_job_to_sent_to_dvla(references, provider.identifier)
+
+    current_app.logger.info("Updated {} letter notifications to sending. ".format(updated_count))
 
 
 @notify_celery.task(bind=True, name='update-letter-job-to-error')

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -309,6 +309,10 @@ def update_job_to_sent_to_dvla(self, job_id):
                             "Updated {} job to {}".format(updated_count, job_id, JOB_STATUS_SENT_TO_DVLA))
 
 
+def update_notifications_to_sent_to_dvla(self, notification_references):
+
+
+
 @notify_celery.task(bind=True, name='update-letter-job-to-error')
 @statsd(namespace="tasks")
 def update_dvla_job_to_error(self, job_id):
@@ -316,7 +320,13 @@ def update_dvla_job_to_error(self, job_id):
     current_app.logger.info("Updated {} job to {}".format(job_id, JOB_STATUS_ERROR))
 
 
-def create_dvla_file_contents(job_id):
+def create_dvla_file_contents_for_job(job_id):
+    notifications = dao_get_all_notifications_for_job(job_id)
+
+    return create_dvla_file_contents_for_notifications(notifications)
+
+
+def create_dvla_file_contents_for_notifications(notifications):
     file_contents = '\n'.join(
         str(LetterDVLATemplate(
             notification.template.__dict__,
@@ -325,7 +335,7 @@ def create_dvla_file_contents(job_id):
             contact_block=notification.service.letter_contact_block,
             org_id=notification.service.dvla_organisation.id,
         ))
-        for notification in dao_get_all_notifications_for_job(job_id)
+        for notification in notifications
     )
     return file_contents
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -46,7 +46,10 @@ from app.models import (
     JOB_STATUS_IN_PROGRESS,
     JOB_STATUS_FINISHED,
     JOB_STATUS_READY_TO_SEND,
-    JOB_STATUS_SENT_TO_DVLA, JOB_STATUS_ERROR)
+    JOB_STATUS_SENT_TO_DVLA, JOB_STATUS_ERROR,
+    NOTIFICATION_SENDING,
+    NOTIFICATION_TECHNICAL_FAILURE
+)
 from app.notifications.process_notifications import persist_notification
 from app.service.utils import service_allowed_to_send_to
 from app.statsd_decorators import statsd
@@ -343,7 +346,6 @@ def update_letter_notifications_to_sent_to_dvla(self, notification_references):
 @statsd(namespace="tasks")
 def update_letter_notifications_to_error(self, notification_references):
     # This task will be called by the FTP app to update notifications as sent to DVLA
-    provider = get_current_provider(LETTER_TYPE)
 
     updated_count = dao_update_notifications_by_reference(
         notification_references,

--- a/app/config.py
+++ b/app/config.py
@@ -229,6 +229,11 @@ class Config(object):
             'task': 'run-letter-jobs',
             'schedule': crontab(hour=17, minute=30),
             'options': {'queue': QueueNames.PERIODIC}
+        },
+        'run-letter-notifications': {
+            'task': 'run-letter-notifications',
+            'schedule': crontab(hour=17, minute=35),
+            'options': {'queue': QueueNames.PERIODIC}
         }
     }
     CELERY_QUEUES = []
@@ -253,7 +258,10 @@ class Config(object):
     FUNCTIONAL_TEST_PROVIDER_SERVICE_ID = None
     FUNCTIONAL_TEST_PROVIDER_SMS_TEMPLATE_ID = None
 
-    DVLA_UPLOAD_BUCKET_NAME = "{}-dvla-file-per-job".format(os.getenv('NOTIFY_ENVIRONMENT'))
+    DVLA_BUCKETS = {
+        'job': '{}-dvla-file-per-job'.format(os.getenv('NOTIFY_ENVIRONMENT')),
+        'notification': '{}-dvla-file-per-job'.format(os.getenv('NOTIFY_ENVIRONMENT'))
+    }
 
     API_KEY_LIMITS = {
         KEY_TYPE_TEAM: {

--- a/app/config.py
+++ b/app/config.py
@@ -230,8 +230,8 @@ class Config(object):
             'schedule': crontab(hour=5, minute=30),
             'options': {'queue': QueueNames.PERIODIC}
         },
-        'run-letter-notifications': {
-            'task': 'run-letter-notifications',
+        'run-letter-api-notifications': {
+            'task': 'run-letter-api-notifications',
             'schedule': crontab(hour=5, minute=40),
             'options': {'queue': QueueNames.PERIODIC}
         }

--- a/app/config.py
+++ b/app/config.py
@@ -137,7 +137,7 @@ class Config(object):
         'visibility_timeout': 310,
         'queue_name_prefix': NOTIFICATION_QUEUE_PREFIX
     }
-    CELERY_ENABLE_UTC = True,
+    CELERY_ENABLE_UTC = True
     CELERY_TIMEZONE = 'Europe/London'
     CELERY_ACCEPT_CONTENT = ['json']
     CELERY_TASK_SERIALIZER = 'json'

--- a/app/config.py
+++ b/app/config.py
@@ -260,7 +260,7 @@ class Config(object):
 
     DVLA_BUCKETS = {
         'job': '{}-dvla-file-per-job'.format(os.getenv('NOTIFY_ENVIRONMENT')),
-        'notification': '{}-dvla-file-per-job'.format(os.getenv('NOTIFY_ENVIRONMENT'))
+        'notification': '{}-dvla-file-letter-api'.format(os.getenv('NOTIFY_ENVIRONMENT'))
     }
 
     API_KEY_LIMITS = {

--- a/app/config.py
+++ b/app/config.py
@@ -165,27 +165,27 @@ class Config(object):
         },
         'delete-sms-notifications': {
             'task': 'delete-sms-notifications',
-            'schedule': crontab(minute=0, hour=0),
+            'schedule': crontab(hour=0, minute=0),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'delete-email-notifications': {
             'task': 'delete-email-notifications',
-            'schedule': crontab(minute=20, hour=0),
+            'schedule': crontab(hour=0, minute=20),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'delete-letter-notifications': {
             'task': 'delete-letter-notifications',
-            'schedule': crontab(minute=40, hour=0),
+            'schedule': crontab(hour=0, minute=40),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'delete-inbound-sms': {
             'task': 'delete-inbound-sms',
-            'schedule': crontab(minute=0, hour=1),
+            'schedule': crontab(hour=1, minute=0),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'send-daily-performance-platform-stats': {
             'task': 'send-daily-performance-platform-stats',
-            'schedule': crontab(minute=0, hour=2),
+            'schedule': crontab(hour=2, minute=0),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'switch-current-sms-provider-on-slow-delivery': {
@@ -195,44 +195,44 @@ class Config(object):
         },
         'timeout-sending-notifications': {
             'task': 'timeout-sending-notifications',
-            'schedule': crontab(minute=0, hour=3),
+            'schedule': crontab(hour=3, minute=0),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'remove_sms_email_jobs': {
             'task': 'remove_csv_files',
-            'schedule': crontab(minute=0, hour=4),
+            'schedule': crontab(hour=4, minute=0),
             'options': {'queue': QueueNames.PERIODIC},
             'kwargs': {'job_types': [EMAIL_TYPE, SMS_TYPE]}
         },
         'remove_letter_jobs': {
             'task': 'remove_csv_files',
-            'schedule': crontab(minute=20, hour=4),
+            'schedule': crontab(hour=4, minute=20),
             'options': {'queue': QueueNames.PERIODIC},
             'kwargs': {'job_types': [LETTER_TYPE]}
         },
         'remove_transformed_dvla_files': {
             'task': 'remove_transformed_dvla_files',
-            'schedule': crontab(minute=40, hour=4),
+            'schedule': crontab(hour=4, minute=40),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'timeout-job-statistics': {
             'task': 'timeout-job-statistics',
-            'schedule': crontab(minute=0, hour=5),
+            'schedule': crontab(hour=5, minute=0),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'populate_monthly_billing': {
             'task': 'populate_monthly_billing',
-            'schedule': crontab(minute=10, hour=5),
+            'schedule': crontab(hour=5, minute=10),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'run-letter-jobs': {
             'task': 'run-letter-jobs',
-            'schedule': crontab(hour=17, minute=30),
+            'schedule': crontab(hour=5, minute=30),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'run-letter-notifications': {
             'task': 'run-letter-notifications',
-            'schedule': crontab(hour=17, minute=35),
+            'schedule': crontab(hour=5, minute=40),
             'options': {'queue': QueueNames.PERIODIC}
         }
     }
@@ -260,7 +260,7 @@ class Config(object):
 
     DVLA_BUCKETS = {
         'job': '{}-dvla-file-per-job'.format(os.getenv('NOTIFY_ENVIRONMENT')),
-        'notification': '{}-dvla-file-letter-api'.format(os.getenv('NOTIFY_ENVIRONMENT'))
+        'notification': '{}-dvla-letter-api-files'.format(os.getenv('NOTIFY_ENVIRONMENT'))
     }
 
     API_KEY_LIMITS = {

--- a/app/config.py
+++ b/app/config.py
@@ -49,7 +49,7 @@ class QueueNames(object):
 
 class TaskNames(object):
     DVLA_JOBS = 'send-jobs-to-dvla'
-    DVLA_NOTIFICATIONS = 'send-notifications-to-dvla'
+    DVLA_NOTIFICATIONS = 'send-api-notifications-to-dvla'
 
 
 class Config(object):

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -477,16 +477,18 @@ def dao_update_notifications_for_job_to_sent_to_dvla(job_id, provider):
 @transactional
 def dao_update_notifications_by_reference(references, update_dict):
     now = datetime.utcnow()
-    updated_count = Notification.query().filter(
+    updated_count = Notification.query.filter(
         Notification.reference.in_(references)
     ).update(
-        update_dict
+        update_dict,
+        synchronize_session=False
     )
 
-    NotificationHistory.query().filter(
+    NotificationHistory.query.filter(
         NotificationHistory.reference.in_(references)
     ).update(
-        update_dict
+        update_dict,
+        synchronize_session=False
     )
 
     return updated_count
@@ -585,11 +587,12 @@ def dao_set_created_live_letter_api_notifications_to_pending():
     from completing until it commits.
     """
     return db.session.query(
-        Notification.id
+        Notification
     ).filter(
         Notification.notification_type == LETTER_TYPE,
         Notification.status == NOTIFICATION_CREATED,
         Notification.key_type == KEY_TYPE_NORMAL,
+        Notification.api_key != None
     ).with_for_update(
     ).all()
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -586,7 +586,7 @@ def dao_set_created_live_letter_api_notifications_to_pending():
     the transaction so that if the task is run more than once concurrently, one task will block the other select
     from completing until it commits.
     """
-    return db.session.query(
+    notifications = db.session.query(
         Notification
     ).filter(
         Notification.notification_type == LETTER_TYPE,
@@ -597,7 +597,7 @@ def dao_set_created_live_letter_api_notifications_to_pending():
     ).all()
 
     for notification in notifications:
-        notification.notification_status = NOTIFICATION_PENDING
+        notification.status = NOTIFICATION_PENDING
 
     db.session.add_all(notifications)
     db.session.commit()

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -592,7 +592,7 @@ def dao_set_created_live_letter_api_notifications_to_pending():
         Notification.notification_type == LETTER_TYPE,
         Notification.status == NOTIFICATION_CREATED,
         Notification.key_type == KEY_TYPE_NORMAL,
-        Notification.api_key != None
+        Notification.api_key != None  # noqa
     ).with_for_update(
     ).all()
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -475,15 +475,19 @@ def dao_update_notifications_for_job_to_sent_to_dvla(job_id, provider):
 
 @statsd(namespace="dao")
 @transactional
-def dao_update_notifications_by_reference_sent_to_dvla(notification_references, provider):
+def dao_update_notifications_by_reference(references, update_dict):
     now = datetime.utcnow()
-    updated_count = db.session.query(
-        Notification).filter(Notification.job_id == job_id).update(
-        {'status': NOTIFICATION_SENDING, "sent_by": provider, "sent_at": now})
+    updated_count = Notification.query().filter(
+        Notification.reference.in_(references)
+    ).update(
+        update_dict
+    )
 
-    db.session.query(
-        NotificationHistory).filter(NotificationHistory.job_id == job_id).update(
-        {'status': NOTIFICATION_SENDING, "sent_by": provider, "sent_at": now, "updated_at": now})
+    NotificationHistory.query().filter(
+        NotificationHistory.reference.in_(references)
+    ).update(
+        update_dict
+    )
 
     return updated_count
 

--- a/app/notifications/process_letter_notifications.py
+++ b/app/notifications/process_letter_notifications.py
@@ -26,10 +26,10 @@ def create_letter_api_job(template):
     return job
 
 
-def create_letter_notification(letter_data, job, api_key):
+def create_letter_notification(letter_data, template, api_key):
     notification = persist_notification(
-        template_id=job.template.id,
-        template_version=job.template.version,
+        template_id=template.id,
+        template_version=template.version,
         # we only accept addresses_with_underscores from the API (from CSV we also accept dashes, spaces etc)
         recipient=letter_data['personalisation']['address_line_1'],
         service=job.service,
@@ -37,8 +37,8 @@ def create_letter_notification(letter_data, job, api_key):
         notification_type=LETTER_TYPE,
         api_key_id=api_key.id,
         key_type=api_key.key_type,
-        job_id=job.id,
-        job_row_number=0,
+        job_id=None,
+        job_row_number=None,
         reference=create_random_identifier(),
         client_reference=letter_data.get('reference')
     )

--- a/app/notifications/process_letter_notifications.py
+++ b/app/notifications/process_letter_notifications.py
@@ -1,38 +1,15 @@
 from app import create_random_identifier
-from app.models import LETTER_TYPE, JOB_STATUS_READY_TO_SEND, Job
-from app.dao.jobs_dao import dao_create_job
+from app.models import LETTER_TYPE
 from app.notifications.process_notifications import persist_notification
-from app.v2.errors import InvalidRequest
-from app.variables import LETTER_API_FILENAME
 
 
-def create_letter_api_job(template):
-    service = template.service
-    if not service.active:
-        raise InvalidRequest('Service {} is inactive'.format(service.id), 403)
-    if template.archived:
-        raise InvalidRequest('Template {} is deleted'.format(template.id), 400)
-
-    job = Job(
-        original_file_name=LETTER_API_FILENAME,
-        service=service,
-        template=template,
-        template_version=template.version,
-        notification_count=1,
-        job_status=JOB_STATUS_READY_TO_SEND,
-        created_by=None
-    )
-    dao_create_job(job)
-    return job
-
-
-def create_letter_notification(letter_data, template, api_key):
+def create_letter_notification(letter_data, template, api_key, status):
     notification = persist_notification(
         template_id=template.id,
         template_version=template.version,
         # we only accept addresses_with_underscores from the API (from CSV we also accept dashes, spaces etc)
         recipient=letter_data['personalisation']['address_line_1'],
-        service=job.service,
+        service=template.service,
         personalisation=letter_data['personalisation'],
         notification_type=LETTER_TYPE,
         api_key_id=api_key.id,
@@ -40,6 +17,7 @@ def create_letter_notification(letter_data, template, api_key):
         job_id=None,
         job_row_number=None,
         reference=create_random_identifier(),
-        client_reference=letter_data.get('reference')
+        client_reference=letter_data.get('reference'),
+        status=status
     )
     return notification

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from flask import current_app
 
+from notifications_utils.clients import redis
 from notifications_utils.recipients import (
     get_international_phone_info,
     validate_and_format_phone_number,
@@ -11,10 +12,8 @@ from notifications_utils.recipients import (
 
 from app import redis_store
 from app.celery import provider_tasks
-from notifications_utils.clients import redis
-
 from app.config import QueueNames
-from app.models import SMS_TYPE, Notification, KEY_TYPE_TEST, EMAIL_TYPE, ScheduledNotification
+from app.models import SMS_TYPE, Notification, KEY_TYPE_TEST, EMAIL_TYPE, NOTIFICATION_CREATED, ScheduledNotification
 from app.dao.notifications_dao import (dao_create_notification,
                                        dao_delete_notifications_and_history_by_id,
                                        dao_created_scheduled_notification)
@@ -52,7 +51,8 @@ def persist_notification(
     client_reference=None,
     notification_id=None,
     simulated=False,
-    created_by_id=None
+    created_by_id=None,
+    status=NOTIFICATION_CREATED
 ):
     notification_created_at = created_at or datetime.utcnow()
     if not notification_id:
@@ -73,7 +73,8 @@ def persist_notification(
         job_row_number=job_row_number,
         client_reference=client_reference,
         reference=reference,
-        created_by_id=created_by_id
+        created_by_id=created_by_id,
+        status=status
     )
 
     if notification_type == SMS_TYPE:

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -153,8 +153,7 @@ def process_letter_notification(*, letter_data, api_key, template):
     if api_key.service.restricted and api_key.key_type != KEY_TYPE_TEST:
         raise BadRequestError(message='Cannot send letters when service is in trial mode', status_code=403)
 
-    job = create_letter_api_job(template)
-    notification = create_letter_notification(letter_data, job, api_key)
+    notification = create_letter_notification(letter_data, template, api_key)
 
     if api_key.service.research_mode or api_key.key_type == KEY_TYPE_TEST:
         # distinguish real API jobs from test jobs by giving the test jobs a different filename

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -43,7 +43,6 @@ from app.v2.notifications.create_response import (
     create_post_email_response_from_notification,
     create_post_letter_response_from_notification
 )
-from app.variables import LETTER_TEST_API_FILENAME
 
 
 @v2_notification_blueprint.route('/<notification_type>', methods=['POST'])

--- a/tests/app/aws/test_s3.py
+++ b/tests/app/aws/test_s3.py
@@ -39,7 +39,7 @@ def test_remove_transformed_dvla_file_makes_correct_call(notify_api, mocker):
     remove_transformed_dvla_file(fake_uuid)
 
     s3_mock.assert_has_calls([
-        call(current_app.config['DVLA_UPLOAD_BUCKET_NAME'], '{}-dvla-job.text'.format(fake_uuid)),
+        call(current_app.config['DVLA_BUCKETS']['job'], '{}-dvla-job.text'.format(fake_uuid)),
         call().delete()
     ])
 

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -1,0 +1,127 @@
+from datetime import datetime
+
+import pytest
+from freezegun import freeze_time
+from flask import current_app
+
+from app.models import (
+    Job,
+    Notification,
+    NOTIFICATION_SENDING,
+    NOTIFICATION_CREATED,
+    NOTIFICATION_TECHNICAL_FAILURE
+)
+from app.celery.tasks import (
+    update_job_to_sent_to_dvla,
+    update_dvla_job_to_error,
+    update_letter_notifications_statuses,
+    update_letter_notifications_to_sent_to_dvla,
+    update_letter_notifications_to_error,
+    process_updates_from_file
+)
+
+from tests.app.db import create_notification
+from tests.conftest import set_config
+
+
+def test_update_job_to_sent_to_dvla(sample_letter_template, sample_letter_job):
+    create_notification(template=sample_letter_template, job=sample_letter_job)
+    create_notification(template=sample_letter_template, job=sample_letter_job)
+    update_job_to_sent_to_dvla(job_id=sample_letter_job.id)
+
+    updated_notifications = Notification.query.all()
+    assert [(n.status == 'sending', n.sent_by == 'dvla') for n in updated_notifications]
+
+    assert Job.query.filter_by(id=sample_letter_job.id).one().job_status == 'sent to dvla'
+
+
+def test_update_dvla_job_to_error(sample_letter_template, sample_letter_job):
+    create_notification(template=sample_letter_template, job=sample_letter_job)
+    create_notification(template=sample_letter_template, job=sample_letter_job)
+    update_dvla_job_to_error(job_id=sample_letter_job.id)
+
+    updated_notifications = Notification.query.all()
+    for n in updated_notifications:
+        assert n.status == 'created'
+        assert not n.sent_by
+
+    assert Job.query.filter_by(id=sample_letter_job.id).one().job_status == 'error'
+
+
+def test_update_letter_notifications_statuses_raises_for_invalid_format(notify_api, mocker):
+    invalid_file = 'ref-foo|Sent|1|Unsorted\nref-bar|Sent|2'
+    mocker.patch('app.celery.tasks.s3.get_s3_file', return_value=invalid_file)
+
+    with pytest.raises(TypeError):
+        update_letter_notifications_statuses(filename='foo.txt')
+
+
+def test_update_letter_notifications_statuses_calls_with_correct_bucket_location(notify_api, mocker):
+    s3_mock = mocker.patch('app.celery.tasks.s3.get_s3_object')
+
+    with set_config(notify_api, 'NOTIFY_EMAIL_DOMAIN', 'foo.bar'):
+        update_letter_notifications_statuses(filename='foo.txt')
+        s3_mock.assert_called_with('{}-ftp'.format(current_app.config['NOTIFY_EMAIL_DOMAIN']), 'foo.txt')
+
+
+def test_update_letter_notifications_statuses_builds_updates_from_content(notify_api, mocker):
+    valid_file = 'ref-foo|Sent|1|Unsorted\nref-bar|Sent|2|Sorted'
+    mocker.patch('app.celery.tasks.s3.get_s3_file', return_value=valid_file)
+    update_mock = mocker.patch('app.celery.tasks.process_updates_from_file')
+
+    update_letter_notifications_statuses(filename='foo.txt')
+
+    update_mock.assert_called_with('ref-foo|Sent|1|Unsorted\nref-bar|Sent|2|Sorted')
+
+
+def test_update_letter_notifications_statuses_builds_updates_list(notify_api, mocker):
+    valid_file = 'ref-foo|Sent|1|Unsorted\nref-bar|Sent|2|Sorted'
+    updates = process_updates_from_file(valid_file)
+
+    assert len(updates) == 2
+
+    assert updates[0].reference == 'ref-foo'
+    assert updates[0].status == 'Sent'
+    assert updates[0].page_count == '1'
+    assert updates[0].cost_threshold == 'Unsorted'
+
+    assert updates[1].reference == 'ref-bar'
+    assert updates[1].status == 'Sent'
+    assert updates[1].page_count == '2'
+    assert updates[1].cost_threshold == 'Sorted'
+
+
+def test_update_letter_notifications_to_sent_to_dvla_updates_based_on_notification_references(
+    client,
+    sample_letter_template
+):
+    first = create_notification(sample_letter_template)
+    second = create_notification(sample_letter_template)
+
+    dt = datetime.utcnow()
+    with freeze_time(dt):
+        update_letter_notifications_to_sent_to_dvla([first.reference])
+
+    assert first.status == NOTIFICATION_SENDING
+    assert first.sent_by == 'dvla'
+    assert first.sent_at == dt
+    assert first.updated_at == dt
+    assert second.status == NOTIFICATION_CREATED
+
+
+def test_update_letter_notifications_to_error_updates_based_on_notification_references(
+    client,
+    sample_letter_template
+):
+    first = create_notification(sample_letter_template)
+    second = create_notification(sample_letter_template)
+
+    dt = datetime.utcnow()
+    with freeze_time(dt):
+        update_letter_notifications_to_error([first.reference])
+
+    assert first.status == NOTIFICATION_TECHNICAL_FAILURE
+    assert first.sent_by is None
+    assert first.sent_at is None
+    assert first.updated_at == dt
+    assert second.status == NOTIFICATION_CREATED

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -741,6 +741,7 @@ def test_run_letter_api_notifications_triggers_ftp_task(client, mocker, sample_l
         queue=QueueNames.PROCESS_FTP
     )
 
+
 def test_run_letter_api_notifications_does_nothing_if_no_created_notifications(
     client,
     mocker,

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -17,7 +17,7 @@ from app.celery import tasks
 from app.celery.tasks import (
     s3,
     build_dvla_file,
-    create_dvla_file_contents,
+    create_dvla_file_contents_for_job,
     update_dvla_job_to_error,
     process_job,
     process_row,
@@ -1081,7 +1081,7 @@ def test_build_dvla_file_retries_if_all_notifications_are_not_created(sample_let
     mocked_send_task.assert_not_called()
 
 
-def test_create_dvla_file_contents(sample_letter_template, mocker):
+def test_create_dvla_file_contents_for_job(sample_letter_template, mocker):
     job = create_job(template=sample_letter_template, notification_count=2)
     create_notification(template=job.template, job=job, reference=1)
     create_notification(template=job.template, job=job, reference=2)
@@ -1089,7 +1089,7 @@ def test_create_dvla_file_contents(sample_letter_template, mocker):
     mocked_letter_template_instance = mocked_letter_template.return_value
     mocked_letter_template_instance.__str__.return_value = "dvla|string"
 
-    create_dvla_file_contents(job.id)
+    create_dvla_file_contents_for_job(job.id)
     calls = mocked_letter_template.call_args_list
     # Template
     assert calls[0][0][0]['subject'] == 'Template subject'

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -25,9 +25,6 @@ from app.celery.tasks import (
     send_email,
     persist_letter,
     get_template_class,
-    update_job_to_sent_to_dvla,
-    update_letter_notifications_statuses,
-    process_updates_from_file,
     send_inbound_sms_to_service)
 from app.config import QueueNames
 from app.dao import jobs_dao, services_dao
@@ -39,11 +36,9 @@ from app.models import (
     SMS_TYPE,
     EMAIL_TYPE,
     LETTER_TYPE,
-    Job,
-    JOB_STATUS_ERROR)
+    Job)
 
 from tests.app import load_example_csv
-from tests.conftest import set_config
 from tests.app.conftest import (
     sample_service as create_sample_service,
     sample_template as create_sample_template,
@@ -642,7 +637,7 @@ def test_should_update_job_to_sent_to_dvla_in_research_mode_for_letter_job(
     A1,A2,A3,A4,A_POST,Alice
     """
     mocker.patch('app.celery.tasks.s3.get_job_from_s3', return_value=csv)
-    mocker.patch('app.celery.tasks.update_job_to_sent_to_dvla.apply_async')
+    mock_update_job_task = mocker.patch('app.celery.tasks.update_job_to_sent_to_dvla.apply_async')
     mocker.patch('app.celery.tasks.persist_letter.apply_async')
     mocker.patch('app.celery.tasks.create_uuid', return_value=fake_uuid)
     mocker.patch('app.celery.tasks.encryption.encrypt', return_value=test_encrypted_data)
@@ -662,7 +657,7 @@ def test_should_update_job_to_sent_to_dvla_in_research_mode_for_letter_job(
         queue=QueueNames.RESEARCH_MODE
     )
 
-    update_job_to_sent_to_dvla.apply_async.assert_called_once_with(
+    mock_update_job_task.assert_called_once_with(
         [str(job.id)], queue=QueueNames.RESEARCH_MODE)
 
 
@@ -1112,73 +1107,6 @@ def test_dvla_letter_template(sample_letter_notification):
          "subject": sample_letter_notification.template.subject}
     letter = LetterDVLATemplate(t, sample_letter_notification.personalisation, "random-string")
     assert str(letter) == "140|500|001||random-string|||||||||||||A1||A2|A3|A4|A5|A6|A_POST|||||||||23 March 2017<cr><cr><h1>Template subject<normal><cr><cr>Dear Sir/Madam, Hello. Yours Truly, The Government.<cr><cr>"  # noqa
-
-
-def test_update_job_to_sent_to_dvla(sample_letter_template, sample_letter_job):
-    create_notification(template=sample_letter_template, job=sample_letter_job)
-    create_notification(template=sample_letter_template, job=sample_letter_job)
-    update_job_to_sent_to_dvla(job_id=sample_letter_job.id)
-
-    updated_notifications = Notification.query.all()
-    assert [(n.status == 'sending', n.sent_by == 'dvla') for n in updated_notifications]
-
-    assert 'sent to dvla' == Job.query.filter_by(id=sample_letter_job.id).one().job_status
-
-
-def test_update_dvla_job_to_error(sample_letter_template, sample_letter_job):
-    create_notification(template=sample_letter_template, job=sample_letter_job)
-    create_notification(template=sample_letter_template, job=sample_letter_job)
-    update_dvla_job_to_error(job_id=sample_letter_job.id)
-
-    updated_notifications = Notification.query.all()
-    for n in updated_notifications:
-        assert n.status == 'created'
-        assert not n.sent_by
-
-    assert 'error' == Job.query.filter_by(id=sample_letter_job.id).one().job_status
-
-
-def test_update_letter_notifications_statuses_raises_for_invalid_format(notify_api, mocker):
-    invalid_file = 'ref-foo|Sent|1|Unsorted\nref-bar|Sent|2'
-    mocker.patch('app.celery.tasks.s3.get_s3_file', return_value=invalid_file)
-
-    with pytest.raises(TypeError):
-        update_letter_notifications_statuses(filename='foo.txt')
-
-
-def test_update_letter_notifications_statuses_calls_with_correct_bucket_location(notify_api, mocker):
-    s3_mock = mocker.patch('app.celery.tasks.s3.get_s3_object')
-
-    with set_config(notify_api, 'NOTIFY_EMAIL_DOMAIN', 'foo.bar'):
-        update_letter_notifications_statuses(filename='foo.txt')
-        s3_mock.assert_called_with('{}-ftp'.format(current_app.config['NOTIFY_EMAIL_DOMAIN']), 'foo.txt')
-
-
-def test_update_letter_notifications_statuses_builds_updates_from_content(notify_api, mocker):
-    valid_file = 'ref-foo|Sent|1|Unsorted\nref-bar|Sent|2|Sorted'
-    mocker.patch('app.celery.tasks.s3.get_s3_file', return_value=valid_file)
-    update_mock = mocker.patch('app.celery.tasks.process_updates_from_file')
-
-    update_letter_notifications_statuses(filename='foo.txt')
-
-    update_mock.assert_called_with('ref-foo|Sent|1|Unsorted\nref-bar|Sent|2|Sorted')
-
-
-def test_update_letter_notifications_statuses_builds_updates_list(notify_api, mocker):
-    valid_file = 'ref-foo|Sent|1|Unsorted\nref-bar|Sent|2|Sorted'
-    updates = process_updates_from_file(valid_file)
-
-    assert len(updates) == 2
-
-    assert updates[0].reference == 'ref-foo'
-    assert updates[0].status == 'Sent'
-    assert updates[0].page_count == '1'
-    assert updates[0].cost_threshold == 'Unsorted'
-
-    assert updates[1].reference == 'ref-bar'
-    assert updates[1].status == 'Sent'
-    assert updates[1].page_count == '2'
-    assert updates[1].cost_threshold == 'Sorted'
 
 
 def test_send_inbound_sms_to_service_post_https_request_to_service(notify_api, sample_service):

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1058,7 +1058,7 @@ def test_build_dvla_file(sample_letter_template, mocker):
     mocked_upload.assert_called_once_with(
         filedata="dvla|string\ndvla|string\n",
         region=current_app.config['AWS_REGION'],
-        bucket_name=current_app.config['DVLA_UPLOAD_BUCKET_NAME'],
+        bucket_name=current_app.config['DVLA_BUCKETS']['job'],
         file_location="{}-dvla-job.text".format(job.id)
     )
     assert Job.query.get(job.id).job_status == 'ready to send'

--- a/tests/app/dao/notification_dao/test_letter_api_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_letter_api_notification_dao.py
@@ -1,0 +1,51 @@
+from app.models import (
+    NOTIFICATION_CREATED,
+    NOTIFICATION_PENDING,
+    NOTIFICATION_SENDING,
+    KEY_TYPE_TEST,
+    KEY_TYPE_NORMAL
+)
+from app.dao.notifications_dao import dao_set_created_live_letter_api_notifications_to_pending
+
+from tests.app.db import create_notification
+
+
+def test_should_only_get_letter_notifications(
+    sample_letter_notification,
+    sample_email_notification,
+    sample_notification
+):
+    ret = dao_set_created_live_letter_api_notifications_to_pending()
+
+    assert sample_letter_notification.status == NOTIFICATION_PENDING
+    assert sample_email_notification.status == NOTIFICATION_CREATED
+    assert sample_notification.status == NOTIFICATION_CREATED
+    assert ret == [sample_letter_notification]
+
+
+def test_should_only_get_created_letters(sample_letter_template):
+    created_noti = create_notification(sample_letter_template, status=NOTIFICATION_CREATED)
+    create_notification(sample_letter_template, status=NOTIFICATION_PENDING)
+    create_notification(sample_letter_template, status=NOTIFICATION_SENDING)
+
+    ret = dao_set_created_live_letter_api_notifications_to_pending()
+
+    assert ret == [created_noti]
+
+
+def test_should_only_get_api_letters(sample_letter_template, sample_letter_job):
+    api_noti = create_notification(sample_letter_template)
+    job_noti = create_notification(sample_letter_template, job=sample_letter_job)
+
+    ret = dao_set_created_live_letter_api_notifications_to_pending()
+
+    assert ret == [api_noti]
+
+
+def test_should_only_get_normal_api_letters(sample_letter_template):
+    live_noti = create_notification(sample_letter_template, key_type=KEY_TYPE_NORMAL)
+    test_noti = create_notification(sample_letter_template, key_type=KEY_TYPE_TEST)
+
+    ret = dao_set_created_live_letter_api_notifications_to_pending()
+
+    assert ret == [live_noti]

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -42,7 +42,10 @@ from app.dao.notifications_dao import (
     is_delivery_slow_for_provider,
     dao_update_notifications_for_job_to_sent_to_dvla,
     dao_get_notifications_by_to_field,
-    dao_created_scheduled_notification, dao_get_scheduled_notifications, set_scheduled_notification_to_processed)
+    dao_created_scheduled_notification,
+    dao_get_scheduled_notifications,
+    set_scheduled_notification_to_processed
+)
 
 from app.dao.services_dao import dao_update_service
 from tests.app.db import create_notification, create_api_key

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -40,7 +40,7 @@ from app.dao.notifications_dao import (
     dao_delete_notifications_and_history_by_id,
     dao_timeout_notifications,
     is_delivery_slow_for_provider,
-    dao_update_notifications_sent_to_dvla,
+    dao_update_notifications_for_job_to_sent_to_dvla,
     dao_get_notifications_by_to_field,
     dao_created_scheduled_notification, dao_get_scheduled_notifications, set_scheduled_notification_to_processed)
 
@@ -1713,11 +1713,11 @@ def test_slow_provider_delivery_does_not_return_for_standard_delivery_time(
     assert not slow_delivery
 
 
-def test_dao_update_notifications_sent_to_dvla(notify_db, notify_db_session, sample_letter_template):
+def test_dao_update_notifications_for_job_to_sent_to_dvla(notify_db, notify_db_session, sample_letter_template):
     job = sample_job(notify_db=notify_db, notify_db_session=notify_db_session, template=sample_letter_template)
     notification = create_notification(template=sample_letter_template, job=job)
 
-    updated_count = dao_update_notifications_sent_to_dvla(job_id=job.id, provider='some provider')
+    updated_count = dao_update_notifications_for_job_to_sent_to_dvla(job_id=job.id, provider='some provider')
 
     assert updated_count == 1
     updated_notification = Notification.query.get(notification.id)
@@ -1732,7 +1732,7 @@ def test_dao_update_notifications_sent_to_dvla(notify_db, notify_db_session, sam
     assert history.updated_at
 
 
-def test_dao_update_notifications_sent_to_dvla_does_update_history_if_test_key(sample_letter_job):
+def test_dao_update_notifications_for_job_to_sent_to_dvla_does_update_history_if_test_key(sample_letter_job):
     api_key = create_api_key(sample_letter_job.service, key_type=KEY_TYPE_TEST)
     notification = create_notification(
         sample_letter_job.template,
@@ -1740,7 +1740,10 @@ def test_dao_update_notifications_sent_to_dvla_does_update_history_if_test_key(s
         api_key=api_key
     )
 
-    updated_count = dao_update_notifications_sent_to_dvla(job_id=sample_letter_job.id, provider='some provider')
+    updated_count = dao_update_notifications_for_job_to_sent_to_dvla(
+        job_id=sample_letter_job.id,
+        provider='some provider'
+    )
 
     assert updated_count == 1
     updated_notification = Notification.query.get(notification.id)

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import uuid
 
-from app import db
+from app import db, create_random_identifier
 from app.dao.jobs_dao import dao_create_job
 from app.dao.service_inbound_api_dao import save_service_inbound_api
 from app.models import (
@@ -22,6 +22,7 @@ from app.models import (
     InboundNumber,
     Organisation,
     EMAIL_TYPE,
+    LETTER_TYPE,
     SMS_TYPE,
     INBOUND_SMS_TYPE,
     KEY_TYPE_NORMAL,
@@ -141,6 +142,9 @@ def create_notification(
         api_key = ApiKey.query.filter(ApiKey.service == template.service, ApiKey.key_type == key_type).first()
         if not api_key:
             api_key = create_api_key(template.service, key_type=key_type)
+
+    if template.template_type == LETTER_TYPE and reference is None:
+        reference = create_random_identifier()
 
     data = {
         'id': uuid.uuid4(),

--- a/tests/app/notifications/test_process_letter_notifications.py
+++ b/tests/app/notifications/test_process_letter_notifications.py
@@ -1,52 +1,10 @@
-import pytest
-
-from app.dao.services_dao import dao_archive_service
-from app.models import Job
-from app.models import JOB_STATUS_READY_TO_SEND
 from app.models import LETTER_TYPE
 from app.models import Notification
+from app.models import NOTIFICATION_CREATED
 from app.notifications.process_letter_notifications import create_letter_notification
-from app.v2.errors import InvalidRequest
-from app.variables import LETTER_API_FILENAME
-
-from tests.app.db import create_service
-from tests.app.db import create_template
 
 
-def test_create_job_rejects_inactive_service(notify_db_session):
-    service = create_service()
-    template = create_template(service, template_type=LETTER_TYPE)
-    dao_archive_service(service.id)
-
-    with pytest.raises(InvalidRequest) as exc_info:
-        create_letter_api_job(template)
-
-    assert exc_info.value.message == 'Service {} is inactive'.format(service.id)
-
-
-def test_create_job_rejects_archived_template(sample_letter_template):
-    sample_letter_template.archived = True
-
-    with pytest.raises(InvalidRequest) as exc_info:
-        create_letter_api_job(sample_letter_template)
-
-    assert exc_info.value.message == 'Template {} is deleted'.format(sample_letter_template.id)
-
-
-def test_create_job_creates_job(sample_letter_template):
-    job = create_letter_api_job(sample_letter_template)
-
-    assert job == Job.query.one()
-    assert job.original_file_name == LETTER_API_FILENAME
-    assert job.service == sample_letter_template.service
-    assert job.template_id == sample_letter_template.id
-    assert job.template_version == sample_letter_template.version
-    assert job.notification_count == 1
-    assert job.job_status == JOB_STATUS_READY_TO_SEND
-    assert job.created_by is None
-
-
-def test_create_letter_notification_creates_notification(sample_letter_job, sample_api_key):
+def test_create_letter_notification_creates_notification(sample_letter_template, sample_api_key):
     data = {
         'personalisation': {
             'address_line_1': 'The Queen',
@@ -55,20 +13,20 @@ def test_create_letter_notification_creates_notification(sample_letter_job, samp
         }
     }
 
-    notification = create_letter_notification(data, sample_letter_job, sample_api_key)
+    notification = create_letter_notification(data, sample_letter_template, sample_api_key, NOTIFICATION_CREATED)
 
     assert notification == Notification.query.one()
-    assert notification.job == sample_letter_job
-    assert notification.template == sample_letter_job.template
+    assert notification.job is None
+    assert notification.status == NOTIFICATION_CREATED
+    assert notification.template == sample_letter_template
     assert notification.api_key == sample_api_key
     assert notification.notification_type == LETTER_TYPE
     assert notification.key_type == sample_api_key.key_type
-    assert notification.job_row_number == 0
     assert notification.reference is not None
     assert notification.client_reference is None
 
 
-def test_create_letter_notification_sets_reference(sample_letter_job, sample_api_key):
+def test_create_letter_notification_sets_reference(sample_letter_template, sample_api_key):
     data = {
         'personalisation': {
             'address_line_1': 'The Queen',
@@ -78,6 +36,6 @@ def test_create_letter_notification_sets_reference(sample_letter_job, sample_api
         'reference': 'foo'
     }
 
-    notification = create_letter_notification(data, sample_letter_job, sample_api_key)
+    notification = create_letter_notification(data, sample_letter_template, sample_api_key, NOTIFICATION_CREATED)
 
     assert notification.client_reference == 'foo'

--- a/tests/app/notifications/test_process_letter_notifications.py
+++ b/tests/app/notifications/test_process_letter_notifications.py
@@ -5,7 +5,6 @@ from app.models import Job
 from app.models import JOB_STATUS_READY_TO_SEND
 from app.models import LETTER_TYPE
 from app.models import Notification
-from app.notifications.process_letter_notifications import create_letter_api_job
 from app.notifications.process_letter_notifications import create_letter_notification
 from app.v2.errors import InvalidRequest
 from app.variables import LETTER_API_FILENAME


### PR DESCRIPTION
Sorry it's a bit of a beast!

### `POST /v2/notifications/letter/`

* No longer create a job
* If test/research mode, create the notification with status `sending`, and then trigger `update-notifications-to-sent-to-dvla`

### new scheduled task `run-letter-api-notifications`

* Runs at 5:40 (`run-letter-jobs runs` is at 5:30)
* gets all notifications that:
  - are letters
  - that were sent via the api
  - using a normal (live) api key
  - that are in status `created`
* sets those notifications to status `pending` to prevent sending twice if the task is triggered twice
* converts these notifications to dvla pipe file format, and concatenates them into one big file
* upload that to a new s3 bucket, `{}-dvla-letter-api-files` (https://github.com/alphagov/notifications-aws/pull/235), with the filename `{ISO_TIMESTAMP}-dvla-notifications.txt`
* tells the FTP app to send the notifications to dvla (https://github.com/alphagov/notifications-ftp/pull/24)

### update status to success error tasks

* two new tasks - `update-letter-notifications-to-error` and `update-letter-notifications-to-sent`
* they are given a list of notification references, and update status based on `reference in ({list_of_refs})`