### PR TITLE
Allow reply-to addresses to be archived

### DIFF
--- a/app/dao/service_email_reply_to_dao.py
+++ b/app/dao/service_email_reply_to_dao.py
@@ -10,7 +10,8 @@ def dao_get_reply_to_by_service_id(service_id):
     reply_to = db.session.query(
         ServiceEmailReplyTo
     ).filter(
-        ServiceEmailReplyTo.service_id == service_id
+        ServiceEmailReplyTo.service_id == service_id,
+        ServiceEmailReplyTo.archived == False  # noqa
     ).order_by(desc(ServiceEmailReplyTo.is_default), desc(ServiceEmailReplyTo.created_at)).all()
     return reply_to
 
@@ -20,7 +21,8 @@ def dao_get_reply_to_by_id(service_id, reply_to_id):
         ServiceEmailReplyTo
     ).filter(
         ServiceEmailReplyTo.service_id == service_id,
-        ServiceEmailReplyTo.id == reply_to_id
+        ServiceEmailReplyTo.id == reply_to_id,
+        ServiceEmailReplyTo.archived == False  # noqa
     ).order_by(ServiceEmailReplyTo.created_at).one()
     return reply_to
 

--- a/app/dao/service_letter_contact_dao.py
+++ b/app/dao/service_letter_contact_dao.py
@@ -10,7 +10,8 @@ def dao_get_letter_contacts_by_service_id(service_id):
     letter_contacts = db.session.query(
         ServiceLetterContact
     ).filter(
-        ServiceLetterContact.service_id == service_id
+        ServiceLetterContact.service_id == service_id,
+        ServiceLetterContact.archived == False  # noqa
     ).order_by(
         desc(ServiceLetterContact.is_default),
         desc(ServiceLetterContact.created_at)
@@ -24,7 +25,8 @@ def dao_get_letter_contact_by_id(service_id, letter_contact_id):
         ServiceLetterContact
     ).filter(
         ServiceLetterContact.service_id == service_id,
-        ServiceLetterContact.id == letter_contact_id
+        ServiceLetterContact.id == letter_contact_id,
+        ServiceLetterContact.archived == False  # noqa
     ).one()
     return letter_contact
 

--- a/app/dao/service_letter_contact_dao.py
+++ b/app/dao/service_letter_contact_dao.py
@@ -3,7 +3,8 @@ from sqlalchemy import desc
 from app import db
 from app.dao.dao_utils import transactional
 from app.errors import InvalidRequest
-from app.models import ServiceLetterContact
+from app.exceptions import ArchiveValidationError
+from app.models import ServiceLetterContact, Template
 
 
 def dao_get_letter_contacts_by_service_id(service_id):
