### PR TITLE
Add versions of brands for organisations on GOV.UK

### DIFF
--- a/migrations/versions/0217_add_govuk_brands.py
+++ b/migrations/versions/0217_add_govuk_brands.py
@@ -1,0 +1,104 @@
+"""
+
+Revision ID: 0217_add_govuk_brands
+Revises: 0216_remove_colours
+Create Date: 2018-08-23 11:48:00.800968
+
+"""
+from alembic import op
+import uuid
+
+revision = '0217_add_govuk_brands'
+down_revision = '0216_remove_colours'
+
+BRAND_NAMES = (
+    'Animal & Plant Health Agency',
+    'Attorney General\'s Office',
+    'Cabinet Office',
+    'Civil Service',
+    'Civil Service Local',
+    'Crown Commercial Service',
+    'Department for Business, Energy & Industrial Strategy',
+    'Department for Digital, Culture, Media & Sport',
+    'Department for Education',
+    'Department for Environment Food & Rural Affairs',
+    'Department for Exiting the European Union',
+    'Department for International  Development',
+    'Department for International Trade',
+    'Department for Transport',
+    'Department for Work & Pensions',
+    'Department of Health & Social Care',
+    'Direct Debit',
+    'Driver & Vehicle Standards Agency',
+    'Education & Skills Funding Agency',
+    'Environment Agency',
+    'Food Standards Agency',
+    'Foreign & Commonwealth Office',
+    'GOV.UK Verify',
+    'Government Actuary\'s Department',
+    'Government Commercial Function',
+    'Government Legal Department',
+    'HM Courts & Tribunals Service',
+    'HM Passport Office',
+    'HM Revenue & Customs',
+    'HM Treasury',
+    'Home Office',
+    'Marine Management Organisation',
+    'Ministry of Defence',
+    'Ministry of Housing, Communities & Local Government',
+    'Ministry of Justice',
+    'Northern Ireland Office',
+    'Office of the Leader of the House of Commons',
+    'Office of the Advocate General for Scotland',
+    'Office of the Leader of the House of Lords',
+    'Office of the Secretary of State for Scotland',
+    'Office of the Secretary of State for Scotland',
+    'Public Health England',
+    'UK Export Finance',
+    'UK Visas & Immigration',
+)
+
+NAME_WITH_GOVUK = '{} and GOV.UK'
+
+
+def upgrade():
+
+    for brand_name in BRAND_NAMES:
+        op.execute("""
+            INSERT INTO email_branding(
+              id,
+              colour,
+              logo,
+              name,
+              text,
+              brand_type
+            )
+            SELECT
+              '{}'
+              colour,
+              logo,
+              '{}',
+              text,
+              'both'
+            FROM
+              email_branding
+            WHERE
+              name = '{}'
+        """.format(
+            uuid.uuid4(),
+            NAME_WITH_GOVUK.format(brand_name),
+            brand_name,
+        ))
+
+
+def downgrade():
+
+    for brand_name in BRAND_NAMES:
+        op.execute("""
+            DELETE FROM
+                email_branding
+            WHERE
+                name = {}
+        """.format(
+            NAME_WITH_GOVUK.format(brand_name)
+        ))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/159986276

Since `brand_type` will no longer be on the service we need a way of separating the GOV.UK and non-GOV.UK variations of the same brand.

The clearest way to do this is by having two separate versions of these brands. This commit makes ‘…and GOV.UK’ versions of all the brands I have manually identified as potentially being combined with the GOV.UK banner.

These are the services that, on production, are actually using the GOV.UK banner with their branding at the moment (only 15):

id                  |                   name                    | branding
--------------------------------------|-------------------------------------------|----------
[`d3cb6e6b-ccab-41bb-b578-47125bf09d12`](https://www.notifications.service.gov.uk/services/d3cb6e6b-ccab-41bb-b578-47125bf09d12) | Pension Wise Telephone Appointments       | both
[`398b66c4-be05-429a-9897-f25252df64dc`](https://www.notifications.service.gov.uk/services/398b66c4-be05-429a-9897-f25252df64dc) | DVSA fines                                | both
[`cf23bf9c-4a42-42d1-a734-5cfc53dda6ca`](https://www.notifications.service.gov.uk/services/cf23bf9c-4a42-42d1-a734-5cfc53dda6ca) | Benefit Appeals                           | both
[`e19e4da2-713a-4bba-8fb9-8106cbfda177`](https://www.notifications.service.gov.uk/services/e19e4da2-713a-4bba-8fb9-8106cbfda177) | Plant Health & Seeds Inspectorate         | both
[`6f8fb35a-9809-48b1-a1a7-0762d64d7989`](https://www.notifications.service.gov.uk/services/6f8fb35a-9809-48b1-a1a7-0762d64d7989) | APHA                                      | both
[`c9bdb461-af4d-4df8-8076-562cd9f07d42`](https://www.notifications.service.gov.uk/services/c9bdb461-af4d-4df8-8076-562cd9f07d42) | Help to Save                              | both
[`b271ab12-e46d-494d-b93c-94cc200fd271`](https://www.notifications.service.gov.uk/services/b271ab12-e46d-494d-b93c-94cc200fd271) | ESFA local authorities                    | both
[`b659651f-de99-4bf4-a1f5-5bfcc45f389d`](https://www.notifications.service.gov.uk/services/b659651f-de99-4bf4-a1f5-5bfcc45f389d) | Active Cyber Defence Notifications System | both
[`20118307-b660-4667-add5-265e99d58e8b`](https://www.notifications.service.gov.uk/services/20118307-b660-4667-add5-265e99d58e8b) | TRUK                                      | both
[`85449f1c-bc6b-4694-96c0-4f219611040b`](https://www.notifications.service.gov.uk/services/85449f1c-bc6b-4694-96c0-4f219611040b) | NCSC Services                             | both
[`8f3d1631-193b-49aa-ba02-ee2e87ca9d48`](https://www.notifications.service.gov.uk/services/8f3d1631-193b-49aa-ba02-ee2e87ca9d48) | Lost or stolen passport                   | both
[`38fcb11b-1fce-4e75-8017-38e65921a484`](https://www.notifications.service.gov.uk/services/38fcb11b-1fce-4e75-8017-38e65921a484) | GOV.UK Pay – Direct Debit                 | both
[`c4808ed3-c8e7-49d9-8dcd-69aaa12415e2`](https://www.notifications.service.gov.uk/services/c4808ed3-c8e7-49d9-8dcd-69aaa12415e2) | ESFA academy financial returns            | both
[`d525f04b-ea51-444d-8b8e-e80fb38f0161`](https://www.notifications.service.gov.uk/services/d525f04b-ea51-444d-8b8e-e80fb38f0161) | Jobseekers Allowance test                 | both
[`a4adf327-7c8f-4677-937d-7cd01bb14788`](https://www.notifications.service.gov.uk/services/a4adf327-7c8f-4677-937d-7cd01bb14788) | Digital Communications                    | both
