### PR TITLE
Renamed 'Pre-compiled PDF' to 'Provided as PDF'

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -642,7 +642,7 @@ class TemplateProcessTypes(db.Model):
     name = db.Column(db.String(255), primary_key=True)
 
 
-PRECOMPILED_TEMPLATE_NAME = 'Pre-compiled PDF'
+PRECOMPILED_TEMPLATE_NAME = 'Provided as PDF'
 
 
 class TemplateBase(db.Model):

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -25,7 +25,8 @@ from app.models import (
     KEY_TYPE_TEAM,
     NOTIFICATION_CREATED,
     NOTIFICATION_SENDING,
-    NOTIFICATION_DELIVERED
+    NOTIFICATION_DELIVERED,
+    PRECOMPILED_TEMPLATE_NAME
 )
 from app.celery.letters_pdf_tasks import create_letters_pdf
 from app.celery.research_mode_tasks import create_fake_letter_response_file
@@ -304,12 +305,12 @@ def get_precompiled_letter_template(service_id):
         return template
 
     template = Template(
-        name=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
+        name=PRECOMPILED_TEMPLATE_NAME,
         created_by=get_user_by_id(current_app.config['NOTIFY_USER_ID']),
         service_id=service_id,
         template_type=LETTER_TYPE,
         hidden=True,
-        subject=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
+        subject=PRECOMPILED_TEMPLATE_NAME,
         content='',
     )
 

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -304,12 +304,12 @@ def get_precompiled_letter_template(service_id):
         return template
 
     template = Template(
-        name='Pre-compiled PDF',
+        name=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
         created_by=get_user_by_id(current_app.config['NOTIFY_USER_ID']),
         service_id=service_id,
         template_type=LETTER_TYPE,
         hidden=True,
-        subject='Pre-compiled PDF',
+        subject=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
         content='',
     )
 

--- a/migrations/versions/0173_precompiled_pdf_rename.py
+++ b/migrations/versions/0173_precompiled_pdf_rename.py
@@ -1,0 +1,50 @@
+"""
+
+Revision ID: 0173_precompiled_pdf_rename
+Revises: 0172_deprioritise_examples
+Create Date: 2018-03-06 17:09:56.619803
+
+"""
+from alembic import op
+
+
+revision = '0173_precompiled_pdf_rename'
+down_revision = '0172_deprioritise_examples'
+
+
+def upgrade():
+    op.get_bind()
+    op.execute(
+        """
+        update templates_history
+        set name = 'Provided as PDF', subject = 'Provided as PDF'
+        where templates_history.hidden = true and templates_history.name = 'Pre-compiled PDF'
+        """
+    )
+
+    op.execute(
+        """
+        update templates
+        set name = 'Provided as PDF', subject = 'Provided as PDF'
+        where templates.hidden = true and templates.name = 'Pre-compiled PDF'
+        """
+    )
+
+
+def downgrade():
+    op.get_bind()
+    op.execute(
+        """
+        update templates_history
+        set name = 'Pre-compiled PDF', subject = 'Pre-compiled PDF'
+        where templates_history.hidden = true and templates_history.name = 'Provided as PDF'
+        """
+    )
+
+    op.execute(
+        """
+        update templates
+        set name = 'Pre-compiled PDF', subject = 'Pre-compiled PDF'
+        where templates.hidden = true and templates.name = 'Provided as PDF'
+        """
+    )

--- a/migrations/versions/0174_precompiled_pdf_rename.py
+++ b/migrations/versions/0174_precompiled_pdf_rename.py
@@ -1,15 +1,15 @@
 """
 
-Revision ID: 0173_precompiled_pdf_rename
-Revises: 0172_deprioritise_examples
+Revision ID: 0174_precompiled_pdf_rename
+Revises: 0173_create_daily_sorted_letter
 Create Date: 2018-03-06 17:09:56.619803
 
 """
 from alembic import op
 
 
