### PR TITLE
log auth errors from the v2 api

### DIFF
--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -92,7 +92,7 @@ def requires_auth():
         g.service_id = api_key.service_id
         _request_ctx_stack.top.authenticated_service = service
         _request_ctx_stack.top.api_user = api_key
-        current_app.logger.info('Succesful login for service {} with api key {}, using client'.format(
+        current_app.logger.info('API authorised for service {} with api key {}, using client {}'.format(
             service.id,
             api_key.id,
             request.headers.get('User-Agent')

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -93,7 +93,11 @@ def requires_auth():
         g.service_id = api_key.service_id
         _request_ctx_stack.top.authenticated_service = service
         _request_ctx_stack.top.api_user = api_key
-        current_app.logger.info('Succesful login for service {} with api key {}'.format(service.id, api_key.id))
+        current_app.logger.info('Succesful login for service {} with api key {}, using client'.format(
+            service.id,
+            api_key.id,
+            request.headers.get('User-Agent')
+        ))
         return
     else:
         # service has API keys, but none matching the one the user provided

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -8,10 +8,15 @@ from app.dao.services_dao import dao_fetch_service_by_id_with_api_keys
 
 
 class AuthError(Exception):
-    def __init__(self, message, code):
+    def __init__(self, message, code, service_id=None, api_key_id=None):
         self.message = {"token": [message]}
         self.short_message = message
         self.code = code
+        self.service_id = service_id
+        self.api_key_id = api_key_id
+
+    def __str__(self):
+        return 'AuthError({message}, {code}, service_id={service_id}, api_key_id={api_key_id})'.format(**self.__dict__)
 
     def to_dict_v2(self):
         return {
@@ -65,28 +70,34 @@ def requires_auth():
         raise AuthError("Invalid token: service not found", 403)
 
     if not service.api_keys:
-        raise AuthError("Invalid token: service has no API keys", 403)
+        raise AuthError("Invalid token: service has no API keys", 403, service_id=service.id)
 
     if not service.active:
-        raise AuthError("Invalid token: service is archived", 403)
+        raise AuthError("Invalid token: service is archived", 403, service_id=service.id)
 
     for api_key in service.api_keys:
         try:
-            get_decode_errors(auth_token, api_key.secret)
+            decode_jwt_token(auth_token, api_key.secret)
         except TokenDecodeError:
             continue
+        except TokenExpiredError:
+            err_msg = (
+                "Invalid token: Tokens must be used within 30 seconds, check that your system clock "
+                "is accurate. Try checking https://time.is/"
+            )
+            raise AuthError(err_msg, 403, service_id=service.id, api_key_id=api_key.id)
 
         if api_key.expiry_date:
-            raise AuthError("Invalid token: API key revoked", 403)
+            raise AuthError("Invalid token: API key revoked", 403, service_id=service.id, api_key_id=api_key.id)
 
         g.service_id = api_key.service_id
         _request_ctx_stack.top.authenticated_service = service
         _request_ctx_stack.top.api_user = api_key
-
+        current_app.logger.info('Succesful login for service {} with api key {}'.format(service.id, api_key.id))
         return
     else:
         # service has API keys, but none matching the one the user provided
-        raise AuthError("Invalid token: signature, api token is not valid", 403)
+        raise AuthError("Invalid token: signature, api token not found", 403, service_id=service.id)
 
 
 def __get_token_issuer(auth_token):
@@ -101,14 +112,8 @@ def __get_token_issuer(auth_token):
 
 def handle_admin_key(auth_token, secret):
     try:
-        get_decode_errors(auth_token, secret)
-        return
-    except TokenDecodeError as e:
-        raise AuthError("Invalid token: signature, api token is not valid", 403)
-
-
-def get_decode_errors(auth_token, unsigned_secret):
-    try:
-        decode_jwt_token(auth_token, unsigned_secret)
+        decode_jwt_token(auth_token, secret)
     except TokenExpiredError:
         raise AuthError("Invalid token: expired, check that your system clock is accurate", 403)
+    except TokenDecodeError as e:
+        raise AuthError("Invalid token: signature, api token is not valid", 403)

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -82,8 +82,7 @@ def requires_auth():
             continue
         except TokenExpiredError:
             err_msg = (
-                "Invalid token: Tokens must be used within 30 seconds, check that your system clock "
-                "is accurate. Try checking https://time.is/"
+                "Error: Your system clock must be accurate to within 30 seconds"
             )
             raise AuthError(err_msg, 403, service_id=service.id, api_key_id=api_key.id)
 

--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -1,8 +1,10 @@
 import json
-from flask import jsonify, current_app
+
+from flask import jsonify, current_app, request
 from jsonschema import ValidationError
 from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
+
 from app.authentication.auth import AuthError
 from app.errors import InvalidRequest
 
@@ -79,7 +81,7 @@ def register_errors(blueprint):
 
     @blueprint.errorhandler(AuthError)
     def auth_error(error):
-        current_app.logger.info('API AuthError: {}'.format(error))
+        current_app.logger.info('API AuthError, client: {} error: {}'.format(request.headers.get('User-Agent'), error))
         return jsonify(error.to_dict_v2()), error.code
 
     @blueprint.errorhandler(Exception)

--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -79,6 +79,7 @@ def register_errors(blueprint):
 
     @blueprint.errorhandler(AuthError)
     def auth_error(error):
+        current_app.logger.info('API AuthError: {}'.format(error))
         return jsonify(error.to_dict_v2()), error.code
 
     @blueprint.errorhandler(Exception)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -27,8 +27,8 @@ def create_authorization_header(service_id=None, key_type=KEY_TYPE_NORMAL):
             secret = api_key.secret
 
     else:
-        client_id = current_app.config.get('ADMIN_CLIENT_USER_NAME')
-        secret = current_app.config.get('ADMIN_CLIENT_SECRET')
+        client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
+        secret = current_app.config['ADMIN_CLIENT_SECRET']
 
     token = create_jwt_token(secret=secret, client_id=client_id)
     return 'Authorization', 'Bearer {}'.format(token)

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -313,7 +313,7 @@ def test_should_return_403_when_token_is_expired(client,
         with pytest.raises(AuthError) as exc:
             request.headers = {'Authorization': 'Bearer {}'.format(token)}
             requires_auth()
-    assert 'check that your system clock is accurate' in exc.value.short_message
+    assert exc.value.short_message == 'Error: Your system clock must be accurate to within 30 seconds'
     assert exc.value.service_id == sample_api_key.service_id
     assert exc.value.api_key_id == sample_api_key.id
 


### PR DESCRIPTION
(will help with tracking down client problems)

We currently don't log anything - but it'll be useful to see if services are getting lots of invalid system clock, or key expired, etc etc.