### PR TITLE
Allow reply to addresses to be made inactive

### DIFF
--- a/app/dao/service_email_reply_to_dao.py
+++ b/app/dao/service_email_reply_to_dao.py
@@ -10,7 +10,8 @@ def dao_get_reply_to_by_service_id(service_id):
     reply_to = db.session.query(
         ServiceEmailReplyTo
     ).filter(
-        ServiceEmailReplyTo.service_id == service_id
+        ServiceEmailReplyTo.service_id == service_id,
+        ServiceEmailReplyTo.is_active == True  # noqa
     ).order_by(desc(ServiceEmailReplyTo.is_default), desc(ServiceEmailReplyTo.created_at)).all()
     return reply_to
 
@@ -20,7 +21,8 @@ def dao_get_reply_to_by_id(service_id, reply_to_id):
         ServiceEmailReplyTo
     ).filter(
         ServiceEmailReplyTo.service_id == service_id,
-        ServiceEmailReplyTo.id == reply_to_id
+        ServiceEmailReplyTo.id == reply_to_id,
+        ServiceEmailReplyTo.is_active == True  # noqa
     ).order_by(ServiceEmailReplyTo.created_at).one()
     return reply_to
 

--- a/app/dao/service_email_reply_to_dao.py
+++ b/app/dao/service_email_reply_to_dao.py
@@ -3,6 +3,7 @@ from sqlalchemy import desc
 from app import db
 from app.dao.dao_utils import transactional
 from app.errors import InvalidRequest
+from app.exceptions import ValidationError
 from app.models import ServiceEmailReplyTo
 
 
