### PR TITLE
Add created_at and updated_at columns to ft_notification_status

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1812,3 +1812,5 @@ class FactNotificationStatus(db.Model):
     key_type = db.Column(db.Text, primary_key=True, nullable=False)
     notification_status = db.Column(db.Text, primary_key=True, nullable=False)
     notification_count = db.Column(db.Integer(), nullable=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)

--- a/migrations/versions/0195_ft_notification_timestamps.py
+++ b/migrations/versions/0195_ft_notification_timestamps.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0195_ft_notification_timestamps
+Revises: 0194_ft_billing_created_at
+Create Date: 2018-05-22 16:01:53.269137
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0195_ft_notification_timestamps'
+down_revision = '0194_ft_billing_created_at'
+
+
+def upgrade():
+    op.add_column('ft_notification_status', sa.Column('created_at', sa.DateTime(), nullable=False))
+    op.add_column('ft_notification_status', sa.Column('updated_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('ft_notification_status', 'updated_at')
+    op.drop_column('ft_notification_status', 'created_at')


### PR DESCRIPTION
Added `created_at` and `updated_at` to the `ft_notification_status` table in order
to make it easier to track down any potential issues with the data.

Also updated the command to populate the data to take `created_at` and
`updated_at` into account and to simplify the command. This can all be done in
the same commit since the table is not being used anywhere yet and can
only be populated manually.