### PR TITLE
Allow letter templates to select the default contact block

### DIFF
--- a/app/history_meta.py
+++ b/app/history_meta.py
@@ -219,6 +219,8 @@ def create_history(obj, history_cls=None):
     data['created_at'] = obj.created_at
 
     for key, value in data.items():
+        if not hasattr(history_cls, key):
+            raise AttributeError("{} has no attribute '{}'".format(history_cls.__name__, key))
         setattr(history, key, value)
 
     return history

--- a/app/models.py
+++ b/app/models.py
@@ -559,6 +559,26 @@ class TemplateBase(db.Model):
 
     redact_personalisation = association_proxy('template_redacted', 'redact_personalisation')
 
+    @declared_attr
+    def service_letter_contact_id(cls):
+        return db.Column(UUID(as_uuid=True), db.ForeignKey('service_letter_contacts.id'), nullable=True)
+
+    @property
+    def reply_to(self):
+        if self.template_type == LETTER_TYPE:
+            return self.service_letter_contact_id
+        else:
+            return None
+
+    @reply_to.setter
+    def reply_to(self, value):
+        if self.template_type == LETTER_TYPE:
+            self.service_letter_contact_id = value
+        elif value is None:
+            pass
+        else:
+            raise ValueError('Unable to set sender for {} template'.format(self.template_type))
+
     def _as_utils_template(self):
         if self.template_type == EMAIL_TYPE:
             return PlainTextEmailTemplate(

--- a/app/models.py
+++ b/app/models.py
@@ -4,6 +4,7 @@ import uuid
 import datetime
 from flask import url_for, current_app
 
+from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.dialects.postgresql import (
     UUID,
@@ -522,50 +523,41 @@ class TemplateProcessTypes(db.Model):
     name = db.Column(db.String(255), primary_key=True)
 
 
-class Template(db.Model):
-    __tablename__ = 'templates'
+class TemplateBase(db.Model):
+    __abstract__ = True
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String(255), nullable=False)
     template_type = db.Column(template_types, nullable=False)
-    created_at = db.Column(
-        db.DateTime,
-        index=False,
-        unique=False,
-        nullable=False,
-        default=datetime.datetime.utcnow)
-    updated_at = db.Column(
-        db.DateTime,
-        index=False,
-        unique=False,
-        nullable=True,
-        onupdate=datetime.datetime.utcnow)
-    content = db.Column(db.Text, index=False, unique=False, nullable=False)
-    archived = db.Column(db.Boolean, index=False, nullable=False, default=False)
-    service_id = db.Column(UUID(as_uuid=True), db.ForeignKey('services.id'), index=True, unique=False, nullable=False)
-    service = db.relationship('Service', backref='templates')
-    subject = db.Column(db.Text, index=False, unique=False, nullable=True)
-    created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
-    created_by = db.relationship('User')
-    version = db.Column(db.Integer, default=0, nullable=False)
-    process_type = db.Column(
-        db.String(255),
-        db.ForeignKey('template_process_type.name'),
-        index=True,
-        nullable=False,
-        default=NORMAL
-    )
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, onupdate=datetime.datetime.utcnow)
+    content = db.Column(db.Text, nullable=False)
+    archived = db.Column(db.Boolean, nullable=False, default=False)
+    subject = db.Column(db.Text)
+
+    @declared_attr
+    def service_id(cls):
+        return db.Column(UUID(as_uuid=True), db.ForeignKey('services.id'), index=True, nullable=False)
+
+    @declared_attr
+    def created_by_id(cls):
+        return db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
+
+    @declared_attr
+    def created_by(cls):
+        return db.relationship('User')
+
+    @declared_attr
+    def process_type(cls):
+        return db.Column(
+            db.String(255),
+            db.ForeignKey('template_process_type.name'),
+            index=True,
+            nullable=False,
+            default=NORMAL
+        )
 
     redact_personalisation = association_proxy('template_redacted', 'redact_personalisation')
