### PR TITLE
Wrap exception to return a sensible message to the client

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -108,7 +108,8 @@ def post_notification(notification_type):
     try:
         request_json = request.get_json()
     except werkzeug.exceptions.BadRequest as e:
-        raise BadRequestError(message=e.description, status_code=400)
+        raise BadRequestError(message="Error decoding arguments: {}".format(e.description),
+                              status_code=400)
 
     if notification_type == EMAIL_TYPE:
         form = validate(request_json, post_email_request)

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -3,6 +3,7 @@ import functools
 import io
 import math
 
+import werkzeug
 from flask import request, jsonify, current_app, abort
 from notifications_utils.pdf import pdf_page_count, PdfReadError
 from notifications_utils.recipients import try_validate_and_format_phone_number
@@ -104,12 +105,17 @@ def post_precompiled_letter_notification():
 
 @v2_notification_blueprint.route('/<notification_type>', methods=['POST'])
 def post_notification(notification_type):
+    try:
+        request_json = request.get_json()
+    except werkzeug.exceptions.BadRequest as e:
+        raise BadRequestError(message=e.description, status_code=400)
+
     if notification_type == EMAIL_TYPE:
-        form = validate(request.get_json(), post_email_request)
+        form = validate(request_json, post_email_request)
     elif notification_type == SMS_TYPE:
-        form = validate(request.get_json(), post_sms_request)
+        form = validate(request_json, post_sms_request)
     elif notification_type == LETTER_TYPE:
-        form = validate(request.get_json(), post_letter_request)
+        form = validate(request_json, post_letter_request)
     else:
         abort(404)
 

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -839,3 +839,12 @@ def test_post_notification_without_document_upload_permission(client, notify_db,
         headers=[('Content-Type', 'application/json'), auth_header])
 
     assert response.status_code == 400, response.get_data(as_text=True)
+
+
+def test_post_notification_returns_400_when_get_json_throws_exception(client, sample_email_template, rmock, mocker):
+    auth_header = create_authorization_header(service_id=sample_email_template.service_id)
+    response = client.post(
+        path="v2/notifications/email",
+        data="[",
+        headers=[('Content-Type', 'application/json'), auth_header])
+    assert response.status_code == 400


### PR DESCRIPTION
We are getting 500 errors when a POST notification has characters that can not be decoded or the json is malformed.

The exception is wrapped and a sensible error message is returned to the client.