### PR TITLE
Introduce new letter rates, valid from 01.10.2018

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -342,6 +342,9 @@ class Development(Config):
     SECRET_KEY = 'dev-notify-secret-key'
     DANGEROUS_SALT = 'dev-notify-salt'
 
+    MMG_INBOUND_SMS_AUTH = ['testkey']
+    MMG_INBOUND_SMS_USERNAME = ['username']
+
     NOTIFY_ENVIRONMENT = 'development'
     NOTIFY_LOG_PATH = 'application.log'
     NOTIFICATION_QUEUE_PREFIX = 'development'
@@ -392,8 +395,6 @@ class Test(Development):
 
     SMS_INBOUND_WHITELIST = ['203.0.113.195']
     FIRETEXT_INBOUND_SMS_AUTH = ['testkey']
-    MMG_INBOUND_SMS_AUTH = ['testkey']
-    MMG_INBOUND_SMS_USERNAME = ['username']
     TEMPLATE_PREVIEW_API_HOST = 'http://localhost:9999'
 
 

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -218,11 +218,11 @@ def get_rate(
         if letter_page_count == 0:
             return 0
         return next(
-            r[3] for r in letter_rates if date > r[0] and crown == r[1]
+            r[3] for r in letter_rates if date >= r[0] and crown == r[1]
             and letter_page_count == r[2] and post_class == r[4]
         )
     elif notification_type == SMS_TYPE:
-        return next(r[2] for r in non_letter_rates if notification_type == r[0] and date > r[1])
+        return next(r[2] for r in non_letter_rates if notification_type == r[0] and date >= r[1])
     else:
         return 0
 

--- a/migrations/versions/0226_new_letter_rates.py
+++ b/migrations/versions/0226_new_letter_rates.py
@@ -1,0 +1,53 @@
+"""empty message
+
+Revision ID: 0226_new_letter_rates
+Revises: 0225_another_letter_org
+
+"""
+
+revision = '0226_new_letter_rates'
+down_revision = '0225_another_letter_org'
+
+import uuid
+from datetime import datetime
+from alembic import op
+
+
+start = datetime(2018, 10, 1, 0, 0, tzinfo=timezone.utc)
+
+NEW_RATES = [
+    (uuid.uuid4(), start, 1, 0.30, True, 'second'),
+    (uuid.uuid4(), start, 1, 0.30, False, 'second'),
+    (uuid.uuid4(), start, 2, 0.35, True, 'second'),
+    (uuid.uuid4(), start, 2, 0.35, False, 'second'),
+    (uuid.uuid4(), start, 3, 0.40, True, 'second'),
+    (uuid.uuid4(), start, 3, 0.40, False, 'second'),
+    (uuid.uuid4(), start, 4, 0.45, True, 'second'),
+    (uuid.uuid4(), start, 4, 0.45, False, 'second'),
+    (uuid.uuid4(), start, 5, 0.50, True, 'second'),
+    (uuid.uuid4(), start, 5, 0.50, False, 'second'),
+    (uuid.uuid4(), start, 1, 0.56, True, 'first'),
+    (uuid.uuid4(), start, 1, 0.56, False, 'first'),
+    (uuid.uuid4(), start, 2, 0.61, True, 'first'),
+    (uuid.uuid4(), start, 2, 0.61, False, 'first'),
+    (uuid.uuid4(), start, 3, 0.66, True, 'first'),
+    (uuid.uuid4(), start, 3, 0.66, False, 'first'),
+    (uuid.uuid4(), start, 4, 0.71, True, 'first'),
+    (uuid.uuid4(), start, 4, 0.71, False, 'first'),
+    (uuid.uuid4(), start, 5, 0.76, True, 'first'),
+    (uuid.uuid4(), start, 5, 0.76, False, 'first'),
+
+]
+
+
+def upgrade():
+    conn = op.get_bind()
+    for id, start_date, sheet_count, rate, crown, post_class in NEW_RATES:
+        conn.execute("""
+            INSERT INTO letter_rates (id, start_date, sheet_count, rate, crown, post_class)
+                VALUES ('{}', '{}', '{}', '{}', '{}', '{}')
+        """.format(id, start_date, sheet_count, rate, crown, post_class))
+
+
+def downgrade():
+    pass

--- a/migrations/versions/0226_new_letter_rates.py
+++ b/migrations/versions/0226_new_letter_rates.py
@@ -9,11 +9,12 @@ revision = '0226_new_letter_rates'
 down_revision = '0225_another_letter_org'
 
 import uuid
+import pytz
 from datetime import datetime
 from alembic import op
 
 
-start = datetime(2018, 10, 1, 0, 0, tzinfo=timezone.utc)
+start = datetime(2018, 10, 1, 0, 0, tzinfo=pytz.utc)
 
 NEW_RATES = [
     (uuid.uuid4(), start, 1, 0.30, True, 'second'),

--- a/migrations/versions/0229_new_letter_rates.py
+++ b/migrations/versions/0229_new_letter_rates.py
@@ -35,7 +35,6 @@ NEW_RATES = [
     (uuid.uuid4(), start, 4, 0.71, False, 'first'),
     (uuid.uuid4(), start, 5, 0.76, True, 'first'),
     (uuid.uuid4(), start, 5, 0.76, False, 'first'),
-
 ]
 
 

--- a/migrations/versions/0229_new_letter_rates.py
+++ b/migrations/versions/0229_new_letter_rates.py
@@ -16,7 +16,6 @@ from alembic import op
 start = datetime(2018, 9, 30, 23, 0)
 
 NEW_RATES = [
-    (uuid.uuid4(), start, 1, 0.30, True, 'second'),
     (uuid.uuid4(), start, 1, 0.30, False, 'second'),
     (uuid.uuid4(), start, 2, 0.35, True, 'second'),
     (uuid.uuid4(), start, 2, 0.35, False, 'second'),

--- a/migrations/versions/0229_new_letter_rates.py
+++ b/migrations/versions/0229_new_letter_rates.py
@@ -11,41 +11,67 @@ down_revision = '0228_notification_postage'
 import uuid
 from datetime import datetime
 from alembic import op
+from sqlalchemy.sql import text
 
 
-start = datetime(2018, 9, 30, 23, 0)
+
+START = datetime(2018, 9, 30, 23, 0)
 
 NEW_RATES = [
-    (uuid.uuid4(), start, 1, 0.30, False, 'second'),
-    (uuid.uuid4(), start, 2, 0.35, True, 'second'),
-    (uuid.uuid4(), start, 2, 0.35, False, 'second'),
-    (uuid.uuid4(), start, 3, 0.40, True, 'second'),
-    (uuid.uuid4(), start, 3, 0.40, False, 'second'),
-    (uuid.uuid4(), start, 4, 0.45, True, 'second'),
-    (uuid.uuid4(), start, 4, 0.45, False, 'second'),
-    (uuid.uuid4(), start, 5, 0.50, True, 'second'),
-    (uuid.uuid4(), start, 5, 0.50, False, 'second'),
-    (uuid.uuid4(), start, 1, 0.56, True, 'first'),
-    (uuid.uuid4(), start, 1, 0.56, False, 'first'),
-    (uuid.uuid4(), start, 2, 0.61, True, 'first'),
-    (uuid.uuid4(), start, 2, 0.61, False, 'first'),
-    (uuid.uuid4(), start, 3, 0.66, True, 'first'),
-    (uuid.uuid4(), start, 3, 0.66, False, 'first'),
-    (uuid.uuid4(), start, 4, 0.71, True, 'first'),
-    (uuid.uuid4(), start, 4, 0.71, False, 'first'),
-    (uuid.uuid4(), start, 5, 0.76, True, 'first'),
-    (uuid.uuid4(), start, 5, 0.76, False, 'first'),
+    (uuid.uuid4(), START, 1, 0.30, False, 'second'),
+    (uuid.uuid4(), START, 2, 0.35, True, 'second'),
+    (uuid.uuid4(), START, 2, 0.35, False, 'second'),
+    (uuid.uuid4(), START, 3, 0.40, True, 'second'),
+    (uuid.uuid4(), START, 3, 0.40, False, 'second'),
+    (uuid.uuid4(), START, 4, 0.45, True, 'second'),
+    (uuid.uuid4(), START, 4, 0.45, False, 'second'),
+    (uuid.uuid4(), START, 5, 0.50, True, 'second'),
+    (uuid.uuid4(), START, 5, 0.50, False, 'second'),
+    (uuid.uuid4(), START, 1, 0.56, True, 'first'),
+    (uuid.uuid4(), START, 1, 0.56, False, 'first'),
+    (uuid.uuid4(), START, 2, 0.61, True, 'first'),
+    (uuid.uuid4(), START, 2, 0.61, False, 'first'),
+    (uuid.uuid4(), START, 3, 0.66, True, 'first'),
+    (uuid.uuid4(), START, 3, 0.66, False, 'first'),
+    (uuid.uuid4(), START, 4, 0.71, True, 'first'),
+    (uuid.uuid4(), START, 4, 0.71, False, 'first'),
+    (uuid.uuid4(), START, 5, 0.76, True, 'first'),
+    (uuid.uuid4(), START, 5, 0.76, False, 'first'),
 ]
 
 
 def upgrade():
     conn = op.get_bind()
+    conn.execute(text("""
+        update
+            letter_rates
+        set
+            end_date = :start
+        where
+            rate != 0.30
+    """), start=START)
+
     for id, start_date, sheet_count, rate, crown, post_class in NEW_RATES:
-        conn.execute("""
+        conn.execute(text("""
             INSERT INTO letter_rates (id, start_date, sheet_count, rate, crown, post_class)
-                VALUES ('{}', '{}', '{}', '{}', '{}', '{}')
-        """.format(id, start_date, sheet_count, rate, crown, post_class))
+                VALUES (:id, :start_date, :sheet_count, :rate, :crown, :post_class)
+        """), id=id, start_date=start_date, sheet_count=sheet_count, rate=rate, crown=crown, post_class=post_class)
 
 
 def downgrade():
-    pass
+    conn = op.get_bind()
+    conn.execute(text("""
+        delete from
+            letter_rates
+        where
+            start_date = :start
+    """), start=START)
+
+    conn.execute(text("""
+        update
+            letter_rates
+        set
+            end_date = null
+        where
+            end_date = :start
+    """), start=START)

--- a/migrations/versions/0229_new_letter_rates.py
+++ b/migrations/versions/0229_new_letter_rates.py
@@ -1,20 +1,19 @@
 """empty message
 
-Revision ID: 0226_new_letter_rates
-Revises: 0225_another_letter_org
+Revision ID: 0229_new_letter_rates
+Revises: 0228_notification_postage
 
 """
 
-revision = '0226_new_letter_rates'
-down_revision = '0225_another_letter_org'
+revision = '0229_new_letter_rates'
+down_revision = '0228_notification_postage'
 
 import uuid
-import pytz
 from datetime import datetime
 from alembic import op
 
 
-start = datetime(2018, 10, 1, 0, 0, tzinfo=pytz.utc)
+start = datetime(2018, 9, 30, 23, 0)
 
 NEW_RATES = [
     (uuid.uuid4(), start, 1, 0.30, True, 'second'),

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -331,21 +331,6 @@ def test_get_rate_for_letter_latest(notify_db_session):
     assert rate == Decimal(0.33)
 
 
-@pytest.mark.parametrize(
-    "letter_post_class,expected_rate", [("first", 0.42), ("second", 0.33)]
-)
-def test_get_rate_filters_letters_byl_post_class(notify_db_session, letter_post_class, expected_rate):
-    non_letter_rates = [(r.notification_type, r.valid_from, r.rate) for r in
-                        Rate.query.order_by(desc(Rate.valid_from)).all()]
-
-    letter_rates = [
-        (datetime(2017, 12, 1), True, 1, Decimal(0.42), 'first'),
-        (datetime(2017, 12, 1), True, 1, Decimal(0.33), 'second')
-    ]
-    rate = get_rate(non_letter_rates, letter_rates, LETTER_TYPE, datetime(2018, 1, 1), True, 1, letter_post_class)
-    assert rate == Decimal(expected_rate)
-
-
 def test_get_rate_for_sms_and_email(notify_db, notify_db_session):
     sms_rate = Rate(valid_from=datetime(2017, 12, 1),
                     rate=Decimal(0.15),

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -23,7 +23,7 @@ def test_reporting_should_have_decorated_tasks_functions():
     assert create_nightly_billing.__wrapped__.__name__ == 'create_nightly_billing'
 
 
-def mocker_get_rate(non_letter_rates, letter_rates, notification_type, date, crown=None, rate_multiplier=None):
+def mocker_get_rate(non_letter_rates, letter_rates, notification_type, date, crown=None, rate_multiplier=None, post_class="second"):
     if notification_type == LETTER_TYPE:
         return Decimal(2.1)
     elif notification_type == SMS_TYPE:
@@ -319,9 +319,10 @@ def test_get_rate_for_letter_latest(notify_db_session):
     non_letter_rates = [(r.notification_type, r.valid_from, r.rate) for r in
                         Rate.query.order_by(desc(Rate.valid_from)).all()]
 
-    # letter rates should be passed into the get_rate function as a tuple of start_date, crown, sheet_count & rate
-    new_letter_rate = (datetime(2017, 12, 1), True, 1, Decimal(0.33))
-    old_letter_rate = (datetime(2016, 12, 1), True, 1, Decimal(0.30))
+    # letter rates should be passed into the get_rate function as a tuple of start_date, crown, sheet_count,
+    # rate and post_class
+    new_letter_rate = (datetime(2017, 12, 1), True, 1, Decimal(0.33), 'second')
+    old_letter_rate = (datetime(2016, 12, 1), True, 1, Decimal(0.30), 'second')
     letter_rates = [new_letter_rate, old_letter_rate]
 
     rate = get_rate(non_letter_rates, letter_rates, LETTER_TYPE, datetime(2018, 1, 1), True, 1)

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -230,7 +230,7 @@ def test_get_rates_for_billing(notify_db_session):
     non_letter_rates, letter_rates = get_rates_for_billing()
 
     assert len(non_letter_rates) == 3
-    assert len(letter_rates) == 30
+    assert len(letter_rates) == 29
 
 
 def test_get_rate(notify_db_session):

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -228,7 +228,7 @@ def test_get_rates_for_billing(notify_db_session):
     non_letter_rates, letter_rates = get_rates_for_billing()
 
     assert len(non_letter_rates) == 3
-    assert len(letter_rates) == 10
+    assert len(letter_rates) == 30
 
 
 def test_get_rate(notify_db_session):

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -4,6 +4,8 @@ from decimal import Decimal
 from datetime import datetime, timedelta
 from freezegun import freeze_time
 
+import pytest
+
 from app import db
 from app.dao.fact_billing_dao import (
     delete_billing_data_for_service_for_day,
@@ -246,6 +248,20 @@ def test_get_rate(notify_db_session):
 
     assert rate == 2.2
     assert letter_rate == Decimal('0.3')
+
+
+@pytest.mark.parametrize("letter_post_class,expected_rate", [("first", "0.61"), ("second", "0.35")])
+def test_get_rate_filters_letters_by_post_class(notify_db_session, letter_post_class, expected_rate):
+    non_letter_rates, letter_rates = get_rates_for_billing()
+    rate = get_rate(non_letter_rates, letter_rates, "letter", datetime(2018, 10, 1), True, 2, letter_post_class)
+    assert rate == Decimal(expected_rate)
+
+
+@pytest.mark.parametrize("date,expected_rate", [(datetime(2018, 9, 30), '0.33'), (datetime(2018, 10, 1), '0.35')])
+def test_get_rate_chooses_right_rate_depending_on_date(notify_db_session, date, expected_rate):
+    non_letter_rates, letter_rates = get_rates_for_billing()
+    rate = get_rate(non_letter_rates, letter_rates, "letter", date, True, 2, "second")
+    assert rate == Decimal(expected_rate)
 
 
 def test_get_rate_for_letters_when_page_count_is_zero(notify_db_session):


### PR DESCRIPTION
Work done:
- insert new rates into the letter_rates table
- use post_class to filter the rates, for now hard-coded as second class
- update existing tests
- write a test for filtering by post_class
- in config, move inbound MMG credentials for local environment from Test class to Development class
- TODO: tests for filtering rates by start date

Pivotal ticket: https://www.pivotaltracker.com/story/show/160229653