-
-    def get_link(self):
-        # TODO: use "/v2/" route once available
-        return url_for(
-            "template.get_template_by_id_and_service_id",
-            service_id=self.service_id,
-            template_id=self.id,
-            _external=True
-        )
 
     def _as_utils_template(self):
         if self.template_type == EMAIL_TYPE:
@@ -605,6 +597,22 @@ class Template(db.Model):
         return serialized
 
 
+class Template(TemplateBase):
+    __tablename__ = 'templates'
+
+    service = db.relationship('Service', backref='templates')
+    version = db.Column(db.Integer, default=0, nullable=False)
+
+    def get_link(self):
+        # TODO: use "/v2/" route once available
+        return url_for(
+            "template.get_template_by_id_and_service_id",
+            service_id=self.service_id,
+            template_id=self.id,
+            _external=True
+        )
+
+
 class TemplateRedacted(db.Model):
     __tablename__ = 'template_redacted'
 
@@ -618,32 +626,16 @@ class TemplateRedacted(db.Model):
     template = db.relationship('Template', uselist=False, backref=db.backref('template_redacted', uselist=False))
 
 
-class TemplateHistory(db.Model):
+class TemplateHistory(TemplateBase):
     __tablename__ = 'templates_history'
 
-    id = db.Column(UUID(as_uuid=True), primary_key=True)
-    name = db.Column(db.String(255), nullable=False)
-    template_type = db.Column(template_types, nullable=False)
-    created_at = db.Column(db.DateTime, nullable=False)
-    updated_at = db.Column(db.DateTime)
-    content = db.Column(db.Text, nullable=False)
-    archived = db.Column(db.Boolean, nullable=False, default=False)
-    service_id = db.Column(UUID(as_uuid=True), db.ForeignKey('services.id'), index=True, nullable=False)
     service = db.relationship('Service')
-    subject = db.Column(db.Text)
-    created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
-    created_by = db.relationship('User')
     version = db.Column(db.Integer, primary_key=True, nullable=False)
-    process_type = db.Column(db.String(255),
-                             db.ForeignKey('template_process_type.name'),
-                             index=True,
-                             nullable=False,
-                             default=NORMAL)
 
-    template_redacted = db.relationship('TemplateRedacted', foreign_keys=[id],
-                                        primaryjoin='TemplateRedacted.template_id == TemplateHistory.id')
-
-    redact_personalisation = association_proxy('template_redacted', 'redact_personalisation')
+    @declared_attr
+    def template_redacted(cls):
+        return db.relationship('TemplateRedacted', foreign_keys=[cls.id],
+                               primaryjoin='TemplateRedacted.template_id == TemplateHistory.id')
 
     def get_link(self):
         return url_for(
@@ -652,12 +644,6 @@ class TemplateHistory(db.Model):
             version=self.version,
             _external=True
         )
-
-    def _as_utils_template(self):
-        return Template._as_utils_template(self)
-
-    def serialize(self):
-        return Template.serialize(self)
 
 
 MMG_PROVIDER = "mmg"

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -314,9 +314,14 @@ class NotificationModelSchema(BaseSchema):
 
 class BaseTemplateSchema(BaseSchema):
 
+    reply_to = fields.Method("get_reply_to", allow_none=True)
+
+    def get_reply_to(self, template):
+        return template.reply_to
+
     class Meta:
         model = models.Template
-        exclude = ("service_id", "jobs")
+        exclude = ("service_id", "jobs", "service_letter_contact_id")
         strict = True
 
 
@@ -339,8 +344,13 @@ class TemplateSchema(BaseTemplateSchema):
 
 class TemplateHistorySchema(BaseSchema):
 
+    reply_to = fields.Method("get_reply_to", allow_none=True)
+
     created_by = fields.Nested(UserSchema, only=['id', 'name', 'email_address'], dump_only=True)
     created_at = field_for(models.Template, 'created_at', format='%Y-%m-%d %H:%M:%S.%f')
