### PR TITLE
Look in email_branding for brand_type, not service 

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -23,7 +23,7 @@ from app.exceptions import NotificationTechnicalFailureException
 from app.models import (
     SMS_TYPE,
     KEY_TYPE_TEST,
-    BRANDING_ORG,
+    BRANDING_BOTH,
     BRANDING_ORG_BANNER,
     BRANDING_GOVUK,
     EMAIL_TYPE,
@@ -189,24 +189,28 @@ def get_logo_url(base_url, logo_file):
 
 
 def get_html_email_options(service):
-    govuk_banner = service.branding not in (BRANDING_ORG, BRANDING_ORG_BANNER)
-    brand_banner = service.branding == BRANDING_ORG_BANNER
-    if service.branding != BRANDING_GOVUK and service.email_branding:
 
-        logo_url = get_logo_url(
-            current_app.config['ADMIN_BASE_URL'],
-            service.email_branding.logo
-        ) if service.email_branding.logo else None
-
-        branding = {
-            'brand_colour': service.email_branding.colour,
-            'brand_logo': logo_url,
-            'brand_name': service.email_branding.text,
+    if (
+        service.email_branding is None or
+        service.email_branding.brand_type == BRANDING_GOVUK
+    ):
+        return {
+            'govuk_banner': True,
+            'brand_banner': False,
         }
-    else:
-        branding = {}
 
-    return dict(govuk_banner=govuk_banner, brand_banner=brand_banner, **branding)
+    logo_url = get_logo_url(
+        current_app.config['ADMIN_BASE_URL'],
+        service.email_branding.logo
+    ) if service.email_branding.logo else None
+
+    return {
+        'govuk_banner': service.email_branding.brand_type == BRANDING_BOTH,
+        'brand_banner': service.email_branding.brand_type == BRANDING_ORG_BANNER,
+        'brand_colour': service.email_branding.colour,
+        'brand_logo': logo_url,
+        'brand_name': service.email_branding.text,
+    }
 
 
 def technical_failure(notification):

--- a/migrations/versions/0217_default_email_branding.py
+++ b/migrations/versions/0217_default_email_branding.py
@@ -1,0 +1,25 @@
+"""
+ Revision ID: 0217_default_email_branding
+Revises: 0216_remove_colours
+Create Date: 2018-08-24 13:36:49.346156
+ """
+from alembic import op
+from app.models import BRANDING_ORG
+
+revision = '0217_default_email_branding'
+down_revision = '0216_remove_colours'
+
+
+def upgrade():
+    op.execute("""
+        update
+            email_branding
+        set
+            brand_type = '{}'
+        where
+            brand_type = null
+    """.format(BRANDING_ORG))
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/159986276

We are now setting the type of branding on the branding itself, not on the service.

This PR switches over from looking in the old place (on the service) to looking in the new place (on the branding).

***

It also sets `brand_type` to `org` if it’s `null` so later we can:
- make it non-nullable
- remove `govuk` as an option

This migration is mostly for people’s local databases, the manual work here has been done on production already.

It’s already impossible to create a new branding without setting a value for `brand_type`.