### PR TITLE
Get rate limit from service.rate_limit column (not config)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -7,7 +7,6 @@ from kombu import Exchange, Queue
 
 from app.models import (
     EMAIL_TYPE, SMS_TYPE, LETTER_TYPE,
-    KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST
 )
 
 if os.environ.get('VCAP_SERVICES'):
@@ -293,21 +292,6 @@ class Config(object):
         'notification': '{}-dvla-letter-api-files'.format(os.getenv('NOTIFY_ENVIRONMENT'))
     }
 
-    API_KEY_LIMITS = {
-        KEY_TYPE_TEAM: {
-            "limit": 3000,
-            "interval": 60
-        },
-        KEY_TYPE_NORMAL: {
-            "limit": 3000,
-            "interval": 60
-        },
-        KEY_TYPE_TEST: {
-            "limit": 3000,
-            "interval": 60
-        }
-    }
-
     FREE_SMS_TIER_FRAGMENT_COUNT = 250000
 
     SMS_INBOUND_WHITELIST = json.loads(os.environ.get('SMS_INBOUND_WHITELIST', '[]'))
@@ -375,21 +359,6 @@ class Test(Config):
     API_RATE_LIMIT_ENABLED = True
     API_HOST_NAME = "http://localhost:6011"
 
-    API_KEY_LIMITS = {
-        KEY_TYPE_TEAM: {
-            "limit": 1,
-            "interval": 2
-        },
-        KEY_TYPE_NORMAL: {
-            "limit": 10,
-            "interval": 20
-        },
-        KEY_TYPE_TEST: {
-            "limit": 100,
-            "interval": 200
-        }
-    }
-
     SMS_INBOUND_WHITELIST = ['203.0.113.195']
     FIRETEXT_INBOUND_SMS_AUTH = ['testkey']
     MMG_INBOUND_SMS_AUTH = ['testkey']
@@ -419,21 +388,6 @@ class Staging(Config):
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = True
     REDIS_ENABLED = True
-
-    API_KEY_LIMITS = {
-        KEY_TYPE_TEAM: {
-            "limit": 24000,
-            "interval": 60
-        },
-        KEY_TYPE_NORMAL: {
-            "limit": 24000,
-            "interval": 60
-        },
-        KEY_TYPE_TEST: {
-            "limit": 24000,
-            "interval": 60
-        }
-    }
 
 
 class Live(Config):

--- a/app/models.py
+++ b/app/models.py
@@ -250,6 +250,7 @@ class Service(db.Model, Versioned):
         nullable=True,
     )
     crown = db.Column(db.Boolean, index=False, nullable=False, default=True)
+    rate_limit = db.Column(db.Integer, index=False, nullable=False, default=3000)
 
     association_proxy('permissions', 'service_permission_types')
 

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -26,8 +26,8 @@ from app.dao.service_letter_contact_dao import dao_get_letter_contact_by_id
 def check_service_over_api_rate_limit(service, api_key):
     if current_app.config['API_RATE_LIMIT_ENABLED'] and current_app.config['REDIS_ENABLED']:
         cache_key = rate_limit_cache_key(service.id, api_key.key_type)
-        rate_limit = current_app.config['API_KEY_LIMITS'][api_key.key_type]['limit']
-        interval = current_app.config['API_KEY_LIMITS'][api_key.key_type]['interval']
+        rate_limit = service.rate_limit
+        interval = 60
         if redis_store.exceeded_rate_limit(cache_key, rate_limit, interval):
             current_app.logger.error("service {} has been rate limited for throughput".format(service.id))
             raise RateLimitError(rate_limit, interval, api_key.key_type)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -233,6 +233,7 @@ def test_create_service(client, sample_user):
     assert not json_resp['data']['research_mode']
     assert json_resp['data']['dvla_organisation'] == '001'
     assert json_resp['data']['sms_sender'] == current_app.config['FROM_NUMBER']
+    assert json_resp['data']['rate_limit'] == 3000
 
     service_db = Service.query.get(json_resp['data']['id'])
     assert service_db.name == 'created service'


### PR DESCRIPTION
PR #1550 added the rate_limit column to the Service table.

This PR removes the rate limits from the config and uses rate_limit from
the Service model instead. Rate limits are still separated into 'team',
'normal' and 'test', but these values are the same for a service.

Pivotal story https://www.pivotaltracker.com/story/show/153992529

Paired with @leohemsted 