### PR TITLE
Set branding_type to org if it’s none

### DIFF
--- a/migrations/versions/0219_default_email_branding.py
+++ b/migrations/versions/0219_default_email_branding.py
@@ -1,0 +1,25 @@
+"""
+ Revision ID: 0219_default_email_branding
+Revises: 0218_another_letter_org
+Create Date: 2018-08-24 13:36:49.346156
+ """
+from alembic import op
+from app.models import BRANDING_ORG
+
+revision = '0219_default_email_branding'
+down_revision = '0218_another_letter_org'
+
+
+def upgrade():
+    op.execute("""
+        update
+            email_branding
+        set
+            brand_type = '{}'
+        where
+            brand_type is null
+    """.format(BRANDING_ORG))
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Same as a0deef06e23e4c81e55d83afb63d4bbab1bdaaa5 but with `is null` not `= null` 🤦🏻‍