### PR TITLE
Set db connection pool size to 1 for all workers

### DIFF
--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -43,6 +43,7 @@ env:
 
   TEMPLATE_PREVIEW_API_HOST: null
   TEMPLATE_PREVIEW_API_KEY: null
+  SQLALCHEMY_POOL_SIZE: 1
 
 applications:
   - name: notify-delivery-celery-beat
@@ -66,7 +67,6 @@ applications:
     command: scripts/run_multi_worker_app_paas.sh celery multi start 3 -c 10 -A run_celery.notify_celery --loglevel=INFO -Q send-sms-tasks,send-email-tasks
     memory: 2G
     env:
-      SQLALCHEMY_POOL_SIZE: 1
       NOTIFY_APP_NAME: delivery-worker-sender
 
   - name: notify-delivery-worker-periodic


### PR DESCRIPTION
The workers are working sequentially so they don't need more than one
connection per thread.

This has been tested with the sender worker and it works fine even
under significant load, so this commit will make it the default for the
other workers as well.