### PR TITLE
Revisit proxy header check

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -219,8 +219,6 @@ def init_app(app):
     def record_user_agent():
         statsd_client.incr("user-agent.{}".format(process_user_agent(request.headers.get('User-Agent', None))))
 
-    app.before_request(request_helper.check_proxy_header_before_request)
-
     @app.before_request
     def record_request_details():
         g.start = monotonic()

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -1,6 +1,7 @@
 from flask import request, _request_ctx_stack, current_app, g
 from notifications_python_client.authentication import decode_jwt_token, get_token_issuer
 from notifications_python_client.errors import TokenDecodeError, TokenExpiredError, TokenIssuerError
+from notifications_utils import request_helper
 from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -48,6 +49,8 @@ def requires_no_auth():
 
 
 def requires_admin_auth():
+    request_helper.check_proxy_header_before_request()
+
     auth_token = get_auth_token(request)
     client = __get_token_issuer(auth_token)
 
@@ -59,6 +62,8 @@ def requires_admin_auth():
 
 
 def requires_auth():
+    request_helper.check_proxy_header_before_request()
+
     auth_token = get_auth_token(request)
     client = __get_token_issuer(auth_token)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,8 +141,10 @@ def pytest_generate_tests(metafunc):
 def set_config(app, name, value):
     old_val = app.config.get(name)
     app.config[name] = value
-    yield
-    app.config[name] = old_val
+    try:
+        yield
+    finally:
+        app.config[name] = old_val
 
 
 @contextmanager
@@ -153,7 +155,8 @@ def set_config_values(app, dict):
         old_values[key] = app.config.get(key)
         app.config[key] = dict[key]
 
-    yield
-
-    for key in dict:
-        app.config[key] = old_values[key]
+    try:
+        yield
+    finally:
+        for key in dict:
+            app.config[key] = old_values[key]


### PR DESCRIPTION
### Move proxy header check to auth-requiring endpoints

The main drive behind this is to allow us to enable http healthchecks on
the `/_status` endpoint. The healthcheck requests are happening directly
on the instances without going to the proxy to get the header properly
set.

In any case, endpoints like `/_status` should be generally accessible by
anything without requiring any form of authorization.

###  Make test context managers more reliable

Sometimes, when a test using one of the `set_config[_values]` context managers
failed or raised an exception it would cause the context to not be able
to revert its config changes, resulting in a 'spooky action at a
distance' where random tests would start to fail for non-obvious reasons.