### PR TITLE
Fixed bug in test which was passing but not testing the services_dao properly

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -576,6 +576,7 @@ def dao_fetch_monthly_historical_usage_by_template_for_service(service_id, year)
         Template, Notification.template_id == Template.id,
     ).filter(
         Notification.created_at >= start_date,
+        Notification.service_id == service_id
     ).group_by(
         Notification.template_id,
         Template.name,

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -1496,6 +1496,13 @@ def test_dao_fetch_monthly_historical_usage_by_template_for_service_only_returns
     notification_history(created_at=datetime(year, 2, day))
 
     service_two = create_service(service_name='other_service')
+    template_two = create_sample_template(
+        notify_db,
+        notify_db_session,
+        template_name='1',
+        template_type='email',
+        service=service_two
+    )
 
     daily_stats_template_usage_by_month()
 
@@ -1503,7 +1510,7 @@ def test_dao_fetch_monthly_historical_usage_by_template_for_service_only_returns
         notify_db,
         notify_db_session,
         service=sample_service,
-        template=template_one,
+        template=template_two,
         created_at=datetime.utcnow()
     )
 


### PR DESCRIPTION
The dao_fetch_monthly_historical_usage_by_template_for_service code wasn't being tested properly due to an bug on the test which created a notification with the same template and hence was not testing that a specific service would have a different template id.

- Fixed the bug in the test
- Update services_dao so that the service id check is made