### PR TITLE
Add a celery scheduled task to alert if letters are still sending

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,6 +8,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_marshmallow import Marshmallow
 from flask_migrate import Migrate
 from monotonic import monotonic
+from notifications_utils.clients import DeskproClient
 from notifications_utils.clients.statsd.statsd_client import StatsdClient
 from notifications_utils.clients.redis.redis_client import RedisClient
 from notifications_utils import logging, request_helper
@@ -34,6 +35,7 @@ loadtest_client = LoadtestingClient()
 mmg_client = MMGClient()
 aws_ses_client = AwsSesClient()
 encryption = Encryption()
+deskpro_client = DeskproClient()
 statsd_client = StatsdClient()
 redis_store = RedisClient()
 performance_platform_client = PerformancePlatformClient()
@@ -58,6 +60,7 @@ def create_app(application):
     db.init_app(application)
     migrate.init_app(application, db=db)
     ma.init_app(application)
+    deskpro_client.init_app(application)
     statsd_client.init_app(application)
     logging.init_app(application, statsd_client)
     firetext_client.init_app(application, statsd_client=statsd_client)

--- a/app/config.py
+++ b/app/config.py
@@ -103,6 +103,14 @@ class Config(object):
     PERFORMANCE_PLATFORM_ENABLED = False
     PERFORMANCE_PLATFORM_URL = 'https://www.performance.service.gov.uk/data/govuk-notify/'
 
+    # Deskpro
+    DESKPRO_API_HOST = os.environ.get('DESKPRO_API_HOST')
+    DESKPRO_API_KEY = os.environ.get('DESKPRO_API_KEY')
+
+    DESKPRO_DEPT_ID = 5
+    DESKPRO_ASSIGNED_AGENT_TEAM_ID = 5
+    DESKPRO_PERSON_EMAIL = 'donotreply@notifications.service.gov.uk'
+
     # Logging
     DEBUG = False
     NOTIFY_LOG_PATH = os.getenv('NOTIFY_LOG_PATH')
@@ -237,6 +245,11 @@ class Config(object):
         'populate_monthly_billing': {
             'task': 'populate_monthly_billing',
             'schedule': crontab(hour=5, minute=10),
+            'options': {'queue': QueueNames.PERIODIC}
+        },
+        'raise-alert-if-letter-notifications-still-sending': {
+            'task': 'raise-alert-if-letter-notifications-still-sending',
+            'schedule': crontab(hour=16, minute=30),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'run-letter-jobs': {

--- a/manifest-api-base.yml
+++ b/manifest-api-base.yml
@@ -27,6 +27,9 @@ env:
 
   STATSD_PREFIX: null
 
+  DESKPRO_API_KEY: null
+  DESKPRO_API_HOST: null
+
   MMG_URL: null
   MMG_API_KEY: null
   MMG_INBOUND_SMS_AUTH: null

--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -26,6 +26,9 @@ env:
 
   STATSD_PREFIX: null
 
+  DESKPRO_API_KEY: null
+  DESKPRO_API_HOST: null
+
   MMG_URL: null
   MMG_API_KEY: null
   MMG_INBOUND_SMS_AUTH: null

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,6 @@ notifications-python-client==4.7.1
 awscli==1.14.25
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@23.4.1#egg=notifications-utils==23.4.1
+git+https://github.com/alphagov/notifications-utils.git@23.5.0#egg=notifications-utils==23.5.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
### Add utils DeskproClient and configuration variables

Deskpro client is used to create tickets from celery alerting tasks (eg alerts for missing ack or response files from DVLA).

### Add a celery scheduled task to alert if letters are still sending

We should receive a response file from DVLA by 4pm the next working day (next Monday for letters created on Friday, Saturday or Sunday).

Response file triggers a task to update the letters status from 'sending' to either 'failed' or 'delivered', at which point there should be no letter notifications in the 'sending' state for that day.

To catch any errors in the process (eg a missing response file from DVLA) we add a scheduled task that checks letter notifications for previous day (or Friday when run on Monday) and raises a Deskpro ticket if it finds any in a 'sending' state. The task runs at 4:30pm, which should give the response file processing task enough time to finish if the file was uploaded at 4pm.