+
+    def get_reply_to(self, template):
+        return template.reply_to
 
     class Meta:
         model = models.TemplateHistory

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -155,7 +155,7 @@ def get_template_versions(service_id, template_id):
 def _template_has_not_changed(current_data, updated_template):
     return all(
         current_data[key] == updated_template[key]
-        for key in ('name', 'content', 'subject', 'archived', 'process_type')
+        for key in ('name', 'content', 'subject', 'archived', 'process_type', 'reply_to')
     )
 
 

--- a/migrations/versions/0144_template_service_letter.py
+++ b/migrations/versions/0144_template_service_letter.py
@@ -1,0 +1,33 @@
+"""
+
+Revision ID: 0144_template_service_letter
+Revises: 0143_remove_reply_to
+Create Date: 2017-11-17 15:42:16.401229
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0144_template_service_letter'
+down_revision = '0143_remove_reply_to'
+
+
+def upgrade():
+    op.add_column('templates',
+                  sa.Column('service_letter_contact_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key('templates_service_letter_contact_id_fkey', 'templates',
+                          'service_letter_contacts', ['service_letter_contact_id'], ['id'])
+
+    op.add_column('templates_history',
+                  sa.Column('service_letter_contact_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key('templates_history_service_letter_contact_id_fkey', 'templates_history',
+                          'service_letter_contacts', ['service_letter_contact_id'], ['id'])
+
+
+def downgrade():
+    op.drop_constraint('templates_service_letter_contact_id_fkey', 'templates', type_='foreignkey')
+    op.drop_column('templates', 'service_letter_contact_id')
+
+    op.drop_constraint('templates_history_service_letter_contact_id_fkey', 'templates_history', type_='foreignkey')
+    op.drop_column('templates_history', 'service_letter_contact_id')


### PR DESCRIPTION
Paired with @klssmith.

### Verify that attribute exists on *History model when versioning objects

When createing a history instance of the updated object `create_history` sets attributes using `setattr`. Since SQLAlchemy model instances are Python objects they don't prevent new attributes being created by setattr, which means that if history models are missing some of the columns the attributes will still be assigned, but their values will not be persisted by SQLAlchemy since database columns for them do not exist.

To avoid this, we check that the attribute is defined on the `history_cls` and raise an error if it isn't.

### Move common Template/TemplateHistory attributes to a base class

This allows us to avoid duplication between Template and TemplateHistory classes and makes it easier to ensure that all columns are copied to the TemplateHistory objects.

### Add template.service_letter_contact_id and reply_to wrapper property

Adds a relationship between Template models and service letter contact blocks.

Depending on template type, we can have a reference to either a letter contact block, email reply-to address or SMS sender record. This means that in order to enforce foreign key constraints we need to define three separate foreign key columns on the template model.

To hide this implementation detail and make it easier to access the sender/reply-to information we define a wrapper property that returns the value from the correct column.

The relationship and the property are only defined for letter templates at the moment.

The setter raises an error when trying to assign a reply_to value for non-letter templates. The exception isn't raised if the value being assigned is `None` since it can get assigned by marshmallow schemas and as it matches the value returned for other template types it doesn't need to be written anywhere.

### Add reply_to fields to template schemas

We're hiding the `service_letter_contact_id` column since it should only be readable and writable using the `.reply_to` wrapper.

Schemas are defined using `fields.Method` since the fields are represented by a property on the Template model that requires template type to be set. When creating a template, if `reply_to` is defined using `fields.String` it gets assigned at the same time as `template_type` (or the order of assignments is not defined), so the schema loader attempts to set `.reply_to` on a Template object with a `None` `template_type`, which raises an exception.

Using `fields.Method` seems to delay `.reply_to` assignment until the Template object is created, which means it already has a valid type.