@@ -54,6 +55,19 @@ def update_reply_to_email_address(service_id, reply_to_id, email_address, is_def
     reply_to_update.is_default = is_default
     db.session.add(reply_to_update)
     return reply_to_update
+
+
+@transactional
+def set_reply_to_inactive(service_id, reply_to_id):
+    reply_to_for_updating = ServiceEmailReplyTo.query.get(reply_to_id)
+
+    if reply_to_for_updating.is_default:
+        raise ValidationError("You cannot delete a default email reply to address")
+
+    reply_to_for_updating.is_active = False
+
+    db.session.add(reply_to_for_updating)
+    return reply_to_for_updating
 
 
 def _get_existing_default(service_id):

--- a/app/dao/service_letter_contact_dao.py
+++ b/app/dao/service_letter_contact_dao.py
@@ -10,7 +10,8 @@ def dao_get_letter_contacts_by_service_id(service_id):
     letter_contacts = db.session.query(
         ServiceLetterContact
     ).filter(
-        ServiceLetterContact.service_id == service_id
+        ServiceLetterContact.service_id == service_id,
+        ServiceLetterContact.is_active == True  # noqa
     ).order_by(
         desc(ServiceLetterContact.is_default),
         desc(ServiceLetterContact.created_at)
@@ -24,7 +25,8 @@ def dao_get_letter_contact_by_id(service_id, letter_contact_id):
         ServiceLetterContact
     ).filter(
         ServiceLetterContact.service_id == service_id,
-        ServiceLetterContact.id == letter_contact_id
+        ServiceLetterContact.id == letter_contact_id,
+        ServiceLetterContact.is_active == True  # noqa
     ).one()
     return letter_contact
 

--- a/app/dao/service_sms_sender_dao.py
+++ b/app/dao/service_sms_sender_dao.py
@@ -19,12 +19,16 @@ def insert_service_sms_sender(service, sms_sender):
 def dao_get_service_sms_senders_by_id(service_id, service_sms_sender_id):
     return ServiceSmsSender.query.filter_by(
         id=service_sms_sender_id,
-        service_id=service_id
+        service_id=service_id,
+        is_active=True
     ).one()
 
 
 def dao_get_sms_senders_by_service_id(service_id):
-    return ServiceSmsSender.query.filter_by(service_id=service_id).order_by(desc(ServiceSmsSender.is_default)).all()
+    return ServiceSmsSender.query.filter_by(
+        service_id=service_id,
+        is_active=True
+    ).order_by(desc(ServiceSmsSender.is_default)).all()
 
 
 @transactional

--- a/app/dao/service_sms_sender_dao.py
+++ b/app/dao/service_sms_sender_dao.py
@@ -2,6 +2,7 @@ from sqlalchemy import desc
 
 from app import db
 from app.dao.dao_utils import transactional
+from app.exceptions import ValidationError
 from app.models import ServiceSmsSender
 
 
@@ -73,6 +74,21 @@ def update_existing_sms_sender_with_inbound_number(service_sms_sender, sms_sende
     service_sms_sender.inbound_number_id = inbound_number_id
     db.session.add(service_sms_sender)
     return service_sms_sender
+
+
+@transactional
+def dao_set_service_sms_sender_inactive(service_id, service_sms_sender_id):
+    sms_sender_to_update = ServiceSmsSender.query.get(service_sms_sender_id)
+
+    if sms_sender_to_update.inbound_number_id:
+        raise ValidationError("You cannot delete an inbound number")
+    if sms_sender_to_update.is_default:
+        raise ValidationError("You cannot delete a default sms sender")
+
+    sms_sender_to_update.is_active = False
+
+    db.session.add(sms_sender_to_update)
+    return sms_sender_to_update
 
 
 def _get_existing_default(service_id):

--- a/app/errors.py
+++ b/app/errors.py
@@ -5,9 +5,10 @@ from flask import (
 from notifications_utils.recipients import InvalidEmailError
 from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
-from marshmallow import ValidationError
+from marshmallow import ValidationError as MarshmallowValidationError
 from jsonschema import ValidationError as JsonSchemaValidationError
 from app.authentication.auth import AuthError
+from app.exceptions import ValidationError
 
 
 class VirusScanError(Exception):
@@ -58,6 +59,11 @@ def register_errors(blueprint):
         return jsonify(result='error', message=error.message), error.code
 
     @blueprint.errorhandler(ValidationError)
+    def validation_error(error):
+        current_app.logger.info(error)
+        return jsonify(result='error', message=str(error)), 400
+
+    @blueprint.errorhandler(MarshmallowValidationError)
     def marshmallow_validation_error(error):
         current_app.logger.info(error)
         return jsonify(result='error', message=error.messages), 400

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -6,3 +6,7 @@ class DVLAException(Exception):
 class NotificationTechnicalFailureException(Exception):
     def __init__(self, message):
         self.message = message
+
+
+class ValidationError(Exception):
+    pass

--- a/app/models.py
+++ b/app/models.py
@@ -472,6 +472,7 @@ class ServiceSmsSender(db.Model):
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey('services.id'), index=True, nullable=False, unique=False)
     service = db.relationship(Service, backref=db.backref("service_sms_senders", uselist=True))
     is_default = db.Column(db.Boolean, nullable=False, default=True)
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
     inbound_number_id = db.Column(UUID(as_uuid=True), db.ForeignKey('inbound_numbers.id'),
                                   unique=True, index=True, nullable=True)
     inbound_number = db.relationship(InboundNumber, backref=db.backref("inbound_number", uselist=False))
@@ -487,6 +488,7 @@ class ServiceSmsSender(db.Model):
             "sms_sender": self.sms_sender,
             "service_id": str(self.service_id),
             "is_default": self.is_default,
+            "is_active": self.is_active,
             "inbound_number_id": str(self.inbound_number_id) if self.inbound_number_id else None,
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
             "updated_at": self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None,
@@ -1670,6 +1672,7 @@ class ServiceEmailReplyTo(db.Model):
 
     email_address = db.Column(db.Text, nullable=False, index=False, unique=False)
     is_default = db.Column(db.Boolean, nullable=False, default=True)
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
 
@@ -1679,6 +1682,7 @@ class ServiceEmailReplyTo(db.Model):
             'service_id': str(self.service_id),
             'email_address': self.email_address,
             'is_default': self.is_default,
+            'is_active': self.is_active,
             'created_at': self.created_at.strftime(DATETIME_FORMAT),
             'updated_at': self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None
         }
@@ -1694,6 +1698,7 @@ class ServiceLetterContact(db.Model):
 
     contact_block = db.Column(db.Text, nullable=False, index=False, unique=False)
     is_default = db.Column(db.Boolean, nullable=False, default=True)
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
 
@@ -1703,6 +1708,7 @@ class ServiceLetterContact(db.Model):
             'service_id': str(self.service_id),
             'contact_block': self.contact_block,
             'is_default': self.is_default,
+            'is_active': self.is_active,
             'created_at': self.created_at.strftime(DATETIME_FORMAT),
             'updated_at': self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None
         }

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -62,6 +62,7 @@ from app.dao.service_letter_contact_dao import (
     dao_get_letter_contacts_by_service_id,
     dao_get_letter_contact_by_id,
     add_letter_contact_for_service,
+    set_letter_contact_inactive,
     update_letter_contact
 )
 from app.dao.provider_statistics_dao import get_fragment_count
