### PR TITLE
Monthly statuses page from ft_notification_status

### DIFF
--- a/app/dao/date_util.py
+++ b/app/dao/date_util.py
@@ -11,7 +11,7 @@ def get_months_for_financial_year(year):
             get_months_for_year(4, 13, year) +
             get_months_for_year(1, 4, year + 1)
         )
-        if month < datetime.now()
+        if convert_bst_to_utc(month) < datetime.now()
     ]
 
 

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -7,7 +7,7 @@ from sqlalchemy.sql.expression import literal
 from sqlalchemy.types import DateTime
 
 from app import db
-from app.models import Notification, NotificationHistory, FactNotificationStatus
+from app.models import Notification, NotificationHistory, FactNotificationStatus, KEY_TYPE_TEST
 from app.utils import convert_bst_to_utc, get_london_midnight_in_utc
 
 
@@ -87,6 +87,7 @@ def fetch_notification_status_for_service_by_month(start_date, end_date, service
         FactNotificationStatus.service_id == service_id,
         FactNotificationStatus.bst_date >= start_date,
         FactNotificationStatus.bst_date < end_date,
+        FactNotificationStatus.key_type != KEY_TYPE_TEST
     ).group_by(
         func.date_trunc('month', FactNotificationStatus.bst_date).label('month'),
         FactNotificationStatus.notification_type,
@@ -104,7 +105,8 @@ def fetch_notification_status_for_service_for_day(bst_day, service_id):
     ).filter(
         Notification.created_at >= get_london_midnight_in_utc(bst_day),
         Notification.created_at < get_london_midnight_in_utc(bst_day + timedelta(days=1)),
-        Notification.service_id == service_id
+        Notification.service_id == service_id,
+        Notification.key_type != KEY_TYPE_TEST
     ).group_by(
         Notification.notification_type,
         Notification.status

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -8,7 +8,7 @@ from sqlalchemy.types import DateTime
 
 from app import db
 from app.models import Notification, NotificationHistory, FactNotificationStatus
-from app.utils import convert_bst_to_utc, get_london_midnight_in_utc, get_london_month_from_utc_column
+from app.utils import convert_bst_to_utc, get_london_midnight_in_utc
 
 
 def fetch_notification_status_for_day(process_day, service_id=None):

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -34,9 +34,7 @@ from app.models import (
     EMAIL_TYPE,
     INTERNATIONAL_SMS_TYPE,
     KEY_TYPE_TEST,
-    NOTIFICATION_STATUS_TYPES,
     SMS_TYPE,
-    TEMPLATE_TYPES,
     LETTER_TYPE,
 )
 from app.utils import get_london_month_from_utc_column, get_london_midnight_in_utc

--- a/app/service/statistics.py
+++ b/app/service/statistics.py
@@ -92,7 +92,7 @@ def create_empty_monthly_notification_status_stats_dict(year):
     # nested dicts - data[month][template type][status] = count
     return {
         convert_utc_to_bst(start).strftime('%Y-%m'): {
-            template_type: {}
+            template_type: defaultdict(int)
             for template_type in TEMPLATE_TYPES
         }
         for start in utc_month_starts
@@ -103,6 +103,6 @@ def add_monthly_notification_status_stats(data, stats):
     for row in stats:
         month = row.month.strftime('%Y-%m')
 
-        data[month][row.notification_type][row.notification_status] = row.count
+        data[month][row.notification_type][row.notification_status] += row.count
 
     return data

--- a/app/service/statistics.py
+++ b/app/service/statistics.py
@@ -1,6 +1,9 @@
+from collections import defaultdict
 from datetime import datetime
 
 from app.models import NOTIFICATION_STATUS_TYPES, TEMPLATE_TYPES
+from app.utils import convert_utc_to_bst
+from app.dao.date_util import get_months_for_financial_year
 
 
 def format_statistics(statistics):
@@ -82,3 +85,24 @@ def _update_statuses_from_row(update_dict, row):
         update_dict['delivered'] += row.count
     elif row.status in ('failed', 'technical-failure', 'temporary-failure', 'permanent-failure'):
         update_dict['failed'] += row.count
+
+
+def create_empty_monthly_notification_status_stats_dict(year):
+    utc_month_starts = get_months_for_financial_year(year)
+    # nested dicts - data[month][template type][status] = count
+    return {
+        convert_utc_to_bst(start).strftime('%Y-%m'): {
+            template_type: defaultdict(int)
+            for template_type in TEMPLATE_TYPES
+        }
+        for start in utc_month_starts
+    }
+
+
+def add_monthly_notification_status_stats(data, stats):
+    for row in stats:
+        month = row.month.strftime('%Y-%m')
+
+        data[month][row.notification_type][row.notification_status] = row.count
+
+    return data

--- a/app/service/statistics.py
+++ b/app/service/statistics.py
@@ -92,7 +92,7 @@ def create_empty_monthly_notification_status_stats_dict(year):
     # nested dicts - data[month][template type][status] = count
     return {
         convert_utc_to_bst(start).strftime('%Y-%m'): {
-            template_type: defaultdict(int)
+            template_type: {}
             for template_type in TEMPLATE_TYPES
         }
         for start in utc_month_starts

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -1,9 +1,14 @@
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, date
 from uuid import UUID
 
-from app.dao.fact_notification_status_dao import update_fact_notification_status, fetch_notification_status_for_day
+from app.dao.fact_notification_status_dao import (
+    update_fact_notification_status,
+    fetch_notification_status_for_day,
+    fetch_notification_status_for_service_by_month,
+    fetch_notification_status_for_service_for_day,
+)
 from app.models import FactNotificationStatus
-from tests.app.db import create_notification, create_service, create_template
+from tests.app.db import create_notification, create_service, create_template, create_ft_notification_status
 
 
 def test_update_fact_notification_status(notify_db_session):
@@ -80,3 +85,87 @@ def test__update_fact_notification_status_updates_row(notify_db_session):
                                                               ).all()
     assert len(updated_fact_data) == 1
     assert updated_fact_data[0].notification_count == 2
+
+
+def test_fetch_notification_status_for_service_by_month(notify_db_session):
+    service_1 = create_service(service_name='service_1')
+    service_2 = create_service(service_name='service_2')
+
+    create_ft_notification_status(date(2018, 1, 1), 'sms', service_1, count=4)
+    create_ft_notification_status(date(2018, 1, 2), 'sms', service_1, count=10)
+    create_ft_notification_status(date(2018, 1, 2), 'sms', service_1, notification_status='created')
+    create_ft_notification_status(date(2018, 1, 3), 'email', service_1)
+
+    create_ft_notification_status(date(2018, 2, 2), 'sms', service_1)
+
+    # not included - too early
+    create_ft_notification_status(date(2017, 12, 31), 'sms', service_1)
+    # not included - too late
+    create_ft_notification_status(date(2017, 3, 1), 'sms', service_1)
+    # not included - wrong service
+    create_ft_notification_status(date(2018, 1, 3), 'sms', service_2)
+
+    results = sorted(
+        fetch_notification_status_for_service_by_month(date(2018, 1, 1), date(2018, 2, 28), service_1.id),
+        key=lambda x: (x.month, x.notification_type, x.notification_status)
+    )
+
+    assert len(results) == 4
+
+    assert results[0].month.date() == date(2018, 1, 1)
+    assert results[0].notification_type == 'email'
+    assert results[0].notification_status == 'delivered'
+    assert results[0].count == 1
+
+    assert results[1].month.date() == date(2018, 1, 1)
+    assert results[1].notification_type == 'sms'
+    assert results[1].notification_status == 'created'
+    assert results[1].count == 1
+
+    assert results[2].month.date() == date(2018, 1, 1)
+    assert results[2].notification_type == 'sms'
+    assert results[2].notification_status == 'delivered'
+    assert results[2].count == 14
+
+    assert results[3].month.date() == date(2018, 2, 1)
+    assert results[3].notification_type == 'sms'
+    assert results[3].notification_status == 'delivered'
+    assert results[3].count == 1
+
+
+def test_fetch_notification_status_for_service_for_day(notify_db_session):
+    service_1 = create_service(service_name='service_1')
+    service_2 = create_service(service_name='service_2')
+
+    create_template(service=service_1)
+    create_template(service=service_2)
+
+    # too early
+    create_notification(service_1.templates[0], created_at=datetime(2018, 5, 31, 22, 59, 0))
+
+    # included
+    create_notification(service_1.templates[0], created_at=datetime(2018, 5, 31, 23, 0, 0))
+    create_notification(service_1.templates[0], created_at=datetime(2018, 6, 1, 22, 59, 0))
+    create_notification(service_1.templates[0], created_at=datetime(2018, 6, 1, 22, 59, 0), status='delivered')
+
+    # wrong service
+    create_notification(service_2.templates[0], created_at=datetime(2018, 5, 31, 23, 0, 0))
+
+    # tomorrow (somehow)
+    create_notification(service_1.templates[0], created_at=datetime(2018, 6, 1, 23, 0, 0))
+
+    results = sorted(
+        fetch_notification_status_for_service_for_day(datetime(2018, 6, 1), service_1.id),
+        key=lambda x: x.notification_status
+    )
+    assert len(results) == 2
+
+    assert results[0].month == datetime(2018, 6, 1, 0, 0)
+    assert results[0].notification_type == 'sms'
+    assert results[0].notification_status == 'created'
+    assert results[0].count == 2
+
+    assert results[1].month == datetime(2018, 6, 1, 0, 0)
+    assert results[1].notification_type == 'sms'
+    assert results[1].notification_status == 'delivered'
+    assert results[1].count == 1

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -24,7 +24,6 @@ from app.dao.services_dao import (
     delete_service_and_all_associated_db_objects,
     dao_fetch_stats_for_service,
     dao_fetch_todays_stats_for_service,
-    dao_fetch_monthly_historical_stats_for_service,
     fetch_todays_total_message_count,
     dao_fetch_todays_stats_for_all_services,
     fetch_stats_by_date_range_for_all_services,
@@ -80,7 +79,6 @@ from tests.app.conftest import (
 
 
 def test_should_have_decorated_services_dao_functions():
-    assert dao_fetch_monthly_historical_stats_for_service.__wrapped__.__name__ == 'dao_fetch_monthly_historical_stats_for_service'  # noqa
     assert dao_fetch_todays_stats_for_service.__wrapped__.__name__ == 'dao_fetch_todays_stats_for_service'  # noqa
     assert dao_fetch_stats_for_service.__wrapped__.__name__ == 'dao_fetch_stats_for_service'  # noqa
 
@@ -646,62 +644,6 @@ def test_fetch_stats_should_not_gather_notifications_older_than_7_days(notify_db
     assert 'delivered' not in stats
     assert stats['failed'] == 3
     assert stats['created'] == 1
-
-
-def test_fetch_monthly_historical_stats_separates_months(notify_db, notify_db_session, sample_template):
-    notification_history = functools.partial(
-        create_notification_history,
-        notify_db,
-        notify_db_session,
-        sample_template
-    )
-    # _before_start_of_financial_year
-    notification_history(created_at=datetime(2016, 3, 31))
-    # start_of_financial_year
-    notification_history(created_at=datetime(2016, 4, 1))
-    # start_of_summer
-    notification_history(created_at=datetime(2016, 6, 20))
-    # start_of_autumn
-    notification_history(created_at=datetime(2016, 9, 30, 23, 30, 0))  # October because BST
-    # start_of_winter
-    notification_history(created_at=datetime(2016, 12, 1), status='delivered')
-    # start_of_spring
-    notification_history(created_at=datetime(2017, 3, 11))
-    # end_of_financial_year
-    notification_history(created_at=datetime(2017, 3, 31))
-    # _after_end_of_financial_year
-    notification_history(created_at=datetime(2017, 3, 31, 23, 30))  # after because BST
-
-    result = dao_fetch_monthly_historical_stats_for_service(sample_template.service_id, 2016)
-
-    for day, status, count in (
-        ('2016-04', 'sending', 0),
-        ('2016-04', 'delivered', 0),
-        ('2016-04', 'pending', 0),
-        ('2016-04', 'failed', 0),
-        ('2016-04', 'technical-failure', 0),
-        ('2016-04', 'temporary-failure', 0),
-        ('2016-04', 'permanent-failure', 0),
-
-        ('2016-06', 'created', 1),
-
-        ('2016-10', 'created', 1),
-
-        ('2016-12', 'created', 0),
-        ('2016-12', 'delivered', 1),
-
-        ('2017-03', 'created', 2),
-    ):
-        assert result[day]['sms'][status] == count
-        assert result[day]['email'][status] == 0
-        assert result[day]['letter'][status] == 0
-
-    assert result.keys() == {
-        '2016-04', '2016-05', '2016-06',
-        '2016-07', '2016-08', '2016-09',
-        '2016-10', '2016-11', '2016-12',
-        '2017-01', '2017-02', '2017-03',
-    }
 
 
 def test_dao_fetch_todays_total_message_count_returns_count_for_today(notify_db,

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -568,7 +568,7 @@ def create_ft_billing(bst_date,
 
 def create_ft_notification_status(
     bst_date,
-    notification_type,
+    notification_type='sms',
     service=None,
     template=None,
     job=None,
@@ -576,9 +576,12 @@ def create_ft_notification_status(
     notification_status='delivered',
     count=1
 ):
-    if not service:
-        service = create_service()
-    if not template:
+    if template:
+        service = template.service
+        notification_type = template.template_type
+    else:
+        if not service:
+            service = create_service()
         template = create_template(service=service, template_type=notification_type)
 
     data = FactNotificationStatus(

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -35,6 +35,7 @@ from app.models import (
     LetterRate,
     InvitedOrganisationUser,
     FactBilling,
+    FactNotificationStatus,
     Complaint
 )
 from app.dao.users_dao import save_model_user
@@ -560,6 +561,36 @@ def create_ft_billing(bst_date,
                        rate=rate,
                        billable_units=billable_unit,
                        notifications_sent=notifications_sent)
+    db.session.add(data)
+    db.session.commit()
+    return data
+
+
+def create_ft_notification_status(
+    bst_date,
+    notification_type,
+    service=None,
+    template=None,
+    job=None,
+    key_type='normal',
+    notification_status='delivered',
+    count=1
+):
+    if not service:
+        service = create_service()
+    if not template:
+        template = create_template(service=service, template_type=notification_type)
+
+    data = FactNotificationStatus(
+        bst_date=bst_date,
+        template_id=template.id,
+        service_id=service.id,
+        job_id=job.id if job else uuid.UUID(int=0),
+        notification_type=notification_type,
+        key_type=key_type,
+        notification_status=notification_status,
+        notification_count=count
+    )
     db.session.add(data)
     db.session.commit()
     return data

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1661,7 +1661,6 @@ def test_get_detailed_services_for_date_range(notify_db, notify_db_session, set_
     }
 
 
-
 def test_search_for_notification_by_to_field(client, sample_template, sample_email_template):
 
     notification1 = create_notification(template=sample_template, to_field='+447700900855',

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -8,7 +8,6 @@ import pytest
 from flask import url_for, current_app
 from freezegun import freeze_time
 
-from app.celery.scheduled_tasks import daily_stats_template_usage_by_month
 from app.dao.organisation_dao import dao_add_service_to_organisation
 from app.dao.service_sms_sender_dao import dao_get_sms_senders_by_service_id
 from app.dao.services_dao import dao_remove_user_from_service
@@ -27,13 +26,11 @@ from app.models import (
     DVLA_ORG_LAND_REGISTRY,
     KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST,
     EMAIL_TYPE, SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INBOUND_SMS_TYPE,
-    PRECOMPILED_TEMPLATE_NAME
 )
 from tests import create_authorization_header
 from tests.app.conftest import (
     sample_user_service_permission as create_user_service_permission,
     sample_notification as create_sample_notification,
-    sample_notification_history as create_notification_history,
     sample_notification_with_job
 )
 from tests.app.db import (
@@ -197,7 +194,7 @@ def test_get_service_by_id_and_user(client, sample_service, sample_user):
         headers=[auth_header]
     )
     assert resp.status_code == 200
-    json_resp = json.loads(resp.get_data(as_text=True))
+    json_resp = resp.json
     assert json_resp['data']['name'] == sample_service.name
     assert json_resp['data']['id'] == str(sample_service.id)
 
@@ -212,7 +209,7 @@ def test_get_service_by_id_should_404_if_no_service_for_user(notify_api, sample_
                 headers=[auth_header]
             )
             assert resp.status_code == 404
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
             assert json_resp['result'] == 'error'
             assert json_resp['message'] == 'No result found'
 
@@ -233,7 +230,7 @@ def test_create_service(client, sample_user):
         '/service',
         data=json.dumps(data),
         headers=headers)
-    json_resp = json.loads(resp.get_data(as_text=True))
+    json_resp = resp.json
     assert resp.status_code == 201
     assert json_resp['data']['id']
     assert json_resp['data']['name'] == 'created service'
@@ -252,7 +249,7 @@ def test_create_service(client, sample_user):
         headers=[auth_header_fetch]
     )
     assert resp.status_code == 200
-    json_resp = json.loads(resp.get_data(as_text=True))
+    json_resp = resp.json
     assert json_resp['data']['name'] == 'created service'
     assert not json_resp['data']['research_mode']
 
@@ -278,7 +275,7 @@ def test_should_not_create_service_with_missing_user_id_field(notify_api, fake_u
                 '/service',
                 data=json.dumps(data),
                 headers=headers)
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
             assert resp.status_code == 400
             assert json_resp['result'] == 'error'
             assert 'Missing data for required field.' in json_resp['message']['user_id']
@@ -301,7 +298,7 @@ def test_should_error_if_created_by_missing(notify_api, sample_user):
                 '/service',
                 data=json.dumps(data),
                 headers=headers)
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
             assert resp.status_code == 400
             assert json_resp['result'] == 'error'
             assert 'Missing data for required field.' in json_resp['message']['created_by']
@@ -328,7 +325,7 @@ def test_should_not_create_service_with_missing_if_user_id_is_not_in_database(no
                 '/service',
                 data=json.dumps(data),
                 headers=headers)
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
             assert resp.status_code == 404
             assert json_resp['result'] == 'error'
             assert json_resp['message'] == 'No result found'
@@ -346,7 +343,7 @@ def test_should_not_create_service_if_missing_data(notify_api, sample_user):
                 '/service',
                 data=json.dumps(data),
                 headers=headers)
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
             assert resp.status_code == 400
             assert json_resp['result'] == 'error'
             assert 'Missing data for required field.' in json_resp['message']['name']
@@ -374,7 +371,7 @@ def test_should_not_create_service_with_duplicate_name(notify_api,
                 '/service',
                 data=json.dumps(data),
                 headers=headers)
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
             assert json_resp['result'] == 'error'
             assert "Duplicate service name '{}'".format(sample_service.name) in json_resp['message']['name']
 
@@ -401,7 +398,7 @@ def test_create_service_should_throw_duplicate_key_constraint_for_existing_email
                 '/service',
                 data=json.dumps(data),
                 headers=headers)
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
             assert json_resp['result'] == 'error'
             assert "Duplicate service name '{}'".format(service_name) in json_resp['message']['name']
 
@@ -429,7 +426,7 @@ def test_update_service(client, notify_db, sample_service):
         data=json.dumps(data),
         headers=[('Content-Type', 'application/json'), auth_header]
     )
-    result = json.loads(resp.get_data(as_text=True))
+    result = resp.json
     assert resp.status_code == 200
     assert result['data']['name'] == 'updated service name'
     assert result['data']['email_from'] == 'updated.service.name'
@@ -472,7 +469,7 @@ def test_update_service_flags(client, sample_service):
         '/service/{}'.format(sample_service.id),
         headers=[auth_header]
     )
-    json_resp = json.loads(resp.get_data(as_text=True))
+    json_resp = resp.json
     assert resp.status_code == 200
     assert json_resp['data']['name'] == sample_service.name
     assert json_resp['data']['research_mode'] is False
@@ -489,7 +486,7 @@ def test_update_service_flags(client, sample_service):
         data=json.dumps(data),
         headers=[('Content-Type', 'application/json'), auth_header]
     )
-    result = json.loads(resp.get_data(as_text=True))
+    result = resp.json
     assert resp.status_code == 200
     assert result['data']['research_mode'] is True
     assert set(result['data']['permissions']) == set([LETTER_TYPE, INTERNATIONAL_SMS_TYPE])
@@ -510,7 +507,7 @@ def test_update_service_sets_crown(client, sample_service, org_type, expected):
         data=json.dumps(data),
         headers=[('Content-Type', 'application/json'), auth_header]
     )
-    result = json.loads(resp.get_data(as_text=True))
+    result = resp.json
     assert resp.status_code == 200
     assert result['data']['crown'] is expected
 
@@ -531,7 +528,7 @@ def test_update_service_flags_with_service_without_default_service_permissions(c
         data=json.dumps(data),
         headers=[('Content-Type', 'application/json'), auth_header]
     )
-    result = json.loads(resp.get_data(as_text=True))
+    result = resp.json
 
     assert resp.status_code == 200
     assert set(result['data']['permissions']) == set([LETTER_TYPE, INTERNATIONAL_SMS_TYPE])
@@ -553,7 +550,7 @@ def test_update_service_flags_will_remove_service_permissions(client, notify_db,
         data=json.dumps(data),
         headers=[('Content-Type', 'application/json'), auth_header]
     )
-    result = json.loads(resp.get_data(as_text=True))
+    result = resp.json
 
     assert resp.status_code == 200
     assert INTERNATIONAL_SMS_TYPE not in result['data']['permissions']
@@ -574,7 +571,7 @@ def test_update_permissions_will_override_permission_flags(client, service_with_
         data=json.dumps(data),
         headers=[('Content-Type', 'application/json'), auth_header]
     )
-    result = json.loads(resp.get_data(as_text=True))
+    result = resp.json
 
     assert resp.status_code == 200
     assert set(result['data']['permissions']) == set([LETTER_TYPE, INTERNATIONAL_SMS_TYPE])
@@ -592,7 +589,7 @@ def test_update_service_permissions_will_add_service_permissions(client, sample_
         data=json.dumps(data),
         headers=[('Content-Type', 'application/json'), auth_header]
     )
-    result = json.loads(resp.get_data(as_text=True))
+    result = resp.json
 
     assert resp.status_code == 200
     assert set(result['data']['permissions']) == set([SMS_TYPE, EMAIL_TYPE, LETTER_TYPE])
@@ -640,7 +637,7 @@ def test_update_permissions_with_an_invalid_permission_will_raise_error(client, 
         data=json.dumps(data),
         headers=[('Content-Type', 'application/json'), auth_header]
     )
-    result = json.loads(resp.get_data(as_text=True))
+    result = resp.json
 
     assert resp.status_code == 400
     assert result['result'] == 'error'
@@ -659,7 +656,7 @@ def test_update_permissions_with_duplicate_permissions_will_raise_error(client, 
         data=json.dumps(data),
         headers=[('Content-Type', 'application/json'), auth_header]
     )
-    result = json.loads(resp.get_data(as_text=True))
+    result = resp.json
 
     assert resp.status_code == 400
     assert result['result'] == 'error'
@@ -674,7 +671,7 @@ def test_update_service_research_mode_throws_validation_error(notify_api, sample
                 '/service/{}'.format(sample_service.id),
                 headers=[auth_header]
             )
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
             assert resp.status_code == 200
             assert json_resp['data']['name'] == sample_service.name
             assert not json_resp['data']['research_mode']
@@ -690,7 +687,7 @@ def test_update_service_research_mode_throws_validation_error(notify_api, sample
                 data=json.dumps(data),
                 headers=[('Content-Type', 'application/json'), auth_header]
             )
-            result = json.loads(resp.get_data(as_text=True))
+            result = resp.json
             assert result['message']['research_mode'][0] == "Not a valid boolean."
             assert resp.status_code == 400
 
@@ -720,7 +717,7 @@ def test_should_not_update_service_with_duplicate_name(notify_api,
                 headers=[('Content-Type', 'application/json'), auth_header]
             )
             assert resp.status_code == 400
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
             assert json_resp['result'] == 'error'
             assert "Duplicate service name '{}'".format(service_name) in json_resp['message']['name']
 
@@ -752,7 +749,7 @@ def test_should_not_update_service_with_duplicate_email_from(notify_api,
                 headers=[('Content-Type', 'application/json'), auth_header]
             )
             assert resp.status_code == 400
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
             assert json_resp['result'] == 'error'
             assert (
                 "Duplicate service name '{}'".format(service_name) in json_resp['message']['name'] or
@@ -791,7 +788,7 @@ def test_get_users_by_service(notify_api, sample_service):
             )
 
             assert resp.status_code == 200
-            result = json.loads(resp.get_data(as_text=True))
+            result = resp.json
             assert len(result['data']) == 1
             assert result['data'][0]['name'] == user_on_service.name
             assert result['data'][0]['email_address'] == user_on_service.email_address
@@ -852,7 +849,7 @@ def test_default_permissions_are_added_for_user_service(notify_api,
                 '/service',
                 data=json.dumps(data),
                 headers=headers)
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
             assert resp.status_code == 201
             assert json_resp['data']['id']
             assert json_resp['data']['name'] == 'created service'
@@ -893,7 +890,7 @@ def test_add_existing_user_to_another_service_with_all_permissions(notify_api,
             )
 
             assert resp.status_code == 200
-            result = json.loads(resp.get_data(as_text=True))
+            result = resp.json
             assert len(result['data']) == 1
             assert result['data'][0]['email_address'] == user_already_in_service.email_address
 
@@ -934,7 +931,7 @@ def test_add_existing_user_to_another_service_with_all_permissions(notify_api,
                 headers=[('Content-Type', 'application/json'), auth_header],
             )
             assert resp.status_code == 200
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
             assert str(user_to_add.id) in json_resp['data']['users']
 
             # check user has all permissions
@@ -943,7 +940,7 @@ def test_add_existing_user_to_another_service_with_all_permissions(notify_api,
                               headers=[('Content-Type', 'application/json'), auth_header])
 
             assert resp.status_code == 200
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
             permissions = json_resp['data']['permissions'][str(sample_service.id)]
             expected_permissions = ['send_texts', 'send_emails', 'send_letters', 'manage_users',
                                     'manage_settings', 'manage_templates', 'manage_api_keys', 'view_activity']
@@ -986,7 +983,7 @@ def test_add_existing_user_to_another_service_with_send_permissions(notify_api,
                               headers=[('Content-Type', 'application/json'), auth_header])
 
             assert resp.status_code == 200
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
 
             permissions = json_resp['data']['permissions'][str(sample_service.id)]
             expected_permissions = ['send_texts', 'send_emails', 'send_letters']
@@ -1029,7 +1026,7 @@ def test_add_existing_user_to_another_service_with_manage_permissions(notify_api
                               headers=[('Content-Type', 'application/json'), auth_header])
 
             assert resp.status_code == 200
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
 
             permissions = json_resp['data']['permissions'][str(sample_service.id)]
             expected_permissions = ['manage_users', 'manage_settings', 'manage_templates']
@@ -1070,7 +1067,7 @@ def test_add_existing_user_to_another_service_with_manage_api_keys(notify_api,
                               headers=[('Content-Type', 'application/json'), auth_header])
 
             assert resp.status_code == 200
-            json_resp = json.loads(resp.get_data(as_text=True))
+            json_resp = resp.json
 
             permissions = json_resp['data']['permissions'][str(sample_service.id)]
             expected_permissions = ['manage_api_keys']
@@ -1102,7 +1099,7 @@ def test_add_existing_user_to_non_existing_service_returns404(notify_api,
                 data=json.dumps(data)
             )
 
-            result = json.loads(resp.get_data(as_text=True))
+            result = resp.json
             expected_message = 'No result found'
 
             assert resp.status_code == 404
@@ -1124,7 +1121,7 @@ def test_add_existing_user_of_service_to_service_returns400(notify_api, notify_d
                 data=json.dumps(data)
             )
 
-            result = json.loads(resp.get_data(as_text=True))
+            result = resp.json
             expected_message = 'User id: {} already part of service id: {}'.format(existing_user_id, sample_service.id)
 
             assert resp.status_code == 400
@@ -1146,7 +1143,7 @@ def test_add_unknown_user_to_service_returns404(notify_api, notify_db, notify_db
                 data=json.dumps(data)
             )
 
-            result = json.loads(resp.get_data(as_text=True))
+            result = resp.json
             expected_message = 'No result found'
 
             assert resp.status_code == 404
@@ -1204,7 +1201,7 @@ def test_cannot_remove_only_user_from_service(notify_api,
                 endpoint,
                 headers=[('Content-Type', 'application/json'), auth_header])
             assert resp.status_code == 400
-            result = json.loads(resp.get_data(as_text=True))
+            result = resp.json
             assert result['message'] == 'You cannot remove the only user for a service'
 
 
@@ -1474,25 +1471,11 @@ def test_get_detailed_service(notify_db, notify_db_session, notify_api, sample_s
             )
 
     assert resp.status_code == 200
-    service = json.loads(resp.get_data(as_text=True))['data']
+    service = resp.json['data']
     assert service['id'] == str(sample_service.id)
     assert 'statistics' in service.keys()
     assert set(service['statistics'].keys()) == {SMS_TYPE, EMAIL_TYPE, LETTER_TYPE}
     assert service['statistics'][SMS_TYPE] == stats
-
-
-@pytest.mark.parametrize('kwargs, expected_json', [
-    ({'year': 'baz'}, {'message': 'Year must be a number', 'result': 'error'}),
-    ({}, {'message': 'Year must be a number', 'result': 'error'}),
-])
-def test_get_monthly_notification_stats_returns_errors(admin_request, sample_service, kwargs, expected_json):
-    response = admin_request.get(
-        'service.get_monthly_notification_stats',
-        service_id=sample_service.id,
-        _expected_status=400,
-        **kwargs
-    )
-    assert response == expected_json
 
 
 def test_get_services_with_detailed_flag(client, notify_db, notify_db_session):
@@ -1507,7 +1490,7 @@ def test_get_services_with_detailed_flag(client, notify_db, notify_db_session):
     )
 
     assert resp.status_code == 200
