### PR TITLE
Add syslog drain service to preview and staging

### DIFF
--- a/manifest-api-preview.yml
+++ b/manifest-api-preview.yml
@@ -2,6 +2,17 @@
 
 inherit: manifest-api-base.yml
 
+services:
+  - notify-aws
+  - notify-config
+  - notify-db
+  - mmg
+  - firetext
+  - hosted-graphite
+  - redis
+  - performance-platform
+  - logit-ssl-syslog-drain
+
 routes:
   - route: notify-api-preview.cloudapps.digital
   - route: api.notify.works

--- a/manifest-api-staging.yml
+++ b/manifest-api-staging.yml
@@ -2,6 +2,17 @@
 
 inherit: manifest-api-base.yml
 
+services:
+  - notify-aws
+  - notify-config
+  - notify-db
+  - mmg
+  - firetext
+  - hosted-graphite
+  - redis
+  - performance-platform
+  - logit-ssl-syslog-drain
+
 routes:
   - route: notify-api-staging.cloudapps.digital
   - route: api.staging-notify.works

--- a/manifest-delivery-preview.yml
+++ b/manifest-delivery-preview.yml
@@ -1,4 +1,16 @@
 ---
 
 inherit: manifest-delivery-base.yml
+
+services:
+  - notify-aws
+  - notify-config
+  - notify-db
+  - mmg
+  - firetext
+  - hosted-graphite
+  - redis
+  - performance-platform
+  - logit-ssl-syslog-drain
+
 memory: 1G

--- a/manifest-delivery-staging.yml
+++ b/manifest-delivery-staging.yml
@@ -2,5 +2,16 @@
 
 inherit: manifest-delivery-base.yml
 
+services:
+  - notify-aws
+  - notify-config
+  - notify-db
+  - mmg
+  - firetext
+  - hosted-graphite
+  - redis
+  - performance-platform
+  - logit-ssl-syslog-drain
+
 instances: 2
 memory: 1G


### PR DESCRIPTION
This should and will be moved back to the approriate manifest-base-*.yml
files when it is configured for production usage.

Related: alphagov/notifications-admin#1556