### PR TITLE
Abort unauthenticated requests for Firetext inbound SMS

### DIFF
--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -60,10 +60,10 @@ def receive_firetext_sms():
     auth = request.authorization
     if not auth:
         current_app.logger.warning("Inbound sms no auth header")
-        # abort(401)
+        abort(401)
     elif auth.username != 'notify' or auth.password not in current_app.config['FIRETEXT_INBOUND_SMS_AUTH']:
         current_app.logger.warning("Inbound sms incorrect username ({}) or password".format(auth.username))
-        # abort(403)
+        abort(403)
 
     inbound_number = strip_leading_forty_four(post_data['destination'])
 

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -400,7 +400,6 @@ def test_strip_leading_country_code(number, expected):
     ["", [], 401],
     ["testkey", [], 403],
 ])
-@pytest.mark.skip(reason="aborts are disabled at the moment")
 def test_firetext_inbound_sms_auth(notify_db_session, notify_api, client, mocker, auth, keys, status_code):
     mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
 


### PR DESCRIPTION
Switches on authentication checks for Firetext inbound SMS callbacks.

This should only be released once Firetext callback URLs have been
updated with authentication details.