### PR TITLE
Send complaints to service teams

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -47,7 +47,7 @@ from app.dao.provider_details_dao import (
     get_current_provider,
     dao_toggle_sms_provider
 )
-from app.dao.service_callback_api_dao import get_service_callback_api_for_service
+from app.dao.service_callback_api_dao import get_service_delivery_status_callback_api_for_service
 from app.dao.services_dao import (
     dao_fetch_monthly_historical_stats_by_template
 )
@@ -210,7 +210,7 @@ def timeout_notifications():
     notifications = technical_failure_notifications + temporary_failure_notifications
     for notification in notifications:
         # queue callback task only if the service_callback_api exists
-        service_callback_api = get_service_callback_api_for_service(service_id=notification.service_id)
+        service_callback_api = get_service_delivery_status_callback_api_for_service(service_id=notification.service_id)
         if service_callback_api:
             encrypted_notification = create_encrypted_callback_data(notification, service_callback_api)
             send_delivery_status_to_service.apply_async([str(notification.id), encrypted_notification],

--- a/app/commands.py
+++ b/app/commands.py
@@ -26,7 +26,7 @@ from app.dao.monthly_billing_dao import (
     get_service_ids_that_need_billing_populated
 )
 from app.dao.provider_rates_dao import create_provider_rates as dao_create_provider_rates
-from app.dao.service_callback_api_dao import get_service_callback_api_for_service
+from app.dao.service_callback_api_dao import get_service_delivery_status_callback_api_for_service
 from app.dao.services_dao import (
     delete_service_and_all_associated_db_objects,
     dao_fetch_all_services_by_user,
@@ -349,7 +349,7 @@ def replay_create_pdf_letters(notification_id):
               help="""The service that the callbacks are for""")
 def replay_service_callbacks(file_name, service_id):
     print("Start send service callbacks for service: ", service_id)
-    callback_api = get_service_callback_api_for_service(service_id=service_id)
+    callback_api = get_service_delivery_status_callback_api_for_service(service_id=service_id)
     if not callback_api:
         print("Callback api was not found for service: {}".format(service_id))
         return

--- a/app/dao/service_callback_api_dao.py
+++ b/app/dao/service_callback_api_dao.py
@@ -4,6 +4,8 @@ from app import db, create_uuid
 from app.dao.dao_utils import transactional, version_class
 from app.models import ServiceCallbackApi
 
+from app.models import DELIVERY_STATUS_CALLBACK_TYPE
+
 
 @transactional
 @version_class(ServiceCallbackApi)
@@ -30,8 +32,11 @@ def get_service_callback_api(service_callback_api_id, service_id):
     return ServiceCallbackApi.query.filter_by(id=service_callback_api_id, service_id=service_id).first()
 
 
-def get_service_callback_api_for_service(service_id):
-    return ServiceCallbackApi.query.filter_by(service_id=service_id).first()
+def get_service_delivery_status_callback_api_for_service(service_id):
+    return ServiceCallbackApi.query.filter_by(
+        service_id=service_id,
+        callback_type=DELIVERY_STATUS_CALLBACK_TYPE
+    ).first()
 
 
 @transactional

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -12,7 +12,7 @@ from app.dao import (
 )
 from app.dao.complaint_dao import save_complaint
 from app.dao.notifications_dao import dao_get_notification_history_by_reference
-from app.dao.service_callback_api_dao import get_service_callback_api_for_service
+from app.dao.service_callback_api_dao import get_service_delivery_status_callback_api_for_service
 from app.models import Complaint
 from app.notifications.process_client_response import validate_callback_data
 from app.celery.service_callback_tasks import (
@@ -146,7 +146,7 @@ def remove_emails_from_complaint(complaint_dict):
 
 def _check_and_queue_callback_task(notification):
     # queue callback task only if the service_callback_api exists
-    service_callback_api = get_service_callback_api_for_service(service_id=notification.service_id)
+    service_callback_api = get_service_delivery_status_callback_api_for_service(service_id=notification.service_id)
     if service_callback_api:
         encrypted_notification = create_encrypted_callback_data(notification, service_callback_api)
         send_delivery_status_to_service.apply_async([str(notification.id), encrypted_notification],

--- a/app/notifications/process_client_response.py
+++ b/app/notifications/process_client_response.py
@@ -14,7 +14,7 @@ from app.celery.service_callback_tasks import (
 )
 from app.config import QueueNames
 from app.dao.notifications_dao import dao_update_notification
-from app.dao.service_callback_api_dao import get_service_callback_api_for_service
+from app.dao.service_callback_api_dao import get_service_delivery_status_callback_api_for_service
 
 sms_response_mapper = {
     'MMG': get_mmg_responses,
@@ -95,7 +95,7 @@ def _process_for_status(notification_status, client_name, provider_reference):
         )
 
     # queue callback task only if the service_callback_api exists
-    service_callback_api = get_service_callback_api_for_service(service_id=notification.service_id)
+    service_callback_api = get_service_delivery_status_callback_api_for_service(service_id=notification.service_id)
 
     if service_callback_api:
         encrypted_notification = create_encrypted_callback_data(notification, service_callback_api)

--- a/migrations/versions/0206_assign_callback_type.py
+++ b/migrations/versions/0206_assign_callback_type.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 0206_assign_callback_type
+Revises: 0205_service_callback_type
+Create Date: 2018-07-18 10:43:43.864835
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0206_assign_callback_type'
+down_revision = '0205_service_callback_type'
+
+
+def upgrade():
+    op.execute("update service_callback_api set callback_type = 'delivery_status' where callback_type is null")
+
+
+def downgrade():
+    pass

--- a/tests/app/dao/test_service_callback_api_dao.py
+++ b/tests/app/dao/test_service_callback_api_dao.py
@@ -8,7 +8,7 @@ from app.dao.service_callback_api_dao import (
     save_service_callback_api,
     reset_service_callback_api,
     get_service_callback_api,
-    get_service_callback_api_for_service)
+    get_service_delivery_status_callback_api_for_service)
 from app.models import ServiceCallbackApi
 from tests.app.db import create_service_callback_api
 
@@ -118,9 +118,9 @@ def test_get_service_callback_api(sample_service):
     assert callback_api.updated_at is None
 
 
-def test_get_service_callback_api_for_service(sample_service):
+def test_get_service_delivery_status_callback_api_for_service(sample_service):
     service_callback_api = create_service_callback_api(service=sample_service)
-    result = get_service_callback_api_for_service(sample_service.id)
+    result = get_service_delivery_status_callback_api_for_service(sample_service.id)
     assert result.id == service_callback_api.id
     assert result.url == service_callback_api.url
     assert result.bearer_token == service_callback_api.bearer_token

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -316,11 +316,13 @@ def create_service_callback_api(
         service,
         url="https://something.com",
         bearer_token="some_super_secret",
+        callback_type="delivery_status"
 ):
     service_callback_api = ServiceCallbackApi(service_id=service.id,
                                               url=url,
                                               bearer_token=bearer_token,
-                                              updated_by_id=service.users[0].id
+                                              updated_by_id=service.users[0].id,
+                                              callback_type=callback_type
                                               )
     save_service_callback_api(service_callback_api)
     return service_callback_api


### PR DESCRIPTION
2nd part of work for this ticket: https://www.pivotaltracker.com/story/show/159003296

We:
- created a migration to assign callback_type "delivery_status" to existing service callback api's
- modified 'get_service_callback_api_for_service' function to only return service callback api's with type "delivery_status"