-    data = json.loads(resp.get_data(as_text=True))['data']
+    data = resp.json['data']
     assert len(data) == 1
     assert data[0]['name'] == 'Sample service'
     assert data[0]['id'] == str(notifications[0].service_id)
@@ -1532,7 +1515,7 @@ def test_get_services_with_detailed_flag_excluding_from_test_key(notify_api, not
         )
 
     assert resp.status_code == 200
-    data = json.loads(resp.get_data(as_text=True))['data']
+    data = resp.json['data']
     assert len(data) == 1
     assert data[0]['statistics'] == {
         EMAIL_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0},
@@ -1677,224 +1660,6 @@ def test_get_detailed_services_for_date_range(notify_db, notify_db_session, set_
         LETTER_TYPE: {'delivered': 0, 'failed': 0, 'requested': 0}
     }
 
-
-@freeze_time('2017-11-11 02:00')
-def test_get_template_usage_by_month_returns_correct_data(
-        notify_db,
-        notify_db_session,
-        client,
-        sample_template
-):
-
-    # add a historical notification for template
-    not1 = create_notification_history(
-        notify_db,
-        notify_db_session,
-        sample_template,
-        created_at=datetime(2016, 4, 1),
-    )
-
-    create_notification_history(
-        notify_db,
-        notify_db_session,
-        sample_template,
-        created_at=datetime(2017, 4, 1),
-        status='sending'
-    )
-
-    create_notification_history(
-        notify_db,
-        notify_db_session,
-        sample_template,
-        created_at=datetime(2017, 4, 1),
-        status='permanent-failure'
-    )
-
-    create_notification_history(
-        notify_db,
-        notify_db_session,
-        sample_template,
-        created_at=datetime(2017, 4, 1),
-        status='temporary-failure'
-    )
-
-    daily_stats_template_usage_by_month()
-
-    create_notification(
-        sample_template,
-        created_at=datetime.utcnow()
-    )
-
-    resp = client.get(
-        '/service/{}/notifications/templates_usage/monthly?year=2017'.format(not1.service_id),
-        headers=[create_authorization_header()]
-    )
-    resp_json = json.loads(resp.get_data(as_text=True)).get('stats')
-
-    assert resp.status_code == 200
-    assert len(resp_json) == 2
-
-    assert resp_json[0]["template_id"] == str(sample_template.id)
-    assert resp_json[0]["name"] == sample_template.name
-    assert resp_json[0]["type"] == sample_template.template_type
-    assert resp_json[0]["month"] == 4
-    assert resp_json[0]["year"] == 2017
-    assert resp_json[0]["count"] == 3
-
-    assert resp_json[1]["template_id"] == str(sample_template.id)
-    assert resp_json[1]["name"] == sample_template.name
-    assert resp_json[1]["type"] == sample_template.template_type
-    assert resp_json[1]["month"] == 11
-    assert resp_json[1]["year"] == 2017
-    assert resp_json[1]["count"] == 1
-
-
-@freeze_time('2017-11-11 02:00')
-def test_get_template_usage_by_month_returns_no_data(
-        notify_db,
-        notify_db_session,
-        client,
-        sample_template
-):
-
-    # add a historical notification for template
-    not1 = create_notification_history(
-        notify_db,
-        notify_db_session,
-        sample_template,
-        created_at=datetime(2016, 4, 1),
-    )
-
-    create_notification_history(
-        notify_db,
-        notify_db_session,
-        sample_template,
-        created_at=datetime(2017, 4, 1),
-        status='sending'
-    )
-
-    create_notification_history(
-        notify_db,
-        notify_db_session,
-        sample_template,
-        created_at=datetime(2017, 4, 1),
-        status='permanent-failure'
-    )
-
-    create_notification_history(
-        notify_db,
-        notify_db_session,
-        sample_template,
-        created_at=datetime(2017, 4, 1),
-        status='temporary-failure'
-    )
-
-    daily_stats_template_usage_by_month()
-
-    create_notification(
-        sample_template,
-        created_at=datetime.utcnow()
-    )
-
-    resp = client.get(
-        '/service/{}/notifications/templates_usage/monthly?year=2015'.format(not1.service_id),
-        headers=[create_authorization_header()]
-    )
-    resp_json = json.loads(resp.get_data(as_text=True)).get('stats')
-
-    assert resp.status_code == 200
-    assert len(resp_json) == 0
-
-
-@freeze_time('2017-11-11 02:00')
-def test_get_template_usage_by_month_returns_two_templates(
-        notify_db,
-        notify_db_session,
-        client,
-        sample_template,
-        sample_service
-):
-
-    template_one = create_template(
-        sample_service,
-        template_type=LETTER_TYPE,
-        template_name=PRECOMPILED_TEMPLATE_NAME,
-        hidden=True
-    )
-
-    # add a historical notification for template
-    not1 = create_notification_history(
-        notify_db,
-        notify_db_session,
-        template_one,
-        created_at=datetime(2017, 4, 1),
-    )
-
-    create_notification_history(
-        notify_db,
-        notify_db_session,
-        sample_template,
-        created_at=datetime(2017, 4, 1),
-        status='sending'
-    )
-
-    create_notification_history(
-        notify_db,
-        notify_db_session,
-        sample_template,
-        created_at=datetime(2017, 4, 1),
-        status='permanent-failure'
-    )
-
-    create_notification_history(
-        notify_db,
-        notify_db_session,
-        sample_template,
-        created_at=datetime(2017, 4, 1),
-        status='temporary-failure'
-    )
-
-    daily_stats_template_usage_by_month()
-
-    create_notification(
-        sample_template,
-        created_at=datetime.utcnow()
-    )
-
-    resp = client.get(
-        '/service/{}/notifications/templates_usage/monthly?year=2017'.format(not1.service_id),
-        headers=[create_authorization_header()]
-    )
-    resp_json = json.loads(resp.get_data(as_text=True)).get('stats')
-
-    assert resp.status_code == 200
-    assert len(resp_json) == 3
-
-    resp_json = sorted(resp_json, key=lambda k: (k.get('year', 0), k.get('month', 0), k.get('count', 0)))
-
-    assert resp_json[0]["template_id"] == str(template_one.id)
-    assert resp_json[0]["name"] == template_one.name
-    assert resp_json[0]["type"] == template_one.template_type
-    assert resp_json[0]["month"] == 4
-    assert resp_json[0]["year"] == 2017
-    assert resp_json[0]["count"] == 1
-    assert resp_json[0]["is_precompiled_letter"] is True
-
-    assert resp_json[1]["template_id"] == str(sample_template.id)
-    assert resp_json[1]["name"] == sample_template.name
-    assert resp_json[1]["type"] == sample_template.template_type
-    assert resp_json[1]["month"] == 4
-    assert resp_json[1]["year"] == 2017
-    assert resp_json[1]["count"] == 3
-    assert resp_json[1]["is_precompiled_letter"] is False
-
-    assert resp_json[2]["template_id"] == str(sample_template.id)
-    assert resp_json[2]["name"] == sample_template.name
-    assert resp_json[2]["type"] == sample_template.template_type
-    assert resp_json[2]["month"] == 11
-    assert resp_json[2]["year"] == 2017
-    assert resp_json[2]["count"] == 1
-    assert resp_json[2]["is_precompiled_letter"] is False
 
 
 def test_search_for_notification_by_to_field(client, sample_template, sample_email_template):
