### PR TITLE
Revert changes to staging for performance tests and increased rate limit

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -392,19 +392,19 @@ class Staging(Config):
     FROM_NUMBER = 'stage'
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = True
-    REDIS_ENABLED = False
+    REDIS_ENABLED = True
 
     API_KEY_LIMITS = {
         KEY_TYPE_TEAM: {
-            "limit": 21000,
+            "limit": 24000,
             "interval": 60
         },
         KEY_TYPE_NORMAL: {
-            "limit": 21000,
+            "limit": 24000,
             "interval": 60
         },
         KEY_TYPE_TEST: {
-            "limit": 21000,
+            "limit": 24000,
             "interval": 60
         }
     }

--- a/manifest-api-staging.yml
+++ b/manifest-api-staging.yml
@@ -1,7 +1,6 @@
 ---
 
 inherit: manifest-api-base.yml
-command: scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py --error-logfile /home/vcap/logs/gunicorn_error.log -w 6 -b 0.0.0.0:$PORT application
 services:
   - notify-aws
   - notify-config


### PR DESCRIPTION
- Reverted the Gunicorn worker number to 5 (this should be investigated further on a well baselined system to compare)
- Enabled REDIS
- Increased the rate limit to 400 req/sec as using early testing yesterday 450+ was being achieved so brings it more inline with what can be acheived