### PR TITLE
Remove caseworking permission

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -245,7 +245,6 @@ EMAIL_AUTH = 'email_auth'
 LETTERS_AS_PDF = 'letters_as_pdf'
 PRECOMPILED_LETTER = 'precompiled_letter'
 UPLOAD_DOCUMENT = 'upload_document'
-CASEWORKING = 'caseworking'
 
 SERVICE_PERMISSION_TYPES = [
     EMAIL_TYPE,
@@ -258,7 +257,6 @@ SERVICE_PERMISSION_TYPES = [
     LETTERS_AS_PDF,
     PRECOMPILED_LETTER,
     UPLOAD_DOCUMENT,
-    CASEWORKING,
 ]
 
 

--- a/migrations/versions/0212_remove_caseworking.py
+++ b/migrations/versions/0212_remove_caseworking.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0212_remove_caseworking
+Revises: 0211_email_branding_update
+Create Date: 2018-07-31 18:00:20.457755
+
+"""
+from alembic import op
+
+
+revision = '0212_remove_caseworking'
+down_revision = '0211_email_branding_update'
+
+PERMISSION_NAME = "caseworking"
+
+
+def upgrade():
+    op.execute("delete from service_permissions where permission = '{}'".format(PERMISSION_NAME))
+    op.execute("delete from service_permission_types where name = '{}'".format(PERMISSION_NAME))
+
+
+def downgrade():
+    op.execute("insert into service_permission_types values('{}')".format(PERMISSION_NAME))


### PR DESCRIPTION
What became ‘caseworking view’ is now available to all services.

***

Depends on:
- [ ] https://github.com/alphagov/notifications-admin/pull/2217