### PR TITLE
Email branding mapping table

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -204,6 +204,7 @@ class ServiceSchema(BaseSchema):
     branding = field_for(models.Service, 'branding')
     dvla_organisation = field_for(models.Service, 'dvla_organisation')
     permissions = fields.Method("service_permissions")
+    email_branding = field_for(models.Service, 'email_branding')
     override_flag = False
     reply_to_email_address = fields.Method(method_name="get_reply_to_email_address")
     sms_sender = fields.Method(method_name="get_sms_sender")

--- a/migrations/versions/0161_email_branding.py
+++ b/migrations/versions/0161_email_branding.py
@@ -1,0 +1,46 @@
+"""
+
+Revision ID: 0161_email_branding
+Revises: 0160_another_letter_org
+Create Date: 2018-01-30 15:35:12.016574
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0161_email_branding'
+down_revision = '0160_another_letter_org'
+
+
+def upgrade():
+    op.create_table('email_branding',
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('colour', sa.String(length=7), nullable=True),
+        sa.Column('logo', sa.String(length=255), nullable=True),
+        sa.Column('name', sa.String(length=255), nullable=True),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_table('service_email_branding',
+        sa.Column('service_id', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('email_branding_id', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.ForeignKeyConstraint(['email_branding_id'], ['email_branding.id'], ),
+        sa.ForeignKeyConstraint(['service_id'], ['services.id'], ),
+        sa.UniqueConstraint('service_id', name='uix_service_email_branding_one_per_service'),
+        sa.PrimaryKeyConstraint('service_id')
+    )
+    op.execute("""
+        INSERT INTO email_branding (id, colour, logo, name)
+        SELECT id, colour, logo, name
+        FROM organisation
+    """)
+    op.execute("""
+        INSERT INTO service_email_branding (service_id, email_branding_id)
+        SELECT id, organisation_id
+        FROM services where organisation_id is not null
+    """)
+
+
+def downgrade():
+    op.drop_table('service_email_branding')
+    op.drop_table('email_branding')

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -13,9 +13,16 @@ from app.dao.services_dao import dao_remove_user_from_service
 from app.dao.templates_dao import dao_redact_template
 from app.dao.users_dao import save_model_user
 from app.models import (
-    User, Organisation, Service, ServicePermission, Notification,
-    ServiceEmailReplyTo, ServiceLetterContact,
-    ServiceSmsSender, InboundNumber,
+    EmailBranding,
+    InboundNumber,
+    Notification,
+    Organisation,
+    Service,
+    ServiceEmailReplyTo,
+    ServiceLetterContact,
+    ServicePermission,
+    ServiceSmsSender,
+    User,
     DVLA_ORG_LAND_REGISTRY,
     KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST,
     EMAIL_TYPE, SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INBOUND_SMS_TYPE
@@ -403,6 +410,10 @@ def test_update_service(client, notify_db, sample_service):
     org = Organisation(colour='#000000', logo='justice-league.png', name='Justice League')
     notify_db.session.add(org)
     notify_db.session.commit()
+    # Need to set this up manually until org->email_branding migration is complete :(
+    brand = EmailBranding(id=org.id, colour='#000000', logo='justice-league.png', name='Justice League')
+    notify_db.session.add(brand)
+    notify_db.session.commit()
 
     auth_header = create_authorization_header()
     resp = client.get(
@@ -412,6 +423,8 @@ def test_update_service(client, notify_db, sample_service):
     json_resp = json.loads(resp.get_data(as_text=True))
     assert resp.status_code == 200
     assert json_resp['data']['name'] == sample_service.name
+    assert json_resp['data']['organisation'] is None
+    assert json_resp['data']['email_branding'] is None
 
     data = {
         'name': 'updated service name',
@@ -434,8 +447,46 @@ def test_update_service(client, notify_db, sample_service):
     assert result['data']['name'] == 'updated service name'
     assert result['data']['email_from'] == 'updated.service.name'
     assert result['data']['organisation'] == str(org.id)
+    assert result['data']['email_branding'] == str(org.id)
     assert result['data']['dvla_organisation'] == DVLA_ORG_LAND_REGISTRY
     assert result['data']['organisation_type'] == 'foo'
+
+
+def test_update_service_remove_org(admin_request, notify_db, sample_service):
+    org = Organisation(colour='#000000', logo='justice-league.png', name='Justice League')
+    notify_db.session.add(org)
+    notify_db.session.commit()
+    # Need to set this up manually until org->email_branding migration is complete :(
+    brand = EmailBranding(id=org.id, colour='#000000', logo='justice-league.png', name='Justice League')
+    sample_service.organisation = org
+    sample_service.email_branding = brand
+    notify_db.session.commit()
+
+    resp = admin_request.post('service.update_service', service_id=sample_service.id, _data={'organisation': None})
+    assert resp['data']['organisation'] is None
+    assert resp['data']['email_branding'] is None
+
+
+def test_update_service_change_org(admin_request, notify_db, sample_service):
+    org1 = Organisation(colour='#000000', logo='justice-league.png', name='Justice League')
+    org2 = Organisation(colour='#111111', logo='avengers.png', name='Avengers')
+    notify_db.session.add_all([org1, org2])
+    notify_db.session.commit()
+    # Need to set this up manually until org->email_branding migration is complete :(
+    brand1 = EmailBranding(id=org1.id, colour='#000000', logo='justice-league.png', name='Justice League')
+    brand2 = EmailBranding(id=org2.id, colour='#111111', logo='avengers.png', name='Avengers')
+    notify_db.session.add_all([brand1, brand2])
+    sample_service.organisation = org1
+    sample_service.email_branding = brand1
+    notify_db.session.commit()
+
+    resp = admin_request.post(
+        'service.update_service',
+        service_id=sample_service.id,
+        _data={'organisation': str(org2.id)}
+    )
+    assert resp['data']['organisation'] == str(org2.id)
+    assert resp['data']['email_branding'] == str(brand2.id)
 
 
 def test_update_service_flags(client, sample_service):


### PR DESCRIPTION
Use a mapping table for email branding.

with `uselist=False` on the relationship we can force this to be one-to-many. Also, I've made the service_id the sole primary key of the mapping table - so we definitely won't end up with two rows for one service