### PR TITLE
Revert service callback eventlets

### DIFF
--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -95,6 +95,6 @@ applications:
       NOTIFY_APP_NAME: delivery-worker-receipts
 
   - name: notify-delivery-worker-service-callbacks
-    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO -P eventlet -c 1000 -Q service-callbacks
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q service-callbacks
     env:
       NOTIFY_APP_NAME: delivery-worker-service-callbacks


### PR DESCRIPTION
We have seen problems with the service callback workers due to the db connection pool being exhausted. When the worker picks up the task, it makes a db query to get the notification, a query to get the callback url, and then closes the session before it makes the 3rd party request.

However, even closing the session before the (potentially lengthy) web request wasn't enough - we've seen significant amounts of `sqlalchemy.exc.TimeoutError`s.

This reverts commit 2dfbd93