@@ -628,10 +629,14 @@ def update_service_letter_contact(service_id, letter_contact_id):
     # validate the service exists, throws ResultNotFound exception.
     dao_fetch_service_by_id(service_id)
     form = validate(request.get_json(), add_service_letter_contact_block_request)
-    new_reply_to = update_letter_contact(service_id=service_id,
-                                         letter_contact_id=letter_contact_id,
-                                         contact_block=form['contact_block'],
-                                         is_default=form.get('is_default', True))
+
+    if form.get('is_active', True) is False:
+        new_reply_to = set_letter_contact_inactive(service_id, letter_contact_id)
+    else:
+        new_reply_to = update_letter_contact(service_id=service_id,
+                                             letter_contact_id=letter_contact_id,
+                                             contact_block=form['contact_block'],
+                                             is_default=form.get('is_default', True))
     return jsonify(data=new_reply_to.serialize()), 200
 
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -54,6 +54,7 @@ from app.dao.service_email_reply_to_dao import (
     add_reply_to_email_address_for_service,
     dao_get_reply_to_by_id,
     dao_get_reply_to_by_service_id,
+    set_reply_to_inactive,
     update_reply_to_email_address
 )
 from app.dao.service_letter_contact_dao import (
@@ -587,10 +588,14 @@ def update_service_reply_to_email_address(service_id, reply_to_email_id):
     # validate the service exists, throws ResultNotFound exception.
     dao_fetch_service_by_id(service_id)
     form = validate(request.get_json(), add_service_email_reply_to_request)
-    new_reply_to = update_reply_to_email_address(service_id=service_id,
-                                                 reply_to_id=reply_to_email_id,
-                                                 email_address=form['email_address'],
-                                                 is_default=form.get('is_default', True))
+
+    if form.get('is_active', True) is False:
+        new_reply_to = set_reply_to_inactive(service_id, reply_to_email_id)
+    else:
+        new_reply_to = update_reply_to_email_address(service_id=service_id,
+                                                     reply_to_id=reply_to_email_id,
+                                                     email_address=form['email_address'],
+                                                     is_default=form.get('is_default', True))
     return jsonify(data=new_reply_to.serialize()), 200
 
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -24,6 +24,7 @@ from app.dao.service_sms_sender_dao import (
     dao_update_service_sms_sender,
     dao_get_service_sms_senders_by_id,
     dao_get_sms_senders_by_service_id,
+    dao_set_service_sms_sender_inactive,
     update_existing_sms_sender_with_inbound_number
 )
 from app.dao.services_dao import (
@@ -674,11 +675,14 @@ def update_service_sms_sender(service_id, sms_sender_id):
         raise InvalidRequest("You can not change the inbound number for service {}".format(service_id),
                              status_code=400)
 
-    new_sms_sender = dao_update_service_sms_sender(service_id=service_id,
-                                                   service_sms_sender_id=sms_sender_id,
-                                                   is_default=form['is_default'],
-                                                   sms_sender=form['sms_sender']
-                                                   )
+    if form.get('is_active', True) is False:
+        new_sms_sender = dao_set_service_sms_sender_inactive(service_id, sms_sender_id)
+    else:
+        new_sms_sender = dao_update_service_sms_sender(service_id=service_id,
+                                                       service_sms_sender_id=sms_sender_id,
+                                                       is_default=form['is_default'],
+                                                       sms_sender=form['sms_sender']
+                                                       )
     return jsonify(new_sms_sender.serialize()), 200
 
 

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -90,14 +90,15 @@ def send_one_off_notification(service_id, post_data):
 def get_reply_to_text(notification_type, sender_id, service, template):
     reply_to = None
     if sender_id:
-        if notification_type == EMAIL_TYPE:
-            try:
-                reply_to = dao_get_reply_to_by_id(service.id, sender_id).email_address
-            except NoResultFound:
+        try:
+            if notification_type == EMAIL_TYPE:
                 message = 'Reply to email address not found'
-                raise BadRequestError(message=message)
-        elif notification_type == SMS_TYPE:
-            reply_to = dao_get_service_sms_senders_by_id(service.id, sender_id).get_reply_to_text()
+                reply_to = dao_get_reply_to_by_id(service.id, sender_id).email_address
+            elif notification_type == SMS_TYPE:
+                message = 'SMS sender not found'
+                reply_to = dao_get_service_sms_senders_by_id(service.id, sender_id).get_reply_to_text()
+        except NoResultFound:
+            raise BadRequestError(message=message)
     else:
         reply_to = template.get_reply_to_text()
     return reply_to

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -1,3 +1,5 @@
+from sqlalchemy.orm.exc import NoResultFound
+
 from app.config import QueueNames
 from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_id
 from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id
@@ -89,7 +91,11 @@ def get_reply_to_text(notification_type, sender_id, service, template):
     reply_to = None
     if sender_id:
         if notification_type == EMAIL_TYPE:
-            reply_to = dao_get_reply_to_by_id(service.id, sender_id).email_address
+            try:
+                reply_to = dao_get_reply_to_by_id(service.id, sender_id).email_address
+            except NoResultFound:
+                message = 'Reply to email address not found'
+                raise BadRequestError(message=message)
         elif notification_type == SMS_TYPE:
             reply_to = dao_get_service_sms_senders_by_id(service.id, sender_id).get_reply_to_text()
     else:

--- a/app/service/service_senders_schema.py
+++ b/app/service/service_senders_schema.py
@@ -21,7 +21,8 @@ add_service_letter_contact_block_request = {
     "title": "Add new letter contact block for service",
     "properties": {
         "contact_block": {"type": "string"},
-        "is_default": {"type": "boolean"}
+        "is_default": {"type": "boolean"},
+        "is_active": {"type": "boolean"}
     },
     "required": ["contact_block", "is_default"]
 }

--- a/app/service/service_senders_schema.py
+++ b/app/service/service_senders_schema.py
@@ -35,6 +35,7 @@ add_service_sms_sender_request = {
     "properties": {
         "sms_sender": {"type": "string"},
         "is_default": {"type": "boolean"},
+        "is_active": {"type": "boolean"},
         "inbound_number_id": uuid
     },
     "required": ["sms_sender", "is_default"]

--- a/app/service/service_senders_schema.py
+++ b/app/service/service_senders_schema.py
@@ -7,7 +7,8 @@ add_service_email_reply_to_request = {
     "title": "Add new email reply to address for service",
     "properties": {
         "email_address": {"type": "string", "format": "email_address"},
-        "is_default": {"type": "boolean"}
+        "is_default": {"type": "boolean"},
+        "is_active": {"type": "boolean"}
     },
     "required": ["email_address", "is_default"]
 }

--- a/tests/app/dao/test_service_email_reply_to_dao.py
+++ b/tests/app/dao/test_service_email_reply_to_dao.py
@@ -4,9 +4,13 @@ import pytest
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.dao.service_email_reply_to_dao import (
+    add_reply_to_email_address_for_service,
+    dao_get_reply_to_by_id,
     dao_get_reply_to_by_service_id,
-    add_reply_to_email_address_for_service, update_reply_to_email_address, dao_get_reply_to_by_id)
+    set_reply_to_inactive,
+    update_reply_to_email_address)
 from app.errors import InvalidRequest
+from app.exceptions import ValidationError
 from app.models import ServiceEmailReplyTo
 from tests.app.db import create_reply_to_email, create_service
 
@@ -167,6 +171,33 @@ def test_update_reply_to_email_address_raises_exception_if_single_reply_to_and_s
                                       reply_to_id=first_reply_to.id,
                                       email_address='should@fail.com',
                                       is_default=False)
+
+
+def test_set_reply_to_inactive_changes_is_active_to_false(sample_service):
+    create_reply_to_email(service=sample_service, email_address="first@address.com")
+    second_reply_to = create_reply_to_email(
+        service=sample_service,
+        email_address="first@address.com",
+        is_default=False)
+
+    set_reply_to_inactive(sample_service.id, second_reply_to.id)
+
+    assert not second_reply_to.is_active
+    assert second_reply_to.updated_at is not None
+
+
+def test_set_reply_to_inactive_does_not_inactivate_a_default_reply_to(sample_service):
+    create_reply_to_email(
+        service=sample_service,
+        email_address="first@address.com",
+        is_default=False)
+    reply_to = create_reply_to_email(service=sample_service, email_address="first@address.com")
+
+    with pytest.raises(ValidationError) as e:
+        set_reply_to_inactive(sample_service.id, reply_to.id)
+
+    assert 'You cannot delete a default email reply to address' in str(e.value)
+    assert reply_to.is_active
 
 
 def test_dao_get_reply_to_by_id(sample_service):

--- a/tests/app/dao/test_service_email_reply_to_dao.py
+++ b/tests/app/dao/test_service_email_reply_to_dao.py
@@ -35,6 +35,7 @@ def test_add_reply_to_email_address_for_service_creates_first_email_for_service(
     assert len(results) == 1
     assert results[0].email_address == 'new@address.com'
     assert results[0].is_default
+    assert results[0].is_active
 
 
 def test_add_reply_to_email_address_for_service_creates_another_email_for_service(notify_db_session):

--- a/tests/app/dao/test_service_letter_contact_dao.py
+++ b/tests/app/dao/test_service_letter_contact_dao.py
@@ -39,9 +39,11 @@ def test_add_letter_contact_for_service_creates_additional_letter_contact_for_se
 
     assert results[0].contact_block == 'Edinburgh, ED1 1AA'
     assert results[0].is_default
+    assert results[0].is_active
 
     assert results[1].contact_block == 'Swansea, SN1 3CC'
     assert not results[1].is_default
+    assert results[1].is_active
 
 
 def test_add_another_letter_contact_as_default_overrides_existing(notify_db_session):

--- a/tests/app/dao/test_service_sms_sender_dao.py
+++ b/tests/app/dao/test_service_sms_sender_dao.py
@@ -58,6 +58,7 @@ def test_dao_add_sms_sender_for_service(notify_db_session):
     assert len(service_sms_senders) == 2
     assert service_sms_senders[0].sms_sender == 'testing'
     assert service_sms_senders[0].is_default
+    assert service_sms_senders[0].is_active
     assert service_sms_senders[1] == new_sms_sender
 
 

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -399,12 +399,14 @@ def create_monthly_billing_entry(
 def create_reply_to_email(
     service,
     email_address,
-    is_default=True
+    is_default=True,
+    is_active=True
 ):
     data = {
         'service': service,
         'email_address': email_address,
         'is_default': is_default,
+        'is_active': is_active,
     }
     reply_to = ServiceEmailReplyTo(**data)
 

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -439,12 +439,14 @@ def create_service_sms_sender(
 def create_letter_contact(
     service,
     contact_block,
-    is_default=True
+    is_default=True,
+    is_active=True
 ):
     data = {
         'service': service,
         'contact_block': contact_block,
         'is_default': is_default,
+        'is_active': is_active,
     }
     letter_content = ServiceLetterContact(**data)
 

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -420,13 +420,15 @@ def create_service_sms_sender(
     service,
     sms_sender,
     is_default=True,
-    inbound_number_id=None
+    inbound_number_id=None,
+    is_active=True
 ):
     data = {
         'service_id': service.id,
         'sms_sender': sms_sender,
         'is_default': is_default,
-        'inbound_number_id': inbound_number_id
+        'inbound_number_id': inbound_number_id,
+        'is_active': is_active,
     }
     service_sms_sender = ServiceSmsSender(**data)
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -10,6 +10,7 @@ from freezegun import freeze_time
 
 from app.celery.scheduled_tasks import daily_stats_template_usage_by_month
 from app.dao.organisation_dao import dao_add_service_to_organisation
+from app.dao.service_sms_sender_dao import dao_get_sms_senders_by_service_id
 from app.dao.services_dao import dao_remove_user_from_service
 from app.dao.templates_dao import dao_redact_template
 from app.dao.users_dao import save_model_user
@@ -2715,9 +2716,10 @@ def test_add_service_sms_sender_can_add_multiple_senders(client, notify_db_sessi
     assert len(senders) == 2
 
 
-def test_add_service_sms_sender_when_it_is_an_inbound_number_updates_the_only_existing_sms_sender(
+def test_add_service_sms_sender_when_it_is_an_inbound_number_updates_the_only_existing_active_sms_sender(
         client, notify_db_session):
     service = create_service_with_defined_sms_sender(sms_sender_value='GOVUK')
+    create_service_sms_sender(service=service, sms_sender="inactive", is_default=False, is_active=False)
     inbound_number = create_inbound_number(number='12345')
     data = {
         "sms_sender": str(inbound_number.id),
@@ -2736,7 +2738,7 @@ def test_add_service_sms_sender_when_it_is_an_inbound_number_updates_the_only_ex
     assert resp_json['inbound_number_id'] == str(inbound_number.id)
     assert resp_json['is_default']
 
-    senders = ServiceSmsSender.query.all()
+    senders = dao_get_sms_senders_by_service_id(service.id)
     assert len(senders) == 1
 
 

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -309,7 +309,7 @@ def test_send_one_off_sms_notification_should_use_default_service_reply_to_text(
     assert notification.reply_to_text == "447123123456"
 
 
-def test_send_one_off_notification_should_throw_exception_if_reply_to_id_doesnot_exist(
+def test_send_one_off_notification_should_throw_exception_if_reply_to_id_does_not_exist(
         sample_email_template
 ):
     data = {
@@ -319,8 +319,9 @@ def test_send_one_off_notification_should_throw_exception_if_reply_to_id_doesnot
         'created_by': str(sample_email_template.service.created_by_id)
     }
 
-    with pytest.raises(expected_exception=SQLAlchemyError):
+    with pytest.raises(expected_exception=BadRequestError)as e:
         send_one_off_notification(service_id=sample_email_template.service.id, post_data=data)
+    assert e.value.message == 'Reply to email address not found'
 
 
 def test_send_one_off_notification_should_throw_exception_if_sms_sender_id_doesnot_exist(

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock
 
 import pytest
 from notifications_utils.recipients import InvalidPhoneError
-from sqlalchemy.exc import SQLAlchemyError
 
 from app.v2.errors import BadRequestError, TooManyRequestsError
 from app.config import QueueNames
@@ -324,7 +323,7 @@ def test_send_one_off_notification_should_throw_exception_if_reply_to_id_does_no
     assert e.value.message == 'Reply to email address not found'
 
 
-def test_send_one_off_notification_should_throw_exception_if_sms_sender_id_doesnot_exist(
+def test_send_one_off_notification_should_throw_exception_if_sms_sender_id_does_not_exist(
         sample_template
 ):
     data = {
@@ -334,5 +333,6 @@ def test_send_one_off_notification_should_throw_exception_if_sms_sender_id_doesn
         'created_by': str(sample_template.service.created_by_id)
     }
 
-    with pytest.raises(expected_exception=SQLAlchemyError):
+    with pytest.raises(expected_exception=BadRequestError) as e:
         send_one_off_notification(service_id=sample_template.service.id, post_data=data)
+    assert e.value.message == 'SMS sender not found'


### PR DESCRIPTION
It should be possible to delete the three types of reply-to addresses:
* `service_email_reply_to`
* `service_sms_sender`
* `service_letter_contact`

It isn't possible to hard delete letter contacts because they are referenced by the Template table, so to keep the ways things work consistent between all notification types, we mark the reply-to addresses as inactive instead.

### Work done
#### Updated DAO functions to return reply-to addresses
The DAO functions to return one and all reply-to addresses now only return the active ones.

#### Added DAO functions that delete the reply-to addresses
Added a DAO function for each notification type which sets the reply-to address to inactive. There are various edge cases that need to be accounted for:
- You shouldn't be able to delete a default reply-to address
- For SMS, you shouldn't be able to delete an inbound number
- In addition to having a default letter contact block for a service, letters can also have default letter contact block for a template - template defaults should not be able to be deleted

### Pivotal story
https://www.pivotaltracker.com/story/show/156476018