### PR TITLE
Update billable units for letters pdf task

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -1,4 +1,6 @@
+from datetime import datetime
 from flask import current_app
+import math
 from requests import (
     post as requests_post,
     RequestException
@@ -9,7 +11,11 @@ from botocore.exceptions import ClientError as BotoClientError
 from app import notify_celery
 from app.aws import s3
 from app.config import QueueNames
-from app.dao.notifications_dao import get_notification_by_id, update_notification_status_by_id
+from app.dao.notifications_dao import (
+    get_notification_by_id,
+    update_notification_status_by_id,
+    dao_update_notifications_by_reference
+)
 from app.statsd_decorators import statsd
 
 
@@ -19,7 +25,7 @@ def create_letters_pdf(self, notification_id):
     try:
         notification = get_notification_by_id(notification_id, _raise=True)
 
-        pdf_data = get_letters_pdf(
+        pdf_data, billable_units = get_letters_pdf(
             notification.template,
             contact_block=notification.reply_to_text,
             org_id=notification.service.dvla_organisation.id,
@@ -28,6 +34,24 @@ def create_letters_pdf(self, notification_id):
         current_app.logger.info("PDF Letter {} reference {} created at {}, {} bytes".format(
             notification.id, notification.reference, notification.created_at, len(pdf_data)))
         s3.upload_letters_pdf(reference=notification.reference, crown=notification.service.crown, filedata=pdf_data)
+
+        updated_count = dao_update_notifications_by_reference(
+            references=[notification.reference],
+            update_dict={
+                "billable_units": billable_units,
+                "updated_at": datetime.utcnow()
+            }
+        )
+
+        if not updated_count:
+            msg = "Update letter notification billing units failed: notification not found with reference {}".format(
+                notification.reference)
+            current_app.logger.error(msg)
+        else:
+            current_app.logger.info(
+                'Letter notification reference {reference}: billable units set to {billable_units}'.format(
+                    reference=str(notification.reference), billable_units=billable_units))
+
     except (RequestException, BotoClientError):
         try:
             current_app.logger.exception(
@@ -62,4 +86,7 @@ def get_letters_pdf(template, contact_block, org_id, values):
     )
     resp.raise_for_status()
 
-    return resp.content
+    pages_per_sheet = 2
+    billable_units = math.ceil(int(resp.headers.get("X-pdf-page-count", 0)) / pages_per_sheet)
+
+    return resp.content, billable_units

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -97,19 +97,6 @@ def test_create_letters_pdf_sets_billable_units(mocker, sample_letter_notificati
     assert noti.billable_units == 1
 
 
-def test_create_letters_pdf_handles_update_failure(mocker, sample_letter_notification):
-    mocker.patch('app.celery.letters_pdf_tasks.get_letters_pdf', return_value=(b'\x00\x01', 1))
-    mocker.patch('app.celery.tasks.s3.upload_letters_pdf')
-    mocker.patch('app.celery.tasks.letters_pdf_tasks.dao_update_notifications_by_reference', return_value=0)
-    mock_error_logger = mocker.patch('app.celery.letters_pdf_tasks.current_app.logger.error')
-
-    create_letters_pdf(sample_letter_notification.id)
-
-    mock_error_logger.assert_called_once_with(
-        "Update letter notification billing units failed: notification not found with reference {}".format(
-            sample_letter_notification.reference))
-
-
 def test_create_letters_pdf_non_existent_notification(notify_api, mocker, fake_uuid):
     with pytest.raises(expected_exception=NoResultFound):
         create_letters_pdf(fake_uuid)


### PR DESCRIPTION
## What 

As we have access to the page count from the template preview service print.pdf endpoint, we should be able to update the billable units using this information after uploading the file to the s3 bucket. 

A billable letter unit is counted per sheet which consists of 2 pages, so to calculate it I use this calculation - 

`billable_units = celiing( page count / 2 )`

| page count | billable_units |
|------------|----------------|
| 1          | 1              |
| 2          | 1              |
| 3          | 2              |
| 4          | 2              |

## Reference

Step 5/5 - https://www.pivotaltracker.com/story/show/151511579