### PR TITLE
Fix bug processing letters with . as address line

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,6 @@ notifications-python-client==4.5.0
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@21.5.0#egg=notifications-utils==21.5.0
+git+https://github.com/alphagov/notifications-utils.git@21.5.1#egg=notifications-utils==21.5.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
If an address line started with punctuation it caused a bug where we couldn’t properly map the address to the columns required in the DVLA file.

This bug is fixed by:
- [x] https://github.com/alphagov/notifications-utils/pull/244