### PR TITLE
Post notification with document upload

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,6 +16,7 @@ from werkzeug.local import LocalProxy
 
 from app.celery.celery import NotifyCelery
 from app.clients import Clients
+from app.clients.document_download import DocumentDownloadClient
 from app.clients.email.aws_ses import AwsSesClient
 from app.clients.sms.firetext import FiretextClient
 from app.clients.sms.loadtesting import LoadtestingClient
@@ -39,6 +40,7 @@ deskpro_client = DeskproClient()
 statsd_client = StatsdClient()
 redis_store = RedisClient()
 performance_platform_client = PerformancePlatformClient()
+document_download_client = DocumentDownloadClient()
 
 clients = Clients()
 
@@ -71,6 +73,7 @@ def create_app(application):
     encryption.init_app(application)
     redis_store.init_app(application)
     performance_platform_client.init_app(application)
+    document_download_client.init_app(application)
     clients.init_app(sms_clients=[firetext_client, mmg_client, loadtest_client], email_clients=[aws_ses_client])
 
     register_blueprint(application)

--- a/app/clients/document_download.py
+++ b/app/clients/document_download.py
@@ -1,0 +1,27 @@
+import base64
+
+import requests
+
+
+class DocumentDownloadClient:
+
+    def init_app(self, app):
+        self.api_host = app.config['DOCUMENT_DOWNLOAD_API_HOST']
+        self.auth_token = app.config['DOCUMENT_DOWNLOAD_API_KEY']
+
+    def get_upload_url(self, service_id):
+        return "{}/services/{}/documents".format(self.api_host, service_id)
+
+    def upload_document(self, service_id, file_contents):
+        response = requests.post(
+            self.get_upload_url(service_id),
+            headers={
+                'Authorization': "Bearer {}".format(self.auth_token),
+            },
+            files={
+                'document': base64.b64decode(file_contents)
+            }
+        )
+        response.raise_for_status()
+
+        return response.json()['document']['url']

--- a/app/clients/document_download.py
+++ b/app/clients/document_download.py
@@ -2,6 +2,25 @@ import base64
 
 import requests
 
+from flask import current_app
+
+
+class DocumentDownloadError(Exception):
+    def __init__(self, message, status_code):
+        self.message = message
+        self.status_code = status_code
+
+    @classmethod
+    def from_exception(cls, e):
+        try:
+            message = e.response.json()['error']
+            status_code = e.response.status_code
+        except (TypeError, ValueError, AttributeError, KeyError):
+            message = 'connection error'
+            status_code = 503
+
+        return cls(message, status_code)
+
 
 class DocumentDownloadClient:
 
@@ -13,15 +32,24 @@ class DocumentDownloadClient:
         return "{}/services/{}/documents".format(self.api_host, service_id)
 
     def upload_document(self, service_id, file_contents):
-        response = requests.post(
-            self.get_upload_url(service_id),
-            headers={
-                'Authorization': "Bearer {}".format(self.auth_token),
-            },
-            files={
-                'document': base64.b64decode(file_contents)
-            }
-        )
-        response.raise_for_status()
+        try:
+            response = requests.post(
+                self.get_upload_url(service_id),
+                headers={
+                    'Authorization': "Bearer {}".format(self.auth_token),
+                },
+                files={
+                    'document': base64.b64decode(file_contents)
+                }
+            )
+
+            response.raise_for_status()
+        except requests.RequestException as e:
+            error = DocumentDownloadError.from_exception(e)
+            current_app.logger.warning(
+                'Document download request failed with error: {}'.format(error.message)
+            )
+
+            raise error
 
         return response.json()['document']['url']

--- a/app/config.py
+++ b/app/config.py
@@ -318,6 +318,9 @@ class Config(object):
     TEMPLATE_PREVIEW_API_HOST = os.environ.get('TEMPLATE_PREVIEW_API_HOST', 'http://localhost:6013')
     TEMPLATE_PREVIEW_API_KEY = os.environ.get('TEMPLATE_PREVIEW_API_KEY', 'my-secret-key')
 
+    DOCUMENT_DOWNLOAD_API_HOST = os.environ.get('DOCUMENT_DOWNLOAD_API_HOST', 'http://localhost:7000')
+    DOCUMENT_DOWNLOAD_API_KEY = os.environ.get('DOCUMENT_DOWNLOAD_API_KEY', 'auth-token')
+
     LETTER_PROCESSING_DEADLINE = time(17, 30)
 
     MMG_URL = "https://api.mmg.co.uk/json/api.php"

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -138,7 +138,7 @@ def post_notification(notification_type):
             reply_to_text=reply_to
         )
     else:
