### PR TITLE
Decreased Gunicorn threads

### DIFF
--- a/manifest-api-staging.yml
+++ b/manifest-api-staging.yml
@@ -1,7 +1,7 @@
 ---
 
 inherit: manifest-api-base.yml
-command: scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py --error-logfile /home/vcap/logs/gunicorn_error.log -w 10 -b 0.0.0.0:$PORT application
+command: scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py --error-logfile /home/vcap/logs/gunicorn_error.log -w 6 -b 0.0.0.0:$PORT application
 services:
   - notify-aws
   - notify-config


### PR DESCRIPTION
Increasing the Gunicorn workers to 10 actually made the API decrease
in performance from ~200 requests/sec with with 20 API instances to
150 requests per/sec. The base value is 5 so this is to test how the API
performs with a slight increase.