### PR TITLE
Add constraints to services.postage

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -167,7 +167,6 @@ def dao_create_service(service, user, service_id=None, service_permissions=None)
     service.active = True
     service.research_mode = False
     service.crown = service.organisation_type == 'central'
-    service.postage = 'second'
 
     for permission in service_permissions:
         service_permission = ServicePermission(service_id=service.id, permission=permission)
@@ -181,7 +180,6 @@ def dao_create_service(service, user, service_id=None, service_permissions=None)
 @transactional
 @version_class(Service)
 def dao_update_service(service):
-    service.postage = service.postage or 'second'
     db.session.add(service)
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -353,7 +353,9 @@ class Service(db.Model, Versioned):
     crown = db.Column(db.Boolean, index=False, nullable=False, default=True)
     rate_limit = db.Column(db.Integer, index=False, nullable=False, default=3000)
     contact_link = db.Column(db.String(255), nullable=True, unique=False)
-    postage = db.Column(db.String(255), index=False, nullable=True)
+    postage = db.Column(db.String(255), index=False, nullable=False, default='second')
+
+    CheckConstraint("'postage' in ('first', 'second')")
 
     organisation = db.relationship(
         'Organisation',

--- a/migrations/versions/0227_postage_constraints.py
+++ b/migrations/versions/0227_postage_constraints.py
@@ -1,0 +1,33 @@
+"""
+Revision ID: 0227_postage_constraints
+Revises: 0226_service_postage
+Create Date: 2018-09-13 16:23:59.168877
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0227_postage_constraints'
+down_revision = '0226_service_postage'
+
+
+def upgrade():
+    op.execute("""
+            update
+                services
+            set
+                postage = 'second'
+        """)
+
+    op.create_check_constraint(
+        'ck_services_postage',
+        'services',
+        "postage in ('second', 'first')"
+    )
+    op.alter_column('services', 'postage', nullable=False)
+
+
+def downgrade():
+    op.drop_constraint('ck_services_postage', 'services')
+    op.alter_column('services', 'postage',
+                    existing_type=sa.VARCHAR(length=255),
+                    nullable=True)


### PR DESCRIPTION
Added constraints to services.postage: not nullable and can only constraint "first" or "second".

I've removed the default values from services_dao.create_service and update_service, because the constraint will take care of that. 