### PR TITLE
Add a column to Notifications to store the reply_to_text.

### DIFF
--- a/migrations/versions/0144_add_notification_reply_to.py
+++ b/migrations/versions/0144_add_notification_reply_to.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 0144_add_notification_reply_to
+Revises: 0143_remove_reply_to
+Create Date: 2017-11-22 14:23:48.806781
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0144_add_notification_reply_to'
+down_revision = '0143_remove_reply_to'
+
+
+def upgrade():
+    op.add_column('notifications', sa.Column('reply_to_text', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('notifications', 'reply_to_text')

--- a/migrations/versions/0145_add_notification_reply_to.py
+++ b/migrations/versions/0145_add_notification_reply_to.py
@@ -1,7 +1,7 @@
 """
 
-Revision ID: 0144_add_notification_reply_to
-Revises: 0143_remove_reply_to
+Revision ID: 0145_add_notification_reply_to
+Revises: 0144_template_service_letter
 Create Date: 2017-11-22 14:23:48.806781
 
 """
@@ -9,8 +9,8 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = '0144_add_notification_reply_to'
-down_revision = '0143_remove_reply_to'
+revision = '0145_add_notification_reply_to'
+down_revision = '0144_template_service_letter'
 
 
 def upgrade():


### PR DESCRIPTION
This is text value of the sender_id, depending on the channel this will be a SMS sender, email reply to address or a letter contact block.
This is the first PR in a series to refactor how we send the "reply_to" the provider, eventually we can eliminate the notification_to_sms_sender and notification_to_email_to tables.

