### PR TITLE
Fix date conversion bug

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -437,8 +437,9 @@ def update_letter_notifications_statuses(self, filename):
 
 
 def get_billing_date_in_bst_from_filename(filename):
-    datetime_string = filename.split('-')[1]
-    datetime_obj = datetime.strptime(datetime_string, '%Y%m%d%H%M%S')
+    # exclude seconds from the date since we don't need it. We got a date ending in 60 second - which is not valid.
+    datetime_string = filename.split('-')[1][:-2]
+    datetime_obj = datetime.strptime(datetime_string, '%Y%m%d%H%M')
     return convert_utc_to_bst(datetime_obj).date()
 
 


### PR DESCRIPTION
Fix problem with invalid seconds in the timestamp of the dvla response file.

We got a file that had 60 for the seconds in the timestamp, which is not valid (0-59). This ignores the seconds in the timestamp to get around that.