### PR TITLE
Updated the notification template endpoint to extract the pdf page

### DIFF
--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -9,9 +9,11 @@ from flask import (
     jsonify,
     request)
 from notifications_utils.pdf import extract_page_from_pdf
+from notifications_utils.template import SMSMessageTemplate
 from requests import post as requests_post
 
 from app.dao.notifications_dao import get_notification_by_id
+from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.templates_dao import (
     dao_update_template,
     dao_create_template,
@@ -21,16 +23,14 @@ from app.dao.templates_dao import (
     dao_get_template_versions,
     dao_update_template_reply_to,
     dao_get_template_by_id)
-from notifications_utils.template import SMSMessageTemplate
-from app.dao.services_dao import dao_fetch_service_by_id
-from app.letters.utils import get_letter_pdf
-from app.models import SMS_TYPE
-from app.notifications.validators import service_has_permission, check_reply_to
-from app.schemas import (template_schema, template_history_schema)
 from app.errors import (
     register_errors,
     InvalidRequest
 )
+from app.letters.utils import get_letter_pdf
+from app.models import SMS_TYPE
+from app.notifications.validators import service_has_permission, check_reply_to
+from app.schemas import (template_schema, template_history_schema)
 from app.utils import get_template_instance, get_public_notify_type_text
 
 template_blueprint = Blueprint('template', __name__, url_prefix='/service/<uuid:service_id>/template')
@@ -205,11 +205,12 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
 
             pdf_file = get_letter_pdf(notification)
 
-        except botocore.exceptions.ClientError:
-            current_app.logger.exception(
-                'Error getting letter file from S3 notification id {}'.format(notification_id))
-            raise InvalidRequest('Error getting letter file from S3 notification id {}'.format(notification_id),
-                                 status_code=500)
+        except botocore.exceptions.ClientError as e:
+            raise InvalidRequest(
+                'Error extracting requested page from PDF file for notification_id {} type {} {}'.format(
+                    notification_id, type(e), e),
+                status_code=500
+            )
 
         content = base64.b64encode(pdf_file).decode('utf-8')
 
@@ -219,11 +220,10 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
                 page_number = page if page else "0"
                 pdf_page = extract_page_from_pdf(BytesIO(pdf_file), int(page_number) - 1)
                 content = base64.b64encode(pdf_page).decode('utf-8')
-            except PdfReadError:
-                current_app.logger.exception(
-                    'Error extracting requested page from PDF file for notification_id {}'.format(notification_id))
+            except PdfReadError as e:
                 raise InvalidRequest(
-                    'Error extracting requested page from PDF file for notification_id {}'.format(notification_id),
+                    'Error extracting requested page from PDF file for notification_id {} type {} {}'.format(
+                        notification_id, type(e), e),
                     status_code=500
                 )
 
@@ -277,14 +277,8 @@ def _get_png_preview(url, data, notification_id, json=True):
         )
 
     if resp.status_code != 200:
-        current_app.logger.exception(
-            'Error generating preview letter for {} \nStatus code: {}\n{}'.format(
-                notification_id,
-                resp.status_code,
-                resp.content
-            ))
         raise InvalidRequest(
-            'Error generating preview letter for {}\nStatus code: {}\n{}'.format(
+            'Error generating preview letter for {} Status code: {} {}'.format(
                 notification_id,
                 resp.status_code,
                 resp.content

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,6 @@ notifications-python-client==4.7.2
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@25.0.0#egg=notifications-utils==25.0.0
+git+https://github.com/alphagov/notifications-utils.git@25.1.0#egg=notifications-utils==25.1.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
Updated the notification template endpoint to extract the pdf page before sending it to template preview. This stops the whole pdf file being sent to template preview for each page which is really inefficient on network traffic and memory usage.

* Added logic to the endpoint to extract the specific page requested
* Updated tests to add a mock for the new call to utils
* Added a new test case for exceptions in the PDF extraction process