### PR TITLE
Backfill redaction for pre-seeded templates

### DIFF
--- a/migrations/versions/0159_add_historical_redact.py
+++ b/migrations/versions/0159_add_historical_redact.py
@@ -1,0 +1,42 @@
+"""empty message
+
+Revision ID: 0159_add_historical_redact
+Revises: 0158_remove_rate_limit_default
+Create Date: 2017-01-17 15:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0159_add_historical_redact'
+down_revision = '0158_remove_rate_limit_default'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from flask import current_app
+
+def upgrade():
+    op.execute(
+        """
+        INSERT INTO template_redacted
+        (
+            template_id,
+            redact_personalisation,
+            updated_at,
+            updated_by_id
+        )
+        SELECT
+            templates.id,
+            false,
+            now(),
+            '{notify_user}'
+        FROM
+            templates
+        LEFT JOIN template_redacted on template_redacted.template_id = templates.id
+        WHERE template_redacted.template_id IS NULL
+        """.format(notify_user=current_app.config['NOTIFY_USER_ID'])
+    )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Will specifically affect the email auth template, which was seeded without a matching row in the `template_redacted` table.

Effectively re-runs c24edcf38825c694fdc14e5a8e3888f136650506

> add historical redaction data
>
> every current template gets a row in the template_redacted table - this inserts one for any template that doesn't already have a row, with redact set to false, the user set to NOTIFY_USER since it was just a script, and the updated_at set to the time the script is run