### PR TITLE
 Process Incomplete Jobs

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -42,8 +42,8 @@ from app.dao.users_dao import delete_codes_older_created_more_than_a_day_ago
 from app.models import (
     Job,
     LETTER_TYPE,
-    JOB_STATUS_READY_TO_SEND,
-    JOB_STATUS_IN_PROGRESS
+    JOB_STATUS_IN_PROGRESS,
+    JOB_STATUS_READY_TO_SEND
 )
 from app.notifications.process_notifications import send_notification_to_queue
 from app.statsd_decorators import statsd

--- a/app/config.py
+++ b/app/config.py
@@ -50,6 +50,7 @@ class QueueNames(object):
 class TaskNames(object):
     DVLA_JOBS = 'send-jobs-to-dvla'
     DVLA_NOTIFICATIONS = 'send-api-notifications-to-dvla'
+    PROCESS_INCOMPLETE_JOBS = 'process-incomplete-jobs'
 
 
 class Config(object):

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -640,3 +640,14 @@ def dao_get_notification_email_reply_for_notification(notification_id):
 
     if email_reply_to:
         return email_reply_to.email_address
+
+
+@statsd(namespace="dao")
+def dao_get_last_notification_added_for_job_id(job_id):
+    last_notification_added = Notification.query.filter(
+        Notification.job_id == job_id
+    ).order_by(
+        Notification.job_row_number.desc()
+    ).first()
+
+    return last_notification_added

--- a/test_csv_files/multiple_letter.csv
+++ b/test_csv_files/multiple_letter.csv
@@ -1,0 +1,11 @@
+address_line_1, address_line_2, address_line_3
+name1, street1, town1, postcode1
+name2, street2, town2, postcode2
+name3, street3, town3, postcode3
+name4, street4, town4, postcode4
+name5, street5, town5, postcode5
+name6, street6, town6, postcode6
+name7, street7, town7, postcode7
+name8, street8, town8, postcode8
+name9, street9, town9, postcode9
+name0, street0, town0, postcode0

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -9,6 +9,7 @@ from freezegun import freeze_time
 
 from app.celery import scheduled_tasks
 from app.celery.scheduled_tasks import (
+    check_job_status,
     delete_dvla_response_files_older_than_seven_days,
     delete_email_notifications_older_than_seven_days,
     delete_inbound_sms_older_than_seven_days,
@@ -22,15 +23,15 @@ from app.celery.scheduled_tasks import (
     run_scheduled_jobs,
     run_letter_jobs,
     run_letter_api_notifications,
+    populate_monthly_billing,
     s3,
     send_daily_performance_platform_stats,
     send_scheduled_notifications,
+    send_total_sent_notifications_to_performance_platform,
     switch_current_sms_provider_on_slow_delivery,
     timeout_job_statistics,
-    timeout_notifications,
-    populate_monthly_billing,
-    send_total_sent_notifications_to_performance_platform, check_job_status, process_incomplete_job,
-    process_incomplete_jobs)
+    timeout_notifications
+)
 from app.clients.performance_platform.performance_platform_client import PerformancePlatformClient
 from app.config import QueueNames, TaskNames
 from app.dao.jobs_dao import dao_get_job_by_id
@@ -48,10 +49,10 @@ from app.models import (
     NOTIFICATION_PENDING,
     NOTIFICATION_CREATED,
     KEY_TYPE_TEST,
-    MonthlyBilling, JOB_STATUS_FINISHED, Job, Notification)
+    MonthlyBilling
+)
 from app.utils import get_london_midnight_in_utc
 from app.v2.errors import JobIncompleteError
