### PR TITLE
Increased Gunicorn threads

### DIFF
--- a/manifest-api-staging.yml
+++ b/manifest-api-staging.yml
@@ -1,7 +1,7 @@
 ---
 
 inherit: manifest-api-base.yml
-
+command: scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py --error-logfile /home/vcap/logs/gunicorn_error.log -w 10 -b 0.0.0.0:$PORT application
 services:
   - notify-aws
   - notify-config


### PR DESCRIPTION
Increased Gunicorn threads to 10 on staging to test if there is a
performance increase when testing request per second. Increased to 10.
Gunicorn recommend 2 x cores + 1 however on PaaS the number of cores
is not consistent.