### PR TITLE
Add endpoint to check for unique organisation names

### DIFF
--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -107,3 +107,26 @@ def get_organisation_users(organisation_id):
 
     result = user_schema.dump(org_users, many=True)
     return jsonify(data=result.data)
+
+
+@organisation_blueprint.route('/unique', methods=["GET"])
+def is_organisation_name_unique():
+    organisation_id, name = check_request_args(request)
+
+    name_exists = Organisation.query.filter(Organisation.name.ilike(name)).first()
+
+    result = (not name_exists) or str(name_exists.id) == organisation_id
+    return jsonify(result=result), 200
+
+
+def check_request_args(request):
+    org_id = request.args.get('org_id')
+    name = request.args.get('name', None)
+    errors = []
+    if not org_id:
+        errors.append({'org_id': ["Can't be empty"]})
+    if not name:
+        errors.append({'name': ["Can't be empty"]})
+    if errors:
+        raise InvalidRequest(errors, status_code=400)
+    return org_id, name


### PR DESCRIPTION
Currently, when changing a service name, a request is made to check if the name is unique before the update request is made. This is so we can give the user good errors before they continue through the flow to verify their password and get hit by a 'name already in use' error anyway.

This PR contains the endpoint to check the organisation name choice is unique, and keep the same standard of error formatting for the user.

**Notes**
- `email_from` has been removed from the organisation expected request params. Unlike a service, it's not necessary for an organisation. In place of email_from, a check will ensure that it is not possible to enter a service name that already exists, albeit in a different case. 
- Also possible for an organisation to bypass the case check if the current identical name happens to belong to the same org id.