### PR TITLE
Remove failed as a possible status

### DIFF
--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -5,7 +5,6 @@ from monotonic import monotonic
 from requests import request, RequestException
 
 from app.clients.sms import (SmsClient, SmsClientResponseException)
-from app.clients import STATISTICS_DELIVERED, STATISTICS_FAILURE
 
 logger = logging.getLogger(__name__)
 
@@ -15,24 +14,9 @@ logger = logging.getLogger(__name__)
 # the notification status to temporary-failure rather than permanent failure.
 #  See the code in the notification_dao.update_notifications_status_by_id
 firetext_responses = {
-    '0': {
-        "message": 'Delivered',
-        "notification_statistics_status": STATISTICS_DELIVERED,
-        "success": True,
-        "notification_status": 'delivered'
-    },
-    '1': {
-        "message": 'Declined',
-        "success": False,
-        "notification_statistics_status": STATISTICS_FAILURE,
-        "notification_status": 'permanent-failure'
-    },
-    '2': {
-        "message": 'Undelivered (Pending with Network)',
-        "success": True,
-        "notification_statistics_status": None,
-        "notification_status": 'pending'
-    }
+    '0': 'delivered',
+    '1': 'permanent-failure',
+    '2': 'pending'
 }
 
 

--- a/app/clients/sms/mmg.py
+++ b/app/clients/sms/mmg.py
@@ -1,45 +1,18 @@
 import json
 from monotonic import monotonic
 from requests import (request, RequestException)
-from app.clients import (STATISTICS_DELIVERED, STATISTICS_FAILURE)
 from app.clients.sms import (SmsClient, SmsClientResponseException)
 
 mmg_response_map = {
-    '2': {
-        "message": ' Permanent failure',
-        "notification_statistics_status": STATISTICS_FAILURE,
-        "success": False,
-        "notification_status": 'permanent-failure'
-    },
-    '3': {
-        "message": 'Delivered',
-        "notification_statistics_status": STATISTICS_DELIVERED,
-        "success": True,
-        "notification_status": 'delivered'
-    },
-    '4': {
-        "message": ' Temporary failure',
-        "notification_statistics_status": STATISTICS_FAILURE,
-        "success": False,
-        "notification_status": 'temporary-failure'
-    },
-    '5': {
-        "message": 'Permanent failure',
-        "notification_statistics_status": STATISTICS_FAILURE,
-        "success": False,
-        "notification_status": 'permanent-failure'
-    },
-    'default': {
-        "message": 'Declined',
-        "success": False,
-        "notification_statistics_status": STATISTICS_FAILURE,
-        "notification_status": 'failed'
-    }
+    '2': 'permanent-failure',
+    '3': 'delivered',
+    '4': 'temporary-failure',
+    '5': 'permanent-failure'
 }
 
 
 def get_mmg_responses(status):
-    return mmg_response_map.get(status, mmg_response_map.get('default'))
+    return mmg_response_map[status]
 
 
 class MMGClientResponseException(SmsClientResponseException):

--- a/app/notifications/process_client_response.py
+++ b/app/notifications/process_client_response.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from flask import current_app
 
 from app import statsd_client
+from app.clients import ClientException
 from app.dao import notifications_dao
 from app.clients.sms.firetext import get_firetext_responses
 from app.clients.sms.mmg import get_mmg_responses
@@ -49,17 +50,19 @@ def process_sms_client_response(status, reference, client_name):
 
     # validate  status
     try:
-        response_dict = response_parser(status)
+        notification_status = response_parser(status)
         current_app.logger.info('{} callback return status of {} for reference: {}'.format(
             client_name, status, reference)
         )
     except KeyError:
-        msg = "{} callback failed: status {} not found.".format(client_name, status)
-        return success, msg
+        process_for_status(notification_status='technical-failure', client_name=client_name, reference=reference)
+        raise ClientException("{} callback failed: status {} not found.".format(client_name, status))
 
-    notification_status = response_dict['notification_status']
-    notification_status_message = response_dict['message']
-    notification_success = response_dict['success']
+    success = process_for_status(notification_status=notification_status, client_name=client_name, reference=reference)
+    return success, errors
+
+
+def process_for_status(notification_status, client_name, reference):
 
     # record stats
     notification = notifications_dao.update_notification_status_by_id(reference, notification_status)
