### PR TITLE
Fix the template history when updating the reply_to for a template.

### DIFF
--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -34,6 +34,36 @@ def dao_update_template(template):
 
 
 @transactional
+def dao_update_template_reply_to(template_id, reply_to):
+    Template.query.filter_by(id=template_id).update(
+        {"service_letter_contact_id": reply_to,
+         "updated_at": datetime.utcnow(),
+         "version": Template.version + 1,
+         }
+    )
+    template = Template.query.filter_by(id=template_id).one()
+
+    history = TemplateHistory(**
+                              {
+                                  "id": template.id,
+                                  "name": template.name,
+                                  "template_type": template.template_type,
+                                  "created_at": template.created_at,
+                                  "updated_at": template.updated_at,
+                                  "content": template.content,
+                                  "service_id": template.service_id,
+                                  "subject": template.subject,
+                                  "created_by_id": template.created_by_id,
+                                  "version": template.version,
+                                  "archived": template.archived,
+                                  "process_type": template.process_type,
+                                  "service_letter_contact_id": template.service_letter_contact_id
+                              })
+    db.session.add(history)
+    return history
+
+
+@transactional
 def dao_redact_template(template, user_id):
     template.template_redacted.redact_personalisation = True
     template.template_redacted.updated_at = datetime.utcnow()

--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -60,7 +60,7 @@ def dao_update_template_reply_to(template_id, reply_to):
                                   "service_letter_contact_id": template.service_letter_contact_id
                               })
     db.session.add(history)
-    return history
+    return template
 
 
 @transactional

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -11,7 +11,8 @@ from app.dao.templates_dao import (
     dao_redact_template,
     dao_get_template_by_id_and_service_id,
     dao_get_all_templates_for_service,
-    dao_get_template_versions
+    dao_get_template_versions,
+    dao_update_template_reply_to
 )
 from notifications_utils.template import SMSMessageTemplate
 from app.dao.services_dao import dao_fetch_service_by_id
@@ -81,6 +82,11 @@ def update_template(service_id, template_id):
     if data.get('redact_personalisation') is True:
         return redact_template(fetched_template, data)
 
+    if "reply_to" in data:
+        check_reply_to(service_id, data.get("reply_to"), fetched_template.template_type)
+        updated = dao_update_template_reply_to(template_id=template_id, reply_to=data.get("reply_to"))
+        return jsonify(data=template_schema.dump(updated).data), 200
+
     current_data = dict(template_schema.dump(fetched_template).data.items())
     updated_template = dict(template_schema.dump(fetched_template).data.items())
     updated_template.update(data)
@@ -88,8 +94,6 @@ def update_template(service_id, template_id):
     # Check if there is a change to make.
     if _template_has_not_changed(current_data, updated_template):
         return jsonify(data=updated_template), 200
-
-    check_reply_to(service_id, updated_template.get('reply_to', None), fetched_template.template_type)
 
     over_limit = _content_count_greater_than_limit(updated_template['content'], fetched_template.template_type)
     if over_limit:
@@ -160,7 +164,7 @@ def get_template_versions(service_id, template_id):
 def _template_has_not_changed(current_data, updated_template):
     return all(
         current_data[key] == updated_template[key]
-        for key in ('name', 'content', 'subject', 'archived', 'process_type', 'reply_to')
+        for key in ('name', 'content', 'subject', 'archived', 'process_type')
     )
 
 

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -144,7 +144,7 @@ def test_dao_update_tempalte_reply_to_some_to_some(sample_service, sample_user):
     assert updated_history.updated_at == updated_history.updated_at
 
 
