### PR TITLE
Pass date of letter to template preview

### DIFF
--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -247,6 +247,7 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
             'letter_contact_block': notification.reply_to_text,
             'template': template_for_letter_print,
             'values': notification.personalisation,
+            'date': notification.created_at.isoformat(),
             'dvla_org_id': service.dvla_organisation_id,
         }
 


### PR DESCRIPTION
Otherwise all letters will show the current date.

Also beefed up the tests around this part of the code a bit.

Template preview will start using this date once this is merged (but it will just ignore it until then): https://github.com/alphagov/notifications-template-preview/pull/120
