### PR TITLE
Fixed bug only where only data being passed to TemplatePreview when JSON is required

### DIFF
--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -266,7 +266,7 @@ def _get_png_preview(url, data, notification_id):
                 resp.content
             ))
         raise InvalidRequest(
-            'Error generating preview letter for {} \nStatus code: {}\n{}'.format(
+            'Error generating preview letter for {}\nStatus code: {}\n{}'.format(
                 notification_id,
                 resp.status_code,
                 resp.content

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -202,9 +202,9 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
 
             pdf_file = get_letter_pdf(notification)
 
-        except botocore.exceptions.ClientError as e:
+        except botocore.exceptions.ClientError:
             current_app.logger.exception(
-                'Error getting letter file from S3 notification id {}'.format(notification_id), e)
+                'Error getting letter file from S3 notification id {}'.format(notification_id))
             raise InvalidRequest('Error getting letter file from S3 notification id {}'.format(notification_id),
                                  status_code=500)
 

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -3,7 +3,6 @@ import json
 import random
 import string
 from datetime import datetime, timedelta
-from json.decoder import JSONDecodeError
 
 import botocore
 import pytest
@@ -996,7 +995,7 @@ def test_preview_letter_template_precompiled_png_file_type(
                 file_type='png'
             )
 
-            with pytest.raises(JSONDecodeError):
+            with pytest.raises(json.decoder.JSONDecodeError):
                 mock_post.last_request.json()
             assert mock_get_letter_pdf.called_once_with(notification)
             assert base64.b64decode(resp['content']) == png_content
@@ -1045,7 +1044,7 @@ def test_preview_letter_template_precompiled_png_template_preview_500_error(
 
             )
 
-            with pytest.raises(JSONDecodeError):
+            with pytest.raises(json.decoder.JSONDecodeError):
                 mock_post.last_request.json()
 
 
@@ -1091,5 +1090,5 @@ def test_preview_letter_template_precompiled_png_template_preview_400_error(
                 _expected_status=500
             )
 
-            with pytest.raises(JSONDecodeError):
+            with pytest.raises(json.decoder.JSONDecodeError):
                 mock_post.last_request.json()

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -3,7 +3,7 @@ import json
 import random
 import string
 from datetime import datetime, timedelta
-from json import JSONDecodeError
+from json.decoder import JSONDecodeError
 
 import botocore
 import pytest

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -3,6 +3,7 @@ import json
 import random
 import string
 from datetime import datetime, timedelta
+from json import JSONDecodeError
 
 import botocore
 import pytest
@@ -828,7 +829,7 @@ def test_preview_letter_template_by_id_valid_file_type(
         with requests_mock.Mocker() as request_mock:
             content = b'\x00\x01'
 
-            request_mock.post(
+            mock_post = request_mock.post(
                 'http://localhost/notifications-template-preview/preview.pdf',
                 content=content,
                 headers={'X-pdf-page-count': '1'},
@@ -842,6 +843,7 @@ def test_preview_letter_template_by_id_valid_file_type(
                 file_type='pdf'
             )
 
+            assert mock_post.last_request.json()
             assert base64.b64decode(resp['content']) == content
 
 
@@ -859,7 +861,7 @@ def test_preview_letter_template_by_id_template_preview_500(
         with requests_mock.Mocker() as request_mock:
             content = b'\x00\x01'
 
-            request_mock.post(
+            mock_post = request_mock.post(
                 'http://localhost/notifications-template-preview/preview.pdf',
                 content=content,
                 headers={'X-pdf-page-count': '1'},
@@ -874,9 +876,9 @@ def test_preview_letter_template_by_id_template_preview_500(
                 _expected_status=500
             )
 
+            assert mock_post.last_request.json()
             assert 'Status code: 404' in resp['message']
             assert 'Error generating preview letter for {}'.format(sample_letter_notification.id) in resp['message']
-
 
 
 def test_preview_letter_template_precompiled_pdf_file_type(
@@ -980,7 +982,7 @@ def test_preview_letter_template_precompiled_png_file_type(
 
             mock_get_letter_pdf = mocker.patch('app.template.rest.get_letter_pdf', return_value=pdf_content)
 
-            request_mock.post(
+            mock_post = request_mock.post(
                 'http://localhost/notifications-template-preview/precompiled-preview.png',
                 content=png_content,
                 headers={'X-pdf-page-count': '1'},
@@ -994,6 +996,8 @@ def test_preview_letter_template_precompiled_png_file_type(
                 file_type='png'
             )
 
+            with pytest.raises(JSONDecodeError):
+                mock_post.last_request.json()
             assert mock_get_letter_pdf.called_once_with(notification)
             assert base64.b64decode(resp['content']) == png_content
 
@@ -1025,7 +1029,7 @@ def test_preview_letter_template_precompiled_png_template_preview_500_error(
 
             mocker.patch('app.template.rest.get_letter_pdf', return_value=pdf_content)
 
-            request_mock.post(
+            mock_post = request_mock.post(
                 'http://localhost/notifications-template-preview/precompiled-preview.png',
                 content=png_content,
                 headers={'X-pdf-page-count': '1'},
@@ -1040,6 +1044,9 @@ def test_preview_letter_template_precompiled_png_template_preview_500_error(
                 _expected_status=500
 
             )
+
+            with pytest.raises(JSONDecodeError):
+                mock_post.last_request.json()
 
 
 def test_preview_letter_template_precompiled_png_template_preview_400_error(
@@ -1069,7 +1076,7 @@ def test_preview_letter_template_precompiled_png_template_preview_400_error(
 
             mocker.patch('app.template.rest.get_letter_pdf', return_value=pdf_content)
 
-            request_mock.post(
+            mock_post = request_mock.post(
                 'http://localhost/notifications-template-preview/precompiled-preview.png',
                 content=png_content,
                 headers={'X-pdf-page-count': '1'},
@@ -1082,5 +1089,7 @@ def test_preview_letter_template_precompiled_png_template_preview_400_error(
                 notification_id=notification.id,
                 file_type='png',
                 _expected_status=500
-
             )
+
+            with pytest.raises(JSONDecodeError):
+                mock_post.last_request.json()

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -874,7 +874,9 @@ def test_preview_letter_template_by_id_template_preview_500(
                 _expected_status=500
             )
 
-            assert resp['message'] == 'Error generating preview for {}'.format(sample_letter_notification.id)
+            assert 'Status code: 404' in resp['message']
+            assert 'Error generating preview letter for {}'.format(sample_letter_notification.id) in resp['message']
+
 
 
 def test_preview_letter_template_precompiled_pdf_file_type(

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -995,7 +995,7 @@ def test_preview_letter_template_precompiled_png_file_type(
                 file_type='png'
             )
 
-            with pytest.raises(json.decoder.JSONDecodeError):
+            with pytest.raises(ValueError):
                 mock_post.last_request.json()
             assert mock_get_letter_pdf.called_once_with(notification)
             assert base64.b64decode(resp['content']) == png_content
@@ -1044,7 +1044,7 @@ def test_preview_letter_template_precompiled_png_template_preview_500_error(
 
             )
 
-            with pytest.raises(json.decoder.JSONDecodeError):
+            with pytest.raises(ValueError):
                 mock_post.last_request.json()
 
 
@@ -1090,5 +1090,5 @@ def test_preview_letter_template_precompiled_png_template_preview_400_error(
                 _expected_status=500
             )
 
-            with pytest.raises(json.decoder.JSONDecodeError):
+            with pytest.raises(ValueError):
                 mock_post.last_request.json()


### PR DESCRIPTION
Some template preview endpoints take data and some take json. After a refactor only 'data' was being passed and hence the call where json was passed was producing an error because the content header is automatically being set based on the parameter.

* Added some logic to handle if the post requires data or json
* Added extra logging to display the error with more detail
* Added tests to ensure the correct data type is being passed to the post request