### PR TITLE
Preview precompiled letters sent using an API test key

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -321,6 +321,7 @@ class Development(Config):
 
     CSV_UPLOAD_BUCKET_NAME = 'development-notifications-csv-upload'
     LETTERS_PDF_BUCKET_NAME = 'development-letters-pdf'
+    TEST_LETTERS_BUCKET_NAME = 'development-test-letters'
     DVLA_RESPONSE_BUCKET_NAME = 'notify.tools-ftp'
 
     ADMIN_CLIENT_SECRET = 'dev-notify-secret-key'
@@ -357,6 +358,7 @@ class Test(Development):
 
     CSV_UPLOAD_BUCKET_NAME = 'test-notifications-csv-upload'
     LETTERS_PDF_BUCKET_NAME = 'test-letters-pdf'
+    TEST_LETTERS_BUCKET_NAME = 'test-test-letters'
     DVLA_RESPONSE_BUCKET_NAME = 'test.notify.com-ftp'
 
     # this is overriden in jenkins and on cloudfoundry
@@ -384,6 +386,7 @@ class Preview(Config):
     NOTIFY_ENVIRONMENT = 'preview'
     CSV_UPLOAD_BUCKET_NAME = 'preview-notifications-csv-upload'
     LETTERS_PDF_BUCKET_NAME = 'preview-letters-pdf'
+    TEST_LETTERS_BUCKET_NAME = 'preview-test-letters'
     DVLA_RESPONSE_BUCKET_NAME = 'notify.works-ftp'
     FROM_NUMBER = 'preview'
     API_RATE_LIMIT_ENABLED = True
@@ -395,6 +398,7 @@ class Staging(Config):
     NOTIFY_ENVIRONMENT = 'staging'
     CSV_UPLOAD_BUCKET_NAME = 'staging-notify-csv-upload'
     LETTERS_PDF_BUCKET_NAME = 'staging-letters-pdf'
+    TEST_LETTERS_BUCKET_NAME = 'staging-test-letters'
     DVLA_RESPONSE_BUCKET_NAME = 'staging-notify.works-ftp'
     STATSD_ENABLED = True
     FROM_NUMBER = 'stage'
@@ -408,6 +412,7 @@ class Live(Config):
     NOTIFY_ENVIRONMENT = 'live'
     CSV_UPLOAD_BUCKET_NAME = 'live-notifications-csv-upload'
     LETTERS_PDF_BUCKET_NAME = 'production-letters-pdf'
+    TEST_LETTERS_BUCKET_NAME = 'production-test-letters'
     DVLA_RESPONSE_BUCKET_NAME = 'notifications.service.gov.uk-ftp'
     STATSD_ENABLED = True
     FROM_NUMBER = 'GOVUK'
@@ -428,6 +433,7 @@ class Sandbox(CloudFoundryConfig):
     NOTIFY_ENVIRONMENT = 'sandbox'
     CSV_UPLOAD_BUCKET_NAME = 'cf-sandbox-notifications-csv-upload'
     LETTERS_PDF_BUCKET_NAME = 'cf-sandbox-letters-pdf'
+    TEST_LETTERS_BUCKET_NAME = 'cf-sandbox-test-letters'
     DVLA_RESPONSE_BUCKET_NAME = 'notify.works-ftp'
     FROM_NUMBER = 'sandbox'
     REDIS_ENABLED = False

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -9,20 +9,27 @@ from app.variables import Retention
 
 
 LETTERS_PDF_FILE_LOCATION_STRUCTURE = \
-    '{folder}/NOTIFY.{reference}.{duplex}.{letter_class}.{colour}.{crown}.{date}.pdf'
+    '{folder}NOTIFY.{reference}.{duplex}.{letter_class}.{colour}.{crown}.{date}.pdf'
 
 PRECOMPILED_BUCKET_PREFIX = '{folder}/NOTIFY.{reference}'
 
 
-def get_letter_pdf_filename(reference, crown):
+def get_folder_name(_now, is_test_letter):
+    if is_test_letter:
+        folder_name = ''
+    else:
+        print_datetime = _now
+        if _now.time() > current_app.config.get('LETTER_PROCESSING_DEADLINE'):
+            print_datetime = _now + timedelta(days=1)
+        folder_name = '{}/'.format(print_datetime.date())
+    return folder_name
+
+
+def get_letter_pdf_filename(reference, crown, is_test_letter=False):
     now = datetime.utcnow()
 
