### PR TITLE
Add callback_type to service callback history records

### DIFF
--- a/migrations/versions/0207_set_callback_history_type.py
+++ b/migrations/versions/0207_set_callback_history_type.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 0207_set_callback_history_type
+Revises: 0206_assign_callback_type
+Create Date: 2018-07-18 10:43:43.864835
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0207_set_callback_history_type'
+down_revision = '0206_assign_callback_type'
+
+
+def upgrade():
+    op.execute("update service_callback_api_history set callback_type = 'delivery_status' where callback_type is null")
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
We've updated the current service callbacks to add callback types
in #1964, but since the table is versioned we also need to add a
type to the history records.

Even though they're not used anywhere at the moment this might make
it easier to restore from a history callback record in the future.