@@ -3065,35 +2830,3 @@ def test_get_platform_stats_creates_zero_stats(client, notify_db_session):
     assert json_resp['email'] == {'failed': 1, 'requested': 2, 'delivered': 1}
     assert json_resp['letter'] == {'failed': 0, 'requested': 0, 'delivered': 0}
     assert json_resp['sms'] == {'failed': 0, 'requested': 4, 'delivered': 3}
-
-
-@pytest.mark.parametrize('today_only, stats', [
-    (False, {'requested': 2, 'delivered': 1, 'failed': 0}),
-    (True, {'requested': 1, 'delivered': 0, 'failed': 0})
-], ids=['seven_days', 'today'])
-def test_get_service_notification_statistics(admin_request, sample_template, today_only, stats):
-    with freeze_time('2000-01-01T12:00:00'):
-        create_notification(sample_template, status='delivered')
-    with freeze_time('2000-01-02T12:00:00'):
-        create_notification(sample_template, status='created')
-        resp = admin_request.get(
-            'service.get_service_notification_statistics',
-            service_id=sample_template.service_id,
-            today_only=today_only
-        )
-
-    assert set(resp['data'].keys()) == {SMS_TYPE, EMAIL_TYPE, LETTER_TYPE}
-    assert resp['data'][SMS_TYPE] == stats
-
-
-def test_get_service_notification_statistics_with_unknown_service(admin_request):
-    resp = admin_request.get(
-        'service.get_service_notification_statistics',
-        service_id=uuid.uuid4()
-    )
-
-    assert resp['data'] == {
-        SMS_TYPE: {'requested': 0, 'delivered': 0, 'failed': 0},
-        EMAIL_TYPE: {'requested': 0, 'delivered': 0, 'failed': 0},
-        LETTER_TYPE: {'requested': 0, 'delivered': 0, 'failed': 0},
-    }

