### PR TITLE
Add ‘caseworking’ service permission

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -239,6 +239,7 @@ EMAIL_AUTH = 'email_auth'
 LETTERS_AS_PDF = 'letters_as_pdf'
 PRECOMPILED_LETTER = 'precompiled_letter'
 UPLOAD_DOCUMENT = 'upload_document'
+CASEWORKING = 'caseworking'
 
 SERVICE_PERMISSION_TYPES = [
     EMAIL_TYPE,
@@ -251,6 +252,7 @@ SERVICE_PERMISSION_TYPES = [
     LETTERS_AS_PDF,
     PRECOMPILED_LETTER,
     UPLOAD_DOCUMENT,
+    CASEWORKING,
 ]
 
 

--- a/migrations/versions/0198_add_caseworking_permission.py
+++ b/migrations/versions/0198_add_caseworking_permission.py
@@ -1,0 +1,26 @@
+"""empty message
+
+Revision ID: 0198_add_caseworking_permission
+Revises: 0197_service_contact_link
+Create Date: 2018-02-21 12:05:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0198_add_caseworking_permission'
+down_revision = '0197_service_contact_link'
+
+from alembic import op
+
+PERMISSION_NAME = "caseworking"
+
+
+def upgrade():
+    op.get_bind()
+    op.execute("insert into service_permission_types values('{}')".format(PERMISSION_NAME))
+
+
+def downgrade():
+    op.get_bind()
+    op.execute("delete from service_permissions where permission = '{}'".format(PERMISSION_NAME))
+    op.execute("delete from service_permission_types where name = '{}'".format(PERMISSION_NAME))


### PR DESCRIPTION
We want to add the option for a user to have a more restricted view of Notify.

This should be opt in/out on a per service basis, because it will be appropriate only for a minority of teams. It shouldn’t be the default because most teams (those without a lot of users or those only using the API) won’t need it.

So this commit adds it as a new service permission, which means we can roll it out:
- in prototype form initially (for doing usability testing)
- then as an opt-in service setting