### PR TITLE
Added a new exception type for DVLAException

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -18,7 +18,7 @@ def make_task(app):
 
         def on_failure(self, exc, task_id, args, kwargs, einfo):
             # ensure task will log exceptions to correct handlers
-            app.logger.exception('Celery task failed')
+            app.logger.exception('Celery task: {} failed'.format(self.name))
             super().on_failure(exc, task_id, args, kwargs, einfo)
 
         def __call__(self, *args, **kwargs):

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,0 +1,3 @@
+class DVLAException(Exception):
+    def __init__(self, message):
+        self.message = message


### PR DESCRIPTION
The Notify team needs to investigate when a notification is marked as failed.
We will process the whole file and mark the notifications with the appropriate status, if any are failed an exception is raised.
The exception will trigger a cloud watch error for the team to investigate.