### PR TITLE
Handle DVLA response file

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -47,7 +47,7 @@ from app.dao.templates_dao import dao_get_template_by_id
 from app.models import (
     Job,
     Notification,
-    DVLA_STATUS_SENT,
+    DVLA_RESPONSE_STATUS_SENT,
     EMAIL_TYPE,
     JOB_STATUS_CANCELLED,
     JOB_STATUS_FINISHED,
@@ -58,7 +58,6 @@ from app.models import (
     KEY_TYPE_NORMAL,
     LETTER_TYPE,
     NOTIFICATION_DELIVERED,
-    NOTIFICATION_FAILED,
     NOTIFICATION_SENDING,
     NOTIFICATION_TECHNICAL_FAILURE,
     SMS_TYPE,
@@ -447,7 +446,8 @@ def update_letter_notifications_statuses(self, filename):
         raise
     else:
         for update in notification_updates:
-            status = NOTIFICATION_DELIVERED if update.status == DVLA_STATUS_SENT else NOTIFICATION_FAILED
+            status = NOTIFICATION_DELIVERED if update.status == DVLA_RESPONSE_STATUS_SENT \
+                else NOTIFICATION_TECHNICAL_FAILURE
             notification = update_notification_status_by_reference(
                 update.reference,
                 status

--- a/app/models.py
+++ b/app/models.py
@@ -875,10 +875,9 @@ NOTIFICATION_STATUS_TYPES_NON_BILLABLE = list(set(NOTIFICATION_STATUS_TYPES) - s
 NOTIFICATION_STATUS_TYPES_ENUM = db.Enum(*NOTIFICATION_STATUS_TYPES, name='notify_status_type')
 
 NOTIFICATION_STATUS_LETTER_ACCEPTED = 'accepted'
-NOTIFICATION_STATUS_LETTER_ACCEPTED_PRETTY = 'Accepted'
 NOTIFICATION_STATUS_LETTER_RECEIVED = 'received'
 
-DVLA_STATUS_SENT = 'Sent'
+DVLA_RESPONSE_STATUS_SENT = 'Sent'
 
 
 class NotificationStatusTypes(db.Model):
@@ -1054,8 +1053,8 @@ class Notification(db.Model):
             },
             'letter': {
                 'technical-failure': 'Technical failure',
-                'sending': NOTIFICATION_STATUS_LETTER_ACCEPTED_PRETTY,
-                'created': NOTIFICATION_STATUS_LETTER_ACCEPTED_PRETTY,
+                'sending': 'Accepted',
+                'created': 'Accepted',
                 'delivered': 'Received'
             }
         }[self.template.template_type].get(self.status, self.status)

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -1,4 +1,9 @@
-from app.models import NOTIFICATION_STATUS_TYPES, NOTIFICATION_STATUS_LETTER_ACCEPTED, TEMPLATE_TYPES
+from app.models import (
+    NOTIFICATION_STATUS_TYPES,
+    NOTIFICATION_STATUS_LETTER_ACCEPTED,
+    NOTIFICATION_STATUS_LETTER_RECEIVED,
+    TEMPLATE_TYPES
+)
 from app.schema_validation.definitions import (uuid, personalisation, letter_personalisation)
 
 
@@ -59,7 +64,8 @@ get_notifications_request = {
         "status": {
             "type": "array",
             "items": {
-                "enum": NOTIFICATION_STATUS_TYPES + [NOTIFICATION_STATUS_LETTER_ACCEPTED]
+                "enum": NOTIFICATION_STATUS_TYPES +
+                    [NOTIFICATION_STATUS_LETTER_ACCEPTED + ', ' + NOTIFICATION_STATUS_LETTER_RECEIVED]
             }
         },
         "template_type": {

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -9,7 +9,7 @@ from app.models import (
     Notification,
     NOTIFICATION_CREATED,
     NOTIFICATION_DELIVERED,
-    NOTIFICATION_FAILED,
+    NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_SENDING,
     NOTIFICATION_STATUS_LETTER_RECEIVED,
     NOTIFICATION_TECHNICAL_FAILURE
@@ -106,7 +106,7 @@ def test_update_letter_notifications_statuses_persisted(notify_api, mocker, samp
     update_letter_notifications_statuses(filename='foo.txt')
 
     assert sent_letter.status == NOTIFICATION_DELIVERED
-    assert failed_letter.status == NOTIFICATION_FAILED
+    assert failed_letter.status == NOTIFICATION_TECHNICAL_FAILURE
 
 
 def test_update_letter_notifications_to_sent_to_dvla_updates_based_on_notification_references(

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -7,21 +7,21 @@ from flask import current_app
 from app.models import (
     Job,
     Notification,
+    NOTIFICATION_CREATED,
     NOTIFICATION_DELIVERED,
     NOTIFICATION_FAILED,
     NOTIFICATION_SENDING,
-    NOTIFICATION_CREATED,
-    NOTIFICATION_TECHNICAL_FAILURE,
-    NOTIFICATION_STATUS_LETTER_RECEIVED
+    NOTIFICATION_STATUS_LETTER_RECEIVED,
+    NOTIFICATION_TECHNICAL_FAILURE
 )
 from app.dao.notifications_dao import dao_update_notifications_by_reference
 from app.celery.tasks import (
-    update_job_to_sent_to_dvla,
+    process_updates_from_file,
     update_dvla_job_to_error,
+    update_job_to_sent_to_dvla,
     update_letter_notifications_statuses,
-    update_letter_notifications_to_sent_to_dvla,
     update_letter_notifications_to_error,
-    process_updates_from_file
+    update_letter_notifications_to_sent_to_dvla
 )
 
 from tests.app.db import create_notification

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -7,10 +7,14 @@ from flask import current_app
 from app.models import (
     Job,
     Notification,
+    NOTIFICATION_DELIVERED,
+    NOTIFICATION_FAILED,
     NOTIFICATION_SENDING,
     NOTIFICATION_CREATED,
-    NOTIFICATION_TECHNICAL_FAILURE
+    NOTIFICATION_TECHNICAL_FAILURE,
+    NOTIFICATION_STATUS_LETTER_RECEIVED
 )
+from app.dao.notifications_dao import dao_update_notifications_by_reference
 from app.celery.tasks import (
     update_job_to_sent_to_dvla,
     update_dvla_job_to_error,
@@ -89,6 +93,20 @@ def test_update_letter_notifications_statuses_builds_updates_list(notify_api, mo
     assert updates[1].status == 'Sent'
     assert updates[1].page_count == '2'
     assert updates[1].cost_threshold == 'Sorted'
+
+
+def test_update_letter_notifications_statuses_persisted(notify_api, mocker, sample_letter_template):
+    sent_letter = create_notification(sample_letter_template, reference='ref-foo', status=NOTIFICATION_SENDING)
+    failed_letter = create_notification(sample_letter_template, reference='ref-bar', status=NOTIFICATION_SENDING)
+
+    valid_file = '{}|Sent|1|Unsorted\n{}|Failed|2|Sorted'.format(
+        sent_letter.reference, failed_letter.reference)
+    mocker.patch('app.celery.tasks.s3.get_s3_file', return_value=valid_file)
+
+    update_letter_notifications_statuses(filename='foo.txt')
+
+    assert sent_letter.status == NOTIFICATION_DELIVERED
+    assert failed_letter.status == NOTIFICATION_FAILED
 
 
 def test_update_letter_notifications_to_sent_to_dvla_updates_based_on_notification_references(

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -10,12 +10,14 @@ from app.models import (
     MOBILE_TYPE,
     EMAIL_TYPE,
     NOTIFICATION_CREATED,
+    NOTIFICATION_DELIVERED,
     NOTIFICATION_SENDING,
     NOTIFICATION_PENDING,
     NOTIFICATION_FAILED,
-    NOTIFICATION_TECHNICAL_FAILURE,
+    NOTIFICATION_STATUS_LETTER_ACCEPTED,
+    NOTIFICATION_STATUS_LETTER_RECEIVED,
     NOTIFICATION_STATUS_TYPES_FAILED,
-    NOTIFICATION_STATUS_LETTER_ACCEPTED
+    NOTIFICATION_TECHNICAL_FAILURE
 )
 from tests.app.conftest import (
     sample_template as create_sample_template,
@@ -71,6 +73,7 @@ def test_should_not_build_service_whitelist_from_invalid_contact(recipient_type,
     ([NOTIFICATION_FAILED], NOTIFICATION_STATUS_TYPES_FAILED),
     ([NOTIFICATION_CREATED], [NOTIFICATION_CREATED]),
     ([NOTIFICATION_TECHNICAL_FAILURE], [NOTIFICATION_TECHNICAL_FAILURE]),
+    (NOTIFICATION_STATUS_LETTER_RECEIVED, NOTIFICATION_DELIVERED),
     # passing in lists containing multiple statuses
     ([NOTIFICATION_FAILED, NOTIFICATION_CREATED], NOTIFICATION_STATUS_TYPES_FAILED + [NOTIFICATION_CREATED]),
     ([NOTIFICATION_CREATED, NOTIFICATION_PENDING], [NOTIFICATION_CREATED, NOTIFICATION_PENDING]),
@@ -132,7 +135,8 @@ def test_notification_for_csv_returns_correct_job_row_number(notify_db, notify_d
     ('sms', 'sent', 'Sent internationally'),
     ('letter', 'created', 'Accepted'),
     ('letter', 'sending', 'Accepted'),
-    ('letter', 'technical-failure', 'Technical failure')
+    ('letter', 'technical-failure', 'Technical failure'),
+    ('letter', 'delivered', 'Received')
 ])
 def test_notification_for_csv_returns_formatted_status(
     notify_db,

--- a/tests/app/v2/notifications/test_notification_schemas.py
+++ b/tests/app/v2/notifications/test_notification_schemas.py
@@ -26,7 +26,7 @@ def test_get_notifications_request_invalid_statuses(
 ):
     partial_error_status = "is not one of " \
         "[created, sending, sent, delivered, pending, failed, " \
-        "technical-failure, temporary-failure, permanent-failure, accepted]"
+        "technical-failure, temporary-failure, permanent-failure, accepted, received]"
 
     with pytest.raises(ValidationError) as e:
         validate({'status': invalid_statuses + valid_statuses}, get_notifications_request)
@@ -73,7 +73,7 @@ def test_get_notifications_request_invalid_statuses_and_template_types():
     error_messages = [error['message'] for error in errors]
     for invalid_status in ["elephant", "giraffe"]:
         assert "status {} is not one of [created, sending, sent, delivered, " \
-            "pending, failed, technical-failure, temporary-failure, permanent-failure, accepted]".format(
+            "pending, failed, technical-failure, temporary-failure, permanent-failure, accepted, received]".format(
                 invalid_status
             ) in error_messages
 


### PR DESCRIPTION
## What

Currently letter responses are not being handled so we have no idea if a letter has been sent, this PR will update letter notifications to a `delivered` or `failed` status based on the DVLA response file.

- status returned in the response file should be either `Sent` or `Failed`
- rather than use an existing `delivered` status in the json response this will be mapped to `received` for requests. Internally we will still use `delivered` status.

## Reference - 

https://www.pivotaltracker.com/story/show/151649162