### PR TITLE
Dates are hard to get right

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -251,8 +251,10 @@ def delete_service_and_all_associated_db_objects(service):
 
 @statsd(namespace="dao")
 def dao_fetch_stats_for_service(service_id):
+    # We want 7 days inclusive
+    start_date = get_london_midnight_in_utc(date.today() - timedelta(days=6))
     return _stats_for_service_query(service_id).filter(
-        func.date(Notification.created_at) >= date.today() - timedelta(days=7)
+        func.date(Notification.created_at) >= start_date
     ).all()
 
 

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -628,13 +628,13 @@ def test_fetch_stats_for_today_only_includes_today(notify_db, notify_db_session,
 def test_fetch_stats_should_not_gather_notifications_older_than_7_days(notify_db, notify_db_session, sample_template):
 
     # 8 days ago
-    create_notification(notify_db, None, to_field='1', status='delivered', created_at='2001-01-01T12:00:00')
+    create_notification(notify_db, None, to_field='1', status='delivered', created_at='2001-01-02T12:00:00')
 
     # 7 days ago, 2hours ago
-    create_notification(notify_db, None, to_field='2', status='failed', created_at='2001-01-02T10:00:00')
+    create_notification(notify_db, None, to_field='2', status='failed', created_at='2001-01-03T10:00:00')
 
     # 7 days ago
-    create_notification(notify_db, None, to_field='2', status='failed', created_at='2001-01-02T12:00:00')
+    create_notification(notify_db, None, to_field='2', status='failed', created_at='2001-01-03T12:00:00')
 
     # right_now
     create_notification(notify_db, None, to_field='3', status='created', created_at='2001-01-09T12:00:00')


### PR DESCRIPTION
Because dates are confusing we need to fix this query once more.
The template statistics are returning 7 days inclusive, however the big numbers on the dashboard are for 8 days.
This PR fixes that.