### PR TITLE
Revert "Update gunicorn to 19.8.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-SQLAlchemy==2.3.2
 Flask==0.12.2
 click-datetime==0.2
 eventlet==0.22.1
-gunicorn==19.8.1
+gunicorn==19.7.1
 iso8601==0.1.12
 jsonschema==2.6.0
 marshmallow-sqlalchemy==0.13.2


### PR DESCRIPTION
Reverts alphagov/notifications-api#1854

We've seen several notify-api instances crash since we upgraded gunicorn - wondering if it's related