### PR TITLE
Send one-off messages as fast as possible

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -118,6 +118,13 @@ def send_notification_to_queue(notification, research_mode, queue=None):
     if research_mode or notification.key_type == KEY_TYPE_TEST:
         queue = QueueNames.RESEARCH_MODE
 
+    if all((
+        not queue,
+        notification.api_key_id is None,
+        notification.job_id is None,
+    )):
+        queue = QueueNames.PRIORITY
+
     if notification.notification_type == SMS_TYPE:
         if not queue:
             queue = QueueNames.SEND_SMS

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -241,6 +241,14 @@ def test_persist_notification_increments_cache_if_key_exists(sample_template, sa
                                                  sample_template.id)
 
 
+SENT_FROM_JOB = [None, None, uuid.uuid4()]
+SENT_ONE_OFF = [None, None, None]
+SENT_BY_API = [uuid.uuid4(), None]
+SENT_BY_API_TEAM_KEY = ['team'] + SENT_BY_API
+SENT_BY_API_NORMAL_KEY = ['normal'] + SENT_BY_API
+SENT_BY_API_TEST_KEY = ['test'] + SENT_BY_API
+
+
 @pytest.mark.parametrize((
     'research_mode,'
     'requested_queue,'
@@ -250,17 +258,41 @@ def test_persist_notification_increments_cache_if_key_exists(sample_template, sa
     'api_key_id,'
     'job_id,'
 ), [
-    (True, None, 'research-mode-tasks', 'sms', 'normal', uuid.uuid4(), uuid.uuid4()),
-    (True, None, 'research-mode-tasks', 'email', 'normal', uuid.uuid4(), uuid.uuid4()),
-    (True, None, 'research-mode-tasks', 'email', 'team', uuid.uuid4(), uuid.uuid4()),
-    (False, None, 'send-sms-tasks', 'sms', 'normal', uuid.uuid4(), uuid.uuid4()),
-    (False, None, 'send-email-tasks', 'email', 'normal', uuid.uuid4(), uuid.uuid4()),
-    (False, None, 'send-sms-tasks', 'sms', 'team', uuid.uuid4(), uuid.uuid4()),
-    (False, None, 'research-mode-tasks', 'sms', 'test', uuid.uuid4(), uuid.uuid4()),
-    (True, 'notify-internal-tasks', 'research-mode-tasks', 'email', 'normal', uuid.uuid4(), uuid.uuid4()),
-    (False, 'notify-internal-tasks', 'notify-internal-tasks', 'sms', 'normal', uuid.uuid4(), uuid.uuid4()),
-    (False, 'notify-internal-tasks', 'notify-internal-tasks', 'email', 'normal', uuid.uuid4(), uuid.uuid4()),
-    (False, 'notify-internal-tasks', 'research-mode-tasks', 'sms', 'test', uuid.uuid4(), uuid.uuid4()),
+
+    # Anything research mode goes to the research queue, no matter how it’s sent
+    [True, None, 'research-mode-tasks', 'sms'] + SENT_FROM_JOB,
+    [True, None, 'research-mode-tasks', 'sms'] + SENT_ONE_OFF,
+    [True, None, 'research-mode-tasks', 'sms'] + SENT_BY_API_NORMAL_KEY,
+    # …or if it’s a different channel
+    [True, None, 'research-mode-tasks', 'email'] + SENT_BY_API_NORMAL_KEY,
+    # …or if it’s using a team key
+    [True, None, 'research-mode-tasks', 'email'] + SENT_BY_API_TEAM_KEY,
+
+    # Job or API messages go to their respective queue for that channel
+    [False, None, 'send-sms-tasks', 'sms'] + SENT_FROM_JOB,
+    [False, None, 'send-sms-tasks', 'sms'] + SENT_BY_API_NORMAL_KEY,
+    [False, None, 'send-email-tasks', 'email'] + SENT_FROM_JOB,
+    [False, None, 'send-email-tasks', 'email'] + SENT_BY_API_NORMAL_KEY,
+
+    # One off messages go to the priority queue
+    [False, None, 'priority-tasks', 'sms'] + SENT_ONE_OFF,
+    [False, None, 'priority-tasks', 'email'] + SENT_ONE_OFF,
+
+    # Team keys behave normally, test keys go to the research mode queue
+    [False, None, 'send-sms-tasks', 'sms'] + SENT_BY_API_TEAM_KEY,
+    [False, None, 'research-mode-tasks', 'sms'] + SENT_BY_API_TEST_KEY,
+
+    # Only research mode can override a requested queue
+    [True, 'notify-internal-tasks', 'research-mode-tasks', 'email'] + SENT_BY_API_NORMAL_KEY,
+    [False, 'notify-internal-tasks', 'notify-internal-tasks', 'sms'] + SENT_BY_API_NORMAL_KEY,
+    [False, 'notify-internal-tasks', 'notify-internal-tasks', 'email'] + SENT_BY_API_NORMAL_KEY,
+    [False, 'notify-internal-tasks', 'research-mode-tasks', 'sms'] + SENT_BY_API_TEST_KEY,
+
+    # Priority queue messages stay priority
+    [False, 'priority-tasks', 'priority-tasks', 'sms'] + SENT_FROM_JOB,
+    [False, 'priority-tasks', 'priority-tasks', 'sms'] + SENT_BY_API_NORMAL_KEY,
+    [False, 'priority-tasks', 'priority-tasks', 'sms'] + SENT_ONE_OFF,
+
 ])
 def test_send_notification_to_queue(
     notify_db,

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -241,23 +241,36 @@ def test_persist_notification_increments_cache_if_key_exists(sample_template, sa
                                                  sample_template.id)
 
 
-@pytest.mark.parametrize('research_mode, requested_queue, expected_queue, notification_type, key_type',
-                         [(True, None, 'research-mode-tasks', 'sms', 'normal'),
-                          (True, None, 'research-mode-tasks', 'email', 'normal'),
-                          (True, None, 'research-mode-tasks', 'email', 'team'),
-                          (False, None, 'send-sms-tasks', 'sms', 'normal'),
-                          (False, None, 'send-email-tasks', 'email', 'normal'),
-                          (False, None, 'send-sms-tasks', 'sms', 'team'),
-                          (False, None, 'research-mode-tasks', 'sms', 'test'),
-                          (True, 'notify-internal-tasks', 'research-mode-tasks', 'email', 'normal'),
-                          (False, 'notify-internal-tasks', 'notify-internal-tasks', 'sms', 'normal'),
-                          (False, 'notify-internal-tasks', 'notify-internal-tasks', 'email', 'normal'),
-                          (False, 'notify-internal-tasks', 'research-mode-tasks', 'sms', 'test')])
-def test_send_notification_to_queue(notify_db, notify_db_session,
-                                    research_mode, requested_queue, expected_queue,
-                                    notification_type, key_type, mocker):
+@pytest.mark.parametrize('research_mode, requested_queue, expected_queue, notification_type, key_type', [
+    (True, None, 'research-mode-tasks', 'sms', 'normal'),
+    (True, None, 'research-mode-tasks', 'email', 'normal'),
+    (True, None, 'research-mode-tasks', 'email', 'team'),
+    (False, None, 'send-sms-tasks', 'sms', 'normal'),
+    (False, None, 'send-email-tasks', 'email', 'normal'),
+    (False, None, 'send-sms-tasks', 'sms', 'team'),
+    (False, None, 'research-mode-tasks', 'sms', 'test'),
+    (True, 'notify-internal-tasks', 'research-mode-tasks', 'email', 'normal'),
+    (False, 'notify-internal-tasks', 'notify-internal-tasks', 'sms', 'normal'),
+    (False, 'notify-internal-tasks', 'notify-internal-tasks', 'email', 'normal'),
+    (False, 'notify-internal-tasks', 'research-mode-tasks', 'sms', 'test'),
+])
+def test_send_notification_to_queue(
+    notify_db,
+    notify_db_session,
+    research_mode,
+    requested_queue,
+    expected_queue,
+    notification_type,
+    key_type,
+    mocker,
+):
     mocked = mocker.patch('app.celery.provider_tasks.deliver_{}.apply_async'.format(notification_type))
-    Notification = namedtuple('Notification', ['id', 'key_type', 'notification_type', 'created_at'])
+    Notification = namedtuple('Notification', [
+        'id',
+        'key_type',
+        'notification_type',
+        'created_at',
+    ])
     notification = Notification(
         id=uuid.uuid4(),
         key_type=key_type,

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -241,18 +241,26 @@ def test_persist_notification_increments_cache_if_key_exists(sample_template, sa
                                                  sample_template.id)
 
 
-@pytest.mark.parametrize('research_mode, requested_queue, expected_queue, notification_type, key_type', [
-    (True, None, 'research-mode-tasks', 'sms', 'normal'),
-    (True, None, 'research-mode-tasks', 'email', 'normal'),
-    (True, None, 'research-mode-tasks', 'email', 'team'),
-    (False, None, 'send-sms-tasks', 'sms', 'normal'),
-    (False, None, 'send-email-tasks', 'email', 'normal'),
-    (False, None, 'send-sms-tasks', 'sms', 'team'),
-    (False, None, 'research-mode-tasks', 'sms', 'test'),
-    (True, 'notify-internal-tasks', 'research-mode-tasks', 'email', 'normal'),
-    (False, 'notify-internal-tasks', 'notify-internal-tasks', 'sms', 'normal'),
-    (False, 'notify-internal-tasks', 'notify-internal-tasks', 'email', 'normal'),
-    (False, 'notify-internal-tasks', 'research-mode-tasks', 'sms', 'test'),
+@pytest.mark.parametrize((
+    'research_mode,'
+    'requested_queue,'
+    'expected_queue,'
+    'notification_type,'
+    'key_type,'
+    'api_key_id,'
+    'job_id,'
+), [
+    (True, None, 'research-mode-tasks', 'sms', 'normal', uuid.uuid4(), uuid.uuid4()),
+    (True, None, 'research-mode-tasks', 'email', 'normal', uuid.uuid4(), uuid.uuid4()),
+    (True, None, 'research-mode-tasks', 'email', 'team', uuid.uuid4(), uuid.uuid4()),
+    (False, None, 'send-sms-tasks', 'sms', 'normal', uuid.uuid4(), uuid.uuid4()),
+    (False, None, 'send-email-tasks', 'email', 'normal', uuid.uuid4(), uuid.uuid4()),
+    (False, None, 'send-sms-tasks', 'sms', 'team', uuid.uuid4(), uuid.uuid4()),
+    (False, None, 'research-mode-tasks', 'sms', 'test', uuid.uuid4(), uuid.uuid4()),
+    (True, 'notify-internal-tasks', 'research-mode-tasks', 'email', 'normal', uuid.uuid4(), uuid.uuid4()),
+    (False, 'notify-internal-tasks', 'notify-internal-tasks', 'sms', 'normal', uuid.uuid4(), uuid.uuid4()),
+    (False, 'notify-internal-tasks', 'notify-internal-tasks', 'email', 'normal', uuid.uuid4(), uuid.uuid4()),
+    (False, 'notify-internal-tasks', 'research-mode-tasks', 'sms', 'test', uuid.uuid4(), uuid.uuid4()),
 ])
 def test_send_notification_to_queue(
     notify_db,
@@ -262,20 +270,26 @@ def test_send_notification_to_queue(
     expected_queue,
     notification_type,
     key_type,
+    api_key_id,
+    job_id,
     mocker,
 ):
     mocked = mocker.patch('app.celery.provider_tasks.deliver_{}.apply_async'.format(notification_type))
     Notification = namedtuple('Notification', [
         'id',
         'key_type',
+        'api_key_id',
         'notification_type',
         'created_at',
+        'job_id',
     ])
     notification = Notification(
         id=uuid.uuid4(),
         key_type=key_type,
+        api_key_id=api_key_id,
         notification_type=notification_type,
         created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+        job_id=job_id,
     )
 
     send_notification_to_queue(notification=notification, research_mode=research_mode, queue=requested_queue)


### PR DESCRIPTION
The vast majority of messages that are being sent one-off are time sensitive. A typical example is a caseworker on the phone who sends a message at the end of the call. They normally wait until the message has been delivered, so all the time they’re waiting is time when they can’t be helping someone else.

What we don’t want to happen is for the messages they’re sending to get stuck behind a big lump of GOV.UK Subscription emails or passport reminder texts. I think the best way to do this is shift them onto the priority queue.

We’re currently seeing queue sizes of up to 5,000 on the ‘normal’ queues; I don’t think there’s any risk of this change making the priority queue more heavily-laden than this. Especially since the
traffic patterns of users sending one-off messages won’t be spiky.

I also split up the parametrize definition in the tests a bit because it was getting really hard to follow.