### PR TITLE
Set Template.hidden as nullable before the new app code gets released

### DIFF
--- a/migrations/versions/0168_hidden_templates.py
+++ b/migrations/versions/0168_hidden_templates.py
@@ -17,12 +17,6 @@ def upgrade():
     op.add_column('templates', sa.Column('hidden', sa.Boolean(), nullable=True))
     op.add_column('templates_history', sa.Column('hidden', sa.Boolean(), nullable=True))
 
-    op.execute('UPDATE templates SET hidden=false')
-    op.execute('UPDATE templates_history SET hidden=false')
-
-    op.alter_column('templates', 'hidden', nullable=False)
-    op.alter_column('templates_history', 'hidden', nullable=False)
-
 
 def downgrade():
     op.drop_column('templates_history', 'hidden')

--- a/migrations/versions/0169_hidden_templates_nullable.py
+++ b/migrations/versions/0169_hidden_templates_nullable.py
@@ -1,0 +1,22 @@
+"""
+
+Revision ID: 0169_hidden_templates_nullable
+Revises: 0168_hidden_templates
+Create Date: 2018-02-21 14:05:04.448977
+
+"""
+from alembic import op
+
+
+revision = '0169_hidden_templates_nullable'
+down_revision = '0168_hidden_templates'
+
+
+def upgrade():
+    op.alter_column('templates', 'hidden', nullable=True)
+    op.alter_column('templates_history', 'hidden', nullable=True)
+
+
+def downgrade():
+    op.alter_column('templates', 'hidden', nullable=False)
+    op.alter_column('templates_history', 'hidden', nullable=False)


### PR DESCRIPTION
Since the application code gets released after the migration setting
a new Template field as non-nullable prevents new templates from being
created by the existing application instances.

This splits the migration to set fields as nullable first and then
update existing records once the application code has been released.

0168 is modified not to run UPDATE query or set non-nullable flag in
staging and production. 0169 is added to rollback preview.