### PR TITLE
Fix an intermittent test failure when creating a template with reply_to

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -526,6 +526,12 @@ class TemplateProcessTypes(db.Model):
 class TemplateBase(db.Model):
     __abstract__ = True
 
+    def __init__(self, **kwargs):
+        if 'template_type' in kwargs:
+            self.template_type = kwargs.pop('template_type')
+
+        super().__init__(**kwargs)
+
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String(255), nullable=False)
     template_type = db.Column(template_types, nullable=False)


### PR DESCRIPTION
reply_to requires template_type to be already set, but the order
of attribute assignment is not defined when a model object is created
from a dictionary. This changes the test to use an OrderedDict instead.

The problem might still exist when the template is created through the
API, so this is a temporary fix to unblock the release.