### PR TITLE
Reduce parallel worker processes to 3

### DIFF
--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -63,7 +63,7 @@ applications:
       NOTIFY_APP_NAME: delivery-worker-research
 
   - name: notify-delivery-worker-sender
-    command: scripts/run_multi_worker_app_paas.sh celery multi start 4 -c 10 -A run_celery.notify_celery --loglevel=INFO -Q send-sms-tasks,send-email-tasks
+    command: scripts/run_multi_worker_app_paas.sh celery multi start 3 -c 10 -A run_celery.notify_celery --loglevel=INFO -Q send-sms-tasks,send-email-tasks
     memory: 2G
     env:
       SQLALCHEMY_POOL_SIZE: 1


### PR DESCRIPTION
This was overly optimistic that 2G would be enough to handle 4 worker
processes as they are already exhausting the 2G limit.

Depending on performance we may need to tweak the memory instead/too.