### PR TITLE
Add banner_colour, single_id_color and domain to email_branding.

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -30,7 +30,8 @@ from app.models import (
     NOTIFICATION_CREATED,
     NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_SENT,
-    NOTIFICATION_SENDING
+    NOTIFICATION_SENDING,
+    BRANDING_BOTH
 )
 
 
@@ -198,8 +199,10 @@ def get_html_email_options(service):
             service.email_branding.logo
         ) if service.email_branding.logo else None
 
+        colour = _set_colour(service)
+
         branding = {
-            'brand_colour': service.email_branding.colour,
+            'brand_colour': colour,
             'brand_logo': logo_url,
             'brand_name': service.email_branding.text,
         }
@@ -207,6 +210,15 @@ def get_html_email_options(service):
         branding = {}
 
     return dict(govuk_banner=govuk_banner, brand_banner=brand_banner, **branding)
+
+
+def _set_colour(service):
+    if service.branding in [BRANDING_BOTH, BRANDING_ORG]:
+        return service.email_branding.single_id_colour or service.email_branding.colour
+    elif service.branding == BRANDING_ORG_BANNER:
+        return service.email_branding.banner_colour or service.email_branding.colour
+    elif service.branding == BRANDING_GOVUK:
+        return None
 
 
 def technical_failure(notification):

--- a/app/email_branding/email_branding_schema.py
+++ b/app/email_branding/email_branding_schema.py
@@ -4,9 +4,12 @@ post_create_email_branding_schema = {
     "type": "object",
     "properties": {
         "colour": {"type": ["string", "null"]},
+        "banner_colour": {"type": ["string", "null"]},
+        "single_id_colour": {"type": ["string", "null"]},
         "name": {"type": ["string", "null"]},
         "text": {"type": ["string", "null"]},
-        "logo": {"type": ["string", "null"]}
+        "logo": {"type": ["string", "null"]},
+        "domain": {"type": ["string", "null"]},
     },
     "required": []
 }
@@ -17,9 +20,12 @@ post_update_email_branding_schema = {
     "type": "object",
     "properties": {
         "colour": {"type": ["string", "null"]},
+        "banner_colour": {"type": ["string", "null"]},
+        "single_id_colour": {"type": ["string", "null"]},
         "name": {"type": ["string", "null"]},
         "text": {"type": ["string", "null"]},
-        "logo": {"type": ["string", "null"]}
+        "logo": {"type": ["string", "null"]},
+        "domain": {"type": ["string", "null"]},
     },
     "required": []
 }

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -77,7 +77,8 @@ def create_service(
         email_from=None,
         prefix_sms=True,
         message_limit=1000,
-        organisation_type='central'
+        organisation_type='central',
+        branding=None
 ):
     service = Service(
         name=service_name,
@@ -86,7 +87,8 @@ def create_service(
         email_from=email_from if email_from else service_name.lower().replace(' ', '.'),
         created_by=user or create_user(email='{}@digital.cabinet-office.gov.uk'.format(uuid.uuid4())),
         prefix_sms=prefix_sms,
-        organisation_type=organisation_type
+        organisation_type=organisation_type,
+        branding=branding
     )
 
     dao_create_service(service, service.created_by, service_id, service_permissions=service_permissions)

--- a/tests/app/email_branding/test_rest.py
+++ b/tests/app/email_branding/test_rest.py
@@ -45,7 +45,10 @@ def test_post_create_email_branding(admin_request, notify_db_session):
     data = {
         'name': 'test email_branding',
         'colour': '#0000ff',
-        'logo': '/images/test_x2.png'
+        'banner_colour': '#808080',
+        'single_id_colour': '#FF0000',
+        'logo': '/images/test_x2.png',
+        'domain': 'gov.uk'
     }
     response = admin_request.post(
         'email_branding.create_email_branding',
@@ -54,8 +57,11 @@ def test_post_create_email_branding(admin_request, notify_db_session):
     )
     assert data['name'] == response['data']['name']
     assert data['colour'] == response['data']['colour']
+    assert data['banner_colour'] == response['data']['banner_colour']
+    assert data['single_id_colour'] == response['data']['single_id_colour']
     assert data['logo'] == response['data']['logo']
     assert data['name'] == response['data']['text']
+    assert data['domain'] == response['data']['domain']
 
 
 def test_post_create_email_branding_without_logo_is_ok(admin_request, notify_db_session):
@@ -142,6 +148,8 @@ def test_post_create_email_branding_with_text_as_none_and_name(admin_request, no
 @pytest.mark.parametrize('data_update', [
     ({'name': 'test email_branding 1'}),
     ({'logo': 'images/text_x3.png', 'colour': '#ffffff'}),
+    ({'logo': 'images/text_x3.png', 'banner_colour': '#ffffff', 'single_id_colour': '#808080'}),
+    ({'logo': 'images/text_x3.png', 'banner_colour': '#ffffff', 'single_id_colour': '#808080', 'domain': 'gov.uk'}),
 ])
 def test_post_update_email_branding_updates_field(admin_request, notify_db_session, data_update):
     data = {


### PR DESCRIPTION
Add banner_colour, single_id_colour, and domain to email_branding_schema.

The Admin app can now be updated to send the new columns to update/create email_branding