### PR TITLE
Use ft billing for usage

### DIFF
--- a/app/billing/billing_schemas.py
+++ b/app/billing/billing_schemas.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 create_or_update_free_sms_fragment_limit_schema = {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "POST annual billing schema",
@@ -8,3 +10,17 @@ create_or_update_free_sms_fragment_limit_schema = {
     },
     "required": ["free_sms_fragment_limit"]
 }
+
+
+def serialize_ft_billing_remove_emails(data):
+    results = []
+    billed_notifications = [x for x in data if x.notification_type != 'email']
+    for notifications in billed_notifications:
+        json_result = {
+            "month": (datetime.strftime(notifications.month, "%B")),
+            "notification_type": notifications.notification_type,
+            "billing_units": int(notifications.billable_units),
+            "rate": float(notifications.rate),
+        }
+        results.append(json_result)
+    return results

--- a/app/billing/rest.py
+++ b/app/billing/rest.py
@@ -32,13 +32,15 @@ register_errors(billing_blueprint)
 
 
 @billing_blueprint.route('/ft-monthly-usage')
-def get_yearly_usage_by_monthy_from_ft_billing(service_id):
+def get_yearly_usage_by_monthly_from_ft_billing(service_id):
     try:
         year = int(request.args.get('year'))
-        results = fetch_monthly_billing_for_year(service_id=service_id, year=year)
-        serialize_ft_billing(results)
     except TypeError:
         return jsonify(result='error', message='No valid year provided'), 400
+
+    results = fetch_monthly_billing_for_year(service_id=service_id, year=year)
+    data = serialize_ft_billing(results)
+    return jsonify(monthly_usage=data)
 
 
 @billing_blueprint.route('/monthly-usage')
