### PR TITLE
Process old letter responses

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -19,6 +19,7 @@ from requests import (
     RequestException
 )
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm.exc import NoResultFound
 
 from app import (
     create_uuid,
@@ -42,6 +43,7 @@ from app.dao.notifications_dao import (
     dao_get_last_notification_added_for_job_id,
     update_notification_status_by_reference,
     dao_get_notification_history_by_reference,
+    dao_get_notification_by_reference,
 )
 from app.dao.provider_details_dao import get_current_provider
 from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
@@ -449,7 +451,12 @@ def update_letter_notification(filename, temporary_failures, update):
 
 
 def check_billable_units(notification_update):
-    notification = dao_get_notification_history_by_reference(notification_update.reference)
+    try:
+        # This try except is necessary because in test keys and research mode does not create notification history.
+        # Otherwise we could just search for the NotificationHistory object
+        notification = dao_get_notification_by_reference(notification_update.reference)
+    except NoResultFound:
+        notification = dao_get_notification_history_by_reference(notification_update.reference)
 
     if int(notification_update.page_count) != notification.billable_units:
         msg = 'Notification with id {} had {} billable_units but a page count of {}'.format(

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -40,8 +40,8 @@ from app.dao.notifications_dao import (
     get_notification_by_id,
     dao_update_notifications_by_reference,
     dao_get_last_notification_added_for_job_id,
-    dao_get_notification_by_reference,
     update_notification_status_by_reference,
+    dao_get_notification_history_by_reference,
 )
 from app.dao.provider_details_dao import get_current_provider
 from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
@@ -449,7 +449,7 @@ def update_letter_notification(filename, temporary_failures, update):
 
 
 def check_billable_units(notification_update):
-    notification = dao_get_notification_by_reference(notification_update.reference)
+    notification = dao_get_notification_history_by_reference(notification_update.reference)
 
     if int(notification_update.page_count) != notification.billable_units:
         msg = 'Notification with id {} had {} billable_units but a page count of {}'.format(

--- a/app/config.py
+++ b/app/config.py
@@ -188,12 +188,11 @@ class Config(object):
             'schedule': crontab(hour=0, minute=20),
             'options': {'queue': QueueNames.PERIODIC}
         },
-        # Suspending the scheduled job to delete letter notifications, because there is a problem with the provider.
-        # 'delete-letter-notifications': {
-        #     'task': 'delete-letter-notifications',
-        #     'schedule': crontab(hour=0, minute=40),
-        #     'options': {'queue': QueueNames.PERIODIC}
-        # },
+        'delete-letter-notifications': {
+            'task': 'delete-letter-notifications',
+            'schedule': crontab(hour=0, minute=40),
+            'options': {'queue': QueueNames.PERIODIC}
+        },
         'delete-inbound-sms': {
             'task': 'delete-inbound-sms',
             'schedule': crontab(hour=1, minute=0),

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -464,6 +464,13 @@ def dao_get_notification_by_reference(reference):
 
 
 @statsd(namespace="dao")
+def dao_get_notification_history_by_reference(reference):
+    return NotificationHistory.query.filter(
+        NotificationHistory.reference == reference
+    ).one()
+
+
+@statsd(namespace="dao")
 def dao_get_notifications_by_references(references):
     return Notification.query.filter(
         Notification.reference.in_(references)

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -31,7 +31,8 @@ from app.dao.notifications_dao import (
     update_notification_status_by_id,
     update_notification_status_by_reference,
     dao_get_notification_by_reference,
-    dao_get_notifications_by_references
+    dao_get_notifications_by_references,
+    dao_get_notification_history_by_reference,
 )
 from app.dao.services_dao import dao_update_service
 from app.models import (
@@ -1996,6 +1997,30 @@ def test_dao_get_notifications_by_reference(sample_template):
     assert len(notifications) == 2
     assert notifications[0].id in [notification_1.id, notification_2.id]
     assert notifications[1].id in [notification_1.id, notification_2.id]
+
+
+def test_dao_get_notification_history_by_reference_with_one_match_returns_notification(
+        sample_letter_template
+):
+    create_notification(template=sample_letter_template, reference='REF1')
+    notification = dao_get_notification_history_by_reference('REF1')
+
+    assert notification.reference == 'REF1'
+
+
+def test_dao_get_notification_history_by_reference_with_multiple_matches_raises_error(
+        sample_letter_template
+):
+    create_notification(template=sample_letter_template, reference='REF1')
+    create_notification(template=sample_letter_template, reference='REF1')
+
+    with pytest.raises(SQLAlchemyError):
+        dao_get_notification_history_by_reference('REF1')
+
+
+def test_dao_get_notification_history_by_reference_with_no_matches_raises_error(notify_db):
+    with pytest.raises(SQLAlchemyError):
+        dao_get_notification_history_by_reference('REF1')
 
 
 @freeze_time("2017-12-18 17:50")


### PR DESCRIPTION
Process responses for letters even after the notification has been deleted.

This will continue to update the notification history for letter notifications.
We currently have an issue where the responses to letters from the provider is taking a long time.
This is due to the manual nature of their process.
Updating the status of the letter will still work if the notification has been purged.

Also turned back on the purge letter notification scheduled task.