### PR TITLE
Bump utils to 30.3.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -25,6 +25,6 @@ notifications-python-client==5.0.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@30.2.0#egg=notifications-utils==30.2.0
+git+https://github.com/alphagov/notifications-utils.git@30.3.1#egg=notifications-utils==30.3.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ notifications-python-client==5.0.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@30.2.0#egg=notifications-utils==30.2.0
+git+https://github.com/alphagov/notifications-utils.git@30.3.1#egg=notifications-utils==30.3.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
@@ -35,20 +35,20 @@ git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 alembic==1.0.0
 amqp==1.4.9
 anyjson==0.3.3
-awscli==1.15.82
+awscli==1.16.20
 bcrypt==3.1.4
 billiard==3.3.0.23
 bleach==2.1.3
 boto3==1.6.16
-botocore==1.10.81
-certifi==2018.8.13
+botocore==1.12.10
+certifi==2018.8.24
 chardet==3.0.4
 click==6.7
 colorama==0.3.9
 docutils==0.14
 Flask-Redis==0.3.0
 future==0.16.0
-greenlet==0.4.14
+greenlet==0.4.15
 html5lib==1.0.1
 idna==2.7
 itsdangerous==0.24
@@ -62,7 +62,7 @@ monotonic==1.5
 orderedset==2.0.1
 phonenumbers==8.9.4
 pyasn1==0.4.4
-pycparser==2.18
+pycparser==2.19
 PyPDF2==1.26.0
 python-dateutil==2.7.3
 python-editor==1.0.3


### PR DESCRIPTION
Brings in stripping of the [line separator character](https://www.fileformat.info/info/unicode/char/2028/index.htm) from emails.

https://github.com/alphagov/notifications-utils/pull/531