### PR TITLE
Update the dvla response data to 0 page count

### DIFF
--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -122,7 +122,7 @@ def firetext_callback(notification_id, to):
 @notify_celery.task(bind=True, name="create-fake-letter-response-file", max_retries=5, default_retry_delay=300)
 def create_fake_letter_response_file(self, reference):
     now = datetime.utcnow()
-    dvla_response_data = '{}|Sent|1|Sorted'.format(reference)
+    dvla_response_data = '{}|Sent|0|Sorted'.format(reference)
     upload_file_name = 'NOTIFY.{}.RSP.TXT'.format(now.strftime('%Y%m%d%H%M%S'))
 
     s3upload(

--- a/tests/app/celery/test_research_mode_tasks.py
+++ b/tests/app/celery/test_research_mode_tasks.py
@@ -124,7 +124,7 @@ def test_create_fake_letter_response_file_uploads_response_file_s3(
         create_fake_letter_response_file('random-ref')
 
         mock_s3upload.assert_called_once_with(
-            filedata='random-ref|Sent|1|Sorted',
+            filedata='random-ref|Sent|0|Sorted',
             region=current_app.config['AWS_REGION'],
             bucket_name=current_app.config['DVLA_RESPONSE_BUCKET_NAME'],
             file_location=filename


### PR DESCRIPTION
When triggering a fake DVLA response file as part of the research service test when creating letter notifications, the notifications billable_unit is left at 0, so the fake dvla response should also be 0. Otherwise there will be confusing logs reporting mismatched page count and billable units which are just research ones. 

This is fairly low priority and impact as only happens on local dev and preview.