### PR TITLE
Set SMS sender to international format

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import UniqueConstraint, CheckConstraint
 from notifications_utils.recipients import (
     validate_email_address,
     validate_phone_number,
+    try_validate_and_format_phone_number,
     InvalidPhoneError,
     InvalidEmailError
 )
@@ -636,7 +637,7 @@ class TemplateBase(db.Model):
         elif self.template_type == EMAIL_TYPE:
             return self.service.get_default_reply_to_email_address()
         elif self.template_type == SMS_TYPE:
-            return self.service.get_default_sms_sender()
+            return try_validate_and_format_phone_number(self.service.get_default_sms_sender())
         else:
             return None
 

--- a/app/models.py
+++ b/app/models.py
@@ -367,6 +367,9 @@ class ServiceSmsSender(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow, nullable=False)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
 
+    def get_reply_to_text(self):
+        return try_validate_and_format_phone_number(self.sms_sender)
+
     def serialize(self):
         return {
             "id": str(self.id),

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -90,7 +90,7 @@ def get_reply_to_text(notification_type, sender_id, service, template):
         if notification_type == EMAIL_TYPE:
             reply_to = dao_get_reply_to_by_id(service.id, sender_id).email_address
         elif notification_type == SMS_TYPE:
-            reply_to = dao_get_service_sms_senders_by_id(service.id, sender_id).sms_sender
+            reply_to = dao_get_service_sms_senders_by_id(service.id, sender_id).get_reply_to_text()
     else:
         reply_to = template.get_reply_to_text()
 

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -2,6 +2,8 @@ import functools
 
 from flask import request, jsonify, current_app, abort
 
+from notifications_utils.recipients import try_validate_and_format_phone_number
+
 from app import api_user, authenticated_service
 from app.config import QueueNames
 from app.models import (
@@ -208,9 +210,13 @@ def get_reply_to_text(notification_type, form, template):
 
     elif notification_type == SMS_TYPE:
         service_sms_sender_id = form.get("sms_sender_id", None)
-        reply_to = check_service_sms_sender_id(
+        sms_sender_id = check_service_sms_sender_id(
             str(authenticated_service.id), service_sms_sender_id, notification_type
-        ) or template.get_reply_to_text()
+        )
+        if sms_sender_id:
+            reply_to = try_validate_and_format_phone_number(sms_sender_id)
+        else:
+            reply_to = template.get_reply_to_text()
 
     elif notification_type == LETTER_TYPE:
         reply_to = template.get_reply_to_text()


### PR DESCRIPTION
Pivotal story: https://www.pivotaltracker.com/story/show/153140515
Branched off #1500

Replaces 0 with 44 in UK SMS sender number to make it possible to respond to the SMS from an international number.

We've tested this and both iOS and Android join the new `+44...` incoming messages with existing `0...` conversation threads, so we're applying this change to all outgoing messages that use a UK phone number as sms_sender.


Paired with @klssmith 