### PR TITLE
refactor post letters

### DIFF
--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -64,16 +64,16 @@ def get_reference_from_filename(filename):
     return filename_parts[1]
 
 
-def upload_letter_pdf(notification, pdf_data):
+def upload_letter_pdf(notification, pdf_data, precompiled=False):
     current_app.logger.info("PDF Letter {} reference {} created at {}, {} bytes".format(
         notification.id, notification.reference, notification.created_at, len(pdf_data)))
 
     upload_file_name = get_letter_pdf_filename(
         notification.reference,
         notification.service.crown,
-        is_scan_letter=notification.template.is_precompiled_letter)
+        is_scan_letter=precompiled)
 
-    if notification.template.is_precompiled_letter:
+    if precompiled:
         bucket_name = current_app.config['LETTERS_SCAN_BUCKET_NAME']
     else:
         bucket_name = current_app.config['LETTERS_PDF_BUCKET_NAME']

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -128,7 +128,7 @@ def test_upload_letter_pdf_to_correct_bucket(
         is_scan_letter=is_precompiled_letter
     )
 
-    upload_letter_pdf(sample_letter_notification, b'\x00\x01')
+    upload_letter_pdf(sample_letter_notification, b'\x00\x01', precompiled=is_precompiled_letter)
 
     mock_s3.assert_called_once_with(
         bucket_name=current_app.config[bucket_config_name],


### PR DESCRIPTION
Refactor process_letter_notification to make the code easier to read.
- Separated the logic of precompiled and template letters.
- Remove the check for research mode, research mode is not relevant to api calls. The test key is used for testing.
Refactor upload_pdf_letter to accept a precompile boolean to save a query to template.