### PR TITLE
Bump utils to start sending email preheaders

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -25,6 +25,6 @@ notifications-python-client==5.0.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@30.1.1#egg=notifications-utils==30.1.1
+git+https://github.com/alphagov/notifications-utils.git@30.2.0#egg=notifications-utils==30.2.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ notifications-python-client==5.0.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@30.1.1#egg=notifications-utils==30.1.1
+git+https://github.com/alphagov/notifications-utils.git@30.2.0#egg=notifications-utils==30.2.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/523

---

Changes: https://github.com/alphagov/notifications-utils/compare/30.1.1...30.2.0