### PR TITLE
if apps crash on startup, then fail deploy process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,6 +281,9 @@ cf-deploy: ## Deploys the app to Cloud Foundry
 	# sleep for 10 seconds to try and make sure that all worker threads (either web api or celery) have finished before we delete
 	# when we delete the DB is unbound from the app, which can cause "permission denied for relation" psycopg2 errors.
 	sleep 10
+
+	# get the new GUID, and find all crash events for that. If there were any crashes we will abort the deploy.
+	[ $(cf curl "/v2/events?q=type:app.crash&q=actee:$$(cf app --guid notify-delivery-worker-receipts)" | jq ".total_results") -eq 0 ]
 	cf delete -f ${CF_APP}-rollback
 
 .PHONY: cf-deploy-api-db-migration

--- a/scripts/run_app_paas.sh
+++ b/scripts/run_app_paas.sh
@@ -55,8 +55,6 @@ function on_exit {
       break
     fi
   done
-  echo "Application process terminated, waiting 10 seconds"
-  sleep 10
   echo "Terminating remaining subprocesses.."
   kill 0
 }


### PR DESCRIPTION
we saw an issue where the app started, then immediately crashed due to a setup error. However, jenkins had already returned positively, and the deploy continued.

cf-deploy should fail if the app doesn't start up.

We do this by looking through the cloudfoundry events, and aborting if there are any `app.crash` events for the new GUID.