### PR TITLE
Remove priority flag from example templates

### DIFF
--- a/migrations/versions/0172_deprioritise_examples.py
+++ b/migrations/versions/0172_deprioritise_examples.py
@@ -1,0 +1,31 @@
+"""
+
+Revision ID: 0172_deprioritise_examples
+Revises: 0171_add_org_invite_template
+Create Date: 2018-02-28 17:09:56.619803
+
+"""
+from alembic import op
+from app.models import NORMAL
+import sqlalchemy as sa
+
+
+revision = '0172_deprioritise_examples'
+down_revision = '0171_add_org_invite_template'
+
+
+def upgrade():
+    op.get_bind()
+    op.execute("""
+        update templates
+        set process_type = '{}'
+        where templates.id in (
+            select templates.id from templates
+            join templates_history on templates.id=templates_history.id
+            where templates_history.name = 'Example text message template'
+        )
+    """.format(NORMAL))
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Since we send all one off messages as priority [now](https://github.com/alphagov/notifications-api/pull/1722), we don’t need to explicitly mark the ‘Example text message template’ template as
being priority.

This commit retroactively removes the priority flag from these templates, so that they can’t be reused to send other messages as priority. I don’t think this is a real problem now, but worth cleaning this up.

This query will hit approximately 827 templates.

Depends on:
- [x] https://github.com/alphagov/notifications-admin/pull/1915 (otherwise we might create some new, unwanted priority templates in the mean time)