### PR TITLE
Add a service permission for uploading documents to Document Download

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -238,6 +238,7 @@ SCHEDULE_NOTIFICATIONS = 'schedule_notifications'
 EMAIL_AUTH = 'email_auth'
 LETTERS_AS_PDF = 'letters_as_pdf'
 PRECOMPILED_LETTER = 'precompiled_letter'
+UPLOAD_DOCUMENT = 'upload_document'
 
 SERVICE_PERMISSION_TYPES = [
     EMAIL_TYPE,
@@ -249,6 +250,7 @@ SERVICE_PERMISSION_TYPES = [
     EMAIL_AUTH,
     LETTERS_AS_PDF,
     PRECOMPILED_LETTER,
+    UPLOAD_DOCUMENT,
 ]
 
 

--- a/migrations/versions/0182_add_upload_document_perm.py
+++ b/migrations/versions/0182_add_upload_document_perm.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: 0182_add_upload_document_perm
+Revises: 0181_billing_primary_key
+Create Date: 2018-03-23 16:20:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0182_add_upload_document_perm'
+down_revision = '0181_billing_primary_key'
+
+from alembic import op
+
+
+def upgrade():
+    op.get_bind()
+    op.execute("insert into service_permission_types values('upload_document')")
+
+
+def downgrade():
+    op.get_bind()
+    op.execute("delete from service_permissions where permission = 'upload_document'")
+    op.execute("delete from service_permission_types where name = 'upload_document'")


### PR DESCRIPTION
Service permission allows attaching a file to a notification API request
that gets uploaded to Document Download API.