### PR TITLE
Removed the performance testing statsd calls

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -28,7 +28,6 @@ from app.dao.notifications_dao import (
     dao_created_scheduled_notification
 )
 
-from app.statsd_decorators import statsd
 from app.v2.errors import BadRequestError
 from app.utils import get_template_instance, cache_key_for_service_template_counter, convert_bst_to_utc
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -46,7 +46,6 @@ def check_placeholders(template_object):
         raise BadRequestError(fields=[{'template': message}], message=message)
 
 
-@statsd(namespace="performance-testing")
 def persist_notification(
     *,
     template_id,
@@ -116,7 +115,6 @@ def persist_notification(
     return notification
 
 
-@statsd(namespace="performance-testing")
 def send_notification_to_queue(notification, research_mode, queue=None):
     if research_mode or notification.key_type == KEY_TYPE_TEST:
         queue = QueueNames.RESEARCH_MODE

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -48,7 +48,6 @@ def check_service_over_daily_message_limit(key_type, service):
             raise TooManyRequestsError(service.message_limit)
 
 
-@statsd(namespace="performance-testing")
 def check_rate_limiting(service, api_key):
     check_service_over_api_rate_limit(service, api_key)
     check_service_over_daily_message_limit(api_key.key_type, service)
@@ -83,14 +82,12 @@ def service_has_permission(notify_type, permissions):
     return notify_type in [p.permission for p in permissions]
 
 
-@statsd(namespace="performance-testing")
 def check_service_has_permission(notify_type, permissions):
     if not service_has_permission(notify_type, permissions):
         raise BadRequestError(message="Cannot send {}".format(
             get_public_notify_type_text(notify_type, plural=True)))
 
 
-@statsd(namespace="performance-testing")
 def check_service_can_schedule_notification(permissions, scheduled_for):
     if scheduled_for:
         if not service_has_permission(SCHEDULE_NOTIFICATIONS, permissions):
@@ -125,7 +122,6 @@ def check_sms_content_char_count(content_count):
         raise BadRequestError(message=message)
 
 
-@statsd(namespace="performance-testing")
 def validate_template(template_id, personalisation, service, notification_type):
     try:
         template = templates_dao.dao_get_template_by_id_and_service_id(

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -14,7 +14,6 @@ from app.models import (
     KEY_TYPE_TEST, KEY_TYPE_TEAM, SCHEDULE_NOTIFICATIONS
 )
 from app.service.utils import service_allowed_to_send_to
-from app.statsd_decorators import statsd
 from app.v2.errors import TooManyRequestsError, BadRequestError, RateLimitError
 from app import redis_store
 from app.notifications.process_notifications import create_content_for_notification

--- a/app/v2/notifications/create_response.py
+++ b/app/v2/notifications/create_response.py
@@ -10,7 +10,6 @@ def create_post_sms_response_from_notification(notification, content, from_numbe
     return noti
 
 
-@statsd(namespace="performance-testing")
 def create_post_email_response_from_notification(notification, content, subject, email_from, url_root, scheduled_for):
     noti = __create_notification_response(notification, url_root, scheduled_for)
     noti['content'] = {

--- a/app/v2/notifications/create_response.py
+++ b/app/v2/notifications/create_response.py
@@ -1,4 +1,3 @@
-from app.statsd_decorators import statsd
 
 
 def create_post_sms_response_from_notification(notification, content, from_number, url_root, scheduled_for):

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -53,7 +53,6 @@ from app.v2.notifications.create_response import (
 
 
 @v2_notification_blueprint.route('/<notification_type>', methods=['POST'])
-@statsd(namespace="performance-testing")
 def post_notification(notification_type):
     if notification_type == EMAIL_TYPE:
         form = validate(request.get_json(), post_email_request)
@@ -124,7 +123,6 @@ def post_notification(notification_type):
     return jsonify(resp), 201
 
 
-@statsd(namespace="performance-testing")
 def process_sms_or_email_notification(*, form, notification_type, api_key, template, service, reply_to_text=None):
     form_send_to = form['email_address'] if notification_type == EMAIL_TYPE else form['phone_number']
 
@@ -199,7 +197,6 @@ def process_letter_notification(*, letter_data, api_key, template, reply_to_text
     return notification
 
 
-@statsd(namespace="performance-testing")
 def get_reply_to_text(notification_type, form, template):
     reply_to = None
     if notification_type == EMAIL_TYPE:

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -37,7 +37,6 @@ from app.notifications.validators import (
     check_service_sms_sender_id
 )
 from app.schema_validation import validate
-from app.statsd_decorators import statsd
 from app.v2.errors import BadRequestError
 from app.v2.notifications import v2_notification_blueprint
 from app.v2.notifications.notification_schemas import (


### PR DESCRIPTION
Removed the performance testing statsd calls as they are no longer needed for monitoring the performance of the v2 endpoints. They were put in as a temporary measure whilst sustained performance testing was taking place.