### PR TITLE
Add create-letters-pdf-tasks to notify-delivery-worker

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -30,7 +30,7 @@ class QueueNames(object):
     RETRY = 'retry-tasks'
     NOTIFY = 'notify-internal-tasks'
     PROCESS_FTP = 'process-ftp-tasks'
-    CREATE_LETTERS_PDF = 'create-letters-pdf'
+    CREATE_LETTERS_PDF = 'create-letters-pdf-tasks'
 
     @staticmethod
     def all_queues():

--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -51,7 +51,7 @@ applications:
       NOTIFY_APP_NAME: delivery-worker-priority
 
   - name: notify-delivery-worker
-    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q job-tasks,retry-tasks,notify-internal-tasks
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q job-tasks,retry-tasks,notify-internal-tasks,create-letters-pdf-tasks
     env:
       NOTIFY_APP_NAME: delivery-worker
 


### PR DESCRIPTION
## What

create-letter-jobs celery was not being called on the celery delivery-worker app because it wasn't configured to look on that queue, this PR should correct that bug.