### PR TITLE
Include the notification sender name when serializing notifications

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1299,6 +1299,12 @@ class Notification(db.Model):
             # Currently can only be technical-failure
             return self.status
 
+    def get_created_by_name(self):
+        if self.created_by:
+            return self.created_by.name
+        else:
+            return None
+
     def serialize_for_csv(self):
         created_at_in_bst = convert_utc_to_bst(self.created_at)
         serialized = {
@@ -1338,6 +1344,7 @@ class Notification(db.Model):
             "body": self.content,
             "subject": self.subject,
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
+            "created_by_name": self.get_created_by_name(),
             "sent_at": self.sent_at.strftime(DATETIME_FORMAT) if self.sent_at else None,
             "completed_at": self.completed_at(),
             "scheduled_for": (

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -225,6 +225,17 @@ def test_letter_notification_serializes_with_address(client, sample_letter_notif
     assert res['postcode'] == 'SW1 1AA'
 
 
+def test_notification_serializes_created_by_name_with_no_created_by_id(client, sample_notification):
+    res = sample_notification.serialize()
+    assert res['created_by_name'] is None
+
+
+def test_notification_serializes_created_by_name_with_created_by_id(client, sample_notification, sample_user):
+    sample_notification.created_by_id = sample_user.id
+    res = sample_notification.serialize()
+    assert res['created_by_name'] == sample_user.name
+
+
 def test_sms_notification_serializes_without_subject(client, sample_template):
     res = sample_template.serialize()
     assert res['subject'] is None

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -70,6 +70,7 @@ def test_get_notification_by_id_returns_200(
         'status': '{}'.format(sample_notification.status),
         'template': expected_template_response,
         'created_at': sample_notification.created_at.strftime(DATETIME_FORMAT),
+        'created_by_name': None,
         'body': sample_notification.template.content,
         "subject": None,
         'sent_at': sample_notification.sent_at,
@@ -120,6 +121,7 @@ def test_get_notification_by_id_with_placeholders_returns_200(
         'status': '{}'.format(sample_notification.status),
         'template': expected_template_response,
         'created_at': sample_notification.created_at.strftime(DATETIME_FORMAT),
+        'created_by_name': None,
         'body': "Hello Bob\nThis is an email from GOV.UK",
         "subject": "Bob",
         'sent_at': sample_notification.sent_at,
@@ -147,6 +149,24 @@ def test_get_notification_by_reference_returns_200(client, sample_template):
 
     assert json_response['notifications'][0]['id'] == str(sample_notification_with_reference.id)
     assert json_response['notifications'][0]['reference'] == "some-client-reference"
+
+
+def test_get_notification_by_id_returns_created_by_name_if_notification_created_by_id(
+    client,
+    sample_user,
+    sample_template,
+):
+    sms_notification = create_notification(template=sample_template)
+    sms_notification.created_by_id = sample_user.id
+
+    auth_header = create_authorization_header(service_id=sms_notification.service_id)
+    response = client.get(
+        path=url_for('v2_notifications.get_notification_by_id', notification_id=sms_notification.id),
+        headers=[('Content-Type', 'application/json'), auth_header]
+    )
+
+    json_response = response.get_json()
+    assert json_response['created_by_name'] == 'Test User'
 
 
 def test_get_notifications_returns_scheduled_for(client, sample_template):


### PR DESCRIPTION
The `serialize` method of the Notification model now includes the
`created_by_name`. If a notification was sent as a one-off message this
value will now be the name of the person who sent the notification. If
a notification was sent through the API or by a CSV upload we don't
record the id of the sender, so `created_by_name` will be `None`.

This change affects the data that gets returned from these endpoints:
* /v2/notifications/<notification_id>
* /v2/notifications

[Pivotal story](https://www.pivotaltracker.com/story/show/158970584)