### PR TITLE
remove check to financial_year_start in schema as it can be None

### DIFF
--- a/app/billing/billing_schemas.py
+++ b/app/billing/billing_schemas.py
@@ -8,7 +8,6 @@ create_or_update_free_sms_fragment_limit_schema = {
     "title": "Create",
     "properties": {
         "free_sms_fragment_limit": {"type": "integer", "minimum": 1},
-        "financial_year_start": {"type": "integer", "minimum": 2016}
     },
     "required": ["free_sms_fragment_limit"]
 }


### PR DESCRIPTION
A small pull request that remove the schema check of financial_year_start as this parameter is allowed to be None