### PR TITLE
Enable Markdown links in emails

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,6 @@ notifications-python-client==4.7.1
 awscli==1.14.16
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@23.3.5#egg=notifications-utils==23.3.5
+git+https://github.com/alphagov/notifications-utils.git@23.4.0#egg=notifications-utils==23.4.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
Brings in:
- [ ] https://github.com/alphagov/notifications-utils/pull/293