### PR TITLE
Stop pytest on 10th failing test

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -31,5 +31,5 @@ flake8 .
 display_result $? 1 "Code style check"
 
 # run with four concurrent threads
-py.test --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml -n 4 -v
+py.test --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml -n4 -v -x
 display_result $? 2 "Unit tests"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -31,5 +31,5 @@ flake8 .
 display_result $? 1 "Code style check"
 
 # run with four concurrent threads
-py.test --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml -n4 -v -x
+py.test --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml -n4 -v --maxfail=10
 display_result $? 2 "Unit tests"


### PR DESCRIPTION
If a PR is going to fail because tests aren’t passing then you:
- should know about it as quick as possible
- shouldn’t waste precious Jenkins CPU running subsequent tests

This commit adds the `-maxfail=10` flag to pytest, which stops the test run once an unacceptable number of tests have failed.