### PR TITLE
Add timestamp columns to ft_billing table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1774,6 +1774,8 @@ class FactBilling(db.Model):
     rate = db.Column(db.Numeric(), nullable=True)
     billable_units = db.Column(db.Integer(), nullable=True)
     notifications_sent = db.Column(db.Integer(), nullable=True)
+    created_at = db.Column(db.DateTime, nullable=True, default=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
 
 
 class DateTimeDimension(db.Model):

--- a/migrations/versions/0193_add_ft_billing_timestamps.py
+++ b/migrations/versions/0193_add_ft_billing_timestamps.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0193_add_ft_billing_timestamps
+Revises: 0192_drop_provider_statistics
+Create Date: 2018-05-22 10:23:21.937262
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0193_add_ft_billing_timestamps'
+down_revision = '0192_drop_provider_statistics'
+
+
+def upgrade():
+    op.add_column('ft_billing', sa.Column('updated_at', sa.DateTime(), nullable=True))
+    op.add_column('ft_billing', sa.Column('created_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('ft_billing', 'created_at')
+    op.drop_column('ft_billing', 'updated_at')


### PR DESCRIPTION
Added `created_at` and `updated_at` to the `ft_billing` table - having these
columns makes it easier to track down issues with the data in this table.

`created_at` is nullable initially, but will be changed to non-nullable
once the column is populated and the DAO etc. have been updated.