### PR TITLE
New endpoint for the updated platform admin stats page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -113,6 +113,7 @@ def register_blueprint(application):
     from app.organisation.rest import organisation_blueprint
     from app.organisation.invite_rest import organisation_invite_blueprint
     from app.complaint.complaint_rest import complaint_blueprint
+    from app.platform_stats.rest import platform_stats_blueprint
 
     service_blueprint.before_request(requires_admin_auth)
     application.register_blueprint(service_blueprint, url_prefix='/service')
@@ -191,6 +192,9 @@ def register_blueprint(application):
 
     complaint_blueprint.before_request(requires_admin_auth)
     application.register_blueprint(complaint_blueprint)
+
+    platform_stats_blueprint.before_request(requires_admin_auth)
+    application.register_blueprint(platform_stats_blueprint, url_prefix='/platform-stats')
 
 
 def register_v2_blueprints(application):

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -617,7 +617,7 @@ def fetch_aggregate_stats_by_date_range_for_all_services(start_date, end_date):
     end_date = get_london_midnight_in_utc(end_date + timedelta(days=1))
     table = NotificationHistory
 
-    if start_date >= datetime.utcnow() - timedelta(days=7):
+    if end_date >= datetime.utcnow() - timedelta(days=7):
         table = Notification
 
     query = db.session.query(

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -609,3 +609,31 @@ def guess_notification_type(search_term):
         return EMAIL_TYPE
     else:
         return SMS_TYPE
+
+
+@statsd(namespace='dao')
+def fetch_new_aggregate_stats_by_date_range_for_all_services(start_date, end_date):
+    start_date = get_london_midnight_in_utc(start_date)
+    end_date = get_london_midnight_in_utc(end_date + timedelta(days=1))
+    table = NotificationHistory
+
+    if start_date >= datetime.utcnow() - timedelta(days=7):
+        table = Notification
+
+    query = db.session.query(
+        table.notification_type,
+        table.status,
+        table.key_type,
+        func.count(table.id).label('count')
+    ).filter(
+        table.created_at >= start_date,
+        table.created_at < end_date
+    ).group_by(
+        table.notification_type,
+        table.key_type,
+        table.status
+    ).order_by(
+        table.notification_type,
+    )
+
+    return query.all()

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -612,7 +612,7 @@ def guess_notification_type(search_term):
 
 
 @statsd(namespace='dao')
-def fetch_new_aggregate_stats_by_date_range_for_all_services(start_date, end_date):
+def fetch_aggregate_stats_by_date_range_for_all_services(start_date, end_date):
     start_date = get_london_midnight_in_utc(start_date)
     end_date = get_london_midnight_in_utc(end_date + timedelta(days=1))
     table = NotificationHistory

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -453,34 +453,6 @@ def fetch_aggregate_stats_by_date_range_for_all_services(start_date, end_date, i
     return query.all()
 
 
-@statsd(namespace='dao')
-def fetch_new_aggregate_stats_by_date_range_for_all_services(start_date, end_date):
-    start_date = get_london_midnight_in_utc(start_date)
-    end_date = get_london_midnight_in_utc(end_date + timedelta(days=1))
-    table = NotificationHistory
-
-    if start_date >= datetime.utcnow() - timedelta(days=7):
-        table = Notification
-
-    query = db.session.query(
-        table.notification_type,
-        table.status,
-        table.key_type,
-        func.count(table.id).label('count')
-    ).filter(
-        table.created_at >= start_date,
-        table.created_at < end_date
-    ).group_by(
-        table.notification_type,
-        table.key_type,
-        table.status
-    ).order_by(
-        table.notification_type,
-    )
-
-    return query.all()
-
-
 @transactional
 @version_class(Service)
 @version_class(ApiKey)

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -453,6 +453,34 @@ def fetch_aggregate_stats_by_date_range_for_all_services(start_date, end_date, i
     return query.all()
 
 
+@statsd(namespace='dao')
+def fetch_new_aggregate_stats_by_date_range_for_all_services(start_date, end_date):
+    start_date = get_london_midnight_in_utc(start_date)
+    end_date = get_london_midnight_in_utc(end_date + timedelta(days=1))
+    table = NotificationHistory
+
+    if start_date >= datetime.utcnow() - timedelta(days=7):
+        table = Notification
+
+    query = db.session.query(
+        table.notification_type,
+        table.status,
+        table.key_type,
+        func.count(table.id).label('count')
+    ).filter(
+        table.created_at >= start_date,
+        table.created_at < end_date
+    ).group_by(
+        table.notification_type,
+        table.key_type,
+        table.status
+    ).order_by(
+        table.notification_type,
+    )
+
+    return query.all()
+
+
 @transactional
 @version_class(Service)
 @version_class(ApiKey)

--- a/app/platform_stats/platform_stats_schema.py
+++ b/app/platform_stats/platform_stats_schema.py
@@ -1,0 +1,10 @@
+platform_stats_request = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "platform stats request schema",
+    "type": "object",
+    "title": "Platform stats request",
+    "properties": {
+        "start_date": {"type": ["string", "null"], "format": "date"},
+        "end_date": {"type": ["string", "null"], "format": "date"},
+    }
+}

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request
+
+from app.dao.notifications_dao import fetch_aggregate_stats_by_date_range_for_all_services
+from app.errors import register_errors
+from app.service.statistics import format_admin_stats
+
+platform_stats_blueprint = Blueprint('platform_stats', __name__)
+
+register_errors(platform_stats_blueprint)
+
+
+@platform_stats_blueprint.route('')
+def get_new_platform_stats():
+    # If start and end date are not set, we are expecting today's stats.
+    today = str(datetime.utcnow().date())
+
+    start_date = datetime.strptime(request.args.get('start_date', today), '%Y-%m-%d').date()
+    end_date = datetime.strptime(request.args.get('end_date', today), '%Y-%m-%d').date()
+    data = fetch_aggregate_stats_by_date_range_for_all_services(start_date=start_date, end_date=end_date)
+    stats = format_admin_stats(data)
+
+    return jsonify(stats)

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -4,7 +4,9 @@ from flask import Blueprint, jsonify, request
 
 from app.dao.notifications_dao import fetch_aggregate_stats_by_date_range_for_all_services
 from app.errors import register_errors
+from app.platform_stats.platform_stats_schema import platform_stats_request
 from app.service.statistics import format_admin_stats
+from app.schema_validation import validate
 
 platform_stats_blueprint = Blueprint('platform_stats', __name__)
 
@@ -12,7 +14,10 @@ register_errors(platform_stats_blueprint)
 
 
 @platform_stats_blueprint.route('')
-def get_new_platform_stats():
+def get_platform_stats():
+    if request.args:
+        validate(request.args, platform_stats_request)
+
     # If start and end date are not set, we are expecting today's stats.
     today = str(datetime.utcnow().date())
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -18,6 +18,7 @@ from app.dao.api_key_dao import (
     get_unsigned_secret,
     expire_api_key)
 from app.dao.inbound_numbers_dao import dao_allocate_number_for_service
+from app.dao.notifications_dao import fetch_new_aggregate_stats_by_date_range_for_all_services
 from app.dao.organisation_dao import dao_get_organisation_by_service_id
 from app.dao.service_sms_sender_dao import (
     archive_sms_sender,
@@ -44,7 +45,6 @@ from app.dao.services_dao import (
     dao_suspend_service,
     dao_update_service,
     fetch_aggregate_stats_by_date_range_for_all_services,
-    fetch_new_aggregate_stats_by_date_range_for_all_services,
     fetch_stats_by_date_range_for_all_services
 )
 from app.dao.service_whitelist_dao import (

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -18,7 +18,6 @@ from app.dao.api_key_dao import (
     get_unsigned_secret,
     expire_api_key)
 from app.dao.inbound_numbers_dao import dao_allocate_number_for_service
-from app.dao.notifications_dao import fetch_new_aggregate_stats_by_date_range_for_all_services
 from app.dao.organisation_dao import dao_get_organisation_by_service_id
 from app.dao.service_sms_sender_dao import (
     archive_sms_sender,
@@ -130,19 +129,6 @@ def get_platform_stats():
 
     result = jsonify(stats)
     return result
-
-
-@service_blueprint.route('/platform-stats-new', methods=['GET'])
-def get_new_platform_stats():
-    # If start and end date are not set, we are expecting today's stats.
-    today = str(datetime.utcnow().date())
-
-    start_date = datetime.strptime(request.args.get('start_date', today), '%Y-%m-%d').date()
-    end_date = datetime.strptime(request.args.get('end_date', today), '%Y-%m-%d').date()
-    data = fetch_new_aggregate_stats_by_date_range_for_all_services(start_date=start_date, end_date=end_date)
-    stats = statistics.format_admin_stats(data)
-
-    return jsonify(stats)
 
 
 @service_blueprint.route('', methods=['GET'])

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -44,6 +44,7 @@ from app.dao.services_dao import (
     dao_suspend_service,
     dao_update_service,
     fetch_aggregate_stats_by_date_range_for_all_services,
+    fetch_new_aggregate_stats_by_date_range_for_all_services,
     fetch_stats_by_date_range_for_all_services
 )
 from app.dao.service_whitelist_dao import (
@@ -129,6 +130,19 @@ def get_platform_stats():
 
     result = jsonify(stats)
     return result
+
+
+@service_blueprint.route('/platform-stats-new', methods=['GET'])
+def get_new_platform_stats():
+    # If start and end date are not set, we are expecting today's stats.
+    today = str(datetime.utcnow().date())
+
+    start_date = datetime.strptime(request.args.get('start_date', today), '%Y-%m-%d').date()
+    end_date = datetime.strptime(request.args.get('end_date', today), '%Y-%m-%d').date()
+    data = fetch_new_aggregate_stats_by_date_range_for_all_services(start_date=start_date, end_date=end_date)
+    stats = statistics.format_admin_stats(data)
+
+    return jsonify(stats)
 
 
 @service_blueprint.route('', methods=['GET'])

--- a/app/service/statistics.py
+++ b/app/service/statistics.py
@@ -14,6 +14,37 @@ def format_statistics(statistics):
     return counts
 
 
+def format_admin_stats(statistics):
+    counts = create_stats_dict()
+
+    for row in statistics:
+        if row.key_type == 'test':
+            counts[row.notification_type]['test-key'] += row.count
+        else:
+            counts[row.notification_type]['total'] += row.count
+            if row.status in ('technical-failure', 'permanent-failure', 'temporary-failure', 'virus-scan-failed'):
+                counts[row.notification_type]['failures'][row.status] += row.count
+
+    return counts
+
+
+def create_stats_dict():
+    stats_dict = {}
+    for template in TEMPLATE_TYPES:
+        stats_dict[template] = {}
+
+        for status in ('total', 'test-key'):
+            stats_dict[template][status] = 0
+
+        stats_dict[template]['failures'] = {
+            'technical-failure': 0,
+            'permanent-failure': 0,
+            'temporary-failure': 0,
+            'virus-scan-failed': 0,
+        }
+    return stats_dict
+
+
 def format_monthly_template_notification_stats(year, rows):
     stats = {
         datetime.strftime(date, '%Y-%m'): {}

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -34,7 +34,7 @@ from app.dao.notifications_dao import (
     dao_get_notifications_by_references,
     dao_get_notification_history_by_reference,
     notifications_not_yet_sent,
-    fetch_new_aggregate_stats_by_date_range_for_all_services,
+    fetch_aggregate_stats_by_date_range_for_all_services,
 )
 from app.dao.services_dao import dao_update_service
 from app.models import (
@@ -1941,7 +1941,7 @@ def test_notifications_not_yet_sent_return_no_rows(sample_service, notification_
     ('NotificationHistory', 3),
 ])
 @freeze_time('2018-01-08')
-def test_fetch_new_aggregate_stats_by_date_range_for_all_services_uses_the_correct_table(
+def test_fetch_aggregate_stats_by_date_range_for_all_services_uses_the_correct_table(
     mocker,
     notify_db_session,
     table_name,
@@ -1952,21 +1952,21 @@ def test_fetch_new_aggregate_stats_by_date_range_for_all_services_uses_the_corre
 
     # mock the table that should not be used, then check it is not being called
     unused_table_mock = mocker.patch('app.dao.services_dao.{}'.format(table_name))
-    fetch_new_aggregate_stats_by_date_range_for_all_services(start_date, end_date)
+    fetch_aggregate_stats_by_date_range_for_all_services(start_date, end_date)
 
     unused_table_mock.assert_not_called()
 
 
-def test_fetch_new_aggregate_stats_by_date_range_for_all_services_returns_empty_list_when_no_stats(notify_db_session):
+def test_fetch_aggregate_stats_by_date_range_for_all_services_returns_empty_list_when_no_stats(notify_db_session):
     start_date = date(2018, 1, 1)
     end_date = date(2018, 1, 5)
 
-    result = fetch_new_aggregate_stats_by_date_range_for_all_services(start_date, end_date)
+    result = fetch_aggregate_stats_by_date_range_for_all_services(start_date, end_date)
     assert result == []
 
 
 @freeze_time('2018-01-08')
-def test_fetch_new_aggregate_stats_by_date_range_for_all_services_groups_stats(
+def test_fetch_aggregate_stats_by_date_range_for_all_services_groups_stats(
     sample_template,
     sample_email_template,
     sample_letter_template,
@@ -1984,7 +1984,7 @@ def test_fetch_new_aggregate_stats_by_date_range_for_all_services_groups_stats(
     create_notification(template=sample_letter_template, status='virus-scan-failed',
                         created_at=today)
 
-    result = fetch_new_aggregate_stats_by_date_range_for_all_services(today, today)
+    result = fetch_aggregate_stats_by_date_range_for_all_services(today, today)
 
     assert len(result) == 5
     assert result[0] == ('email', 'permanent-failure', 'normal', 3)
@@ -1994,12 +1994,12 @@ def test_fetch_new_aggregate_stats_by_date_range_for_all_services_groups_stats(
     assert result[4] == ('letter', 'virus-scan-failed', 'normal', 1)
 
 
-def test_fetch_new_aggregate_stats_by_date_range_for_all_services_uses_bst_date(sample_template):
+def test_fetch_aggregate_stats_by_date_range_for_all_services_uses_bst_date(sample_template):
     query_day = datetime(2018, 6, 5).date()
     create_notification(sample_template, status='sent', created_at=datetime(2018, 6, 4, 23, 59))
     create_notification(sample_template, status='created', created_at=datetime(2018, 6, 5, 23, 00))
 
-    result = fetch_new_aggregate_stats_by_date_range_for_all_services(query_day, query_day)
+    result = fetch_aggregate_stats_by_date_range_for_all_services(query_day, query_day)
 
     assert len(result) == 1
     assert result[0].status == 'sent'

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 import uuid
 import functools
 
@@ -33,8 +33,7 @@ from app.dao.services_dao import (
     dao_fetch_active_users_for_service,
     dao_fetch_service_by_inbound_number,
     dao_fetch_monthly_historical_stats_by_template,
-    dao_fetch_monthly_historical_usage_by_template_for_service,
-    fetch_new_aggregate_stats_by_date_range_for_all_services)
+    dao_fetch_monthly_historical_usage_by_template_for_service)
 from app.dao.service_permissions_dao import dao_add_service_permission, dao_remove_service_permission
 from app.dao.users_dao import save_model_user
 from app.models import (
@@ -816,66 +815,6 @@ def test_fetch_stats_by_date_range_for_all_services(notify_db, notify_db_session
     assert results[0] == (result_one.service.id, result_one.service.name, result_one.service.restricted,
                           result_one.service.research_mode, result_one.service.active,
                           result_one.service.created_at, 'sms', 'created', 2)
-
-
-@pytest.mark.parametrize('table_name, days_ago', [
-    ('Notification', 8),
-    ('NotificationHistory', 3),
-])
-@freeze_time('2018-01-08')
-def test_fetch_new_aggregate_stats_by_date_range_for_all_services_uses_the_correct_table(
-    mocker,
-    notify_db_session,
-    table_name,
-    days_ago
-):
-    start_date = datetime.now().date() - timedelta(days=days_ago)
-    end_date = datetime.now().date()
-
-    # mock the table that should not be used, then check it is not being called
-    unused_table_mock = mocker.patch('app.dao.services_dao.{}'.format(table_name))
-    fetch_new_aggregate_stats_by_date_range_for_all_services(start_date, end_date)
-
-    unused_table_mock.assert_not_called()
-
-
-def test_fetch_new_aggregate_stats_by_date_range_for_all_services_returns_empty_list_when_no_stats(notify_db_session):
-    start_date = date(2018, 1, 1)
-    end_date = date(2018, 1, 5)
-
-    result = fetch_new_aggregate_stats_by_date_range_for_all_services(start_date, end_date)
-    assert result == []
-
-
-@freeze_time('2018-01-08')
-def test_fetch_new_aggregate_stats_by_date_range_for_all_services_groups_stats(
-    notify_db,
-    notify_db_session,
-    sample_template,
-    sample_email_template,
-    sample_letter_template,
-):
-    today = datetime.now().date()
-
-    for i in range(3):
-        create_notification(notify_db, notify_db_session, template=sample_email_template, status='permanent-failure',
-                            created_at=today)
-
-    create_notification(notify_db, notify_db_session, template=sample_email_template, status='sent', created_at=today)
-    create_notification(notify_db, notify_db_session, template=sample_template, status='sent', created_at=today)
-    create_notification(notify_db, notify_db_session, template=sample_template, status='sent', created_at=today,
-                        key_type=KEY_TYPE_TEAM)
-    create_notification(notify_db, notify_db_session, template=sample_letter_template, status='virus-scan-failed',
-                        created_at=today)
-
-    result = fetch_new_aggregate_stats_by_date_range_for_all_services(today, today)
-
-    assert len(result) == 5
-    assert result[0] == ('email', 'permanent-failure', 'normal', 3)
-    assert result[1] == ('email', 'sent', 'normal', 1)
-    assert result[2] == ('sms', 'sent', 'normal', 1)
-    assert result[3] == ('sms', 'sent', 'team', 1)
-    assert result[4] == ('letter', 'virus-scan-failed', 'normal', 1)
 
 
 @freeze_time('2001-01-01T23:59:00')

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -4,22 +4,34 @@ from freezegun import freeze_time
 
 
 @freeze_time('2018-06-01')
-def test_get_new_platform_stats_uses_todays_date_if_no_start_or_end_date_is_provided(admin_request, mocker):
+def test_get_platform_stats_uses_todays_date_if_no_start_or_end_date_is_provided(admin_request, mocker):
     today = datetime.now().date()
     dao_mock = mocker.patch('app.platform_stats.rest.fetch_aggregate_stats_by_date_range_for_all_services')
     mocker.patch('app.service.rest.statistics.format_statistics')
 
-    admin_request.get('platform_stats.get_new_platform_stats')
+    admin_request.get('platform_stats.get_platform_stats')
 
     dao_mock.assert_called_once_with(start_date=today, end_date=today)
 
 
-def test_get_new_platform_stats_can_filter_by_date(admin_request, mocker):
+def test_get_platform_stats_can_filter_by_date(admin_request, mocker):
     start_date = date(2017, 1, 1)
     end_date = date(2018, 1, 1)
     dao_mock = mocker.patch('app.platform_stats.rest.fetch_aggregate_stats_by_date_range_for_all_services')
     mocker.patch('app.service.rest.statistics.format_statistics')
 
-    admin_request.get('platform_stats.get_new_platform_stats', start_date=start_date, end_date=end_date)
+    admin_request.get('platform_stats.get_platform_stats', start_date=start_date, end_date=end_date)
 
     dao_mock.assert_called_once_with(start_date=start_date, end_date=end_date)
+
+
+def test_get_platform_stats_validates_the_date(admin_request):
+    start_date = '1234-56-78'
+
+    response = admin_request.get(
+        'platform_stats.get_platform_stats', start_date=start_date,
+        _expected_status=400
+    )
+
+    assert response['errors'][0]['message'] == 'start_date time data {} does not match format %Y-%m-%d'.format(
+        start_date)

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -1,0 +1,25 @@
+from datetime import date, datetime
+
+from freezegun import freeze_time
+
+
+@freeze_time('2018-06-01')
+def test_get_new_platform_stats_uses_todays_date_if_no_start_or_end_date_is_provided(admin_request, mocker):
+    today = datetime.now().date()
+    dao_mock = mocker.patch('app.platform_stats.rest.fetch_aggregate_stats_by_date_range_for_all_services')
+    mocker.patch('app.service.rest.statistics.format_statistics')
+
+    admin_request.get('platform_stats.get_new_platform_stats')
+
+    dao_mock.assert_called_once_with(start_date=today, end_date=today)
+
+
+def test_get_new_platform_stats_can_filter_by_date(admin_request, mocker):
+    start_date = date(2017, 1, 1)
+    end_date = date(2018, 1, 1)
+    dao_mock = mocker.patch('app.platform_stats.rest.fetch_aggregate_stats_by_date_range_for_all_services')
+    mocker.patch('app.service.rest.statistics.format_statistics')
+
+    admin_request.get('platform_stats.get_new_platform_stats', start_date=start_date, end_date=end_date)
+
+    dao_mock.assert_called_once_with(start_date=start_date, end_date=end_date)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3085,28 +3085,6 @@ def test_get_platform_stats_creates_zero_stats(client, notify_db_session):
     assert json_resp['sms'] == {'failed': 0, 'requested': 4, 'delivered': 3}
 
 
-@freeze_time('2018-06-01')
-def test_get_new_platform_stats_uses_todays_date_if_no_start_or_end_date_is_provided(admin_request, mocker):
-    today = datetime.now().date()
-    dao_mock = mocker.patch('app.service.rest.fetch_new_aggregate_stats_by_date_range_for_all_services')
-    mocker.patch('app.service.rest.statistics.format_statistics')
-
-    admin_request.get('service.get_new_platform_stats')
-
-    dao_mock.assert_called_once_with(start_date=today, end_date=today)
-
-
-def test_get_new_platform_stats_can_filter_by_date(admin_request, mocker):
-    start_date = date(2017, 1, 1)
-    end_date = date(2018, 1, 1)
-    dao_mock = mocker.patch('app.service.rest.fetch_new_aggregate_stats_by_date_range_for_all_services')
-    mocker.patch('app.service.rest.statistics.format_statistics')
-
-    admin_request.get('service.get_new_platform_stats', start_date=start_date, end_date=end_date)
-
-    dao_mock.assert_called_once_with(start_date=start_date, end_date=end_date)
-
-
 @pytest.mark.parametrize('today_only, stats', [
     (False, {'requested': 2, 'delivered': 1, 'failed': 0}),
     (True, {'requested': 1, 'delivered': 0, 'failed': 0})

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3085,6 +3085,28 @@ def test_get_platform_stats_creates_zero_stats(client, notify_db_session):
     assert json_resp['sms'] == {'failed': 0, 'requested': 4, 'delivered': 3}
 
 
+@freeze_time('2018-06-01')
+def test_get_new_platform_stats_uses_todays_date_if_no_start_or_end_date_is_provided(admin_request, mocker):
+    today = datetime.now().date()
+    dao_mock = mocker.patch('app.service.rest.fetch_new_aggregate_stats_by_date_range_for_all_services')
+    mocker.patch('app.service.rest.statistics.format_statistics')
+
+    admin_request.get('service.get_new_platform_stats')
+
+    dao_mock.assert_called_once_with(start_date=today, end_date=today)
+
+
+def test_get_new_platform_stats_can_filter_by_date(admin_request, mocker):
+    start_date = date(2017, 1, 1)
+    end_date = date(2018, 1, 1)
+    dao_mock = mocker.patch('app.service.rest.fetch_new_aggregate_stats_by_date_range_for_all_services')
+    mocker.patch('app.service.rest.statistics.format_statistics')
+
+    admin_request.get('service.get_new_platform_stats', start_date=start_date, end_date=end_date)
+
+    dao_mock.assert_called_once_with(start_date=start_date, end_date=end_date)
+
+
 @pytest.mark.parametrize('today_only, stats', [
     (False, {'requested': 2, 'delivered': 1, 'failed': 0}),
     (True, {'requested': 1, 'delivered': 0, 'failed': 0})


### PR DESCRIPTION
Added in a new endpoint and DAO function to provide the data for the new
platform admin statistics page. The new DAO method gets different data from
the Notifications / NotificationHistory table and also groups it differently.

The old endpoint has not been deleted yet to allow the numbers on the
old and new pages to be compared.