### PR TITLE
Raise alert every day to compare ack files with every zip file

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -107,3 +107,19 @@ def upload_letters_pdf(reference, crown, filedata):
 
     current_app.logger.info("Uploading letters PDF {} to {}".format(
         upload_file_name, current_app.config['LETTERS_PDF_BUCKET_NAME']))
+
+
+def get_list_of_files_by_suffix(bucket_name, subfolder='', suffix=''):
+    s3_client = client('s3', current_app.config['AWS_REGION'])
+    paginator = s3_client.get_paginator('list_objects_v2')
+
+    page_iterator = paginator.paginate(
+        Bucket=bucket_name,
+        Prefix=subfolder
+    )
+
+    for page in page_iterator:
+        for obj in page['Contents']:
+            key = obj['Key']
+            if key.endswith(suffix):
+                yield key

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -447,3 +447,22 @@ def daily_stats_template_usage_by_month():
                 result.year,
                 result.count
             )
+
+
+@notify_celery.task(name='raise-alert-if-no-letter-ack-file')
+@statsd(namespace="tasks")
+def raise_alert_if_no_letter_ack_file():
+    """
+    Get all files sent "today"
+    list_of_zip_files => get file names s3.get_s3_bucket_objects() look in the folder with todays date
+
+    list_of_ack_files => Get all files sent today with name containing ack.txt from a diff bucket
+
+    For filename in list_of_zip_files:
+        for ack_file in list_of_ack_files if name= file.strip("NOTIFY.", ".ZIP")
+        IF no ack_file
+            raise NoAckFileReceived(status=500, message="No ack file received for {filename}")
+
+    """
+
+    pass

