### PR TITLE
update utils to 23.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,9 @@ notifications-python-client==4.6.0
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@23.1.0#egg=notifications-utils==23.1.0
+git+https://github.com/alphagov/notifications-utils.git@23.2.1#egg=notifications-utils==23.2.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
+
+# required by utils
+git+https://github.com/leohemsted/smartypants.py.git@regex-speedup#egg=smartypants==2.1.0


### PR DESCRIPTION
Previously, making nice quotes for 250 8400-character notifications took `34.42` seconds, resulting in a 502. 😢 
Now it takes `2.99` seconds 🎉 🔥 🔥 🔥 💨 


note: this requires adding smartypants as a line in requirements.txt, due to it coming from a git repo. Once the new version of smartypants is in pypi, this line will no longer be required.

- [ ] https://github.com/alphagov/notifications-utils/pull/259