### PR TITLE
Drop api-paas.* route

### DIFF
--- a/manifest-api-preview.yml
+++ b/manifest-api-preview.yml
@@ -4,7 +4,6 @@ inherit: manifest-api-base.yml
 
 routes:
   - route: notify-api-preview.cloudapps.digital
-  - route: api-paas.notify.works
   - route: api.notify.works
 
 instances: 1

--- a/manifest-api-production.yml
+++ b/manifest-api-production.yml
@@ -4,7 +4,6 @@ inherit: manifest-api-base.yml
 
 routes:
   - route: notify-api-production.cloudapps.digital
-  - route: api-paas.notifications.service.gov.uk
   - route: api.notifications.service.gov.uk
 instances: 2
 memory: 1G

--- a/manifest-api-staging.yml
+++ b/manifest-api-staging.yml
@@ -4,7 +4,6 @@ inherit: manifest-api-base.yml
 
 routes:
   - route: notify-api-staging.cloudapps.digital
-  - route: api-paas.staging-notify.works
   - route: api.staging-notify.works
 instances: 2
 memory: 1G


### PR DESCRIPTION
This was introduced during the migration and is no longer needed nor
should it be used.