### PR TITLE
Fix task name for notification status updates

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -217,7 +217,7 @@ class Config(object):
             'options': {'queue': QueueNames.PERIODIC}
         },
         'create-nightly-notification-status': {
-            'task': 'create-nightly-billing',
+            'task': 'create-nightly-notification-status',
             'schedule': crontab(hour=4, minute=30),
             'options': {'queue': QueueNames.PERIODIC}
         },


### PR DESCRIPTION
The periodic task to populate ft_notification_status was calling the wrong task, this fixes that.