### PR TITLE
ensure emails are formatted before sending

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -3,7 +3,8 @@ from datetime import datetime
 
 from flask import current_app
 from notifications_utils.recipients import (
-    validate_and_format_phone_number
+    validate_and_format_phone_number,
+    validate_and_format_email_address
 )
 from notifications_utils.template import HTMLEmailTemplate, PlainTextEmailTemplate, SMSMessageTemplate
 
@@ -130,11 +131,11 @@ def send_email_to_provider(notification):
 
             reference = provider.send_email(
                 from_address,
-                notification.to,
+                validate_and_format_email_address(notification.to),
                 plain_text_email.subject,
                 body=str(plain_text_email),
                 html_body=str(html_email),
-                reply_to_address=email_reply_to,
+                reply_to_address=validate_and_format_email_address(email_reply_to) if email_reply_to else None,
             )
             notification.reference = reference
             update_notification(notification, provider)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,6 @@ notifications-python-client==4.4.0
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@21.3.1#egg=notifications-utils==21.3.1
+git+https://github.com/alphagov/notifications-utils.git@21.4.1#egg=notifications-utils==21.4.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -109,7 +109,7 @@ def create_notification(
     template,
     job=None,
     job_row_number=None,
-    to_field='+447700900855',
+    to_field=None,
     status='created',
     reference=None,
     created_at=None,
@@ -130,6 +130,9 @@ def create_notification(
 ):
     if created_at is None:
         created_at = datetime.utcnow()
+
+    if to_field is None:
+        to_field = '+447700900855' if template.template_type == SMS_TYPE else 'test@example.com'
 
     if status != 'created':
         sent_at = sent_at or datetime.utcnow()


### PR DESCRIPTION
we allow some invalid to addresses - for example, phone numbers with spaces or brackets - in the database. This is so that users can match up their data in a format that they expect (since they passed it in). When we send SMS, we strip this formatting just before sending - but we weren't with email. This commit changes that and adds some tests.

It also adds formatting for reply_to addresses. We should never expect invalid reply_to email addresses in our data, but just in case, lets validate them here.

Also, bump requirements.txt to capture some more email validation