### PR TITLE
Create a separate delivery app to consume the notify-internal-tasks

### DIFF
--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -79,9 +79,15 @@ applications:
       NOTIFY_APP_NAME: delivery-worker-priority
 
   - name: notify-delivery-worker
-    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q job-tasks,retry-tasks,notify-internal-tasks,create-letters-pdf-tasks,letter-tasks
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q job-tasks,retry-tasks,create-letters-pdf-tasks,letter-tasks
     env:
       NOTIFY_APP_NAME: delivery-worker
+
+  # Only consume the notify-internal-tasks queue on this app so that Notify messages are processed as a priority
+  - name: notify-delivery-worker-internal
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q notify-internal-tasks
+    env:
+      NOTIFY_APP_NAME: delivery-worker-internal
 
   - name: notify-delivery-worker-receipts
     command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q ses-callbacks,service-callbacks


### PR DESCRIPTION
Tasks that are put on the notify-internal-tasks queue are notifications
sent by the notify service, including 2FA and email auth messages.
These should never be delayed by other messages in the queue.

Created a separate delivery app to consume the notify-internal-tasks
queue and only that queue.