@@ -207,16 +209,15 @@ def update_free_sms_fragment_limit_data(service_id, free_sms_fragment_limit, fin
 
 def serialize_ft_billing(data):
     results = []
-
     for d in data:
         j = {
-            "Month": d.month,
-            "service_id": d.service_id,
+            "month": (datetime.strftime(d.month, "%B")),
+            "service_id": str(d.service_id),
             "notifications_type": d.notification_type,
-            "notifications_sent": d.notifications_sent,
-            "billable_units": d.billable_units,
-            "rate": d.rate,
-            "rate_multiplier": d.rate_multiplier,
+            "notifications_sent": int(d.notifications_sent),
+            "billable_units": int(d.billable_units),
+            "rate": float(d.rate),
+            "rate_multiplier": int(d.rate_multiplier),
             "international": d.international,
         }
         results.append(j)

--- a/app/commands.py
+++ b/app/commands.py
@@ -599,4 +599,4 @@ def compare_ft_billing_to_monthly_billing(year, service_id=None):
         with current_app.test_request_context(
                 path='/service/{}/billing/ft-monthly-usage?year={}'.format(service_id, year)):
             ft_billing_response = get_yearly_usage_by_monthly_from_ft_billing(service_id)
-        compare_ft_billing_to_monthly_billing(ft_billing_response, monthly_billing_response)
+        compare_monthly_billing_to_ft_billing(ft_billing_response, monthly_billing_response)

--- a/app/commands.py
+++ b/app/commands.py
@@ -579,7 +579,10 @@ def compare_ft_billing_to_monthly_billing(year, service_id=None):
         # Remove the rows with 0 billing_units and rate, ft_billing doesn't populate those rows.
         mo_json = json.loads(monthly_billing_response.get_data(as_text=True))
         rm_zero_rows = [x for x in mo_json if x['billing_units'] != 0 and x['rate'] != 0]
-        assert rm_zero_rows == json.loads(ft_billing_response.get_data(as_text=True))
+        try:
+            assert rm_zero_rows == json.loads(ft_billing_response.get_data(as_text=True))
+        except AssertionError:
+            print("Comparison failed for service: {} and year: {}".format(service_id, year))
 
     if not service_id:
         start_date, end_date = get_financial_year(year=int(year))

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, time
 
 from flask import current_app
-from sqlalchemy import func, case, desc, extract
+from sqlalchemy import func, case, desc
 
 from app import db
 from app.dao.date_util import get_financial_year
@@ -33,7 +33,7 @@ def fetch_monthly_billing_for_year(service_id, year):
                 update_fact_billing(data=d, process_day=day)
 
     yearly_data = db.session.query(
-        extract('month', FactBilling.bst_date).label("Month"),
+        func.date_trunc('month', FactBilling.bst_date).label("month"),
         func.sum(FactBilling.notifications_sent).label("notifications_sent"),
         func.sum(FactBilling.billable_units).label("billable_units"),
         FactBilling.service_id,
@@ -46,7 +46,7 @@ def fetch_monthly_billing_for_year(service_id, year):
         FactBilling.bst_date >= year_start_date,
         FactBilling.bst_date <= year_end_date
     ).group_by(
-        'Month',
+        'month',
         FactBilling.service_id,
         FactBilling.rate,
         FactBilling.rate_multiplier,
@@ -54,7 +54,7 @@ def fetch_monthly_billing_for_year(service_id, year):
         FactBilling.notification_type
     ).order_by(
         FactBilling.service_id,
-        'Month',
+        'month',
         FactBilling.notification_type
     ).all()
 

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -20,7 +20,7 @@ from app.models import (
 from app.utils import convert_utc_to_bst, convert_bst_to_utc
 
 
-def fetch_montly_billing_for_year(service_id, year):
+def fetch_monthly_billing_for_year(service_id, year):
     year_start_date, year_end_date = get_financial_year(year)
     utcnow = datetime.utcnow()
     today = convert_utc_to_bst(utcnow).date()
@@ -39,7 +39,8 @@ def fetch_montly_billing_for_year(service_id, year):
         FactBilling.service_id,
         FactBilling.rate,
         FactBilling.rate_multiplier,
-        FactBilling.international
+        FactBilling.international,
+        FactBilling.notification_type
     ).filter(
         FactBilling.service_id == service_id,
         FactBilling.bst_date >= year_start_date,
@@ -49,7 +50,12 @@ def fetch_montly_billing_for_year(service_id, year):
         FactBilling.service_id,
         FactBilling.rate,
         FactBilling.rate_multiplier,
-        FactBilling.international
+        FactBilling.international,
+        FactBilling.notification_type
+    ).order_by(
+        FactBilling.service_id,
+        'Month',
+        FactBilling.notification_type
     ).all()
 
     return yearly_data

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, time
 
 from flask import current_app
-from sqlalchemy import func, case, desc
+from sqlalchemy import func, case, desc, Date
 
 from app import db
 from app.dao.date_util import get_financial_year
@@ -33,7 +33,7 @@ def fetch_monthly_billing_for_year(service_id, year):
                 update_fact_billing(data=d, process_day=day)
 
     yearly_data = db.session.query(
-        func.date_trunc('month', FactBilling.bst_date).label("month"),
+        func.date_trunc('month', FactBilling.bst_date).cast(Date).label("month"),
         func.sum(FactBilling.notifications_sent).label("notifications_sent"),
         func.sum(FactBilling.billable_units * FactBilling.rate_multiplier).label("billable_units"),
         FactBilling.service_id,

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -23,9 +23,9 @@ from app.utils import convert_utc_to_bst, convert_bst_to_utc
 def fetch_monthly_billing_for_year(service_id, year):
     year_start_date, year_end_date = get_financial_year(year)
     utcnow = datetime.utcnow()
-    today = convert_utc_to_bst(utcnow).date()
+    today = convert_utc_to_bst(utcnow)
     # if year end date is less than today, we are calculating for data in the past and have no need for deltas.
-    if year_end_date.date() >= today:
+    if year_end_date >= today:
         yesterday = today - timedelta(days=1)
         for day in [yesterday, today]:
             data = fetch_billing_data_for_day(process_day=day, service_id=service_id)
@@ -35,11 +35,9 @@ def fetch_monthly_billing_for_year(service_id, year):
     yearly_data = db.session.query(
         func.date_trunc('month', FactBilling.bst_date).label("month"),
         func.sum(FactBilling.notifications_sent).label("notifications_sent"),
-        func.sum(FactBilling.billable_units).label("billable_units"),
+        func.sum(FactBilling.billable_units * FactBilling.rate_multiplier).label("billable_units"),
         FactBilling.service_id,
         FactBilling.rate,
-        FactBilling.rate_multiplier,
-        FactBilling.international,
         FactBilling.notification_type
     ).filter(
         FactBilling.service_id == service_id,
@@ -49,8 +47,6 @@ def fetch_monthly_billing_for_year(service_id, year):
         'month',
         FactBilling.service_id,
         FactBilling.rate,
-        FactBilling.rate_multiplier,
-        FactBilling.international,
         FactBilling.notification_type
     ).order_by(
         FactBilling.service_id,
@@ -125,7 +121,7 @@ def update_fact_billing(data, process_day):
     inserted_records = 0
     updated_records = 0
     non_letter_rates, letter_rates = get_rates_for_billing()
-
+    print("process_day: {} {}".format(type(process_day), process_day))
     update_count = FactBilling.query.filter(
         FactBilling.bst_date == datetime.date(process_day),
         FactBilling.template_id == data.template_id,

--- a/app/dao/monthly_billing_dao.py
+++ b/app/dao/monthly_billing_dao.py
@@ -100,7 +100,8 @@ def get_yearly_billing_data_for_date_range(
         MonthlyBilling.end_date <= end_date,
         MonthlyBilling.notification_type.in_(notification_types)
     ).order_by(
-        MonthlyBilling.notification_type
+        MonthlyBilling.start_date,
+        MonthlyBilling.notification_type,
     ).all()
 
     return results

--- a/tests/app/billing/test_billing.py
+++ b/tests/app/billing/test_billing.py
@@ -1,3 +1,4 @@
+from calendar import monthrange
 from datetime import datetime, timedelta
 import json
 
@@ -438,8 +439,7 @@ def test_get_yearly_usage_by_monthly_from_ft_billing(client, notify_db_session):
     letter_template = create_template(service=service, template_type="letter")
     for month in range(1, 13):
         mon = str(month).zfill(2)
-        days_in_month = {1: 32, 2: 30, 3: 32, 4: 31, 5: 32, 6: 31, 7: 32, 8: 32, 9: 31, 10: 32, 11: 31, 12: 32}
-        for day in range(1, days_in_month[month]):
+        for day in range(1, monthrange(2016, month)[1] + 1):
             d = str(day).zfill(2)
             create_ft_billing(bst_date='2016-{}-{}'.format(mon, d),
                               service=service,
@@ -489,10 +489,9 @@ def test_compare_ft_billing_to_monthly_billing(client, notify_db_session):
     sms_template = create_template(service=service, template_type="sms")
     email_template = create_template(service=service, template_type="email")
     letter_template = create_template(service=service, template_type="letter")
-    for month in range(4, 9):
+    for month in range(1, 13):
         mon = str(month).zfill(2)
-        days_in_month = {1: 32, 2: 30, 3: 32, 4: 31, 5: 32, 6: 31, 7: 32, 8: 32, 9: 31, 10: 32, 11: 31, 12: 32}
-        for day in range(1, days_in_month[month]):
+        for day in range(1, monthrange(2016, month)[1] + 1):
             d = str(day).zfill(2)
             create_ft_billing(bst_date='2016-{}-{}'.format(mon, d),
                               service=service,
@@ -515,7 +514,6 @@ def test_compare_ft_billing_to_monthly_billing(client, notify_db_session):
                               template=letter_template,
                               notification_type='letter',
                               rate=0.33)
-
         start_date, end_date = get_month_start_and_end_date_in_utc(datetime(2016, int(mon), 1))
         create_monthly_billing_entry(service=service, start_date=start_date,
                                      end_date=end_date,

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -221,14 +221,14 @@ def test_fetch_monthly_billing_for_year(notify_db_session):
     results = fetch_monthly_billing_for_year(service_id=service.id, year=2018)
 
     assert len(results) == 2
-    assert str(results[0].month.date()) == "2018-06-01"
+    assert str(results[0].month) == "2018-06-01"
     assert results[0].notifications_sent == 30
     assert results[0].billable_units == Decimal('60')
     assert results[0].service_id == service.id
     assert results[0].rate == Decimal('0.162')
     assert results[0].notification_type == 'sms'
 
-    assert str(results[1].month.date()) == "2018-07-01"
+    assert str(results[1].month) == "2018-07-01"
     assert results[1].notifications_sent == 31
     assert results[1].billable_units == Decimal('31')
     assert results[1].service_id == service.id
@@ -287,20 +287,20 @@ def test_fetch_monthly_billing_for_year_return_financial_year(notify_db_session)
     # Orders by Month
 
     assert len(results) == 36
-    assert str(results[0].month.date()) == "2016-04-01"
+    assert str(results[0].month) == "2016-04-01"
     assert results[0].notification_type == 'email'
     assert results[0].notifications_sent == 30
     assert results[0].billable_units == 30
     assert results[0].rate == Decimal('0')
-    assert str(results[1].month.date()) == "2016-04-01"
+    assert str(results[1].month) == "2016-04-01"
     assert results[1].notification_type == 'letter'
     assert results[1].notifications_sent == 30
     assert results[1].billable_units == 30
     assert results[1].rate == Decimal('0.33')
-    assert str(results[2].month.date()) == "2016-04-01"
+    assert str(results[2].month) == "2016-04-01"
     assert results[2].notification_type == 'sms'
     assert results[2].notifications_sent == 30
     assert results[2].billable_units == 30
     assert results[2].rate == Decimal('0.162')
-    assert str(results[3].month.date()) == "2016-05-01"
-    assert str(results[35].month.date()) == "2017-03-01"
+    assert str(results[3].month) == "2016-05-01"
+    assert str(results[35].month) == "2017-03-01"

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -5,7 +5,7 @@ from freezegun import freeze_time
 
 from app import db
 from app.dao.fact_billing_dao import (
-    fetch_montly_billing_for_year, fetch_billing_data_for_day, get_rates_for_billing,
+    fetch_monthly_billing_for_year, fetch_billing_data_for_day, get_rates_for_billing,
     get_rate
 )
 from app.models import FactBilling
@@ -132,6 +132,25 @@ def test_fetch_billing_data_for_day_is_grouped_by_international(notify_db_sessio
     assert results[1].notifications_sent == 1
 
 
+def test_fetch_billing_data_for_day_is_grouped_by_notification_type(notify_db_session):
+    service = create_service()
+    sms_template = create_template(service=service, template_type='sms')
+    email_template = create_template(service=service, template_type='email')
+    letter_template = create_template(service=service, template_type='letter')
+    create_notification(template=sms_template, status='delivered')
+    create_notification(template=sms_template, status='delivered')
+    create_notification(template=sms_template, status='delivered')
+    create_notification(template=email_template, status='delivered')
+    create_notification(template=email_template, status='delivered')
+    create_notification(template=letter_template, status='delivered')
+
+    today = convert_utc_to_bst(datetime.utcnow())
+    results = fetch_billing_data_for_day(today)
+    assert len(results) == 3
+    notification_types = [x[2] for x in results if x[2] in ['email', 'sms', 'letter']]
+    assert len(notification_types) == 3
+
+
 def test_fetch_billing_data_for_day_returns_empty_list(notify_db_session):
     today = convert_utc_to_bst(datetime.utcnow())
     results = fetch_billing_data_for_day(today)
@@ -181,7 +200,7 @@ def test_get_rate(notify_db_session):
     assert letter_rate == Decimal('4.4')
 
 
-def test_fetch_annual_billing_for_year(notify_db_session):
+def test_fetch_monthly_billing_for_year(notify_db_session):
     service = create_service()
     template = create_template(service=service, template_type="sms")
     for i in range(1, 31):
@@ -197,28 +216,30 @@ def test_fetch_annual_billing_for_year(notify_db_session):
                           notification_type='sms',
                           rate=0.158)
 
-    results = fetch_montly_billing_for_year(service_id=service.id, year=2018)
+    results = fetch_monthly_billing_for_year(service_id=service.id, year=2018)
 
     assert len(results) == 2
-    assert results[0][0] == 6.0
-    assert results[0][1] == 30
-    assert results[0][2] == Decimal('30')
-    assert results[0][3] == service.id
-    assert results[0][4] == Decimal('0.162')
-    assert results[0][5] == Decimal('1')
-    assert results[0][6] is False
+    assert results[0].Month == 6.0
+    assert results[0].notifications_sent == 30
+    assert results[0].billable_units == Decimal('30')
+    assert results[0].service_id == service.id
+    assert results[0].rate == Decimal('0.162')
+    assert results[0].rate_multiplier == Decimal('1')
+    assert results[0].international is False
+    assert results[0].notification_type == 'sms'
 
-    assert results[1][0] == 7.0
-    assert results[1][1] == 31
-    assert results[1][2] == Decimal('31')
-    assert results[1][3] == service.id
-    assert results[1][4] == Decimal('0.158')
-    assert results[1][5] == Decimal('1')
-    assert results[1][6] is False
+    assert results[1].Month == 7.0
+    assert results[1].notifications_sent == 31
+    assert results[1].billable_units == Decimal('31')
+    assert results[1].service_id == service.id
+    assert results[1].rate == Decimal('0.158')
+    assert results[1].rate_multiplier == Decimal('1')
+    assert results[1].international is False
+    assert results[1].notification_type == 'sms'
 
 
 @freeze_time('2018-08-01 13:30:00')
-def test_fetch_annual_billing_for_year_adds_data_for_today(notify_db_session):
+def test_fetch_monthly_billing_for_year_adds_data_for_today(notify_db_session):
     service = create_service()
     template = create_template(service=service, template_type="email")
     for i in range(1, 32):
@@ -230,7 +251,47 @@ def test_fetch_annual_billing_for_year_adds_data_for_today(notify_db_session):
     create_notification(template=template, status='delivered')
 
     assert db.session.query(FactBilling.bst_date).count() == 31
-    results = fetch_montly_billing_for_year(service_id=service.id,
-                                            year=2018)
+    results = fetch_monthly_billing_for_year(service_id=service.id,
+                                             year=2018)
     assert db.session.query(FactBilling.bst_date).count() == 32
     assert len(results) == 2
+
+
+def test_fetch_monthly_billing_for_year(notify_db_session):
+    service = create_service()
+    sms_template = create_template(service=service, template_type="email")
+    email_template = create_template(service=service, template_type="email")
+    letter_template = create_template(service=service, template_type="email")
+    for month in range(1, 13):
+        mon = str(month).zfill(2)
+        days_in_month = {1: 32, 2: 30, 3: 32, 4: 31, 5: 32, 6: 31, 7: 32, 8: 32, 9: 31, 10: 32, 11: 31, 12: 32}
+        for day in range(1, days_in_month[month]):
+            d = str(day).zfill(2)
+            create_ft_billing(bst_date='2016-{}-{}'.format(mon, d),
+                              service=service,
+                              template=sms_template,
+                              notification_type='sms',
+                              rate=0.162)
+            create_ft_billing(bst_date='2016-{}-{}'.format(mon, d),
+                              service=service,
+                              template=email_template,
+                              notification_type='email',
+                              rate=0)
+            create_ft_billing(bst_date='2016-{}-{}'.format(mon, d),
+                              service=service,
+                              template=letter_template,
+                              notification_type='letter',
+                              rate=0.33)
+
+    results = fetch_monthly_billing_for_year(service.id, 2016)
+    # returns 3 rows, per month, returns financial year april to december
+    # Orders by Month
+    assert len(results) == 27
+    assert results[0][0] == 4
+    assert results[1][0] == 4
+    assert results[2][0] == 4
+    assert results[3][0] == 5
+    assert results[26][0] == 12
+
+
+

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -221,14 +221,14 @@ def test_fetch_monthly_billing_for_year(notify_db_session):
     results = fetch_monthly_billing_for_year(service_id=service.id, year=2018)
 
     assert len(results) == 2
-    assert str(results[0].month) == "2018-06-01 00:00:00+01:00"
+    assert str(results[0].month.date()) == "2018-06-01"
     assert results[0].notifications_sent == 30
     assert results[0].billable_units == Decimal('60')
     assert results[0].service_id == service.id
     assert results[0].rate == Decimal('0.162')
     assert results[0].notification_type == 'sms'
 
-    assert str(results[1].month) == "2018-07-01 00:00:00+01:00"
+    assert str(results[1].month.date()) == "2018-07-01"
     assert results[1].notifications_sent == 31
     assert results[1].billable_units == Decimal('31')
     assert results[1].service_id == service.id
@@ -287,20 +287,20 @@ def test_fetch_monthly_billing_for_year_return_financial_year(notify_db_session)
     # Orders by Month
 
     assert len(results) == 36
-    assert str(results[0].month) == "2016-04-01 00:00:00+01:00"
+    assert str(results[0].month.date()) == "2016-04-01"
     assert results[0].notification_type == 'email'
     assert results[0].notifications_sent == 30
     assert results[0].billable_units == 30
     assert results[0].rate == Decimal('0')
-    assert str(results[1].month) == "2016-04-01 00:00:00+01:00"
+    assert str(results[1].month.date()) == "2016-04-01"
     assert results[1].notification_type == 'letter'
     assert results[1].notifications_sent == 30
     assert results[1].billable_units == 30
     assert results[1].rate == Decimal('0.33')
-    assert str(results[2].month) == "2016-04-01 00:00:00+01:00"
+    assert str(results[2].month.date()) == "2016-04-01"
     assert results[2].notification_type == 'sms'
     assert results[2].notifications_sent == 30
     assert results[2].billable_units == 30
     assert results[2].rate == Decimal('0.162')
-    assert str(results[3].month) == "2016-05-01 00:00:00+01:00"
-    assert str(results[35].month) == "2017-03-01 00:00:00+00:00"
+    assert str(results[3].month.date()) == "2016-05-01"
+    assert str(results[35].month.date()) == "2017-03-01"

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -219,7 +219,7 @@ def test_fetch_monthly_billing_for_year(notify_db_session):
     results = fetch_monthly_billing_for_year(service_id=service.id, year=2018)
 
     assert len(results) == 2
-    assert results[0].Month == 6.0
+    assert str(results[0].month) == "2018-06-01 00:00:00+01:00"
     assert results[0].notifications_sent == 30
     assert results[0].billable_units == Decimal('30')
     assert results[0].service_id == service.id
@@ -228,7 +228,7 @@ def test_fetch_monthly_billing_for_year(notify_db_session):
     assert results[0].international is False
     assert results[0].notification_type == 'sms'
 
-    assert results[1].Month == 7.0
+    assert str(results[1].month) == "2018-07-01 00:00:00+01:00"
     assert results[1].notifications_sent == 31
     assert results[1].billable_units == Decimal('31')
     assert results[1].service_id == service.id
@@ -257,11 +257,11 @@ def test_fetch_monthly_billing_for_year_adds_data_for_today(notify_db_session):
     assert len(results) == 2
 
 
-def test_fetch_monthly_billing_for_year(notify_db_session):
+def test_fetch_monthly_billing_for_year_return_financial_year(notify_db_session):
     service = create_service()
-    sms_template = create_template(service=service, template_type="email")
+    sms_template = create_template(service=service, template_type="sms")
     email_template = create_template(service=service, template_type="email")
-    letter_template = create_template(service=service, template_type="email")
+    letter_template = create_template(service=service, template_type="letter")
     for month in range(1, 13):
         mon = str(month).zfill(2)
         days_in_month = {1: 32, 2: 30, 3: 32, 4: 31, 5: 32, 6: 31, 7: 32, 8: 32, 9: 31, 10: 32, 11: 31, 12: 32}
@@ -286,12 +286,13 @@ def test_fetch_monthly_billing_for_year(notify_db_session):
     results = fetch_monthly_billing_for_year(service.id, 2016)
     # returns 3 rows, per month, returns financial year april to december
     # Orders by Month
+
     assert len(results) == 27
-    assert results[0][0] == 4
-    assert results[1][0] == 4
-    assert results[2][0] == 4
-    assert results[3][0] == 5
-    assert results[26][0] == 12
-
-
-
+    assert str(results[0].month) == "2016-04-01 00:00:00+01:00"
+    assert results[0].notification_type == 'email'
+    assert str(results[1].month) == "2016-04-01 00:00:00+01:00"
+    assert results[1].notification_type == 'letter'
+    assert str(results[2].month) == "2016-04-01 00:00:00+01:00"
+    assert results[2].notification_type == 'sms'
+    assert str(results[3].month) == "2016-05-01 00:00:00+01:00"
+    assert str(results[26].month) == "2016-12-01 00:00:00+00:00"

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -208,6 +208,7 @@ def test_fetch_monthly_billing_for_year(notify_db_session):
                           service=service,
                           template=template,
                           notification_type='sms',
+                          rate_multiplier=2,
                           rate=0.162)
     for i in range(1, 32):
         create_ft_billing(bst_date='2018-07-{}'.format(i),
@@ -221,11 +222,9 @@ def test_fetch_monthly_billing_for_year(notify_db_session):
     assert len(results) == 2
     assert str(results[0].month) == "2018-06-01 00:00:00+01:00"
     assert results[0].notifications_sent == 30
-    assert results[0].billable_units == Decimal('30')
+    assert results[0].billable_units == Decimal('60')
     assert results[0].service_id == service.id
     assert results[0].rate == Decimal('0.162')
-    assert results[0].rate_multiplier == Decimal('1')
-    assert results[0].international is False
     assert results[0].notification_type == 'sms'
 
     assert str(results[1].month) == "2018-07-01 00:00:00+01:00"
@@ -233,8 +232,6 @@ def test_fetch_monthly_billing_for_year(notify_db_session):
     assert results[1].billable_units == Decimal('31')
     assert results[1].service_id == service.id
     assert results[1].rate == Decimal('0.158')
-    assert results[1].rate_multiplier == Decimal('1')
-    assert results[1].international is False
     assert results[1].notification_type == 'sms'
 
 


### PR DESCRIPTION
This PR adds a new endpoint to get yearly usage by month from the ft_billing table. 

If usage is requested for the current year, the deltas added to ft_billing before executing the query to fetch the data. 

There is a command to compare the results of ft_billing to monthly_billing that will give us confidence before switching to the new endpoint on the admin app. 