### PR TITLE
SMS sender id for post notifications

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -43,8 +43,8 @@ from app.models import (
     NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
     NOTIFICATION_PERMANENT_FAILURE,
-    NOTIFICATION_SENT
-)
+    NOTIFICATION_SENT,
+    NotificationSmsSender)
 
 from app.dao.dao_utils import transactional
 from app.statsd_decorators import statsd
@@ -650,3 +650,12 @@ def dao_get_last_notification_added_for_job_id(job_id):
     ).first()
 
     return last_notification_added
+
+
+@transactional
+def dao_create_notification_sms_sender_mapping(notification_id, sms_sender_id):
+    notification_to_sms_sender = NotificationSmsSender(
+        notification_id=notification_id,
+        service_sms_sender_id=sms_sender_id
+    )
+    db.session.add(notification_to_sms_sender)

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -44,7 +44,9 @@ from app.models import (
     NOTIFICATION_TEMPORARY_FAILURE,
     NOTIFICATION_PERMANENT_FAILURE,
     NOTIFICATION_SENT,
-    NotificationSmsSender)
+    NotificationSmsSender,
+    ServiceSmsSender
+)
 
 from app.dao.dao_utils import transactional
 from app.statsd_decorators import statsd
@@ -659,3 +661,14 @@ def dao_create_notification_sms_sender_mapping(notification_id, sms_sender_id):
         service_sms_sender_id=sms_sender_id
     )
     db.session.add(notification_to_sms_sender)
+
+
+def dao_get_notification_sms_sender_mapping(notification_id):
+    sms_sender = ServiceSmsSender.query.join(
+        NotificationSmsSender
+    ).filter(
+        NotificationSmsSender.notification_id == notification_id
+    ).first()
+
+    if sms_sender:
+        return sms_sender.sms_sender

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -390,7 +390,6 @@ def delete_notifications_created_more_than_a_week_ago_by_type(notification_type)
             notification_sender_mapping_table.notification_id.in_(subq)
         ).delete(synchronize_session='fetch')
 
