### PR TITLE
remove trailing underscore, which is sometimes created by alembic

### DIFF
--- a/scripts/check_if_new_migration.py
+++ b/scripts/check_if_new_migration.py
@@ -8,7 +8,8 @@ def get_latest_db_migration_to_apply():
     project_dir = dirname(dirname(abspath(__file__)))  # Get the main project directory
     migrations_dir = '{}/migrations/versions/'.format(project_dir)
     migration_files = [migration_file for migration_file in os.listdir(migrations_dir) if migration_file.endswith('py')]
-    latest_file = sorted(migration_files, reverse=True)[0].replace('.py', '')
+    # sometimes there's a trailing underscore, if script was created with `python app.py db migrate --rev-id=...`
+    latest_file = sorted(migration_files, reverse=True)[0].replace('_.py', '').replace('.py', '')
     return latest_file
 
 


### PR DESCRIPTION
was causing jenkins to always run DB migrations