### PR TITLE
Store organisation type against each service

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -228,6 +228,10 @@ class Service(db.Model, Versioned):
         nullable=False,
         default=BRANDING_GOVUK
     )
+    organisation_type = db.Column(
+        db.String(255),
+        nullable=True,
+    )
 
     association_proxy('permissions', 'service_permission_types')
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -177,6 +177,7 @@ class ServiceSchema(BaseSchema):
 
     created_by = field_for(models.Service, 'created_by', required=True)
     organisation = field_for(models.Service, 'organisation')
+    organisation_type = field_for(models.Service, 'organisation_type')
     branding = field_for(models.Service, 'branding')
     dvla_organisation = field_for(models.Service, 'dvla_organisation')
     free_sms_fragment_limit = field_for(models.Service, 'free_sms_fragment_limit')

--- a/migrations/versions/0125_add_organisation_type.py
+++ b/migrations/versions/0125_add_organisation_type.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0125_add_organisation_type
+Revises: 0124_add_free_sms_fragment_limit
+Create Date: 2017-10-05 14:03:00.248005
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0125_add_organisation_type'
+down_revision = '0124_add_free_sms_fragment_limit'
+
+
+def upgrade():
+    op.add_column('services', sa.Column('organisation_type', sa.String(length=255), nullable=True))
+    op.add_column('services_history', sa.Column('organisation_type', sa.String(length=255), nullable=True))
+
+
+def downgrade():
+    op.drop_column('services', 'organisation_type')
+    op.drop_column('services_history', 'organisation_type')

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -177,6 +177,19 @@ def test_get_detailed_service_by_id_returns_free_sms_limit(client, sample_servic
     assert json_resp['data']['free_sms_fragment_limit'] == current_app.config['FREE_SMS_TIER_FRAGMENT_COUNT']
 
 
+@pytest.mark.parametrize('endpoint', ['/service/{}', '/service/{}?detailed=True'])
+def test_get_service_by_id_returns_organisation_type(client, sample_service, endpoint):
+
+    auth_header = create_authorization_header()
+    resp = client.get(
+        endpoint.format(sample_service.id),
+        headers=[auth_header]
+    )
+    assert resp.status_code == 200
+    json_resp = json.loads(resp.get_data(as_text=True))
+    assert json_resp['data']['organisation_type'] is None
+
+
 def test_get_service_list_has_default_permissions(client, service_factory):
     service_factory.get('one')
     service_factory.get('one')
@@ -499,7 +512,8 @@ def test_update_service(client, notify_db, sample_service):
         'email_from': 'updated.service.name',
         'created_by': str(sample_service.created_by.id),
         'organisation': str(org.id),
-        'dvla_organisation': DVLA_ORG_LAND_REGISTRY
+        'dvla_organisation': DVLA_ORG_LAND_REGISTRY,
+        'organisation_type': 'foo',
     }
 
     auth_header = create_authorization_header()
@@ -515,6 +529,7 @@ def test_update_service(client, notify_db, sample_service):
     assert result['data']['email_from'] == 'updated.service.name'
     assert result['data']['organisation'] == str(org.id)
     assert result['data']['dvla_organisation'] == DVLA_ORG_LAND_REGISTRY
+    assert result['data']['organisation_type'] == 'foo'
 
 
 def test_update_service_flags(client, sample_service):


### PR DESCRIPTION
> So that we can default services to their appropriate text allowance, we need to find out what sector they're in. So let's start collecting that from teams as they create new services.

In order to work out what a team’s allowance should be, we need to know what part of government they’re from. We’re going to do this logic in the admin app and then `POST` the allowance to the API.

So all we need to do with the information that the users give us is store it against the service, so we have a record. Doesn’t need any logic doing as a result of it, doesn’t need foreign keying to the organisations table, etc.

---

https://www.pivotaltracker.com/story/show/151207049