### PR TITLE
New worker for service-callbacks

### DIFF
--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -90,6 +90,11 @@ applications:
       NOTIFY_APP_NAME: delivery-worker-internal
 
   - name: notify-delivery-worker-receipts
-    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q ses-callbacks,service-callbacks
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q ses-callbacks
+    env:
+      NOTIFY_APP_NAME: delivery-worker-receipts
+
+  - name: notify-delivery-worker-service-callbacks
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q service-callbacks
     env:
       NOTIFY_APP_NAME: delivery-worker-receipts


### PR DESCRIPTION
When there are high volumes of emails being processed the SES callback task will trigger the service-callback task.

This PR creates a new worker to deal with the service-callback so that one event doesn't block the other.