### PR TITLE
Update page count when processing response file for letters

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -33,20 +33,19 @@ from app.dao.jobs_dao import (
     dao_get_job_by_id,
     all_notifications_are_created_for_job,
     dao_get_all_notifications_for_job,
-    dao_update_job_status)
+    dao_update_job_status
+)
 from app.dao.notifications_dao import (
     get_notification_by_id,
-    update_notification_status_by_reference,
     dao_update_notifications_for_job_to_sent_to_dvla,
     dao_update_notifications_by_reference,
-    dao_get_last_notification_added_for_job_id)
+    dao_get_last_notification_added_for_job_id
+)
 from app.dao.provider_details_dao import get_current_provider
 from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
 from app.dao.services_dao import dao_fetch_service_by_id, fetch_todays_total_message_count
 from app.dao.templates_dao import dao_get_template_by_id
 from app.models import (
-    Job,
-    Notification,
     DVLA_RESPONSE_STATUS_SENT,
     EMAIL_TYPE,
     JOB_STATUS_CANCELLED,
@@ -449,9 +448,12 @@ def update_letter_notifications_statuses(self, filename):
         for update in notification_updates:
             status = NOTIFICATION_DELIVERED if update.status == DVLA_RESPONSE_STATUS_SENT \
                 else NOTIFICATION_TECHNICAL_FAILURE
-            notification = update_notification_status_by_reference(
-                update.reference,
-                status
+            notification = dao_update_notifications_by_reference(
+                references=[update.reference],
+                update_dict={"status": status,
+                             "billable_units": update.page_count,
+                             "updated_at": datetime.utcnow()
+                             }
             )
 
             if not notification:

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -493,7 +493,6 @@ def dao_update_notifications_for_job_to_sent_to_dvla(job_id, provider):
 @statsd(namespace="dao")
 @transactional
 def dao_update_notifications_by_reference(references, update_dict):
-    now = datetime.utcnow()
     updated_count = Notification.query.filter(
         Notification.reference.in_(references)
     ).update(

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -109,7 +109,7 @@ def test_update_letter_notifications_statuses_persisted(notify_api, mocker, samp
     assert sent_letter.updated_at
     assert failed_letter.status == NOTIFICATION_TECHNICAL_FAILURE
     assert failed_letter.billable_units == 2
-    assert failed_letter.updated
+    assert failed_letter.updated_at
 
 
 def test_update_letter_notifications_to_sent_to_dvla_updates_based_on_notification_references(

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -9,12 +9,9 @@ from app.models import (
     Notification,
     NOTIFICATION_CREATED,
     NOTIFICATION_DELIVERED,
-    NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_SENDING,
-    NOTIFICATION_STATUS_LETTER_RECEIVED,
     NOTIFICATION_TECHNICAL_FAILURE
 )
-from app.dao.notifications_dao import dao_update_notifications_by_reference
 from app.celery.tasks import (
     process_updates_from_file,
     update_dvla_job_to_error,
@@ -96,8 +93,10 @@ def test_update_letter_notifications_statuses_builds_updates_list(notify_api, mo
 
 
 def test_update_letter_notifications_statuses_persisted(notify_api, mocker, sample_letter_template):
-    sent_letter = create_notification(sample_letter_template, reference='ref-foo', status=NOTIFICATION_SENDING)
-    failed_letter = create_notification(sample_letter_template, reference='ref-bar', status=NOTIFICATION_SENDING)
+    sent_letter = create_notification(sample_letter_template, reference='ref-foo', status=NOTIFICATION_SENDING,
+                                      billable_units=0)
+    failed_letter = create_notification(sample_letter_template, reference='ref-bar', status=NOTIFICATION_SENDING,
+                                        billable_units=0)
 
     valid_file = '{}|Sent|1|Unsorted\n{}|Failed|2|Sorted'.format(
         sent_letter.reference, failed_letter.reference)
@@ -106,7 +105,11 @@ def test_update_letter_notifications_statuses_persisted(notify_api, mocker, samp
     update_letter_notifications_statuses(filename='foo.txt')
 
     assert sent_letter.status == NOTIFICATION_DELIVERED
+    assert sent_letter.billable_units == 1
+    assert sent_letter.updated_at
     assert failed_letter.status == NOTIFICATION_TECHNICAL_FAILURE
+    assert failed_letter.billable_units == 2
+    assert failed_letter.updated
 
 
 def test_update_letter_notifications_to_sent_to_dvla_updates_based_on_notification_references(


### PR DESCRIPTION
Update the billable units with the page count from the response file for letter notifications.