### PR TITLE
modified dao_timeout_notifications

### DIFF
--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1201,7 +1201,7 @@ def test_dao_timeout_notifications(sample_template):
     assert Notification.query.get(sending.id).status == 'sending'
     assert Notification.query.get(pending.id).status == 'pending'
     assert Notification.query.get(delivered.id).status == 'delivered'
-    updated = dao_timeout_notifications(1)
+    updated_ids = dao_timeout_notifications(1)
     assert Notification.query.get(created.id).status == 'technical-failure'
     assert Notification.query.get(sending.id).status == 'temporary-failure'
     assert Notification.query.get(pending.id).status == 'temporary-failure'
@@ -1210,7 +1210,7 @@ def test_dao_timeout_notifications(sample_template):
     assert NotificationHistory.query.get(sending.id).status == 'temporary-failure'
     assert NotificationHistory.query.get(pending.id).status == 'temporary-failure'
     assert NotificationHistory.query.get(delivered.id).status == 'delivered'
-    assert updated == 3
+    assert len(updated_ids) == 3
 
 
 def test_dao_timeout_notifications_only_updates_for_older_notifications(sample_template):
@@ -1224,12 +1224,12 @@ def test_dao_timeout_notifications_only_updates_for_older_notifications(sample_t
     assert Notification.query.get(sending.id).status == 'sending'
     assert Notification.query.get(pending.id).status == 'pending'
     assert Notification.query.get(delivered.id).status == 'delivered'
-    updated = dao_timeout_notifications(1)
+    updated_ids = dao_timeout_notifications(1)
     assert NotificationHistory.query.get(created.id).status == 'created'
     assert NotificationHistory.query.get(sending.id).status == 'sending'
     assert NotificationHistory.query.get(pending.id).status == 'pending'
     assert NotificationHistory.query.get(delivered.id).status == 'delivered'
-    assert updated == 0
+    assert len(updated_ids) == 0
 
 
 def test_dao_timeout_notifications_doesnt_affect_letters(sample_letter_template):
@@ -1244,13 +1244,13 @@ def test_dao_timeout_notifications_doesnt_affect_letters(sample_letter_template)
     assert Notification.query.get(pending.id).status == 'pending'
     assert Notification.query.get(delivered.id).status == 'delivered'
 
-    updated = dao_timeout_notifications(1)
+    updated_ids = dao_timeout_notifications(1)
 
     assert NotificationHistory.query.get(created.id).status == 'created'
     assert NotificationHistory.query.get(sending.id).status == 'sending'
     assert NotificationHistory.query.get(pending.id).status == 'pending'
     assert NotificationHistory.query.get(delivered.id).status == 'delivered'
-    assert updated == 0
+    assert len(updated_ids) == 0
 
 
 def test_should_return_notifications_excluding_jobs_by_default(sample_template, sample_job, sample_api_key):


### PR DESCRIPTION
As part of the pivotal story of https://www.pivotaltracker.com/story/show/153087419

We should also send delivery status from calling scheduled timeout tasks as it is one of the final status update place. 

