### PR TITLE
Notification reply to text from template

### DIFF
--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -16,7 +16,7 @@ from app.dao.templates_dao import (
 from notifications_utils.template import SMSMessageTemplate
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.models import SMS_TYPE
-from app.notifications.validators import service_has_permission
+from app.notifications.validators import service_has_permission, check_reply_to
 from app.schemas import (template_schema, template_history_schema)
 from app.errors import (
     register_errors,
@@ -58,6 +58,8 @@ def create_template(service_id):
         errors = {'content': [message]}
         raise InvalidRequest(errors, status_code=400)
 
+    check_reply_to(service_id, new_template.reply_to, new_template.template_type)
+
     dao_create_template(new_template)
     return jsonify(data=template_schema.dump(new_template).data), 201
 
@@ -93,6 +95,9 @@ def update_template(service_id, template_id):
         message = 'Content has a character count greater than the limit of {}'.format(char_count_limit)
         errors = {'content': [message]}
         raise InvalidRequest(errors, status_code=400)
+
+    check_reply_to(service_id, update_dict.reply_to, fetched_template.template_type)
+
     dao_update_template(update_dict)
     return jsonify(data=template_schema.dump(update_dict).data), 200
 

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -123,7 +123,8 @@ def create_template(
     template_name=None,
     subject='Template subject',
     content='Dear Sir/Madam, Hello. Yours Truly, The Government.',
-    template_id=None
+    template_id=None,
+    reply_to=None
 ):
     data = {
         'name': template_name or '{} Template Name'.format(template_type),
@@ -131,6 +132,7 @@ def create_template(
         'content': content,
         'service': service,
         'created_by': service.created_by,
+        'reply_to': reply_to,
     }
     if template_type != SMS_TYPE:
         data['subject'] = subject

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -28,6 +28,7 @@ from tests.app.db import (
     create_service,
     create_template,
     create_reply_to_email,
+    create_letter_contact,
     create_service_sms_sender,
     create_service_with_inbound_number
 )
@@ -639,3 +640,26 @@ def test_post_email_notification_with_invalid_reply_to_id_returns_400(client, sa
     assert 'email_reply_to_id {} does not exist in database for service id {}'. \
         format(fake_uuid, sample_email_template.service_id) in resp_json['errors'][0]['message']
     assert 'BadRequestError' in resp_json['errors'][0]['error']
+
+
+def test_letter_notification_should_use_template_reply_to(client, sample_letter_template):
+    letter_contact = create_letter_contact(sample_letter_template.service, "Edinburgh, ED1 1AA", is_default=False)
+    sample_letter_template.reply_to = str(letter_contact.id)
+
+    data = {
+        'template_id': str(sample_letter_template.id),
+        'personalisation': {
+            'address_line_1': '123',
+            'address_line_2': '234',
+            'postcode': 'W1A1AA',
+        }
+    }
+    response = client.post("v2/notifications/letter",
+                           data=json.dumps(data),
+                           headers=[('Content-Type', 'application/json'),
+                                    create_authorization_header(service_id=sample_letter_template.service.id)]
+                           )
+    assert response.status_code == 201, response.get_data(as_text=True)
+    notifications = Notification.query.all()
+    assert len(notifications) == 1
+    assert notifications[0].reply_to_text == "Edinburgh, ED1 1AA"


### PR DESCRIPTION
### Add validators for service_letter_contact_id and reply_to

Validators check that service_letter_contact_id belongs to the same service as the notification/template.

Generic reply_to validator calls the correct function for the given type (for either notification or template). It can be used by the template API endpoints to verify that given reply_to ID has the same service_id as the template itself.

The original approach was to create a DB foreign key constraint, but this caused issues with the `version_class` decorator saving related Service objects without creating a history record.

### Validate that template reply_to belongs to template's service

Checks that email/sms/letter reply to object has the same service_id as the template it's being attached to, to make sure it's not possible to retrieve data about return addresses for other services.

### Allow setting reply_to when creating a test template


### Add Template.get_reply_to_text helper method

Returns either template's reply_to text if set or the related field from the default service record.

Return value can be used as default for `Notification.reply_to_text` when per-notification value is not provided.

### Update notificaiton API endpoints to use template's reply_to

Sets the reply_to_text on notification from the template value if it's set.

### Set job notifications reply_to_text from the template.reply_to

When creating notification objects from the job sets the reply_to_text from template's reply_to if it's present. Otherwise uses the service default.
