### PR TITLE
Allow services to add punctuation to or change the case of their name

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -673,15 +673,24 @@ def get_organisation_for_service(service_id):
 
 @service_blueprint.route('/unique', methods=["GET"])
 def is_service_name_unique():
-    name, email_from = check_request_args(request)
+    service_id, name, email_from = check_request_args(request)
 
     name_exists = Service.query.filter_by(name=name).first()
-    email_from_exists = Service.query.filter_by(email_from=email_from).first()
+
+    if service_id:
+        email_from_exists = Service.query.filter(
+            Service.email_from == email_from,
+            Service.id != service_id
+        ).first()
+    else:
+        email_from_exists = Service.query.filter_by(email_from=email_from).first()
+
     result = not (name_exists or email_from_exists)
     return jsonify(result=result), 200
 
 
 def check_request_args(request):
+    service_id = request.args.get('service_id')
     name = request.args.get('name', None)
     email_from = request.args.get('email_from', None)
     errors = []
@@ -691,4 +700,4 @@ def check_request_args(request):
         errors.append({'email_from': ["Can't be empty"]})
     if errors:
         raise InvalidRequest(errors, status_code=400)
-    return name, email_from
+    return service_id, name, email_from

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2202,6 +2202,58 @@ def test_is_service_name_unique_returns_200_if_unique(client):
     assert json.loads(response.get_data(as_text=True)) == {"result": True}
 
 
+def test_is_service_name_unique_returns_200_if_unique_and_service_id_given(
+    client,
+    notify_db,
+    notify_db_session
+):
+    service = create_service(service_name='unique', email_from='unique')
+    service_id = str(service.id)
+
+    response = client.get(
+        '/service/unique?service_id={}&name=something&email_from=something'.format(service_id),
+        headers=[create_authorization_header()]
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.get_data(as_text=True)) == {"result": True}
+
+
+def test_is_service_name_unique_returns_200_when_capitalized(
+    client,
+    notify_db,
+    notify_db_session
+):
+    service = create_service(service_name='unique', email_from='unique')
+    service_id = str(service.id)
+
+    response = client.get(
+        '/service/unique?service_id={}&name={}&email_from={}'.format(service_id, 'UNIQUE', 'unique'),
+        headers=[create_authorization_header()]
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.get_data(as_text=True)) == {"result": True}
+
+
+def test_is_service_name_unique_returns_false_if_checking_capitalization_of_different_service(
+    client,
+    notify_db,
+    notify_db_session
+):
+    create_service(service_name='unique', email_from='unique')
+    different_service_id = '111aa111-2222-bbbb-aaaa-111111111111'
+
+    response = client.get(
+        '/service/unique?service_id={}&name={}&email_from={}'.format(
+            different_service_id, 'UNIQUE', 'unique'),
+        headers=[create_authorization_header()]
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.get_data(as_text=True)) == {"result": False}
+
+
 @pytest.mark.parametrize('name, email_from',
                          [("something unique", "something"),
                           ("unique", "something.unique"),


### PR DESCRIPTION
Changed the `/service/unique` endpoint to optionally accept the
`service_id` parameter. It now doesn't matter if a user tries to change
the capitalization or add punctuation to their own service name. But
there should still be an error if a user tries to change the punctuation
or capitalization of another service.

`service_id` needs to be allowed to be `None` until notifications-admin is
updated to always pass it in.

[Pivotal story](https://www.pivotaltracker.com/story/show/155127026)