### PR TITLE
Update utils with a bug fix for addresses in LetterDVLA template

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -326,6 +326,7 @@ def build_dvla_file(self, job_id):
             current_app.logger.info("All notifications for job {} are not persisted".format(job_id))
             self.retry(queue=QueueNames.RETRY, exc="All notifications for job {} are not persisted".format(job_id))
     except Exception as e:
+        # ? should this retry?
         current_app.logger.exception("build_dvla_file threw exception")
         raise e
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -351,3 +351,14 @@ class PopulateAnnualBilling(Command):
             db.session.commit()
 
             print("Populated annual billing {} for {} services".format(fy, services_result1.rowcount))
+
+
+class ReRunBuildDvlaFileForJob(Command):
+    option_list = (
+        Option('-j', '--job_id', dest='job_id', help="Enter the job id to rebuild the dvla file for"),
+    )
+
+    def run(self, job_id):
+        from app.celery.tasks import build_dvla_file
+        from app.config import QueueNames
+        build_dvla_file.apply_async([job_id], queue=QueueNames.JOBS)

--- a/application.py
+++ b/application.py
@@ -23,8 +23,8 @@ manager.add_command('populate_service_sms_sender', commands.PopulateServiceSmsSe
 manager.add_command('populate_service_letter_contact', commands.PopulateServiceLetterContact)
 manager.add_command('populate_service_and_service_history_free_sms_fragment_limit',
                     commands.PopulateServiceAndServiceHistoryFreeSmsFragmentLimit)
-manager.add_command('populate_annual_billing',
-                    commands.PopulateAnnualBilling)
+manager.add_command('populate_annual_billing', commands.PopulateAnnualBilling)
+manager.add_command('rerun_build_dvla_file', commands.ReRunBuildDvlaFileForJob)
 
 
 @manager.command

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,6 @@ notifications-python-client==4.5.0
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@21.5.0#egg=notifications-utils==21.5.0
+git+https://github.com/alphagov/notifications-utils.git@21.5.1#egg=notifications-utils==21.5.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
- Update utils with a fix for address formats for letters. 
- Added a command to re-run the build_dvla_file for a given job id.  
There was an instance where the file failed to create because the address in the personalisation had punctuation which caused the address lines to merge into one.
Utils has been updated to fix that problem, this task will allow us to re-run the task so that the notifications can be sent.