### PR TITLE
Switch to using the pdf letter flow.

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -170,11 +170,6 @@ class Config(object):
             'schedule': crontab(minute=1),
             'options': {'queue': QueueNames.PERIODIC}
         },
-        # 'send-scheduled-notifications': {
-        #     'task': 'send-scheduled-notifications',
-        #     'schedule': crontab(minute='*/15'),
-        #     'options': {'queue': 'periodic'}
-        # },
         'delete-verify-codes': {
             'task': 'delete-verify-codes',
             'schedule': timedelta(minutes=63),
@@ -252,11 +247,6 @@ class Config(object):
             'schedule': crontab(hour=16, minute=30),
             'options': {'queue': QueueNames.PERIODIC}
         },
-        'run-letter-jobs': {
-            'task': 'run-letter-jobs',
-            'schedule': crontab(hour=17, minute=30),
-            'options': {'queue': QueueNames.PERIODIC}
-        },
         'trigger-letter-pdfs-for-day': {
             'task': 'trigger-letter-pdfs-for-day',
             'schedule': crontab(hour=17, minute=50),
@@ -265,11 +255,6 @@ class Config(object):
         'raise-alert-if-no-letter-ack-file': {
             'task': 'raise-alert-if-no-letter-ack-file',
             'schedule': crontab(hour=23, minute=00),
-            'options': {'queue': QueueNames.PERIODIC}
-        },
-        'run-letter-api-notifications': {
-            'task': 'run-letter-api-notifications',
-            'schedule': crontab(hour=17, minute=40),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'check-job-status': {

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -183,20 +183,19 @@ def process_letter_notification(*, letter_data, api_key, template, reply_to_text
                                               status=status,
                                               reply_to_text=reply_to_text)
 
-    if api_key.service.has_permission('letters_as_pdf'):
-        if should_send:
-            create_letters_pdf.apply_async(
-                [str(notification.id)],
-                queue=QueueNames.CREATE_LETTERS_PDF
-            )
-        elif (api_key.service.research_mode and
-              current_app.config['NOTIFY_ENVIRONMENT'] in ['preview', 'development']):
-            create_fake_letter_response_file.apply_async(
-                (notification.reference,),
-                queue=QueueNames.RESEARCH_MODE
-            )
-        else:
-            update_notification_status_by_reference(notification.reference, NOTIFICATION_DELIVERED)
+    if should_send:
+        create_letters_pdf.apply_async(
+            [str(notification.id)],
+            queue=QueueNames.CREATE_LETTERS_PDF
+        )
+    elif (api_key.service.research_mode and
+          current_app.config['NOTIFY_ENVIRONMENT'] in ['preview', 'development']):
+        create_fake_letter_response_file.apply_async(
+            (notification.reference,),
+            queue=QueueNames.RESEARCH_MODE
+        )
+    else:
+        update_notification_status_by_reference(notification.reference, NOTIFICATION_DELIVERED)
 
     return notification
 


### PR DESCRIPTION
We are ready to send all letters to our provider as a PDF and not a text file that they then use to create a PDF. 
In this PR, anytime we are sending a letter it will create a PDF to use to send to the provider at the scheduled time of day. 
