### PR TITLE
New columns for EmailBranding.

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -203,9 +203,12 @@ class EmailBranding(db.Model):
     __tablename__ = 'email_branding'
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     colour = db.Column(db.String(7), nullable=True)
+    banner_colour = db.Column(db.String(7), nullable=True)
+    single_id_colour = db.Column(db.String(7), nullable=True)
     logo = db.Column(db.String(255), nullable=True)
     name = db.Column(db.String(255), nullable=True)
     text = db.Column(db.String(255), nullable=True)
+    domain = db.Column(db.Text, nullable=True)
 
     def serialize(self):
         serialized = {
@@ -214,6 +217,9 @@ class EmailBranding(db.Model):
             "logo": self.logo,
             "name": self.name,
             "text": self.text,
+            "banner_colour": self.banner_colour,
+            "single_id_colour": self.single_id_colour,
+            "domain": self.domain
         }
 
         return serialized

--- a/migrations/versions/0213_brand_colour_domain_.py
+++ b/migrations/versions/0213_brand_colour_domain_.py
@@ -1,0 +1,24 @@
+"""
+
+Revision ID: 0213_brand_colour_domain
+Revises: 0212_remove_caseworking
+Create Date: 2018-08-16 16:29:41.374944
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0213_brand_colour_domain'
+down_revision = '0212_remove_caseworking'
+
+
+def upgrade():
+    op.add_column('email_branding', sa.Column('banner_colour', sa.String(length=7), nullable=True))
+    op.add_column('email_branding', sa.Column('domain', sa.Text(), nullable=True))
+    op.add_column('email_branding', sa.Column('single_id_colour', sa.String(length=7), nullable=True))
+
+
+def downgrade():
+    op.drop_column('email_branding', 'single_id_colour')
+    op.drop_column('email_branding', 'domain')
+    op.drop_column('email_branding', 'banner_colour')

--- a/tests/app/email_branding/test_rest.py
+++ b/tests/app/email_branding/test_rest.py
@@ -32,7 +32,8 @@ def test_get_email_branding_by_id(admin_request, notify_db, notify_db_session):
         email_branding_id=email_branding.id
     )
 
-    assert set(response['email_branding'].keys()) == {'colour', 'logo', 'name', 'id', 'text'}
+    assert set(response['email_branding'].keys()) == {'colour', 'logo', 'name', 'id', 'text',
+                                                      'banner_colour', 'single_id_colour', 'domain'}
     assert response['email_branding']['colour'] == '#FFFFFF'
     assert response['email_branding']['logo'] == '/path/image.png'
     assert response['email_branding']['name'] == 'Some Org'


### PR DESCRIPTION
There is a requirement for the colour of the banner to be different to the single id colour. In order to accomodate that we are adding two new columns for that data.
These columns will be updated manually and not done with a data migration.

A new column called domain has been added. This will be used as a default domain, if the user that creates the service has a matching domain this email brand will be set for the service.

This PR only adds the new columns to the model and db.

https://www.pivotaltracker.com/story/show/159660295