### PR TITLE
Bump utils to 29.3.6

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -25,6 +25,6 @@ notifications-python-client==5.0.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@29.3.5#egg=notifications-utils==29.3.5
+git+https://github.com/alphagov/notifications-utils.git@29.3.6#egg=notifications-utils==29.3.6
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ notifications-python-client==5.0.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@29.3.5#egg=notifications-utils==29.3.5
+git+https://github.com/alphagov/notifications-utils.git@29.3.6#egg=notifications-utils==29.3.6
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
@@ -35,13 +35,13 @@ git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 alembic==1.0.0
 amqp==1.4.9
 anyjson==0.3.3
-awscli==1.15.74
+awscli==1.15.76
 bcrypt==3.1.4
 billiard==3.3.0.23
 bleach==2.1.3
 boto3==1.6.16
-botocore==1.10.73
-certifi==2018.4.16
+botocore==1.10.75
+certifi==2018.8.13
 chardet==3.0.4
 click==6.7
 colorama==0.3.9


### PR DESCRIPTION
Brings in a fix for a bug in the email template:

https://github.com/alphagov/notifications-utils/pull/513