### PR TITLE
Update notification response for precompiled

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -92,20 +92,10 @@ def post_precompiled_letter_notification():
         precompiled=True
     )
 
-    create_resp_partial = functools.partial(
-        create_post_letter_response_from_notification,
-        subject=template.subject,
-    )
-
-    resp = create_resp_partial(
-        notification=notification,
-        content=None,
-        url_root=request.url_root,
-        scheduled_for=None,
-    )
-
-    # Precompile should be the same as a letter without the template as its auto generated
-    resp.pop('template', None)
+    resp = {
+        'id': notification.id,
+        'reference': notification.client_reference
+    }
 
     return jsonify(resp), 201
 

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -104,6 +104,9 @@ def post_precompiled_letter_notification():
         scheduled_for=None,
     )
 
+    # Precompile should be the same as a letter without the template as its auto generated
+    resp.pop('template', None)
+
     return jsonify(resp), 201
 
 

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -760,11 +760,8 @@ def test_post_precompiled_letter_notification_returns_201(client, notify_user, m
     resp_json = json.loads(response.get_data(as_text=True))
 
     assert resp_json == {
-        'content': {'body': None, 'subject': 'Pre-compiled PDF'},
         'id': str(notification.id),
-        'reference': 'letter-reference',
-        'scheduled_for': None,
-        'uri': ANY
+        'reference': 'letter-reference'
     }
 
 

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -758,16 +758,12 @@ def test_post_precompiled_letter_notification_returns_201(client, notify_user, m
     assert notification.billable_units == 3
 
     resp_json = json.loads(response.get_data(as_text=True))
+
     assert resp_json == {
         'content': {'body': None, 'subject': 'Pre-compiled PDF'},
         'id': str(notification.id),
         'reference': 'letter-reference',
         'scheduled_for': None,
-        'template': {
-            'id': ANY,
-            'uri': ANY,
-            'version': 1
-        },
         'uri': ANY
     }
 


### PR DESCRIPTION
Updated the precompiled response to only include the notification id and the client reference. It could confuse the client consumer so best to remove it from the response altogether.

* Respond with only the notification_id and client_reference
* Updated the test to check for the response without the template