### PR TITLE
Format data for csv

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -353,8 +353,13 @@ def get_all_notifications_for_service(service_id):
     )
     kwargs = request.args.to_dict()
     kwargs['service_id'] = service_id
+
+    if data.get('format_for_csv'):
+        notifications = [notification.serialize_for_csv() for notification in pagination.items]
+    else:
+        notifications = notification_with_template_schema.dump(pagination.items, many=True).data
     return jsonify(
-        notifications=notification_with_template_schema.dump(pagination.items, many=True).data,
+        notifications=notifications,
         page_size=page_size,
         total=pagination.total,
         links=pagination_links(

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1253,6 +1253,24 @@ def test_get_all_notifications_for_service_in_order(notify_api, notify_db, notif
         assert response.status_code == 200
 
 
+def test_get_all_notifications_for_service_formatted_for_csv(client, sample_template):
+    notification = create_notification(template=sample_template)
+    auth_header = create_authorization_header()
+
+    response = client.get(
+        path='/service/{}/notifications?format_for_csv=True'.format(sample_template.service_id),
+        headers=[auth_header])
+
+    resp = json.loads(response.get_data(as_text=True))
+    assert response.status_code == 200
+    assert len(resp['notifications']) == 1
+    assert resp['notifications'][0]['recipient'] == notification.to
+    assert not resp['notifications'][0]['row_number']
+    assert resp['notifications'][0]['template_name'] == sample_template.name
+    assert resp['notifications'][0]['template_type'] == notification.notification_type
+    assert resp['notifications'][0]['status'] == 'Sending'
+
+
 def test_get_notification_for_service_without_uuid(client, notify_db, notify_db_session):
     service_1 = create_service(service_name="1", email_from='1')
     response = client.get(


### PR DESCRIPTION
Format the data for the CSV for the service notifications endpoint.
To enable the download report on the notification activity page, we need the data in the right format.