### PR TITLE
Add FIRETEXT_INBOUND_SMS_AUTH config variable and auth check

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -45,6 +45,7 @@ def extract_notify_config(notify_config):
     os.environ['SECRET_KEY'] = notify_config['credentials']['secret_key']
     os.environ['DANGEROUS_SALT'] = notify_config['credentials']['dangerous_salt']
     os.environ['SMS_INBOUND_WHITELIST'] = json.dumps(notify_config['credentials']['allow_ip_inbound_sms'])
+    os.environ['FIRETEXT_INBOUND_SMS_AUTH'] = json.dumps(notify_config['credentials']['firetext_inbound_sms_auth'])
     os.environ['ROUTE_SECRET_KEY_1'] = notify_config['credentials']['route_secret_key_1']
     os.environ['ROUTE_SECRET_KEY_2'] = notify_config['credentials']['route_secret_key_2']
 

--- a/app/config.py
+++ b/app/config.py
@@ -295,6 +295,8 @@ class Config(object):
     FREE_SMS_TIER_FRAGMENT_COUNT = 250000
 
     SMS_INBOUND_WHITELIST = json.loads(os.environ.get('SMS_INBOUND_WHITELIST', '[]'))
+    FIRETEXT_INBOUND_SMS_AUTH = json.loads(os.environ.get('FIRETEXT_INBOUND_SMS_AUTH', '[]'))
+
     ROUTE_SECRET_KEY_1 = os.environ.get('ROUTE_SECRET_KEY_1', '')
     ROUTE_SECRET_KEY_2 = os.environ.get('ROUTE_SECRET_KEY_2', '')
 
@@ -364,6 +366,7 @@ class Test(Config):
     }
 
     SMS_INBOUND_WHITELIST = ['203.0.113.195']
+    FIRETEXT_INBOUND_SMS_AUTH = ['testkey']
 
 
 class Preview(Config):

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -17,6 +17,7 @@ def notify_config():
             'secret_key': 'secret key',
             'dangerous_salt': 'dangerous salt',
             'allow_ip_inbound_sms': ['111.111.111.111', '100.100.100.100'],
+            'firetext_inbound_sms_auth': ['testkey'],
             'route_secret_key_1': "key_1",
             'route_secret_key_2': ""
         }
@@ -209,6 +210,13 @@ def test_sms_inbound_config():
     extract_cloudfoundry_config()
 
     assert os.environ['SMS_INBOUND_WHITELIST'] == json.dumps(['111.111.111.111', '100.100.100.100'])
+
+
+@pytest.mark.usefixtures('os_environ', 'cloudfoundry_environ')
+def test_firetext_inbound_sms_auth_config():
+    extract_cloudfoundry_config()
+
+    assert os.environ['FIRETEXT_INBOUND_SMS_AUTH'] == json.dumps(['testkey'])
 
 
 @pytest.mark.usefixtures('os_environ', 'cloudfoundry_environ')


### PR DESCRIPTION
Checks authentication header value on inbound SMS requests from
Firetext against a list of allowed API keys set in the application
config.

At the moment, we're only logging the attempts without aborting the
requests. Once this is rolled out to production and we've checked
the logs we'll switch on the aborts and add the tests for 401 and 403
responses.

Pivotal: https://www.pivotaltracker.com/story/show/152964252