### PR TITLE
fix 500 when receiving delivery receipt from some international nums

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -134,7 +134,8 @@ def _decide_permanent_temporary_failure(current_status, status):
 
 
 def country_records_delivery(phone_prefix):
-    return INTERNATIONAL_BILLING_RATES[phone_prefix]['attributes']['dlr'].lower() == 'yes'
+    dlr = INTERNATIONAL_BILLING_RATES[phone_prefix]['attributes']['dlr']
+    return dlr and dlr.lower() == 'yes'
 
 
 def _update_notification_status(notification, status):

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -470,6 +470,20 @@ def test_should_not_update_status_by_reference_if_from_country_with_no_delivery_
     assert notification.status == NOTIFICATION_SENT
 
 
+def test_should_not_update_status_by_id_if_sent_to_country_with_unknown_delivery_receipts(sample_template):
+    notification = create_notification(
+        sample_template,
+        status=NOTIFICATION_SENT,
+        international=True,
+        phone_prefix='249'  # sudan has no delivery receipts (or at least, that we know about)
+    )
+
+    res = update_notification_status_by_id(notification.id, 'delivered')
+
+    assert res is None
+    assert notification.status == NOTIFICATION_SENT
+
+
 def test_should_not_update_status_by_id_if_sent_to_country_with_carrier_delivery_receipts(sample_template):
     notification = create_notification(
         sample_template,


### PR DESCRIPTION
if the international_billing_rates.yml has `dlr: null`, that means we don't know what delivery receipts they provide - they might not provide any. So if we do get an update, we don't know for sure that the message was actually delivered - lets not update it.