### PR TITLE
Store PDF letters in S3 bucket for research mode services

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -81,7 +81,7 @@ def remove_transformed_dvla_file(job_id):
     return obj.delete()
 
 
-def upload_letters_pdf(reference, crown, filedata):
+def upload_letters_pdf(reference, crown, filedata, research_mode=False):
     now = datetime.utcnow()
 
     print_datetime = now
@@ -98,11 +98,13 @@ def upload_letters_pdf(reference, crown, filedata):
         date=now.strftime('%Y%m%d%H%M%S')
     ).upper()
 
+    file_location = ('research/' + upload_file_name) if research_mode else upload_file_name
+
     utils_s3upload(
         filedata=filedata,
         region=current_app.config['AWS_REGION'],
         bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
-        file_location=upload_file_name
+        file_location=file_location
     )
 
     current_app.logger.info("Uploading letters PDF {} to {}".format(

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 import math
 
 from flask import current_app
@@ -6,6 +7,8 @@ from requests import (
     RequestException
 )
 from botocore.exceptions import ClientError as BotoClientError
+
+from notifications_utils.s3 import s3upload
 
 from app import notify_celery
 from app.aws import s3
@@ -19,10 +22,34 @@ from app.dao.notifications_dao import (
 from app.models import NOTIFICATION_CREATED
 from app.statsd_decorators import statsd
 
+LETTERS_PDF_FILE_LOCATION_STRUCTURE = \
+    '{research_mode}{folder}/NOTIFY.{reference}.{duplex}.{letter_class}.{colour}.{crown}.{date}.pdf'
+
+
+def get_letter_pdf_filename(reference, crown, research_mode=False):
+    now = datetime.utcnow()
+
+    print_datetime = now
+    if now.time() > current_app.config.get('LETTER_PROCESSING_DEADLINE'):
+        print_datetime = now + timedelta(days=1)
+
+    upload_file_name = LETTERS_PDF_FILE_LOCATION_STRUCTURE.format(
+        research_mode='research/' if research_mode else '',
+        folder=print_datetime.date(),
+        reference=reference,
+        duplex="D",
+        letter_class="2",
+        colour="C",
+        crown="C" if crown else "N",
+        date=now.strftime('%Y%m%d%H%M%S')
+    ).upper()
+
+    return upload_file_name
+
 
 @notify_celery.task(bind=True, name="create-letters-pdf", max_retries=15, default_retry_delay=300)
 @statsd(namespace="tasks")
-def create_letters_pdf(self, notification_id, research_mode=False):
+def create_letters_pdf(self, notification_id):
     try:
         notification = get_notification_by_id(notification_id, _raise=True)
 
@@ -34,12 +61,19 @@ def create_letters_pdf(self, notification_id, research_mode=False):
         )
         current_app.logger.info("PDF Letter {} reference {} created at {}, {} bytes".format(
             notification.id, notification.reference, notification.created_at, len(pdf_data)))
-        s3.upload_letters_pdf(
-            reference=notification.reference,
-            crown=notification.service.crown,
+
+        upload_file_name = get_letter_pdf_filename(
+            notification.reference, notification.service.crown, notification.service.research_mode)
+
+        s3upload(
             filedata=pdf_data,
-            research_mode=research_mode
+            region=current_app.config['AWS_REGION'],
+            bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
+            file_location=upload_file_name
         )
+
+        current_app.logger.info("Uploaded letters PDF {} to {}".format(
+            upload_file_name, current_app.config['LETTERS_PDF_BUCKET_NAME']))
 
         notification.billable_units = billable_units
         dao_update_notification(notification)

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -22,7 +22,7 @@ from app.statsd_decorators import statsd
 
 @notify_celery.task(bind=True, name="create-letters-pdf", max_retries=15, default_retry_delay=300)
 @statsd(namespace="tasks")
-def create_letters_pdf(self, notification_id):
+def create_letters_pdf(self, notification_id, research_mode=False):
     try:
         notification = get_notification_by_id(notification_id, _raise=True)
 
@@ -34,7 +34,12 @@ def create_letters_pdf(self, notification_id):
         )
         current_app.logger.info("PDF Letter {} reference {} created at {}, {} bytes".format(
             notification.id, notification.reference, notification.created_at, len(pdf_data)))
-        s3.upload_letters_pdf(reference=notification.reference, crown=notification.service.crown, filedata=pdf_data)
+        s3.upload_letters_pdf(
+            reference=notification.reference,
+            crown=notification.service.crown,
+            filedata=pdf_data,
+            research_mode=research_mode
+        )
 
         notification.billable_units = billable_units
         dao_update_notification(notification)

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -526,7 +526,7 @@ def letter_raise_alert_if_no_ack_file_for_zip():
     deskpro_message = "Letter ack file does not contains all zip files sent. " \
                       "Missing ack for zip files: {}, " \
                       "pdf bucket: {}, subfolder: {}, " \
-                      "ack bucket: {}".format(str(zip_file_set - ack_content_set),
+                      "ack bucket: {}".format(str(sorted(zip_file_set - ack_content_set)),
                                               current_app.config['LETTERS_PDF_BUCKET_NAME'],
                                               datetime.utcnow().strftime('%Y-%m-%d') + '/zips_sent',
                                               current_app.config['DVLA_RESPONSE_BUCKET_NAME'])

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -322,17 +322,10 @@ def save_letter(
         )
 
         if service.has_permission('letters_as_pdf'):
-            if not service.research_mode:
-                letters_pdf_tasks.create_letters_pdf.apply_async(
-                    [str(saved_notification.id)],
-                    queue=QueueNames.CREATE_LETTERS_PDF
-                )
-            else:
-                letters_pdf_tasks.create_letters_pdf.apply_async(
-                    [str(saved_notification.id)],
-                    queue=QueueNames.CREATE_LETTERS_PDF,
-                    kwargs={'research_mode': True}
-                )
+            letters_pdf_tasks.create_letters_pdf.apply_async(
+                [str(saved_notification.id)],
+                queue=QueueNames.CREATE_LETTERS_PDF
+            )
 
         current_app.logger.info("Letter {} created at {}".format(saved_notification.id, saved_notification.created_at))
     except SQLAlchemyError as e:

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -328,9 +328,10 @@ def save_letter(
                     queue=QueueNames.CREATE_LETTERS_PDF
                 )
             else:
-                update_letter_notifications_to_sent_to_dvla.apply_async(
-                    kwargs={'notification_references': [saved_notification.reference]},
-                    queue=QueueNames.RESEARCH_MODE
+                letters_pdf_tasks.create_letters_pdf.apply_async(
+                    [str(saved_notification.id)],
+                    queue=QueueNames.CREATE_LETTERS_PDF,
+                    kwargs={'research_mode': True}
                 )
 
         current_app.logger.info("Letter {} created at {}".format(saved_notification.id, saved_notification.created_at))

--- a/app/models.py
+++ b/app/models.py
@@ -11,6 +11,7 @@ from sqlalchemy.dialects.postgresql import (
     JSON
 )
 from sqlalchemy import UniqueConstraint, CheckConstraint
+from notifications_utils.columns import Columns
 from notifications_utils.recipients import (
     validate_email_address,
     validate_phone_number,
@@ -1223,12 +1224,13 @@ class Notification(db.Model):
         }
 
         if self.notification_type == LETTER_TYPE:
-            serialized['line_1'] = self.personalisation['address_line_1']
-            serialized['line_2'] = self.personalisation.get('address_line_2')
-            serialized['line_3'] = self.personalisation.get('address_line_3')
-            serialized['line_4'] = self.personalisation.get('address_line_4')
-            serialized['line_5'] = self.personalisation.get('address_line_5')
-            serialized['line_6'] = self.personalisation.get('address_line_6')
+            col = Columns(self.personalisation)
+            serialized['line_1'] = col.get('address_line_1')
+            serialized['line_2'] = col.get('address_line_2')
+            serialized['line_3'] = col.get('address_line_3')
+            serialized['line_4'] = col.get('address_line_4')
+            serialized['line_5'] = col.get('address_line_5')
+            serialized['line_6'] = col.get('address_line_6')
             serialized['postcode'] = self.personalisation['postcode']
             serialized['estimated_delivery'] = \
                 get_letter_timings(serialized['created_at'])\

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -186,8 +186,7 @@ def process_letter_notification(*, letter_data, api_key, template, reply_to_text
         if should_create_pdf:
             create_letters_pdf.apply_async(
                 [str(notification.id)],
-                queue=QueueNames.CREATE_LETTERS_PDF,
-                kwargs={'research_mode': api_key.service.research_mode}
+                queue=QueueNames.CREATE_LETTERS_PDF
             )
     else:
         should_send = not (api_key.service.research_mode or api_key.key_type == KEY_TYPE_TEST)

--- a/tests/app/aws/test_s3.py
+++ b/tests/app/aws/test_s3.py
@@ -11,7 +11,6 @@ from app.aws.s3 import (
     get_s3_file,
     filter_s3_bucket_objects_within_date_range,
     remove_transformed_dvla_file,
-    upload_letters_pdf,
     get_list_of_files_by_suffix,
 )
 from tests.app.conftest import datetime_in_past
@@ -142,38 +141,6 @@ def test_get_s3_bucket_objects_does_not_return_outside_of_date_range(notify_api,
     filtered_items = filter_s3_bucket_objects_within_date_range(s3_objects_stub)
 
     assert len(filtered_items) == 0
-
-
-@pytest.mark.parametrize('crown_flag,expected_crown_text', [
-    (True, 'C'),
-    (False, 'N'),
-])
-@freeze_time("2017-12-04 17:29:00")
-def test_upload_letters_pdf_calls_utils_s3upload_with_correct_args(
-        notify_api, mocker, crown_flag, expected_crown_text):
-    s3_upload_mock = mocker.patch('app.aws.s3.utils_s3upload')
-    upload_letters_pdf(reference='foo', crown=crown_flag, filedata='some_data')
-
-    s3_upload_mock.assert_called_with(
-        filedata='some_data',
-        region='eu-west-1',
-        bucket_name='test-letters-pdf',
-        file_location='2017-12-04/NOTIFY.FOO.D.2.C.{}.20171204172900.PDF'.format(expected_crown_text)
-    )
-
-
-@freeze_time("2017-12-04 17:31:00")
-def test_upload_letters_pdf_puts_in_tomorrows_bucket_after_half_five(notify_api, mocker):
-    s3_upload_mock = mocker.patch('app.aws.s3.utils_s3upload')
-    upload_letters_pdf(reference='foo', crown=True, filedata='some_data')
-
-    s3_upload_mock.assert_called_with(
-        filedata='some_data',
-        region='eu-west-1',
-        bucket_name='test-letters-pdf',
-        # in tomorrow's folder, but still has this evening's timestamp
-        file_location='2017-12-05/NOTIFY.FOO.D.2.C.C.20171204173100.PDF'
-    )
 
 
 @freeze_time("2018-01-11 00:00:00")

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -88,7 +88,8 @@ def test_create_letters_pdf_calls_upload_letters_pdf(mocker, sample_letter_notif
     mock_s3.assert_called_with(
         reference=sample_letter_notification.reference,
         crown=sample_letter_notification.service.crown,
-        filedata=b'\x00\x01'
+        filedata=b'\x00\x01',
+        research_mode=False
     )
 
 

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -1,5 +1,8 @@
+from flask import current_app
+
 from unittest.mock import call
 
+from freezegun import freeze_time
 import pytest
 import requests_mock
 from botocore.exceptions import ClientError
@@ -13,6 +16,7 @@ from app.celery.letters_pdf_tasks import (
     collate_letter_pdfs_for_day,
     group_letters,
     letter_in_created_state,
+    get_letter_pdf_filename,
 )
 from app.models import Notification, NOTIFICATION_SENDING
 
@@ -21,6 +25,25 @@ from tests.conftest import set_config_values
 
 def test_should_have_decorated_tasks_functions():
     assert create_letters_pdf.__wrapped__.__name__ == 'create_letters_pdf'
+
+
+@pytest.mark.parametrize('crown_flag,expected_crown_text', [
+    (True, 'C'),
+    (False, 'N'),
+])
+@freeze_time("2017-12-04 17:29:00")
+def test_get_letter_pdf_filename_returns_correct_filename(
+        notify_api, mocker, crown_flag, expected_crown_text):
+    filename = get_letter_pdf_filename(reference='foo', crown=crown_flag)
+
+    assert filename == '2017-12-04/NOTIFY.FOO.D.2.C.{}.20171204172900.PDF'.format(expected_crown_text)
+
+
+@freeze_time("2017-12-04 17:31:00")
+def test_get_letter_pdf_filename_returns_tomorrows_filename(notify_api, mocker):
+    filename = get_letter_pdf_filename(reference='foo', crown=True)
+
+    assert filename == '2017-12-05/NOTIFY.FOO.D.2.C.C.20171204173100.PDF'
 
 
 @pytest.mark.parametrize('personalisation', [{'name': 'test'}, None])
@@ -79,23 +102,27 @@ def test_get_letters_pdf_calculates_billing_units(
     assert billable_units == expected_billable_units
 
 
-def test_create_letters_pdf_calls_upload_letters_pdf(mocker, sample_letter_notification):
+def test_create_letters_pdf_calls_s3upload(mocker, sample_letter_notification):
     mocker.patch('app.celery.letters_pdf_tasks.get_letters_pdf', return_value=(b'\x00\x01', '1'))
-    mock_s3 = mocker.patch('app.celery.tasks.s3.upload_letters_pdf')
+    mock_s3 = mocker.patch('app.celery.letters_pdf_tasks.s3upload')
 
     create_letters_pdf(sample_letter_notification.id)
 
-    mock_s3.assert_called_with(
+    filename = get_letter_pdf_filename(
         reference=sample_letter_notification.reference,
-        crown=sample_letter_notification.service.crown,
+        crown=sample_letter_notification.service.crown
+    )
+
+    mock_s3.assert_called_with(
+        bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
+        file_location=filename,
         filedata=b'\x00\x01',
-        research_mode=False
+        region=current_app.config['AWS_REGION']
     )
 
 
 def test_create_letters_pdf_sets_billable_units(mocker, sample_letter_notification):
     mocker.patch('app.celery.letters_pdf_tasks.get_letters_pdf', return_value=(b'\x00\x01', 1))
-    mocker.patch('app.celery.tasks.s3.upload_letters_pdf')
 
     create_letters_pdf(sample_letter_notification.id)
     noti = Notification.query.filter(Notification.reference == sample_letter_notification.reference).one()
@@ -119,7 +146,7 @@ def test_create_letters_pdf_handles_request_errors(mocker, sample_letter_notific
 
 def test_create_letters_pdf_handles_s3_errors(mocker, sample_letter_notification):
     mocker.patch('app.celery.letters_pdf_tasks.get_letters_pdf', return_value=(b'\x00\x01', 1))
-    mock_s3 = mocker.patch('app.celery.tasks.s3.upload_letters_pdf', side_effect=ClientError({}, 'operation_name'))
+    mock_s3 = mocker.patch('app.celery.letters_pdf_tasks.s3upload', side_effect=ClientError({}, 'operation_name'))
     mock_retry = mocker.patch('app.celery.letters_pdf_tasks.create_letters_pdf.retry')
 
     create_letters_pdf(sample_letter_notification.id)
@@ -138,7 +165,6 @@ def test_create_letters_pdf_sets_technical_failure_max_retries(mocker, sample_le
 
     assert mock_get_letters_pdf.called
     assert mock_retry.called
-    assert mock_update_noti.called
     mock_update_noti.assert_called_once_with(sample_letter_notification.id, 'technical-failure')
 
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -1159,7 +1159,7 @@ def test_letter_raise_alert_if_ack_files_not_match_zip_list(mocker, notify_db):
     deskpro_message = "Letter ack file does not contains all zip files sent. " \
                       "Missing ack for zip files: {}, " \
                       "pdf bucket: {}, subfolder: {}, " \
-                      "ack bucket: {}".format(str(set(['NOTIFY.20180111175009.ZIP', 'NOTIFY.20180111175010.ZIP'])),
+                      "ack bucket: {}".format(str(['NOTIFY.20180111175009.ZIP', 'NOTIFY.20180111175010.ZIP']),
                                               current_app.config['LETTERS_PDF_BUCKET_NAME'],
                                               datetime.utcnow().strftime('%Y-%m-%d') + '/zips_sent',
                                               current_app.config['DVLA_RESPONSE_BUCKET_NAME'])

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1178,8 +1178,7 @@ def test_save_letter_calls_create_letters_pdf_task_with_letters_as_pdf_permissio
     assert mock_create_letters_pdf.called
     mock_create_letters_pdf.assert_called_once_with(
         [str(notification_id)],
-        queue=QueueNames.CREATE_LETTERS_PDF,
-        kwargs={'research_mode': True}
+        queue=QueueNames.CREATE_LETTERS_PDF
     )
 
 

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -294,3 +294,16 @@ def test_service_get_default_contact_letter(sample_service):
 def test_service_get_default_sms_sender(notify_db_session):
     service = create_service()
     assert service.get_default_sms_sender() == 'testing'
+
+
+def test_letter_notification_serializes_correctly(client, sample_letter_notification):
+    sample_letter_notification.personalisation = {
+        'addressline1': 'test',
+        'addressline2': 'London',
+        'postcode': 'N1',
+    }
+
+    json = sample_letter_notification.serialize()
+    assert json['line_1'] == 'test'
+    assert json['line_2'] == 'London'
+    assert json['postcode'] == 'N1'

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -137,7 +137,7 @@ def test_post_letter_notification_for_letters_as_pdf_calls_celery_task(
     notification = Notification.query.one()
 
     fake_task.assert_called_once_with(
-        [str(notification.id)], queue=QueueNames.CREATE_LETTERS_PDF, kwargs={'research_mode': research_mode})
+        [str(notification.id)], queue=QueueNames.CREATE_LETTERS_PDF)
 
 
 def test_post_letter_notification_returns_400_and_missing_template(

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -82,8 +82,12 @@ def test_post_letter_notification_returns_201(client, sample_letter_template, mo
     assert not notification.reply_to_text
 
 
-def test_post_letter_notification_for_letters_as_pdf_calls_celery_task(client, sample_letter_template, mocker):
+@pytest.mark.parametrize('research_mode', [False, True])
+def test_post_letter_notification_for_letters_as_pdf_test_key(
+    client, sample_letter_template, mocker, research_mode
+):
     service_permissions_dao.dao_add_service_permission(sample_letter_template.service.id, 'letters_as_pdf')
+    sample_letter_template.service.research_mode = research_mode
 
     data = {
         'template_id': str(sample_letter_template.id),
@@ -96,13 +100,44 @@ def test_post_letter_notification_for_letters_as_pdf_calls_celery_task(client, s
         },
         'reference': 'foo'
     }
-    fake_task = mocker.patch('app.celery.tasks.letters_pdf_tasks.create_letters_pdf.apply_async')
+
+    fake_task = mocker.patch('app.celery.letters_pdf_tasks.create_letters_pdf.apply_async')
+
+    letter_request(client, data, key_type=KEY_TYPE_TEST, service_id=sample_letter_template.service_id)
+
+    notification = Notification.query.one()
+
+    assert notification.status == NOTIFICATION_SENDING
+    assert not fake_task.called
+
+
+@pytest.mark.parametrize('research_mode', [False, True])
+def test_post_letter_notification_for_letters_as_pdf_calls_celery_task(
+    client, sample_letter_template, mocker, research_mode
+):
+    service_permissions_dao.dao_add_service_permission(sample_letter_template.service.id, 'letters_as_pdf')
+    sample_letter_template.service.research_mode = research_mode
+
+    data = {
+        'template_id': str(sample_letter_template.id),
+        'personalisation': {
+            'address_line_1': 'Her Royal Highness Queen Elizabeth II',
+            'address_line_2': 'Buckingham Palace',
+            'address_line_3': 'London',
+            'postcode': 'SW1 1AA',
+            'name': 'Lizzie'
+        },
+        'reference': 'foo'
+    }
+
+    fake_task = mocker.patch('app.celery.letters_pdf_tasks.create_letters_pdf.apply_async')
 
     letter_request(client, data, service_id=sample_letter_template.service_id)
 
     notification = Notification.query.one()
 
-    fake_task.assert_called_once_with([str(notification.id)], queue=QueueNames.CREATE_LETTERS_PDF)
+    fake_task.assert_called_once_with(
+        [str(notification.id)], queue=QueueNames.CREATE_LETTERS_PDF, kwargs={'research_mode': research_mode})
 
 
 def test_post_letter_notification_returns_400_and_missing_template(
@@ -247,8 +282,6 @@ def test_post_letter_notification_queues_success(
     research_mode,
     key_type
 ):
-    fake_task = mocker.patch('app.celery.tasks.update_letter_notifications_to_sent_to_dvla.apply_async')
-
     service = create_service(research_mode=research_mode, service_permissions=[LETTER_TYPE])
     template = create_template(service, template_type=LETTER_TYPE)
 
@@ -261,10 +294,6 @@ def test_post_letter_notification_queues_success(
 
     notification = Notification.query.one()
     assert notification.status == NOTIFICATION_SENDING
-    fake_task.assert_called_once_with(
-        kwargs={'notification_references': [notification.reference]},
-        queue='research-mode-tasks'
-    )
 
 
 def test_post_letter_notification_doesnt_accept_team_key(client, sample_letter_template):
@@ -308,8 +337,6 @@ def test_post_letter_notification_fakes_dvla_when_service_is_in_trial_mode_but_u
     sample_trial_letter_template,
     mocker
 ):
-    update_task = mocker.patch('app.celery.tasks.update_letter_notifications_to_sent_to_dvla.apply_async')
-
     data = {
         "template_id": sample_trial_letter_template.id,
         "personalisation": {'address_line_1': 'Foo', 'address_line_2': 'Bar', 'postcode': 'Baz'}
@@ -319,10 +346,6 @@ def test_post_letter_notification_fakes_dvla_when_service_is_in_trial_mode_but_u
 
     notification = Notification.query.one()
     assert notification.status == NOTIFICATION_SENDING
-    update_task.assert_called_once_with(
-        kwargs={'notification_references': [notification.reference]},
-        queue='research-mode-tasks'
-    )
 
 
 def test_post_letter_notification_persists_notification_reply_to_text(


### PR DESCRIPTION
We now upload letters as PDF to S3 when a service is in research mode. These letters are uploaded to a 'research' sub-directory of the S3 bucket we normally use.

We also ensure that letter personalisation is always serialized in the same way.

Pivotal story: https://www.pivotaltracker.com/story/show/151511723