@@ -63,6 +64,32 @@ def update_letter_contact(service_id, letter_contact_id, contact_block, is_defau
     letter_contact_update.is_default = is_default
     db.session.add(letter_contact_update)
     return letter_contact_update
+
+
+@transactional
+def archive_letter_contact(service_id, letter_contact_id):
+    letter_contact_to_archive = ServiceLetterContact.query.filter_by(
+        id=letter_contact_id,
+        service_id=service_id
+    ).one()
+
+    if _is_template_default(letter_contact_id):
+        raise ArchiveValidationError("You cannot delete the default letter contact block for a template")
+    if letter_contact_to_archive.is_default:
+        raise ArchiveValidationError("You cannot delete a default letter contact block")
+
+    letter_contact_to_archive.archived = True
+
+    db.session.add(letter_contact_to_archive)
+    return letter_contact_to_archive
+
+
+def _is_template_default(letter_contact_id):
+    template_defaults = Template.query.filter_by(
+        service_letter_contact_id=letter_contact_id
+    ).all()
+
+    return any(template_defaults)
 
 
 def _get_existing_default(service_id):

--- a/app/dao/service_sms_sender_dao.py
+++ b/app/dao/service_sms_sender_dao.py
@@ -19,12 +19,16 @@ def insert_service_sms_sender(service, sms_sender):
 def dao_get_service_sms_senders_by_id(service_id, service_sms_sender_id):
     return ServiceSmsSender.query.filter_by(
         id=service_sms_sender_id,
-        service_id=service_id
+        service_id=service_id,
+        archived=False
     ).one()
 
 
 def dao_get_sms_senders_by_service_id(service_id):
-    return ServiceSmsSender.query.filter_by(service_id=service_id).order_by(desc(ServiceSmsSender.is_default)).all()
+    return ServiceSmsSender.query.filter_by(
+        service_id=service_id,
+        archived=False
+    ).order_by(desc(ServiceSmsSender.is_default)).all()
 
 
 @transactional

--- a/app/dao/service_sms_sender_dao.py
+++ b/app/dao/service_sms_sender_dao.py
@@ -2,6 +2,7 @@ from sqlalchemy import desc
 
 from app import db
 from app.dao.dao_utils import transactional
+from app.exceptions import ArchiveValidationError
 from app.models import ServiceSmsSender
 
 
@@ -73,6 +74,24 @@ def update_existing_sms_sender_with_inbound_number(service_sms_sender, sms_sende
     service_sms_sender.inbound_number_id = inbound_number_id
     db.session.add(service_sms_sender)
     return service_sms_sender
+
+
+@transactional
+def archive_sms_sender(service_id, sms_sender_id):
+    sms_sender_to_archive = ServiceSmsSender.query.filter_by(
+        id=sms_sender_id,
+        service_id=service_id
+    ).one()
+
+    if sms_sender_to_archive.inbound_number_id:
+        raise ArchiveValidationError("You cannot delete an inbound number")
+    if sms_sender_to_archive.is_default:
+        raise ArchiveValidationError("You cannot delete a default sms sender")
+
+    sms_sender_to_archive.archived = True
+
+    db.session.add(sms_sender_to_archive)
+    return sms_sender_to_archive
 
 
 def _get_existing_default(service_id):

--- a/app/errors.py
+++ b/app/errors.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from marshmallow import ValidationError
 from jsonschema import ValidationError as JsonSchemaValidationError
 from app.authentication.auth import AuthError
+from app.exceptions import ArchiveValidationError
 
 
 class VirusScanError(Exception):
@@ -66,6 +67,11 @@ def register_errors(blueprint):
     def jsonschema_validation_error(error):
         current_app.logger.info(error)
         return jsonify(json.loads(error.message)), 400
+
+    @blueprint.errorhandler(ArchiveValidationError)
+    def archive_validation_error(error):
+        current_app.logger.info(error)
+        return jsonify(result='error', message=str(error)), 400
 
     @blueprint.errorhandler(InvalidRequest)
     def invalid_data(error):

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -6,3 +6,7 @@ class DVLAException(Exception):
 class NotificationTechnicalFailureException(Exception):
     def __init__(self, message):
         self.message = message
+
+
+class ArchiveValidationError(Exception):
+    pass

--- a/app/models.py
+++ b/app/models.py
@@ -472,6 +472,7 @@ class ServiceSmsSender(db.Model):
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey('services.id'), index=True, nullable=False, unique=False)
     service = db.relationship(Service, backref=db.backref("service_sms_senders", uselist=True))
     is_default = db.Column(db.Boolean, nullable=False, default=True)
+    archived = db.Column(db.Boolean, nullable=False, default=False)
     inbound_number_id = db.Column(UUID(as_uuid=True), db.ForeignKey('inbound_numbers.id'),
                                   unique=True, index=True, nullable=True)
     inbound_number = db.relationship(InboundNumber, backref=db.backref("inbound_number", uselist=False))
@@ -487,6 +488,7 @@ class ServiceSmsSender(db.Model):
             "sms_sender": self.sms_sender,
             "service_id": str(self.service_id),
             "is_default": self.is_default,
+            "archived": self.archived,
             "inbound_number_id": str(self.inbound_number_id) if self.inbound_number_id else None,
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
             "updated_at": self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None,
@@ -1670,6 +1672,7 @@ class ServiceEmailReplyTo(db.Model):
 
     email_address = db.Column(db.Text, nullable=False, index=False, unique=False)
     is_default = db.Column(db.Boolean, nullable=False, default=True)
+    archived = db.Column(db.Boolean, nullable=False, default=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
 
@@ -1679,6 +1682,7 @@ class ServiceEmailReplyTo(db.Model):
             'service_id': str(self.service_id),
             'email_address': self.email_address,
             'is_default': self.is_default,
+            'archived': self.archived,
             'created_at': self.created_at.strftime(DATETIME_FORMAT),
             'updated_at': self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None
         }
@@ -1694,6 +1698,7 @@ class ServiceLetterContact(db.Model):
 
     contact_block = db.Column(db.Text, nullable=False, index=False, unique=False)
     is_default = db.Column(db.Boolean, nullable=False, default=True)
+    archived = db.Column(db.Boolean, nullable=False, default=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
 
@@ -1703,6 +1708,7 @@ class ServiceLetterContact(db.Model):
             'service_id': str(self.service_id),
             'contact_block': self.contact_block,
             'is_default': self.is_default,
+            'archived': self.archived,
             'created_at': self.created_at.strftime(DATETIME_FORMAT),
             'updated_at': self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None
         }

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -20,6 +20,7 @@ from app.dao.api_key_dao import (
 from app.dao.inbound_numbers_dao import dao_allocate_number_for_service
 from app.dao.organisation_dao import dao_get_organisation_by_service_id
 from app.dao.service_sms_sender_dao import (
+    archive_sms_sender,
     dao_add_sms_sender_for_service,
     dao_update_service_sms_sender,
     dao_get_service_sms_senders_by_id,
@@ -683,6 +684,13 @@ def update_service_sms_sender(service_id, sms_sender_id):
                                                    sms_sender=form['sms_sender']
                                                    )
     return jsonify(new_sms_sender.serialize()), 200
+
+
+@service_blueprint.route('/<uuid:service_id>/sms-sender/<uuid:sms_sender_id>/archive', methods=['POST'])
+def delete_service_sms_sender(service_id, sms_sender_id):
+    sms_sender = archive_sms_sender(service_id, sms_sender_id)
+
+    return jsonify(data=sms_sender.serialize()), 200
 
 
 @service_blueprint.route('/<uuid:service_id>/sms-sender/<uuid:sms_sender_id>', methods=['GET'])

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -52,6 +52,7 @@ from app.dao.service_whitelist_dao import (
 )
 from app.dao.service_email_reply_to_dao import (
     add_reply_to_email_address_for_service,
+    archive_reply_to_email_address,
     dao_get_reply_to_by_id,
     dao_get_reply_to_by_service_id,
     update_reply_to_email_address
@@ -592,6 +593,13 @@ def update_service_reply_to_email_address(service_id, reply_to_email_id):
                                                  email_address=form['email_address'],
                                                  is_default=form.get('is_default', True))
     return jsonify(data=new_reply_to.serialize()), 200
+
+
+@service_blueprint.route('/<uuid:service_id>/email-reply-to/<uuid:reply_to_email_id>/archive', methods=['POST'])
+def delete_service_reply_to_email_address(service_id, reply_to_email_id):
+    archived_reply_to = archive_reply_to_email_address(service_id, reply_to_email_id)
+
+    return jsonify(data=archived_reply_to.serialize()), 200
 
 
 @service_blueprint.route('/<uuid:service_id>/letter-contact', methods=["GET"])

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -59,6 +59,7 @@ from app.dao.service_email_reply_to_dao import (
     update_reply_to_email_address
 )
 from app.dao.service_letter_contact_dao import (
+    archive_letter_contact,
     dao_get_letter_contacts_by_service_id,
     dao_get_letter_contact_by_id,
     add_letter_contact_for_service,
@@ -636,6 +637,13 @@ def update_service_letter_contact(service_id, letter_contact_id):
                                          contact_block=form['contact_block'],
                                          is_default=form.get('is_default', True))
     return jsonify(data=new_reply_to.serialize()), 200
+
+
+@service_blueprint.route('/<uuid:service_id>/letter-contact/<uuid:letter_contact_id>/archive', methods=['POST'])
+def delete_service_letter_contact(service_id, letter_contact_id):
+    archived_letter_contact = archive_letter_contact(service_id, letter_contact_id)
+
+    return jsonify(data=archived_letter_contact.serialize()), 200
 
 
 @service_blueprint.route('/<uuid:service_id>/sms-sender', methods=['POST'])

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -90,14 +90,15 @@ def send_one_off_notification(service_id, post_data):
 def get_reply_to_text(notification_type, sender_id, service, template):
     reply_to = None
     if sender_id:
-        if notification_type == EMAIL_TYPE:
-            try:
-                reply_to = dao_get_reply_to_by_id(service.id, sender_id).email_address
-            except NoResultFound:
+        try:
+            if notification_type == EMAIL_TYPE:
                 message = 'Reply to email address not found'
-                raise BadRequestError(message=message)
-        elif notification_type == SMS_TYPE:
-            reply_to = dao_get_service_sms_senders_by_id(service.id, sender_id).get_reply_to_text()
+                reply_to = dao_get_reply_to_by_id(service.id, sender_id).email_address
+            elif notification_type == SMS_TYPE:
+                message = 'SMS sender not found'
+                reply_to = dao_get_service_sms_senders_by_id(service.id, sender_id).get_reply_to_text()
+        except NoResultFound:
+            raise BadRequestError(message=message)
     else:
         reply_to = template.get_reply_to_text()
     return reply_to

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -1,3 +1,5 @@
+from sqlalchemy.orm.exc import NoResultFound
+
 from app.config import QueueNames
 from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_id
 from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id
@@ -89,7 +91,11 @@ def get_reply_to_text(notification_type, sender_id, service, template):
     reply_to = None
     if sender_id:
         if notification_type == EMAIL_TYPE:
-            reply_to = dao_get_reply_to_by_id(service.id, sender_id).email_address
+            try:
+                reply_to = dao_get_reply_to_by_id(service.id, sender_id).email_address
+            except NoResultFound:
+                message = 'Reply to email address not found'
+                raise BadRequestError(message=message)
         elif notification_type == SMS_TYPE:
             reply_to = dao_get_service_sms_senders_by_id(service.id, sender_id).get_reply_to_text()
     else:

--- a/tests/app/dao/test_service_email_reply_to_dao.py
+++ b/tests/app/dao/test_service_email_reply_to_dao.py
@@ -25,6 +25,23 @@ def test_dao_get_reply_to_by_service_id(notify_db_session):
     assert second_reply_to == results[2]
 
 
+def test_dao_get_reply_to_by_service_id_does_not_return_archived_reply_tos(notify_db_session):
+    service = create_service()
+    create_reply_to_email(service=service, email_address='something@email.com')
+    create_reply_to_email(service=service, email_address='another@email.com', is_default=False)
+    archived_reply_to = create_reply_to_email(
+        service=service,
+        email_address='second@email.com',
+        is_default=False,
+        archived=True
+    )
+
+    results = dao_get_reply_to_by_service_id(service_id=service.id)
+
+    assert len(results) == 2
+    assert archived_reply_to not in results
+
+
 def test_add_reply_to_email_address_for_service_creates_first_email_for_service(notify_db_session):
     service = create_service()
     add_reply_to_email_address_for_service(service_id=service.id,
@@ -161,6 +178,18 @@ def test_dao_get_reply_to_by_id(sample_service):
 def test_dao_get_reply_to_by_id_raises_sqlalchemy_error_when_reply_to_does_not_exist(sample_service):
     with pytest.raises(SQLAlchemyError):
         dao_get_reply_to_by_id(service_id=sample_service.id, reply_to_id=uuid.uuid4())
+
+
+def test_dao_get_reply_to_by_id_raises_sqlalchemy_error_when_reply_to_is_archived(sample_service):
+    create_reply_to_email(service=sample_service, email_address='email@address.com')
+    archived_reply_to = create_reply_to_email(
+        service=sample_service,
+        email_address='email_two@address.com',
+        is_default=False,
+        archived=True)
+
+    with pytest.raises(SQLAlchemyError):
+        dao_get_reply_to_by_id(service_id=sample_service.id, reply_to_id=archived_reply_to.id)
 
 
 def test_dao_get_reply_to_by_id_raises_sqlalchemy_error_when_service_does_not_exist(sample_service):

--- a/tests/app/dao/test_service_email_reply_to_dao.py
+++ b/tests/app/dao/test_service_email_reply_to_dao.py
@@ -35,6 +35,7 @@ def test_add_reply_to_email_address_for_service_creates_first_email_for_service(
     assert len(results) == 1
     assert results[0].email_address == 'new@address.com'
     assert results[0].is_default
+    assert not results[0].archived
 
 
 def test_add_reply_to_email_address_for_service_creates_another_email_for_service(notify_db_session):

--- a/tests/app/dao/test_service_letter_contact_dao.py
+++ b/tests/app/dao/test_service_letter_contact_dao.py
@@ -39,9 +39,11 @@ def test_add_letter_contact_for_service_creates_additional_letter_contact_for_se
 
     assert results[0].contact_block == 'Edinburgh, ED1 1AA'
     assert results[0].is_default
+    assert not results[0].archived
 
     assert results[1].contact_block == 'Swansea, SN1 3CC'
     assert not results[1].is_default
+    assert not results[1].archived
 
 
 def test_add_another_letter_contact_as_default_overrides_existing(notify_db_session):

--- a/tests/app/dao/test_service_letter_contact_dao.py
+++ b/tests/app/dao/test_service_letter_contact_dao.py
@@ -27,6 +27,23 @@ def test_dao_get_letter_contacts_by_service_id(notify_db_session):
     assert second_letter_contact == results[2]
 
 
+def test_dao_get_letter_contacts_by_service_id_does_not_return_archived_contacts(notify_db_session):
+    service = create_service()
+    create_letter_contact(service=service, contact_block='Edinburgh, ED1 1AA')
+    create_letter_contact(service=service, contact_block='Cardiff, CA1 2DB', is_default=False)
+    archived_contact = create_letter_contact(
+        service=service,
+        contact_block='London, E1 8QS',
+        is_default=False,
+        archived=True
+    )
+
+    results = dao_get_letter_contacts_by_service_id(service_id=service.id)
+
+    assert len(results) == 2
+    assert archived_contact not in results
+
+
 def test_add_letter_contact_for_service_creates_additional_letter_contact_for_service(notify_db_session):
     service = create_service()
 
@@ -162,6 +179,15 @@ def test_dao_get_letter_contact_by_id(sample_service):
 def test_dao_get_letter_contact_by_id_raises_sqlalchemy_error_when_letter_contact_does_not_exist(sample_service):
     with pytest.raises(SQLAlchemyError):
         dao_get_letter_contact_by_id(service_id=sample_service.id, letter_contact_id=uuid.uuid4())
+
+
+def test_dao_get_letter_contact_by_id_raises_sqlalchemy_error_when_letter_contact_is_archived(sample_service):
+    archived_contact = create_letter_contact(
+        service=sample_service,
+        contact_block='Aberdeen, AB12 23X',
+        archived=True)
+    with pytest.raises(SQLAlchemyError):
+        dao_get_letter_contact_by_id(service_id=sample_service.id, letter_contact_id=archived_contact.id)
 
 
 def test_dao_get_letter_contact_by_id_raises_sqlalchemy_error_when_service_does_not_exist(sample_service):

--- a/tests/app/dao/test_service_sms_sender_dao.py
+++ b/tests/app/dao/test_service_sms_sender_dao.py
@@ -58,6 +58,7 @@ def test_dao_add_sms_sender_for_service(notify_db_session):
     assert len(service_sms_senders) == 2
     assert service_sms_senders[0].sms_sender == 'testing'
     assert service_sms_senders[0].is_default
+    assert not service_sms_senders[0].archived
     assert service_sms_senders[1] == new_sms_sender
 
 

--- a/tests/app/dao/test_service_sms_sender_dao.py
+++ b/tests/app/dao/test_service_sms_sender_dao.py
@@ -10,7 +10,7 @@ from app.dao.service_sms_sender_dao import (
     dao_get_sms_senders_by_service_id,
     update_existing_sms_sender_with_inbound_number)
 from app.models import ServiceSmsSender
-from tests.app.db import create_service, create_inbound_number
+from tests.app.db import create_service, create_inbound_number, create_service_sms_sender
 
 
 def test_dao_get_service_sms_senders_id(notify_db_session):
@@ -32,6 +32,18 @@ def test_dao_get_service_sms_senders_id_raise_exception_when_not_found(notify_db
                                           service_sms_sender_id=uuid.uuid4())
 
 
+def test_dao_get_service_sms_senders_id_raises_exception_with_archived_sms_sender(notify_db_session):
+    service = create_service()
+    archived_sms_sender = create_service_sms_sender(
+        service=service,
+        sms_sender="second",
+        is_default=False,
+        archived=True)
+    with pytest.raises(expected_exception=SQLAlchemyError):
+        dao_get_service_sms_senders_by_id(service_id=service.id,
+                                          service_sms_sender_id=archived_sms_sender.id)
+
+
 def test_dao_get_sms_senders_by_service_id(notify_db_session):
     service = create_service()
     second_sender = dao_add_sms_sender_for_service(service_id=service.id,
@@ -45,6 +57,19 @@ def test_dao_get_sms_senders_by_service_id(notify_db_session):
             assert x.sms_sender == 'testing'
         else:
             assert x == second_sender
+
+
+def test_dao_get_sms_senders_by_service_id_does_not_return_archived_senders(notify_db_session):
+    service = create_service()
+    archived_sms_sender = create_service_sms_sender(
+        service=service,
+        sms_sender="second",
+        is_default=False,
+        archived=True)
+    results = dao_get_sms_senders_by_service_id(service_id=service.id)
+
+    assert len(results) == 1
+    assert archived_sms_sender not in results
 
 
 def test_dao_add_sms_sender_for_service(notify_db_session):

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -398,14 +398,16 @@ def create_monthly_billing_entry(
 
 
 def create_reply_to_email(
-        service,
-        email_address,
-        is_default=True
+    service,
+    email_address,
+    is_default=True,
+    archived=False
 ):
     data = {
         'service': service,
         'email_address': email_address,
         'is_default': is_default,
+        'archived': archived,
     }
     reply_to = ServiceEmailReplyTo(**data)
 

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -418,16 +418,18 @@ def create_reply_to_email(
 
 
 def create_service_sms_sender(
-        service,
-        sms_sender,
-        is_default=True,
-        inbound_number_id=None
+    service,
+    sms_sender,
+    is_default=True,
+    inbound_number_id=None,
+    archived=False
 ):
     data = {
         'service_id': service.id,
         'sms_sender': sms_sender,
         'is_default': is_default,
-        'inbound_number_id': inbound_number_id
+        'inbound_number_id': inbound_number_id,
+        'archived': archived,
     }
     service_sms_sender = ServiceSmsSender(**data)
 

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -438,14 +438,16 @@ def create_service_sms_sender(
 
 
 def create_letter_contact(
-        service,
-        contact_block,
-        is_default=True
+    service,
+    contact_block,
+    is_default=True,
+    archived=False
 ):
     data = {
         'service': service,
         'contact_block': contact_block,
         'is_default': is_default,
+        'archived': archived,
     }
     letter_content = ServiceLetterContact(**data)
 

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock
 
 import pytest
 from notifications_utils.recipients import InvalidPhoneError
-from sqlalchemy.exc import SQLAlchemyError
 
 from app.v2.errors import BadRequestError, TooManyRequestsError
 from app.config import QueueNames
@@ -334,5 +333,6 @@ def test_send_one_off_notification_should_throw_exception_if_sms_sender_id_doesn
         'created_by': str(sample_template.service.created_by_id)
     }
 
-    with pytest.raises(expected_exception=SQLAlchemyError):
+    with pytest.raises(expected_exception=BadRequestError) as e:
         send_one_off_notification(service_id=sample_template.service.id, post_data=data)
+    assert e.value.message == 'SMS sender not found'

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -319,8 +319,9 @@ def test_send_one_off_notification_should_throw_exception_if_reply_to_id_doesnot
         'created_by': str(sample_email_template.service.created_by_id)
     }
 
-    with pytest.raises(expected_exception=SQLAlchemyError):
+    with pytest.raises(expected_exception=BadRequestError) as e:
         send_one_off_notification(service_id=sample_email_template.service.id, post_data=data)
+    assert e.value.message == 'Reply to email address not found'
 
 
 def test_send_one_off_notification_should_throw_exception_if_sms_sender_id_doesnot_exist(

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -485,6 +485,30 @@ def test_post_sms_notification_returns_400_if_not_allowed_to_send_int_sms(
     ]
 
 
+def test_post_sms_notification_with_archived_reply_to_id_returns_400(client, sample_template, mocker):
+    archived_sender = create_service_sms_sender(
+        sample_template.service,
+        '12345',
+        is_default=False,
+        archived=True)
+    mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
+    data = {
+        "phone_number": '+447700900855',
+        "template_id": sample_template.id,
+        'sms_sender_id': archived_sender.id
+    }
+    auth_header = create_authorization_header(service_id=sample_template.service_id)
+    response = client.post(
+        path="v2/notifications/sms",
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert response.status_code == 400
+    resp_json = json.loads(response.get_data(as_text=True))
+    assert 'sms_sender_id {} does not exist in database for service id {}'. \
+        format(archived_sender.id, sample_template.service_id) in resp_json['errors'][0]['message']
+    assert 'BadRequestError' in resp_json['errors'][0]['error']
+
+
 @pytest.mark.parametrize('recipient,label,template_factory,expected_error', [
     ('07700 900000', 'phone_number', sample_template_without_sms_permission, 'Cannot send text messages'),
     ('someone@test.com', 'email_address', sample_template_without_email_permission, 'Cannot send emails')])

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -700,6 +700,30 @@ def test_post_email_notification_with_invalid_reply_to_id_returns_400(client, sa
     assert 'BadRequestError' in resp_json['errors'][0]['error']
 
 
+def test_post_email_notification_with_archived_reply_to_id_returns_400(client, sample_email_template, mocker):
+    archived_reply_to = create_reply_to_email(
+        sample_email_template.service,
+        'reply_to@test.com',
+        is_default=False,
+        archived=True)
+    mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
+    data = {
+        "email_address": 'test@test.com',
+        "template_id": sample_email_template.id,
+        'email_reply_to_id': archived_reply_to.id
+    }
+    auth_header = create_authorization_header(service_id=sample_email_template.service_id)
+    response = client.post(
+        path="v2/notifications/email",
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert response.status_code == 400
+    resp_json = json.loads(response.get_data(as_text=True))
+    assert 'email_reply_to_id {} does not exist in database for service id {}'. \
+        format(archived_reply_to.id, sample_email_template.service_id) in resp_json['errors'][0]['message']
+    assert 'BadRequestError' in resp_json['errors'][0]['error']
+
+
 def test_post_notification_with_document_upload(client, notify_db, notify_db_session, mocker):
     service = sample_service(notify_db, notify_db_session, permissions=[EMAIL_TYPE, UPLOAD_DOCUMENT])
     template = create_sample_template(


### PR DESCRIPTION
It should be possible to archive the three types of reply-to addresses:
* `service_email_reply_to`
* `service_sms_sender`
* `service_letter_contact`

It isn't possible to hard delete letter contacts because they are referenced by the Template table, so to keep the ways things work consistent between all notification types, we mark the reply-to addresses as archived instead.

### Work done
#### Updated DAO functions to only return non-archived reply-to addresses
The DAO functions to return one and all reply-to addresses now only return the non-archived ones.

#### Added DAO functions that mark reply-to addresses to archived
Added a DAO function for each notification type which sets the reply-to address to archived. There are various edge cases that need to be accounted for:
- You shouldn't be able to archive a default reply-to address
- For SMS, you shouldn't be able to archive an inbound number
- In addition to having a default letter contact block for a service, letters can also have default letter contact block for a template - template defaults should not be able to be archived

### Pivotal story
https://www.pivotaltracker.com/story/show/156476018