### PR TITLE
Add command to populate 'free sms fragment limit'

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -305,3 +305,27 @@ class PopulateServiceLetterContact(Command):
         db.session.commit()
 
         print("Populated letter contacts for {} services".format(result.rowcount))
+
+
+class PopulateServiceAndServiceHistoryFreeSmsFragmentLimit(Command):
+
+    def run(self):
+        services_to_update = """
+            UPDATE services
+            SET free_sms_fragment_limit = 250000
+            WHERE free_sms_fragment_limit IS NULL
+        """
+
+        services_history_to_update = """
+            UPDATE services_history
+            SET free_sms_fragment_limit = 250000
+            WHERE free_sms_fragment_limit IS NULL
+        """
+
+        services_result = db.session.execute(services_to_update)
+        services_history_result = db.session.execute(services_history_to_update)
+
+        db.session.commit()
+
+        print("Populated free sms fragment limits for {} services".format(services_result.rowcount))
+        print("Populated free sms fragment limits for {} services history".format(services_history_result.rowcount))

--- a/app/models.py
+++ b/app/models.py
@@ -211,6 +211,7 @@ class Service(db.Model, Versioned):
     _letter_contact_block = db.Column('letter_contact_block', db.Text, index=False, unique=False, nullable=True)
     sms_sender = db.Column(db.String(11), nullable=False, default=lambda: current_app.config['FROM_NUMBER'])
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey('organisation.id'), index=True, nullable=True)
+    free_sms_fragment_limit = db.Column(db.BigInteger, index=False, unique=False, nullable=True)
     organisation = db.relationship('Organisation')
     dvla_organisation_id = db.Column(
         db.String,
@@ -229,10 +230,6 @@ class Service(db.Model, Versioned):
     )
 
     association_proxy('permissions', 'service_permission_types')
-
-    @staticmethod
-    def free_sms_fragment_limit():
-        return current_app.config['FREE_SMS_TIER_FRAGMENT_COUNT']
 
     @classmethod
     def from_json(cls, data):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -175,19 +175,16 @@ class ProviderDetailsHistorySchema(BaseSchema):
 
 class ServiceSchema(BaseSchema):
 
-    free_sms_fragment_limit = fields.Method(method_name='get_free_sms_fragment_limit')
     created_by = field_for(models.Service, 'created_by', required=True)
     organisation = field_for(models.Service, 'organisation')
     branding = field_for(models.Service, 'branding')
     dvla_organisation = field_for(models.Service, 'dvla_organisation')
+    free_sms_fragment_limit = field_for(models.Service, 'free_sms_fragment_limit')
     permissions = fields.Method("service_permissions")
     override_flag = False
     reply_to_email_address = fields.Method(method_name="get_reply_to_email_address")
     sms_sender = fields.Method(method_name="get_sms_sender")
     letter_contact_block = fields.Method(method_name="get_letter_contact")
-
-    def get_free_sms_fragment_limit(selfs, service):
-        return service.free_sms_fragment_limit()
 
     def service_permissions(self, service):
         return [p.permission for p in service.permissions]
@@ -203,7 +200,7 @@ class ServiceSchema(BaseSchema):
 
     class Meta:
         model = models.Service
-        dump_only = ['free_sms_fragment_limit', 'reply_to_email_address', 'letter_contact_block']
+        dump_only = ['reply_to_email_address', 'letter_contact_block']
         exclude = (
             'updated_at',
             'created_at',
@@ -251,11 +248,6 @@ class ServiceSchema(BaseSchema):
 
 class DetailedServiceSchema(BaseSchema):
     statistics = fields.Dict()
-
-    free_sms_fragment_limit = fields.Method(method_name='get_free_sms_fragment_limit')
-
-    def get_free_sms_fragment_limit(selfs, service):
-        return service.free_sms_fragment_limit()
 
     class Meta:
         model = models.Service

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -134,9 +134,14 @@ def get_service_by_id(service_id):
 @service_blueprint.route('', methods=['POST'])
 def create_service():
     data = request.get_json()
+
     if not data.get('user_id', None):
         errors = {'user_id': ['Missing data for required field.']}
         raise InvalidRequest(errors, status_code=400)
+
+    # TODO: to be removed when front-end is updated
+    if 'free_sms_fragment_limit' not in data:
+        data['free_sms_fragment_limit'] = current_app.config['FREE_SMS_TIER_FRAGMENT_COUNT']
 
     # validate json with marshmallow
     service_schema.load(request.get_json())
@@ -147,6 +152,7 @@ def create_service():
     valid_service = Service.from_json(data)
 
     dao_create_service(valid_service, user)
+
     return jsonify(data=service_schema.dump(valid_service).data), 201
 
 

--- a/application.py
+++ b/application.py
@@ -21,6 +21,8 @@ manager.add_command('backfill_processing_time', commands.BackfillProcessingTime)
 manager.add_command('populate_service_email_reply_to', commands.PopulateServiceEmailReplyTo)
 manager.add_command('populate_service_sms_sender', commands.PopulateServiceSmsSender)
 manager.add_command('populate_service_letter_contact', commands.PopulateServiceLetterContact)
+manager.add_command('populate_service_and_service_history_free_sms_fragment_limit',
+                    commands.PopulateServiceAndServiceHistoryFreeSmsFragmentLimit)
 
 
 @manager.command

--- a/environment_test.sh
+++ b/environment_test.sh
@@ -5,6 +5,7 @@ export NOTIFY_ENVIRONMENT='test'
 export ADMIN_CLIENT_SECRET='dev-notify-secret-key'
 export ADMIN_BASE_URL='http://localhost:6012'
 export FROM_NUMBER='from_number'
+export FREE_SMS_TIER_FRAGMENT_COUNT='250000'
 export MMG_URL="https://api.mmg.co.uk/json/api.php"
 export MMG_API_KEY='mmg-secret-key'
 export LOADTESTING_API_KEY="loadtesting"

--- a/migrations/versions/0124_add_free_sms_fragment_limit.py
+++ b/migrations/versions/0124_add_free_sms_fragment_limit.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0124_add_free_sms_fragment_limit
+Revises: 0123_add_noti_to_email_reply
+Create Date: 2017-10-10 11:30:16.225980
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0124_add_free_sms_fragment_limit'
+down_revision = '0123_add_noti_to_email_reply'
+
+
+def upgrade():
+    op.add_column('services_history', sa.Column('free_sms_fragment_limit', sa.BigInteger(), nullable=True))
+    op.add_column('services', sa.Column('free_sms_fragment_limit', sa.BigInteger(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('services_history', 'free_sms_fragment_limit')
+    op.drop_column('services', 'free_sms_fragment_limit')

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -139,6 +139,7 @@ def sample_service(
     email_from=None,
     permissions=[SMS_TYPE, EMAIL_TYPE],
     research_mode=None,
+    free_sms_fragment_limit=250000
 ):
     if user is None:
         user = create_user()
@@ -150,7 +151,8 @@ def sample_service(
         'message_limit': limit,
         'restricted': restricted,
         'email_from': email_from,
-        'created_by': user
+        'created_by': user,
+        'free_sms_fragment_limit': free_sms_fragment_limit
     }
     service = Service.query.filter_by(name=service_name).first()
     if not service:


### PR DESCRIPTION
Added a one-off command to set values of the `free_sms_fragment_limit` in
the `services` table to the default of 250000.

_Note_ - only the last commit has been added - this will be rebased onto master when the branch it is based off is merged.