### PR TITLE
Work out SMS message prefixing in a way that is aware of multiple SMS senders

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -48,7 +48,7 @@ def send_sms_to_provider(notification):
         )
         template_model = dao_get_template_by_id(notification.template_id, notification.template_version)
 
-        sender_has_been_customised = (not service.prefix_sms_with_service_name())
+        sender_has_been_customised = (not service.get_prefix_sms_with_service_name())
 
         template = SMSMessageTemplate(
             template_model.__dict__,

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -47,11 +47,14 @@ def send_sms_to_provider(notification):
             "Starting sending SMS {} to provider at {}".format(notification.id, datetime.utcnow())
         )
         template_model = dao_get_template_by_id(notification.template_id, notification.template_version)
+
+        sender_has_been_customised = (not service.prefix_sms_with_service_name())
+
         template = SMSMessageTemplate(
             template_model.__dict__,
             values=notification.personalisation,
             prefix=service.name,
-            sender=service.sms_sender not in {None, current_app.config['FROM_NUMBER']}
+            sender=sender_has_been_customised,
         )
 
         if service.research_mode or notification.key_type == KEY_TYPE_TEST:

--- a/app/models.py
+++ b/app/models.py
@@ -224,6 +224,7 @@ class Service(db.Model, Versioned):
     _reply_to_email_address = db.Column("reply_to_email_address", db.Text, index=False, unique=False, nullable=True)
     _letter_contact_block = db.Column('letter_contact_block', db.Text, index=False, unique=False, nullable=True)
     sms_sender = db.Column(db.String(11), nullable=False, default=lambda: current_app.config['FROM_NUMBER'])
+    prefix_sms = db.Column(db.Boolean, nullable=True)
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey('organisation.id'), index=True, nullable=True)
     free_sms_fragment_limit = db.Column(db.BigInteger, index=False, unique=False, nullable=True)
     organisation = db.relationship('Organisation')
@@ -280,7 +281,9 @@ class Service(db.Model, Versioned):
         default_letter_contact = [x for x in self.letter_contacts if x.is_default]
         return default_letter_contact[0].contact_block if default_letter_contact else None
 
-    def prefix_sms_with_service_name(self):
+    def get_prefix_sms_with_service_name(self):
+        if self.prefix_sms is not None:
+            return self.prefix_sms
         return self.get_default_sms_sender() == current_app.config['FROM_NUMBER']
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -280,6 +280,9 @@ class Service(db.Model, Versioned):
         default_letter_contact = [x for x in self.letter_contacts if x.is_default]
         return default_letter_contact[0].contact_block if default_letter_contact else None
 
+    def prefix_sms_with_service_name(self):
+        return self.get_default_sms_sender() == current_app.config['FROM_NUMBER']
+
 
 class AnnualBilling(db.Model):
     __tablename__ = "annual_billing"

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -188,6 +188,7 @@ class ServiceSchema(BaseSchema):
     reply_to_email_address = fields.Method(method_name="get_reply_to_email_address")
     sms_sender = fields.Method(method_name="get_sms_sender")
     letter_contact_block = fields.Method(method_name="get_letter_contact")
+    prefix_sms_with_service_name = fields.Method(method_name="get_prefix_sms_with_service_name")
 
     def service_permissions(self, service):
         return [p.permission for p in service.permissions]
@@ -200,6 +201,9 @@ class ServiceSchema(BaseSchema):
 
     def get_letter_contact(self, service):
         return service.get_default_letter_contact()
+
+    def get_prefix_sms_with_service_name(self, service):
+        return service.prefix_sms_with_service_name()
 
     class Meta:
         model = models.Service

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -203,7 +203,7 @@ class ServiceSchema(BaseSchema):
         return service.get_default_letter_contact()
 
     def get_prefix_sms_with_service_name(self, service):
-        return service.prefix_sms_with_service_name()
+        return service.get_prefix_sms_with_service_name()
 
     class Meta:
         model = models.Service

--- a/migrations/versions/0132_add_sms_prefix_setting.py
+++ b/migrations/versions/0132_add_sms_prefix_setting.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0132_add_sms_prefix_setting
+Revises: 0131_user_auth_types
+Create Date: 2017-11-03 11:07:40.537006
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0132_add_sms_prefix_setting'
+down_revision = '0131_user_auth_types'
+
+
+def upgrade():
+    op.add_column('services', sa.Column('prefix_sms', sa.Boolean(), nullable=True))
+    op.add_column('services_history', sa.Column('prefix_sms', sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('services_history', 'prefix_sms')
+    op.drop_column('services', 'prefix_sms')

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -67,7 +67,8 @@ def create_service(
     research_mode=False,
     active=True,
     do_create_inbound_number=True,
-    email_from=None
+    email_from=None,
+    prefix_sms=None,
 ):
     service = Service(
         name=service_name,
@@ -76,6 +77,7 @@ def create_service(
         email_from=email_from if email_from else service_name.lower().replace(' ', '.'),
         created_by=user or create_user(email='{}@digital.cabinet-office.gov.uk'.format(uuid.uuid4())),
         sms_sender=sms_sender,
+        prefix_sms=prefix_sms,
     )
 
     dao_create_service(service, service.created_by, service_id, service_permissions=service_permissions)


### PR DESCRIPTION
## Add prefix SMS with service name to service model

If the service is sending messages from GOVUK, then its messages should be prefixed with the service name. Right now this logic is:
- worked out separately in the admin app and API
- isn’t aware of multiple senders

This commit moves the logic to one place (the service model). It does this in a slightly naive way, in that it only looks at the default sender, not the actual sender of the message.

In the future this will go away because we’ll move it to being a setting that’s controlled independently of the service name. But this is the first step towards that.

## Look at model to work out whether to prefix message

`service.sms_sender` has been deprecated; we should be looking at which of the service’s SMS senders is default to work out if the message has been sent from GOVUK or not (and if it has, then prefix the message with the service name). This logic is now in the model, so this commit makes use of it.

The arguments to `SMSMessageTemplate` are _super_ badly named – `sender` isn’t really used as a string, it’s a boolean that effectively means ‘is this a custom sender (`True`) or the platform default (`False`)’. We should rename it once this bug is fixed.