### PR TITLE
Migrate prefix SMS setting to be true or false

### DIFF
--- a/migrations/versions/0133_set_services_sms_prefix.py
+++ b/migrations/versions/0133_set_services_sms_prefix.py
@@ -1,0 +1,42 @@
+import os
+from app import config
+"""
+
+Revision ID: 0133_set_services_sms_prefix
+Revises: 0132_add_sms_prefix_setting
+Create Date: 2017-11-03 15:55:35.657488
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0133_set_services_sms_prefix'
+down_revision = '0132_add_sms_prefix_setting'
+
+
+config = config.configs[os.environ['NOTIFY_ENVIRONMENT']]
+default_sms_sender = config.FROM_NUMBER
+
+
+def upgrade():
+    op.execute("""
+        update services set prefix_sms = True
+        where id in (
+            select service_id from service_sms_senders
+            where is_default = True and sms_sender = '{}'
+        )
+    """.format(default_sms_sender))
+    op.execute("""
+        update services set prefix_sms = False
+        where id in (
+            select service_id from service_sms_senders
+            where is_default = True and sms_sender != '{}'
+        )
+    """.format(default_sms_sender))
+
+
+def downgrade():
+    op.execute("""
+        UPDATE services set prefix_sms = null
+    """)


### PR DESCRIPTION
We want services to have control over this setting, rather than deriving it from the value of their sender. This commit does that derivation one last time, and stores it in the column, where it can be changed as and when needed.

Depends on: 
- [x] https://github.com/alphagov/notifications-api/pull/1369