### PR TITLE
Change NotificationHistory.updated_at on update

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1409,7 +1409,7 @@ class NotificationHistory(db.Model, HistoryModel):
     created_at = db.Column(db.DateTime, index=True, unique=False, nullable=False)
     sent_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
     sent_by = db.Column(db.String, nullable=True)
-    updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
+    updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.datetime.utcnow)
     status = db.Column(
         'notification_status',
         db.String,

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -34,6 +34,7 @@ from app.dao import jobs_dao, services_dao
 from app.models import (
     Job,
     Notification,
+    NotificationHistory,
     EMAIL_TYPE,
     KEY_TYPE_NORMAL,
     KEY_TYPE_TEAM,
@@ -1560,6 +1561,11 @@ def test_process_returned_letters_list(mocker, sample_letter_template):
 
     process_returned_letters_list(['ref1', 'ref2', 'unknown-ref'])
 
-    assert [
-        n.status for n in Notification.query.all()
-    ] == ['returned-letter', 'returned-letter']
+    notifications = Notification.query.all()
+    history = NotificationHistory.query.all()
+
+    assert [n.status for n in notifications] == ['returned-letter', 'returned-letter']
+    assert all(n.updated_at for n in notifications)
+
+    assert [n.status for n in history] == ['returned-letter', 'returned-letter']
+    assert all(n.updated_at for n in history)


### PR DESCRIPTION
Sets the updated_at to current time when the NotificationHistory is modified (which happens occasionally for example to set status to returned letter).