### PR TITLE
Fix a date time format problem - need to use AWS S3 format

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -64,6 +64,7 @@ from app.utils import convert_utc_to_bst
 from app.v2.errors import JobIncompleteError, NoAckFileReceived
 from app.dao.service_callback_api_dao import get_service_callback_api_for_service
 from app.celery.service_callback_tasks import send_delivery_status_to_service
+import pytz
 
 
 @worker_process_shutdown.connect
@@ -503,8 +504,9 @@ def letter_raise_alert_if_no_ack_file_for_zip():
 
     # get acknowledgement file
     ack_file_set = set()
-    # yesterday = datetime.now(tz=pytz.utc) - timedelta(days=1)
-    yesterday = datetime.utcnow() - timedelta(days=1)
+
+    yesterday = datetime.now(tz=pytz.utc) - timedelta(days=1)   # AWS datetime format
+
     for key in s3.get_list_of_files_by_suffix(bucket_name=current_app.config['DVLA_RESPONSE_BUCKET_NAME'],
                                               subfolder='root/dispatch', suffix='.ACK.txt', last_modified=yesterday):
         ack_file_set.add(key)

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from functools import partial
 from unittest.mock import call, patch, PropertyMock
-
+import pytz
 import functools
 from flask import current_app
 
@@ -1132,7 +1132,7 @@ def test_letter_not_raise_alert_if_ack_files_match_zip_list(mocker, notify_db):
 
     letter_raise_alert_if_no_ack_file_for_zip()
 
-    yesterday = datetime.utcnow() - timedelta(days=1)
+    yesterday = datetime.now(tz=pytz.utc) - timedelta(days=1)   # Datatime format on AWS
     subfoldername = datetime.utcnow().strftime('%Y-%m-%d') + '/zips_sent'
     assert mock_file_list.call_count == 2
     assert mock_file_list.call_args_list == [


### PR DESCRIPTION
Aws s3 use this format (datetime.now(tz=pytz.utc)) when returning datetime. 
example return: datetime.datetime(2018, 1, 16, 17, 8, 17, tzinfo=tzutc())

Otherwise, we would get "can't compare offset-naive and offset-aware datetimes error". 

