### PR TITLE
Letter class constraints

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -167,6 +167,7 @@ def dao_create_service(service, user, service_id=None, service_permissions=None)
     service.active = True
     service.research_mode = False
     service.crown = service.organisation_type == 'central'
+    service.letter_class = 'second'
 
     for permission in service_permissions:
         service_permission = ServicePermission(service_id=service.id, permission=permission)
@@ -180,6 +181,7 @@ def dao_create_service(service, user, service_id=None, service_permissions=None)
 @transactional
 @version_class(Service)
 def dao_update_service(service):
+    service.letter_class = service.letter_class or 'second'
     db.session.add(service)
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -353,7 +353,7 @@ class Service(db.Model, Versioned):
     crown = db.Column(db.Boolean, index=False, nullable=False, default=True)
     rate_limit = db.Column(db.Integer, index=False, nullable=False, default=3000)
     contact_link = db.Column(db.String(255), nullable=True, unique=False)
-    letter_class = db.Column(db.String(255), index=False, nullable=True)
+    letter_class = db.Column(db.String(255), index=False, nullable=False, default='second')
 
     organisation = db.relationship(
         'Organisation',
@@ -366,6 +366,8 @@ class Service(db.Model, Versioned):
         secondary=service_email_branding,
         uselist=False,
         backref=db.backref('services', lazy='dynamic'))
+
+    CheckConstraint("'letter_class' in ('first', 'second')")
 
     @classmethod
     def from_json(cls, data):

--- a/app/models.py
+++ b/app/models.py
@@ -353,6 +353,7 @@ class Service(db.Model, Versioned):
     crown = db.Column(db.Boolean, index=False, nullable=False, default=True)
     rate_limit = db.Column(db.Integer, index=False, nullable=False, default=3000)
     contact_link = db.Column(db.String(255), nullable=True, unique=False)
+    letter_class = db.Column(db.String(255), index=False, nullable=True)
 
     organisation = db.relationship(
         'Organisation',

--- a/migrations/versions/0225_letter_class.py
+++ b/migrations/versions/0225_letter_class.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0225_letter_class
+Revises: 0224_returned_letter_status
+Create Date: 2018-09-13 16:23:59.168877
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0225_letter_class'
+down_revision = '0224_returned_letter_status'
+
+
+def upgrade():
+    op.add_column('services', sa.Column('letter_class', sa.String(length=255), nullable=True))
+    op.add_column('services_history', sa.Column('letter_class', sa.String(length=255), nullable=True))
+
+
+def downgrade():
+    op.drop_column('services_history', 'letter_class')
+    op.drop_column('services', 'letter_class')

--- a/migrations/versions/0226_letter_class_constraint.py
+++ b/migrations/versions/0226_letter_class_constraint.py
@@ -1,0 +1,44 @@
+"""
+
+Revision ID: 0226_letter_class_constraint
+Revises: 0225_letter_class
+Create Date: 2018-09-14 18:11:16.998693
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0226_letter_class_constraint'
+down_revision = '0225_letter_class'
+
+
+def upgrade():
+    op.execute("""
+            update
+                services
+            set
+                letter_class = 'second'
+        """)
+    op.execute("""
+            update
+                services_history
+            set
+                letter_class = 'second'
+        """)
+    op.create_check_constraint(
+        'ck_services_letter_class',
+        'services',
+        "letter_class in ('second', 'first')"
+    )
+    op.alter_column('services_history', 'letter_class', nullable=False)
+    op.alter_column('services', 'letter_class', nullable=False)
+
+
+def downgrade():
+    op.drop_constraint('ck_services_letter_class', 'services')
+    op.alter_column('services_history', 'letter_class',
+                    existing_type=sa.VARCHAR(length=255),
+                    nullable=True)
+    op.alter_column('services', 'letter_class',
+                    existing_type=sa.VARCHAR(length=255),
+                    nullable=True)

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -427,7 +427,7 @@ def test_update_service_permission_creates_a_history_record_with_current_data(sa
     assert Service.get_history_model().query.filter_by(name='service_name').all()[2].version == 3
 
 
-def test_update_service_set_letter_class_to_default(sample_user):
+def test_update_service_sets_letter_class_to_default(sample_user):
     assert Service.query.count() == 0
     assert Service.get_history_model().query.count() == 0
     service = Service(name="service_name",
@@ -442,7 +442,7 @@ def test_update_service_set_letter_class_to_default(sample_user):
     dao_update_service(service_from_db)
     service_with_update = Service.query.first()
     assert service_with_update.letter_class == 'second'
-    service_history_with_update = Service.get_history_model().query.filter_by(version=2)
+    service_history_with_update = Service.get_history_model().query.filter_by(version=2).first()
     assert service_history_with_update.letter_class == 'second'
 
 

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -100,6 +100,7 @@ def test_create_service(sample_user):
     assert service_db.email_from == 'email_from'
     assert service_db.research_mode is False
     assert service_db.prefix_sms is True
+    assert service_db.letter_class == 'second'
     assert service.active is True
     assert sample_user in service_db.users
     assert service_db.organisation_type == 'central'
@@ -345,10 +346,12 @@ def test_create_service_creates_a_history_record_with_current_data(sample_user):
     assert service_from_db.name == service_history.name
     assert service_from_db.version == 1
     assert service_from_db.version == service_history.version
+    assert service_from_db.letter_class == 'second'
     assert sample_user.id == service_history.created_by_id
     assert service_from_db.created_by.id == service_history.created_by_id
     assert service_from_db.dvla_organisation_id == DVLA_ORG_HM_GOVERNMENT
     assert service_history.dvla_organisation_id == DVLA_ORG_HM_GOVERNMENT
+    assert service_history.letter_class == 'second'
 
 
 def test_update_service_creates_a_history_record_with_current_data(sample_user):
@@ -422,6 +425,25 @@ def test_update_service_permission_creates_a_history_record_with_current_data(sa
 
     assert len(Service.get_history_model().query.filter_by(name='service_name').all()) == 3
     assert Service.get_history_model().query.filter_by(name='service_name').all()[2].version == 3
+
+
+def test_update_service_set_letter_class_to_default(sample_user):
+    assert Service.query.count() == 0
+    assert Service.get_history_model().query.count() == 0
+    service = Service(name="service_name",
+                      email_from="email_from",
+                      message_limit=1000,
+                      restricted=False,
+                      created_by=sample_user)
+    dao_create_service(service, sample_user)
+
+    service_from_db = Service.query.first()
+    service_from_db.letter_class = None
+    dao_update_service(service_from_db)
+    service_with_update = Service.query.first()
+    assert service_with_update.letter_class == 'second'
+    service_history_with_update = Service.get_history_model().query.filter_by(version=2)
+    assert service_history_with_update.letter_class == 'second'
 
 
 def test_create_service_and_history_is_transactional(sample_user):


### PR DESCRIPTION
This is the second PR to be able to send first class letters on a service.

Add a constraint that the letter_class can only be second or first.
Update all services.letter_class = second, and all history records
Set services.letter_class to NOT NULL.

- [ ] https://github.com/alphagov/notifications-api/pull/2092