### PR TITLE
Do not update billable_units if page count does not match postal provider

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -470,7 +470,6 @@ def update_letter_notification(filename, temporary_failures, update):
     updated_count, _ = dao_update_notifications_by_reference(
         references=[update.reference],
         update_dict={"status": status,
-                     "billable_units": update.page_count,
                      "updated_at": datetime.utcnow()
                      }
     )
@@ -491,7 +490,7 @@ def check_billable_units(notification_update):
         notification = dao_get_notification_history_by_reference(notification_update.reference)
 
     if int(notification_update.page_count) != notification.billable_units:
-        msg = 'Notification with id {} had {} billable_units but a page count of {}'.format(
+        msg = 'Notification with id {} has {} billable_units but DVLA says page count is {}'.format(
             notification.id, notification.billable_units, notification_update.page_count)
         try:
             raise DVLAException(msg)

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -172,9 +172,9 @@ def test_update_letter_notifications_statuses_builds_updates_list(notify_api, mo
 
 def test_update_letter_notifications_statuses_persisted(notify_api, mocker, sample_letter_template):
     sent_letter = create_notification(sample_letter_template, reference='ref-foo', status=NOTIFICATION_SENDING,
-                                      billable_units=0)
+                                      billable_units=1)
     failed_letter = create_notification(sample_letter_template, reference='ref-bar', status=NOTIFICATION_SENDING,
-                                        billable_units=0)
+                                        billable_units=2)
     create_service_callback_api(service=sample_letter_template.service, url="https://original_url.com")
     valid_file = '{}|Sent|1|Unsorted\n{}|Failed|2|Sorted'.format(
         sent_letter.reference, failed_letter.reference)
@@ -315,7 +315,7 @@ def test_check_billable_units_when_billable_units_does_not_match_page_count(
     check_billable_units(notification_update)
 
     mock_logger.assert_called_once_with(
-        'Notification with id {} had 3 billable_units but a page count of 1'.format(notification.id)
+        'Notification with id {} has 3 billable_units but DVLA says page count is 1'.format(notification.id)
     )
 
 


### PR DESCRIPTION
Sometimes the page counts from DVLA do not match our page counts. Our counts have always been right. This PR does not update notification with the DVLA page count but does still let us know the difference happened.