-from tests.app import load_example_csv
 from tests.app.db import create_notification, create_service, create_template, create_job, create_rate
 from tests.app.conftest import (
     sample_job as create_sample_job,
@@ -830,164 +831,6 @@ def test_check_job_status_task_raises_job_incomplete_error_for_multiple_jobs(moc
 
     mock_celery.assert_called_once_with(
         name=TaskNames.PROCESS_INCOMPLETE_JOBS,
-        args=([str(job.id), str(job_2.id)],),
+        args=([str(job_2.id), str(job.id)],),
         queue=QueueNames.JOBS
     )
-
-
-def test_check_job_status_task_does_not_raise_error(sample_template):
-    job = create_job(template=sample_template, notification_count=3,
-                     created_at=datetime.utcnow() - timedelta(hours=2),
-                     scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-                     processing_started=datetime.utcnow() - timedelta(minutes=31),
-                     job_status=JOB_STATUS_FINISHED)
-    job_2 = create_job(template=sample_template, notification_count=3,
-                       created_at=datetime.utcnow() - timedelta(minutes=31),
-                       processing_started=datetime.utcnow() - timedelta(minutes=31),
-                       job_status=JOB_STATUS_FINISHED)
-
-    check_job_status()
-
-
-def test_process_incomplete_job(mocker, sample_template):
-
-    mocker.patch('app.celery.tasks.s3.get_job_from_s3', return_value=load_example_csv('multiple_sms'))
-    send_sms = mocker.patch('app.celery.tasks.send_sms.apply_async')
-
-    job = create_job(template=sample_template, notification_count=3,
-                     created_at=datetime.utcnow() - timedelta(hours=2),
-                     scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-                     processing_started=datetime.utcnow() - timedelta(minutes=31),
-                     job_status=JOB_STATUS_IN_PROGRESS)
-
-    create_notification(sample_template, job, 0)
-    create_notification(sample_template, job, 1)
-
-    assert Notification.query.filter(Notification.job_id == job.id).count() == 2
-
-    process_incomplete_job(str(job.id))
-
-    completed_job = Job.query.filter(Job.id == job.id).one()
-
-    assert completed_job.job_status == JOB_STATUS_FINISHED
-
-    assert send_sms.call_count == 8  # There are 10 in the file and we've added two already
-
-
-def test_process_incomplete_job_with_notifications_all_sent(mocker, sample_template):
-
-    mocker.patch('app.celery.tasks.s3.get_job_from_s3', return_value=load_example_csv('multiple_sms'))
-    send_sms = mocker.patch('app.celery.tasks.send_sms.apply_async')
-
-    job = create_job(template=sample_template, notification_count=3,
-                     created_at=datetime.utcnow() - timedelta(hours=2),
-                     scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-                     processing_started=datetime.utcnow() - timedelta(minutes=31),
-                     job_status=JOB_STATUS_IN_PROGRESS)
-
-    create_notification(sample_template, job, 0)
-    create_notification(sample_template, job, 1)
-    create_notification(sample_template, job, 2)
-    create_notification(sample_template, job, 3)
-    create_notification(sample_template, job, 4)
-    create_notification(sample_template, job, 5)
-    create_notification(sample_template, job, 6)
-    create_notification(sample_template, job, 7)
-    create_notification(sample_template, job, 8)
-    create_notification(sample_template, job, 9)
-
-    assert Notification.query.filter(Notification.job_id == job.id).count() == 10
-
-    process_incomplete_job(str(job.id))
-
-    completed_job = Job.query.filter(Job.id == job.id).one()
-
-    assert completed_job.job_status == JOB_STATUS_FINISHED
-
-    assert send_sms.call_count == 0  # There are 10 in the file and we've added two already
-
-
-def test_process_incomplete_jobs(mocker, sample_template):
-
-    mocker.patch('app.celery.tasks.s3.get_job_from_s3', return_value=load_example_csv('multiple_sms'))
-    send_sms = mocker.patch('app.celery.tasks.send_sms.apply_async')
-
-    job = create_job(template=sample_template, notification_count=3,
-                     created_at=datetime.utcnow() - timedelta(hours=2),
-                     scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-                     processing_started=datetime.utcnow() - timedelta(minutes=31),
-                     job_status=JOB_STATUS_IN_PROGRESS)
-    create_notification(sample_template, job, 0)
-    create_notification(sample_template, job, 1)
-    create_notification(sample_template, job, 2)
-
-    assert Notification.query.filter(Notification.job_id == job.id).count() == 3
-
-    job2 = create_job(template=sample_template, notification_count=3,
-                      created_at=datetime.utcnow() - timedelta(hours=2),
-                      scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-                      processing_started=datetime.utcnow() - timedelta(minutes=31),
-                      job_status=JOB_STATUS_IN_PROGRESS)
-
-    create_notification(sample_template, job2, 0)
-    create_notification(sample_template, job2, 1)
-    create_notification(sample_template, job2, 2)
-    create_notification(sample_template, job2, 3)
-    create_notification(sample_template, job2, 4)
-
-    assert Notification.query.filter(Notification.job_id == job2.id).count() == 5
-
-    jobs = [job.id, job2.id]
-    process_incomplete_jobs(jobs)
-
-    completed_job = Job.query.filter(Job.id == job.id).one()
-    completed_job2 = Job.query.filter(Job.id == job2.id).one()
-
-    assert completed_job.job_status == JOB_STATUS_FINISHED
-
-    assert completed_job2.job_status == JOB_STATUS_FINISHED
-
-    assert send_sms.call_count == 12  # There are 20 in total over 2 jobs we've added 8 already
-
-
-def test_process_incomplete_jobs_no_notifications_added(mocker, sample_template):
-    mocker.patch('app.celery.tasks.s3.get_job_from_s3', return_value=load_example_csv('multiple_sms'))
-    send_sms = mocker.patch('app.celery.tasks.send_sms.apply_async')
-
-    job = create_job(template=sample_template, notification_count=3,
-                     created_at=datetime.utcnow() - timedelta(hours=2),
-                     scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-                     processing_started=datetime.utcnow() - timedelta(minutes=31),
-                     job_status=JOB_STATUS_IN_PROGRESS)
-
-    assert Notification.query.filter(Notification.job_id == job.id).count() == 0
-
-    process_incomplete_job(job.id)
-
-    completed_job = Job.query.filter(Job.id == job.id).one()
-
-    assert completed_job.job_status == JOB_STATUS_FINISHED
-
-    assert send_sms.call_count == 10  # There are 10 in the csv file
-
-
-def test_process_incomplete_jobs(mocker):
-
-    mocker.patch('app.celery.tasks.s3.get_job_from_s3', return_value=load_example_csv('multiple_sms'))
-    send_sms = mocker.patch('app.celery.tasks.send_sms.apply_async')
-
-    jobs = []
-    process_incomplete_jobs(jobs)
-
-    assert send_sms.call_count == 0  # There are 20 in total over 2 jobs we've added 8 already
-
-
-def test_process_incomplete_job_no_job_in_database(mocker, fake_uuid):
-
-    mocker.patch('app.celery.tasks.s3.get_job_from_s3', return_value=load_example_csv('multiple_sms'))
-    send_sms = mocker.patch('app.celery.tasks.send_sms.apply_async')
-
-    with pytest.raises(expected_exception=Exception) as e:
-        process_incomplete_job(fake_uuid)
-
-    assert send_sms.call_count == 0  # There are 20 in total over 2 jobs we've added 8 already


### PR DESCRIPTION
- Added a new task to process incomplete jobs
- Added tests to test the new task
- Updated the check for incomplete jobs method to start the new task if incomplete jobs are found.

This will effectively resume tasks which for some reason were interrupted
whilst they were being processed e.g. if the application unintentionally restarted. In some cases only some of the csv is processed, this will find the place in the csv and continue processing the job from that point and mark the job as complete.