### PR TITLE
upload letter pdfs with retention tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 coverage.xml
 test_results.xml
 *,cover

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -14,6 +14,7 @@ from notifications_utils.s3 import s3upload
 from app import notify_celery
 from app.aws import s3
 from app.config import QueueNames, TaskNames
+from app.variables import Retention
 from app.dao.notifications_dao import (
     get_notification_by_id,
     update_notification_status_by_id,
@@ -68,7 +69,8 @@ def create_letters_pdf(self, notification_id):
             filedata=pdf_data,
             region=current_app.config['AWS_REGION'],
             bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
-            file_location=upload_file_name
+            file_location=upload_file_name,
+            tags={Retention.KEY: Retention.ONE_WEEK}
         )
 
         current_app.logger.info("Uploaded letters PDF {} to {}".format(

--- a/app/variables.py
+++ b/app/variables.py
@@ -1,3 +1,10 @@
 # all jobs for letters created via the api must have this filename
 LETTER_API_FILENAME = 'letter submitted via api'
 LETTER_TEST_API_FILENAME = 'test letter submitted via api'
+
+
+# S3 tags
+class Retention:
+    KEY = 'retention'
+
+    ONE_WEEK = 'ONE_WEEK'

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,6 @@ notifications-python-client==4.7.1
 awscli==1.14.32
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@23.5.3#egg=notifications-utils==23.5.3
+git+https://github.com/alphagov/notifications-utils.git@23.6.0#egg=notifications-utils==23.6.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -10,6 +10,7 @@ from celery.exceptions import MaxRetriesExceededError
 from requests import RequestException
 from sqlalchemy.orm.exc import NoResultFound
 
+from app.variables import Retention
 from app.celery.letters_pdf_tasks import (
     create_letters_pdf,
     get_letters_pdf,
@@ -117,7 +118,8 @@ def test_create_letters_pdf_calls_s3upload(mocker, sample_letter_notification):
         bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
         file_location=filename,
         filedata=b'\x00\x01',
-        region=current_app.config['AWS_REGION']
+        region=current_app.config['AWS_REGION'],
+        tags={Retention.KEY: Retention.ONE_WEEK}
     )
 
 


### PR DESCRIPTION
so we can delete them automatically with s3's lifecycle policy

- [x] https://github.com/alphagov/notifications-utils/pull/333
- [x] https://github.com/alphagov/notifications-aws/pull/321