### PR TITLE
Fix how the letter rates are selected

### DIFF
--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -47,6 +47,11 @@ def set_up_yearly_data():
                                   template=letter_template,
                                   notification_type='letter',
                                   rate=0.33)
+                create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
+                                  service=service,
+                                  template=letter_template,
+                                  notification_type='letter',
+                                  rate=0.30)
     return service
 
 
@@ -236,7 +241,7 @@ def test_get_rate(notify_db_session):
     letter_rate = get_rate(non_letter_rates=non_letter_rates, letter_rates=letter_rates,
                            notification_type='letter',
                            crown=True,
-                           rate_multiplier=1,
+                           letter_page_count=1,
                            date=datetime.utcnow())
 
     assert rate == 2.2
@@ -302,7 +307,7 @@ def test_fetch_monthly_billing_for_year_return_financial_year(notify_db_session)
     # returns 3 rows, per month, returns financial year april to end of march
     # Orders by Month
 
-    assert len(results) == 36
+    assert len(results) == 48
     assert str(results[0].month) == "2016-04-01"
     assert results[0].notification_type == 'email'
     assert results[0].notifications_sent == 30
@@ -312,21 +317,26 @@ def test_fetch_monthly_billing_for_year_return_financial_year(notify_db_session)
     assert results[1].notification_type == 'letter'
     assert results[1].notifications_sent == 30
     assert results[1].billable_units == 30
-    assert results[1].rate == Decimal('0.33')
-    assert str(results[2].month) == "2016-04-01"
-    assert results[2].notification_type == 'sms'
+    assert results[1].rate == Decimal('0.30')
+    assert str(results[1].month) == "2016-04-01"
+    assert results[2].notification_type == 'letter'
     assert results[2].notifications_sent == 30
     assert results[2].billable_units == 30
-    assert results[2].rate == Decimal('0.162')
-    assert str(results[3].month) == "2016-05-01"
-    assert str(results[35].month) == "2017-03-01"
+    assert results[2].rate == Decimal('0.33')
+    assert str(results[3].month) == "2016-04-01"
+    assert results[3].notification_type == 'sms'
+    assert results[3].notifications_sent == 30
+    assert results[3].billable_units == 30
+    assert results[3].rate == Decimal('0.162')
+    assert str(results[4].month) == "2016-05-01"
+    assert str(results[47].month) == "2017-03-01"
 
 
 def test_fetch_billing_totals_for_year(notify_db_session):
     service = set_up_yearly_data()
     results = fetch_billing_totals_for_year(service_id=service.id, year=2016)
 
-    assert len(results) == 3
+    assert len(results) == 4
     assert results[0].notification_type == 'email'
     assert results[0].notifications_sent == 365
     assert results[0].billable_units == 365
@@ -335,9 +345,14 @@ def test_fetch_billing_totals_for_year(notify_db_session):
     assert results[1].notification_type == 'letter'
     assert results[1].notifications_sent == 365
     assert results[1].billable_units == 365
-    assert results[1].rate == Decimal('0.33')
+    assert results[1].rate == Decimal('0.3')
 
-    assert results[2].notification_type == 'sms'
+    assert results[2].notification_type == 'letter'
     assert results[2].notifications_sent == 365
     assert results[2].billable_units == 365
-    assert results[2].rate == Decimal('0.162')
+    assert results[2].rate == Decimal('0.33')
+
+    assert results[3].notification_type == 'sms'
+    assert results[3].notifications_sent == 365
+    assert results[3].billable_units == 365
+    assert results[3].rate == Decimal('0.162')


### PR DESCRIPTION
To correctly select the rate for letters you need the billable_unit or page count match on the letter_rates.

A new column is added to the query to populate ft_billing which is only populated for letter.