### PR TITLE
Add MMG_INBOUND_SMS_AUTH config variable and auth check

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -49,6 +49,7 @@ def extract_notify_config(notify_config):
     os.environ['SMS_INBOUND_WHITELIST'] = json.dumps(notify_config['credentials']['allow_ip_inbound_sms'])
     os.environ['FIRETEXT_INBOUND_SMS_AUTH'] = json.dumps(notify_config['credentials']['firetext_inbound_sms_auth'])
     os.environ['MMG_INBOUND_SMS_AUTH'] = json.dumps(notify_config['credentials']['mmg_inbound_sms_auth'])
+    os.environ['MMG_INBOUND_SMS_USERNAME'] = json.dumps(notify_config['credentials']['mmg_inbound_sms_username'])
     os.environ['ROUTE_SECRET_KEY_1'] = notify_config['credentials']['route_secret_key_1']
     os.environ['ROUTE_SECRET_KEY_2'] = notify_config['credentials']['route_secret_key_2']
 

--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -48,6 +48,7 @@ def extract_notify_config(notify_config):
     os.environ['DANGEROUS_SALT'] = notify_config['credentials']['dangerous_salt']
     os.environ['SMS_INBOUND_WHITELIST'] = json.dumps(notify_config['credentials']['allow_ip_inbound_sms'])
     os.environ['FIRETEXT_INBOUND_SMS_AUTH'] = json.dumps(notify_config['credentials']['firetext_inbound_sms_auth'])
+    os.environ['MMG_INBOUND_SMS_AUTH'] = json.dumps(notify_config['credentials']['mmg_inbound_sms_auth'])
     os.environ['ROUTE_SECRET_KEY_1'] = notify_config['credentials']['route_secret_key_1']
     os.environ['ROUTE_SECRET_KEY_2'] = notify_config['credentials']['route_secret_key_2']
 

--- a/app/config.py
+++ b/app/config.py
@@ -301,6 +301,7 @@ class Config(object):
     SMS_INBOUND_WHITELIST = json.loads(os.environ.get('SMS_INBOUND_WHITELIST', '[]'))
     FIRETEXT_INBOUND_SMS_AUTH = json.loads(os.environ.get('FIRETEXT_INBOUND_SMS_AUTH', '[]'))
     MMG_INBOUND_SMS_AUTH = json.loads(os.environ.get('MMG_INBOUND_SMS_AUTH', '[]'))
+    MMG_INBOUND_SMS_USERNAME = json.loads(os.environ.get('MMG_INBOUND_SMS_USERNAME', '[]'))
 
     ROUTE_SECRET_KEY_1 = os.environ.get('ROUTE_SECRET_KEY_1', '')
     ROUTE_SECRET_KEY_2 = os.environ.get('ROUTE_SECRET_KEY_2', '')
@@ -378,6 +379,7 @@ class Test(Config):
     SMS_INBOUND_WHITELIST = ['203.0.113.195']
     FIRETEXT_INBOUND_SMS_AUTH = ['testkey']
     MMG_INBOUND_SMS_AUTH = ['testkey']
+    MMG_INBOUND_SMS_USERNAME = ['username']
     TEMPLATE_PREVIEW_API_HOST = 'http://localhost:9999'
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -300,6 +300,7 @@ class Config(object):
 
     SMS_INBOUND_WHITELIST = json.loads(os.environ.get('SMS_INBOUND_WHITELIST', '[]'))
     FIRETEXT_INBOUND_SMS_AUTH = json.loads(os.environ.get('FIRETEXT_INBOUND_SMS_AUTH', '[]'))
+    MMG_INBOUND_SMS_AUTH = json.loads(os.environ.get('MMG_INBOUND_SMS_AUTH', '[]'))
 
     ROUTE_SECRET_KEY_1 = os.environ.get('ROUTE_SECRET_KEY_1', '')
     ROUTE_SECRET_KEY_2 = os.environ.get('ROUTE_SECRET_KEY_2', '')
@@ -376,6 +377,7 @@ class Test(Config):
 
     SMS_INBOUND_WHITELIST = ['203.0.113.195']
     FIRETEXT_INBOUND_SMS_AUTH = ['testkey']
+    MMG_INBOUND_SMS_AUTH = ['testkey']
     TEMPLATE_PREVIEW_API_HOST = 'http://localhost:9999'
 
 

