### PR TITLE
Add antivirus check on precompiled letters sent with test key

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -179,7 +179,7 @@ def process_virus_scan_passed(filename):
 
 @notify_celery.task(name='process-virus-scan-failed')
 def process_virus_scan_failed(filename):
-    current_app.logger.error('Virus scan failed: {}'.format(filename))
+    current_app.logger.exception('Virus scan failed: {}'.format(filename))
     delete_pdf_from_letters_scan_bucket(filename)
     reference = get_reference_from_filename(filename)
     updated_count = update_letter_pdf_status(reference, NOTIFICATION_VIRUS_SCAN_FAILED)

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -92,7 +92,8 @@ def move_scanned_pdf_to_test_or_live_pdf_bucket(filename, is_test_letter=False):
 
     s3 = boto3.resource('s3')
     copy_source = {'Bucket': source_bucket_name, 'Key': filename}
-    target_filename = get_folder_name(datetime.utcnow()) + filename
+    target_filename = get_folder_name(datetime.utcnow(), is_test_letter) + filename
+
     target_bucket = s3.Bucket(target_bucket_name)
     obj = target_bucket.Object(target_filename)
 

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -140,13 +140,13 @@ def test_upload_letter_pdf_to_correct_bucket(
 
 
 @mock_s3
-@pytest.mark.parametrize('is_test_letter,bucket_config_name', [
-    (False, 'LETTERS_PDF_BUCKET_NAME'),
-    (True, 'TEST_LETTERS_BUCKET_NAME')
+@pytest.mark.parametrize('is_test_letter,bucket_config_name,folder_date_name', [
+    (False, 'LETTERS_PDF_BUCKET_NAME', '2018-03-14/'),
+    (True, 'TEST_LETTERS_BUCKET_NAME', '')
 ])
 @freeze_time(FROZEN_DATE_TIME)
 def test_move_scanned_letter_pdf_to_processing_bucket(
-    notify_api, is_test_letter, bucket_config_name
+    notify_api, is_test_letter, bucket_config_name, folder_date_name
 ):
     filename = 'test.pdf'
     source_bucket_name = current_app.config['LETTERS_SCAN_BUCKET_NAME']
@@ -161,5 +161,5 @@ def test_move_scanned_letter_pdf_to_processing_bucket(
 
     move_scanned_pdf_to_test_or_live_pdf_bucket(filename, is_test_letter=is_test_letter)
 
-    assert '2018-03-14/' + filename in [o.key for o in target_bucket.objects.all()]
+    assert folder_date_name + filename in [o.key for o in target_bucket.objects.all()]
     assert filename not in [o.key for o in source_bucket.objects.all()]


### PR DESCRIPTION
## What 

Before previewing precompiled PDFs sent with a test key we should run it pass the antivirus scan.

- precompiled PDFs sent by test key uploaded to scan bucket
- set status to `virus-scan-failed` for pdfs failing virus scan rather than `permanent-failure`
- Make call to AV app for precompiled letters sent via a test key, and set notification status to 'pending-virus-scan`
 - Successful scans should set the notification to `delivered`
- Failed scans should be set to `virus-scan-failed` and deleted from the scan bucket

## Reference 

https://www.pivotaltracker.com/story/show/155856605