### PR TITLE
Ensure update letter notification statuses task handles temporary failure

### DIFF
--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -123,7 +123,7 @@ def firetext_callback(notification_id, to):
 def create_fake_letter_response_file(self, reference):
     now = datetime.utcnow()
     dvla_response_data = '{}|Sent|0|Sorted'.format(reference)
-    upload_file_name = 'NOTIFY.{}.RSP.TXT'.format(now.strftime('%Y%m%d%H%M%S'))
+    upload_file_name = 'NOTIFY-{}-RSP.TXT'.format(now.strftime('%Y%m%d%H%M%S'))
 
     s3upload(
         filedata=dvla_response_data,

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -420,22 +420,23 @@ def update_letter_notifications_statuses(self, filename):
             update_letter_notification(filename, temporary_failures, update)
             sorted_letter_counts[update.cost_threshold] += 1
 
-        if temporary_failures:
-            # This will alert Notify that DVLA was unable to deliver the letters, we need to investigate
-            message = "DVLA response file: {filename} has failed letters with notification.reference {failures}".format(
-                filename=filename, failures=temporary_failures)
-            raise DVLAException(message)
+        try:
+            if sorted_letter_counts.keys() - {'Unsorted', 'Sorted'}:
+                unknown_status = sorted_letter_counts.keys() - {'Unsorted', 'Sorted'}
 
-        if sorted_letter_counts.keys() - {'Unsorted', 'Sorted'}:
-            unknown_status = sorted_letter_counts.keys() - {'Unsorted', 'Sorted'}
+                message = 'DVLA response file: {} contains unknown Sorted status {}'.format(
+                    filename, unknown_status
+                )
+                raise DVLAException(message)
 
-            message = 'DVLA response file: {} contains unknown Sorted status {}'.format(
-                filename, unknown_status
-            )
-            raise DVLAException(message)
-
-        billing_date = get_billing_date_in_bst_from_filename(filename)
-        persist_daily_sorted_letter_counts(billing_date, sorted_letter_counts)
+            billing_date = get_billing_date_in_bst_from_filename(filename)
+            persist_daily_sorted_letter_counts(billing_date, sorted_letter_counts)
+        finally:
+            if temporary_failures:
+                # This will alert Notify that DVLA was unable to deliver the letters, we need to investigate
+                message = "DVLA response file: {filename} has failed letters with notification.reference {failures}" \
+                    .format(filename=filename, failures=temporary_failures)
+                raise DVLAException(message)
 
 
 def get_billing_date_in_bst_from_filename(filename):

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -440,7 +440,7 @@ def update_letter_notifications_statuses(self, filename):
 
 
 def get_billing_date_in_bst_from_filename(filename):
-    datetime_string = filename.split('.')[1]
+    datetime_string = filename.split('-')[1]
     datetime_obj = datetime.strptime(datetime_string, '%Y%m%d%H%M%S')
     return convert_utc_to_bst(datetime_obj).date()
 

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -113,6 +113,25 @@ def test_update_letter_notifications_statuses_raises_error_for_unknown_sorted_st
     ) in str(e)
 
 
+def test_update_letter_notifications_statuses_still_raises_temp_failure_error_with_unknown_sorted_status(
+    notify_api,
+    mocker,
+    sample_letter_template
+):
+    valid_file = 'ref-foo|Failed|1|unknown'
+    mocker.patch('app.celery.tasks.s3.get_s3_file', return_value=valid_file)
+    create_notification(sample_letter_template, reference='ref-foo', status=NOTIFICATION_SENDING,
+                        billable_units=0)
+
+    with pytest.raises(DVLAException) as e:
+        update_letter_notifications_statuses(filename="failed.txt")
+
+    failed = ["ref-foo"]
+    assert "DVLA response file: {filename} has failed letters with notification.reference {failures}".format(
+        filename="failed.txt", failures=failed
+    ) in str(e)
+
+
 def test_update_letter_notifications_statuses_calls_with_correct_bucket_location(notify_api, mocker):
     s3_mock = mocker.patch('app.celery.tasks.s3.get_s3_object')
 

--- a/tests/app/celery/test_research_mode_tasks.py
+++ b/tests/app/celery/test_research_mode_tasks.py
@@ -112,7 +112,7 @@ def test_failure_firetext_callback(phone_number):
 def test_create_fake_letter_response_file_uploads_response_file_s3(
         notify_api, mocker):
     mock_s3upload = mocker.patch('app.celery.research_mode_tasks.s3upload')
-    filename = 'NOTIFY.20180125140000.RSP.TXT'
+    filename = 'NOTIFY-20180125140000-RSP.TXT'
 
     with requests_mock.Mocker() as request_mock:
         request_mock.post(
@@ -135,7 +135,7 @@ def test_create_fake_letter_response_file_uploads_response_file_s3(
 def test_create_fake_letter_response_file_calls_dvla_callback_on_development(
         notify_api, mocker):
     mocker.patch('app.celery.research_mode_tasks.s3upload')
-    filename = 'NOTIFY.20180125140000.RSP.TXT'
+    filename = 'NOTIFY-20180125140000-RSP.TXT'
 
     with set_config_values(notify_api, {
         'NOTIFY_ENVIRONMENT': 'development'

--- a/tests/app/notifications/rest/test_callbacks.py
+++ b/tests/app/notifications/rest/test_callbacks.py
@@ -96,12 +96,12 @@ def test_dvla_rs_txt_file_callback_calls_update_letter_notifications_task(client
 def test_dvla_rsp_txt_file_callback_calls_update_letter_notifications_task(client, mocker):
     update_task = \
         mocker.patch('app.notifications.notifications_letter_callback.update_letter_notifications_statuses.apply_async')
-    data = _sample_sns_s3_callback('NOTIFY.20170823160812.RSP.TXT')
+    data = _sample_sns_s3_callback('NOTIFY-20170823160812-RSP.TXT')
     response = dvla_post(client, data)
 
     assert response.status_code == 200
     assert update_task.called
-    update_task.assert_called_with(['NOTIFY.20170823160812.RSP.TXT'], queue='notify-internal-tasks')
+    update_task.assert_called_with(['NOTIFY-20170823160812-RSP.TXT'], queue='notify-internal-tasks')
 
 
 def test_dvla_ack_calls_does_not_call_letter_notifications_task(client, mocker):


### PR DESCRIPTION
Two small updates to the `update-letter-notifications-statuses` task -

* We ensure that temporary failures are always handled, regardless of whether 
the response file we receive contains unknown Sorted statuses or not by putting
this code in a `finally` block.

* When getting the billing date from the name of the letter response file we now split
on `-` instead of `.` since the files we receive use `-` in the filename now.

This is an update to [this Pivotal story.](https://www.pivotaltracker.com/story/show/154395015)