### PR TITLE
Turn letters on by default for new services

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -37,7 +37,8 @@ from app.models import (
     KEY_TYPE_TEST,
     NOTIFICATION_STATUS_TYPES,
     SMS_TYPE,
-    TEMPLATE_TYPES
+    TEMPLATE_TYPES,
+    LETTER_TYPE,
 )
 from app.statsd_decorators import statsd
 from app.utils import get_london_month_from_utc_column, get_london_midnight_in_utc
@@ -45,6 +46,7 @@ from app.utils import get_london_month_from_utc_column, get_london_midnight_in_u
 DEFAULT_SERVICE_PERMISSIONS = [
     SMS_TYPE,
     EMAIL_TYPE,
+    LETTER_TYPE,
     INTERNATIONAL_SMS_TYPE,
 ]
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -152,7 +152,7 @@ def test_get_service_list_has_default_permissions(admin_request, service_factory
         set(
             json['permissions']
         ) == set([
-            EMAIL_TYPE, SMS_TYPE, INTERNATIONAL_SMS_TYPE,
+            EMAIL_TYPE, SMS_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE
         ])
         for json in json_resp['data']
     )
@@ -164,7 +164,7 @@ def test_get_service_by_id_has_default_service_permissions(admin_request, sample
     assert set(
         json_resp['data']['permissions']
     ) == set([
-        EMAIL_TYPE, SMS_TYPE, INTERNATIONAL_SMS_TYPE,
+        EMAIL_TYPE, SMS_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE
     ])
 
 


### PR DESCRIPTION
Letters is a mature enough feature now – and one that we’ve been talking about offering for long enough – that we shouldn’t make people dig around in the settings.

I think we’d want to wait a bit longer/indefinitely before deciding to turn it on for existing services across the platform.

---

This takes letters from 4 to 5:

![image](https://user-images.githubusercontent.com/355079/35330994-a11a8e78-00fd-11e8-8a23-4bc1f8562bc8.png)