--- a/app/config.py
+++ b/app/config.py
@@ -251,7 +251,7 @@ class Config(object):
         },
         'raise-alert-if-no-letter-ack-file': {
             'task': 'raise-alert-if-no-letter-ack-file',
-            'schedule': crontab(hour=19, minute=00),
+            'schedule': crontab(hour=23, minute=00),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'run-letter-api-notifications': {

--- a/app/config.py
+++ b/app/config.py
@@ -249,6 +249,11 @@ class Config(object):
             'schedule': crontab(hour=17, minute=50),
             'options': {'queue': QueueNames.PERIODIC}
         },
+        'raise-alert-if-no-letter-ack-file': {
+            'task': 'raise-alert-if-no-letter-ack-file',
+            'schedule': crontab(hour=19, minute=00),
+            'options': {'queue': QueueNames.PERIODIC}
+        },
         'run-letter-api-notifications': {
             'task': 'run-letter-api-notifications',
             'schedule': crontab(hour=17, minute=40),

--- a/app/notifications/notifications_letter_callback.py
+++ b/app/notifications/notifications_letter_callback.py
@@ -53,6 +53,7 @@ def process_letter_response():
         message = json.loads(req_json['Message'])
         filename = message['Records'][0]['s3']['object']['key']
         current_app.logger.info('Received file from DVLA: {}'.format(filename))
+        # IF file name contains .rs.txt THEN continue ELSE log message with file name. and return
         current_app.logger.info('DVLA callback: Calling task to update letter notifications')
         update_letter_notifications_statuses.apply_async([filename], queue=QueueNames.NOTIFY)
 

--- a/app/notifications/notifications_letter_callback.py
+++ b/app/notifications/notifications_letter_callback.py
@@ -53,7 +53,6 @@ def process_letter_response():
         message = json.loads(req_json['Message'])
         filename = message['Records'][0]['s3']['object']['key']
         current_app.logger.info('Received file from DVLA: {}'.format(filename))
-        # IF file name contains .rs.txt THEN continue ELSE log message with file name. and return
         current_app.logger.info('DVLA callback: Calling task to update letter notifications')
         update_letter_notifications_statuses.apply_async([filename], queue=QueueNames.NOTIFY)
 

--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -26,6 +26,23 @@ class JobIncompleteError(Exception):
         }
 
 
+class NoAckFileReceived(Exception):
+    def __init__(self, message):
+        self.message = message
+        self.status_code = 500
+
+    def to_dict_v2(self):
+        return {
+            'status_code': self.status_code,
+            "errors": [
+                {
+                    "error": 'NoAckFileReceived',
+                    "message": str(self.message)
+                }
+            ]
+        }
+
+
 class TooManyRequestsError(InvalidRequest):
     status_code = 429
     message_template = 'Exceeded send limits ({}) for today'

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,6 @@ notifications-python-client==4.7.1
 awscli==1.14.16
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@23.4.0#egg=notifications-utils==23.4.0
+git+https://github.com/alphagov/notifications-utils.git@23.4.1#egg=notifications-utils==23.4.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/scripts/test_s3.py
+++ b/scripts/test_s3.py
@@ -1,0 +1,66 @@
+from app.aws.s3 import get_list_of_files_by_suffix, get_s3_file
+
+
+zip_bucket_name = 'development-letters-pdf'
+zip_sub_folder = '2018-01-11'
+zip_file_name = '2018-01-11/NOTIFY.20180111175007.ZIP'
+ack_bucket_name = 'development-letters-pdf'
+ack_subfolder = 'root/dispatch'
+ack_file_name = 'root/dispatch/NOTIFY.20180111175733.ACK.txt'
+
+# Tests for boto3 and s3, can only perform locally against the Tools aws account and have permissions to access S3.
+# The tests are based on the above folders and files already uploaded to S3 Tools aws account (If these are removed or
+# renamed, the tests won't pass.
+
+
+def test_get_zip_files():
+    zip_file_list = []
+    for key in get_list_of_files_by_suffix(bucket_name=zip_bucket_name, subfolder=zip_sub_folder, suffix='.ZIP'):
+        print('File: ' + key)
+        zip_file_list.append(key)
+    assert zip_file_name in zip_file_list
+
+
+def test_get_ack_files():
+    ack_file_list = []
+    for key in get_list_of_files_by_suffix(bucket_name=ack_bucket_name, subfolder=ack_subfolder, suffix='.ACK.txt'):
+        print('File: ' + key)
+        ack_file_list.append(key)
+    assert ack_file_name in ack_file_list
+
+
+def test_get_file_content():
+    ack_file_list = []
+    for key in get_list_of_files_by_suffix(bucket_name=ack_bucket_name, subfolder=ack_subfolder, suffix='.ACK.txt'):
+        ack_file_list.append(key)
+    assert ack_file_name in key
+
+    todaystr = '20180111'
+    for key in ack_file_list:
+        if todaystr in key:
+            content = get_s3_file(ack_bucket_name, key)
+            print(content)
+
+
+def test_letter_ack_file_strip_correctly():
+    # Test ack files are stripped correctly. In the acknowledgement file, there should be 2 zip files,
+    # 'NOTIFY.20180111175007.ZIP','NOTIFY.20180111175008.ZIP'.
+    zip_file_list = ['NOTIFY.20180111175007.ZIP', 'NOTIFY.20180111175008.ZIP', 'NOTIFY.20180111175009.ZIP']
+    # get acknowledgement file
+    ack_file_list = []
+    for key in get_list_of_files_by_suffix(bucket_name=ack_bucket_name, subfolder=ack_subfolder, suffix='.ACK.txt'):
+        ack_file_list.append(key)
+
+    for key in ack_file_list:
+        if '20180111' in key:
+            content = get_s3_file(ack_bucket_name, key)
+            print(content)
+            for zip_file in content.split():  # iterate each line
+                s = zip_file.split('|')
+                print(s[0])
+                for zf in zip_file_list:
+                    if s[0] in zf:
+                        zip_file_list.remove(zf)
+
+    print('zip_file_list: ' + str(zip_file_list))
+    assert zip_file_list == ['NOTIFY.20180111175009.ZIP']


### PR DESCRIPTION
Pivotal story: https://www.pivotaltracker.com/story/show/152965020

DVLA sends an acknowledgement file everyday if we send them a zip file. This file contains a list of all the zip files they received for the day. We process this file every day at 23:00 (this time may be adjusted in the future). If there is/are zip files that is not acknowledged, we raise a 500 exception, which contains a list of zip files. 

**Get a list of S3 key name based on a defined suffix**
This function is used to get a list of '.zip' files and '.ack.txt' files from S3 buckets

**Only process letter callback if it is a status update file**
update_letter_notifications_statuses is only called if the filename contains '.rs.txt', which indicates it is a response file, not an acknowledgement file. 

**Define new type of error NoAckFileReceived to be sent to cloudwatch**

**Schedule checking task**
At 23:00 everyday, API checks the received acknowledgement file agains the list of zip files we have. Raise an alert if there are missing zip file acknowledgement

**Build s3 test**
These are unit tests that can be run on the local machine to process s3 buckets and folders. 

