### PR TITLE
Refactor letter research processing for letter pdfs

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -5,10 +5,7 @@ from flask import current_app
 import pytz
 from boto3 import client, resource
 
-from notifications_utils.s3 import s3upload as utils_s3upload
-
 FILE_LOCATION_STRUCTURE = 'service-{}-notify/{}.csv'
-LETTERS_PDF_FILE_LOCATION_STRUCTURE = '{folder}/NOTIFY.{reference}.{duplex}.{letter_class}.{colour}.{crown}.{date}.pdf'
 
 
 def get_s3_file(bucket_name, file_location):
@@ -79,34 +76,6 @@ def remove_transformed_dvla_file(job_id):
     file_location = '{}-dvla-job.text'.format(job_id)
     obj = get_s3_object(bucket_name, file_location)
     return obj.delete()
-
-
-def upload_letters_pdf(reference, crown, filedata):
-    now = datetime.utcnow()
-
-    print_datetime = now
-    if now.time() > current_app.config.get('LETTER_PROCESSING_DEADLINE'):
-        print_datetime = now + timedelta(days=1)
-
-    upload_file_name = LETTERS_PDF_FILE_LOCATION_STRUCTURE.format(
-        folder=print_datetime.date(),
-        reference=reference,
-        duplex="D",
-        letter_class="2",
-        colour="C",
-        crown="C" if crown else "N",
-        date=now.strftime('%Y%m%d%H%M%S')
-    ).upper()
-
-    utils_s3upload(
-        filedata=filedata,
-        region=current_app.config['AWS_REGION'],
-        bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
-        file_location=upload_file_name
-    )
-
-    current_app.logger.info("Uploading letters PDF {} to {}".format(
-        upload_file_name, current_app.config['LETTERS_PDF_BUCKET_NAME']))
 
 
 def get_list_of_files_by_suffix(bucket_name, subfolder='', suffix='', last_modified=None):

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 import math
 
 from flask import current_app
@@ -6,6 +7,8 @@ from requests import (
     RequestException
 )
 from botocore.exceptions import ClientError as BotoClientError
+
+from notifications_utils.s3 import s3upload
 
 from app import notify_celery
 from app.aws import s3
@@ -18,6 +21,29 @@ from app.dao.notifications_dao import (
 )
 from app.models import NOTIFICATION_CREATED
 from app.statsd_decorators import statsd
+
+LETTERS_PDF_FILE_LOCATION_STRUCTURE = \
+    '{folder}/NOTIFY.{reference}.{duplex}.{letter_class}.{colour}.{crown}.{date}.pdf'
+
+
+def get_letter_pdf_filename(reference, crown):
+    now = datetime.utcnow()
+
+    print_datetime = now
+    if now.time() > current_app.config.get('LETTER_PROCESSING_DEADLINE'):
+        print_datetime = now + timedelta(days=1)
+
+    upload_file_name = LETTERS_PDF_FILE_LOCATION_STRUCTURE.format(
+        folder=print_datetime.date(),
+        reference=reference,
+        duplex="D",
+        letter_class="2",
+        colour="C",
+        crown="C" if crown else "N",
+        date=now.strftime('%Y%m%d%H%M%S')
+    ).upper()
+
+    return upload_file_name
 
 
 @notify_celery.task(bind=True, name="create-letters-pdf", max_retries=15, default_retry_delay=300)
@@ -34,7 +60,19 @@ def create_letters_pdf(self, notification_id):
         )
         current_app.logger.info("PDF Letter {} reference {} created at {}, {} bytes".format(
             notification.id, notification.reference, notification.created_at, len(pdf_data)))
-        s3.upload_letters_pdf(reference=notification.reference, crown=notification.service.crown, filedata=pdf_data)
+
+        upload_file_name = get_letter_pdf_filename(
+            notification.reference, notification.service.crown)
+
+        s3upload(
+            filedata=pdf_data,
+            region=current_app.config['AWS_REGION'],
+            bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
+            file_location=upload_file_name
+        )
+
+        current_app.logger.info("Uploaded letters PDF {} to {}".format(
+            upload_file_name, current_app.config['LETTERS_PDF_BUCKET_NAME']))
 
         notification.billable_units = billable_units
         dao_update_notification(notification)

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -526,7 +526,7 @@ def letter_raise_alert_if_no_ack_file_for_zip():
     deskpro_message = "Letter ack file does not contains all zip files sent. " \
                       "Missing ack for zip files: {}, " \
                       "pdf bucket: {}, subfolder: {}, " \
