### PR TITLE
 Update created_at column of ft_billing to be non-nullable 

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -229,7 +229,8 @@ def update_fact_billing(data, process_day):
     stmt = stmt.on_conflict_do_update(
         constraint="ft_billing_pkey",
         set_={"notifications_sent": stmt.excluded.notifications_sent,
-              "billable_units": stmt.excluded.billable_units
+              "billable_units": stmt.excluded.billable_units,
+              "updated_at": datetime.utcnow()
               }
     )
     db.session.connection().execute(stmt)

--- a/app/models.py
+++ b/app/models.py
@@ -1774,7 +1774,7 @@ class FactBilling(db.Model):
     rate = db.Column(db.Numeric(), nullable=True)
     billable_units = db.Column(db.Integer(), nullable=True)
     notifications_sent = db.Column(db.Integer(), nullable=True)
-    created_at = db.Column(db.DateTime, nullable=True, default=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
 
 

--- a/migrations/versions/0194_ft_billing_created_at.py
+++ b/migrations/versions/0194_ft_billing_created_at.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0194_ft_billing_created_at
+Revises: 0193_add_ft_billing_timestamps
+Create Date: 2018-05-22 14:34:27.852096
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0194_ft_billing_created_at'
+down_revision = '0193_add_ft_billing_timestamps'
+
+
+def upgrade():
+    op.execute("UPDATE ft_billing SET created_at = NOW()")
+    op.alter_column('ft_billing', 'created_at', nullable=False)
+
+
+def downgrade():
+    op.alter_column('ft_billing', 'created_at', nullable=True)
+    op.execute("UPDATE ft_billing SET created_at = null")

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -447,6 +447,7 @@ def test_create_nightly_billing_update_when_record_exists(
     assert len(records) == 1
     assert records[0].bst_date == date(2018, 1, 14)
     assert records[0].billable_units == 1
+    assert not records[0].updated_at
 
     sample_notification(
         notify_db,
@@ -465,3 +466,4 @@ def test_create_nightly_billing_update_when_record_exists(
     create_nightly_billing()
     assert len(records) == 1
     assert records[0].billable_units == 2
+    assert records[0].updated_at


### PR DESCRIPTION
`created_at` was added previously and made nullable temporarily. This
commit now populates the column, ensures that it will always have a
value, and makes `created_at` non-nullable.