### PR TITLE
List templates in alphabetical order

### DIFF
--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import uuid
 
-from sqlalchemy import desc
+from sqlalchemy import asc, desc
 from sqlalchemy.sql.expression import bindparam
 
 from app import db
@@ -65,14 +65,16 @@ def dao_get_all_templates_for_service(service_id, template_type=None):
             template_type=template_type,
             archived=False
         ).order_by(
-            desc(Template.created_at)
+            asc(Template.name),
+            asc(Template.template_type),
         ).all()
 
     return Template.query.filter_by(
         service_id=service_id,
         archived=False
     ).order_by(
-        desc(Template.created_at)
+        asc(Template.name),
+        asc(Template.template_type),
     ).all()
 
 

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -163,7 +163,7 @@ def test_get_all_templates_for_service(notify_db, notify_db_session, service_fac
     assert len(dao_get_all_templates_for_service(service_2.id)) == 2
 
 
-def test_get_all_templates_for_service_shows_newest_created_first(notify_db, notify_db_session, sample_service):
+def test_get_all_templates_for_service_is_alphabetised(notify_db, notify_db_session, sample_service):
     template_1 = create_sample_template(
         notify_db,
         notify_db_session,
@@ -190,14 +190,14 @@ def test_get_all_templates_for_service_shows_newest_created_first(notify_db, not
     )
 
     assert Template.query.count() == 3
-    assert dao_get_all_templates_for_service(sample_service.id)[0].name == 'Sample Template 3'
+    assert dao_get_all_templates_for_service(sample_service.id)[0].name == 'Sample Template 1'
     assert dao_get_all_templates_for_service(sample_service.id)[1].name == 'Sample Template 2'
-    assert dao_get_all_templates_for_service(sample_service.id)[2].name == 'Sample Template 1'
+    assert dao_get_all_templates_for_service(sample_service.id)[2].name == 'Sample Template 3'
 
-    template_2.name = 'Sample Template 2 (updated)'
+    template_2.name = 'AAAAA Sample Template 2'
     dao_update_template(template_2)
-    assert dao_get_all_templates_for_service(sample_service.id)[0].name == 'Sample Template 3'
-    assert dao_get_all_templates_for_service(sample_service.id)[1].name == 'Sample Template 2 (updated)'
+    assert dao_get_all_templates_for_service(sample_service.id)[0].name == 'AAAAA Sample Template 2'
+    assert dao_get_all_templates_for_service(sample_service.id)[1].name == 'Sample Template 1'
 
 
 def test_get_all_returns_empty_list_if_no_templates(sample_service):

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -120,12 +120,13 @@ def create_service_with_defined_sms_sender(
 def create_template(
     service,
     template_type=SMS_TYPE,
+    template_name=None,
     subject='Template subject',
     content='Dear Sir/Madam, Hello. Yours Truly, The Government.',
     template_id=None
 ):
     data = {
-        'name': '{} Template Name'.format(template_type),
+        'name': template_name or '{} Template Name'.format(template_type),
         'template_type': template_type,
         'content': content,
         'service': service,

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -301,10 +301,10 @@ def test_should_be_able_to_get_all_templates_for_a_service(client, sample_user, 
 
     assert response.status_code == 200
     update_json_resp = json.loads(response.get_data(as_text=True))
-    assert update_json_resp['data'][0]['name'] == 'my template 2'
+    assert update_json_resp['data'][0]['name'] == 'my template 1'
     assert update_json_resp['data'][0]['version'] == 1
     assert update_json_resp['data'][0]['created_at']
-    assert update_json_resp['data'][1]['name'] == 'my template 1'
+    assert update_json_resp['data'][1]['name'] == 'my template 2'
     assert update_json_resp['data'][1]['version'] == 1
     assert update_json_resp['data'][1]['created_at']
 


### PR DESCRIPTION
# Screenshots

Before | After 
--- | ---
![image](https://user-images.githubusercontent.com/355079/33172007-5767db1a-d046-11e7-85e2-bce22b21dac6.png) | ![image](https://user-images.githubusercontent.com/355079/33171995-4758536c-d046-11e7-8b9b-18298bcedbbb.png)

# Ordering templates by created at isn’t working great

Currently templates are ordered by the newest created first. This made sense when, after creating a new template, you were landed on the page that listed all the templates. In other words, you needed to see confirmation of the thing that you’ve just done.

Since https://github.com/alphagov/notifications-admin/pull/1195 (March 2017) you get landed on the page for just that template. So you always see the template you’ve just created, no matter how the list of templates is ordered. So we are free to change the order of the templates.

Ordering by time created is not great, because it gives users no control over which templates appear first. For example, our research reported this from one team:

> One frustration they have is that when you add a new template it automatically goes to the top of the list. To get round this, whenever they add a new template they delete all of the existing ones and start again because they want to keep their templates in numerical order. They'd like to be able to control the order of templates in the list.

# Ordering by alphabetical is better

We _could_ give people some sort of drag-and-drop template ordering thing. But this feels like overkill. I think that alphabetical order is better because:

## It’s discoverable

Anyone who wants to know how a list is ordered can quickly tell just by looking at it

## It’s universal

Everyone knows how alphabetical ordering works

## It’s familiar

This is how people documents on their computer are ordered; there’s no new UI to learn

## It’s the behaviour that users are exhibiting already

From the same service as above:
  > They number their templates 1,2a, 2b, 3a etc

So this commit changes the ordering from newest created first to alphabetical.

# Background reading

Previous changes to template order and navigation:
- https://github.com/alphagov/notifications-admin/pull/1163
- https://github.com/alphagov/notifications-admin/pull/1195
- https://github.com/alphagov/notifications-admin/pull/1330