### PR TITLE
Add postage to ft_billing primary key

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -237,7 +237,7 @@ def update_fact_billing(data, process_day):
                     process_day,
                     data.crown,
                     data.letter_page_count,
-                    "second")
+                    data.postage)
     billing_record = create_billing_record(data, rate, process_day)
     table = FactBilling.__table__
     '''

--- a/app/models.py
+++ b/app/models.py
@@ -1811,7 +1811,7 @@ class FactBilling(db.Model):
     rate_multiplier = db.Column(db.Integer(), nullable=False, primary_key=True)
     international = db.Column(db.Boolean, nullable=False, primary_key=True)
     rate = db.Column(db.Numeric(), nullable=False, primary_key=True)
-    postage = db.Column(db.String)
+    postage = db.Column(db.String, nullable=False, primary_key=True)
     billable_units = db.Column(db.Integer(), nullable=True)
     notifications_sent = db.Column(db.Integer(), nullable=True)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)

--- a/migrations/versions/0235_add_postage_to_pk.py
+++ b/migrations/versions/0235_add_postage_to_pk.py
@@ -1,0 +1,39 @@
+"""
+
+Revision ID: 0235_add_postage_to_pk
+Revises: 0234_ft_billing_postage
+Create Date: 2018-09-28 15:39:21.115358
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0235_add_postage_to_pk'
+down_revision = '0234_ft_billing_postage'
+
+
+def upgrade():
+    op.drop_constraint('ft_billing_pkey', 'ft_billing', type_='primary')
+    op.create_primary_key('ft_billing_pkey', 'ft_billing', ['bst_date',
+                                                            'template_id',
+                                                            'service_id',
+                                                            'notification_type',
+                                                            'provider',
+                                                            'rate_multiplier',
+                                                            'international',
+                                                            'rate',
+                                                            'postage'])
+
+
+def downgrade():
+    op.drop_constraint('ft_billing_pkey', 'ft_billing', type_='primary')
+    op.alter_column('ft_billing', 'postage', nullable=True)
+    op.create_primary_key('ft_billing_pkey', 'ft_billing', ['bst_date',
+                                                            'template_id',
+                                                            'service_id',
+                                                            'notification_type',
+                                                            'provider',
+                                                            'rate_multiplier',
+                                                            'international',
+                                                            'rate'])


### PR DESCRIPTION
Added a migration to make the `postage` column part of the composite primary key for the `ft_billing` table. There should be no null values in the postage column since this column was backfilled in a previous migration.

Also started to use the real postage data when inserting rows into `ft_billing`, instead of hard-coding 'second'.

[Pivotal story](https://www.pivotaltracker.com/story/show/160660570)