### PR TITLE
Rename service contact_link to service contact_details

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -348,7 +348,7 @@ class Service(db.Model, Versioned):
     )
     crown = db.Column(db.Boolean, index=False, nullable=False, default=True)
     rate_limit = db.Column(db.Integer, index=False, nullable=False, default=3000)
-    contact_link = db.Column(db.String(255), nullable=True, unique=False)
+    contact_details = db.Column(db.String(255), nullable=True, unique=False)
 
     organisation = db.relationship(
         'Organisation',

--- a/migrations/versions/0213_rename_service_contact_link.py
+++ b/migrations/versions/0213_rename_service_contact_link.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0213_rename_service_contact_link
+Revises: 0212_remove_caseworking
+Create Date: 2018-08-13 11:05:52.413611
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0213_rename_service_contact_link'
+down_revision = '0212_remove_caseworking'
+
+
+def upgrade():
+    op.alter_column('services', 'contact_link', new_column_name='contact_details')
+    op.alter_column('services_history', 'contact_link', new_column_name='contact_details')
+
+
+def downgrade():
+    op.alter_column('services', 'contact_details', new_column_name='contact_link')
+    op.alter_column('services_history', 'contact_details', new_column_name='contact_link')


### PR DESCRIPTION
Services now have a choice of setting a link, email address or phone number for document download users to use to contact them, so this change renames the columns on the `services` and `services_history` table to reflect this.

[Pivotal story](https://www.pivotaltracker.com/story/show/159490824)