### PR TITLE
bump requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-boto3==1.5.28
 cffi==1.11.0 # pyup: != 1.11.1, != 1.11.2 # These versions are missing .whl
 celery==3.1.25 # pyup: <4
 docopt==0.6.2
@@ -17,15 +16,13 @@ marshmallow==2.15.0
 monotonic==1.4
 psycopg2-binary==2.7.4
 PyJWT==1.5.3
-SQLAlchemy-Utils==0.32.21
-SQLAlchemy==1.2.2
+SQLAlchemy==1.2.4
 
 notifications-python-client==4.7.2
 
 # PaaS
-awscli==1.14.38
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@23.6.2#egg=notifications-utils==23.6.2
+git+https://github.com/alphagov/notifications-utils.git@23.8.0#egg=notifications-utils==23.8.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -4,7 +4,7 @@ pytest==3.4.1
 pytest-env==0.6.2
 pytest-mock==1.7.0
 pytest-cov==2.5.1
-pytest-xdist==1.22.1
+pytest-xdist==1.22.2
 coveralls==1.2.0
 freezegun==0.3.9
 requests-mock==1.4.0


### PR DESCRIPTION
notably, remove awscli and boto3 - they're both required by utils, and
are generating a lot of PR noise