### PR TITLE
Enable syslog drain on all environments

### DIFF
--- a/manifest-api-base.yml
+++ b/manifest-api-base.yml
@@ -2,8 +2,11 @@
 
 buildpack: python_buildpack
 command: scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py application
+
 services:
   - notify-db
+  - logit-ssl-syslog-drain
+
 env:
   NOTIFY_APP_NAME: public-api
   CW_APP_NAME: api

--- a/manifest-api-preview.yml
+++ b/manifest-api-preview.yml
@@ -2,10 +2,6 @@
 
 inherit: manifest-api-base.yml
 
-services:
-  - notify-db
-  - logit-ssl-syslog-drain
-
 routes:
   - route: notify-api-preview.cloudapps.digital
   - route: api.notify.works

--- a/manifest-api-staging.yml
+++ b/manifest-api-staging.yml
@@ -2,10 +2,6 @@
 
 inherit: manifest-api-base.yml
 
-services:
-  - notify-db
-  - logit-ssl-syslog-drain
-
 routes:
   - route: notify-api-staging.cloudapps.digital
   - route: api.staging-notify.works

--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -3,8 +3,11 @@
 buildpack: python_buildpack
 health-check-type: none
 no-route: true
+
 services:
   - notify-db
+  - logit-ssl-syslog-drain
+
 instances: 1
 memory: 1G
 

--- a/manifest-delivery-preview.yml
+++ b/manifest-delivery-preview.yml
@@ -2,8 +2,4 @@
 
 inherit: manifest-delivery-base.yml
 
-services:
-  - notify-db
-  - logit-ssl-syslog-drain
-
 memory: 1G

--- a/manifest-delivery-staging.yml
+++ b/manifest-delivery-staging.yml
@@ -2,9 +2,5 @@
 
 inherit: manifest-delivery-base.yml
 
-services:
-  - notify-db
-  - logit-ssl-syslog-drain
-
 instances: 2
 memory: 1G


### PR DESCRIPTION
To be merged after alphagov/notifications-aws#387 and once #1902 has been tested for a few days.

This puts the `logit-ssl-syslog-drain` service in the base manifest for both api and delivery boxes so it will be enabled for all environments.