### PR TITLE
Add template preview host url and key to cf config

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -36,6 +36,8 @@ def set_config_env_vars(vcap_services):
             extract_redis_config(s)
         elif s['name'] == 'performance-platform':
             extract_performance_platform_config(s)
+        elif s['name'] == 'notify-template-preview':
+            extract_template_preview_config(s)
 
 
 def extract_notify_config(notify_config):
@@ -77,3 +79,8 @@ def extract_firetext_config(firetext_config):
 def extract_redis_config(redis_config):
     os.environ['REDIS_ENABLED'] = redis_config['credentials']['redis_enabled']
     os.environ['REDIS_URL'] = redis_config['credentials']['redis_url']
+
+
+def extract_template_preview_config(template_preview_config):
+    os.environ['TEMPLATE_PREVIEW_API_HOST'] = template_preview_config['credentials']['api_host']
+    os.environ['TEMPLATE_PREVIEW_API_KEY'] = template_preview_config['credentials']['api_key']

--- a/app/config.py
+++ b/app/config.py
@@ -374,6 +374,7 @@ class Test(Config):
 
     SMS_INBOUND_WHITELIST = ['203.0.113.195']
     FIRETEXT_INBOUND_SMS_AUTH = ['testkey']
+    TEMPLATE_PREVIEW_API_HOST = 'http://localhost:9999'
 
 
 class Preview(Config):

--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -7,6 +7,7 @@ services:
   - notify-aws
   - notify-config
   - notify-db
+  - notify-template-preview
   - mmg
   - firetext
   - hosted-graphite

--- a/manifest-delivery-preview.yml
+++ b/manifest-delivery-preview.yml
@@ -6,6 +6,7 @@ services:
   - notify-aws
   - notify-config
   - notify-db
+  - notify-template-preview
   - mmg
   - firetext
   - hosted-graphite

--- a/manifest-delivery-staging.yml
+++ b/manifest-delivery-staging.yml
@@ -6,6 +6,7 @@ services:
   - notify-aws
   - notify-config
   - notify-db
+  - notify-template-preview
   - mmg
   - firetext
   - hosted-graphite

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -102,6 +102,17 @@ def performance_platform_config():
 
 
 @pytest.fixture
+def template_preview_config():
+    return {
+        'name': 'notify-template-preview',
+        'credentials': {
+            'api_host': 'template-preview api host',
+            'api_key': 'template-preview api key'
+        }
+    }
+
+
+@pytest.fixture
 def cloudfoundry_config(
         postgres_config,
         notify_config,
@@ -110,7 +121,8 @@ def cloudfoundry_config(
         mmg_config,
         firetext_config,
         redis_config,
-        performance_platform_config
+        performance_platform_config,
+        template_preview_config
 ):
     return {
         'postgres': postgres_config,
@@ -121,7 +133,8 @@ def cloudfoundry_config(
             mmg_config,
             firetext_config,
             redis_config,
-            performance_platform_config
+            performance_platform_config,
+            template_preview_config
         ]
     }
 
@@ -227,3 +240,11 @@ def test_performance_platform_config():
         'foo': 'my_token',
         'bar': 'other_token'
     }
+
+
+@pytest.mark.usefixtures('os_environ', 'cloudfoundry_environ')
+def test_template_preview_config():
+    extract_cloudfoundry_config()
+
+    assert os.environ['TEMPLATE_PREVIEW_API_HOST'] == 'template-preview api host'
+    assert os.environ['TEMPLATE_PREVIEW_API_KEY'] == 'template-preview api key'


### PR DESCRIPTION
## What

In order for the different environments on paas to pick up the template preview host url and key we need to put it in a cf config file.

