### PR TITLE
Make branding type non-nullable

### DIFF
--- a/migrations/versions/0220_email_brand_type_non_null.py
+++ b/migrations/versions/0220_email_brand_type_non_null.py
@@ -1,0 +1,17 @@
+"""
+ Revision ID: 0220_email_brand_type_non_null
+Revises: 0219_default_email_branding
+Create Date: 2018-08-24 13:36:49.346156
+ """
+from alembic import op
+
+revision = '0220_email_brand_type_non_null'
+down_revision = '0219_default_email_branding'
+
+
+def upgrade():
+    op.alter_column('email_branding', 'brand_type', nullable=False)
+
+
+def downgrade():
+    op.alter_column('email_branding', 'brand_type', nullable=True)


### PR DESCRIPTION
We’ve already removed all the `null` values, and made it impossible to add new brandings with a `null` brand type.

Making it a database constraint just gives us extra safety.