### PR TITLE
Fix a typo error on task argument

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -119,8 +119,12 @@ def get_list_of_files_by_suffix(bucket_name, subfolder='', suffix='', last_modif
     )
 
     for page in page_iterator:
-        for obj in page['Contents']:
-            key = obj['Key'].lower()
-            if key.endswith(suffix.lower()):
-                if not last_modified or obj['LastModified'] >= last_modified:
-                    yield key
+        try:
+            for obj in page['Contents']:
+                key = obj['Key'].lower()
+                if key.endswith(suffix.lower()):
+                    if not last_modified or obj['LastModified'] >= last_modified:
+                        yield key
+        except KeyError:
+            # Not content for today
+            pass

--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -119,12 +119,8 @@ def get_list_of_files_by_suffix(bucket_name, subfolder='', suffix='', last_modif
     )
 
     for page in page_iterator:
-        try:
-            for obj in page['Contents']:
-                key = obj['Key'].lower()
-                if key.endswith(suffix.lower()):
-                    if not last_modified or obj['LastModified'] >= last_modified:
-                        yield key
-        except KeyError:
-            # Not content for today
-            pass
+        for obj in page.get('Contents', []):
+            key = obj['Key'].lower()
+            if key.endswith(suffix.lower()):
+                if not last_modified or obj['LastModified'] >= last_modified:
+                    yield key

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -465,7 +465,7 @@ def letter_raise_alert_if_no_ack_file_for_zip():
     # yesterday = datetime.now(tz=pytz.utc) - timedelta(days=1)
     yesterday = datetime.utcnow() - timedelta(days=1)
     for key in s3.get_list_of_files_by_suffix(bucket_name=current_app.config['DVLA_RESPONSE_BUCKET_NAME'],
-                                              subfolder='root/dispatch', suffix='.ACK.txt', lastModified=yesterday):
+                                              subfolder='root/dispatch', suffix='.ACK.txt', last_modified=yesterday):
         ack_file_list.append(key)
 
     today_str = datetime.utcnow().strftime('%Y%m%d')

--- a/tests/app/aws/test_s3.py
+++ b/tests/app/aws/test_s3.py
@@ -208,3 +208,18 @@ def test_get_list_of_files_by_suffix(notify_api, mocker, suffix_str, days_before
     assert sum(1 for x in key) == returned_no
     for k in key:
         assert k == 'bar/foo.ACK.txt'
+
+
+def test_get_list_of_files_by_suffix_empty_contents_return_with_no_error(notify_api, mocker):
+    paginator_mock = mocker.patch('app.aws.s3.client')
+    multiple_pages_s3_object = [
+        {
+            "other_content": [
+                'some_values',
+            ]
+        }
+    ]
+    paginator_mock.return_value.get_paginator.return_value.paginate.return_value = multiple_pages_s3_object
+    key = get_list_of_files_by_suffix('foo-bucket', subfolder='bar', suffix='.pdf')
+
+    assert sum(1 for x in key) == 0

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -1029,7 +1029,7 @@ def test_dao_fetch_monthly_historical_stats_by_template_null_template_id_not_cou
     assert len(result) == 1
 
 
-def mock_s3_get_list_match(bucket_name, subfolder='', suffix='', lastModified=None):
+def mock_s3_get_list_match(bucket_name, subfolder='', suffix='', last_modified=None):
 
     if subfolder == '2018-01-11':
         return ['NOTIFY.20180111175007.ZIP', 'NOTIFY.20180111175008.ZIP']
@@ -1037,7 +1037,7 @@ def mock_s3_get_list_match(bucket_name, subfolder='', suffix='', lastModified=No
         return ['root/dispatch/NOTIFY.20180111175733.ACK.txt']
 
 
-def mock_s3_get_list_diff(bucket_name, subfolder='', suffix='', lastModified=None):
+def mock_s3_get_list_diff(bucket_name, subfolder='', suffix='', last_modified=None):
     if subfolder == '2018-01-11':
         return ['NOTIFY.20180111175007.ZIP', 'NOTIFY.20180111175008.ZIP', 'NOTIFY.20180111175009.ZIP',
                 'NOTIFY.20180111175010.ZIP']
@@ -1054,7 +1054,13 @@ def test_letter_not_raise_alert_if_ack_files_match_zip_list(mocker, notify_db):
 
     letter_raise_alert_if_no_ack_file_for_zip()
 
+    yesterday = datetime.utcnow() - timedelta(days=1)
+    subfoldername = datetime.utcnow().strftime('%Y-%m-%d')
     assert mock_file_list.call_count == 2
+    assert mock_file_list.call_args_list == [
+        call(bucket_name='test-letters-pdf', subfolder=subfoldername, suffix='.zip'),
+        call(bucket_name='test.notify.com-ftp', subfolder='root/dispatch', suffix='.ACK.txt', last_modified=yesterday),
+    ]
     assert mock_get_file.call_count == 1
 
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -1058,8 +1058,9 @@ def test_letter_not_raise_alert_if_ack_files_match_zip_list(mocker, notify_db):
     subfoldername = datetime.utcnow().strftime('%Y-%m-%d')
     assert mock_file_list.call_count == 2
     assert mock_file_list.call_args_list == [
-        call(bucket_name='test-letters-pdf', subfolder=subfoldername, suffix='.zip'),
-        call(bucket_name='test.notify.com-ftp', subfolder='root/dispatch', suffix='.ACK.txt', last_modified=yesterday),
+        call(bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'], subfolder=subfoldername, suffix='.zip'),
+        call(bucket_name=current_app.config['DVLA_RESPONSE_BUCKET_NAME'], subfolder='root/dispatch',
+             suffix='.ACK.txt', last_modified=yesterday),
     ]
     assert mock_get_file.call_count == 1
 


### PR DESCRIPTION
A small task to fix a typo error in schedule_task to compare zip files
Modified unit test to be more robust
Related to this PR
https://github.com/alphagov/notifications-api/pull/1567