### PR TITLE
Don’t show HTML entities in plain text emails

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,6 @@ notifications-python-client==4.8.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@25.2.1#egg=notifications-utils==25.2.1
+git+https://github.com/alphagov/notifications-utils.git@25.2.2#egg=notifications-utils==25.2.2
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/427