### PR TITLE
fix bug where we s3upload crashed if you didn't supply tags

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,6 @@ notifications-python-client==4.7.2
 awscli==1.14.32
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@23.6.0#egg=notifications-utils==23.6.0
+git+https://github.com/alphagov/notifications-utils.git@23.6.1#egg=notifications-utils==23.6.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
- [x] https://github.com/alphagov/notifications-utils/pull/338