### PR TITLE
Allow include jobs request param on v2 get all notifications

### DIFF
--- a/app/v2/notifications/get_notifications.py
+++ b/app/v2/notifications/get_notifications.py
@@ -35,6 +35,9 @@ def get_notifications():
     if 'reference' in _data:
         _data['reference'] = _data['reference'][0]
 
+    if 'include_jobs' in _data:
+        _data['include_jobs'] = _data['include_jobs'][0]
+
     data = validate(_data, get_notifications_request)
 
     paginated_notifications = notifications_dao.get_notifications_for_service(
@@ -44,7 +47,8 @@ def get_notifications():
         personalisation=True,
         older_than=data.get('older_than'),
         client_reference=data.get('reference'),
-        page_size=current_app.config.get('API_PAGE_SIZE')
+        page_size=current_app.config.get('API_PAGE_SIZE'),
+        include_jobs=data.get('include_jobs')
     )
 
     def _build_links(notifications):

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -74,6 +74,7 @@ get_notifications_request = {
                 "enum": TEMPLATE_TYPES
             }
         },
+        "include_jobs": {"enum": ["true", "True"]},
         "older_than": uuid
     },
     "additionalProperties": False,
@@ -88,7 +89,7 @@ get_notifications_response = {
             "type": "array",
             "items": {
                 "type": "object",
-                "ref": get_notification_response
+                "$ref": "#/definitions/notification"
             }
         },
         "links": {
@@ -106,7 +107,11 @@ get_notifications_response = {
         }
     },
     "additionalProperties": False,
-    "required": ["notifications", "links"]
+    "required": ["notifications", "links"],
+    "definitions": {
+        "notification": get_notification_response
+    },
+
 }
 
 post_sms_request = {

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -266,7 +266,8 @@ def test_get_notification_doesnt_have_delivery_estimate_for_non_letters(
     assert 'estimated_delivery' not in json.loads(response.get_data(as_text=True))
 
 
-def test_get_all_notifications_returns_200(client, sample_template):
+def test_get_all_notifications_except_job_notifications_returns_200(client, sample_template, sample_job):
+    create_notification(template=sample_template, job=sample_job)  # should not return this job notification
     notifications = [create_notification(template=sample_template) for _ in range(2)]
     notification = notifications[-1]
 

--- a/tests/app/v2/notifications/test_notification_schemas.py
+++ b/tests/app/v2/notifications/test_notification_schemas.py
@@ -5,12 +5,29 @@ from flask import json
 from freezegun import freeze_time
 from jsonschema import ValidationError
 
+from app.models import NOTIFICATION_CREATED, EMAIL_TYPE
 from app.schema_validation import validate
 from app.v2.notifications.notification_schemas import (
     get_notifications_request,
     post_sms_request as post_sms_request_schema,
     post_email_request as post_email_request_schema
 )
+
+
+valid_get_json = {}
+
+valid_get_with_optionals_json = {
+    "reference": "test reference",
+    "status": [NOTIFICATION_CREATED],
+    "template_type": [EMAIL_TYPE],
+    "include_jobs": "true",
+    "older_than": "a5149c32-f03b-4711-af49-ad6993797d45"
+}
+
+
+@pytest.mark.parametrize("input", [valid_get_json, valid_get_with_optionals_json])
+def test_get_notifications_valid_json(input):
+    assert validate(input, get_notifications_request) == input
 
 
 @pytest.mark.parametrize('invalid_statuses, valid_statuses', [


### PR DESCRIPTION
## What

In order to get the functional tests to work with the v2 endpoint we need to allow it to handle the `include_jobs` argument to return all notifications including ones created by jobs.

## Reference 

https://www.pivotaltracker.com/story/show/152925357