### PR TITLE
Match on partial email addresses and phone numbers in search

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -446,7 +446,7 @@ def dao_get_notifications_by_to_field(service_id, search_term, statuses=None):
 
     filters = [
         Notification.service_id == service_id,
-        Notification.normalised_to == normalised,
+        Notification.normalised_to.like("%{}%".format(normalised)),
         Notification.key_type != KEY_TYPE_TEST,
     ]
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -435,7 +435,7 @@ def dao_update_notifications_by_reference(references, update_dict):
 
 
 @statsd(namespace="dao")
-def dao_get_notifications_by_to_field(service_id, search_term, statuses=None):
+def dao_get_notifications_by_to_field(service_id, search_term, statuses=None, notification_type=None):
     try:
         normalised = validate_and_format_phone_number(search_term)
     except InvalidPhoneError:
@@ -457,6 +457,8 @@ def dao_get_notifications_by_to_field(service_id, search_term, statuses=None):
 
     if statuses:
         filters.append(Notification.status.in_(statuses))
+    if notification_type:
+        filters.append(Notification.notification_type == notification_type)
 
     results = db.session.query(Notification).filter(*filters).order_by(desc(Notification.created_at)).all()
     return results

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -444,6 +444,11 @@ def dao_get_notifications_by_to_field(service_id, search_term, statuses=None):
         except InvalidEmailError:
             normalised = search_term
 
