### PR TITLE
Have workers also look at the priority queue

### DIFF
--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -63,7 +63,7 @@ applications:
       NOTIFY_APP_NAME: delivery-worker-research
 
   - name: notify-delivery-worker-sender
-    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q send-sms-tasks,send-email-tasks
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q priority-tasks,send-sms-tasks,send-email-tasks
     env:
       NOTIFY_APP_NAME: delivery-worker-sender
 


### PR DESCRIPTION
This is to try to work around a Celery problem where the worker doesn’t look at the queue often enough because it’s often empty.

Want to deploy this and see if it makes a difference to the performance of priority messages.