### PR TITLE
Process job fix

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -559,6 +559,10 @@ def process_incomplete_job(job_id):
 
     job = dao_get_job_by_id(job_id)
 
+    # reset the processing start time so that the check_job_status scheduled task doesn't pick this job up again
+    job.processing_started = datetime.utcnow()
+    dao_update_job(job)
+
     last_notification_added = dao_get_last_notification_added_for_job_id(job_id)
 
     if last_notification_added:

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -560,6 +560,7 @@ def process_incomplete_job(job_id):
     job = dao_get_job_by_id(job_id)
 
     # reset the processing start time so that the check_job_status scheduled task doesn't pick this job up again
+    job.job_status = JOB_STATUS_PENDING
     job.processing_started = datetime.utcnow()
     dao_update_job(job)
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -53,6 +53,7 @@ from app.models import (
     JOB_STATUS_READY_TO_SEND,
     JOB_STATUS_IN_PROGRESS,
     JOB_STATUS_SENT_TO_DVLA,
+    JOB_STATUS_ERROR,
     LETTER_TYPE,
     SMS_TYPE
 )
@@ -924,6 +925,38 @@ def test_check_job_status_task_only_sends_old_tasks(mocker, sample_template):
         args=([str(job.id)],),
         queue=QueueNames.JOBS
     )
+
+
+def test_check_job_status_task_sets_jobs_to_error(mocker, sample_template):
+    mock_celery = mocker.patch('app.celery.tasks.notify_celery.send_task')
+    job = create_job(
+        template=sample_template,
+        notification_count=3,
+        created_at=datetime.utcnow() - timedelta(hours=2),
+        scheduled_for=datetime.utcnow() - timedelta(minutes=31),
+        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        job_status=JOB_STATUS_IN_PROGRESS
+    )
+    job_2 = create_job(
+        template=sample_template,
+        notification_count=3,
+        created_at=datetime.utcnow() - timedelta(minutes=31),
+        processing_started=datetime.utcnow() - timedelta(minutes=29),
+        job_status=JOB_STATUS_IN_PROGRESS
+    )
+    with pytest.raises(expected_exception=JobIncompleteError) as e:
+        check_job_status()
+    assert str(job.id) in e.value.message
+    assert str(job_2.id) not in e.value.message
+
+    # job 2 not in celery task
+    mock_celery.assert_called_once_with(
+        name=TaskNames.PROCESS_INCOMPLETE_JOBS,
+        args=([str(job.id)],),
+        queue=QueueNames.JOBS
+    )
+    assert job.job_status == JOB_STATUS_ERROR
+    assert job_2.job_status == JOB_STATUS_IN_PROGRESS
 
 
 def test_daily_stats_template_usage_by_month(notify_db, notify_db_session):

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1365,7 +1365,7 @@ def test_process_incomplete_job_sms(mocker, sample_template):
 @freeze_time('2017-01-01')
 def test_process_incomplete_job_resets_start_time(mocker, sample_template):
     mocker.patch('app.celery.tasks.s3.get_job_from_s3', return_value=load_example_csv('multiple_sms'))
-    save_sms = mocker.patch('app.celery.tasks.save_sms.apply_async')
+    mocker.patch('app.celery.tasks.save_sms.apply_async')
 
     job = create_job(template=sample_template, notification_count=10,
                      created_at=datetime.utcnow() - timedelta(hours=2),


### PR DESCRIPTION
# reset job processing time when re-processing incomplete jobs 

we might stop processing jobs mid-way through if, for example, a deploy or downscale kills the box working on it. We have a scheduled task that identifies any job that we started processing more than half an hour ago that is still processing.

However, we encountered a bug where we triggered the process_incomplete_job multiple times, because the processing_started of the job was still set to half an hour ago. If we reset the processing_started to the current time, then it won't get picked up by future runs of the check_job_status scheduled task.

#### update:

process_incomplete_jobs loops through jobs processing them in a single task. This means that if the job statuses are all 'error', and then the process_incomplete_jobs task fails, the later jobs in the list that never got picked up won't have their status set back to in progress, or their processing_started time - so will be stuck in 'error' forever.

Instead, we set the job statuses to in progress and the start time to now before we process any - so if the incomplete_jobs task fails later, the jobs will be picked up (again) by the check_job_statuses task in half an hour's time

# set job status to error in the check_job_status scheduled task 

the process_incomplete_jobs task runs through all incomplete jobs in a loop, so it might not get a chance to update the processing_started time of the last job before check_job_status runs again (every minute).
So before we even trigger the process_incomplete_jobs task, lets set the status of the jobs to error, so that we don't identify them for re-processing again.
