### PR TITLE
Send service callback if sent at is none

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -33,7 +33,7 @@ def deliver_sms(self, notification_id):
             )
             self.retry(queue=QueueNames.RETRY)
         except self.MaxRetriesExceededError:
-            message = "RETRY FAILED: task send_sms_to_provider failed for notification {}. " \
+            message = "RETRY FAILED: Max retries reached. The task send_sms_to_provider failed for notification {}. " \
                       "Notification has been updated to technical-failure".format(notification_id)
             update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)
             raise NotificationTechnicalFailureException(message)
@@ -57,7 +57,8 @@ def deliver_email(self, notification_id):
             )
             self.retry(queue=QueueNames.RETRY)
         except self.MaxRetriesExceededError:
-            message = "RETRY FAILED: task send_email_to_provider failed for notification {}. " \
+            message = "RETRY FAILED: Max retries reached. " \
+                      "The task send_email_to_provider failed for notification {}. " \
                       "Notification has been updated to technical-failure".format(notification_id)
             update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)
             raise NotificationTechnicalFailureException(message)

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -9,6 +9,8 @@ from app.config import QueueNames
 from app.dao import notifications_dao
 from app.dao.notifications_dao import update_notification_status_by_id
 from app.delivery import send_to_providers
+from app.exceptions import NotificationTechnicalFailureException
+from app.models import NOTIFICATION_TECHNICAL_FAILURE
 
 
 @worker_process_shutdown.connect
@@ -31,10 +33,10 @@ def deliver_sms(self, notification_id):
             )
             self.retry(queue=QueueNames.RETRY)
         except self.MaxRetriesExceededError:
-            current_app.logger.exception(
-                "RETRY FAILED: task send_sms_to_provider failed for notification {}".format(notification_id),
-            )
-            update_notification_status_by_id(notification_id, 'technical-failure')
+            message = "RETRY FAILED: task send_sms_to_provider failed for notification {}. " \
+                      "Notification has been updated to technical-failure".format(notification_id)
+            update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)
+            raise NotificationTechnicalFailureException(message)
 
 
 @notify_celery.task(bind=True, name="deliver_email", max_retries=48, default_retry_delay=300)
@@ -55,7 +57,7 @@ def deliver_email(self, notification_id):
             )
             self.retry(queue=QueueNames.RETRY)
         except self.MaxRetriesExceededError:
-            current_app.logger.error(
-                "RETRY FAILED: task send_email_to_provider failed for notification {}".format(notification_id)
-            )
-            update_notification_status_by_id(notification_id, 'technical-failure')
+            message = "RETRY FAILED: task send_email_to_provider failed for notification {}. " \
+                      "Notification has been updated to technical-failure".format(notification_id)
+            update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)
+            raise NotificationTechnicalFailureException(message)

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -59,10 +59,15 @@ from app.celery.tasks import (
     process_job
 )
 from app.config import QueueNames, TaskNames
-from app.utils import convert_utc_to_bst
+from app.utils import (
+    convert_utc_to_bst
+)
 from app.v2.errors import JobIncompleteError
 from app.dao.service_callback_api_dao import get_service_callback_api_for_service
-from app.celery.service_callback_tasks import send_delivery_status_to_service
+from app.celery.service_callback_tasks import (
+    send_delivery_status_to_service,
+    create_encrypted_callback_data,
+)
 import pytz
 
 
@@ -201,9 +206,10 @@ def timeout_notifications():
     for notification in notifications:
         # queue callback task only if the service_callback_api exists
         service_callback_api = get_service_callback_api_for_service(service_id=notification.service_id)
-
         if service_callback_api:
-            send_delivery_status_to_service.apply_async([str(notification.id)], queue=QueueNames.CALLBACKS)
+            encrypted_notification = create_encrypted_callback_data(notification, service_callback_api)
+            send_delivery_status_to_service.apply_async([str(notification.id), encrypted_notification],
+                                                        queue=QueueNames.CALLBACKS)
 
     current_app.logger.info(
         "Timeout period reached for {} notifications, status has been updated.".format(len(notifications)))

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -141,3 +141,21 @@ def process_update_with_notification_id(self, notification_id):
                 """Retry: send_delivery_status_to_service has retried the max num of times
                  for notification: {}""".format(notification_id)
             )
