### PR TITLE
Pin to a specific version of cffi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.4.7
-cffi==1.11.0
+cffi==1.11.0 # pyup: != 1.11.1 # 1.11.1 is missing .whl
 celery==3.1.25 # pyup: <4
 docopt==0.6.2
 Flask-Bcrypt==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boto3==1.4.7
+cffi==1.11.0
 celery==3.1.25 # pyup: <4
 docopt==0.6.2
 Flask-Bcrypt==0.7.1


### PR DESCRIPTION
Version 1.11.1 seems to be
[broken](https://bitbucket.org/cffi/cffi/issues?status=new&status=open)

It's pulled in because of [Flask-bcrypt](https://github.com/alphagov/notifications-api/blob/master/requirements.txt#L4)
which [depends on bcrypt](https://github.com/maxcountryman/flask-bcrypt/blob/master/setup.py#L33) which
[asks for a version of cffi >= 1.1](https://github.com/pyca/bcrypt/blob/master/setup.py#L12)