-                      "ack bucket: {}".format(str(zip_file_set - ack_content_set),
+                      "ack bucket: {}".format(str(sorted(zip_file_set - ack_content_set)),
                                               current_app.config['LETTERS_PDF_BUCKET_NAME'],
                                               datetime.utcnow().strftime('%Y-%m-%d') + '/zips_sent',
                                               current_app.config['DVLA_RESPONSE_BUCKET_NAME'])

--- a/app/models.py
+++ b/app/models.py
@@ -11,6 +11,7 @@ from sqlalchemy.dialects.postgresql import (
     JSON
 )
 from sqlalchemy import UniqueConstraint, CheckConstraint
+from notifications_utils.columns import Columns
 from notifications_utils.recipients import (
     validate_email_address,
     validate_phone_number,
@@ -1223,12 +1224,13 @@ class Notification(db.Model):
         }
 
         if self.notification_type == LETTER_TYPE:
-            serialized['line_1'] = self.personalisation['address_line_1']
-            serialized['line_2'] = self.personalisation.get('address_line_2')
-            serialized['line_3'] = self.personalisation.get('address_line_3')
-            serialized['line_4'] = self.personalisation.get('address_line_4')
-            serialized['line_5'] = self.personalisation.get('address_line_5')
-            serialized['line_6'] = self.personalisation.get('address_line_6')
+            col = Columns(self.personalisation)
+            serialized['line_1'] = col.get('address_line_1')
+            serialized['line_2'] = col.get('address_line_2')
+            serialized['line_3'] = col.get('address_line_3')
+            serialized['line_4'] = col.get('address_line_4')
+            serialized['line_5'] = col.get('address_line_5')
+            serialized['line_6'] = col.get('address_line_6')
             serialized['postcode'] = self.personalisation['postcode']
             serialized['estimated_delivery'] = \
                 get_letter_timings(serialized['created_at'])\

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -6,6 +6,7 @@ from notifications_utils.recipients import try_validate_and_format_phone_number
 
 from app import api_user, authenticated_service
 from app.config import QueueNames
+from app.dao.notifications_dao import update_notification_status_by_reference
 from app.models import (
     SMS_TYPE,
     EMAIL_TYPE,
@@ -14,9 +15,11 @@ from app.models import (
     KEY_TYPE_TEST,
     KEY_TYPE_TEAM,
     NOTIFICATION_CREATED,
-    NOTIFICATION_SENDING
+    NOTIFICATION_SENDING,
+    NOTIFICATION_DELIVERED
 )
 from app.celery.letters_pdf_tasks import create_letters_pdf
+from app.celery.research_mode_tasks import create_fake_letter_response_file
 from app.celery.tasks import update_letter_notifications_to_sent_to_dvla
 from app.notifications.process_notifications import (
     persist_notification,
@@ -171,7 +174,7 @@ def process_letter_notification(*, letter_data, api_key, template, reply_to_text
     if api_key.key_type == KEY_TYPE_TEAM:
         raise BadRequestError(message='Cannot send letters with a team api key', status_code=403)
 
-    if api_key.service.restricted and api_key.key_type != KEY_TYPE_TEST:
+    if not api_key.service.research_mode and api_key.service.restricted and api_key.key_type != KEY_TYPE_TEST:
         raise BadRequestError(message='Cannot send letters when service is in trial mode', status_code=403)
 
     should_send = not (api_key.service.research_mode or api_key.key_type == KEY_TYPE_TEST)
@@ -191,10 +194,19 @@ def process_letter_notification(*, letter_data, api_key, template, reply_to_text
         )
 
     if api_key.service.has_permission('letters_as_pdf'):
-        create_letters_pdf.apply_async(
-            [str(notification.id)],
-            queue=QueueNames.CREATE_LETTERS_PDF
-        )
+        if should_send:
+            create_letters_pdf.apply_async(
+                [str(notification.id)],
+                queue=QueueNames.CREATE_LETTERS_PDF
+            )
+        elif (api_key.service.research_mode and
+              current_app.config['NOTIFY_ENVIRONMENT'] in ['preview', 'development']):
+            create_fake_letter_response_file.apply_async(
+                (notification.reference,),
+                queue=QueueNames.RESEARCH_MODE
+            )
+        else:
+            update_notification_status_by_reference(notification.reference, NOTIFICATION_DELIVERED)
 
     return notification
 

--- a/tests/app/aws/test_s3.py
+++ b/tests/app/aws/test_s3.py
@@ -11,7 +11,6 @@ from app.aws.s3 import (
     get_s3_file,
     filter_s3_bucket_objects_within_date_range,
     remove_transformed_dvla_file,
-    upload_letters_pdf,
     get_list_of_files_by_suffix,
 )
 from tests.app.conftest import datetime_in_past
@@ -142,38 +141,6 @@ def test_get_s3_bucket_objects_does_not_return_outside_of_date_range(notify_api,
     filtered_items = filter_s3_bucket_objects_within_date_range(s3_objects_stub)
 
     assert len(filtered_items) == 0
-
-
-@pytest.mark.parametrize('crown_flag,expected_crown_text', [
-    (True, 'C'),
-    (False, 'N'),
-])
-@freeze_time("2017-12-04 17:29:00")
-def test_upload_letters_pdf_calls_utils_s3upload_with_correct_args(
-        notify_api, mocker, crown_flag, expected_crown_text):
-    s3_upload_mock = mocker.patch('app.aws.s3.utils_s3upload')
-    upload_letters_pdf(reference='foo', crown=crown_flag, filedata='some_data')
-
-    s3_upload_mock.assert_called_with(
-        filedata='some_data',
-        region='eu-west-1',
-        bucket_name='test-letters-pdf',
-        file_location='2017-12-04/NOTIFY.FOO.D.2.C.{}.20171204172900.PDF'.format(expected_crown_text)
-    )
-
-
-@freeze_time("2017-12-04 17:31:00")
-def test_upload_letters_pdf_puts_in_tomorrows_bucket_after_half_five(notify_api, mocker):
-    s3_upload_mock = mocker.patch('app.aws.s3.utils_s3upload')
-    upload_letters_pdf(reference='foo', crown=True, filedata='some_data')
-
-    s3_upload_mock.assert_called_with(
-        filedata='some_data',
-        region='eu-west-1',
-        bucket_name='test-letters-pdf',
-        # in tomorrow's folder, but still has this evening's timestamp
-        file_location='2017-12-05/NOTIFY.FOO.D.2.C.C.20171204173100.PDF'
-    )
 
 
 @freeze_time("2018-01-11 00:00:00")

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -1159,7 +1159,7 @@ def test_letter_raise_alert_if_ack_files_not_match_zip_list(mocker, notify_db):
     deskpro_message = "Letter ack file does not contains all zip files sent. " \
                       "Missing ack for zip files: {}, " \
                       "pdf bucket: {}, subfolder: {}, " \
-                      "ack bucket: {}".format(str(set(['NOTIFY.20180111175009.ZIP', 'NOTIFY.20180111175010.ZIP'])),
+                      "ack bucket: {}".format(str(['NOTIFY.20180111175009.ZIP', 'NOTIFY.20180111175010.ZIP']),
                                               current_app.config['LETTERS_PDF_BUCKET_NAME'],
                                               datetime.utcnow().strftime('%Y-%m-%d') + '/zips_sent',
                                               current_app.config['DVLA_RESPONSE_BUCKET_NAME'])

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -68,6 +68,7 @@ from tests.app.db import (
     create_reply_to_email,
     create_service_with_defined_sms_sender,
 )
+from tests.conftest import set_config_values
 
 
 class AnyStringWith(str):
@@ -1149,13 +1150,15 @@ def test_save_sms_uses_sms_sender_reply_to_text(mocker, notify_db_session):
     assert persisted_notification.reply_to_text == '447123123123'
 
 
-def test_save_letter_calls_update_noti_to_sent_task_with_letters_as_pdf_permission_in_research_mode(
-        mocker, notify_db_session, sample_letter_job):
+@pytest.mark.parametrize('env', ['staging', 'live'])
+def test_save_letter_sets_delivered_letters_as_pdf_permission_in_research_mode_in_staging_live(
+        notify_api, mocker, notify_db_session, sample_letter_job, env):
     sample_letter_job.service.research_mode = True
+    sample_reference = "this-is-random-in-real-life"
     service_permissions_dao.dao_add_service_permission(sample_letter_job.service.id, 'letters_as_pdf')
-    mock_update_letter_noti_sent = mocker.patch(
-        'app.celery.tasks.update_letter_notifications_to_sent_to_dvla.apply_async')
-    mocker.patch('app.celery.tasks.create_random_identifier', return_value="this-is-random-in-real-life")
+    mock_create_fake_letter_response_file = mocker.patch(
+        'app.celery.research_mode_tasks.create_fake_letter_response_file.apply_async')
+    mocker.patch('app.celery.tasks.create_random_identifier', return_value=sample_reference)
 
     personalisation = {
         'addressline1': 'Foo',
@@ -1171,15 +1174,55 @@ def test_save_letter_calls_update_noti_to_sent_task_with_letters_as_pdf_permissi
     )
     notification_id = uuid.uuid4()
 
-    save_letter(
-        sample_letter_job.service_id,
-        notification_id,
-        encryption.encrypt(notification_json),
-    )
+    with set_config_values(notify_api, {
+        'NOTIFY_ENVIRONMENT': env
+    }):
+        save_letter(
+            sample_letter_job.service_id,
+            notification_id,
+            encryption.encrypt(notification_json),
+        )
 
-    assert mock_update_letter_noti_sent.called
-    mock_update_letter_noti_sent.assert_called_once_with(
-        kwargs={'notification_references': ['this-is-random-in-real-life']},
+    notification = Notification.query.filter(Notification.id == notification_id).one()
+    assert notification.status == 'delivered'
+    assert not mock_create_fake_letter_response_file.called
+
+
+@pytest.mark.parametrize('env', ['development', 'preview'])
+def test_save_letter_calls_create_fake_response_for_letters_as_pdf_permission_in_research_mode_on_development_preview(
+        notify_api, mocker, notify_db_session, sample_letter_job, env):
+    sample_letter_job.service.research_mode = True
+    sample_reference = "this-is-random-in-real-life"
+    service_permissions_dao.dao_add_service_permission(sample_letter_job.service.id, 'letters_as_pdf')
+    mock_create_fake_letter_response_file = mocker.patch(
+        'app.celery.research_mode_tasks.create_fake_letter_response_file.apply_async')
+    mocker.patch('app.celery.tasks.create_random_identifier', return_value=sample_reference)
+
+    personalisation = {
+        'addressline1': 'Foo',
+        'addressline2': 'Bar',
+        'postcode': 'Flob',
+    }
+    notification_json = _notification_json(
+        template=sample_letter_job.template,
+        to='Foo',
+        personalisation=personalisation,
+        job_id=sample_letter_job.id,
+        row_number=1
+    )
+    notification_id = uuid.uuid4()
+
+    with set_config_values(notify_api, {
+        'NOTIFY_ENVIRONMENT': env
+    }):
+        save_letter(
+            sample_letter_job.service_id,
+            notification_id,
+            encryption.encrypt(notification_json),
+        )
+
+    mock_create_fake_letter_response_file.assert_called_once_with(
+        (sample_reference,),
         queue=QueueNames.RESEARCH_MODE
     )
 

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -294,3 +294,16 @@ def test_service_get_default_contact_letter(sample_service):
 def test_service_get_default_sms_sender(notify_db_session):
     service = create_service()
     assert service.get_default_sms_sender() == 'testing'
+
+
+def test_letter_notification_serializes_correctly(client, sample_letter_notification):
+    sample_letter_notification.personalisation = {
+        'addressline1': 'test',
+        'addressline2': 'London',
+        'postcode': 'N1',
+    }
+
+    json = sample_letter_notification.serialize()
+    assert json['line_1'] == 'test'
+    assert json['line_2'] == 'London'
+    assert json['postcode'] == 'N1'


### PR DESCRIPTION
## What 

In order to run letter functional tests we need to improve the way that API handles letters in research mode. I've also had to fix some bugs that I picked up during the functional tests.

- Fixed the way that the personalisation for letters is serialized so that it can serialize regardless of how it is stored
- Refactored the code so that the business logic resides in the letter task handling rather than s3 handling
- fixed ACK file handling as it was reporting random errors due to random order of sets
- added a create fake letter response file task in research mode tasks which will also trigger the dvla callback in development environment
- updated handling of letter jobs for letter pdfs to call the create response file task in preview and development environments
- updated handling of letter apis for letter pdfs to call the create response file task in preview and development environments

## How to test locally

- set a service to research mode
- Jobs 
  - create a letter template
  - set the service as sending letters as pdf
  - upload a recipients csv for letters

- API
  - create a test API key from that service and use in 
  - using the python client repo

```
PYTHONPATH=. python ./utils/make_api_call.py http://localhost:6011 research-API-TEST-KEY create --type=letter --template=[letter template id] --personalisation="{\"address_line_1\":\"someone\", \"address_line_2\":\"London\", \"postcode\":\"N1\"}"
```

- logs should have something like `DVLA file: NOTIFY.20180126142426.RSP.TXT, notification updated to delivered`

## Reference 

https://www.pivotaltracker.com/story/show/154597494