### PR TITLE
Add is_active column for the 3 reply_to tables

### DIFF
--- a/migrations/versions/0185_add_is_active_to_reply_tos.py
+++ b/migrations/versions/0185_add_is_active_to_reply_tos.py
@@ -1,0 +1,25 @@
+"""
+
+Revision ID: 0185_add_is_active_to_reply_tos
+Revises: 0184_alter_primary_key_1
+Create Date: 2018-04-10 16:35:41.824981
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0185_add_is_active_to_reply_tos'
+down_revision = '0184_alter_primary_key_1'
+
+
+def upgrade():
+    op.add_column('service_email_reply_to', sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.true()))
+    op.add_column('service_letter_contacts', sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.true()))
+    op.add_column('service_sms_senders', sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.true()))
+
+
+def downgrade():
+    op.drop_column('service_sms_senders', 'is_active')
+    op.drop_column('service_letter_contacts', 'is_active')
+    op.drop_column('service_email_reply_to', 'is_active')


### PR DESCRIPTION
Added a new boolean column, `is_active` to the tables for the reply_to addresses:
* `service_email_reply_to`
* `service_sms_senders`
* `service_letter_contacts`

This has a database default of `True` in order to backfill the data, but
this default will be replaced with a model default and then removed later.

[Pivotal story](https://www.pivotaltracker.com/story/show/156476018)