-def test_dao_update_tempalte_reply_to_some_to_none(sample_service, sample_user):
+def test_dao_update_template_reply_to_some_to_none(sample_service, sample_user):
     letter_contact = create_letter_contact(sample_service, 'Edinburgh, ED1 1AA')
     data = {
         'name': 'Sample Template',

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -111,6 +111,29 @@ def test_update_template_reply_to(sample_service, sample_user):
     assert template_history.service_letter_contact_id
 
 
+def test_update_template_reply_to_updates_history(sample_service, sample_user):
+    letter_contact = create_letter_contact(sample_service, 'Edinburgh, ED1 1AA')
+
+    data = {
+        'name': 'Sample Template',
+        'template_type': "letter",
+        'content': "Template content",
+        'service': sample_service,
+        'created_by': sample_user,
+    }
+    template = Template(**data)
+    dao_create_template(template)
+    created = dao_get_all_templates_for_service(sample_service.id)[0]
+    assert created.reply_to is None
+
+    created.reply_to = letter_contact.id
+    dao_update_template(created)
+    assert dao_get_all_templates_for_service(sample_service.id)[0].reply_to == letter_contact.id
+
+    template_history = TemplateHistory.query.filter_by(id=created.id, version=2).one()
+    assert template_history.service_letter_contact_id == letter_contact.id
+
+
 def test_redact_template(sample_template):
     redacted = TemplateRedacted.query.one()
     assert redacted.template_id == sample_template.id

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -662,6 +662,28 @@ def test_update_template_reply_to(client, sample_letter_template):
     assert th.service_letter_contact_id == letter_contact.id
 
 
+def test_update_template_reply_to_set_to_blank(client, notify_db_session):
+    auth_header = create_authorization_header()
+    service = create_service(service_permissions=['letter'])
+    letter_contact = create_letter_contact(service, "Edinburgh, ED1 1AA")
+    template = create_template(service=service, template_type='letter', reply_to=letter_contact.id)
+
+    data = {
+        'reply_to': None,
+    }
+
+    resp = client.post('/service/{}/template/{}'.format(template.service_id, template.id),
+                       data=json.dumps(data),
+                       headers=[('Content-Type', 'application/json'), auth_header])
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+
+    template = dao_get_template_by_id(template.id)
+    assert template.service_letter_contact_id is None
+    th = TemplateHistory.query.filter_by(id=template.id, version=2).one()
+    assert th.service_letter_contact_id is None
+
+
 def test_update_template_with_foreign_service_reply_to(client, sample_letter_template):
     auth_header = create_authorization_header()
 

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 import pytest
 from freezegun import freeze_time
 
-from app.models import Template, SMS_TYPE, EMAIL_TYPE, LETTER_TYPE
+from app.models import Template, SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, TemplateHistory
 from app.dao.templates_dao import dao_get_template_by_id, dao_redact_template
 
 from tests import create_authorization_header
@@ -587,6 +587,8 @@ def test_create_a_template_with_reply_to(admin_request, sample_user):
     template = Template.query.get(json_resp['data']['id'])
     from app.schemas import template_schema
     assert sorted(json_resp['data']) == sorted(template_schema.dump(template).data)
+    th = TemplateHistory.query.filter_by(id=template.id, version=1).one()
+    assert th.service_letter_contact_id == letter_contact.id
 
 
 def test_create_a_template_with_foreign_service_reply_to(admin_request, sample_user):
@@ -644,7 +646,6 @@ def test_get_template_reply_to(client, sample_service, template_default, service
 def test_update_template_reply_to(client, sample_letter_template):
     auth_header = create_authorization_header()
     letter_contact = create_letter_contact(sample_letter_template.service, "Edinburgh, ED1 1AA")
-
     data = {
         'reply_to': str(letter_contact.id),
     }
@@ -656,7 +657,9 @@ def test_update_template_reply_to(client, sample_letter_template):
     assert resp.status_code == 200, resp.get_data(as_text=True)
 
     template = dao_get_template_by_id(sample_letter_template.id)
-    assert template.reply_to == letter_contact.id
+    assert template.service_letter_contact_id == letter_contact.id
+    th = TemplateHistory.query.filter_by(id=sample_letter_template.id, version=2).one()
+    assert th.service_letter_contact_id == letter_contact.id
 
 
 def test_update_template_with_foreign_service_reply_to(client, sample_letter_template):


### PR DESCRIPTION
It seems selecting the service_letter_contact in the validation method was causing SQLAlchemy to persist the object. When the dao was called to save the object nothing was different so we didn't persist the history object.

It may be time to take another look at how we version. :(