-        notification, personalisation = process_sms_or_email_notification(
+        notification = process_sms_or_email_notification(
             form=form,
             notification_type=notification_type,
             api_key=api_user,
@@ -147,7 +147,7 @@ def post_notification(notification_type):
             reply_to_text=reply_to
         )
 
-        template_with_content.values = personalisation
+        template_with_content.values = notification.personalisation
 
     if notification_type == SMS_TYPE:
         create_resp_partial = functools.partial(
@@ -216,7 +216,7 @@ def process_sms_or_email_notification(*, form, notification_type, api_key, templ
         else:
             current_app.logger.debug("POST simulated notification for id: {}".format(notification.id))
 
-    return notification, personalisation
+    return notification
 
 
 def process_document_uploads(personalisation_data, service, simulated=False):

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -7,7 +7,7 @@ from flask import request, jsonify, current_app, abort
 from notifications_utils.pdf import pdf_page_count, PdfReadError
 from notifications_utils.recipients import try_validate_and_format_phone_number
 
-from app import api_user, authenticated_service, notify_celery
+from app import api_user, authenticated_service, notify_celery, document_download_client
 from app.config import QueueNames, TaskNames
 from app.dao.notifications_dao import dao_update_notification, update_notification_status_by_reference
 from app.dao.templates_dao import dao_create_template
@@ -19,6 +19,7 @@ from app.models import (
     EMAIL_TYPE,
     LETTER_TYPE,
     PRECOMPILED_LETTER,
+    UPLOAD_DOCUMENT,
     PRIORITY,
     KEY_TYPE_TEST,
     KEY_TYPE_TEAM,
@@ -136,7 +137,7 @@ def post_notification(notification_type):
             reply_to_text=reply_to
         )
     else:
-        notification = process_sms_or_email_notification(
+        notification, personalisation = process_sms_or_email_notification(
             form=form,
             notification_type=notification_type,
             api_key=api_user,
@@ -144,6 +145,8 @@ def post_notification(notification_type):
             service=authenticated_service,
             reply_to_text=reply_to
         )
+
+        template_with_content.values = personalisation
 
     if notification_type == SMS_TYPE:
         create_resp_partial = functools.partial(
@@ -182,12 +185,14 @@ def process_sms_or_email_notification(*, form, notification_type, api_key, templ
     # Do not persist or send notification to the queue if it is a simulated recipient
     simulated = simulated_recipient(send_to, notification_type)
 
+    personalisation = process_document_uploads(form.get('personalisation'), service, simulated=simulated)
+
     notification = persist_notification(
         template_id=template.id,
         template_version=template.version,
         recipient=form_send_to,
         service=service,
-        personalisation=form.get('personalisation', None),
+        personalisation=personalisation,
         notification_type=notification_type,
         api_key_id=api_key.id,
         key_type=api_key.key_type,
@@ -210,7 +215,27 @@ def process_sms_or_email_notification(*, form, notification_type, api_key, templ
         else:
             current_app.logger.debug("POST simulated notification for id: {}".format(notification.id))
 
-    return notification
+    return notification, personalisation
+
+
+def process_document_uploads(personalisation_data, service, simulated=False):
+    file_keys = [k for k, v in (personalisation_data or {}).items() if isinstance(v, dict) and 'file' in v]
+    if not file_keys:
+        return personalisation_data
+
+    personalisation_data = personalisation_data.copy()
+
+    check_service_has_permission(UPLOAD_DOCUMENT, authenticated_service.permissions)
+
+    for key in file_keys:
+        if simulated:
+            personalisation_data[key] = document_download_client.get_upload_url(service.id) + '/test-document'
+        else:
+            personalisation_data[key] = document_download_client.upload_document(
+                service.id, personalisation_data[key]['file']
+            )
+
+    return personalisation_data
 
 
 def process_letter_notification(*, letter_data, api_key, template, reply_to_text, precompiled=False):

--- a/tests/app/clients/test_document_download.py
+++ b/tests/app/clients/test_document_download.py
@@ -1,0 +1,37 @@
+import requests
+import requests_mock
+import pytest
+
+from app.clients.document_download import DocumentDownloadClient
+
+
+@pytest.fixture(scope='function')
+def document_download(client, mocker):
+    client = DocumentDownloadClient()
+    current_app = mocker.Mock(config={
+        'DOCUMENT_DOWNLOAD_API_HOST': 'https://document-download',
+        'DOCUMENT_DOWNLOAD_API_KEY': 'test-key'
+    })
+    client.init_app(current_app)
+    return client
+
+
+def test_get_upload_url(document_download):
+    assert document_download.get_upload_url('service-id') == 'https://document-download/services/service-id/documents'
+
+
+def test_upload_document(document_download):
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post('https://document-download/services/service-id/documents', json={
+            'document': {'url': 'https://document-download/services/service-id/documents/uploaded-url'}
+        }, status_code=201)
+
+        resp = document_download.upload_document('service-id', 'abababab')
+
+    assert resp == 'https://document-download/services/service-id/documents/uploaded-url'
+
+
+def test_should_raise_for_status(document_download):
+    with pytest.raises(requests.HTTPError), requests_mock.Mocker() as request_mock:
+        request_mock.post('https://document-download/services/service-id/documents', json={}, status_code=403)
+        document_download.upload_document('service-id', 'abababab')

--- a/tests/app/clients/test_document_download.py
+++ b/tests/app/clients/test_document_download.py
@@ -24,6 +24,8 @@ def test_upload_document(document_download):
     with requests_mock.Mocker() as request_mock:
         request_mock.post('https://document-download/services/service-id/documents', json={
             'document': {'url': 'https://document-download/services/service-id/documents/uploaded-url'}
+        }, request_headers={
+            'Authorization': 'Bearer test-key',
         }, status_code=201)
 
         resp = document_download.upload_document('service-id', 'abababab')


### PR DESCRIPTION
### Add a document download client

Allows uploading documents to the Document Download API. The client is configured with an API host and auth token. There's no need for a flag to disable the client in the test environments at the moment since the upload is only triggered by a specific payload which would only be sent with an explicit goal of using document download.

### Upload files from personalisation data to document download

Adds support for a new personalisation value type: file upload.

File uploads are represented as a dictionary with a "file" key and a base64-encoded file data as the key's value:

``` personalisation={ 'field1': {'file': '<base64-encoded file contents>'} } ```

Post notification endpoint checks the request personalisation data looking for the file uploads in personalisation data. If any are found and the service has permissions to upload documents the files are sent to document download API and personalisation values are replaced with the URLs returned in the document download response.

A fake document URL is returned for simulated notifications, no documents are stored in Document Download.

Multiple files can be uploaded for one notification by providing a file upload in more than one personalisation field.
