### PR TITLE
Default new services to prefixing text messages

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -224,7 +224,7 @@ class Service(db.Model, Versioned):
     _reply_to_email_address = db.Column("reply_to_email_address", db.Text, index=False, unique=False, nullable=True)
     _letter_contact_block = db.Column('letter_contact_block', db.Text, index=False, unique=False, nullable=True)
     sms_sender = db.Column(db.String(11), nullable=False, default=lambda: current_app.config['FROM_NUMBER'])
-    prefix_sms = db.Column(db.Boolean, nullable=True)
+    prefix_sms = db.Column(db.Boolean, nullable=True, default=True)
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey('organisation.id'), index=True, nullable=True)
     free_sms_fragment_limit = db.Column(db.BigInteger, index=False, unique=False, nullable=True)
     organisation = db.relationship('Organisation')

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -93,6 +93,7 @@ def test_create_service(sample_user):
     assert service_db.branding == BRANDING_GOVUK
     assert service_db.dvla_organisation_id == DVLA_ORG_HM_GOVERNMENT
     assert service_db.research_mode is False
+    assert service_db.prefix_sms is True
     assert service.active is True
     assert sample_user in service_db.users
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1562,18 +1562,18 @@ def test_set_sms_sender_for_service_rejects_null(client, sample_service):
     assert result['message'] == {'sms_sender': ['Field may not be null.']}
 
 
-@pytest.mark.parametrize('default_sms_sender, should_prefix', [
-    (None, True),  # None means use default
-    ('Foo', False),
+@pytest.mark.parametrize('service_attribute, should_prefix', [
+    (True, True),
+    (False, False),
 ])
 def test_prefixing_messages_based_on_sms_sender(
     client,
     notify_db_session,
-    default_sms_sender,
+    service_attribute,
     should_prefix,
 ):
     service = create_service(
-        sms_sender=default_sms_sender or current_app.config['FROM_NUMBER']
+        prefix_sms=service_attribute
     )
     create_service_sms_sender(
         service=service,


### PR DESCRIPTION
We want new services, when they do the tour, to see how the service name they just made shows up in the messages. This is how it (should) work at the moment (although got broken because of the multiple senders stuff).

Need to do this before we do the migration now otherwise a new service could sneak in with this setting still set to `null`.

---

Depends on:
- [x] https://github.com/alphagov/notifications-admin/pull/1610 (otherwise new services will have no way of undoing this)