### PR TITLE
Handling Null template_id for monthly stats

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -414,9 +414,10 @@ def daily_stats_template_usage_by_month():
     results = dao_fetch_monthly_historical_stats_by_template()
 
     for result in results:
-        insert_or_update_stats_for_template(
-            result.template_id,
-            result.month,
-            result.year,
-            result.count
-        )
+        if result.template_id:
+            insert_or_update_stats_for_template(
+                result.template_id,
+                result.month,
+                result.year,
+                result.count
+            )


### PR DESCRIPTION
There are some Null template_ids in the production database which was
causing a failure as the stats_template_usage_by_month has a constraint
that it should not be null. This update only adds populated template_ids

- Updated Celery task
- Add a new test to test for null template_ids and not try to add them to the stats