### PR TITLE
Logging refactor to make debugging Antivirus scans easier

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -10,6 +10,12 @@ from jsonschema import ValidationError as JsonSchemaValidationError
 from app.authentication.auth import AuthError
 
 
+class VirusScanError(Exception):
+    def __init__(self, message):
+
+        super().__init__(message)
+
+
 class InvalidRequest(Exception):
     code = None
     fields = []


### PR DESCRIPTION
Before, the filename needed to be known. Added the notification id to the logging message so that
the notification can be traced through the logging system by knowing the notification id, making it easier to debug. Also changed to raise an exception so that alerts are generated. This way we should get an email to say that there has been an error.