### PR TITLE
Improve get services

### DIFF
--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -682,7 +682,7 @@ def test_dao_fetch_todays_stats_for_all_services_includes_all_services(notify_db
     assert stats == sorted(stats, key=lambda x: x.service_id)
 
 
-def test_dao_fetch_todays_stats_for_all_services_only_includes_today(notify_db):
+def test_dao_fetch_todays_stats_for_all_services_only_includes_today(notify_db, notify_db_session):
     with freeze_time('2001-01-01T23:59:00'):
         just_before_midnight_yesterday = create_notification(notify_db, None, to_field='1', status='delivered')
 
@@ -712,10 +712,14 @@ def test_dao_fetch_todays_stats_for_all_services_groups_correctly(notify_db, not
 
     stats = dao_fetch_todays_stats_for_all_services()
     assert len(stats) == 4
-    assert (service1.id, service1.name, service1.restricted, service1.research_mode, 'sms', 'created', 2) in stats
-    assert (service1.id, service1.name, service1.restricted, service1.research_mode, 'sms', 'failed', 1) in stats
-    assert (service1.id, service1.name, service1.restricted, service1.research_mode, 'email', 'created', 1) in stats
-    assert (service2.id, service2.name, service2.restricted, service2.research_mode, 'sms', 'created', 1) in stats
+    assert (service1.id, service1.name, service1.restricted, service1.research_mode, service1.active,
+            service1.created_at, 'sms', 'created', 2) in stats
+    assert (service1.id, service1.name, service1.restricted, service1.research_mode, service1.active,
+            service1.created_at, 'sms', 'failed', 1) in stats
+    assert (service1.id, service1.name, service1.restricted, service1.research_mode, service1.active,
+            service1.created_at, 'email', 'created', 1) in stats
+    assert (service2.id, service2.name, service2.restricted, service2.research_mode, service2.active,
+            service2.created_at, 'sms', 'created', 1) in stats
 
 
 def test_dao_fetch_todays_stats_for_all_services_includes_all_keys_by_default(notify_db, notify_db_session):
@@ -754,7 +758,8 @@ def test_fetch_stats_by_date_range_for_all_services(notify_db, notify_db_session
 
     assert len(results) == 1
     assert results[0] == (result_one.service.id, result_one.service.name, result_one.service.restricted,
-                          result_one.service.research_mode, 'sms', 'created', 2)
+                          result_one.service.research_mode, result_one.service.active,
+                          result_one.service.created_at, 'sms', 'created', 2)
 
 
 @freeze_time('2001-01-01T23:59:00')
@@ -794,7 +799,8 @@ def test_fetch_stats_by_date_range_for_all_services_returns_test_notifications(n
 
     assert len(results) == 1
     assert results[0] == (result_one.service.id, result_one.service.name, result_one.service.restricted,
-                          result_one.service.research_mode, 'sms', 'created', int(expected))
+                          result_one.service.research_mode, result_one.service.active, result_one.service.created_at,
+                          'sms', 'created', int(expected))
 
 
 @pytest.mark.parametrize("start_delta, end_delta, expected",
@@ -822,7 +828,8 @@ def test_fetch_stats_by_date_range_during_bst_hour_for_all_services_returns_test
 
     assert len(results) == 1
     assert results[0] == (result_one.service.id, result_one.service.name, result_one.service.restricted,
-                          result_one.service.research_mode, 'sms', 'created', int(expected))
+                          result_one.service.research_mode, result_one.service.active, result_one.service.created_at,
+                          'sms', 'created', int(expected))
 
 
 @freeze_time('2001-01-01T23:59:00')

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -711,12 +711,11 @@ def test_dao_fetch_todays_stats_for_all_services_groups_correctly(notify_db, not
     create_notification(notify_db, notify_db_session, service=service2)
 
     stats = dao_fetch_todays_stats_for_all_services()
-
     assert len(stats) == 4
-    assert ('sms', 'created', service1.id, 2) in stats
-    assert ('sms', 'failed', service1.id, 1) in stats
-    assert ('email', 'created', service1.id, 1) in stats
-    assert ('sms', 'created', service2.id, 1) in stats
+    assert (service1.id, service1.name, service1.restricted, service1.research_mode, 'sms', 'created', 2) in stats
+    assert (service1.id, service1.name, service1.restricted, service1.research_mode, 'sms', 'failed', 1) in stats
+    assert (service1.id, service1.name, service1.restricted, service1.research_mode, 'email', 'created', 1) in stats
+    assert (service2.id, service2.name, service2.restricted, service2.research_mode, 'sms', 'created', 1) in stats
 
 
 def test_dao_fetch_todays_stats_for_all_services_includes_all_keys_by_default(notify_db, notify_db_session):
@@ -754,7 +753,8 @@ def test_fetch_stats_by_date_range_for_all_services(notify_db, notify_db_session
     results = fetch_stats_by_date_range_for_all_services(start_date, end_date)
 
     assert len(results) == 1
-    assert results[0] == ('sms', 'created', result_one.service_id, 2)
+    assert results[0] == (result_one.service.id, result_one.service.name, result_one.service.restricted,
+                          result_one.service.research_mode, 'sms', 'created', 2)
 
 
 @freeze_time('2001-01-01T23:59:00')
@@ -793,7 +793,8 @@ def test_fetch_stats_by_date_range_for_all_services_returns_test_notifications(n
     results = fetch_stats_by_date_range_for_all_services(start_date, end_date, include_from_test_key=True)
 
     assert len(results) == 1
-    assert results[0] == ('sms', 'created', result_one.service_id, int(expected))
+    assert results[0] == (result_one.service.id, result_one.service.name, result_one.service.restricted,
+                          result_one.service.research_mode, 'sms', 'created', int(expected))
 
 
 @pytest.mark.parametrize("start_delta, end_delta, expected",
@@ -820,7 +821,8 @@ def test_fetch_stats_by_date_range_during_bst_hour_for_all_services_returns_test
     results = fetch_stats_by_date_range_for_all_services(start_date, end_date, include_from_test_key=True)
 
     assert len(results) == 1
-    assert results[0] == ('sms', 'created', result_one.service_id, int(expected))
+    assert results[0] == (result_one.service.id, result_one.service.name, result_one.service.restricted,
+                          result_one.service.research_mode, 'sms', 'created', int(expected))
 
 
 @freeze_time('2001-01-01T23:59:00')

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1753,8 +1753,7 @@ def test_get_detailed_services_only_includes_todays_notifications(notify_db, not
 
 @pytest.mark.parametrize(
     'set_time',
-    ['2017-03-28T12:00:00']
-        #, '2017-01-28T12:00:00', '2017-01-02T12:00:00', '2017-10-31T12:00:00']
+    ['2017-03-28T12:00:00', '2017-01-28T12:00:00', '2017-01-02T12:00:00', '2017-10-31T12:00:00']
 )
 def test_get_detailed_services_for_date_range(notify_db, notify_db_session, set_time):
     from app.service.rest import get_detailed_services

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1753,7 +1753,8 @@ def test_get_detailed_services_only_includes_todays_notifications(notify_db, not
 
 @pytest.mark.parametrize(
     'set_time',
-    ['2017-03-28T12:00:00', '2017-01-28T12:00:00', '2017-01-02T12:00:00', '2017-10-31T12:00:00']
+    ['2017-03-28T12:00:00']
+        #, '2017-01-28T12:00:00', '2017-01-02T12:00:00', '2017-10-31T12:00:00']
 )
 def test_get_detailed_services_for_date_range(notify_db, notify_db_session, set_time):
     from app.service.rest import get_detailed_services


### PR DESCRIPTION
Refactored the get_detailed_services to stop using marshmallow. 
Also removed an extra query to services.
The query has been refactored to use an outer join to services on the notifications or notification_history table.
The expectation is that this change will improve the performance of the trial/live-services pages for platform admins.