### PR TITLE
User mobile optional

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -94,7 +94,7 @@ def register_errors(blueprint):
         current_app.logger.exception(e)
         if hasattr(e, 'orig') and hasattr(e.orig, 'pgerror') and e.orig.pgerror and \
             ('duplicate key value violates unique constraint "services_name_key"' in e.orig.pgerror or
-                'duplicate key value violates unique constraint "services_email_from_key"' in e.orig.pgerror):
+             'duplicate key value violates unique constraint "services_email_from_key"' in e.orig.pgerror):
             return jsonify(
                 result='error',
                 message={'name': ["Duplicate service name '{}'".format(

--- a/app/models.py
+++ b/app/models.py
@@ -563,7 +563,7 @@ class Template(db.Model):
         nullable=False,
         default=NORMAL
     )
-    
+
     redact_personalisation = association_proxy('template_redacted', 'redact_personalisation')
 
     def get_link(self):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -105,6 +105,26 @@ class UserSchema(BaseSchema):
             "_password", "verify_codes")
         strict = True
 
+    @validates('name')
+    def validate_name(self, value):
+        if not value:
+            raise ValidationError('Invalid name')
+
+    @validates('email_address')
+    def validate_email_address(self, value):
+        try:
+            validate_email_address(value)
+        except InvalidEmailError as e:
+            raise ValidationError(str(e))
+
+    @validates('mobile_number')
+    def validate_mobile_number(self, value):
+        try:
+            if value is not None:
+                validate_phone_number(value, international=True)
+        except InvalidPhoneError as error:
+            raise ValidationError('Invalid phone number: {}'.format(error))
+
 
 class UserUpdateAttributeSchema(BaseSchema):
     auth_type = field_for(models.User, 'auth_type')
@@ -132,7 +152,8 @@ class UserUpdateAttributeSchema(BaseSchema):
     @validates('mobile_number')
     def validate_mobile_number(self, value):
         try:
-            validate_phone_number(value, international=True)
+            if value is not None:
+                validate_phone_number(value, international=True)
         except InvalidPhoneError as error:
             raise ValidationError('Invalid phone number: {}'.format(error))
 

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from urllib.parse import urlencode
 
 from flask import (jsonify, request, Blueprint, current_app, abort)
+from sqlalchemy.exc import IntegrityError
 
 from app.config import QueueNames
 from app.dao.users_dao import (
@@ -50,6 +51,19 @@ from app.schema_validation import validate
 
 user_blueprint = Blueprint('user', __name__)
 register_errors(user_blueprint)
+
+
+@user_blueprint.errorhandler(IntegrityError)
+def handle_integrity_error(exc):
+    """
+    Handle integrity errors caused by the auth type/mobile number check constraint
+    """
+    if 'ck_users_mobile_or_email_auth' in str(exc):
+        # we don't expect this to trip, so still log error
+        current_app.logger.exception('Check constraint ck_users_mobile_or_email_auth triggered')
+        return jsonify(result='error', message='Mobile number must be set if auth_type is set to sms_auth'), 400
+
+    raise
 
 
 @user_blueprint.route('', methods=['POST'])

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -77,23 +77,6 @@ def create_user():
     return jsonify(data=user_schema.dump(user_to_create).data), 201
 
 
-@user_blueprint.route('/<uuid:user_id>', methods=['PUT'])
-def update_user(user_id):
-    user_to_update = get_user_by_id(user_id=user_id)
-    req_json = request.get_json()
-    update_dct, errors = user_schema_load_json.load(req_json)
-    # TODO don't let password be updated in this PUT method (currently used by the forgot password flow)
-    pwd = req_json.get('password', None)
-    if pwd is not None:
-        if not pwd:
-            errors.update({'password': ['Invalid data for field']})
-            raise InvalidRequest(errors, status_code=400)
-        else:
-            reset_failed_login_count(user_to_update)
-    save_model_user(user_to_update, update_dict=update_dct, pwd=pwd)
-    return jsonify(data=user_schema.dump(user_to_update).data), 200
-
-
 @user_blueprint.route('/<uuid:user_id>', methods=['POST'])
 def update_user_attribute(user_id):
     user_to_update = get_user_by_id(user_id=user_id)

--- a/migrations/versions/0136_user_mobile_nullable.py
+++ b/migrations/versions/0136_user_mobile_nullable.py
@@ -1,0 +1,28 @@
+"""
+
+Revision ID: 0136_user_mobile_nullable
+Revises: 0135_stats_template_usage
+Create Date: 2017-11-08 11:49:05.773974
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import column
+from sqlalchemy.dialects import postgresql
+
+revision = '0136_user_mobile_nullable'
+down_revision = '0135_stats_template_usage'
+
+
+def upgrade():
+    op.alter_column('users', 'mobile_number', nullable=True)
+
+    op.create_check_constraint(
+        'ck_users_mobile_or_email_auth',
+        'users',
+        "auth_type = 'email_auth' or mobile_number is not null"
+    )
+
+def downgrade():
+    op.alter_column('users', 'mobile_number', nullable=False)
+    op.drop_constraint('ck_users_mobile_or_email_auth', 'users')

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -564,3 +564,13 @@ def test_cannot_update_user_with_mobile_number_as_empty_string(admin_request, sa
         _expected_status=400
     )
     assert resp['message']['mobile_number'] == ['Invalid phone number: Not enough digits']
+
+
+def test_cannot_update_user_password_using_attributes_method(admin_request, sample_user):
+    resp = admin_request.post(
+        'user.update_user_attribute',
+        user_id=sample_user.id,
+        _data={'password': 'foo'},
+        _expected_status=400
+    )
+    assert resp['message']['_schema'] == ['Unknown field name password']


### PR DESCRIPTION
You can set both at the same time if you want.

If not, it currently gives a message "Mobile number must be set if auth_type is set to sms_auth". idk if we want to tweak that to make it a front-end display ready error message.


Also removed `PUT /user/<id>` as it's unused on the front-end