+
+
+def create_encrypted_callback_data(notification, service_callback_api):
+    from app import DATETIME_FORMAT, encryption
+    data = {
+        "notification_id": str(notification.id),
+        "notification_client_reference": notification.client_reference,
+        "notification_to": notification.to,
+        "notification_status": notification.status,
+        "notification_created_at": notification.created_at.strftime(DATETIME_FORMAT),
+        "notification_updated_at":
+            notification.updated_at.strftime(DATETIME_FORMAT) if notification.updated_at else None,
+        "notification_sent_at": notification.sent_at.strftime(DATETIME_FORMAT) if notification.sent_at else None,
+        "notification_type": notification.notification_type,
+        "service_callback_api_url": service_callback_api.url,
+        "service_callback_api_bearer_token": service_callback_api.bearer_token,
+    }
+    return encryption.encrypt(data)

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -62,7 +62,7 @@ def send_delivery_status_to_service(self, notification_id,
             response.raise_for_status()
         except RequestException as e:
             current_app.logger.warning(
-                "send_delivery_status_to_service request failed for service_id: {} and url: {}. exc: {}".format(
+                "send_delivery_status_to_service request failed for notification_id: {} and url: {}. exc: {}".format(
                     notification_id,
                     status_update['service_callback_api_url'],
                     e
@@ -119,7 +119,7 @@ def process_update_with_notification_id(self, notification_id):
         response.raise_for_status()
     except RequestException as e:
         current_app.logger.warning(
-            "send_delivery_status_to_service request failed for service_id: {} and url: {}. exc: {}".format(
+            "send_delivery_status_to_service request failed for notification_id: {} and url: {}. exc: {}".format(
                 notification_id,
                 service_callback_api.url,
                 e

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -50,7 +50,7 @@ from app.dao.provider_details_dao import get_current_provider
 from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
 from app.dao.services_dao import dao_fetch_service_by_id, fetch_todays_total_message_count
 from app.dao.templates_dao import dao_get_template_by_id
-from app.exceptions import DVLAException
+from app.exceptions import DVLAException, NotificationTechnicalFailureException
 from app.models import (
     DVLA_RESPONSE_STATUS_SENT,
     EMAIL_TYPE,
@@ -371,8 +371,10 @@ def update_letter_notifications_to_error(self, notification_references):
             'updated_at': datetime.utcnow()
         }
     )
-
-    current_app.logger.debug("Updated {} letter notifications to technical-failure".format(updated_count))
+    message = "Updated {} letter notifications to technical-failure with references {}".format(
+        updated_count, notification_references
+    )
+    raise NotificationTechnicalFailureException(message=message)
 
 
 def handle_exception(task, notification, notification_id, exc):

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -375,14 +375,15 @@ def dao_timeout_notifications(timeout_period_in_seconds):
     timeout = functools.partial(_timeout_notifications, timeout_start=timeout_start, updated_at=updated_at)
 
     # Notifications still in created status are marked with a technical-failure:
-    updated_ids = timeout([NOTIFICATION_CREATED], NOTIFICATION_TECHNICAL_FAILURE)
+    technical_failure_notifications = timeout([NOTIFICATION_CREATED], NOTIFICATION_TECHNICAL_FAILURE)
 
     # Notifications still in sending or pending status are marked with a temporary-failure:
-    updated_ids += timeout([NOTIFICATION_SENDING, NOTIFICATION_PENDING], NOTIFICATION_TEMPORARY_FAILURE)
+    temporary_failure_notifications = timeout([NOTIFICATION_SENDING, NOTIFICATION_PENDING],
+                                              NOTIFICATION_TEMPORARY_FAILURE)
 
     db.session.commit()
 
-    return updated_ids
+    return technical_failure_notifications, temporary_failure_notifications
 
 
 def get_total_sent_notifications_in_date_range(start_date, end_date, notification_type):

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -19,6 +19,7 @@ from app.dao.provider_details_dao import (
 )
 from app.celery.research_mode_tasks import send_sms_response, send_email_response
 from app.dao.templates_dao import dao_get_template_by_id
+from app.exceptions import NotificationTechnicalFailureException
 from app.models import (
     SMS_TYPE,
     KEY_TYPE_TEST,
@@ -211,7 +212,7 @@ def get_html_email_options(service):
 def technical_failure(notification):
     notification.status = NOTIFICATION_TECHNICAL_FAILURE
     dao_update_notification(notification)
-    current_app.logger.warn(
+    raise NotificationTechnicalFailureException(
         "Send {} for notification id {} to provider is not allowed: service {} is inactive".format(
             notification.notification_type,
             notification.id,

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,3 +1,8 @@
 class DVLAException(Exception):
     def __init__(self, message):
         self.message = message
+
+
+class NotificationTechnicalFailureException(Exception):
+    def __init__(self, message):
+        self.message = message

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -5,7 +5,7 @@ import pytest
 from freezegun import freeze_time
 from flask import current_app
 
-from app.exceptions import DVLAException
+from app.exceptions import DVLAException, NotificationTechnicalFailureException
 from app.models import (
     Job,
     Notification,
@@ -276,7 +276,9 @@ def test_update_letter_notifications_to_error_updates_based_on_notification_refe
     create_service_callback_api(service=sample_letter_template.service, url="https://original_url.com")
     dt = datetime.utcnow()
     with freeze_time(dt):
-        update_letter_notifications_to_error([first.reference])
+        with pytest.raises(NotificationTechnicalFailureException) as e:
+            update_letter_notifications_to_error([first.reference])
+    assert first.reference in e.value.message
 
     assert first.status == NOTIFICATION_TECHNICAL_FAILURE
     assert first.sent_by is None

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -44,6 +44,7 @@ from app.dao.provider_details_dao import (
     dao_update_provider_details,
     get_current_provider
 )
+from app.exceptions import NotificationTechnicalFailureException
 from app.models import (
     MonthlyBilling,
     NotificationHistory,
@@ -181,8 +182,10 @@ def test_update_status_of_notifications_after_timeout(notify_api, sample_templat
             status='pending',
             created_at=datetime.utcnow() - timedelta(
                 seconds=current_app.config.get('SENDING_NOTIFICATIONS_TIMEOUT_PERIOD') + 10))
-        timeout_notifications()
-
+        with pytest.raises(NotificationTechnicalFailureException) as e:
+            timeout_notifications()
+        print(e.value.message)
+        assert str(not2.id) in e.value.message
         assert not1.status == 'temporary-failure'
         assert not2.status == 'technical-failure'
         assert not3.status == 'temporary-failure'

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -57,6 +57,7 @@ from app.models import (
     SMS_TYPE
 )
 from app.utils import get_london_midnight_in_utc
+from app.celery.service_callback_tasks import create_encrypted_callback_data
 from app.v2.errors import JobIncompleteError
 from tests.app.db import (
     create_notification, create_service, create_template, create_job, create_rate,
@@ -210,7 +211,7 @@ def test_should_not_update_status_of_letter_notifications(client, sample_letter_
 
 
 def test_timeout_notifications_sends_status_update_to_service(client, sample_template, mocker):
-    create_service_callback_api(service=sample_template.service)
+    callback_api = create_service_callback_api(service=sample_template.service)
     mocked = mocker.patch('app.celery.service_callback_tasks.send_delivery_status_to_service.apply_async')
     notification = create_notification(
         template=sample_template,
@@ -218,7 +219,9 @@ def test_timeout_notifications_sends_status_update_to_service(client, sample_tem
         created_at=datetime.utcnow() - timedelta(
             seconds=current_app.config.get('SENDING_NOTIFICATIONS_TIMEOUT_PERIOD') + 10))
     timeout_notifications()
-    mocked.assert_called_once_with([str(notification.id)], queue=QueueNames.CALLBACKS)
+
+    encrypted_data = create_encrypted_callback_data(notification, callback_api)
+    mocked.assert_called_once_with([str(notification.id), encrypted_data], queue=QueueNames.CALLBACKS)
 
 
 def test_should_update_scheduled_jobs_and_put_on_queue(notify_db, notify_db_session, mocker):

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -184,7 +184,6 @@ def test_update_status_of_notifications_after_timeout(notify_api, sample_templat
                 seconds=current_app.config.get('SENDING_NOTIFICATIONS_TIMEOUT_PERIOD') + 10))
         with pytest.raises(NotificationTechnicalFailureException) as e:
             timeout_notifications()
-        print(e.value.message)
         assert str(not2.id) in e.value.message
         assert not1.status == 'temporary-failure'
         assert not2.status == 'technical-failure'

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1222,7 +1222,7 @@ def test_dao_timeout_notifications(sample_template):
     assert Notification.query.get(sending.id).status == 'sending'
     assert Notification.query.get(pending.id).status == 'pending'
     assert Notification.query.get(delivered.id).status == 'delivered'
-    updated_ids = dao_timeout_notifications(1)
+    technical_failure_notifications, temporary_failure_notifications = dao_timeout_notifications(1)
     assert Notification.query.get(created.id).status == 'technical-failure'
     assert Notification.query.get(sending.id).status == 'temporary-failure'
     assert Notification.query.get(pending.id).status == 'temporary-failure'
@@ -1231,7 +1231,7 @@ def test_dao_timeout_notifications(sample_template):
     assert NotificationHistory.query.get(sending.id).status == 'temporary-failure'
     assert NotificationHistory.query.get(pending.id).status == 'temporary-failure'
     assert NotificationHistory.query.get(delivered.id).status == 'delivered'
-    assert len(updated_ids) == 3
+    assert len(technical_failure_notifications + temporary_failure_notifications) == 3
 
 
 def test_dao_timeout_notifications_only_updates_for_older_notifications(sample_template):
@@ -1245,12 +1245,12 @@ def test_dao_timeout_notifications_only_updates_for_older_notifications(sample_t
     assert Notification.query.get(sending.id).status == 'sending'
     assert Notification.query.get(pending.id).status == 'pending'
     assert Notification.query.get(delivered.id).status == 'delivered'
-    updated_ids = dao_timeout_notifications(1)
+    technical_failure_notifications, temporary_failure_notifications = dao_timeout_notifications(1)
     assert NotificationHistory.query.get(created.id).status == 'created'
     assert NotificationHistory.query.get(sending.id).status == 'sending'
     assert NotificationHistory.query.get(pending.id).status == 'pending'
     assert NotificationHistory.query.get(delivered.id).status == 'delivered'
-    assert len(updated_ids) == 0
+    assert len(technical_failure_notifications + temporary_failure_notifications) == 0
 
 
 def test_dao_timeout_notifications_doesnt_affect_letters(sample_letter_template):
@@ -1265,13 +1265,13 @@ def test_dao_timeout_notifications_doesnt_affect_letters(sample_letter_template)
     assert Notification.query.get(pending.id).status == 'pending'
     assert Notification.query.get(delivered.id).status == 'delivered'
 
-    updated_ids = dao_timeout_notifications(1)
+    technical_failure_notifications, temporary_failure_notifications = dao_timeout_notifications(1)
 
     assert NotificationHistory.query.get(created.id).status == 'created'
     assert NotificationHistory.query.get(sending.id).status == 'sending'
     assert NotificationHistory.query.get(pending.id).status == 'pending'
     assert NotificationHistory.query.get(delivered.id).status == 'delivered'
-    assert len(updated_ids) == 0
+    assert len(technical_failure_notifications + temporary_failure_notifications) == 0
 
 
 def test_should_return_notifications_excluding_jobs_by_default(sample_template, sample_job, sample_api_key):


### PR DESCRIPTION
## Context
When a notification is timed out in the scheduled task that may happen because the notification has not been sent.
Which means the sent_at date for the notification could be empty causing the service callback to fail.

## What has changed in this PR
- Allow code to work if notification.sent_at or updated_at is None
- Update calls to send_delivery_status_to_service to send the data encrypted so that the task does not need to use the db.
- Throw an exception whenever we updated a notification to technical failure. If this is happening we want to know about it.