### PR TITLE
Adjust get_service_stats to get counts for a maximum of 7 days ago

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -251,7 +251,9 @@ def delete_service_and_all_associated_db_objects(service):
 
 @statsd(namespace="dao")
 def dao_fetch_stats_for_service(service_id):
-    return _stats_for_service_query(service_id).all()
+    return _stats_for_service_query(service_id).filter(
+        func.date(Notification.created_at) >= date.today() - timedelta(days=7)
+    ).all()
 
 
 @statsd(namespace="dao")


### PR DESCRIPTION
## Adjust get_service_stats to get counts for a maximum of 7 days ago
### Summary
Previously, the dashboard totals on the main page and activity page were gathering counts based off all the notifications in the table. This PR filters the amount of notifications gathered so that the count is only based off the previous 7 days, inclusive of all hours on the 7th day due to only checking on day rather than hour. 
### Changes
``` dao_fetch_stats_for_service ``` has an extra filter to filter out notifications with a created at older than 7 days from today.
### Tests 
- Test to ensure the notifications are correctly counted, notifcations with createdAts set to:
  - Current time
  - 7 days ago
  - 7 days 2 hours ago (To ensure it checks for the entire day) 
  - 8 days ago

