### PR TITLE
Template usage stats updates for FY usage and bug fix

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -550,7 +550,7 @@ def dao_fetch_monthly_historical_usage_by_template_for_service(service_id, year)
 
     results = dao_get_template_usage_stats_by_service(service_id, year)
 
-    stats = list()
+    stats = []
     for result in results:
         stat = type("", (), {})()
         stat.template_id = result.template_id
@@ -575,7 +575,7 @@ def dao_fetch_monthly_historical_usage_by_template_for_service(service_id, year)
     ).join(
         Template, Notification.template_id == Template.id,
     ).filter(
-        Notification.created_at >= start_date
+        Notification.created_at >= start_date,
     ).group_by(
         Notification.template_id,
         Template.name,
@@ -599,8 +599,8 @@ def dao_fetch_monthly_historical_usage_by_template_for_service(service_id, year)
             new_stat.template_id = today_result.template_id
             new_stat.template_type = today_result.template_type
             new_stat.name = today_result.name
-            new_stat.month = today_result.month
-            new_stat.year = today_result.year
+            new_stat.month = int(today_result.month)
+            new_stat.year = int(today_result.year)
             new_stat.count = today_result.count
             stats.append(new_stat)
 

--- a/app/dao/stats_template_usage_by_month_dao.py
+++ b/app/dao/stats_template_usage_by_month_dao.py
@@ -1,3 +1,5 @@
+from sqlalchemy import or_, and_
+
 from app import db
 from app.statsd_decorators import statsd
 from app.dao.dao_utils import transactional
@@ -41,6 +43,15 @@ def dao_get_template_usage_stats_by_service(service_id, year):
     ).join(
         Template, StatsTemplateUsageByMonth.template_id == Template.id
     ).filter(
-        Template.service_id == service_id,
-        StatsTemplateUsageByMonth.year == year
+        Template.service_id == service_id
+    ).filter(
+        or_(
+            and_(
+                StatsTemplateUsageByMonth.month.in_([4, 5, 6, 7, 8, 9, 10, 11, 12]),
+                StatsTemplateUsageByMonth.year == year
+            ), and_(
+                StatsTemplateUsageByMonth.month.in_([1, 2, 3]),
+                StatsTemplateUsageByMonth.year == year + 1
+            )
+        )
     ).all()

--- a/tests/app/dao/test_stats_template_usage_by_month_dao.py
+++ b/tests/app/dao/test_stats_template_usage_by_month_dao.py
@@ -51,55 +51,75 @@ def test_dao_get_template_usage_stats_by_service(sample_service):
 
     email_template = create_template(service=sample_service, template_type="email")
 
-    stats1 = StatsTemplateUsageByMonth(
+    new_service = create_service(service_name="service_one")
+
+    template_new_service = create_template(service=new_service)
+
+    db.session.add(StatsTemplateUsageByMonth(
         template_id=email_template.id,
-        month=1,
+        month=4,
         year=2017,
         count=10
-    )
+    ))
 
-    stats2 = StatsTemplateUsageByMonth(
-        template_id=email_template.id,
-        month=2,
+    db.session.add(StatsTemplateUsageByMonth(
+        template_id=template_new_service.id,
+        month=4,
         year=2017,
         count=10
-    )
-
-    db.session.add(stats1)
-    db.session.add(stats2)
+    ))
 
     result = dao_get_template_usage_stats_by_service(sample_service.id, 2017)
 
-    assert len(result) == 2
+    assert len(result) == 1
 
 
 def test_dao_get_template_usage_stats_by_service_specific_year(sample_service):
 
     email_template = create_template(service=sample_service, template_type="email")
 
-    stats1 = StatsTemplateUsageByMonth(
+    db.session.add(StatsTemplateUsageByMonth(
         template_id=email_template.id,
-        month=1,
-        year=2016,
-        count=10
-    )
-
-    stats2 = StatsTemplateUsageByMonth(
-        template_id=email_template.id,
-        month=2,
+        month=3,
         year=2017,
         count=10
-    )
+    ))
 
-    db.session.add(stats1)
-    db.session.add(stats2)
+    db.session.add(StatsTemplateUsageByMonth(
+        template_id=email_template.id,
+        month=4,
+        year=2017,
+        count=10
+    ))
+
+    db.session.add(StatsTemplateUsageByMonth(
+        template_id=email_template.id,
+        month=3,
+        year=2018,
+        count=10
+    ))
+
+    db.session.add(StatsTemplateUsageByMonth(
+        template_id=email_template.id,
+        month=4,
+        year=2018,
+        count=10
+    ))
 
     result = dao_get_template_usage_stats_by_service(sample_service.id, 2017)
 
-    assert len(result) == 1
+    assert len(result) == 2
+
     assert result[0].template_id == email_template.id
     assert result[0].name == email_template.name
     assert result[0].template_type == email_template.template_type
-    assert result[0].month == 2
+    assert result[0].month == 4
     assert result[0].year == 2017
     assert result[0].count == 10
+
+    assert result[1].template_id == email_template.id
+    assert result[1].name == email_template.name
+    assert result[1].template_type == email_template.template_type
+    assert result[1].month == 3
+    assert result[1].year == 2018
+    assert result[1].count == 10


### PR DESCRIPTION
Return financial year not calendar year as the report on the admin UI is FY only and ensure double precision values are not returned from queries as the admin UI convert the number of the month to a word and this requires an int, however the 'extract' database function was returning a double precision float.

- Updated stats_template_usage_by_month_dao.py to return the results for financial year not calendar, as the report os for FY only and hence only the FY data is required
- Updated services_dao.py to ensure double precision values are converted to an int as the 'exact' function returns double precision from the database query, as the admin code requires the value for month to be an int
- Added tests for the above