+    for character in ['(', ')', ' ']:
+        normalised = normalised.replace(character, '')
+
+    normalised = normalised.lstrip('+0')
+
     filters = [
         Notification.service_id == service_id,
         Notification.normalised_to.like("%{}%".format(normalised)),

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -8,10 +8,9 @@ from datetime import (
 from flask import current_app
 
 from notifications_utils.recipients import (
-    validate_and_format_phone_number,
     validate_and_format_email_address,
-    InvalidPhoneError,
     InvalidEmailError,
+    try_validate_and_format_phone_number
 )
 from notifications_utils.statsd_decorators import statsd
 from werkzeug.datastructures import MultiDict
@@ -23,6 +22,7 @@ from notifications_utils.international_billing_rates import INTERNATIONAL_BILLIN
 
 from app import db, create_uuid
 from app.dao import days_ago
+from app.errors import InvalidRequest
 from app.models import (
     Notification,
     NotificationHistory,
@@ -40,7 +40,9 @@ from app.models import (
     NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
     NOTIFICATION_PERMANENT_FAILURE,
-    NOTIFICATION_SENT
+    NOTIFICATION_SENT,
+    SMS_TYPE,
+    EMAIL_TYPE
 )
 
 from app.dao.dao_utils import transactional
@@ -435,19 +437,23 @@ def dao_update_notifications_by_reference(references, update_dict):
 
 
 @statsd(namespace="dao")
-def dao_get_notifications_by_to_field(service_id, search_term, statuses=None, notification_type=None):
-    try:
-        normalised = validate_and_format_phone_number(search_term)
-    except InvalidPhoneError:
+def dao_get_notifications_by_to_field(service_id, search_term, notification_type, statuses=None):
+
+    if notification_type == SMS_TYPE:
+        normalised = try_validate_and_format_phone_number(search_term)
+
+        for character in {'(', ')', ' ', '-'}:
+            normalised = normalised.replace(character, '')
+
+        normalised = normalised.lstrip('+0')
+
+    elif notification_type == EMAIL_TYPE:
         try:
             normalised = validate_and_format_email_address(search_term)
         except InvalidEmailError:
-            normalised = search_term
-
-    for character in ['(', ')', ' ']:
-        normalised = normalised.replace(character, '')
-
-    normalised = normalised.lstrip('+0')
+            normalised = search_term.lower()
+    else:
+        raise InvalidRequest("Only email and SMS can use search by recipient", 400)
 
     filters = [
         Notification.service_id == service_id,

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -337,7 +337,11 @@ def get_service_history(service_id):
 def get_all_notifications_for_service(service_id):
     data = notifications_filter_schema.load(request.args).data
     if data.get('to'):
-        return search_for_notification_by_to_field(service_id, data['to'], statuses=data.get('status'))
+        notification_type = data.get('template_type')[0] if data.get('template_type') else None
+        return search_for_notification_by_to_field(service_id=service_id,
+                                                   search_term=data['to'],
+                                                   statuses=data.get('status'),
+                                                   notification_type=notification_type)
     page = data['page'] if 'page' in data else 1
     page_size = data['page_size'] if 'page_size' in data else current_app.config.get('PAGE_SIZE')
     limit_days = data.get('limit_days')
@@ -380,8 +384,8 @@ def get_notification_for_service(service_id, notification_id):
     ), 200
 
 
-def search_for_notification_by_to_field(service_id, search_term, statuses):
-    results = notifications_dao.dao_get_notifications_by_to_field(service_id, search_term, statuses)
+def search_for_notification_by_to_field(service_id, search_term, statuses, notification_type):
+    results = notifications_dao.dao_get_notifications_by_to_field(service_id, search_term, statuses, notification_type)
     return jsonify(
         notifications=notification_with_template_schema.dump(results, many=True).data
     ), 200

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -385,7 +385,12 @@ def get_notification_for_service(service_id, notification_id):
 
 
 def search_for_notification_by_to_field(service_id, search_term, statuses, notification_type):
-    results = notifications_dao.dao_get_notifications_by_to_field(service_id, search_term, statuses, notification_type)
+    results = notifications_dao.dao_get_notifications_by_to_field(
+        service_id=service_id,
+        search_term=search_term,
+        statuses=statuses,
+        notification_type=notification_type
+    )
     return jsonify(
         notifications=notification_with_template_schema.dump(results, many=True).data
     ), 200

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1751,6 +1751,21 @@ def test_dao_get_notifications_by_to_field_search_is_not_case_sensitive(sample_t
     assert notification.id in notification_ids
 
 
+def test_dao_get_notifications_by_to_field_matches_partial_emails(sample_template):
+    notification_1 = create_notification(
+        template=sample_template, to_field='jack@gmail.com', normalised_to='jack@gmail.com'
+    )
+    notification_2 = create_notification(
+        template=sample_template, to_field='jacque@gmail.com', normalised_to='jacque@gmail.com'
+    )
+    results = dao_get_notifications_by_to_field(notification_1.service_id, 'ack')
+    notification_ids = [notification.id for notification in results]
+
+    assert len(results) == 1
+    assert notification_1.id in notification_ids
+    assert notification_2.id not in notification_ids
+
+
 @pytest.mark.parametrize('to', [
     'not@email', '123'
 ])

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1766,6 +1766,41 @@ def test_dao_get_notifications_by_to_field_matches_partial_emails(sample_templat
     assert notification_2.id not in notification_ids
 
 
+@pytest.mark.parametrize('search_term', [
+    '001',
+    '100',
+    '09001',
+    '077009001',
+    '07700 9001',
+    '(0)7700 9001',
+    '4477009001',
+    '+4477009001',
+    pytest.mark.skip('+44077009001', reason='No easy way to normalise this'),
+    pytest.mark.skip('+44(0)77009001', reason='No easy way to normalise this'),
+])
+def test_dao_get_notifications_by_to_field_matches_partial_phone_numbers(
+    sample_template,
+    search_term,
+):
+
+    notification_1 = create_notification(
+        template=sample_template,
+        to_field='+447700900100',
+        normalised_to='447700900100',
+    )
+    notification_2 = create_notification(
+        template=sample_template,
+        to_field='+447700900200',
+        normalised_to='447700900200',
+    )
+    results = dao_get_notifications_by_to_field(notification_1.service_id, search_term)
+    notification_ids = [notification.id for notification in results]
+
+    assert len(results) == 1
+    assert notification_1.id in notification_ids
+    assert notification_2.id not in notification_ids
+
+
 @pytest.mark.parametrize('to', [
     'not@email', '123'
 ])

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1838,6 +1838,26 @@ def test_dao_get_notifications_by_to_field_search_ignores_spaces(sample_template
     assert notification3.id in notification_ids
 
 
+def test_dao_get_notifications_by_to_field_only_searches_for_notification_type(
+    notify_db_session
+):
+    service = create_service()
+    sms_template = create_template(service=service)
+    email_template = create_template(service=service, template_type='email')
+    sms = create_notification(template=sms_template, to_field='0771111111', normalised_to='0771111111')
+    email = create_notification(
+        template=email_template, to_field='077@example.com', normalised_to='077@example.com'
+    )
+    results = dao_get_notifications_by_to_field(service.id, "077")
+    assert len(results) == 2
+    results = dao_get_notifications_by_to_field(service.id, "077", notification_type='sms')
+    assert len(results) == 1
+    assert results[0].id == sms.id
+    results = dao_get_notifications_by_to_field(service.id, "077", notification_type='email')
+    assert len(results) == 1
+    assert results[0].id == email.id
+
+
 def test_dao_created_scheduled_notification(sample_notification):
 
     scheduled_notification = ScheduledNotification(notification_id=sample_notification.id,

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1914,13 +1914,15 @@ def test_get_template_usage_by_month_returns_two_templates(
     assert resp_json[2]["is_precompiled_letter"] is False
 
 
-def test_search_for_notification_by_to_field(client, notify_db, notify_db_session):
-    create_notification = partial(create_sample_notification, notify_db, notify_db_session)
-    notification1 = create_notification(to_field='+447700900855', normalised_to='447700900855')
-    notification2 = create_notification(to_field='jack@gmail.com', normalised_to='jack@gmail.com')
+def test_search_for_notification_by_to_field(client, sample_template, sample_email_template):
+
+    notification1 = create_notification(template=sample_template, to_field='+447700900855',
+                                        normalised_to='447700900855')
+    notification2 = create_notification(template=sample_email_template, to_field='jack@gmail.com',
+                                        normalised_to='jack@gmail.com')
 
     response = client.get(
-        '/service/{}/notifications?to={}'.format(notification1.service_id, 'jack@gmail.com'),
+        '/service/{}/notifications?to={}&template_type={}'.format(notification1.service_id, 'jack@gmail.com', 'email'),
         headers=[create_authorization_header()]
     )
     notifications = json.loads(response.get_data(as_text=True))['notifications']
@@ -1938,7 +1940,7 @@ def test_search_for_notification_by_to_field_return_empty_list_if_there_is_no_ma
     create_notification(to_field='jack@gmail.com')
 
     response = client.get(
-        '/service/{}/notifications?to={}'.format(notification1.service_id, '+447700900800'),
+        '/service/{}/notifications?to={}&template_type={}'.format(notification1.service_id, '+447700900800', 'sms'),
         headers=[create_authorization_header()]
     )
     notifications = json.loads(response.get_data(as_text=True))['notifications']
@@ -1955,7 +1957,7 @@ def test_search_for_notification_by_to_field_return_multiple_matches(client, not
     notification4 = create_notification(to_field='jack@gmail.com', normalised_to='jack@gmail.com')
 
     response = client.get(
-        '/service/{}/notifications?to={}'.format(notification1.service_id, '+447700900855'),
+        '/service/{}/notifications?to={}&template_type={}'.format(notification1.service_id, '+447700900855', 'sms'),
         headers=[create_authorization_header()]
     )
     notifications = json.loads(response.get_data(as_text=True))['notifications']
@@ -2049,8 +2051,8 @@ def test_search_for_notification_by_to_field_filters_by_status(client, notify_db
     create_notification(status='sending')
 
     response = client.get(
-        '/service/{}/notifications?to={}&status={}'.format(
-            notification1.service_id, '+447700900855', 'delivered'
+        '/service/{}/notifications?to={}&status={}&template_type={}'.format(
+            notification1.service_id, '+447700900855', 'delivered', 'sms'
         ),
         headers=[create_authorization_header()]
     )
@@ -2074,8 +2076,8 @@ def test_search_for_notification_by_to_field_filters_by_statuses(client, notify_
     notification2 = create_notification(status='sending')
 
     response = client.get(
-        '/service/{}/notifications?to={}&status={}&status={}'.format(
-            notification1.service_id, '+447700900855', 'delivered', 'sending'
+        '/service/{}/notifications?to={}&status={}&status={}&template_type={}'.format(
+            notification1.service_id, '+447700900855', 'delivered', 'sending', 'sms'
         ),
         headers=[create_authorization_header()]
     )
@@ -2104,8 +2106,8 @@ def test_search_for_notification_by_to_field_returns_content(
     )
 
     response = client.get(
-        '/service/{}/notifications?to={}'.format(
-            sample_template_with_placeholders.service_id, '+447700900855'
+        '/service/{}/notifications?to={}&template_type={}'.format(
+            sample_template_with_placeholders.service_id, '+447700900855', 'sms'
         ),
         headers=[create_authorization_header()]
     )
@@ -2225,8 +2227,8 @@ def test_search_for_notification_by_to_field_returns_personlisation(
     )
 
     response = client.get(
-        '/service/{}/notifications?to={}'.format(
-            sample_template_with_placeholders.service_id, '+447700900855'
+        '/service/{}/notifications?to={}&template_type={}'.format(
+            sample_template_with_placeholders.service_id, '+447700900855', 'sms'
         ),
         headers=[create_authorization_header()]
     )

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1972,6 +1972,18 @@ def test_search_for_notification_by_to_field_return_multiple_matches(client, not
     assert str(notification4.id) not in notification_ids
 
 
+def test_search_for_notification_by_to_field_return_400_for_letter_type(
+        client, notify_db, notify_db_session, sample_service
+):
+    response = client.get(
+        '/service/{}/notifications?to={}&template_type={}'.format(sample_service.id, 'A. Name', 'letter'),
+        headers=[create_authorization_header()]
+    )
+    response.status_code = 400
+    error_message= json.loads(response.get_data(as_text=True))
+    assert error_message['message'] == 'Only email and SMS can use search by recipient'
+
+
 def test_update_service_calls_send_notification_as_service_becomes_live(notify_db, notify_db_session, client, mocker):
     send_notification_mock = mocker.patch('app.service.rest.send_notification_to_service_users')
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1980,7 +1980,7 @@ def test_search_for_notification_by_to_field_return_400_for_letter_type(
         headers=[create_authorization_header()]
     )
     response.status_code = 400
-    error_message= json.loads(response.get_data(as_text=True))
+    error_message = json.loads(response.get_data(as_text=True))
     assert error_message['message'] == 'Only email and SMS can use search by recipient'
 
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2238,6 +2238,42 @@ def test_search_for_notification_by_to_field_returns_personlisation(
     assert notifications[0]['personalisation']['name'] == 'Foo'
 
 
+def test_search_for_notification_by_to_field_returns_notifications_by_type(
+    client,
+    notify_db,
+    notify_db_session,
+    sample_template,
+    sample_email_template
+):
+    sms_notification = create_sample_notification(
+        notify_db,
+        notify_db_session,
+        to_field='+447700900855',
+        normalised_to='447700900855',
+        template=sample_template
+    )
+    create_sample_notification(
+        notify_db,
+        notify_db_session,
+        to_field='44770@gamil.com',
+        normalised_to='44770@gamil.com',
+        template=sample_email_template
+    )
+
+    response = client.get(
+        '/service/{}/notifications?to={}&template_type={}'.format(
+            sms_notification.service_id, '0770', 'sms'
+
+        ),
+        headers=[create_authorization_header()]
+    )
+    notifications = json.loads(response.get_data(as_text=True))['notifications']
+
+    assert response.status_code == 200
+    assert len(notifications) == 1
+    assert notifications[0]['id'] == str(sms_notification.id)
+
+
 def test_is_service_name_unique_returns_200_if_unique(admin_request, notify_db, notify_db_session):
     service = create_service(service_name='unique', email_from='unique')
 


### PR DESCRIPTION
Users expect the search to work on partial email addresses ‘similar to Gov.Pay’. We can’t have a situation where Pay are doing something better than us 😜