### PR TITLE
Make SMS prefix setting non-nullable

### DIFF
--- a/migrations/versions/0140_sms_prefix_non_nullable.py
+++ b/migrations/versions/0140_sms_prefix_non_nullable.py
@@ -1,0 +1,46 @@
+"""
+
+Revision ID: 0140_sms_prefix_non_nullable
+Revises: 0139_migrate_sms_allowance_data
+Create Date: 2017-11-07 13:04:04.077142
+
+"""
+from alembic import op
+from flask import current_app
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0140_sms_prefix_non_nullable'
+down_revision = '0139_migrate_sms_allowance_data'
+
+
+def upgrade():
+
+    op.execute("""
+        update services
+        set prefix_sms = false
+        where id = '{}'
+    """.format(current_app.config['NOTIFY_SERVICE_ID']))
+
+    op.alter_column(
+        'services',
+        'prefix_sms',
+        existing_type=sa.BOOLEAN(),
+        nullable=False,
+    )
+
+
+def downgrade():
+
+    op.alter_column(
+        'services',
+        'prefix_sms',
+        existing_type=sa.BOOLEAN(),
+        nullable=True,
+    )
+
+    op.execute("""
+        update services
+        set prefix_sms = null
+        where id = '{}'
+    """.format(current_app.config['NOTIFY_SERVICE_ID']))

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -992,7 +992,7 @@ def notify_service(notify_db, notify_db_session):
             'active': True,
             'restricted': False,
             'email_from': 'notify.service',
-            'created_by': user
+            'created_by': user,
         }
         service = Service(**data)
         db.session.add(service)

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -68,7 +68,7 @@ def create_service(
     research_mode=False,
     active=True,
     email_from=None,
-    prefix_sms=None,
+    prefix_sms=True,
 ):
     service = Service(
         name=service_name,

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -159,6 +159,7 @@ def test_get_service_by_id(client, sample_service):
     assert json_resp['data']['dvla_organisation'] == '001'
     assert json_resp['data']['sms_sender'] == current_app.config['FROM_NUMBER']
     assert json_resp['data']['prefix_sms_with_service_name'] is True
+    assert json_resp['data']['prefix_sms'] is True
 
 
 def test_get_service_by_id_returns_free_sms_limit(client, sample_service):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1551,7 +1551,6 @@ def test_prefixing_messages_based_on_prefix_sms(
 @pytest.mark.parametrize('posted_value, stored_value, returned_value', [
     (True, True, True),
     (False, False, False),
-    (None, None, True),
 ])
 def test_set_sms_prefixing_for_service(
     client,
@@ -1579,6 +1578,18 @@ def test_set_sms_prefixing_for_service(
     # The derived value is dependent on the service sending from the platform’s
     # default from number
     assert result['data']['sms_sender'] == current_app.config['FROM_NUMBER']
+
+
+def test_set_sms_prefixing_for_service_cant_be_none(
+    admin_request,
+    sample_service,
+):
+    admin_request.post(
+        'service.update_service',
+        service_id=sample_service.id,
+        _data={'prefix_sms': None},
+        _expected_status=500,
+    )
 
 
 @pytest.mark.parametrize('today_only,stats', [

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1553,25 +1553,18 @@ def test_prefixing_messages_based_on_prefix_sms(
     (False, False, False),
 ])
 def test_set_sms_prefixing_for_service(
+    admin_request,
     client,
     sample_service,
     posted_value,
     stored_value,
     returned_value,
 ):
-    data = {
-        'prefix_sms': posted_value,
-    }
-
-    auth_header = create_authorization_header()
-
-    resp = client.post(
-        '/service/{}'.format(sample_service.id),
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header]
+    result = admin_request.post(
+        'service.update_service',
+        service_id=sample_service.id,
+        _data={'prefix_sms': posted_value},
     )
-    result = json.loads(resp.get_data(as_text=True))
-    assert resp.status_code == 200
     assert result['data']['prefix_sms'] == stored_value
     # This derived value will go away eventually, once we’ve done a migration
     assert result['data']['prefix_sms_with_service_name'] == returned_value


### PR DESCRIPTION
We have now:
- defaulted new services to start with this column set to `true`
- migrated all preexisting services to have either `true` or `false` set for this column

There is no way for a service to switch back from `true`/`false` to `null`.

This means that we can safely enforce a non-nullable constraint on this column now.

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/1370