### PR TITLE
Handle zero as a letter page count in billing.

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -213,6 +213,8 @@ def get_service_ids_that_need_billing_populated(start_date, end_date):
 
 def get_rate(non_letter_rates, letter_rates, notification_type, date, crown=None, letter_page_count=None):
     if notification_type == LETTER_TYPE:
+        if letter_page_count == 0:
+            return 0
         return next(r[3] for r in letter_rates if date > r[0] and crown == r[1] and letter_page_count == r[2])
     elif notification_type == SMS_TYPE:
         return next(r[2] for r in non_letter_rates if notification_type == r[0] and date > r[1])

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -248,6 +248,16 @@ def test_get_rate(notify_db_session):
     assert letter_rate == Decimal('0.3')
 
 
+def test_get_rate_for_letters_when_page_count_is_zero(notify_db_session):
+    non_letter_rates, letter_rates = get_rates_for_billing()
+    letter_rate = get_rate(non_letter_rates=non_letter_rates, letter_rates=letter_rates,
+                           notification_type='letter',
+                           crown=True,
+                           letter_page_count=0,
+                           date=datetime.utcnow())
+    assert letter_rate == 0
+
+
 def test_fetch_monthly_billing_for_year(notify_db_session):
     service = create_service()
     template = create_template(service=service, template_type="sms")


### PR DESCRIPTION
Last night we had some letter notifications that were in permanent failure and had page count = 0.

This causes the create-nighlty-billing task to fail.
This will make sure that 0 is returned in this case.