### PR TITLE
Install libffi-dev and python-dev in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,8 @@ RUN \
 		build-essential \
 		zip \
 		libpq-dev \
+		libffi-dev \
+		python-dev \
 		jq \
 	&& echo "Clean up" \
 	&& rm -rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
This is to allow us to build cffi