### PR TITLE
Fixed typo in log call so that the name of the task is returned

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -12,7 +12,7 @@ class NotifyTask(Task):
         elapsed_time = time.time() - self.start
         current_app.logger.info(
             "{task_name} took {time}".format(
-                task_name=Task.name, time="{0:.4f}".format(elapsed_time)
+                task_name=self.name, time="{0:.4f}".format(elapsed_time)
             )
         )
 

--- a/app/config.py
+++ b/app/config.py
@@ -60,8 +60,6 @@ class TaskNames(object):
 
 
 class Config(object):
-    NOTIFY_LOG_LEVEL = 'INFO'
-
     # URL of admin app
     ADMIN_BASE_URL = os.environ['ADMIN_BASE_URL']
 

--- a/app/config.py
+++ b/app/config.py
@@ -60,7 +60,7 @@ class TaskNames(object):
 
 
 class Config(object):
-    NOTIFY_LOG_LEVEL = 'DEBUG'
+    NOTIFY_LOG_LEVEL = 'INFO'
 
     # URL of admin app
     ADMIN_BASE_URL = os.environ['ADMIN_BASE_URL']

--- a/app/config.py
+++ b/app/config.py
@@ -60,6 +60,8 @@ class TaskNames(object):
 
 
 class Config(object):
+    NOTIFY_LOG_LEVEL = 'DEBUG'
+
     # URL of admin app
     ADMIN_BASE_URL = os.environ['ADMIN_BASE_URL']
 


### PR DESCRIPTION
Fixed typo in call, should be self.name not Task.name.

Task.name always returned None.