### PR TITLE
Add precompiled_letter service permission

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -200,6 +200,7 @@ INBOUND_SMS_TYPE = 'inbound_sms'
 SCHEDULE_NOTIFICATIONS = 'schedule_notifications'
 EMAIL_AUTH = 'email_auth'
 LETTERS_AS_PDF = 'letters_as_pdf'
+PRECOMPILED_LETTER = 'precompiled_letter'
 
 SERVICE_PERMISSION_TYPES = [
     EMAIL_TYPE,
@@ -210,6 +211,7 @@ SERVICE_PERMISSION_TYPES = [
     SCHEDULE_NOTIFICATIONS,
     EMAIL_AUTH,
     LETTERS_AS_PDF,
+    PRECOMPILED_LETTER,
 ]
 
 

--- a/migrations/versions/0167_add_precomp_letter_svc_perm.py
+++ b/migrations/versions/0167_add_precomp_letter_svc_perm.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: 0167_add_precomp_letter_svc_perm
+Revises: 0166_add_org_user_stuff
+Create Date: 2018-02-21 12:05:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0167_add_precomp_letter_svc_perm'
+down_revision = '0166_add_org_user_stuff'
+
+from alembic import op
+
+
+def upgrade():
+    op.get_bind()
+    op.execute("insert into service_permission_types values('precompiled_letter')")
+
+
+def downgrade():
+    op.get_bind()
+    op.execute("delete from service_permissions where permission = 'precompiled_letter'")
+    op.execute("delete from service_permission_types where name = 'precompiled_letter'")


### PR DESCRIPTION
## What 

migration script to add precompiled_letter in service_permission_types table and also added to service permission types list in models.py

## Reference

https://www.pivotaltracker.com/story/show/155323023