### PR TITLE
Convert the day_start from a string to a datetime.

### DIFF
--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -17,7 +17,9 @@ def create_nightly_billing(day_start=None):
     # 3 days of data counting back from day_start is consolidated
     if day_start is None:
         day_start = datetime.today() - timedelta(days=1)
-
+    else:
+        # When calling the task its a string in the format of "YYYY-MM-DD"
+        day_start = datetime.strptime(day_start, "%Y-%m-%d")
     for i in range(0, 3):
         process_day = day_start - timedelta(days=i)
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -581,13 +581,12 @@ def compare_ft_billing_to_monthly_billing(year, service_id=None):
     This command checks the results of monthly_billing to ft_billing for the given year.
     If service id is not included all services are compared for the given year.
     """
-
-    def compare_monthly_billing_to_ft_billing(ft_billing_response, monthly_billing_response):
+    def compare_monthly_billing_to_ft_billing(ft_billing_resp, monthly_billing_resp):
         # Remove the rows with 0 billing_units and rate, ft_billing doesn't populate those rows.
-        mo_json = json.loads(monthly_billing_response.get_data(as_text=True))
+        mo_json = json.loads(monthly_billing_resp.get_data(as_text=True))
         rm_zero_rows = [x for x in mo_json if x['billing_units'] != 0 and x['rate'] != 0]
         try:
-            assert rm_zero_rows == json.loads(ft_billing_response.get_data(as_text=True))
+            assert rm_zero_rows == json.loads(ft_billing_resp.get_data(as_text=True))
         except AssertionError:
             print("Comparison failed for service: {} and year: {}".format(service_id, year))
 

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -76,7 +76,9 @@ def test_create_nightly_billing_sms_rate_multiplier(
     records = FactBilling.query.all()
     assert len(records) == 0
 
-    create_nightly_billing(yesterday)
+    # Celery expects the arguments to be a string or primitive type.
+    yesterday_str = datetime.strftime(yesterday, "%Y-%m-%d")
+    create_nightly_billing(yesterday_str)
     records = FactBilling.query.order_by('rate_multiplier').all()
     assert len(records) == records_num
     for i, record in enumerate(records):
@@ -124,8 +126,9 @@ def test_create_nightly_billing_different_templates(
 
     records = FactBilling.query.all()
     assert len(records) == 0
-
-    create_nightly_billing(yesterday)
+    # Celery expects the arguments to be a string or primitive type.
+    yesterday_str = datetime.strftime(yesterday, "%Y-%m-%d")
+    create_nightly_billing(yesterday_str)
     records = FactBilling.query.order_by('rate_multiplier').all()
 
     assert len(records) == 2
@@ -179,7 +182,9 @@ def test_create_nightly_billing_different_sent_by(
     records = FactBilling.query.all()
     assert len(records) == 0
 
-    create_nightly_billing(yesterday)
+    # Celery expects the arguments to be a string or primitive type.
+    yesterday_str = datetime.strftime(yesterday, "%Y-%m-%d")
+    create_nightly_billing(yesterday_str)
     records = FactBilling.query.order_by('rate_multiplier').all()
 
     assert len(records) == 2
@@ -215,8 +220,9 @@ def test_create_nightly_billing_letter(
 
     records = FactBilling.query.all()
     assert len(records) == 0
-
-    create_nightly_billing(yesterday)
+    # Celery expects the arguments to be a string or primitive type.
+    yesterday_str = datetime.strftime(yesterday, "%Y-%m-%d")
+    create_nightly_billing(yesterday_str)
     records = FactBilling.query.order_by('rate_multiplier').all()
     assert len(records) == 1
     record = records[0]
@@ -253,7 +259,9 @@ def test_create_nightly_billing_null_sent_by_sms(
     records = FactBilling.query.all()
     assert len(records) == 0
 
-    create_nightly_billing(yesterday)
+    # Celery expects the arguments to be a string or primitive type.
+    yesterday_str = datetime.strftime(yesterday, "%Y-%m-%d")
+    create_nightly_billing(yesterday_str)
     records = FactBilling.query.all()
 
     assert len(records) == 1


### PR DESCRIPTION
Celery expects the arguments are a string or primitive data type. The create_nightly_billing task needs to convert the string to a datetime before continuing. 