-revision = '0173_precompiled_pdf_rename'
-down_revision = '0172_deprioritise_examples'
+revision = '0174_precompiled_pdf_rename'
+down_revision = '0173_create_daily_sorted_letter'
 
 
 def upgrade():

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2187,8 +2187,8 @@ def test_get_all_notifications_for_service_includes_template_hidden(admin_reques
     precompiled_template = create_template(
         sample_service,
         template_type=LETTER_TYPE,
-        template_name='Pre-compiled PDF',
-        subject='Pre-compiled PDF',
+        template_name=PRECOMPILED_TEMPLATE_NAME,
+        subject=PRECOMPILED_TEMPLATE_NAME,
         hidden=True
     )
 

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 import botocore
 import pytest
 import requests_mock
+from flask import current_app
 from freezegun import freeze_time
 
 from app.models import Template, SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, TemplateHistory
@@ -890,8 +891,8 @@ def test_preview_letter_template_precompiled_pdf_file_type(
 
     template = create_template(sample_service,
                                template_type='letter',
-                               template_name='Pre-compiled PDF',
-                               subject='Pre-compiled PDF',
+                               template_name=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
+                               subject=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
                                hidden=True)
 
     notification = create_notification(template)
@@ -927,8 +928,8 @@ def test_preview_letter_template_precompiled_s3_error(
 
     template = create_template(sample_service,
                                template_type='letter',
-                               template_name='Pre-compiled PDF',
-                               subject='Pre-compiled PDF',
+                               template_name=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
+                               subject=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
                                hidden=True)
 
     notification = create_notification(template)
@@ -964,8 +965,8 @@ def test_preview_letter_template_precompiled_png_file_type(
 
     template = create_template(sample_service,
                                template_type='letter',
-                               template_name='Pre-compiled PDF',
-                               subject='Pre-compiled PDF',
+                               template_name=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
+                               subject=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
                                hidden=True)
 
     notification = create_notification(template)
@@ -1011,8 +1012,8 @@ def test_preview_letter_template_precompiled_png_template_preview_500_error(
 
     template = create_template(sample_service,
                                template_type='letter',
-                               template_name='Pre-compiled PDF',
-                               subject='Pre-compiled PDF',
+                               template_name=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
+                               subject=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
                                hidden=True)
 
     notification = create_notification(template)
@@ -1058,8 +1059,8 @@ def test_preview_letter_template_precompiled_png_template_preview_400_error(
 
     template = create_template(sample_service,
                                template_type='letter',
-                               template_name='Pre-compiled PDF',
-                               subject='Pre-compiled PDF',
+                               template_name=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
+                               subject=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
                                hidden=True)
 
     notification = create_notification(template)

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -7,10 +7,9 @@ from datetime import datetime, timedelta
 import botocore
 import pytest
 import requests_mock
-from flask import current_app
 from freezegun import freeze_time
 
-from app.models import Template, SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, TemplateHistory
+from app.models import Template, SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, PRECOMPILED_TEMPLATE_NAME, TemplateHistory
 from app.dao.templates_dao import dao_get_template_by_id, dao_redact_template
 
 from tests import create_authorization_header
@@ -891,8 +890,8 @@ def test_preview_letter_template_precompiled_pdf_file_type(
 
     template = create_template(sample_service,
                                template_type='letter',
-                               template_name=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
-                               subject=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
+                               template_name=PRECOMPILED_TEMPLATE_NAME,
+                               subject=PRECOMPILED_TEMPLATE_NAME,
                                hidden=True)
 
     notification = create_notification(template)
@@ -928,8 +927,8 @@ def test_preview_letter_template_precompiled_s3_error(
 
     template = create_template(sample_service,
                                template_type='letter',
-                               template_name=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
-                               subject=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
+                               template_name=PRECOMPILED_TEMPLATE_NAME,
+                               subject=PRECOMPILED_TEMPLATE_NAME,
                                hidden=True)
 
     notification = create_notification(template)
@@ -965,8 +964,8 @@ def test_preview_letter_template_precompiled_png_file_type(
 
     template = create_template(sample_service,
                                template_type='letter',
-                               template_name=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
-                               subject=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
+                               template_name=PRECOMPILED_TEMPLATE_NAME,
+                               subject=PRECOMPILED_TEMPLATE_NAME,
                                hidden=True)
 
     notification = create_notification(template)
@@ -1012,8 +1011,8 @@ def test_preview_letter_template_precompiled_png_template_preview_500_error(
 
     template = create_template(sample_service,
                                template_type='letter',
-                               template_name=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
-                               subject=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
+                               template_name=PRECOMPILED_TEMPLATE_NAME,
+                               subject=PRECOMPILED_TEMPLATE_NAME,
                                hidden=True)
 
     notification = create_notification(template)
@@ -1059,8 +1058,8 @@ def test_preview_letter_template_precompiled_png_template_preview_400_error(
 
     template = create_template(sample_service,
                                template_type='letter',
-                               template_name=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
-                               subject=current_app.config['PRECOMPILED_TEMPLATE_NAME'],
+                               template_name=PRECOMPILED_TEMPLATE_NAME,
+                               subject=PRECOMPILED_TEMPLATE_NAME,
                                hidden=True)
 
     notification = create_notification(template)

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -9,7 +9,8 @@ from app.models import (
     ScheduledNotification,
     SCHEDULE_NOTIFICATIONS,
     EMAIL_TYPE,
-    SMS_TYPE
+    SMS_TYPE,
+    PRECOMPILED_TEMPLATE_NAME
 )
 from flask import json, current_app
 
@@ -759,7 +760,7 @@ def test_post_precompiled_letter_notification_returns_201(client, notify_user, m
 
     resp_json = json.loads(response.get_data(as_text=True))
     assert resp_json == {
-        'content': {'body': None, 'subject': current_app.config['PRECOMPILED_TEMPLATE_NAME']},
+        'content': {'body': None, 'subject': PRECOMPILED_TEMPLATE_NAME},
         'id': str(notification.id),
         'reference': 'letter-reference',
         'scheduled_for': None,

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -759,7 +759,7 @@ def test_post_precompiled_letter_notification_returns_201(client, notify_user, m
 
     resp_json = json.loads(response.get_data(as_text=True))
     assert resp_json == {
-        'content': {'body': None, 'subject': 'Pre-compiled PDF'},
+        'content': {'body': None, 'subject': current_app.config['PRECOMPILED_TEMPLATE_NAME']},
         'id': str(notification.id),
         'reference': 'letter-reference',
         'scheduled_for': None,


### PR DESCRIPTION
Initially we used the term 'Pre-compiled PDF' but after a time demo to
the rest of the team we decided on 'Provided as PDF'. This updates the
config to use the term and updates any file in the code base which uses
a static string to use the configuration item so that it is easier to
maintain in future and static strings don't get hidden away.

* Updated the Config with the new name
* Updated endpoint to use config item
* Updated static strings in tests to use the config item