### PR TITLE
Added Service contact_link column

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -342,6 +342,7 @@ class Service(db.Model, Versioned):
     )
     crown = db.Column(db.Boolean, index=False, nullable=False, default=True)
     rate_limit = db.Column(db.Integer, index=False, nullable=False, default=3000)
+    contact_link = db.Column(db.String(255), nullable=True, unique=False)
 
     organisation = db.relationship(
         'Organisation',

--- a/migrations/versions/0196_service_contact_link.py
+++ b/migrations/versions/0196_service_contact_link.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0196_service_contact_link
+Revises: 0195_ft_notification_timestamps
+Create Date: 2018-05-31 15:01:32.977620
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0196_service_contact_link'
+down_revision = '0195_ft_notification_timestamps'
+
+
+def upgrade():
+    op.add_column('services', sa.Column('contact_link', sa.String(length=255), nullable=True))
+    op.add_column('services_history', sa.Column('contact_link', sa.String(length=255), nullable=True))
+
+
+def downgrade():
+    op.drop_column('services_history', 'contact_link')
+    op.drop_column('services', 'contact_link')

--- a/migrations/versions/0197_service_contact_link.py
+++ b/migrations/versions/0197_service_contact_link.py
@@ -1,7 +1,7 @@
 """
 
-Revision ID: 0196_service_contact_link
-Revises: 0195_ft_notification_timestamps
+Revision ID: 0197_service_contact_link
+Revises: 0196_complaints_table
 Create Date: 2018-05-31 15:01:32.977620
 
 """
@@ -9,8 +9,8 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = '0196_service_contact_link'
-down_revision = '0195_ft_notification_timestamps'
+revision = '0197_service_contact_link'
+down_revision = '0196_complaints_table'
 
 
 def upgrade():


### PR DESCRIPTION
This is going to be used for for the document download citizen landing page, a service will add a contact link e.g. https://customerservicecontactnumber.uk/dwp/ which will allow the
user to contact the sending department if there is an error or any issues with the download. This link will be shown along with the Service name.

* Added the contact link to the model
* Added db migration script to add the column to the database