### PR TITLE
Update utils to fix size of non-gov logos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,6 @@ notifications-python-client==4.8.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@25.1.0#egg=notifications-utils==25.1.0
+git+https://github.com/alphagov/notifications-utils.git@25.2.1#egg=notifications-utils==25.2.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/421

---

Changes: https://github.com/alphagov/notifications-utils/compare/25.1.0...54px-non-gov-branding