### PR TITLE
Improve error message for wrong template ID

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -92,8 +92,11 @@ def register_errors(blueprint):
     @blueprint.errorhandler(NoResultFound)
     @blueprint.errorhandler(DataError)
     def no_result_found(e):
+        message = {
+            'template': 'Template not found'
+        }.get(blueprint.name, 'No result found')
         current_app.logger.info(e)
-        return jsonify(result='error', message="No result found"), 404
+        return jsonify(result='error', message=message), 404
 
     @blueprint.errorhandler(SQLAlchemyError)
     def db_error(e):

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -84,7 +84,7 @@ def test_should_raise_error_if_service_does_not_exist_on_create(client, sample_u
     json_resp = json.loads(response.get_data(as_text=True))
     assert response.status_code == 404
     assert json_resp['result'] == 'error'
-    assert json_resp['message'] == 'No result found'
+    assert json_resp['message'] == 'Template not found'
 
 
 @pytest.mark.parametrize('permissions, template_type, subject, expected_error', [
@@ -184,7 +184,7 @@ def test_should_be_error_if_service_does_not_exist_on_update(client, fake_uuid):
     json_resp = json.loads(response.get_data(as_text=True))
     assert response.status_code == 404
     assert json_resp['result'] == 'error'
-    assert json_resp['message'] == 'No result found'
+    assert json_resp['message'] == 'Template not found'
 
 
 @pytest.mark.parametrize('template_type', [EMAIL_TYPE, LETTER_TYPE])
@@ -463,7 +463,7 @@ def test_should_return_404_if_no_templates_for_service_with_id(client, sample_se
     assert response.status_code == 404
     json_resp = json.loads(response.get_data(as_text=True))
     assert json_resp['result'] == 'error'
-    assert json_resp['message'] == 'No result found'
+    assert json_resp['message'] == 'Template not found'
 
 
 def test_create_400_for_over_limit_content(client, notify_api, sample_user, sample_service, fake_uuid):


### PR DESCRIPTION
If you try to send a notification from a template which doesn’t exist, or there’s a typo in the ID then the error you get isn’t useful enough that you can figure out what to do to fix it.

This commit makes the error message more helpful.