### PR TITLE
Hide notify tag on first page

### DIFF
--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -200,7 +200,6 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
     template = dao_get_template_by_id(notification.template_id)
 
     if template.is_precompiled_letter:
-
         try:
 
             pdf_file = get_letter_pdf(notification)
@@ -215,9 +214,9 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
         content = base64.b64encode(pdf_file).decode('utf-8')
 
         if file_type == 'png':
-
             try:
-                page_number = page if page else "0"
+                page_number = page if page else "1"
+
                 pdf_page = extract_page_from_pdf(BytesIO(pdf_file), int(page_number) - 1)
                 content = base64.b64encode(pdf_page).decode('utf-8')
             except PdfReadError as e:
@@ -227,12 +226,12 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
                     status_code=500
                 )
 
-            url = '{}/precompiled-preview.png'.format(
-                current_app.config['TEMPLATE_PREVIEW_API_HOST']
+            url = '{}/precompiled-preview.png{}'.format(
+                current_app.config['TEMPLATE_PREVIEW_API_HOST'],
+                '?hide_notify=true' if page_number == '1' else ''
             )
 
             content = _get_png_preview(url, content, notification.id, json=False)
-
     else:
 
         template_for_letter_print = {
@@ -256,7 +255,6 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
             file_type,
             '?page={}'.format(page) if page else ''
         )
-
         content = _get_png_preview(url, data, notification.id, json=True)
 
     return jsonify({"content": content})

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -169,37 +169,33 @@ def test_move_scanned_letter_pdf_to_processing_bucket(
 @freeze_time(FROZEN_DATE_TIME)
 def test_move_failed_pdf_error(notify_api):
     filename = 'test.pdf'
-    source_bucket_name = current_app.config['LETTERS_SCAN_BUCKET_NAME']
-    target_bucket_name = current_app.config['LETTERS_SCAN_BUCKET_NAME']
+    bucket_name = current_app.config['LETTERS_SCAN_BUCKET_NAME']
 
     conn = boto3.resource('s3', region_name='eu-west-1')
-    source_bucket = conn.create_bucket(Bucket=source_bucket_name)
-    target_bucket = conn.create_bucket(Bucket=target_bucket_name)
+    bucket = conn.create_bucket(Bucket=bucket_name)
 
     s3 = boto3.client('s3', region_name='eu-west-1')
-    s3.put_object(Bucket=source_bucket_name, Key=filename, Body=b'pdf_content')
+    s3.put_object(Bucket=bucket_name, Key=filename, Body=b'pdf_content')
 
     move_failed_pdf(filename, ScanErrorType.ERROR)
 
-    assert 'ERROR/' + filename in [o.key for o in target_bucket.objects.all()]
-    assert filename not in [o.key for o in source_bucket.objects.all()]
+    assert 'ERROR/' + filename in [o.key for o in bucket.objects.all()]
+    assert filename not in [o.key for o in bucket.objects.all()]
 
 
 @mock_s3
 @freeze_time(FROZEN_DATE_TIME)
 def test_move_failed_pdf_scan_failed(notify_api):
     filename = 'test.pdf'
-    source_bucket_name = current_app.config['LETTERS_SCAN_BUCKET_NAME']
-    target_bucket_name = current_app.config['LETTERS_SCAN_BUCKET_NAME']
+    bucket_name = current_app.config['LETTERS_SCAN_BUCKET_NAME']
 
     conn = boto3.resource('s3', region_name='eu-west-1')
-    source_bucket = conn.create_bucket(Bucket=source_bucket_name)
-    target_bucket = conn.create_bucket(Bucket=target_bucket_name)
+    bucket = conn.create_bucket(Bucket=bucket_name)
 
     s3 = boto3.client('s3', region_name='eu-west-1')
-    s3.put_object(Bucket=source_bucket_name, Key=filename, Body=b'pdf_content')
+    s3.put_object(Bucket=bucket_name, Key=filename, Body=b'pdf_content')
 
     move_failed_pdf(filename, ScanErrorType.FAILURE)
 
-    assert 'FAILURE/' + filename in [o.key for o in target_bucket.objects.all()]
-    assert filename not in [o.key for o in source_bucket.objects.all()]
+    assert 'FAILURE/' + filename in [o.key for o in bucket.objects.all()]
+    assert filename not in [o.key for o in bucket.objects.all()]


### PR DESCRIPTION
## What

As API only sends a one page pdf to template preview, this means that template preview has no way of knowing whether the notify tag should be hidden or not. 
So a flag needs to be sent to template preview to tell it whether or not to hide the Notify tag on the first page of a pdf.