-    print_datetime = now
-    if now.time() > current_app.config.get('LETTER_PROCESSING_DEADLINE'):
-        print_datetime = now + timedelta(days=1)
-
     upload_file_name = LETTERS_PDF_FILE_LOCATION_STRUCTURE.format(
-        folder=print_datetime.date(),
+        folder=get_folder_name(now, is_test_letter),
         reference=reference,
         duplex="D",
         letter_class="2",
@@ -43,23 +50,28 @@ def get_bucket_prefix_for_notification(notification):
     return upload_file_name
 
 
-def upload_letter_pdf(notification, pdf_data):
+def upload_letter_pdf(notification, pdf_data, is_test_letter=False):
     current_app.logger.info("PDF Letter {} reference {} created at {}, {} bytes".format(
         notification.id, notification.reference, notification.created_at, len(pdf_data)))
 
     upload_file_name = get_letter_pdf_filename(
-        notification.reference, notification.service.crown)
+        notification.reference, notification.service.crown, is_test_letter)
+
+    if is_test_letter:
+        bucket_name = current_app.config['TEST_LETTERS_BUCKET_NAME']
+    else:
+        bucket_name = current_app.config['LETTERS_PDF_BUCKET_NAME']
 
     s3upload(
         filedata=pdf_data,
         region=current_app.config['AWS_REGION'],
-        bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
+        bucket_name=bucket_name,
         file_location=upload_file_name,
         tags={Retention.KEY: Retention.ONE_WEEK}
     )
 
     current_app.logger.info("Uploaded letters PDF {} to {} for notification id {}".format(
-        upload_file_name, current_app.config['LETTERS_PDF_BUCKET_NAME'], notification.id))
+        upload_file_name, bucket_name, notification.id))
 
 
 def get_letter_pdf(notification):

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -265,6 +265,8 @@ def process_letter_notification(*, letter_data, api_key, template, reply_to_text
             queue=QueueNames.RESEARCH_MODE
         )
     else:
+        if precompiled and api_key.key_type == KEY_TYPE_TEST:
+            upload_letter_pdf(notification, letter_content, is_test_letter=True)
         update_notification_status_by_reference(notification.reference, NOTIFICATION_DELIVERED)
 
     return notification

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 flake8==3.5.0
+moto==1.1.25
 pytest==3.4.2
 pytest-env==0.6.2
 pytest-mock==1.7.1

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -28,25 +28,6 @@ def test_should_have_decorated_tasks_functions():
     assert create_letters_pdf.__wrapped__.__name__ == 'create_letters_pdf'
 
 
-@pytest.mark.parametrize('crown_flag,expected_crown_text', [
-    (True, 'C'),
-    (False, 'N'),
-])
-@freeze_time("2017-12-04 17:29:00")
-def test_get_letter_pdf_filename_returns_correct_filename(
-        notify_api, mocker, crown_flag, expected_crown_text):
-    filename = get_letter_pdf_filename(reference='foo', crown=crown_flag)
-
-    assert filename == '2017-12-04/NOTIFY.FOO.D.2.C.{}.20171204172900.PDF'.format(expected_crown_text)
-
-
-@freeze_time("2017-12-04 17:31:00")
-def test_get_letter_pdf_filename_returns_tomorrows_filename(notify_api, mocker):
-    filename = get_letter_pdf_filename(reference='foo', crown=True)
-
-    assert filename == '2017-12-05/NOTIFY.FOO.D.2.C.C.20171204173100.PDF'
-
-
 @pytest.mark.parametrize('personalisation', [{'name': 'test'}, None])
 def test_get_letters_pdf_calls_notifications_template_preview_service_correctly(
         notify_api, mocker, client, sample_letter_template, personalisation):

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -1,6 +1,8 @@
 import pytest
 
-from app.letters.utils import get_bucket_prefix_for_notification
+from freezegun import freeze_time
+
+from app.letters.utils import get_bucket_prefix_for_notification, get_letter_pdf_filename
 
 
 def test_get_bucket_prefix_for_notification_valid_notification(sample_notification):
@@ -16,3 +18,30 @@ def test_get_bucket_prefix_for_notification_valid_notification(sample_notificati
 def test_get_bucket_prefix_for_notification_invalid_notification():
     with pytest.raises(AttributeError):
         get_bucket_prefix_for_notification(None)
+
+
+@pytest.mark.parametrize('crown_flag,expected_crown_text', [
+    (True, 'C'),
+    (False, 'N'),
+])
+@freeze_time("2017-12-04 17:29:00")
+def test_get_letter_pdf_filename_returns_correct_filename(
+        notify_api, mocker, crown_flag, expected_crown_text):
+    filename = get_letter_pdf_filename(reference='foo', crown=crown_flag)
+
+    assert filename == '2017-12-04/NOTIFY.FOO.D.2.C.{}.20171204172900.PDF'.format(expected_crown_text)
+
+
+@freeze_time("2017-12-04 17:29:00")
+def test_get_letter_pdf_filename_returns_correct_filename_for_test_letters(
+        notify_api, mocker):
+    filename = get_letter_pdf_filename(reference='foo', crown='C', is_test_letter=True)
+
+    assert filename == 'NOTIFY.FOO.D.2.C.C.20171204172900.PDF'
+
+
+@freeze_time("2017-12-04 17:31:00")
+def test_get_letter_pdf_filename_returns_tomorrows_filename(notify_api, mocker):
+    filename = get_letter_pdf_filename(reference='foo', crown=True)
+
+    assert filename == '2017-12-05/NOTIFY.FOO.D.2.C.C.20171204173100.PDF'


### PR DESCRIPTION
## What 
To break down this PR, you can have a look at this first - 

https://github.com/alphagov/notifications-api/pull/1772

This PR will access the PDF from the correct bucket for a preview image sent using a test API key

## Dependencies 

This is a branch off https://github.com/alphagov/notifications-api/tree/ken-upload-test_key-precompiled-to-test_letters-bucket, so should be merged after that branch has merged or can be merged in place of the merging of the parent branch.

## Reference 

https://www.pivotaltracker.com/story/show/155974923