### PR TITLE
Fix BST date bug

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -46,6 +46,7 @@ from app.models import (
 )
 
 from app.dao.dao_utils import transactional
+from app.utils import convert_utc_to_bst
 
 
 @statsd(namespace="dao")
@@ -317,7 +318,7 @@ def _filter_query(query, filter_dict=None):
 @statsd(namespace="dao")
 @transactional
 def delete_notifications_created_more_than_a_week_ago_by_type(notification_type):
-    seven_days_ago = date.today() - timedelta(days=7)
+    seven_days_ago = convert_utc_to_bst(datetime.utcnow()).date() - timedelta(days=7)
     deleted = db.session.query(Notification).filter(
         func.date(Notification.created_at) < seven_days_ago,
         Notification.notification_type == notification_type,


### PR DESCRIPTION
Now that we are in British Summer Time the delete notification scheduled tasks were running at 23:40, but the code expects that the task runs the following day.

Which resulted in the notifications being around for 8 days.
This PR fixes that.