### PR TITLE
Celery dev null

### DIFF
--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -56,12 +56,12 @@ applications:
       NOTIFY_APP_NAME: delivery-celery-beat
 
   - name: notify-delivery-worker-database
-    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q database-tasks
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q database-tasks 2> /dev/null
     env:
       NOTIFY_APP_NAME: delivery-worker-database
 
   - name: notify-delivery-worker-research
-    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5 -Q research-mode-tasks
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5 -Q research-mode-tasks 2> /dev/null
     env:
       NOTIFY_APP_NAME: delivery-worker-research
 
@@ -72,33 +72,33 @@ applications:
       NOTIFY_APP_NAME: delivery-worker-sender
 
   - name: notify-delivery-worker-periodic
-    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=2 -Q periodic-tasks,statistics-tasks
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=2 -Q periodic-tasks,statistics-tasks 2> /dev/null
     instances: 1
     env:
       NOTIFY_APP_NAME: delivery-worker-periodic
 
   - name: notify-delivery-worker-priority
-    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5 -Q priority-tasks
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5 -Q priority-tasks 2> /dev/null
     env:
       NOTIFY_APP_NAME: delivery-worker-priority
 
   - name: notify-delivery-worker
-    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q job-tasks,retry-tasks,create-letters-pdf-tasks,letter-tasks
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q job-tasks,retry-tasks,create-letters-pdf-tasks,letter-tasks 2> /dev/null
     env:
       NOTIFY_APP_NAME: delivery-worker
 
   # Only consume the notify-internal-tasks queue on this app so that Notify messages are processed as a priority
   - name: notify-delivery-worker-internal
-    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q notify-internal-tasks
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q notify-internal-tasks 2> /dev/null
     env:
       NOTIFY_APP_NAME: delivery-worker-internal
 
   - name: notify-delivery-worker-receipts
-    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q ses-callbacks
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q ses-callbacks 2> /dev/null
     env:
       NOTIFY_APP_NAME: delivery-worker-receipts
 
   - name: notify-delivery-worker-service-callbacks
-    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q service-callbacks
+    command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q service-callbacks 2> /dev/null
     env:
       NOTIFY_APP_NAME: delivery-worker-service-callbacks

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.4
+python-3.5.5

--- a/tests/test_manifest_delivery_base.py
+++ b/tests/test_manifest_delivery_base.py
@@ -13,11 +13,8 @@ def test_queue_names_set_in_manifest_delivery_base_correctly():
             start_of_queue_arg = command.find(search)
             if start_of_queue_arg > 0:
                 start_of_queue_names = start_of_queue_arg + len(search)
-                queues = command[start_of_queue_names:].split(',')
-                for q in queues:
-                    if "2>" in q:
-                        q = q.split("2>")[0].strip()
-                    watched_queues.add(q)
+                end_of_queue_names = command.find('2>') if '2>' in command else len(command)
+                watched_queues.update({q.strip() for q in command[start_of_queue_names:end_of_queue_names].split(',')})
 
         # ses-callbacks isn't used in api (only used in SNS lambda)
         ignored_queues = {'ses-callbacks'}

--- a/tests/test_manifest_delivery_base.py
+++ b/tests/test_manifest_delivery_base.py
@@ -14,7 +14,10 @@ def test_queue_names_set_in_manifest_delivery_base_correctly():
             if start_of_queue_arg > 0:
                 start_of_queue_names = start_of_queue_arg + len(search)
                 queues = command[start_of_queue_names:].split(',')
-                watched_queues.update(queues)
+                for q in queues:
+                    if "2>" in q:
+                        q = q.split("2>")[0].strip()
+                    watched_queues.add(q)
 
         # ses-callbacks isn't used in api (only used in SNS lambda)
         ignored_queues = {'ses-callbacks'}


### PR DESCRIPTION
#### Redirect stderr of workers to /dev/null

Celery prints its own stuff to stderr in a non-json format.

These get picked up by syslog drain and are shipped to
logstash together with the normal json-formatted logs resulting in
duplicate information and reducing the usability of the logs.