### PR TITLE
Post pre-compiled letter PDF notification endpoint

### DIFF
--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -75,9 +75,10 @@ def dao_get_template_by_id_and_service_id(template_id, service_id, version=None)
     if version is not None:
         return TemplateHistory.query.filter_by(
             id=template_id,
+            hidden=False,
             service_id=service_id,
             version=version).one()
-    return Template.query.filter_by(id=template_id, service_id=service_id).one()
+    return Template.query.filter_by(id=template_id, hidden=False, service_id=service_id).one()
 
 
 def dao_get_template_by_id(template_id, version=None):
@@ -93,6 +94,7 @@ def dao_get_all_templates_for_service(service_id, template_type=None):
         return Template.query.filter_by(
             service_id=service_id,
             template_type=template_type,
+            hidden=False,
             archived=False
         ).order_by(
             asc(Template.name),
@@ -101,6 +103,7 @@ def dao_get_all_templates_for_service(service_id, template_type=None):
 
     return Template.query.filter_by(
         service_id=service_id,
+        hidden=False,
         archived=False
     ).order_by(
         asc(Template.name),
@@ -110,7 +113,8 @@ def dao_get_all_templates_for_service(service_id, template_type=None):
 
 def dao_get_template_versions(service_id, template_id):
     return TemplateHistory.query.filter_by(
-        service_id=service_id, id=template_id
+        service_id=service_id, id=template_id,
+        hidden=False,
     ).order_by(
         desc(TemplateHistory.version)
     ).all()

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timedelta
+
+from flask import current_app
+
+from notifications_utils.s3 import s3upload
+
+from app.variables import Retention
+
+
+LETTERS_PDF_FILE_LOCATION_STRUCTURE = \
+    '{folder}/NOTIFY.{reference}.{duplex}.{letter_class}.{colour}.{crown}.{date}.pdf'
+
+
+def get_letter_pdf_filename(reference, crown):
+    now = datetime.utcnow()
+
+    print_datetime = now
+    if now.time() > current_app.config.get('LETTER_PROCESSING_DEADLINE'):
+        print_datetime = now + timedelta(days=1)
+
+    upload_file_name = LETTERS_PDF_FILE_LOCATION_STRUCTURE.format(
+        folder=print_datetime.date(),
+        reference=reference,
+        duplex="D",
+        letter_class="2",
+        colour="C",
+        crown="C" if crown else "N",
+        date=now.strftime('%Y%m%d%H%M%S')
+    ).upper()
+
+    return upload_file_name
+
+
+def upload_letter_pdf(notification, pdf_data):
+    current_app.logger.info("PDF Letter {} reference {} created at {}, {} bytes".format(
+        notification.id, notification.reference, notification.created_at, len(pdf_data)))
+
+    upload_file_name = get_letter_pdf_filename(
+        notification.reference, notification.service.crown)
+
+    s3upload(
+        filedata=pdf_data,
+        region=current_app.config['AWS_REGION'],
+        bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
+        file_location=upload_file_name,
+        tags={Retention.KEY: Retention.ONE_WEEK}
+    )
+
+    current_app.logger.info("Uploaded letters PDF {} to {}".format(
+        upload_file_name, current_app.config['LETTERS_PDF_BUCKET_NAME']))

--- a/app/models.py
+++ b/app/models.py
@@ -664,6 +664,7 @@ class TemplateBase(db.Model):
     updated_at = db.Column(db.DateTime, onupdate=datetime.datetime.utcnow)
     content = db.Column(db.Text, nullable=False)
     archived = db.Column(db.Boolean, nullable=False, default=False)
+    hidden = db.Column(db.Boolean, nullable=False, default=False)
     subject = db.Column(db.Text)
 
     @declared_attr

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -206,7 +206,6 @@ post_email_response = {
     "required": ["id", "content", "uri", "template"]
 }
 
-
 post_letter_request = {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "POST letter notification schema",
@@ -218,6 +217,19 @@ post_letter_request = {
         "personalisation": letter_personalisation
     },
     "required": ["template_id", "personalisation"],
+    "additionalProperties": False
+}
+
+post_precompiled_letter_request = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "POST precompiled letter notification schema",
+    "type": "object",
+    "title": "POST v2/notifications/letter",
+    "properties": {
+        "reference": {"type": "string"},
+        "content": {"type": "string"}
+    },
+    "required": ["reference", "content"],
     "additionalProperties": False
 }
 

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -16,7 +16,7 @@ from app.models import (
     SMS_TYPE,
     EMAIL_TYPE,
     LETTER_TYPE,
-    # PRECOMPILED_LETTER,
+    PRECOMPILED_LETTER,
     PRIORITY,
     KEY_TYPE_TEST,
     KEY_TYPE_TEAM,
@@ -69,7 +69,7 @@ def post_precompiled_letter_notification():
 
     # Check both permission to send letters and permission to send pre-compiled PDFs
     check_service_has_permission(LETTER_TYPE, authenticated_service.permissions)
-    # check_service_has_permission(PRECOMPILED_LETTER, authenticated_service.permissions)
+    check_service_has_permission(PRECOMPILED_LETTER, authenticated_service.permissions)
 
     check_rate_limiting(authenticated_service, api_user)
 

--- a/migrations/versions/0168_hidden_templates.py
+++ b/migrations/versions/0168_hidden_templates.py
@@ -1,0 +1,29 @@
+"""
+
+Revision ID: 0168_hidden_templates
+Revises: 0167_add_precomp_letter_svc_perm
+Create Date: 2018-02-21 14:05:04.448977
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0168_hidden_templates'
+down_revision = '0167_add_precomp_letter_svc_perm'
+
+
+def upgrade():
+    op.add_column('templates', sa.Column('hidden', sa.Boolean(), nullable=True))
+    op.add_column('templates_history', sa.Column('hidden', sa.Boolean(), nullable=True))
+
+    op.execute('UPDATE templates SET hidden=false')
+    op.execute('UPDATE templates_history SET hidden=false')
+
+    op.alter_column('templates', 'hidden', nullable=False)
+    op.alter_column('templates_history', 'hidden', nullable=False)
+
+
+def downgrade():
+    op.drop_column('templates_history', 'hidden')
+    op.drop_column('templates', 'hidden')

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -16,9 +16,9 @@ from app.celery.letters_pdf_tasks import (
     get_letters_pdf,
     collate_letter_pdfs_for_day,
     group_letters,
-    letter_in_created_state,
-    get_letter_pdf_filename,
+    letter_in_created_state
 )
+from app.letters.utils import get_letter_pdf_filename
 from app.models import Notification, NOTIFICATION_SENDING
 
 from tests.conftest import set_config_values
@@ -106,7 +106,7 @@ def test_get_letters_pdf_calculates_billing_units(
 @freeze_time("2017-12-04 17:31:00")
 def test_create_letters_pdf_calls_s3upload(mocker, sample_letter_notification):
     mocker.patch('app.celery.letters_pdf_tasks.get_letters_pdf', return_value=(b'\x00\x01', '1'))
-    mock_s3 = mocker.patch('app.celery.letters_pdf_tasks.s3upload')
+    mock_s3 = mocker.patch('app.letters.utils.s3upload')
 
     create_letters_pdf(sample_letter_notification.id)
 
@@ -126,7 +126,7 @@ def test_create_letters_pdf_calls_s3upload(mocker, sample_letter_notification):
 
 def test_create_letters_pdf_sets_billable_units(mocker, sample_letter_notification):
     mocker.patch('app.celery.letters_pdf_tasks.get_letters_pdf', return_value=(b'\x00\x01', 1))
-    mocker.patch('app.celery.letters_pdf_tasks.s3upload')
+    mocker.patch('app.letters.utils.s3upload')
 
     create_letters_pdf(sample_letter_notification.id)
     noti = Notification.query.filter(Notification.reference == sample_letter_notification.reference).one()
@@ -150,7 +150,7 @@ def test_create_letters_pdf_handles_request_errors(mocker, sample_letter_notific
 
 def test_create_letters_pdf_handles_s3_errors(mocker, sample_letter_notification):
     mocker.patch('app.celery.letters_pdf_tasks.get_letters_pdf', return_value=(b'\x00\x01', 1))
-    mock_s3 = mocker.patch('app.celery.letters_pdf_tasks.s3upload', side_effect=ClientError({}, 'operation_name'))
+    mock_s3 = mocker.patch('app.letters.utils.s3upload', side_effect=ClientError({}, 'operation_name'))
     mock_retry = mocker.patch('app.celery.letters_pdf_tasks.create_letters_pdf.retry')
 
     create_letters_pdf(sample_letter_notification.id)

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -102,6 +102,14 @@ def sample_user(notify_db_session):
     return create_user()
 
 
+@pytest.fixture(scope='function')
+def notify_user(notify_db_session):
+    return create_user(
+        email="notify-service-user@digital.cabinet-office.gov.uk",
+        id_=current_app.config['NOTIFY_USER_ID']
+    )
+
+
 def create_code(notify_db, notify_db_session, code_type, usr=None, code=None):
     if code is None:
         code = create_secret_code()

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -216,6 +216,7 @@ def sample_template(
     template_type="sms",
     content="This is a template:\nwith a newline",
     archived=False,
+    hidden=False,
     subject_line='Subject',
     user=None,
     service=None,
@@ -237,6 +238,7 @@ def sample_template(
         'service': service,
         'created_by': created_by,
         'archived': archived,
+        'hidden': hidden,
         'process_type': process_type
     }
     if template_type in ['email', 'letter']:

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -286,6 +286,29 @@ def test_get_all_templates_ignores_archived_templates(notify_db, notify_db_sessi
     assert templates[0] == normal_template
 
 
+def test_get_all_templates_ignores_hidden_templates(notify_db, notify_db_session, sample_service):
+    normal_template = create_sample_template(
+        notify_db,
+        notify_db_session,
+        template_name='Normal Template',
+        service=sample_service,
+        archived=False
+    )
+
+    create_sample_template(
+        notify_db,
+        notify_db_session,
+        template_name='Hidden Template',
+        hidden=True,
+        service=sample_service
+    )
+
+    templates = dao_get_all_templates_for_service(sample_service.id)
+
+    assert len(templates) == 1
+    assert templates[0] == normal_template
+
+
 def test_get_template_by_id_and_service(notify_db, notify_db_session, sample_service):
     sample_template = create_sample_template(
         notify_db,
@@ -299,6 +322,39 @@ def test_get_template_by_id_and_service(notify_db, notify_db_session, sample_ser
     assert template.name == 'Test Template'
     assert template.version == sample_template.version
     assert not template.redact_personalisation
+
+
+def test_get_template_by_id_and_service_returns_none_for_hidden_templates(notify_db, notify_db_session, sample_service):
+    sample_template = create_sample_template(
+        notify_db,
+        notify_db_session,
+        template_name='Test Template',
+        hidden=True,
+        service=sample_service
+    )
+
+    with pytest.raises(NoResultFound):
+        dao_get_template_by_id_and_service_id(
+            template_id=sample_template.id,
+            service_id=sample_service.id
+        )
+
+
+def test_get_template_version_returns_none_for_hidden_templates(notify_db, notify_db_session, sample_service):
+    sample_template = create_sample_template(
+        notify_db,
+        notify_db_session,
+        template_name='Test Template',
+        hidden=True,
+        service=sample_service
+    )
+
+    with pytest.raises(NoResultFound):
+        dao_get_template_by_id_and_service_id(
+            sample_template.id,
+            sample_service.id,
+            '1'
+        )
 
 
 def test_get_template_by_id_and_service_returns_none_if_no_template(sample_service, fake_uuid):
@@ -406,6 +462,18 @@ def test_get_template_versions(sample_template):
     from app.schemas import template_history_schema
     v = template_history_schema.load(versions, many=True)
     assert len(v) == 2
+
+
+def test_get_template_versions_is_empty_for_hidden_templates(notify_db, notify_db_session, sample_service):
+    sample_template = create_sample_template(
+        notify_db,
+        notify_db_session,
+        template_name='Test Template',
+        hidden=True,
+        service=sample_service
+    )
+    versions = dao_get_template_versions(service_id=sample_template.service_id, template_id=sample_template.id)
+    assert len(versions) == 0
 
 
 def test_get_templates_by_ids_successful(notify_db, notify_db_session):

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -45,9 +45,9 @@ from app.dao.email_branding_dao import dao_create_email_branding
 from app.dao.organisation_dao import dao_create_organisation
 
 
-def create_user(mobile_number="+447700900986", email="notify@digital.cabinet-office.gov.uk", state='active'):
+def create_user(mobile_number="+447700900986", email="notify@digital.cabinet-office.gov.uk", state='active', id_=None):
     data = {
-        'id': uuid.uuid4(),
+        'id': id_ or uuid.uuid4(),
         'name': 'Test User',
         'email_address': email,
         'password': 'password',

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -714,6 +714,27 @@ def test_post_precompiled_letter_requires_permission(client, sample_service, not
     assert resp_json['errors'][0]['message'] == 'Cannot send precompiled_letters'
 
 
+def test_post_precompiled_letter_with_invalid_base64(client, notify_user, mocker):
+    sample_service = create_service(service_permissions=['letter', 'precompiled_letter'])
+    mocker.patch('app.v2.notifications.post_notifications.upload_letter_pdf')
+
+    data = {
+        "reference": "letter-reference",
+        "content": "hi"
+    }
+    auth_header = create_authorization_header(service_id=sample_service.id)
+    response = client.post(
+        path="v2/notifications/letter",
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header])
+
+    assert response.status_code == 400, response.get_data(as_text=True)
+    resp_json = json.loads(response.get_data(as_text=True))
+    assert resp_json['errors'][0]['message'] == 'Cannot decode letter content (invalid base64 encoding)'
+
+    assert not Notification.query.first()
+
+
 def test_post_precompiled_letter_notification_returns_201(client, notify_user, mocker):
     sample_service = create_service(service_permissions=['letter', 'precompiled_letter'])
     s3mock = mocker.patch('app.v2.notifications.post_notifications.upload_letter_pdf')
@@ -731,10 +752,12 @@ def test_post_precompiled_letter_notification_returns_201(client, notify_user, m
 
     s3mock.assert_called_once_with(ANY, b'letter-content')
 
+    notification = Notification.query.first()
+
     resp_json = json.loads(response.get_data(as_text=True))
     assert resp_json == {
         'content': {'body': None, 'subject': 'Pre-compiled PDF'},
-        'id': ANY,
+        'id': str(notification.id),
         'reference': 'letter-reference',
         'scheduled_for': None,
         'template': {


### PR DESCRIPTION
### Add a hidden column to templates

Allows hiding templates from the templates list in the admin app and related API responses.

This is used for 'internal' templates that we create for notifications that wouldn't have a template otherwise (eg pre-compiled PDF letters)

### Add a DB migration to create Templates.hidden column

Creates the column as nullable, sets the value to false for all existing templates and template versions and then applies a not-nullable constraint.

All future Templates are created with `False` as the default set in SQLAlchemy.

### Set Notify service user as the creator of Pre-compiled PDF template


### Add a view function for pre-compiled PDF letters

Adds a separate view function that is registered under the same route as existing letter POST notification.

### Upload pre-compiled letter PDF to S3

Pre-compiled letter endpoint uploads PDF contents to S3 directly instead of creating a letter task to generate PDF using template preview.

This moves some of the utility functions used by existing letter celery tasks to app.letters.utils, so that they can be reused by the API endpoint.

### Check for precompiled letter permission in the post notification


### Return 400 response for invalid per-compiled letter content


### Don't return hidden templates in API service template responses

Removes hidden templates from the service templates list and returns 404 when searching for a hidden template or template versions by ID.
