### PR TITLE
Handle malformed invite tokens

### DIFF
--- a/app/accept_invite/rest.py
+++ b/app/accept_invite/rest.py
@@ -4,7 +4,7 @@ from flask import (
     current_app
 )
 
-from itsdangerous import SignatureExpired
+from itsdangerous import SignatureExpired, BadData
 
 from notifications_utils.url_safe_token import check_token
 
@@ -37,6 +37,9 @@ def validate_invitation_token(invitation_type, token):
         errors = {'invitation':
                   ['Your invitation to GOV.UK Notify has expired. '
                    'Please ask the person that invited you to send you another one']}
+        raise InvalidRequest(errors, status_code=400)
+    except BadData:
+        errors = {'invitation': 'Something’s wrong with this link. Make sure you’ve copied the whole thing.'}
         raise InvalidRequest(errors, status_code=400)
 
     if invitation_type == 'service':

--- a/tests/app/accept_invite/test_accept_invite_rest.py
+++ b/tests/app/accept_invite/test_accept_invite_rest.py
@@ -61,3 +61,23 @@ def test_validate_invitation_token_returns_400_when_invited_user_does_not_exist(
     json_resp = json.loads(response.get_data(as_text=True))
     assert json_resp['result'] == 'error'
     assert json_resp['message'] == 'No result found'
+
+
+@pytest.mark.parametrize('invitation_type', ['service', 'organisation'])
+def test_validate_invitation_token_returns_400_when_token_is_malformed(client, invitation_type):
+    token = generate_token(
+        str(uuid.uuid4()),
+        current_app.config['SECRET_KEY'],
+        current_app.config['DANGEROUS_SALT']
+    )[:-2]
+
+    url = '/invite/{}/{}'.format(invitation_type, token)
+    auth_header = create_authorization_header()
+    response = client.get(url, headers=[('Content-Type', 'application/json'), auth_header])
+
+    assert response.status_code == 400
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert json_resp['result'] == 'error'
+    assert json_resp['message'] == {
+        'invitation': 'Something’s wrong with this link. Make sure you’ve copied the whole thing.'
+    }


### PR DESCRIPTION
Currently, If a malformed invite token hits the API, the server will return with a 500. This PR handles the bad tokens and returns a 400 with an error message, the same as used in malformed email login tokens. 