### PR TITLE
Postage constraint

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1193,7 +1193,7 @@ class Notification(db.Model):
     postage = db.Column(db.String, nullable=True)
     CheckConstraint("""
         CASE WHEN notification_type = 'letter' THEN
-            postage in ('first', 'second')
+            postage is not null and postage in ('first', 'second')
         ELSE
             postage is null
         END
@@ -1453,7 +1453,7 @@ class NotificationHistory(db.Model, HistoryModel):
     postage = db.Column(db.String, nullable=True)
     CheckConstraint("""
         CASE WHEN notification_type = 'letter' THEN
-            postage in ('first', 'second')
+            postage is not null and postage in ('first', 'second')
         ELSE
             postage is null
         END

--- a/app/models.py
+++ b/app/models.py
@@ -1191,7 +1191,13 @@ class Notification(db.Model):
     reply_to_text = db.Column(db.String, nullable=True)
 
     postage = db.Column(db.String, nullable=True)
-    CheckConstraint("notification_type != 'letter' or postage in ('first', 'second')")
+    CheckConstraint("""
+        CASE WHEN notification_type = 'letter' THEN
+            postage in ('first', 'second')
+        ELSE
+            postage is null
+        END
+    """)
 
     __table_args__ = (
         db.ForeignKeyConstraint(
@@ -1445,7 +1451,13 @@ class NotificationHistory(db.Model, HistoryModel):
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), nullable=True)
 
     postage = db.Column(db.String, nullable=True)
-    CheckConstraint("notification_type != 'letter' or postage in ('first', 'second')")
+    CheckConstraint("""
+        CASE WHEN notification_type = 'letter' THEN
+            postage in ('first', 'second')
+        ELSE
+            postage is null
+        END
+    """)
 
     __table_args__ = (
         db.ForeignKeyConstraint(

--- a/migrations/versions/0230_noti_postage_constraint.py
+++ b/migrations/versions/0230_noti_postage_constraint.py
@@ -1,0 +1,44 @@
+"""
+
+Revision ID: 0230_noti_postage_constraint
+Revises: 0229_new_letter_rates
+Create Date: 2018-09-19 11:42:52.229430
+
+"""
+from alembic import op
+
+
+revision = '0230_noti_postage_constraint'
+down_revision = '0229_new_letter_rates'
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE notifications ADD CONSTRAINT "chk_notifications_postage_null"
+        CHECK (
+            CASE WHEN notification_type = 'letter' THEN
+                postage in ('first', 'second')
+            ELSE
+                postage is null
+            END
+        )
+        NOT VALID
+    """)
+    op.execute("""
+        ALTER TABLE notification_history ADD CONSTRAINT "chk_notification_history_postage_null"
+        CHECK (
+            CASE WHEN notification_type = 'letter' THEN
+                postage in ('first', 'second')
+            ELSE
+                postage is null
+            END
+        )
+        NOT VALID
+    """)
+    op.execute('ALTER TABLE notifications VALIDATE CONSTRAINT "chk_notifications_postage_null"')
+    op.execute('ALTER TABLE notification_history VALIDATE CONSTRAINT "chk_notification_history_postage_null"')
+
+
+def downgrade():
+    op.drop_constraint('chk_notifications_postage_null', 'notifications', type_='check')
+    op.drop_constraint('chk_notification_history_postage_null', 'notification_history', type_='check')

--- a/migrations/versions/0230_noti_postage_constraint.py
+++ b/migrations/versions/0230_noti_postage_constraint.py
@@ -17,7 +17,7 @@ def upgrade():
         ALTER TABLE notifications ADD CONSTRAINT "chk_notifications_postage_null"
         CHECK (
             CASE WHEN notification_type = 'letter' THEN
-                postage in ('first', 'second')
+                postage is not null and postage in ('first', 'second')
             ELSE
                 postage is null
             END
@@ -28,7 +28,7 @@ def upgrade():
         ALTER TABLE notification_history ADD CONSTRAINT "chk_notification_history_postage_null"
         CHECK (
             CASE WHEN notification_type = 'letter' THEN
-                postage in ('first', 'second')
+                postage is not null and postage in ('first', 'second')
             ELSE
                 postage is null
             END


### PR DESCRIPTION
A not valid constraint only checks against new rows, not existing rows. We can call VALIDATE CONSTRAINT against this new constraint to check the old rows (which we know are good, having run the command from 7496178). Adding a normal constraint acquires an ACCESS EXCLUSIVE lock, but validate constraint only needs a SHARE UPDATE EXCLUSIVE lock.

see 9d4b896 and 0a50993 for more information on marking constraints as not valid.
