### PR TITLE
Updated utils to the latest version and add celery logging

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -76,7 +76,7 @@ def create_app(application):
     register_blueprint(application)
     register_v2_blueprints(application)
 
-    # avoid circular imports by importing this file later 😬
+    # avoid circular imports by importing this file later
     from app.commands import setup_commands
     setup_commands(application)
 

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -1,9 +1,20 @@
+import time
+
 from flask import current_app
 from celery import Celery, Task
 
 
 class NotifyTask(Task):
     abstract = True
+    start = None
+
+    def on_success(self, retval, task_id, args, kwargs):
+        elapsed_time = time.time() - self.start
+        current_app.logger.info(
+            "{task_name} took {time}".format(
+                task_name=Task.name, time="{0:.4f}".format(elapsed_time)
+            )
+        )
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         # ensure task will log exceptions to correct handlers
@@ -13,6 +24,7 @@ class NotifyTask(Task):
     def __call__(self, *args, **kwargs):
         # ensure task has flask context to access config, logger, etc
         with current_app.app_context():
+            self.start = time.time()
             return super().__call__(*args, **kwargs)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,6 @@ notifications-python-client==4.7.1
 awscli==1.14.31
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@23.5.2#egg=notifications-utils==23.5.2
+git+https://github.com/alphagov/notifications-utils.git@23.5.3#egg=notifications-utils==23.5.3
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
Updated utils to the latest version. This version of utils has less logging at info level and as such no longer prints out the celery task timing, which are useful to find out if a tasks has been called but also the timing for the task. Added an extra timing message for celery tasks so that it can be determined if the these are less frequent than the API calls and provide more useful information.