### PR TITLE
Brings in spacing changes to the email template

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -25,6 +25,6 @@ notifications-python-client==4.8.2
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@29.3.2#egg=notifications-utils==29.3.2
+git+https://github.com/alphagov/notifications-utils.git@29.3.3#egg=notifications-utils==29.3.3
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ notifications-python-client==4.8.2
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@29.3.2#egg=notifications-utils==29.3.2
+git+https://github.com/alphagov/notifications-utils.git@29.3.3#egg=notifications-utils==29.3.3
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
@@ -34,12 +34,12 @@ git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 alembic==1.0.0
 amqp==1.4.9
 anyjson==0.3.3
-awscli==1.15.59
+awscli==1.15.64
 bcrypt==3.1.4
 billiard==3.3.0.23
 bleach==2.1.3
 boto3==1.6.16
-botocore==1.10.58
+botocore==1.10.63
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7
@@ -47,7 +47,7 @@ colorama==0.3.9
 docutils==0.14
 Flask-Redis==0.3.0
 future==0.16.0
-greenlet==0.4.13
+greenlet==0.4.14
 html5lib==1.0.1
 idna==2.7
 itsdangerous==0.24


### PR DESCRIPTION
Fixes some issues with the email template in various versions of Outlook.

Full description is here: https://github.com/alphagov/notifications-utils/pull/499

Intention is to help an issue one of our users has with Outlook 2016 on Windows 10. We can't replicate it but hopefully these fixes for similar problems will have an impact. 

Related issue: https://www.pivotaltracker.com/story/show/158835491