### PR TITLE
 Template usage always aggregating today's stats 

### DIFF
--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -1471,6 +1471,13 @@ def test_dao_fetch_monthly_historical_usage_by_template_for_service_returns_fina
     assert result[4].month == 3
     assert result[4].year == 2018
 
+    result = sorted(
+        dao_fetch_monthly_historical_usage_by_template_for_service(n.service_id, 2014),
+        key=lambda x: (x.year, x.month)
+    )
+
+    assert len(result) == 0
+
 
 @freeze_time("2018-03-10 11:09:00.000000")
 def test_dao_fetch_monthly_historical_usage_by_template_for_service_only_returns_for_service(

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1862,7 +1862,7 @@ def test_get_template_usage_by_month_returns_correct_data(
         notify_db,
         notify_db_session,
         sample_template,
-        created_at=datetime(2016, 4, 1),
+        created_at=datetime(2017, 4, 1),
         status='sending'
     )
 
@@ -1870,7 +1870,7 @@ def test_get_template_usage_by_month_returns_correct_data(
         notify_db,
         notify_db_session,
         sample_template,
-        created_at=datetime(2016, 4, 1),
+        created_at=datetime(2017, 4, 1),
         status='permanent-failure'
     )
 
@@ -1878,7 +1878,7 @@ def test_get_template_usage_by_month_returns_correct_data(
         notify_db,
         notify_db_session,
         sample_template,
-        created_at=datetime(2016, 4, 1),
+        created_at=datetime(2017, 4, 1),
         status='temporary-failure'
     )
 
@@ -1890,7 +1890,7 @@ def test_get_template_usage_by_month_returns_correct_data(
     )
 
     resp = client.get(
-        '/service/{}/notifications/templates_usage/monthly?year=2016'.format(not1.service_id),
+        '/service/{}/notifications/templates_usage/monthly?year=2017'.format(not1.service_id),
         headers=[create_authorization_header()]
     )
     resp_json = json.loads(resp.get_data(as_text=True)).get('stats')
@@ -1902,8 +1902,8 @@ def test_get_template_usage_by_month_returns_correct_data(
     assert resp_json[0]["name"] == sample_template.name
     assert resp_json[0]["type"] == sample_template.template_type
     assert resp_json[0]["month"] == 4
-    assert resp_json[0]["year"] == 2016
-    assert resp_json[0]["count"] == 4
+    assert resp_json[0]["year"] == 2017
+    assert resp_json[0]["count"] == 3
 
     assert resp_json[1]["template_id"] == str(sample_template.id)
     assert resp_json[1]["name"] == sample_template.name
@@ -1911,6 +1911,63 @@ def test_get_template_usage_by_month_returns_correct_data(
     assert resp_json[1]["month"] == 11
     assert resp_json[1]["year"] == 2017
     assert resp_json[1]["count"] == 1
+
+
+@freeze_time('2017-11-11 02:00')
+def test_get_template_usage_by_month_returns_no_data(
+        notify_db,
+        notify_db_session,
+        client,
+        sample_template
+):
+
+    # add a historical notification for template
+    not1 = create_notification_history(
+        notify_db,
+        notify_db_session,
+        sample_template,
+        created_at=datetime(2016, 4, 1),
+    )
+
+    create_notification_history(
+        notify_db,
+        notify_db_session,
+        sample_template,
+        created_at=datetime(2017, 4, 1),
+        status='sending'
+    )
+
+    create_notification_history(
+        notify_db,
+        notify_db_session,
+        sample_template,
+        created_at=datetime(2017, 4, 1),
+        status='permanent-failure'
+    )
+
+    create_notification_history(
+        notify_db,
+        notify_db_session,
+        sample_template,
+        created_at=datetime(2017, 4, 1),
+        status='temporary-failure'
+    )
+
+    daily_stats_template_usage_by_month()
+
+    create_notification(
+        sample_template,
+        created_at=datetime.utcnow()
+    )
+
+    resp = client.get(
+        '/service/{}/notifications/templates_usage/monthly?year=2015'.format(not1.service_id),
+        headers=[create_authorization_header()]
+    )
+    resp_json = json.loads(resp.get_data(as_text=True)).get('stats')
+
+    assert resp.status_code == 200
+    assert len(resp_json) == 0
 
 
 @freeze_time('2017-11-11 02:00')
@@ -1929,14 +1986,14 @@ def test_get_template_usage_by_month_returns_two_templates(
         notify_db,
         notify_db_session,
         template_one,
-        created_at=datetime(2016, 4, 1),
+        created_at=datetime(2017, 4, 1),
     )
 
     create_notification_history(
         notify_db,
         notify_db_session,
         sample_template,
-        created_at=datetime(2016, 4, 1),
+        created_at=datetime(2017, 4, 1),
         status='sending'
     )
 
@@ -1944,7 +2001,7 @@ def test_get_template_usage_by_month_returns_two_templates(
         notify_db,
         notify_db_session,
         sample_template,
-        created_at=datetime(2016, 4, 1),
+        created_at=datetime(2017, 4, 1),
         status='permanent-failure'
     )
 
@@ -1952,7 +2009,7 @@ def test_get_template_usage_by_month_returns_two_templates(
         notify_db,
         notify_db_session,
         sample_template,
-        created_at=datetime(2016, 4, 1),
+        created_at=datetime(2017, 4, 1),
         status='temporary-failure'
     )
 
@@ -1964,7 +2021,7 @@ def test_get_template_usage_by_month_returns_two_templates(
     )
 
     resp = client.get(
-        '/service/{}/notifications/templates_usage/monthly?year=2016'.format(not1.service_id),
+        '/service/{}/notifications/templates_usage/monthly?year=2017'.format(not1.service_id),
         headers=[create_authorization_header()]
     )
     resp_json = json.loads(resp.get_data(as_text=True)).get('stats')
@@ -1978,14 +2035,14 @@ def test_get_template_usage_by_month_returns_two_templates(
     assert resp_json[0]["name"] == template_one.name
     assert resp_json[0]["type"] == template_one.template_type
     assert resp_json[0]["month"] == 4
-    assert resp_json[0]["year"] == 2016
+    assert resp_json[0]["year"] == 2017
     assert resp_json[0]["count"] == 1
 
     assert resp_json[1]["template_id"] == str(sample_template.id)
     assert resp_json[1]["name"] == sample_template.name
     assert resp_json[1]["type"] == sample_template.template_type
     assert resp_json[1]["month"] == 4
-    assert resp_json[1]["year"] == 2016
+    assert resp_json[1]["year"] == 2017
     assert resp_json[1]["count"] == 3
 
     assert resp_json[2]["template_id"] == str(sample_template.id)


### PR DESCRIPTION
- Added a check to ensure that the current date falls in between the financial year for the year supplied by the method, so that the todays stats will only be appended in that situation.
- The integration tests did test for zero return. Added a method to test for a year which has no data and also tweaked the existing tests to ensure they are testing the year more fully.

Pivotal: https://www.pivotaltracker.com/story/show/151679396