### PR TITLE
Changed the time of the daily-stats-template-usage-by-month task to run at 00:05

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -279,7 +279,7 @@ class Config(object):
         },
         'daily-stats-template-usage-by-month': {
             'task': 'daily-stats-template-usage-by-month',
-            'schedule': crontab(hour=0, minute=50),
+            'schedule': crontab(hour=0, minute=5),
             'options': {'queue': QueueNames.PERIODIC}
         }
     }


### PR DESCRIPTION
Changed the time of the daily-stats-template-usage-by-month task to run at 00:05 as the query gets data for the day before 0:00, so to minimise the report being out of date run the query at 0:05.