### PR TITLE
Add letters pdf task & api

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -99,3 +99,6 @@ def upload_letters_pdf(reference, crown, filedata):
         bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
         file_location=upload_file_name
     )
+
+    current_app.logger.info("Uploading letters PDF {} to {}".format(
+        upload_file_name, current_app.config['LETTERS_PDF_BUCKET_NAME']))

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -5,7 +5,6 @@ from requests import (
 )
 
 from botocore.exceptions import ClientError as BotoClientError
-from sqlalchemy.orm.exc import NoResultFound
 
 from app import notify_celery
 from app.aws import s3
@@ -18,9 +17,7 @@ from app.statsd_decorators import statsd
 @statsd(namespace="tasks")
 def create_letters_pdf(self, notification_id):
     try:
-        notification = get_notification_by_id(notification_id)
-        if not notification:
-            raise NoResultFound()
+        notification = get_notification_by_id(notification_id, _raise=True)
 
         pdf_data = get_letters_pdf(
             notification.template,

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -30,7 +30,7 @@ def create_letters_pdf(self, notification_id):
         )
         current_app.logger.info("PDF Letter {} reference {} created at {}, {} bytes".format(
             notification.id, notification.reference, notification.created_at, len(pdf_data)))
-        s3.upload_letters_pdf(reference=notification.reference, crown=True, filedata=pdf_data)
+        s3.upload_letters_pdf(reference=notification.reference, crown=notification.service.crown, filedata=pdf_data)
     except (RequestException, BotoClientError):
         try:
             current_app.logger.exception(

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -1,0 +1,68 @@
+from flask import current_app
+from requests import (
+    post as requests_post,
+    RequestException
+)
+
+from botocore.exceptions import ClientError as BotoClientError
+from sqlalchemy.orm.exc import NoResultFound
+
+from app import notify_celery
+from app.aws import s3
+from app.config import QueueNames
+from app.dao.notifications_dao import get_notification_by_id, update_notification_status_by_id
+from app.statsd_decorators import statsd
+
+
+@notify_celery.task(bind=True, name="create-letters-pdf", max_retries=15, default_retry_delay=300)
+@statsd(namespace="tasks")
+def create_letters_pdf(self, notification_id):
+    try:
+        notification = get_notification_by_id(notification_id)
+        if not notification:
+            raise NoResultFound()
+
+        pdf_data = get_letters_pdf(
+            notification.template,
+            contact_block=notification.reply_to_text,
+            org_id=notification.service.dvla_organisation.id,
+            values=notification.personalisation
+        )
+        current_app.logger.info("PDF Letter {} reference {} created at {}, {} bytes".format(
+            notification.id, notification.reference, notification.created_at, len(pdf_data)))
+        s3.upload_letters_pdf(reference=notification.reference, crown=True, filedata=pdf_data)
+    except (RequestException, BotoClientError):
+        try:
+            current_app.logger.exception(
+                "Letters PDF notification creation for id: {} failed".format(notification_id)
+            )
+            self.retry(queue=QueueNames.RETRY)
+        except self.MaxRetriesExceededError:
+            current_app.logger.exception(
+                "RETRY FAILED: task create_letters_pdf failed for notification {}".format(notification_id),
+            )
+            update_notification_status_by_id(notification_id, 'technical-failure')
+
+
+def get_letters_pdf(template, contact_block, org_id, values):
+    template_for_letter_print = {
+        "subject": template.subject,
+        "content": template.content
+    }
+
+    data = {
+        'letter_contact_block': contact_block,
+        'template': template_for_letter_print,
+        'values': values,
+        'dvla_org_id': org_id,
+    }
+    resp = requests_post(
+        '{}/print.pdf'.format(
+            current_app.config['TEMPLATE_PREVIEW_API_HOST']
+        ),
+        json=data,
+        headers={'Authorization': 'Token {}'.format(current_app.config['TEMPLATE_PREVIEW_API_KEY'])}
+    )
+    resp.raise_for_status()
+
+    return resp.content

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -4,6 +4,8 @@ from collections import namedtuple
 
 from celery.signals import worker_process_shutdown
 from flask import current_app
+import requests
+
 from notifications_utils.recipients import (
     RecipientCSV
 )
@@ -18,6 +20,7 @@ from requests import (
     RequestException
 )
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm.exc import NoResultFound
 from botocore.exceptions import ClientError as BotoClientError
 
 from app import (
@@ -44,7 +47,8 @@ from app.dao.notifications_dao import (
     dao_update_notifications_for_job_to_sent_to_dvla,
     dao_update_notifications_by_reference,
     dao_get_last_notification_added_for_job_id,
-    dao_get_notifications_by_references
+    dao_get_notifications_by_references,
+    update_notification_status_by_id
 )
 from app.dao.provider_details_dao import get_current_provider
 from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
@@ -121,11 +125,17 @@ def process_job(job_id):
 
 
 def job_complete(job, service, template_type, resumed=False, start=None):
-    if template_type == LETTER_TYPE:
+    if (
+        template_type == LETTER_TYPE and
+        'letters_as_pdf' not in [p.permission for p in service.permissions]
+    ):
         if service.research_mode:
             update_job_to_sent_to_dvla.apply_async([str(job.id)], queue=QueueNames.RESEARCH_MODE)
         else:
-            build_dvla_file.apply_async([str(job.id)], queue=QueueNames.JOBS)
+            build_dvla_file.apply_async(
+                [str(job.id)],
+                queue=QueueNames.JOBS
+            )
             current_app.logger.info("send job {} to build-dvla-file in the {} queue".format(job.id, QueueNames.JOBS))
     else:
         job.job_status = JOB_STATUS_FINISHED
@@ -311,6 +321,14 @@ def save_letter(
             reference=create_random_identifier(),
             reply_to_text=service.get_default_letter_contact()
         )
+
+        if (
+            'letters_as_pdf' in [p.permission for p in service.permissions] and not service.research_mode
+        ):
+            create_letters_pdf.apply_async(
+                [str(saved_notification.id)],
+                queue=QueueNames.JOBS
+            )
 
         current_app.logger.info("Letter {} created at {}".format(saved_notification.id, saved_notification.created_at))
     except SQLAlchemyError as e:
@@ -581,3 +599,57 @@ def process_incomplete_job(job_id):
             process_row(row_number, recipient, personalisation, template, job, job.service)
 
     job_complete(job, job.service, template.template_type, resumed=True)
+
+
+@notify_celery.task(bind=True, name="create-letters-pdf", max_retries=15, default_retry_delay=300)
+@statsd(namespace="tasks")
+def create_letters_pdf(self, notification_id):
+    try:
+        notification = get_notification_by_id(notification_id)
+        if not notification:
+            raise NoResultFound()
+
+        pdf_data = get_letters_pdf(
+            notification.template,
+            contact_block=notification.reply_to_text,
+            org_id=notification.service.dvla_organisation.id,
+            values=notification.personalisation
+        )
+        current_app.logger.info("PDF Letter {} reference {} created at {}, {} bytes".format(
+            notification.id, notification.reference, notification.created_at, len(pdf_data)))
+        s3.upload_letters_pdf(reference=notification.reference, crown=True, filedata=pdf_data)
+    except (RequestException, BotoClientError):
+        try:
+            current_app.logger.exception(
+                "Letters PDF notification creation for id: {} failed".format(notification_id)
+            )
+            self.retry(queue=QueueNames.RETRY)
+        except self.MaxRetriesExceededError:
+            current_app.logger.exception(
+                "RETRY FAILED: task create_letters_pdf failed for notification {}".format(notification_id),
+            )
+            update_notification_status_by_id(notification_id, 'technical-failure')
+
+
+def get_letters_pdf(template, contact_block=None, org_id='001', values=None):
+    template_for_letter_print = {
+        "subject": template.subject,
+        "content": template.content
+    }
+
+    data = {
+        'letter_contact_block': contact_block,
+        'template': template_for_letter_print,
+        'values': values,
+        'dvla_org_id': org_id,
+    }
+    resp = requests.post(
+        '{}/print.pdf'.format(
+            current_app.config['TEMPLATE_PREVIEW_API_HOST']
+        ),
+        json=data,
+        headers={'Authorization': 'Token {}'.format(current_app.config['TEMPLATE_PREVIEW_API_KEY'])}
+    )
+    resp.raise_for_status()
+
+    return resp.content

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -132,10 +132,7 @@ def job_complete(job, service, template_type, resumed=False, start=None):
         if service.research_mode:
             update_job_to_sent_to_dvla.apply_async([str(job.id)], queue=QueueNames.RESEARCH_MODE)
         else:
-            build_dvla_file.apply_async(
-                [str(job.id)],
-                queue=QueueNames.JOBS
-            )
+            build_dvla_file.apply_async([str(job.id)], queue=QueueNames.JOBS)
             current_app.logger.info("send job {} to build-dvla-file in the {} queue".format(job.id, QueueNames.JOBS))
     else:
         job.job_status = JOB_STATUS_FINISHED
@@ -146,7 +143,7 @@ def job_complete(job, service, template_type, resumed=False, start=None):
 
     if resumed:
         current_app.logger.info(
-            "Resumed Job {} completed at {}".format(job.id, job.created_at, start, finished)
+            "Resumed Job {} completed at {}".format(job.id, job.created_at)
         )
     else:
         current_app.logger.info(
@@ -327,7 +324,7 @@ def save_letter(
         ):
             create_letters_pdf.apply_async(
                 [str(saved_notification.id)],
-                queue=QueueNames.JOBS
+                queue=QueueNames.CREATE_LETTERS_PDF
             )
 
         current_app.logger.info("Letter {} created at {}".format(saved_notification.id, saved_notification.created_at))
@@ -631,7 +628,7 @@ def create_letters_pdf(self, notification_id):
             update_notification_status_by_id(notification_id, 'technical-failure')
 
 
-def get_letters_pdf(template, contact_block=None, org_id='001', values=None):
+def get_letters_pdf(template, contact_block, org_id, values=None):
     template_for_letter_print = {
         "subject": template.subject,
         "content": template.content

--- a/app/config.py
+++ b/app/config.py
@@ -30,6 +30,7 @@ class QueueNames(object):
     RETRY = 'retry-tasks'
     NOTIFY = 'notify-internal-tasks'
     PROCESS_FTP = 'process-ftp-tasks'
+    CREATE_LETTERS_PDF = 'create-letters-pdf'
 
     @staticmethod
     def all_queues():
@@ -44,6 +45,7 @@ class QueueNames(object):
             QueueNames.JOBS,
             QueueNames.RETRY,
             QueueNames.NOTIFY,
+            QueueNames.CREATE_LETTERS_PDF,
         ]
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -304,6 +304,9 @@ class Config(object):
     # {"dataset_1": "token_1", ...}
     PERFORMANCE_PLATFORM_ENDPOINTS = json.loads(os.environ.get('PERFORMANCE_PLATFORM_ENDPOINTS', '{}'))
 
+    TEMPLATE_PREVIEW_API_HOST = os.environ.get('TEMPLATE_PREVIEW_API_HOST', 'http://localhost:6013')
+    TEMPLATE_PREVIEW_API_KEY = os.environ.get('TEMPLATE_PREVIEW_API_KEY', 'my-secret-key')
+
 
 ######################
 # Config overrides ###

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -226,8 +226,11 @@ def get_notification_with_personalisation(service_id, notification_id, key_type)
 
 
 @statsd(namespace="dao")
-def get_notification_by_id(notification_id):
-    return Notification.query.filter_by(id=notification_id).first()
+def get_notification_by_id(notification_id, _raise=False):
+    if _raise:
+        return Notification.query.filter_by(id=notification_id).one()
+    else:
+        return Notification.query.filter_by(id=notification_id).first()
 
 
 def get_notifications(filter_dict=None):
@@ -547,24 +550,19 @@ def dao_set_created_live_letter_api_notifications_to_pending():
     Note - do not process services that have letters_as_pdf permission as they
            will get processed when the letters PDF zip task is created
     """
-
-    # Ignore services that have letters_as_pdf permission
-    services_without_letters_as_pdf = [
-        s.id for s in Service.query.filter(
-            ~Service.permissions.any(
-                ServicePermission.permission == 'letters_as_pdf'
-            )
-        ).all()
-    ]
-
     notifications = db.session.query(
         Notification
+    ).join(
+        Service
     ).filter(
         Notification.notification_type == LETTER_TYPE,
         Notification.status == NOTIFICATION_CREATED,
         Notification.key_type == KEY_TYPE_NORMAL,
         Notification.api_key != None,  # noqa
-        Notification.service_id.in_(services_without_letters_as_pdf)
+        # Ignore services that have letters_as_pdf permission
+        ~Service.permissions.any(
+            ServicePermission.permission == 'letters_as_pdf'
+        )
     ).with_for_update(
     ).all()
 

--- a/app/models.py
+++ b/app/models.py
@@ -283,6 +283,9 @@ class Service(db.Model, Versioned):
         default_letter_contact = [x for x in self.letter_contacts if x.is_default]
         return default_letter_contact[0].contact_block if default_letter_contact else None
 
+    def has_permission(self, permission):
+        return permission in [p.permission for p in self.permissions]
+
 
 class AnnualBilling(db.Model):
     __tablename__ = "annual_billing"

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -54,7 +54,7 @@ def test_create_letters_pdf_calls_upload_letters_pdf(mocker, sample_letter_notif
 
     mock_s3.assert_called_with(
         reference=sample_letter_notification.reference,
-        crown=True,
+        crown=sample_letter_notification.service.crown,
         filedata=b'\x00\x01'
     )
 

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -1,0 +1,99 @@
+import pytest
+import requests_mock
+
+from botocore.exceptions import ClientError
+from celery.exceptions import MaxRetriesExceededError
+from requests import RequestException
+from sqlalchemy.orm.exc import NoResultFound
+
+from app.celery.letters_pdf_tasks import (
+    create_letters_pdf,
+    get_letters_pdf,
+)
+
+from tests.conftest import set_config_values
+
+
+def test_should_have_decorated_tasks_functions():
+    assert create_letters_pdf.__wrapped__.__name__ == 'create_letters_pdf'
+
+
+@pytest.mark.parametrize('personalisation', [{'name': 'test'}, None])
+def test_get_letters_pdf_calls_notifications_template_preview_service_correctly(
+        notify_api, mocker, client, sample_letter_template, personalisation):
+    contact_block = 'Mr Foo,\n1 Test Street,\nLondon\nN1'
+    dvla_org_id = '002'
+
+    with set_config_values(notify_api, {
+        'TEMPLATE_PREVIEW_API_HOST': 'http://localhost/notifications-template-preview',
+        'TEMPLATE_PREVIEW_API_KEY': 'test-key'
+    }):
+        with requests_mock.Mocker() as request_mock:
+            mock_post = request_mock.post(
+                'http://localhost/notifications-template-preview/print.pdf', content=b'\x00\x01', status_code=200)
+
+            get_letters_pdf(
+                sample_letter_template, contact_block=contact_block, org_id=dvla_org_id, values=personalisation)
+
+    assert mock_post.last_request.json() == {
+        'values': personalisation,
+        'letter_contact_block': contact_block,
+        'dvla_org_id': dvla_org_id,
+        'template': {
+            'subject': sample_letter_template.subject,
+            'content': sample_letter_template.content
+        }
+    }
+
+
+def test_create_letters_pdf_calls_upload_letters_pdf(mocker, sample_letter_notification):
+    mocker.patch('app.celery.letters_pdf_tasks.get_letters_pdf', return_value=b'\x00\x01')
+    mock_s3 = mocker.patch('app.celery.tasks.s3.upload_letters_pdf')
+
+    create_letters_pdf(sample_letter_notification.id)
+
+    mock_s3.assert_called_with(
+        reference=sample_letter_notification.reference,
+        crown=True,
+        filedata=b'\x00\x01'
+    )
+
+
+def test_create_letters_pdf_non_existent_notification(notify_api, mocker, fake_uuid):
+    with pytest.raises(expected_exception=NoResultFound):
+        create_letters_pdf(fake_uuid)
+
+
+def test_create_letters_pdf_handles_request_errors(mocker, sample_letter_notification):
+    mock_get_letters_pdf = mocker.patch('app.celery.letters_pdf_tasks.get_letters_pdf', side_effect=RequestException)
+    mock_retry = mocker.patch('app.celery.letters_pdf_tasks.create_letters_pdf.retry')
+
+    create_letters_pdf(sample_letter_notification.id)
+
+    assert mock_get_letters_pdf.called
+    assert mock_retry.called
+
+
+def test_create_letters_pdf_handles_s3_errors(mocker, sample_letter_notification):
+    mocker.patch('app.celery.letters_pdf_tasks.get_letters_pdf')
+    mock_s3 = mocker.patch('app.celery.tasks.s3.upload_letters_pdf', side_effect=ClientError({}, 'operation_name'))
+    mock_retry = mocker.patch('app.celery.letters_pdf_tasks.create_letters_pdf.retry')
+
+    create_letters_pdf(sample_letter_notification.id)
+
+    assert mock_s3.called
+    assert mock_retry.called
+
+
+def test_create_letters_pdf_sets_technical_failure_max_retries(mocker, sample_letter_notification):
+    mock_get_letters_pdf = mocker.patch('app.celery.letters_pdf_tasks.get_letters_pdf', side_effect=RequestException)
+    mock_retry = mocker.patch(
+        'app.celery.letters_pdf_tasks.create_letters_pdf.retry', side_effect=MaxRetriesExceededError)
+    mock_update_noti = mocker.patch('app.celery.letters_pdf_tasks.update_notification_status_by_id')
+
+    create_letters_pdf(sample_letter_notification.id)
+
+    assert mock_get_letters_pdf.called
+    assert mock_retry.called
+    assert mock_update_noti.called
+    mock_update_noti.assert_called_once_with(sample_letter_notification.id, 'technical-failure')

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1436,7 +1436,6 @@ def test_process_incomplete_job_email(mocker, sample_email_template):
 
 
 def test_process_incomplete_job_letter(mocker, sample_letter_template):
-
     mocker.patch('app.celery.tasks.s3.get_job_from_s3', return_value=load_example_csv('multiple_letter'))
     mock_letter_saver = mocker.patch('app.celery.tasks.save_letter.apply_async')
     mock_build_dvla = mocker.patch('app.celery.tasks.build_dvla_file.apply_async')
@@ -1456,3 +1455,4 @@ def test_process_incomplete_job_letter(mocker, sample_letter_template):
 
     assert mock_build_dvla.called
     assert mock_letter_saver.call_count == 8
+    

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -9,8 +9,9 @@ from flask import current_app
 from freezegun import freeze_time
 from requests import RequestException
 from sqlalchemy.exc import SQLAlchemyError
-from celery.exceptions import Retry
+from celery.exceptions import Retry, MaxRetriesExceededError
 from botocore.exceptions import ClientError
+from sqlalchemy.orm.exc import NoResultFound
 from notifications_utils.template import SMSMessageTemplate, WithSubjectTemplate, LetterDVLATemplate
 
 from app import (encryption, DATETIME_FORMAT)
@@ -20,6 +21,9 @@ from app.celery.scheduled_tasks import check_job_status
 from app.celery.tasks import (
     build_dvla_file,
     create_dvla_file_contents_for_job,
+    create_letters_pdf,
+    get_letters_pdf,
+    job_complete,
     process_job,
     process_row,
     save_sms,
@@ -32,7 +36,7 @@ from app.celery.tasks import (
     send_inbound_sms_to_service,
 )
 from app.config import QueueNames
-from app.dao import jobs_dao, services_dao
+from app.dao import jobs_dao, services_dao, service_permissions_dao
 from app.models import (
     Job,
     Notification,
@@ -47,6 +51,7 @@ from app.models import (
     SMS_TYPE
 )
 
+from tests.conftest import set_config_values
 from tests.app import load_example_csv
 from tests.app.conftest import (
     sample_service as create_sample_service,
@@ -94,6 +99,7 @@ def test_should_have_decorated_tasks_functions():
     assert save_sms.__wrapped__.__name__ == 'save_sms'
     assert save_email.__wrapped__.__name__ == 'save_email'
     assert save_letter.__wrapped__.__name__ == 'save_letter'
+    assert create_letters_pdf.__wrapped__.__name__ == 'create_letters_pdf'
 
 
 @pytest.fixture
@@ -1039,6 +1045,50 @@ def test_save_letter_saves_letter_to_database(mocker, notify_db_session):
     assert notification_db.reply_to_text == "Address contact"
 
 
+def test_save_letter_saves_letter_calls_create_letters_as_pdf_with_letters_as_pdf_permission(
+        mocker, notify_db_session, sample_letter_job):
+    service_permissions_dao.dao_add_service_permission(sample_letter_job.service.id, 'letters_as_pdf')
+    mock_create_letters_pdf = mocker.patch('app.celery.tasks.create_letters_pdf.apply_async')
+
+    personalisation = {
+        'addressline1': 'Foo',
+        'addressline2': 'Bar',
+        'postcode': 'Flob',
+    }
+    notification_json = _notification_json(
+        template=sample_letter_job.template,
+        to='Foo',
+        personalisation=personalisation,
+        job_id=sample_letter_job.id,
+        row_number=1
+    )
+    notification_id = uuid.uuid4()
+
+    save_letter(
+        sample_letter_job.service_id,
+        notification_id,
+        encryption.encrypt(notification_json),
+    )
+
+    assert mock_create_letters_pdf.called
+    mock_create_letters_pdf.assert_called_once_with(
+        [str(notification_id)],
+        queue=QueueNames.CREATE_LETTERS_PDF
+    )
+
+
+def test_job_complete_does_not_call_build_dvla_file_with_letters_as_pdf_permission(
+        mocker, notify_db_session, sample_letter_job):
+    service_permissions_dao.dao_add_service_permission(sample_letter_job.service.id, 'letters_as_pdf')
+    mock_build_dvla_files = mocker.patch('app.celery.tasks.build_dvla_file.apply_async')
+
+    job_complete(sample_letter_job, sample_letter_job.service, sample_letter_job.template.template_type)
+
+    assert not sample_letter_job.service.research_mode
+    assert not mock_build_dvla_files.called
+    assert sample_letter_job.job_status == JOB_STATUS_FINISHED
+
+
 def test_should_cancel_job_if_service_is_inactive(sample_service,
                                                   sample_job,
                                                   mocker):
@@ -1455,3 +1505,83 @@ def test_process_incomplete_job_letter(mocker, sample_letter_template):
 
     assert mock_build_dvla.called
     assert mock_letter_saver.call_count == 8
+
+
+@pytest.mark.parametrize('personalisation', [{'name': 'test'}, None])
+def test_get_letters_pdf_calls_notifications_template_preview_service_correctly(
+        notify_api, mocker, client, sample_letter_template, personalisation):
+    contact_block = 'Mr Foo,\n1 Test Street,\nLondon\nN1'
+    dvla_org_id = '002'
+
+    with set_config_values(notify_api, {
+        'TEMPLATE_PREVIEW_API_HOST': 'http://localhost/notifications-template-preview',
+        'TEMPLATE_PREVIEW_API_KEY': 'test-key'
+    }):
+        with requests_mock.Mocker() as request_mock:
+            mock_post = request_mock.post(
+                'http://localhost/notifications-template-preview/print.pdf', content=b'\x00\x01', status_code=200)
+
+            get_letters_pdf(
+                sample_letter_template, contact_block=contact_block, org_id=dvla_org_id, values=personalisation)
+
+    assert mock_post.last_request.json() == {
+        'values': personalisation,
+        'letter_contact_block': contact_block,
+        'dvla_org_id': dvla_org_id,
+        'template': {
+            'subject': sample_letter_template.subject,
+            'content': sample_letter_template.content
+        }
+    }
+
+
+def test_create_letters_pdf_calls_upload_letters_pdf(mocker, sample_letter_notification):
+    mocker.patch('app.celery.tasks.get_letters_pdf', return_value=b'\x00\x01')
+    mock_s3 = mocker.patch('app.celery.tasks.s3.upload_letters_pdf')
+
+    create_letters_pdf(sample_letter_notification.id)
+
+    mock_s3.assert_called_with(
+        reference=sample_letter_notification.reference,
+        crown=True,
+        filedata=b'\x00\x01'
+    )
+
+
+def test_create_letters_pdf_non_existent_notification(notify_api, mocker, fake_uuid):
+    with pytest.raises(expected_exception=NoResultFound):
+        create_letters_pdf(fake_uuid)
+
+
+def test_create_letters_pdf_handles_request_errors(mocker, sample_letter_notification):
+    mock_get_letters_pdf = mocker.patch('app.celery.tasks.get_letters_pdf', side_effect=RequestException)
+    mock_retry = mocker.patch('app.celery.tasks.create_letters_pdf.retry')
+
+    create_letters_pdf(sample_letter_notification.id)
+
+    assert mock_get_letters_pdf.called
+    assert mock_retry.called
+
+
+def test_create_letters_pdf_handles_s3_errors(mocker, sample_letter_notification):
+    mocker.patch('app.celery.tasks.get_letters_pdf')
+    mock_s3 = mocker.patch('app.celery.tasks.s3.upload_letters_pdf', side_effect=ClientError({}, 'operation_name'))
+    mock_retry = mocker.patch('app.celery.tasks.create_letters_pdf.retry')
+
+    create_letters_pdf(sample_letter_notification.id)
+
+    assert mock_s3.called
+    assert mock_retry.called
+
+
+def test_create_letters_pdf_sets_technical_failure_max_retries(mocker, sample_letter_notification):
+    mock_get_letters_pdf = mocker.patch('app.celery.tasks.get_letters_pdf', side_effect=RequestException)
+    mock_retry = mocker.patch('app.celery.tasks.create_letters_pdf.retry', side_effect=MaxRetriesExceededError)
+    mock_update_noti = mocker.patch('app.celery.tasks.update_notification_status_by_id')
+
+    create_letters_pdf(sample_letter_notification.id)
+
+    assert mock_get_letters_pdf.called
+    assert mock_retry.called
+    assert mock_update_noti.called
+    mock_update_noti.assert_called_once_with(sample_letter_notification.id, 'technical-failure')

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -9,9 +9,8 @@ from flask import current_app
 from freezegun import freeze_time
 from requests import RequestException
 from sqlalchemy.exc import SQLAlchemyError
-from celery.exceptions import Retry, MaxRetriesExceededError
+from celery.exceptions import Retry
 from botocore.exceptions import ClientError
-from sqlalchemy.orm.exc import NoResultFound
 from notifications_utils.template import SMSMessageTemplate, WithSubjectTemplate, LetterDVLATemplate
 
 from app import (encryption, DATETIME_FORMAT)
@@ -21,8 +20,6 @@ from app.celery.scheduled_tasks import check_job_status
 from app.celery.tasks import (
     build_dvla_file,
     create_dvla_file_contents_for_job,
-    create_letters_pdf,
-    get_letters_pdf,
     job_complete,
     process_job,
     process_row,
@@ -51,7 +48,6 @@ from app.models import (
     SMS_TYPE
 )
 
-from tests.conftest import set_config_values
 from tests.app import load_example_csv
 from tests.app.conftest import (
     sample_service as create_sample_service,
@@ -99,7 +95,6 @@ def test_should_have_decorated_tasks_functions():
     assert save_sms.__wrapped__.__name__ == 'save_sms'
     assert save_email.__wrapped__.__name__ == 'save_email'
     assert save_letter.__wrapped__.__name__ == 'save_letter'
-    assert create_letters_pdf.__wrapped__.__name__ == 'create_letters_pdf'
 
 
 @pytest.fixture
@@ -1048,7 +1043,7 @@ def test_save_letter_saves_letter_to_database(mocker, notify_db_session):
 def test_save_letter_saves_letter_calls_create_letters_as_pdf_with_letters_as_pdf_permission(
         mocker, notify_db_session, sample_letter_job):
     service_permissions_dao.dao_add_service_permission(sample_letter_job.service.id, 'letters_as_pdf')
-    mock_create_letters_pdf = mocker.patch('app.celery.tasks.create_letters_pdf.apply_async')
+    mock_create_letters_pdf = mocker.patch('app.celery.letters_pdf_tasks.create_letters_pdf.apply_async')
 
     personalisation = {
         'addressline1': 'Foo',
@@ -1505,83 +1500,3 @@ def test_process_incomplete_job_letter(mocker, sample_letter_template):
 
     assert mock_build_dvla.called
     assert mock_letter_saver.call_count == 8
-
-
-@pytest.mark.parametrize('personalisation', [{'name': 'test'}, None])
-def test_get_letters_pdf_calls_notifications_template_preview_service_correctly(
-        notify_api, mocker, client, sample_letter_template, personalisation):
-    contact_block = 'Mr Foo,\n1 Test Street,\nLondon\nN1'
-    dvla_org_id = '002'
-
-    with set_config_values(notify_api, {
-        'TEMPLATE_PREVIEW_API_HOST': 'http://localhost/notifications-template-preview',
-        'TEMPLATE_PREVIEW_API_KEY': 'test-key'
-    }):
-        with requests_mock.Mocker() as request_mock:
-            mock_post = request_mock.post(
-                'http://localhost/notifications-template-preview/print.pdf', content=b'\x00\x01', status_code=200)
-
-            get_letters_pdf(
-                sample_letter_template, contact_block=contact_block, org_id=dvla_org_id, values=personalisation)
-
-    assert mock_post.last_request.json() == {
-        'values': personalisation,
-        'letter_contact_block': contact_block,
-        'dvla_org_id': dvla_org_id,
-        'template': {
-            'subject': sample_letter_template.subject,
-            'content': sample_letter_template.content
-        }
-    }
-
-
-def test_create_letters_pdf_calls_upload_letters_pdf(mocker, sample_letter_notification):
-    mocker.patch('app.celery.tasks.get_letters_pdf', return_value=b'\x00\x01')
-    mock_s3 = mocker.patch('app.celery.tasks.s3.upload_letters_pdf')
-
-    create_letters_pdf(sample_letter_notification.id)
-
-    mock_s3.assert_called_with(
-        reference=sample_letter_notification.reference,
-        crown=True,
-        filedata=b'\x00\x01'
-    )
-
-
-def test_create_letters_pdf_non_existent_notification(notify_api, mocker, fake_uuid):
-    with pytest.raises(expected_exception=NoResultFound):
-        create_letters_pdf(fake_uuid)
-
-
-def test_create_letters_pdf_handles_request_errors(mocker, sample_letter_notification):
-    mock_get_letters_pdf = mocker.patch('app.celery.tasks.get_letters_pdf', side_effect=RequestException)
-    mock_retry = mocker.patch('app.celery.tasks.create_letters_pdf.retry')
-
-    create_letters_pdf(sample_letter_notification.id)
-
-    assert mock_get_letters_pdf.called
-    assert mock_retry.called
-
-
-def test_create_letters_pdf_handles_s3_errors(mocker, sample_letter_notification):
-    mocker.patch('app.celery.tasks.get_letters_pdf')
-    mock_s3 = mocker.patch('app.celery.tasks.s3.upload_letters_pdf', side_effect=ClientError({}, 'operation_name'))
-    mock_retry = mocker.patch('app.celery.tasks.create_letters_pdf.retry')
-
-    create_letters_pdf(sample_letter_notification.id)
-
-    assert mock_s3.called
-    assert mock_retry.called
-
-
-def test_create_letters_pdf_sets_technical_failure_max_retries(mocker, sample_letter_notification):
-    mock_get_letters_pdf = mocker.patch('app.celery.tasks.get_letters_pdf', side_effect=RequestException)
-    mock_retry = mocker.patch('app.celery.tasks.create_letters_pdf.retry', side_effect=MaxRetriesExceededError)
-    mock_update_noti = mocker.patch('app.celery.tasks.update_notification_status_by_id')
-
-    create_letters_pdf(sample_letter_notification.id)
-
-    assert mock_get_letters_pdf.called
-    assert mock_retry.called
-    assert mock_update_noti.called
-    mock_update_noti.assert_called_once_with(sample_letter_notification.id, 'technical-failure')

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1455,4 +1455,3 @@ def test_process_incomplete_job_letter(mocker, sample_letter_template):
 
     assert mock_build_dvla.called
     assert mock_letter_saver.call_count == 8
-    

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -299,6 +299,10 @@ def sample_template_without_email_permission(notify_db, notify_db_session):
 
 @pytest.fixture
 def sample_letter_template(sample_service_full_permissions):
+    # remove letters_as_pdf from fixture until we drop building of dvla files
+    from app.dao.service_permissions_dao import dao_remove_service_permission
+    dao_remove_service_permission(sample_service_full_permissions.id, 'letters_as_pdf')
+
     return create_template(sample_service_full_permissions, template_type=LETTER_TYPE)
 
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -161,7 +161,7 @@ def sample_service(
         'message_limit': limit,
         'restricted': restricted,
         'email_from': email_from,
-        'created_by': user
+        'created_by': user,
     }
     service = Service.query.filter_by(name=service_name).first()
     if not service:
@@ -188,7 +188,7 @@ def sample_service_full_permissions(notify_db, notify_db_session):
         notify_db_session,
         # ensure name doesn't clash with regular sample service
         service_name="sample service full permissions",
-        permissions=SERVICE_PERMISSION_TYPES
+        permissions=set(SERVICE_PERMISSION_TYPES) - {'letters_as_pdf'}
     )
 
 
@@ -299,10 +299,6 @@ def sample_template_without_email_permission(notify_db, notify_db_session):
 
 @pytest.fixture
 def sample_letter_template(sample_service_full_permissions):
-    # remove letters_as_pdf from fixture until we drop building of dvla files
-    from app.dao.service_permissions_dao import dao_remove_service_permission
-    dao_remove_service_permission(sample_service_full_permissions.id, 'letters_as_pdf')
-
     return create_template(sample_service_full_permissions, template_type=LETTER_TYPE)
 
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -603,7 +603,7 @@ def sample_letter_notification(sample_letter_template):
         'address_line_6': 'A6',
         'postcode': 'A_POST'
     }
-    return create_notification(sample_letter_template, personalisation=address)
+    return create_notification(sample_letter_template, reference='foo', personalisation=address)
 
 
 @pytest.fixture(scope='function')

--- a/tests/app/dao/notification_dao/test_letter_api_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_letter_api_notification_dao.py
@@ -25,9 +25,7 @@ def test_should_only_get_letter_notifications(
     assert ret == [sample_letter_notification]
 
 
-def test_should_ignore_letters_as_pdf(
-    sample_letter_notification,
-):
+def test_should_ignore_letters_as_pdf(sample_letter_notification):
     service = create_service(service_permissions=[LETTER_TYPE, 'letters_as_pdf'])
     template = create_template(service, template_type=LETTER_TYPE)
     create_notification(template)

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -63,7 +63,7 @@ def test_cloudfoundry_config_has_different_defaults():
 def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()
-    assert len(queues) == 10
+    assert len(queues) == 11
     assert set([
         QueueNames.PRIORITY,
         QueueNames.PERIODIC,
@@ -74,5 +74,6 @@ def test_queue_names_all_queues_correct():
         QueueNames.STATISTICS,
         QueueNames.JOBS,
         QueueNames.RETRY,
-        QueueNames.NOTIFY
+        QueueNames.NOTIFY,
+        QueueNames.CREATE_LETTERS_PDF
     ]) == set(queues)


### PR DESCRIPTION
## What

- Added a task to create a cmyk pdf and store this in the letters-pdf bucket on s3.
- Only allow this for services that have `letters_as_pdf` set
- Ensure that for these services the `build_dvla_file` is not called so that DVLA only get pdfs or csv files to process.
- Ensure that letter notifications API calls the create letters pdf task when in `letters_as_pdf` service
- Make sure that only notifications not in `letters_as_pdf` services are processed for api calls that are building dvla files.

## How to manually test

- From admin settings, switch a service to send letters as pdf
- then from a letter template upload a csv file
  - you should be able to see the newly created CMYK files on the s3 bucket for that environment
  - or from celery logs you should be able to see something like this -
  `PDF Letter [noti id] reference [reference] created at [datetime], [pdf size] bytes`
  `Uploading letters [pdf file location] to [environment]-letters-pdf`

- From an API call - 
`PYTHONPATH=. python ./utils/make_api_call.py http://localhost:6011 [test key for service with letters_as_pdf] create --type=letter --template=[letter template id] --personalisation="{\"address_line_1\":\"someone\", \"address_line_2\":\"London\", \"postcode\":\"N1\"}" --reference="test letters"`

## Reference 

Step 4/5 https://www.pivotaltracker.com/story/show/151511579