@@ -67,14 +70,8 @@ def process_sms_client_response(status, reference, client_name):
         current_app.logger.warning("{} callback failed: notification {} either not found or already updated "
                                    "from sending. Status {}".format(client_name,
                                                                     reference,
-                                                                    notification_status_message))
-        return success, errors
-
-    if not notification_success:
-        current_app.logger.info(
-            "{} delivery failed: notification {} has error found. Status {}".format(client_name,
-                                                                                    reference,
-                                                                                    notification_status_message))
+                                                                    notification_status))
+        return
 
     statsd_client.incr('callback.{}.{}'.format(client_name.lower(), notification_status))
     if notification.sent_at:
@@ -92,4 +89,4 @@ def process_sms_client_response(status, reference, client_name):
         send_delivery_status_to_service.apply_async([str(notification.id)], queue=QueueNames.CALLBACKS)
 
     success = "{} callback succeeded. reference {} updated".format(client_name, reference)
-    return success, errors
+    return success

--- a/tests/app/clients/test_firetext.py
+++ b/tests/app/clients/test_firetext.py
@@ -9,27 +9,15 @@ from app.clients.sms.firetext import get_firetext_responses, SmsClientResponseEx
 
 
 def test_should_return_correct_details_for_delivery():
-    response_dict = get_firetext_responses('0')
-    assert response_dict['message'] == 'Delivered'
-    assert response_dict['notification_status'] == 'delivered'
-    assert response_dict['notification_statistics_status'] == 'delivered'
-    assert response_dict['success']
+    get_firetext_responses('0') == 'delivered'
 
 
 def test_should_return_correct_details_for_bounced():
-    response_dict = get_firetext_responses('1')
-    assert response_dict['message'] == 'Declined'
-    assert response_dict['notification_status'] == 'permanent-failure'
-    assert response_dict['notification_statistics_status'] == 'failure'
-    assert not response_dict['success']
+    get_firetext_responses('1') == 'permanent-failure'
 
 
 def test_should_return_correct_details_for_complaint():
-    response_dict = get_firetext_responses('2')
-    assert response_dict['message'] == 'Undelivered (Pending with Network)'
-    assert response_dict['notification_status'] == 'pending'
-    assert response_dict['notification_statistics_status'] is None
-    assert response_dict['success']
+    get_firetext_responses('2') == 'pending'
 
 
 def test_should_be_none_if_unrecognised_status_code():

--- a/tests/app/clients/test_mmg.py
+++ b/tests/app/clients/test_mmg.py
@@ -10,27 +10,22 @@ from app.clients.sms.mmg import get_mmg_responses, MMGClientResponseException
 
 
 def test_should_return_correct_details_for_delivery():
-    response_dict = get_mmg_responses('3')
-    assert response_dict['message'] == 'Delivered'
-    assert response_dict['notification_status'] == 'delivered'
-    assert response_dict['notification_statistics_status'] == 'delivered'
-    assert response_dict['success']
+    get_mmg_responses('3') == 'delivered'
 
 
-def test_should_return_correct_details_for_bounced():
-    response_dict = get_mmg_responses('50')
-    assert response_dict['message'] == 'Declined'
-    assert response_dict['notification_status'] == 'failed'
-    assert response_dict['notification_statistics_status'] == 'failure'
-    assert not response_dict['success']
+def test_should_return_correct_details_for_temporary_failure():
+    get_mmg_responses('4') == 'temporary-failure'
 
 
-def test_should_be_none_if_unrecognised_status_code():
-    response_dict = get_mmg_responses('blah')
-    assert response_dict['message'] == 'Declined'
-    assert response_dict['notification_status'] == 'failed'
-    assert response_dict['notification_statistics_status'] == 'failure'
-    assert not response_dict['success']
+@pytest.mark.parametrize('status', ['5', '2'])
+def test_should_return_correct_details_for_bounced(status):
+    get_mmg_responses(status) == 'permanent-failure'
+
+
+def test_should_be_raise_if_unrecognised_status_code():
+    with pytest.raises(KeyError) as e:
+        get_mmg_responses('99')
+    assert '99' in str(e.value)
 
 
 def test_send_sms_successful_returns_mmg_response(notify_api, mocker):


### PR DESCRIPTION
We are not handling the case of an unknown status code sent by the SMS provider. This PR attempts to fix that. `failed` is a deprecated failure type.

- If the SMS client sends a status code that we do not recognize raise a ClientException and set the notification status to technical-failure
- Simplified the code in process_client_response, using a simple map.