### PR TITLE
Don't join to scheduled_notifications

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -449,7 +449,7 @@ class NotificationWithTemplateSchema(BaseSchema):
     class Meta:
         model = models.Notification
         strict = True
-        exclude = ('_personalisation', )
+        exclude = ('_personalisation', 'scheduled_notification')
 
     template = fields.Nested(
         TemplateSchema,


### PR DESCRIPTION
For the NotificationWithTemplateSchema exclude the scheduled_notifications so we do not query that table.

The scheduled_notifications is not used as of yet.

Also, I am not sure if this will improve the performance. But I do know this will not query scheduled_notifications for n notifications in the resultset