### PR TITLE
Task 4 - Allow API calls to specify the reply address option

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -8,7 +8,10 @@ from notifications_utils.recipients import (
 from notifications_utils.template import HTMLEmailTemplate, PlainTextEmailTemplate, SMSMessageTemplate
 
 from app import clients, statsd_client, create_uuid
-from app.dao.notifications_dao import dao_update_notification, dao_get_notification_email_reply_for_notification
+from app.dao.notifications_dao import (
+    dao_update_notification,
+    dao_get_notification_email_reply_for_notification
+)
 from app.dao.provider_details_dao import (
     get_provider_details_by_notification_type,
     dao_toggle_sms_provider

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -28,7 +28,7 @@ from app.models import (
     KEY_TYPE_NORMAL,
     ServiceInboundApi,
     ServiceEmailReplyTo,
-    ServiceLetterContact, ServiceSmsSender)
+    ServiceLetterContact, ServiceSmsSender, NotificationEmailReplyTo)
 from app.dao.users_dao import save_model_user
 from app.dao.notifications_dao import dao_create_notification, dao_created_scheduled_notification
 from app.dao.templates_dao import dao_create_template
@@ -384,3 +384,21 @@ def create_letter_contact(
     db.session.commit()
 
     return letter_content
+
+
+def create_reply_to_email_for_notification(
+    notification_id,
+    service,
+    email_address,
+    is_default=True
+):
+    reply_to = create_reply_to_email(service, email_address, is_default)
+
+    notification_email_reply_to = NotificationEmailReplyTo(
+        notification_id=str(notification_id),
+        service_email_reply_to_id=str(reply_to.id)
+    )
+    db.session.add(notification_email_reply_to)
+    db.session.commit()
+
+    return reply_to

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -1,34 +1,33 @@
 from datetime import datetime
 import uuid
 
-from app import db, create_random_identifier
+from app import db
 from app.dao.jobs_dao import dao_create_job
 from app.dao.service_inbound_api_dao import save_service_inbound_api
 from app.models import (
     ApiKey,
-    EMAIL_TYPE,
-    SMS_TYPE,
-    KEY_TYPE_NORMAL,
-    Service,
-    User,
-    Template,
-    MonthlyBilling,
-    Notification,
-    ScheduledNotification,
-    ServicePermission,
-    Rate,
-    Job,
     InboundSms,
     InboundNumber,
+    Job,
+    MonthlyBilling,
+    Notification,
+    NotificationEmailReplyTo,
     Organisation,
+    Rate,
+    Service,
+    ServiceEmailReplyTo,
+    ServiceInboundApi,
+    ServiceLetterContact,
+    ScheduledNotification,
+    ServicePermission,
+    ServiceSmsSender,
+    Template,
+    User,
     EMAIL_TYPE,
-    LETTER_TYPE,
     SMS_TYPE,
     INBOUND_SMS_TYPE,
-    KEY_TYPE_NORMAL,
-    ServiceInboundApi,
-    ServiceEmailReplyTo,
-    ServiceLetterContact, ServiceSmsSender, NotificationEmailReplyTo)
+    KEY_TYPE_NORMAL
+)
 from app.dao.users_dao import save_model_user
 from app.dao.notifications_dao import dao_create_notification, dao_created_scheduled_notification
 from app.dao.templates_dao import dao_create_template

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -6,7 +6,6 @@ from unittest.mock import ANY, call
 import pytest
 from notifications_utils.recipients import validate_and_format_phone_number
 from flask import current_app
-from requests_mock import mock
 
 import app
 from app import mmg_client, firetext_client
@@ -22,10 +21,17 @@ from app.models import (
     BRANDING_ORG,
     BRANDING_GOVUK,
     BRANDING_BOTH,
-    BRANDING_ORG_BANNER, NotificationEmailReplyTo)
+    BRANDING_ORG_BANNER
+)
 
-from tests.app.db import create_service, create_template, create_notification, create_inbound_number, \
-    create_reply_to_email, create_reply_to_email_for_notification
+from tests.app.db import (
+    create_service,
+    create_template,
+    create_notification,
+    create_inbound_number,
+    create_reply_to_email,
+    create_reply_to_email_for_notification
+)
 
 
 def test_should_return_highest_priority_active_provider(restore_provider_details):

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, call
 import pytest
 from notifications_utils.recipients import validate_and_format_phone_number
 from flask import current_app
+from requests_mock import mock
 
 import app
 from app import mmg_client, firetext_client
@@ -21,10 +22,10 @@ from app.models import (
     BRANDING_ORG,
     BRANDING_GOVUK,
     BRANDING_BOTH,
-    BRANDING_ORG_BANNER)
+    BRANDING_ORG_BANNER, NotificationEmailReplyTo)
 
 from tests.app.db import create_service, create_template, create_notification, create_inbound_number, \
-    create_reply_to_email
+    create_reply_to_email, create_reply_to_email_for_notification
 
 
 def test_should_return_highest_priority_active_provider(restore_provider_details):
@@ -696,4 +697,66 @@ def test_should_use_inbound_number_as_sender_if_set(
         content=ANY,
         reference=str(notification.id),
         sender=inbound_number.number
+    )
+
+
+def test_send_email_to_provider_get_linked_email_reply_to_default_is_false(
+        sample_service,
+        sample_email_template,
+        mocker):
+    mocker.patch('app.aws_ses_client.send_email', return_value='reference')
+    mocker.patch('app.delivery.send_to_providers.create_initial_notification_statistic_tasks')
+
+    db_notification = create_notification(template=sample_email_template)
+    create_reply_to_email(service=sample_service, email_address='foo@bar.com')
+
+    reply_to = create_reply_to_email_for_notification(
+        db_notification.id,
+        sample_service,
+        "test@test.com",
+        is_default=False
+    )
+
+    send_to_providers.send_email_to_provider(
+        db_notification,
+    )
+
+    app.aws_ses_client.send_email.assert_called_once_with(
+        ANY,
+        ANY,
+        ANY,
+        body=ANY,
+        html_body=ANY,
+        reply_to_address=reply_to.email_address
+    )
+
+
+def test_send_email_to_provider_get_linked_email_reply_to_create_service_email_after_notification_mapping(
+        sample_service,
+        sample_email_template,
+        mocker):
+    mocker.patch('app.aws_ses_client.send_email', return_value='reference')
+    mocker.patch('app.delivery.send_to_providers.create_initial_notification_statistic_tasks')
+
+    db_notification = create_notification(template=sample_email_template)
+
+    reply_to = create_reply_to_email_for_notification(
+        db_notification.id,
+        sample_service,
+        "test@test.com"
+    )
+
+    create_reply_to_email(service=sample_service, email_address='foo@bar.com', is_default=False)
+
+    send_to_providers.send_email_to_provider(
+        db_notification,
+    )
+
+    app.aws_ses_client.send_email.assert_called_once_with(
+        ANY,
+        ANY,
+        ANY,
+        body=ANY,
+        html_body=ANY,
+        reply_to_address=reply_to.email_address
     )


### PR DESCRIPTION
- Updated send_to_providers.py to allow the email to pick up the mapped reply to address, if there is no reply to address mapped it uses the default for the service
- Added tests to test the functionality