### PR TITLE
Add import to reporting_tasks in scheduled tasks

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -70,7 +70,6 @@ from app.celery.service_callback_tasks import (
     create_encrypted_callback_data,
 )
 import pytz
-from app.celery.reporting_tasks import create_nightly_billing   # noqa - otherwise task won't start
 
 
 @worker_process_shutdown.connect

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -70,6 +70,7 @@ from app.celery.service_callback_tasks import (
     create_encrypted_callback_data,
 )
 import pytz
+from app.celery.reporting_tasks import create_nightly_billing   # noqa - otherwise task won't start
 
 
 @worker_process_shutdown.connect

--- a/app/config.py
+++ b/app/config.py
@@ -161,7 +161,7 @@ class Config(object):
     CELERY_TIMEZONE = 'Europe/London'
     CELERY_ACCEPT_CONTENT = ['json']
     CELERY_TASK_SERIALIZER = 'json'
-    CELERY_IMPORTS = ('app.celery.tasks', 'app.celery.scheduled_tasks')
+    CELERY_IMPORTS = ('app.celery.tasks', 'app.celery.scheduled_tasks', 'app.celery.reporting_tasks')
     CELERYBEAT_SCHEDULE = {
         'run-scheduled-jobs': {
             'task': 'run-scheduled-jobs',

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -261,7 +261,7 @@ def test_create_nightly_billing_null_sent_by_sms(
     assert record.rate == Decimal(1.33)
     assert record.billable_units == 1
     assert record.rate_multiplier == 1
-    assert record.provider in ['mmg', 'firetext']
+    assert record.provider == 'unknown'
 
 
 @freeze_time('2018-01-15T03:30:00')


### PR DESCRIPTION
1. Add 'create-nightly-billing' task at config.py CELERY_IMPORTS to include this. 

2. Also removed retry from the task. 

3. Mark records as 'unknown' rather than randomly assign them to providers if its null. 