### PR TITLE
Create letters pdf queue was renamed with tasks, but was lost in another merge

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -30,7 +30,7 @@ class QueueNames(object):
     RETRY = 'retry-tasks'
     NOTIFY = 'notify-internal-tasks'
     PROCESS_FTP = 'process-ftp-tasks'
-    CREATE_LETTERS_PDF = 'create-letters-pdf'
+    CREATE_LETTERS_PDF = 'create-letters-pdf-tasks'
     CALLBACKS = 'service-callbacks'
 
     @staticmethod


### PR DESCRIPTION
## What

Create letters PDF needs to be name matching the `manifest-base-delivery.yml` otherwise the delivery worker will not pick up the queue to process the task