--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -30,6 +30,15 @@ def receive_mmg_sms():
     """
     post_data = request.get_json()
 
+    auth = request.authorization
+
+    if not auth:
+        current_app.logger.warning("Inbound sms (MMG) no auth header")
+        # abort(401)
+    elif auth.username != 'mmg_co_2017' or auth.password not in current_app.config['MMG_INBOUND_SMS_AUTH']:
+        current_app.logger.warning("Inbound sms (MMG) incorrect username ({}) or password".format(auth.username))
+        # abort(403)
+
     inbound_number = strip_leading_forty_four(post_data['Number'])
 
     service = fetch_potential_service(inbound_number, 'mmg')
@@ -49,20 +58,23 @@ def receive_mmg_sms():
 
     tasks.send_inbound_sms_to_service.apply_async([str(inbound.id), str(service.id)], queue=QueueNames.NOTIFY)
 
-    return 'RECEIVED', 200
+    current_app.logger.info(
+        '{} received inbound SMS with reference {} from MMG'.format(service.id, inbound.provider_reference))
+    return jsonify({
+        "status": "ok"
+    }), 200
 
 
 @receive_notifications_blueprint.route('/notifications/sms/receive/firetext', methods=['POST'])
 def receive_firetext_sms():
     post_data = request.form
 
-    # This is pre-implementation test code to validate the provider is basic auth headers.
     auth = request.authorization
     if not auth:
-        current_app.logger.warning("Inbound sms no auth header")
+        current_app.logger.warning("Inbound sms (Firetext) no auth header")
         abort(401)
     elif auth.username != 'notify' or auth.password not in current_app.config['FIRETEXT_INBOUND_SMS_AUTH']:
-        current_app.logger.warning("Inbound sms incorrect username ({}) or password".format(auth.username))
+        current_app.logger.warning("Inbound sms (Firetext) incorrect username ({}) or password".format(auth.username))
         abort(403)
 
     inbound_number = strip_leading_forty_four(post_data['destination'])

--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -35,7 +35,8 @@ def receive_mmg_sms():
     if not auth:
         current_app.logger.warning("Inbound sms (MMG) no auth header")
         # abort(401)
-    elif auth.username != 'mmg_co_2017' or auth.password not in current_app.config['MMG_INBOUND_SMS_AUTH']:
+    elif auth.username not in current_app.config['MMG_INBOUND_SMS_USERNAME'] \
+            or auth.password not in current_app.config['MMG_INBOUND_SMS_AUTH']:
         current_app.logger.warning("Inbound sms (MMG) incorrect username ({}) or password".format(auth.username))
         # abort(403)
 

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -44,7 +44,7 @@ def mmg_post(client, data, auth=True, password='testkey'):
     ]
 
     if auth:
-        auth_value = base64.b64encode("notify:{}".format(password).encode('utf-8')).decode('utf-8')
+        auth_value = base64.b64encode("username:{}".format(password).encode('utf-8')).decode('utf-8')
         headers.append(('Authorization', 'Basic ' + auth_value))
 
     return client.post(
@@ -438,7 +438,15 @@ def test_mmg_inbound_sms_auth(notify_db_session, notify_api, client, mocker, aut
         service_name='b', inbound_number='07111111111', service_permissions=[EMAIL_TYPE, SMS_TYPE, INBOUND_SMS_TYPE]
     )
 
-    data = "source=07999999999&destination=07111111111&message=this is a message&time=2017-01-01 12:00:00"
+    data = {
+        "ID": "1234",
+        "MSISDN": "07111111111",
+        "Message": "Some message to notify",
+        "Trigger": "Trigger?",
+        "Number": "testing",
+        "Channel": "SMS",
+        "DateRecieved": "2012-06-27 12:33:00"
+    }
 
     with set_config(notify_api, 'MMG_INBOUND_SMS_AUTH', keys):
         response = mmg_post(client, data, auth=bool(auth), password=auth)

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -19,6 +19,7 @@ def notify_config():
             'allow_ip_inbound_sms': ['111.111.111.111', '100.100.100.100'],
             'firetext_inbound_sms_auth': ['testkey'],
             'mmg_inbound_sms_auth': ['testkey'],
+            'mmg_inbound_sms_username': ['username'],
             'route_secret_key_1': "key_1",
             'route_secret_key_2': ""
         }
@@ -238,6 +239,13 @@ def test_mmg_inbound_sms_auth_config():
     extract_cloudfoundry_config()
 
     assert os.environ['MMG_INBOUND_SMS_AUTH'] == json.dumps(['testkey'])
+
+
+@pytest.mark.usefixtures('os_environ', 'cloudfoundry_environ')
+def test_mmg_inbound_sms_username_config():
+    extract_cloudfoundry_config()
+
+    assert os.environ['MMG_INBOUND_SMS_USERNAME'] == json.dumps(['username'])
 
 
 @pytest.mark.usefixtures('os_environ', 'cloudfoundry_environ')

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -18,6 +18,7 @@ def notify_config():
             'dangerous_salt': 'dangerous salt',
             'allow_ip_inbound_sms': ['111.111.111.111', '100.100.100.100'],
             'firetext_inbound_sms_auth': ['testkey'],
+            'mmg_inbound_sms_auth': ['testkey'],
             'route_secret_key_1': "key_1",
             'route_secret_key_2': ""
         }
@@ -230,6 +231,13 @@ def test_firetext_inbound_sms_auth_config():
     extract_cloudfoundry_config()
 
     assert os.environ['FIRETEXT_INBOUND_SMS_AUTH'] == json.dumps(['testkey'])
+
+
+@pytest.mark.usefixtures('os_environ', 'cloudfoundry_environ')
+def test_mmg_inbound_sms_auth_config():
+    extract_cloudfoundry_config()
+
+    assert os.environ['MMG_INBOUND_SMS_AUTH'] == json.dumps(['testkey'])
 
 
 @pytest.mark.usefixtures('os_environ', 'cloudfoundry_environ')


### PR DESCRIPTION
Checks authentication header value on inbound SMS requests from
MMG  against a list of allowed API keys set in the application
config.

At the moment, we're only logging the attempts without aborting the
requests. Once this is rolled out to production and we've checked
the logs we'll switch on the aborts and add the tests for 401 and 403
responses.

This work has already been done for Firetext in a previous PR:
https://github.com/alphagov/notifications-api/pull/1409

Paired with @venusbb 

To be merged after deploying new env variables