### PR TITLE
Add worker-receipts app

### DIFF
--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -53,3 +53,8 @@ applications:
     command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q job-tasks,retry-tasks,notify-internal-tasks
     env:
       NOTIFY_APP_NAME: delivery-worker
+
+  - name: notify-delivery-worker-receipts
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q ses-callbacks
+    env:
+      NOTIFY_APP_NAME: delivery-worker-receipts


### PR DESCRIPTION
This needs to go in after alphagov/notifications-aws#246

It creates a new app to handle delivery receipts which will monitor its own queue and will scale autonomously without affecting existing apps.