### PR TITLE
Sanitise precompiled pdfs after virus scan

### DIFF
--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -90,16 +90,6 @@ def upload_letter_pdf(notification, pdf_data, precompiled=False):
     return upload_file_name
 
 
-def move_scanned_pdf_to_test_or_live_pdf_bucket(source_filename, is_test_letter=False):
-    source_bucket_name = current_app.config['LETTERS_SCAN_BUCKET_NAME']
-    target_bucket_config = 'TEST_LETTERS_BUCKET_NAME' if is_test_letter else 'LETTERS_PDF_BUCKET_NAME'
-    target_bucket_name = current_app.config[target_bucket_config]
-
-    target_filename = get_folder_name(datetime.utcnow(), is_test_letter) + source_filename
-
-    _move_s3_object(source_bucket_name, source_filename, target_bucket_name, target_filename)
-
-
 def move_failed_pdf(source_filename, scan_error_type):
     scan_bucket = current_app.config['LETTERS_SCAN_BUCKET_NAME']
 


### PR DESCRIPTION
Notify antivirus, on success, calls the process_virus_scan_passed task.

### Previously, this task would:

* update status to created (or delivered for test keys)
* copy the file from the scan bucket to either the live or test bucket based on the results
* delete the old file in the scan bucket

### We want it to:

* download file from scan bucket
* sanitise PDF using new template-preview functionality
* if sanitise failed, set to new status "validation-failed" and save the pdf somewhere.
* send new pdf to live/test bucket
* update status to created (or delivered for test keys)
* delete the original file in the scan bucket

 ### This PR does some of that:

* download file from scan bucket
* sanitise PDF using new template-preview functionality
* if sanitise failed, just log.
* send OLD pdf to live/test bucket
* update status to created (or delivered for test keys)
* delete the original file in the scan bucket

So if sanitising fails, we won't fall over and not deliver the letter, we'll just log a message for now. If sanitise throws an unexpected error (as opposed to a 400), we'll retry up to fifteen times (the same as when creating a new letter). I've added the code for using the sanitised pdf, but it's commented out for now