### PR TITLE
Increase the number of days we calculate billing from 3 to 10 days.

### DIFF
--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -21,7 +21,7 @@ def create_nightly_billing(day_start=None):
     else:
         # When calling the task its a string in the format of "YYYY-MM-DD"
         day_start = datetime.strptime(day_start, "%Y-%m-%d")
-    for i in range(0, 3):
+    for i in range(0, 10):
         process_day = day_start - timedelta(days=i)
 
         transit_data = fetch_billing_data_for_day(process_day=process_day)

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -491,8 +491,10 @@ def check_billable_units(notification_update):
     if int(notification_update.page_count) != notification.billable_units:
         msg = 'Notification with id {} had {} billable_units but a page count of {}'.format(
             notification.id, notification.billable_units, notification_update.page_count)
-
-        current_app.logger.error(msg)
+        try:
+            raise DVLAException(msg)
+        except DVLAException:
+            current_app.logger.exception(msg)
 
 
 @notify_celery.task(bind=True, name="send-inbound-sms", max_retries=5, default_retry_delay=300)

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -308,7 +308,7 @@ def test_check_billable_units_when_billable_units_does_not_match_page_count(
     mocker,
     notification_update
 ):
-    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.error')
+    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.exception')
 
     notification = create_notification(sample_letter_template, reference='REFERENCE_ABC', billable_units=3)
 

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -287,7 +287,7 @@ def test_create_nightly_billing_consolidate_from_3_days_delta(
     mocker.patch('app.dao.fact_billing_dao.get_rate', side_effect=mocker_get_rate)
 
     # create records from 11th to 15th
-    for i in range(0, 5):
+    for i in range(0, 11):
         sample_notification(
             notify_db,
             notify_db_session,
@@ -302,7 +302,7 @@ def test_create_nightly_billing_consolidate_from_3_days_delta(
         )
 
     notification = Notification.query.order_by(Notification.created_at).all()
-    assert datetime.date(notification[0].created_at) == date(2018, 1, 11)
+    assert datetime.date(notification[0].created_at) == date(2018, 1, 5)
 
     records = FactBilling.query.all()
     assert len(records) == 0
@@ -310,8 +310,8 @@ def test_create_nightly_billing_consolidate_from_3_days_delta(
     create_nightly_billing()
     records = FactBilling.query.order_by(FactBilling.bst_date).all()
 
-    assert len(records) == 3
-    assert records[0].bst_date == date(2018, 1, 12)
+    assert len(records) == 10
+    assert records[0].bst_date == date(2018, 1, 5)
     assert records[-1].bst_date == date(2018, 1, 14)
 
 


### PR DESCRIPTION
Log exception if the billing counts for letters are different in the dvla response file than what we collected.