### PR TITLE
Increase pool size to 15 permanent connections

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -2,7 +2,7 @@ import os
 import sys
 import traceback
 
-workers = 5
+workers = 4
 worker_class = "eventlet"
 worker_connections = 256
 errorlog = "/home/vcap/logs/gunicorn_error.log"

--- a/manifest-api-base.yml
+++ b/manifest-api-base.yml
@@ -9,7 +9,7 @@ env:
   CW_APP_NAME: api
   # required by cf run-task
   FLASK_APP: application.py
-  SQLALCHEMY_POOL_SIZE: 10
+  SQLALCHEMY_POOL_SIZE: 15
 
   # Credentials variables
   ADMIN_BASE_URL: null


### PR DESCRIPTION
At the same time, decrease the number of workers from 5 to 4.

Effect on max db connections will be the same - although with a higher
"resting" number of connections.

Before:
12 (instances) * 5 (workers) * 20 (10 permanent + 10 overflow) = 1200

After:
12 (instances) * 4 (workers) * 25 (15 permanent + 10 overflow) = 1200