### PR TITLE
Don’t respect the whitelist for one off sending

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -67,8 +67,8 @@ def check_template_is_active(template):
                               message="Template has been deleted")
 
 
-def service_can_send_to_recipient(send_to, key_type, service):
-    if not service_allowed_to_send_to(send_to, service, key_type):
+def service_can_send_to_recipient(send_to, key_type, service, allow_whitelisted_recipients=True):
+    if not service_allowed_to_send_to(send_to, service, key_type, allow_whitelisted_recipients):
         if key_type == KEY_TYPE_TEAM:
             message = 'Can’t send to this recipient using a team-only API key'
         else:
@@ -97,11 +97,11 @@ def check_service_can_schedule_notification(permissions, scheduled_for):
             raise BadRequestError(message="Cannot schedule notifications (this feature is invite-only)")
 
 
-def validate_and_format_recipient(send_to, key_type, service, notification_type):
+def validate_and_format_recipient(send_to, key_type, service, notification_type, allow_whitelisted_recipients=True):
     if send_to is None:
         raise BadRequestError(message="Recipient can't be empty")
 
-    service_can_send_to_recipient(send_to, key_type, service)
+    service_can_send_to_recipient(send_to, key_type, service, allow_whitelisted_recipients)
 
     if notification_type == SMS_TYPE:
         international_phone_info = get_international_phone_info(send_to)

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -49,7 +49,8 @@ def send_one_off_notification(service_id, post_data):
         send_to=post_data['to'],
         key_type=KEY_TYPE_NORMAL,
         service=service,
-        notification_type=template.template_type
+        notification_type=template.template_type,
+        allow_whitelisted_recipients=False,
     )
 
     validate_created_by(service, post_data['created_by'])

--- a/app/service/utils.py
+++ b/app/service/utils.py
@@ -26,7 +26,7 @@ def get_whitelist_objects(service_id, request_json):
     ]
 
 
-def service_allowed_to_send_to(recipient, service, key_type):
+def service_allowed_to_send_to(recipient, service, key_type, allow_whitelisted_recipients=True):
     if key_type == KEY_TYPE_TEST:
         return True
 
@@ -38,6 +38,7 @@ def service_allowed_to_send_to(recipient, service, key_type):
     )
     whitelist_members = [
         member.recipient for member in service.whitelist
+        if allow_whitelisted_recipients
     ]
 
     if (


### PR DESCRIPTION
The whitelist was built to help developers and designers making prototypes to do realistic usability testing of them, without having to go through the whole go live process.

These users are sending messages using the API. The whitelist wasn’t made available to users uploading spreadsheets. The users sending one off messages are similar to those uploading spreadsheets, not those using the API. Therefore they shouldn’t be able to use the whitelist to
expand the range of recipients they can send to.

Passing the argument through three methods doesn’t feel that great, but can’t think of a better way without major refactoring…

---

https://www.pivotaltracker.com/story/show/153787321