### PR TITLE
Fix serialization on precompiled letter

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1313,7 +1313,7 @@ class Notification(db.Model):
             serialized['line_4'] = col.get('address_line_4')
             serialized['line_5'] = col.get('address_line_5')
             serialized['line_6'] = col.get('address_line_6')
-            serialized['postcode'] = self.personalisation['postcode']
+            serialized['postcode'] = col.get('postcode')
             serialized['estimated_delivery'] = \
                 get_letter_timings(serialized['created_at'])\
                 .earliest_delivery\

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -307,3 +307,15 @@ def test_letter_notification_serializes_correctly(client, sample_letter_notifica
     assert json['line_1'] == 'test'
     assert json['line_2'] == 'London'
     assert json['postcode'] == 'N1'
+
+
+def test_letter_notification_postcode_can_be_null_for_precompiled_letters(client, sample_letter_notification):
+    sample_letter_notification.personalisation = {
+        'address_line_1': 'test',
+        'address_line_2': 'London',
+    }
+
+    json = sample_letter_notification.serialize()
+    assert json['line_1'] == 'test'
+    assert json['line_2'] == 'London'
+    assert json['postcode'] is None


### PR DESCRIPTION
Postcodes are required for created letters, but not for precompiled, this fix allows postcodes to be None in the model.

As postcodes are still required for created letter they should be caught by validation schemas in the POST handler for created letters