### PR TITLE
Update Python version to match PaaS

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4-slim
+FROM python:3.5-slim
 
 ARG HTTP_PROXY
 ARG HTTPS_PROXY


### PR DESCRIPTION
We use Python 3.5.4 in production. 