### PR TITLE
Allow admin to specify domain for email auth links

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -196,7 +196,7 @@ def send_user_email_code(user_to_send_to, data):
     secret_code = str(uuid.uuid4())
     personalisation = {
         'name': user_to_send_to.name,
-        'url': _create_2fa_url(user_to_send_to, secret_code, data.get('next'))
+        'url': _create_2fa_url(user_to_send_to, secret_code, data.get('next'), data.get('email_auth_link_host'))
     }
 
     create_2fa_code(
@@ -413,10 +413,10 @@ def _create_confirmation_url(user, email_address):
     return url_with_token(data, url, current_app.config)
 
 
-def _create_2fa_url(user, secret_code, next_redir):
+def _create_2fa_url(user, secret_code, next_redir, email_auth_link_host):
     data = json.dumps({'user_id': str(user.id), 'secret_code': secret_code})
     url = '/email-auth/'
-    ret = url_with_token(data, url, current_app.config)
+    ret = url_with_token(data, url, current_app.config, base_url=email_auth_link_host)
     if next_redir:
         ret += '?{}'.format(urlencode({'next': next_redir}))
     return ret

--- a/app/user/users_schema.py
+++ b/app/user/users_schema.py
@@ -22,6 +22,7 @@ post_send_user_email_code_schema = {
         # doesn't need 'to' as we'll just grab user.email_address. but lets keep it
         # as allowed to keep admin code cleaner, but only as null to prevent confusion
         'to': {'type': 'null'},
+        'email_auth_link_host': {'type': ['string', 'null']},
         'next': {'type': ['string', 'null']},
     },
     'required': [],

--- a/app/utils.py
+++ b/app/utils.py
@@ -20,10 +20,10 @@ def pagination_links(pagination, endpoint, **kwargs):
     return links
 
 
-def url_with_token(data, url, config):
+def url_with_token(data, url, config, base_url=None):
     from notifications_utils.url_safe_token import generate_token
     token = generate_token(data, config['SECRET_KEY'], config['DANGEROUS_SALT'])
-    base_url = config['ADMIN_BASE_URL'] + url
+    base_url = (base_url or config['ADMIN_BASE_URL']) + url
     return base_url + token
 
 


### PR DESCRIPTION
Similar to https://github.com/alphagov/notifications-api/pull/1515

This lets the admin app pass in a domain to use for email auth links, so that when it’s running on a different URL users who try to sign in will get an email auth link for the domain they sign in on, not the default admin domain for the environment in which the API is running.