### PR TITLE
PR for discussion

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -249,7 +249,8 @@ def get_notifications_for_service(
     include_jobs=False,
     include_from_test_key=False,
     older_than=None,
-    client_reference=None
+    client_reference=None,
+    include_created_by_user=False
 ):
     if page_size is None:
         page_size = current_app.config['PAGE_SIZE']
@@ -286,6 +287,10 @@ def get_notifications_for_service(
     if include_jobs:
         query = query.options(
             joinedload('job')
+        )
+    if include_created_by_user:
+        query = query.options(
+            joinedload('created_by')
         )
 
     return query.order_by(desc(Notification.created_at)).paginate(

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -283,6 +283,10 @@ def get_notifications_for_service(
         query = query.options(
             joinedload('template')
         )
+    if include_jobs:
+        query = query.options(
+            joinedload('job')
+        )
 
     return query.order_by(desc(Notification.created_at)).paginate(
         page=page,

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -454,7 +454,7 @@ class NotificationWithTemplateSchema(BaseSchema):
     class Meta:
         model = models.Notification
         strict = True
-        exclude = ('_personalisation', )
+        exclude = ('_personalisation', 'scheduled_notification')
 
     template = fields.Nested(
         TemplateSchema,

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -355,6 +355,7 @@ def get_all_notifications_for_service_csv(service_id):
     limit_days = data.get('limit_days')
     include_jobs = data.get('include_jobs', True)
     include_from_test_key = data.get('include_from_test_key', False)
+    include_created_by_user = data.get('include_created_by_user', False)
 
     pagination = notifications_dao.get_notifications_for_service(
         service_id,
@@ -364,7 +365,8 @@ def get_all_notifications_for_service_csv(service_id):
         limit_days=limit_days,
         include_jobs=include_jobs,
         include_from_test_key=include_from_test_key,
-        personalisation=False
+        personalisation=True,
+        include_created_by_user=include_created_by_user
     )
     kwargs = request.args.to_dict()
     kwargs['service_id'] = service_id

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -69,6 +69,7 @@ from app.errors import (
 from app.models import Service
 from app.schema_validation import validate
 from app.service import statistics
+from app.service.service_notification_schema import build_notification_for_service
 from app.service.service_senders_schema import (
     add_service_email_reply_to_request,
     add_service_letter_contact_block_request,
@@ -334,6 +335,45 @@ def get_all_notifications_for_service(service_id):
     kwargs['service_id'] = service_id
     return jsonify(
         notifications=notification_with_template_schema.dump(pagination.items, many=True).data,
+        page_size=page_size,
+        total=pagination.total,
+        links=pagination_links(
+            pagination,
+            '.get_all_notifications_for_service',
+            **kwargs
+        )
+    ), 200
+
+
+@service_blueprint.route('/<uuid:service_id>/notifications/csv', methods=['GET'])
+def get_all_notifications_for_service_csv(service_id):
+    data = notifications_filter_schema.load(request.args).data
+    if data.get('to'):
+        return search_for_notification_by_to_field(service_id, data['to'], statuses=data.get('status'))
+    page = data['page'] if 'page' in data else 1
+    page_size = data['page_size'] if 'page_size' in data else current_app.config.get('PAGE_SIZE')
+    limit_days = data.get('limit_days')
+    include_jobs = data.get('include_jobs', True)
+    include_from_test_key = data.get('include_from_test_key', False)
+
+    pagination = notifications_dao.get_notifications_for_service(
+        service_id,
+        filter_dict=data,
+        page=page,
+        page_size=page_size,
+        limit_days=limit_days,
+        include_jobs=include_jobs,
+        include_from_test_key=include_from_test_key,
+        personalisation=False
+    )
+    kwargs = request.args.to_dict()
+    kwargs['service_id'] = service_id
+    results = []
+    for n in pagination.items:
+        results.append(build_notification_for_service(n))
+
+    return jsonify(
+        notifications=results,
         page_size=page_size,
         total=pagination.total,
         links=pagination_links(

--- a/app/service/service_notification_schema.py
+++ b/app/service/service_notification_schema.py
@@ -1,0 +1,68 @@
+from app import DATETIME_FORMAT
+from app.models import LETTER_TYPE
+from app.schema_validation.definitions import uuid
+
+template = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "template schema",
+    "type": "object",
+    "title": "notification content",
+    "properties": {
+        "id": uuid,
+        "version": {"type": "integer"},
+        "name": {"type": "string"}
+    },
+    "required": ["id", "version", "name"]
+}
+
+notification_for_service_no_content = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "GET notification for service schema",
+    "type": "object",
+    "title": "response service/{service_id}/notifications",
+    "properties": {
+        "id": {"type": ["string", "null"]},
+        "recipient": {"type": ["string", "null"]},
+        "type": {"enum": ["sms", "letter", "email"]},
+        "status": {"type": "string"},
+        "template": template,
+        "created_at": {"type": "string"},
+        "sent_at": {"type": ["string", "null"]},
+        "completed_at": {"type": ["string", "null"]},
+        "job": {"type": ["string", "null"]},
+        "sent_by": {"type": ["string", "null"]},
+    },
+    "required": [
+        # technically, all keys are required since we always have all of them
+        "id", "recipient",
+        "type", "status", "template",
+        "created_at", "sent_at", "completed_at"
+    ]
+}
+
+
+def build_notification_for_service(notification):
+    return {
+        "id": notification.id,
+        "recipient": notification.to,
+        "type": notification.notification_type,
+        "status": _build_status(notification),
+        "template": _build_template(notification),
+        "created_at": notification.created_at.strftime(DATETIME_FORMAT),
+        "sent_at": notification.sent_at.strftime(DATETIME_FORMAT) if notification.sent_at else None,
+        "completed_at": notification.completed_at(),
+        "job": notification.job.original_file_name if notification.job_id else None,
+        "sent_by": notification.sent_by
+    }
+
+
+def _build_status(notification):
+    return notification.get_letter_status() if notification.notification_type == LETTER_TYPE else notification.status
+
+
+def _build_template(notification):
+    return {
+        "id": notification.template.id,
+        "version": notification.template.version,
+        "name": notification.template.name
+    }

--- a/app/service/service_notification_schema.py
+++ b/app/service/service_notification_schema.py
@@ -52,7 +52,7 @@ def build_notification_for_service(notification):
         "sent_at": notification.sent_at.strftime(DATETIME_FORMAT) if notification.sent_at else None,
         "completed_at": notification.completed_at(),
         "job": notification.job.original_file_name if notification.job_id else None,
-        "sent_by": notification.sent_by
+        "sent_by": notification.created_by.name if notification.created_by_id else None
     }
 
 

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -166,7 +166,8 @@ def create_notification(
     normalised_to=None,
     one_off=False,
     sms_sender_id=None,
-    reply_to_text=None
+    reply_to_text=None,
+    created_by_id=None
 ):
     if created_at is None:
         created_at = datetime.utcnow()
@@ -211,7 +212,8 @@ def create_notification(
         'international': international,
         'phone_prefix': phone_prefix,
         'normalised_to': normalised_to,
-        'reply_to_text': reply_to_text
+        'reply_to_text': reply_to_text,
+        'created_by_id': created_by_id
     }
     notification = Notification(**data)
     dao_create_notification(notification)

--- a/tests/app/service/test_service_notification_schema.py
+++ b/tests/app/service/test_service_notification_schema.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+
+from flask import json
+
+from app.schema_validation import validate
+from app.service.service_notification_schema import notification_for_service_no_content
+from tests import create_authorization_header
+from tests.app.db import create_service, create_notification, create_template, create_job
+
+
+def test_get_notifications_for_service(client, notify_db_session):
+    service = create_service()
+    sms_template = create_template(service=service)
+    email_template = create_template(service=service, template_type='email')
+    email_template2 = create_template(service=service, template_type='email', content="with ((some)) placeholders")
+    create_template(service=service, template_type='letter')
+    job = create_job(template=sms_template)
+    create_notification(template=sms_template, status='sending', sent_at=datetime.utcnow(),
+                        updated_at=datetime.utcnow())
+    create_notification(template=sms_template, status='created')
+    create_notification(template=email_template, status='temporary-failure',
+                        sent_at=datetime.utcnow(), updated_at=datetime.utcnow())
+    create_notification(template=sms_template, status='delivered',
+                        sent_at=datetime.utcnow(), updated_at=datetime.utcnow())
+    create_notification(template=email_template2, job=job, job_row_number=1, personalisation={"some": "any"})
+
+    auth_header = create_authorization_header()
+
+    response = client.get(
+        path='/service/{}/notifications/csv'.format(
+            service.id
+        ),
+        headers=[auth_header]
+    )
+
+    results = json.loads(response.get_data(as_text=True))['notifications']
+    for n in results:
+        assert n == validate(n, notification_for_service_no_content)

--- a/tests/app/service/test_service_notification_schema.py
+++ b/tests/app/service/test_service_notification_schema.py
@@ -17,7 +17,7 @@ def test_get_notifications_for_service(client, notify_db_session):
     job = create_job(template=sms_template)
     create_notification(template=sms_template, status='sending', sent_at=datetime.utcnow(),
                         updated_at=datetime.utcnow())
-    create_notification(template=sms_template, status='created')
+    create_notification(template=sms_template, status='created', created_by_id=service.users[0].id)
     create_notification(template=email_template, status='temporary-failure',
                         sent_at=datetime.utcnow(), updated_at=datetime.utcnow())
     create_notification(template=sms_template, status='delivered',
@@ -25,7 +25,6 @@ def test_get_notifications_for_service(client, notify_db_session):
     create_notification(template=email_template2, job=job, job_row_number=1, personalisation={"some": "any"})
 
     auth_header = create_authorization_header()
-
     response = client.get(
         path='/service/{}/notifications/csv'.format(
             service.id


### PR DESCRIPTION
While trying to add the `download csv` link for the notifications activity page, I found that the rendering of the marshmallow schema was causing performance issues.

Why? Because the schema will make a query for every unique row to all the tables that have a foreign key. For example for every unique template there is a query to template.
Options to fix this problem:
 - update the schema to exclude anything you do not need
 - create a new schema to include only the columns you care about
This seems easy but the problem is also deciding when to join to the table in the query and when to let the schema do it. Another problem is that the get_all_notificaitons_for_services is used on many different pages in the admin app. Each has a different data set.

Approach:
 - create a unique endpoint and schema for each endpoint.
 - ensure the query is joining only to the tables that it needs to.

I have opted for creating the new schema in json schema for two reasons:
 - it doesn't use a framework to do the serialisation
 - can easily control what columns to include, meaning there is higher visibility on what extra queries are being made.
 - we are only returning the data that the calling app needs

Complications:
 - this means we need a new endpoint for each call from the admin app, requiring some refactoring in the admin.
 - leads to more code - however, it should be clearer.

The dao function could probably be simplified, I have not really changed that.

There are more tests to write.