### PR TITLE
Added a freezetime to the test test_create_letters_pdf_calls_s3upload

### DIFF
--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -1,3 +1,4 @@
+import time
 from flask import current_app
 
 from unittest.mock import call
@@ -103,6 +104,7 @@ def test_get_letters_pdf_calculates_billing_units(
     assert billable_units == expected_billable_units
 
 
+@freeze_time("2017-12-04 17:31:00")
 def test_create_letters_pdf_calls_s3upload(mocker, sample_letter_notification):
     mocker.patch('app.celery.letters_pdf_tasks.get_letters_pdf', return_value=(b'\x00\x01', '1'))
     mock_s3 = mocker.patch('app.celery.letters_pdf_tasks.s3upload')

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -1,4 +1,3 @@
-import time
 from flask import current_app
 
 from unittest.mock import call


### PR DESCRIPTION
as it failed on prodction and I managed to get it to fail locally

in running 'for i in {1..20}; do pytest -k test_create_letters_pdf_calls_s3upload; done' I managed it to fail on my local machine however running it a second and third time it did not.

{'file_location': '2018-02-12/NOTIFY.FOO.D.2.C.N.20180212164427.PDF'}
!= {'file_location': '2018-02-12/NOTIFY.FOO.D.2.C.N.20180212164428.PDF'}

A freeze time till ensure that the filename which is based on the time will not fail.