### PR TITLE
Paginate complaints

### DIFF
--- a/app/dao/complaint_dao.py
+++ b/app/dao/complaint_dao.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from flask import current_app
 from sqlalchemy import desc
 
 from app import db
@@ -11,6 +12,15 @@ from app.utils import get_london_midnight_in_utc
 @transactional
 def save_complaint(complaint):
     db.session.add(complaint)
+
+
+def fetch_paginated_complaints(page=1):
+    return Complaint.query.order_by(
+        desc(Complaint.created_at)
+    ).paginate(
+        page=page,
+        per_page=current_app.config['PAGE_SIZE']
+    )
 
 
 def fetch_complaints_by_service(service_id):

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1966,11 +1966,11 @@ def test_fetch_aggregate_stats_by_date_range_for_all_services_groups_stats(
     result = fetch_aggregate_stats_by_date_range_for_all_services(today, today)
 
     assert len(result) == 5
-    assert result[0] == ('email', 'permanent-failure', 'normal', 3)
-    assert result[1] == ('email', 'sent', 'normal', 1)
-    assert result[2] == ('sms', 'sent', 'normal', 1)
-    assert result[3] == ('sms', 'sent', 'team', 1)
-    assert result[4] == ('letter', 'virus-scan-failed', 'normal', 1)
+    assert ('email', 'permanent-failure', 'normal', 3) in result
+    assert ('email', 'sent', 'normal', 1) in result
+    assert ('sms', 'sent', 'normal', 1) in result
+    assert ('sms', 'sent', 'team', 1) in result
+    assert ('letter', 'virus-scan-failed', 'normal', 1) in result
 
 
 def test_fetch_aggregate_stats_by_date_range_for_all_services_uses_bst_date(sample_template):


### PR DESCRIPTION
Updated the function which gets all complaints to be paginated. The endpoint which uses this DAO function has been updated to take a page number as a query parameter.