### PR TITLE
Raise 400 for a validation error

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -2,6 +2,7 @@ from flask import (
     jsonify,
     current_app,
     json)
+from notifications_utils.recipients import InvalidEmailError
 from sqlalchemy.exc import SQLAlchemyError, DataError
 from sqlalchemy.orm.exc import NoResultFound
 from marshmallow import ValidationError
@@ -40,6 +41,11 @@ class InvalidRequest(Exception):
 
 
 def register_errors(blueprint):
+    @blueprint.errorhandler(InvalidEmailError)
+    def invalid_format(error):
+        # Please not that InvalidEmailError is re-raised for InvalidEmail or InvalidPhone,
+        # work should be done in the utils app to tidy up these errors.
+        return jsonify(result='error', message=str(error)), 400
 
     @blueprint.errorhandler(AuthError)
     def authentication_error(error):

--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -2,6 +2,7 @@ import json
 
 from flask import jsonify, current_app, request
 from jsonschema import ValidationError
+from notifications_utils.recipients import InvalidEmailError
 from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -74,6 +75,14 @@ class BadRequestError(InvalidRequest):
 
 
 def register_errors(blueprint):
+    @blueprint.errorhandler(InvalidEmailError)
+    def invalid_format(error):
+        # Please not that InvalidEmailError is re-raised for InvalidEmail or InvalidPhone,
+        # work should be done in the utils app to tidy up these errors.
+        current_app.logger.exception(error)
+        return jsonify(status_code=400,
+                       errors=[{"error": error.__class__.__name__, "message": str(error)}]), 400
+
     @blueprint.errorhandler(InvalidRequest)
     def invalid_data(error):
         current_app.logger.error(error)


### PR DESCRIPTION
There were some exceptions in production today where a one off message was sending a message with an invalid email address.

The admin app validation did not catch this problem. But the API did.
This PR is a small fix to catch the erorr thrown by the notifications-utils/recipient validation methods and return a 400 status rather than a 500.
This only solves the issue of the user seeing "We are experiencing technical difficulties" rather than "invalid email address"

The bug can be replicated if you enter use quotes when entering the email address.

More work needs to be done so that the admin app does the same validation as the api so the user sees a nice form validtion error rather than a 400 after clicking send.
See: https://www.pivotaltracker.com/story/show/154472625