### PR TITLE
Add validation to check that sms recipient is not None

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -98,6 +98,9 @@ def check_service_can_schedule_notification(permissions, scheduled_for):
 
 
 def validate_and_format_recipient(send_to, key_type, service, notification_type):
+    if send_to is None:
+        raise BadRequestError(message="Recipient can't be empty")
+
     service_can_send_to_recipient(send_to, key_type, service)
 
     if notification_type == SMS_TYPE:

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -347,6 +347,13 @@ def test_allows_api_calls_with_international_numbers_if_service_does_allow_int_s
     assert result == '201212341234'
 
 
+def test_rejects_api_calls_with_no_recipient():
+    with pytest.raises(BadRequestError) as e:
+        validate_and_format_recipient(None, 'key_type', 'service', 'SMS_TYPE')
+    assert e.value.status_code == 400
+    assert e.value.message == "Recipient can't be empty"
+
+
 @pytest.mark.parametrize('notification_type', ['sms', 'email', 'letter'])
 def test_check_service_email_reply_to_id_where_reply_to_id_is_none(notification_type):
     assert check_service_email_reply_to_id(None, None, notification_type) is None


### PR DESCRIPTION
Previously, if the SMS recipient was None there would be a 500 error
with no message displayed to the user. We now check if the recipient is
None and raise a BadRequestError if this is the case.