### PR TITLE
[4/4] Use letter contact from the new table

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -370,7 +370,7 @@ def create_dvla_file_contents_for_notifications(notifications):
             notification.template.__dict__,
             notification.personalisation,
             notification_reference=notification.reference,
-            contact_block=notification.service.letter_contact_block,
+            contact_block=notification.service.get_default_letter_contact(),
             org_id=notification.service.dvla_organisation.id,
         ))
         for notification in notifications

--- a/app/models.py
+++ b/app/models.py
@@ -541,7 +541,7 @@ class Template(db.Model):
             return LetterDVLATemplate(
                 {'content': self.content, 'subject': self.subject},
                 notification_reference=1,
-                contact_block=self.service.letter_contact_block,
+                contact_block=self.service.get_default_letter_contact(),
             )
 
     def serialize(self):

--- a/app/models.py
+++ b/app/models.py
@@ -208,8 +208,7 @@ class Service(db.Model, Versioned):
     created_by = db.relationship('User')
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
     _reply_to_email_address = db.Column("reply_to_email_address", db.Text, index=False, unique=False, nullable=True)
-    letter_contact_block = db.Column(db.Text, index=False, unique=False, nullable=True)
-    # This column is now deprecated
+    _letter_contact_block = db.Column('letter_contact_block', db.Text, index=False, unique=False, nullable=True)
     sms_sender = db.Column(db.String(11), nullable=False, default=lambda: current_app.config['FROM_NUMBER'])
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey('organisation.id'), index=True, nullable=True)
     organisation = db.relationship('Organisation')
@@ -268,8 +267,7 @@ class Service(db.Model, Versioned):
         if len(default_letter_contact) > 1:
             raise Exception("There should only ever be one default")
         else:
-            return default_letter_contact[0].contact_block if default_letter_contact else \
-                self.letter_contact_block  # need to update this to None after dropping the letter_contact_block column
+            return default_letter_contact[0].contact_block if default_letter_contact else None
 
 
 class InboundNumber(db.Model):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -183,6 +183,7 @@ class ServiceSchema(BaseSchema):
     permissions = fields.Method("service_permissions")
     override_flag = False
     reply_to_email_address = fields.Method(method_name="get_reply_to_email_address")
+    letter_contact_block = fields.Method(method_name="get_letter_contact")
 
     def get_free_sms_fragment_limit(selfs, service):
         return service.free_sms_fragment_limit()
@@ -193,9 +194,12 @@ class ServiceSchema(BaseSchema):
     def get_reply_to_email_address(self, service):
         return service.get_default_reply_to_email_address()
 
+    def get_letter_contact(self, service):
+        return service.get_default_letter_contact()
+
     class Meta:
         model = models.Service
-        dump_only = ['free_sms_fragment_limit', 'reply_to_email_address']
+        dump_only = ['free_sms_fragment_limit', 'reply_to_email_address', 'letter_contact_block']
         exclude = (
             'updated_at',
             'created_at',

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -147,7 +147,6 @@ def update_service(service_id):
     fetched_service = dao_fetch_service_by_id(service_id)
     # Capture the status change here as Marshmallow changes this later
     service_going_live = fetched_service.restricted and not req_json.get('restricted', True)
-
     current_data = dict(service_schema.dump(fetched_service).data.items())
     current_data.update(request.get_json())
     update_dict = service_schema.load(current_data).data

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -46,7 +46,8 @@ from tests.app.db import (
     create_notification,
     create_service,
     create_api_key,
-    create_inbound_number
+    create_inbound_number,
+    create_letter_contact,
 )
 
 
@@ -138,7 +139,6 @@ def sample_service(
     email_from=None,
     permissions=[SMS_TYPE, EMAIL_TYPE],
     research_mode=None,
-    letter_contact_block='London,\nSW1A 1AA',
 ):
     if user is None:
         user = create_user()
@@ -183,7 +183,9 @@ def sample_service_full_permissions(notify_db, notify_db_session):
 
 @pytest.fixture(scope='function')
 def sample_service_custom_letter_contact_block(notify_db, notify_db_session):
-    return sample_service(notify_db, notify_db_session, letter_contact_block='((contact block))')
+    service = sample_service(notify_db, notify_db_session)
+    create_letter_contact(service, contact_block='((contact block))')
+    return service
 
 
 @pytest.fixture(scope='function')

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -150,8 +150,7 @@ def sample_service(
         'message_limit': limit,
         'restricted': restricted,
         'email_from': email_from,
-        'created_by': user,
-        'letter_contact_block': letter_contact_block,
+        'created_by': user
     }
     service = Service.query.filter_by(name=service_name).first()
     if not service:

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -274,8 +274,3 @@ def test_service_get_default_contact_letter(sample_service):
     create_letter_contact(service=sample_service, contact_block='London,\nNW1A 1AA')
 
     assert sample_service.get_default_letter_contact() == 'London,\nNW1A 1AA'
-
-
-# this test will need to be removed after letter_contact_block is dropped
-def test_service_get_default_letter_contact_block_from_service(sample_service):
-    assert sample_service.get_default_letter_contact() == sample_service.letter_contact_block


### PR DESCRIPTION
_Note: This was branched off from https://github.com/alphagov/notifications-api/pull/1277 and will be rebased off master once that's merged._

This uses the new table to retrieve the default letter contact for a service and updates the schema to return the default letter contact from the new table or `None`.

## Dependencies

- [x] - https://github.com/alphagov/notifications-admin/pull/1511
