### PR TITLE
admin to api not passing trial_mode_service 

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -358,15 +358,13 @@ def dao_fetch_monthly_historical_stats_for_service(service_id, year):
 
 
 @statsd(namespace='dao')
-def dao_fetch_todays_stats_for_all_services(include_from_test_key=True, trial_mode_services=None):
+def dao_fetch_todays_stats_for_all_services(include_from_test_key=True):
 
     query = db.session.query(
         Notification.notification_type,
         Notification.status,
         Notification.service_id,
         func.count(Notification.id).label('count')
-    ).join(
-        Service
     ).filter(
         func.date(Notification.created_at) == date.today(),
     ).group_by(
@@ -379,9 +377,6 @@ def dao_fetch_todays_stats_for_all_services(include_from_test_key=True, trial_mo
 
     if not include_from_test_key:
         query = query.filter(Notification.key_type != KEY_TYPE_TEST)
-
-    if trial_mode_services is not None:
-        query = query.filter(Service.restricted == trial_mode_services)
 
     return query.all()
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -90,7 +90,6 @@ def get_services():
     detailed = request.args.get('detailed') == 'True'
     user_id = request.args.get('user_id', None)
     include_from_test_key = request.args.get('include_from_test_key', 'True') != 'False'
-    trial_mode_services = request.args.get('trial_mode_services')
 
     # If start and end date are not set, we are expecting today's stats.
     today = str(datetime.utcnow().date())
@@ -103,8 +102,7 @@ def get_services():
     elif detailed:
         result = jsonify(data=get_detailed_services(start_date=start_date, end_date=end_date,
                                                     only_active=only_active,
-                                                    include_from_test_key=include_from_test_key,
-                                                    trial_mode_services=trial_mode_services
+                                                    include_from_test_key=include_from_test_key
                                                     ))
         return result
     else:
@@ -369,12 +367,10 @@ def get_detailed_service(service_id, today_only=False):
     return detailed_service_schema.dump(service).data
 
 
-def get_detailed_services(start_date, end_date, only_active=False, include_from_test_key=True,
-                          trial_mode_services=None):
+def get_detailed_services(start_date, end_date, only_active=False, include_from_test_key=True):
     services = {service.id: service for service in dao_fetch_all_services(only_active)}
     if start_date == datetime.utcnow().date():
-        stats = dao_fetch_todays_stats_for_all_services(include_from_test_key=include_from_test_key,
-                                                        trial_mode_services=trial_mode_services)
+        stats = dao_fetch_todays_stats_for_all_services(include_from_test_key=include_from_test_key)
     else:
 
         stats = fetch_stats_by_date_range_for_all_services(start_date=start_date,

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1548,8 +1548,7 @@ def test_get_services_with_detailed_flag_accepts_date_range(client, mocker):
         start_date=date(2001, 1, 1),
         end_date=date(2002, 2, 2),
         only_active=ANY,
-        include_from_test_key=ANY,
-        trial_mode_services=ANY
+        include_from_test_key=ANY
     )
     assert resp.status_code == 200
 
@@ -1566,8 +1565,7 @@ def test_get_services_with_detailed_flag_defaults_to_today(client, mocker):
         end_date=date(2002, 2, 2),
         include_from_test_key=ANY,
         only_active=ANY,
-        start_date=date(2002, 2, 2),
-        trial_mode_services=ANY
+        start_date=date(2002, 2, 2)
     )
 
     assert resp.status_code == 200


### PR DESCRIPTION
**Why**
This is to reverse part of the pull request in #1506. Passing trial_mode_service parameter requires joining the service schema, which creates extra delay in loading the data.
#1506

**Change**
Do not pass trial_mode_service to api.

**Pivotal Story**
Platform Admin performance issue
#151371820