### PR TITLE
Remove the delivery receipt callback for letters

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -31,7 +31,6 @@ from app import (
 from app.aws import s3
 from app.celery import provider_tasks
 from app.celery import letters_pdf_tasks
-from app.celery.service_callback_tasks import send_delivery_status_to_service
 from app.config import QueueNames
 from app.dao.inbound_sms_dao import dao_get_inbound_sms_by_id
 from app.dao.jobs_dao import (
@@ -46,13 +45,11 @@ from app.dao.notifications_dao import (
     dao_update_notifications_for_job_to_sent_to_dvla,
     dao_update_notifications_by_reference,
     dao_get_last_notification_added_for_job_id,
-    dao_get_notifications_by_references,
 )
 from app.dao.provider_details_dao import get_current_provider
 from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
 from app.dao.services_dao import dao_fetch_service_by_id, fetch_todays_total_message_count
 from app.dao.templates_dao import dao_get_template_by_id
-from app.dao.service_callback_api_dao import get_service_callback_api_for_service
 from app.models import (
     DVLA_RESPONSE_STATUS_SENT,
     EMAIL_TYPE,
@@ -416,12 +413,6 @@ def update_letter_notifications_to_error(self, notification_references):
     )
 
     current_app.logger.info("Updated {} letter notifications to technical-failure".format(updated_count))
-    notifications = dao_get_notifications_by_references(references=notification_references)
-    # queue callback task only if the service_callback_api exists
-    service_callback_api = get_service_callback_api_for_service(service_id=notifications[0].service_id)
-    if service_callback_api:
-        for notification in notifications:
-            send_delivery_status_to_service.apply_async([str(notification.id)], queue=QueueNames.CALLBACKS)
 
 
 def create_dvla_file_contents_for_job(job_id):
@@ -503,12 +494,6 @@ def update_letter_notifications_statuses(self, filename):
                 current_app.logger.info(
                     'DVLA file: {filename}, notification updated to {status}: {reference}'.format(
                         filename=filename, status=status, reference=str(update.reference)))
-                notifications = dao_get_notifications_by_references(references=[update.reference])
-                # queue callback task only if the service_callback_api exists
-                service_callback_api = get_service_callback_api_for_service(service_id=notifications[0].service_id)
-                if service_callback_api:
-                    for notification in notifications:
-                        send_delivery_status_to_service.apply_async([str(notification.id)], queue=QueueNames.CALLBACKS)
 
 
 def process_updates_from_file(response_file):


### PR DESCRIPTION
This has been removed because the services only see one status.

Pivotal story: https://www.pivotaltracker.com/story/show/153674962

Paired with @allait 