--- a/tests/app/service/test_statistics.py
+++ b/tests/app/service/test_statistics.py
@@ -1,5 +1,8 @@
 import collections
+from datetime import datetime
+from unittest.mock import Mock
 
+from freezegun import freeze_time
 import pytest
 
 from app.service.statistics import (
@@ -7,6 +10,8 @@ from app.service.statistics import (
     format_statistics,
     create_stats_dict,
     create_zeroed_stats_dicts,
+    create_empty_monthly_notification_status_stats_dict,
+    add_monthly_notification_status_stats
 )
 
 StatsRow = collections.namedtuple('row', ('notification_type', 'status', 'count'))
@@ -129,3 +134,73 @@ def test_format_admin_stats_counts_non_test_key_notifications_correctly():
     assert stats_dict['sms']['failures']['permanent-failure'] == 0
 
     assert stats_dict['letter']['total'] == 1
+
+
+def _stats(requested, delivered, failed):
+    return {'requested': requested, 'delivered': delivered, 'failed': failed}
+
+
+@pytest.mark.parametrize('year, expected_years', [
+    (
+        2018,
+        [
+            '2018-04',
+            '2018-05',
+            '2018-06'
+        ]
+    ),
+    (
+        2017,
+        [
+            '2017-04',
+            '2017-05',
+            '2017-06',
+            '2017-07',
+            '2017-08',
+            '2017-09',
+            '2017-10',
+            '2017-11',
+            '2017-12',
+            '2018-01',
+            '2018-02',
+            '2018-03'
+        ]
+    )
+])
+@freeze_time('2018-05-31 23:59:59')
+def test_create_empty_monthly_notification_status_stats_dict(year, expected_years):
+    output = create_empty_monthly_notification_status_stats_dict(year)
+    assert sorted(output.keys()) == expected_years
+    for v in output.values():
+        assert v == {'sms': {}, 'email': {}, 'letter': {}}
+
+
+@freeze_time('2018-05-31 23:59:59')
+def test_add_monthly_notification_status_stats():
+    row_data = [
+        {'month': datetime(2018, 4, 1), 'notification_type': 'sms', 'notification_status': 'sending', 'count': 1},
+        {'month': datetime(2018, 4, 1), 'notification_type': 'sms', 'notification_status': 'delivered', 'count': 2},
+        {'month': datetime(2018, 4, 1), 'notification_type': 'email', 'notification_status': 'sending', 'count': 4},
+        {'month': datetime(2018, 5, 1), 'notification_type': 'sms', 'notification_status': 'sending', 'count': 8},
+    ]
+    rows = []
+    for r in row_data:
+        m = Mock(spec=[])
+        for k, v in r.items():
+            setattr(m, k, v)
+        rows.append(m)
+
+    data = create_empty_monthly_notification_status_stats_dict(2018)
+    # this data won't be affected
+    data['2018-05']['email']['sending'] = 32
+
+    # this data will get overwritten
+    data['2018-05']['sms']['sending'] = 16
+
+    add_monthly_notification_status_stats(data, rows)
+
+    assert data == {
+        '2018-04': {'sms': {'sending': 1, 'delivered': 2}, 'email': {'sending': 4}, 'letter': {}},
+        '2018-05': {'sms': {'sending': 8}, 'email': {'sending': 32}, 'letter': {}},
+        '2018-06': {'sms': {}, 'email': {}, 'letter': {}},
+    }

--- a/tests/app/service/test_statistics.py
+++ b/tests/app/service/test_statistics.py
@@ -194,13 +194,13 @@ def test_add_monthly_notification_status_stats():
     # this data won't be affected
     data['2018-05']['email']['sending'] = 32
 
-    # this data will get overwritten
+    # this data will get combined with the 8 from row_data
     data['2018-05']['sms']['sending'] = 16
 
     add_monthly_notification_status_stats(data, rows)
 
     assert data == {
         '2018-04': {'sms': {'sending': 1, 'delivered': 2}, 'email': {'sending': 4}, 'letter': {}},
-        '2018-05': {'sms': {'sending': 8}, 'email': {'sending': 32}, 'letter': {}},
+        '2018-05': {'sms': {'sending': 24}, 'email': {'sending': 32}, 'letter': {}},
         '2018-06': {'sms': {}, 'email': {}, 'letter': {}},
     }

--- a/tests/app/service/test_statistics_rest.py
+++ b/tests/app/service/test_statistics_rest.py
@@ -1,0 +1,165 @@
+import uuid
+from datetime import datetime
+
+import pytest
+from freezegun import freeze_time
+
+from app.celery.scheduled_tasks import daily_stats_template_usage_by_month
+from app.models import EMAIL_TYPE, SMS_TYPE, LETTER_TYPE, PRECOMPILED_TEMPLATE_NAME
+
+from tests.app.db import (
+    create_template,
+    create_notification,
+)
+
+
+@freeze_time('2017-11-11 02:00')
+def test_get_template_usage_by_month_returns_correct_data(
+        admin_request,
+        sample_template
+):
+    create_notification(sample_template, created_at=datetime(2016, 4, 1), status='created')
+    create_notification(sample_template, created_at=datetime(2017, 4, 1), status='sending')
+    create_notification(sample_template, created_at=datetime(2017, 4, 1), status='permanent-failure')
+    create_notification(sample_template, created_at=datetime(2017, 4, 1), status='temporary-failure')
+
+    daily_stats_template_usage_by_month()
+
+    create_notification(sample_template, created_at=datetime.utcnow())
+
+    resp_json = admin_request.get(
+        'service.get_monthly_template_usage',
+        service_id=sample_template.service_id,
+        year=2017
+    )
+    resp_json = resp_json['stats']
+
+    assert len(resp_json) == 2
+
+    assert resp_json[0]["template_id"] == str(sample_template.id)
+    assert resp_json[0]["name"] == sample_template.name
+    assert resp_json[0]["type"] == sample_template.template_type
+    assert resp_json[0]["month"] == 4
+    assert resp_json[0]["year"] == 2017
+    assert resp_json[0]["count"] == 3
+
+    assert resp_json[1]["template_id"] == str(sample_template.id)
+    assert resp_json[1]["name"] == sample_template.name
+    assert resp_json[1]["type"] == sample_template.template_type
+    assert resp_json[1]["month"] == 11
+    assert resp_json[1]["year"] == 2017
+    assert resp_json[1]["count"] == 1
+
+
+@freeze_time('2017-11-11 02:00')
+def test_get_template_usage_by_month_returns_no_data(admin_request, sample_template):
+    create_notification(sample_template, created_at=datetime(2016, 4, 1), status='created')
+
+    daily_stats_template_usage_by_month()
+
+    create_notification(sample_template, created_at=datetime.utcnow())
+
+    resp_json = admin_request.get(
+        'service.get_monthly_template_usage',
+        service_id=sample_template.service_id,
+        year=2015
+    )
+    assert resp_json['stats'] == []
+
+
+@freeze_time('2017-11-11 02:00')
+def test_get_template_usage_by_month_returns_two_templates(admin_request, sample_template, sample_service):
+    template_one = create_template(
+        sample_service,
+        template_type=LETTER_TYPE,
+        template_name=PRECOMPILED_TEMPLATE_NAME,
+        hidden=True
+    )
+
+    create_notification(template_one, created_at=datetime(2017, 4, 1), status='created')
+    create_notification(sample_template, created_at=datetime(2017, 4, 1), status='sending')
+    create_notification(sample_template, created_at=datetime(2017, 4, 1), status='permanent-failure')
+    create_notification(sample_template, created_at=datetime(2017, 4, 1), status='temporary-failure')
+
+    daily_stats_template_usage_by_month()
+
+    create_notification(sample_template, created_at=datetime.utcnow())
+
+    resp_json = admin_request.get(
+        'service.get_monthly_template_usage',
+        service_id=sample_template.service_id,
+        year=2017
+    )
+
+    resp_json = sorted(resp_json['stats'], key=lambda k: (k['year'], k['month'], k['count']))
+    assert len(resp_json) == 3
+
+    assert resp_json[0]["template_id"] == str(template_one.id)
+    assert resp_json[0]["name"] == template_one.name
+    assert resp_json[0]["type"] == template_one.template_type
+    assert resp_json[0]["month"] == 4
+    assert resp_json[0]["year"] == 2017
+    assert resp_json[0]["count"] == 1
+    assert resp_json[0]["is_precompiled_letter"] is True
+
+    assert resp_json[1]["template_id"] == str(sample_template.id)
+    assert resp_json[1]["name"] == sample_template.name
+    assert resp_json[1]["type"] == sample_template.template_type
+    assert resp_json[1]["month"] == 4
+    assert resp_json[1]["year"] == 2017
+    assert resp_json[1]["count"] == 3
+    assert resp_json[1]["is_precompiled_letter"] is False
+
+    assert resp_json[2]["template_id"] == str(sample_template.id)
+    assert resp_json[2]["name"] == sample_template.name
+    assert resp_json[2]["type"] == sample_template.template_type
+    assert resp_json[2]["month"] == 11
+    assert resp_json[2]["year"] == 2017
+    assert resp_json[2]["count"] == 1
+    assert resp_json[2]["is_precompiled_letter"] is False
+
+
+@pytest.mark.parametrize('today_only, stats', [
+    (False, {'requested': 2, 'delivered': 1, 'failed': 0}),
+    (True, {'requested': 1, 'delivered': 0, 'failed': 0})
+], ids=['seven_days', 'today'])
+def test_get_service_notification_statistics(admin_request, sample_template, today_only, stats):
+    with freeze_time('2000-01-01T12:00:00'):
+        create_notification(sample_template, status='delivered')
+    with freeze_time('2000-01-02T12:00:00'):
+        create_notification(sample_template, status='created')
+        resp = admin_request.get(
+            'service.get_service_notification_statistics',
+            service_id=sample_template.service_id,
+            today_only=today_only
+        )
+
+    assert set(resp['data'].keys()) == {SMS_TYPE, EMAIL_TYPE, LETTER_TYPE}
+    assert resp['data'][SMS_TYPE] == stats
+
+
+def test_get_service_notification_statistics_with_unknown_service(admin_request):
+    resp = admin_request.get(
+        'service.get_service_notification_statistics',
+        service_id=uuid.uuid4()
+    )
+
+    assert resp['data'] == {
+        SMS_TYPE: {'requested': 0, 'delivered': 0, 'failed': 0},
+        EMAIL_TYPE: {'requested': 0, 'delivered': 0, 'failed': 0},
+        LETTER_TYPE: {'requested': 0, 'delivered': 0, 'failed': 0},
+    }
+
+
+@pytest.mark.parametrize('kwargs, expected_json', [
+    ({'year': 'baz'}, {'message': 'Year must be a number', 'result': 'error'}),
+    ({}, {'message': 'Year must be a number', 'result': 'error'}),
+])
+def test_get_monthly_notification_stats_returns_errors(admin_request, sample_service, kwargs, expected_json):
+    response = admin_request.get(
+        'service.get_monthly_notification_stats',
+        service_id=sample_service.id,
+        _expected_status=400,
+        **kwargs
+    )
+    assert response == expected_json

--- a/tests/app/service/test_statistics_rest.py
+++ b/tests/app/service/test_statistics_rest.py
@@ -5,11 +5,21 @@ import pytest
 from freezegun import freeze_time
 
 from app.celery.scheduled_tasks import daily_stats_template_usage_by_month
-from app.models import EMAIL_TYPE, SMS_TYPE, LETTER_TYPE, PRECOMPILED_TEMPLATE_NAME
+from app.models import (
+    EMAIL_TYPE,
+    SMS_TYPE,
+    LETTER_TYPE,
+    PRECOMPILED_TEMPLATE_NAME,
+    KEY_TYPE_TEST,
+    KEY_TYPE_TEAM,
+    KEY_TYPE_NORMAL,
+)
 
 from tests.app.db import (
+    create_service,
     create_template,
     create_notification,
+    create_ft_notification_status
 )
 
 
@@ -163,3 +173,148 @@ def test_get_monthly_notification_stats_returns_errors(admin_request, sample_ser
         **kwargs
     )
     assert response == expected_json
+
+
+def test_get_monthly_notification_stats_returns_404_if_no_service(admin_request):
+    response = admin_request.get(
+        'service.get_monthly_notification_stats',
+        service_id=uuid.uuid4(),
+        _expected_status=404,
+    )
+    assert response == {'message': 'No result found', 'result': 'error'}
+
+
+def test_get_monthly_notification_stats_returns_empty_stats_with_correct_dates(admin_request, sample_service):
+    response = admin_request.get(
+        'service.get_monthly_notification_stats',
+        service_id=sample_service.id,
+        year=2016
+    )
+    assert len(response['data']) == 12
+
+    keys = [
+        '2016-04', '2016-05', '2016-06', '2016-07', '2016-08', '2016-09', '2016-10', '2016-11', '2016-12',
+        '2017-01', '2017-02', '2017-03'
+    ]
+    assert sorted(response['data'].keys()) == keys
+    for val in response['data'].values():
+        assert val == {'sms': {}, 'email': {}, 'letter': {}}
+
+
+def test_get_monthly_notification_stats_returns_stats(admin_request, sample_service):
+    sms_t1 = create_template(sample_service)
+    sms_t2 = create_template(sample_service)
+    email_template = create_template(sample_service, template_type=EMAIL_TYPE)
+
+    create_ft_notification_status(datetime(2016, 6, 1), template=sms_t1)
+    create_ft_notification_status(datetime(2016, 6, 2), template=sms_t1)
+
+    create_ft_notification_status(datetime(2016, 7, 1), template=sms_t1)
+    create_ft_notification_status(datetime(2016, 7, 1), template=sms_t2)
+    create_ft_notification_status(datetime(2016, 7, 1), template=sms_t1, notification_status='created')
+    create_ft_notification_status(datetime(2016, 7, 1), template=email_template)
+
+    response = admin_request.get(
+        'service.get_monthly_notification_stats',
+        service_id=sample_service.id,
+        year=2016
+    )
+    assert len(response['data']) == 12
+
+    assert response['data']['2016-06'] == {
+        'sms': {
+            # it combines the two days
+            'delivered': 2
+        },
+        'email': {},
+        'letter': {}
+    }
+    assert response['data']['2016-07'] == {
+        # it combines the two template types
+        'sms': {
+            'created': 1,
+            'delivered': 2,
+        },
+        'email': {
+            'delivered': 1
+        },
+        'letter': {}
+    }
+
+
+@freeze_time('2016-06-05 12:00:00')
+def test_get_monthly_notification_stats_combines_todays_data_and_historic_stats(admin_request, sample_template):
+    create_ft_notification_status(datetime(2016, 5, 1), template=sample_template, count=1)
+    create_ft_notification_status(datetime(2016, 6, 1), template=sample_template, notification_status='created', count=2)  # noqa
+
+    create_notification(sample_template, created_at=datetime(2016, 6, 5), status='created')
+    create_notification(sample_template, created_at=datetime(2016, 6, 5), status='delivered')
+
+    # this doesn't get returned in the stats because it is old - it should be in ft_notification_status by now
+    create_notification(sample_template, created_at=datetime(2016, 6, 4), status='sending')
+
+    response = admin_request.get(
+        'service.get_monthly_notification_stats',
+        service_id=sample_template.service_id,
+        year=2016
+    )
+
+    assert len(response['data']) == 3  # apr, may, jun
+    assert response['data']['2016-05'] == {
+        'sms': {
+            'delivered': 1
+        },
+        'email': {},
+        'letter': {}
+    }
+    assert response['data']['2016-06'] == {
+        'sms': {
+            # combines the stats from the historic ft_notification_status and the current notifications
+            'created': 3,
+            'delivered': 1,
+        },
+        'email': {},
+        'letter': {}
+    }
+
+
+def test_get_monthly_notification_stats_ignores_test_keys(admin_request, sample_service):
+    create_ft_notification_status(datetime(2016, 6, 1), service=sample_service, key_type=KEY_TYPE_NORMAL, count=1)
+    create_ft_notification_status(datetime(2016, 6, 1), service=sample_service, key_type=KEY_TYPE_TEAM, count=2)
+    create_ft_notification_status(datetime(2016, 6, 1), service=sample_service, key_type=KEY_TYPE_TEST, count=4)
+
+    response = admin_request.get('service.get_monthly_notification_stats', service_id=sample_service.id, year=2016)
+
+    assert response['data']['2016-06']['sms'] == {'delivered': 3}
+
+
+def test_get_monthly_notification_stats_checks_dates(admin_request, sample_service):
+    t = create_template(sample_service)
+    create_ft_notification_status(datetime(2016, 3, 31), template=t, notification_status='created')
+    create_ft_notification_status(datetime(2016, 4, 1), template=t, notification_status='sending')
+    create_ft_notification_status(datetime(2017, 3, 31), template=t, notification_status='delivered')
+    create_ft_notification_status(datetime(2017, 4, 11), template=t, notification_status='permanent-failure')
+
+    response = admin_request.get('service.get_monthly_notification_stats', service_id=sample_service.id, year=2016)
+
+    assert '2016-03' not in response['data']
+    assert '2017-04' not in response['data']
+    assert response['data']['2016-04']['sms'] == {'sending': 1}
+    assert response['data']['2017-03']['sms'] == {'delivered': 1}
+
+
+def test_get_monthly_notification_stats_only_gets_for_one_service(admin_request, notify_db_session):
+    services = [create_service(), create_service(service_name="2")]
+
+    templates = [create_template(services[0]), create_template(services[1])]
+
+    create_ft_notification_status(datetime(2016, 6, 1), template=templates[0], notification_status='created')
+    create_ft_notification_status(datetime(2016, 6, 1), template=templates[1], notification_status='delivered')
+
+    response = admin_request.get('service.get_monthly_notification_stats', service_id=services[0].id, year=2016)
+
+    assert response['data']['2016-06'] == {
+        'sms': {'created': 1},
+        'email': {},
+        'letter': {}
+    }


### PR DESCRIPTION
gets historical data from ft_notification_status table, grouped by month. It returns data in the format:

```{ 'YYYY-MM' : {'template_type': {'status_1': 1, 'status_2': 823}}}```

Note that all relevant months will be there, all template types will be there, but if there is no data statuses will be omitted (so months with no data will still have sms, email, letter, but each one will be an empty dict).

If you request for this year it'll only return months up until today - and today's data will be retrieved from the notifications table and combined with the data from the ft_notification_status table. the ft_notification_status table won't be updated with these numbers - leave that for the nightly job.