### PR TITLE
Add document-download-api environment variables to PaaS instances

### DIFF
--- a/manifest-api-base.yml
+++ b/manifest-api-base.yml
@@ -45,6 +45,9 @@ env:
   TEMPLATE_PREVIEW_API_HOST: null
   TEMPLATE_PREVIEW_API_KEY: null
 
+  DOCUMENT_DOWNLOAD_API_HOST: null
+  DOCUMENT_DOWNLOAD_API_KEY: null
+
 instances: 1
 memory: 1G
 


### PR DESCRIPTION
Document Download keys have been added to the PaaS environment
credentials so we can use the manifest to set them on the app
instances.