-
     deleted = db.session.query(Notification).filter(
         func.date(Notification.created_at) < seven_days_ago,
         Notification.notification_type == notification_type,

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -10,7 +10,7 @@ from app.dao.dao_utils import (
     transactional,
     version_class
 )
-from app.dao.notifications_dao import get_financial_year
+from app.dao.date_util import get_financial_year
 from app.dao.service_sms_sender_dao import insert_service_sms_sender
 from app.models import (
     NotificationStatistics,

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -17,7 +17,8 @@ from app.models import SMS_TYPE, Notification, KEY_TYPE_TEST, EMAIL_TYPE, NOTIFI
 from app.dao.notifications_dao import (dao_create_notification,
                                        dao_delete_notifications_and_history_by_id,
                                        dao_created_scheduled_notification,
-                                       dao_create_notification_email_reply_to_mapping)
+                                       dao_create_notification_email_reply_to_mapping,
+                                       dao_create_notification_sms_sender_mapping)
 from app.v2.errors import BadRequestError
 from app.utils import get_template_instance, cache_key_for_service_template_counter, convert_bst_to_utc
 
@@ -146,3 +147,7 @@ def persist_scheduled_notification(notification_id, scheduled_for):
 
 def persist_email_reply_to_id_for_notification(notification_id, email_reply_to_id):
     dao_create_notification_email_reply_to_mapping(notification_id, email_reply_to_id)
+
+
+def persist_sms_sender_id_for_notification(notification_id, sms_sender_id):
+    dao_create_notification_sms_sender_mapping(notification_id, sms_sender_id)

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -137,9 +137,9 @@ def validate_template(template_id, personalisation, service, notification_type):
 
 
 def check_service_email_reply_to_id(service_id, reply_to_id, notification_type):
-    if not (reply_to_id is None):
+    if reply_to_id:
         if notification_type != EMAIL_TYPE:
-            message = 'You sent a email_reply_to_id for a {} notification type'.format(notification_type)
+            message = 'email_reply_to_id is not a valid option for {} notification'.format(notification_type)
             raise BadRequestError(message=message)
         try:
             dao_get_reply_to_by_id(service_id, reply_to_id)
@@ -150,9 +150,9 @@ def check_service_email_reply_to_id(service_id, reply_to_id, notification_type):
 
 
 def check_service_sms_sender_id(service_id, sms_sender_id, notification_type):
-    if not (sms_sender_id is None):
+    if sms_sender_id:
         if notification_type != SMS_TYPE:
-            message = 'You sent a sms_sender_id for a {} notification type'.format(notification_type)
+            message = 'sms_sender_id is not a valid option for {} notification'.format(notification_type)
             raise BadRequestError(message=message)
         try:
             dao_get_service_sms_senders_by_id(service_id, sms_sender_id)

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -8,6 +8,7 @@ from notifications_utils.recipients import (
 from notifications_utils.clients.redis import rate_limit_cache_key, daily_limit_cache_key
 
 from app.dao import services_dao, templates_dao
+from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id
 from app.models import (
     INTERNATIONAL_SMS_TYPE, SMS_TYPE, EMAIL_TYPE,
     KEY_TYPE_TEST, KEY_TYPE_TEAM, SCHEDULE_NOTIFICATIONS
@@ -135,11 +136,27 @@ def validate_template(template_id, personalisation, service, notification_type):
     return template, template_with_content
 
 
-def check_service_email_reply_to_id(service_id, reply_to_id):
+def check_service_email_reply_to_id(service_id, reply_to_id, notification_type):
     if not (reply_to_id is None):
+        if notification_type != EMAIL_TYPE:
+            message = 'You sent a email_reply_to_id for a {} notification type'.format(notification_type)
+            raise BadRequestError(message=message)
         try:
             dao_get_reply_to_by_id(service_id, reply_to_id)
         except NoResultFound:
             message = 'email_reply_to_id {} does not exist in database for service id {}'\
                 .format(reply_to_id, service_id)
+            raise BadRequestError(message=message)
+
+
+def check_service_sms_sender_id(service_id, sms_sender_id, notification_type):
+    if not (sms_sender_id is None):
+        if notification_type != SMS_TYPE:
+            message = 'You sent a sms_sender_id for a {} notification type'.format(notification_type)
+            raise BadRequestError(message=message)
+        try:
+            dao_get_service_sms_senders_by_id(service_id, sms_sender_id)
+        except NoResultFound:
+            message = 'sms_sender_id {} does not exist in database for service id {}'\
+                .format(sms_sender_id, service_id)
             raise BadRequestError(message=message)

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -119,7 +119,8 @@ post_sms_request = {
         "phone_number": {"type": "string", "format": "phone_number"},
         "template_id": uuid,
         "personalisation": personalisation,
-        "scheduled_for": {"type": ["string", "null"], "format": "datetime"}
+        "scheduled_for": {"type": ["string", "null"], "format": "datetime"},
+        "sms_sender_id": uuid
     },
     "required": ["phone_number", "template_id"]
 }

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -52,8 +52,8 @@ from app.dao.notifications_dao import (
     update_notification_status_by_reference,
     dao_get_last_notification_added_for_job_id,
     dao_update_notifications_by_reference,
-    dao_create_notification_sms_sender_mapping
-)
+    dao_create_notification_sms_sender_mapping,
+    dao_get_notification_sms_sender_mapping)
 
 from app.dao.services_dao import dao_update_service
 from tests.app.db import (
@@ -2112,3 +2112,16 @@ def test_dao_create_notification_sms_sender_mapping(sample_notification):
     assert len(notification_to_senders) == 1
     assert notification_to_senders[0].notification_id == sample_notification.id
     assert notification_to_senders[0].service_sms_sender_id == sms_sender.id
+
+
+def test_dao_get_notification_sms_sender_mapping(sample_notification):
+    sms_sender = create_service_sms_sender(service=sample_notification.service, sms_sender='123456')
+    dao_create_notification_sms_sender_mapping(notification_id=sample_notification.id,
+                                               sms_sender_id=sms_sender.id)
+    notification_to_sender = dao_get_notification_sms_sender_mapping(sample_notification.id)
+    assert notification_to_sender == '123456'
+
+
+def test_dao_get_notification_sms_sender_mapping_returns_none(sample_notification):
+    notification_to_sender = dao_get_notification_sms_sender_mapping(sample_notification.id)
+    assert not notification_to_sender

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -12,9 +12,11 @@ from app.models import (
     Notification,
     NotificationEmailReplyTo,
     NotificationHistory,
+    NotificationSmsSender,
     NotificationStatistics,
     ScheduledNotification,
     EMAIL_TYPE,
+    SMS_TYPE,
     NOTIFICATION_STATUS_TYPES,
     NOTIFICATION_STATUS_TYPES_FAILED,
     NOTIFICATION_SENT,
@@ -22,16 +24,20 @@ from app.models import (
     KEY_TYPE_NORMAL,
     KEY_TYPE_TEAM,
     KEY_TYPE_TEST,
-    JOB_STATUS_IN_PROGRESS, NotificationSmsSender, SMS_TYPE)
+    JOB_STATUS_IN_PROGRESS
+)
 
 from app.dao.notifications_dao import (
     dao_create_notification,
     dao_create_notification_email_reply_to_mapping,
+    dao_create_notification_sms_sender_mapping,
     dao_created_scheduled_notification,
     dao_delete_notifications_and_history_by_id,
+    dao_get_last_notification_added_for_job_id,
     dao_get_last_template_usage,
     dao_get_notification_email_reply_for_notification,
     dao_get_notifications_by_to_field,
+    dao_get_notification_sms_sender_mapping,
     dao_get_notification_statistics_for_service_and_day,
     dao_get_potential_notification_statistics_for_day,
     dao_get_scheduled_notifications,
@@ -39,6 +45,7 @@ from app.dao.notifications_dao import (
     dao_timeout_notifications,
     dao_update_notification,
     dao_update_notifications_for_job_to_sent_to_dvla,
+    dao_update_notifications_by_reference,
     delete_notifications_created_more_than_a_week_ago_by_type,
     get_notification_by_id,
     get_notification_for_job,
@@ -49,11 +56,8 @@ from app.dao.notifications_dao import (
     is_delivery_slow_for_provider,
     set_scheduled_notification_to_processed,
     update_notification_status_by_id,
-    update_notification_status_by_reference,
-    dao_get_last_notification_added_for_job_id,
-    dao_update_notifications_by_reference,
-    dao_create_notification_sms_sender_mapping,
-    dao_get_notification_sms_sender_mapping)
+    update_notification_status_by_reference
+)
 
 from app.dao.services_dao import dao_update_service
 from tests.app.db import (

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -29,7 +29,11 @@ from app.models import (
     KEY_TYPE_NORMAL
 )
 from app.dao.users_dao import save_model_user
-from app.dao.notifications_dao import dao_create_notification, dao_created_scheduled_notification
+from app.dao.notifications_dao import (
+    dao_create_notification,
+    dao_created_scheduled_notification,
+    dao_create_notification_sms_sender_mapping
+)
 from app.dao.templates_dao import dao_create_template
 from app.dao.services_dao import dao_create_service
 from app.dao.service_permissions_dao import dao_add_service_permission
@@ -128,6 +132,7 @@ def create_notification(
     scheduled_for=None,
     normalised_to=None,
     one_off=False,
+    sms_sender_id=None
 ):
     if created_at is None:
         created_at = datetime.utcnow()
@@ -184,6 +189,9 @@ def create_notification(
         if status != 'created':
             scheduled_notification.pending = False
         dao_created_scheduled_notification(scheduled_notification)
+    if sms_sender_id:
+        dao_create_notification_sms_sender_mapping(notification_id=notification.id,
+                                                   sms_sender_id=sms_sender_id)
     return notification
 
 

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -8,15 +8,23 @@ from freezegun import freeze_time
 from collections import namedtuple
 
 from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_service_id
-from app.models import Template, Notification, NotificationHistory, ScheduledNotification, NotificationEmailReplyTo, \
-    NotificationSmsSender
+from app.models import (
+    Notification,
+    NotificationHistory,
+    NotificationEmailReplyTo,
+    NotificationSmsSender,
+    ScheduledNotification,
+    Template
+)
 from app.notifications.process_notifications import (
     create_content_for_notification,
     persist_notification,
-    send_notification_to_queue,
-    simulated_recipient,
+    persist_email_reply_to_id_for_notification,
     persist_scheduled_notification,
-    persist_email_reply_to_id_for_notification, persist_sms_sender_id_for_notification)
+    persist_sms_sender_id_for_notification,
+    send_notification_to_queue,
+    simulated_recipient
+)
 from notifications_utils.recipients import validate_and_format_phone_number, validate_and_format_email_address
 from app.utils import cache_key_for_service_template_counter
 from app.v2.errors import BadRequestError

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -311,9 +311,9 @@ def test_should_not_rate_limit_if_limiting_is_disabled(
 
 @pytest.mark.parametrize('key_type', ['test', 'normal'])
 def test_rejects_api_calls_with_international_numbers_if_service_does_not_allow_int_sms(
-    key_type,
-    notify_db,
-    notify_db_session,
+        key_type,
+        notify_db,
+        notify_db_session,
 ):
     service = create_service(notify_db, notify_db_session, permissions=[SMS_TYPE])
     with pytest.raises(BadRequestError) as e:
@@ -336,12 +336,17 @@ def test_check_service_email_reply_to_id_where_reply_to_id_is_none(notification_
     assert check_service_email_reply_to_id(None, None, notification_type) is None
 
 
+def test_check_service_email_reply_to_where_email_reply_to_is_found(sample_service):
+    reply_to_address = create_reply_to_email(sample_service, "test@test.com")
+    assert check_service_email_reply_to_id(sample_service.id, reply_to_address.id, EMAIL_TYPE) is None
+
+
 def test_check_service_email_reply_to_id_where_service_id_is_not_found(sample_service, fake_uuid):
     reply_to_address = create_reply_to_email(sample_service, "test@test.com")
     with pytest.raises(BadRequestError) as e:
         check_service_email_reply_to_id(fake_uuid, reply_to_address.id, EMAIL_TYPE)
     assert e.value.status_code == 400
-    assert e.value.message == 'email_reply_to_id {} does not exist in database for service id {}'\
+    assert e.value.message == 'email_reply_to_id {} does not exist in database for service id {}' \
         .format(reply_to_address.id, fake_uuid)
 
 
@@ -349,30 +354,25 @@ def test_check_service_email_reply_to_id_where_reply_to_id_is_not_found(sample_s
     with pytest.raises(BadRequestError) as e:
         check_service_email_reply_to_id(sample_service.id, fake_uuid, EMAIL_TYPE)
     assert e.value.status_code == 400
-    assert e.value.message == 'email_reply_to_id {} does not exist in database for service id {}'\
+    assert e.value.message == 'email_reply_to_id {} does not exist in database for service id {}' \
         .format(fake_uuid, sample_service.id)
 
 
-def test_check_service_sms_sender_id_where_sms_sender_id_is_found(sample_service):
-    sms_sender = create_service_sms_sender(service=sample_service, sms_sender='123456')
-    assert check_service_sms_sender_id(sample_service.id, sms_sender.id, SMS_TYPE) is None
-
-
-@pytest.mark.parametrize('notification_type', ['email', 'letter'])
-def test_check_service_sms_sender_id_when_channel_type_is_wrong(sample_service, notification_type):
-    sms_sender = create_service_sms_sender(service=sample_service, sms_sender='123456')
+@pytest.mark.parametrize('notification_type', ['sms', 'letter'])
+def test_check_service_email_reply_to_id_when_channel_type_is_wrong(sample_service, notification_type):
+    reply_to_address = create_reply_to_email(sample_service, "test@test.com")
     with pytest.raises(BadRequestError) as e:
-        check_service_sms_sender_id(sample_service.id, sms_sender.id, notification_type)
+        check_service_email_reply_to_id(sample_service.id, reply_to_address.id, notification_type)
     assert e.value.status_code == 400
-    assert e.value.message == 'You sent a sms_sender_id for a {} notification type'.format(notification_type)
+    assert e.value.message == 'email_reply_to_id is not a valid option for {} notification'.format(notification_type)
 
 
 @pytest.mark.parametrize('notification_type', ['sms', 'email', 'letter'])
-def test_check_service_sms_sender_id_where_reply_to_id_is_valid(notification_type):
+def test_check_service_sms_sender_id_where_sms_sender_id_is_none(notification_type):
     assert check_service_sms_sender_id(None, None, notification_type) is None
 
 
-def test_check_service_sms_sender_id_where_reply_to_id_is_found(sample_service):
+def test_check_service_sms_sender_id_where_sms_sender_id_is_found(sample_service):
     sms_sender = create_service_sms_sender(service=sample_service, sms_sender='123456')
     assert check_service_sms_sender_id(sample_service.id, sms_sender.id, SMS_TYPE) is None
 
@@ -382,22 +382,22 @@ def test_check_service_sms_sender_id_where_service_id_is_not_found(sample_servic
     with pytest.raises(BadRequestError) as e:
         check_service_sms_sender_id(fake_uuid, sms_sender.id, SMS_TYPE)
     assert e.value.status_code == 400
-    assert e.value.message == 'sms_sender_id {} does not exist in database for service id {}'\
+    assert e.value.message == 'sms_sender_id {} does not exist in database for service id {}' \
         .format(sms_sender.id, fake_uuid)
 
 
-def test_check_service_sms_sender_id_where_reply_to_id_is_not_found(sample_service, fake_uuid):
+def test_check_service_sms_sender_id_where_sms_sender_is_not_found(sample_service, fake_uuid):
     with pytest.raises(BadRequestError) as e:
         check_service_sms_sender_id(sample_service.id, fake_uuid, SMS_TYPE)
     assert e.value.status_code == 400
-    assert e.value.message == 'sms_sender_id {} does not exist in database for service id {}'\
+    assert e.value.message == 'sms_sender_id {} does not exist in database for service id {}' \
         .format(fake_uuid, sample_service.id)
 
 
 @pytest.mark.parametrize('notification_type', ['email', 'letter'])
-def test_check_service_email_reply_to_id_when_channel_type_is_wrong(sample_service, notification_type):
+def test_check_service_sms_sender_id_when_channel_type_is_wrong(sample_service, notification_type):
     sms_sender = create_service_sms_sender(service=sample_service, sms_sender='123456')
     with pytest.raises(BadRequestError) as e:
         check_service_sms_sender_id(sample_service.id, sms_sender.id, notification_type)
     assert e.value.status_code == 400
-    assert e.value.message == 'You sent a sms_sender_id for a {} notification type'.format(notification_type)
+    assert e.value.message == 'sms_sender_id is not a valid option for {} notification'.format(notification_type)

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -28,7 +28,6 @@ from tests.app.db import (
     create_service,
     create_inbound_number,
     create_reply_to_email,
-    create_service_sms_sender,
     create_letter_contact
 )
 from tests.conftest import set_config


### PR DESCRIPTION
We have recently add the functionality to add multiple SMS senders for a service. This PR allows a service to send the SMS sender in the POST notification request, that SMS sender is then used as the sender id. At the moment only the default sender is used for a notification.

- Added an optional parameter in the form for POST /v2/notifications/sms and /service/<service_id>/send-notification to pass in the SMS sender id.

- Get the sms sender from the notification_sms_sender mapping table if that does not exist get the default sms sender to pass on to the sms provider.
- Added the notification_to_sms_sender mapping table to the purge notifications query

As part of https://www.pivotaltracker.com/story/show/152106587