### PR TITLE
Refactor usage queries and stop rebuilding monthly_billing when not needed. 

### DIFF
--- a/app/billing/billing_schemas.py
+++ b/app/billing/billing_schemas.py
@@ -16,12 +16,12 @@ create_or_update_free_sms_fragment_limit_schema = {
 def serialize_ft_billing_remove_emails(data):
     results = []
     billed_notifications = [x for x in data if x.notification_type != 'email']
-    for notifications in billed_notifications:
+    for notification in billed_notifications:
         json_result = {
-            "month": (datetime.strftime(notifications.month, "%B")),
-            "notification_type": notifications.notification_type,
-            "billing_units": int(notifications.billable_units),
-            "rate": float(notifications.rate),
+            "month": (datetime.strftime(notification.month, "%B")),
+            "notification_type": notification.notification_type,
+            "billing_units": notification.billable_units,
+            "rate": float(notification.rate),
         }
         results.append(json_result)
     return results

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -27,8 +27,8 @@ def fetch_billing_totals_for_year(service_id, year):
     year_start_date, year_end_date = get_financial_year(year)
     """
       Billing for email: only record the total number of emails.
-      Billing for letters: The billing units is used to fetch the correct rate for the sheet count of the letter. 
-            Total cost is notifications_sent * rate.
+      Billing for letters: The billing units is used to fetch the correct rate for the sheet count of the letter.
+      Total cost is notifications_sent * rate.
       Rate multiplier does not apply to email or letters.
     """
     email_and_letters = db.session.query(

--- a/app/dao/monthly_billing_dao.py
+++ b/app/dao/monthly_billing_dao.py
@@ -116,11 +116,11 @@ def get_monthly_billing_by_notification_type(service_id, billing_month, notifica
 
 @statsd(namespace="dao")
 def get_billing_data_for_financial_year(service_id, year, notification_types=[SMS_TYPE, EMAIL_TYPE, LETTER_TYPE]):
-    # Update totals to the latest so we include data for today
     now = convert_utc_to_bst(datetime.utcnow())
-    create_or_update_monthly_billing(service_id=service_id, billing_month=now)
-
     start_date, end_date = get_financial_year(year)
+    if start_date <= now <= end_date:
+        # Update totals to the latest so we include data for today
+        create_or_update_monthly_billing(service_id=service_id, billing_month=now)
 
     results = get_yearly_billing_data_for_date_range(
         service_id, start_date, end_date, notification_types

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -266,14 +266,12 @@ def test_fetch_monthly_billing_for_year(notify_db_session):
     assert str(results[0].month) == "2018-06-01"
     assert results[0].notifications_sent == 30
     assert results[0].billable_units == Decimal('60')
-    assert results[0].service_id == service.id
     assert results[0].rate == Decimal('0.162')
     assert results[0].notification_type == 'sms'
 
     assert str(results[1].month) == "2018-07-01"
     assert results[1].notifications_sent == 31
     assert results[1].billable_units == Decimal('31')
-    assert results[1].service_id == service.id
     assert results[1].rate == Decimal('0.158')
     assert results[1].notification_type == 'sms'
 
@@ -330,19 +328,16 @@ def test_fetch_billing_totals_for_year(notify_db_session):
 
     assert len(results) == 3
     assert results[0].notification_type == 'email'
-    assert results[0].service_id == service.id
     assert results[0].notifications_sent == 365
     assert results[0].billable_units == 365
     assert results[0].rate == Decimal('0')
 
     assert results[1].notification_type == 'letter'
-    assert results[1].service_id == service.id
     assert results[1].notifications_sent == 365
     assert results[1].billable_units == 365
     assert results[1].rate == Decimal('0.33')
 
     assert results[2].notification_type == 'sms'
-    assert results[2].service_id == service.id
     assert results[2].notifications_sent == 365
     assert results[2].billable_units == 365
     assert results[2].rate == Decimal('0.162')

--- a/tests/app/dao/test_monthly_billing.py
+++ b/tests/app/dao/test_monthly_billing.py
@@ -511,3 +511,13 @@ def test_get_yearly_billing_data_for_year_includes_current_day_totals(sample_tem
     )
 
     assert billing_data[0].monthly_totals[0]['billing_units'] == 3
+
+
+@freeze_time("2017-06-16 13:00:00")
+def test_get_billing_data_for_financial_year_updated_monthly_billing_if_today_is_in_current_year(
+        sample_service,
+        mocker
+):
+    mock = mocker.patch("app.dao.monthly_billing_dao.create_or_update_monthly_billing")
+    get_billing_data_for_financial_year(sample_service.id, 2016)
+    mock.assert_not_called()


### PR DESCRIPTION
- Only rebuild current month for monthly_billing if today is in the current year.
- Change the usage queries to a union so that billing_units is correct for all notification types. Removing the business logic from the schema.
- Added tests for different fragment counts, rates and sheet counts.