### PR TITLE
bump utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,9 +26,6 @@ notifications-python-client==4.6.0
 awscli==1.14.4
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@23.3.4#egg=notifications-utils==23.3.4
+git+https://github.com/alphagov/notifications-utils.git@23.3.5#egg=notifications-utils==23.3.5
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
-
-# required by utils
-git+https://github.com/leohemsted/smartypants.py.git@regex-speedup#egg=smartypants==2.1.0


### PR DESCRIPTION
no longer needs smartypants from git