### PR TITLE
Fix logging for a bounce message

### DIFF
--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -95,7 +95,8 @@ def process_ses_response(ses_request):
 
 
 def determine_notification_bounce_type(notification_type, ses_message):
-    current_app.logger.info('SES bounce dict: {}'.format(remove_emails_from_bounce(ses_message['bounce'])))
+    remove_emails_from_bounce(ses_message['bounce'])
+    current_app.logger.info('SES bounce dict: {}'.format(ses_message['bounce']))
     if ses_message['bounce']['bounceType'] == 'Permanent':
         notification_type = ses_message['bounce']['bounceType']  # permanent or not
     else:


### PR DESCRIPTION
We'd like to see what the bounce message is from SES.
If there is a bounce we update the email to failed.
However, there is more than one reason for the failed message. Adding this logging will give us more details about the failure message.

There was a bug in the code where the log message was always empty because the function to remove the email was returns None but alters the dict. This PR corrects that. 