### PR TITLE
fix awscli botocore dependency

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,6 +23,7 @@ SQLAlchemy==1.2.11
 notifications-python-client==5.0.0
 
 # PaaS
+awscli==1.15.82
 awscli-cwlogs>=1.4,<1.5
 botocore<1.11.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ SQLAlchemy==1.2.11
 notifications-python-client==5.0.0
 
 # PaaS
+awscli==1.15.82
 awscli-cwlogs>=1.4,<1.5
 botocore<1.11.0
 
@@ -36,7 +37,6 @@ git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 alembic==1.0.0
 amqp==1.4.9
 anyjson==0.3.3
-awscli==1.16.23
 bcrypt==3.1.4
 billiard==3.3.0.23
 bleach==2.1.3
@@ -68,7 +68,7 @@ python-dateutil==2.7.3
 python-editor==1.0.3
 python-json-logger==0.1.8
 pytz==2018.5
-PyYAML==3.12
+PyYAML==3.13
 redis==2.10.6
 requests==2.19.1
 rsa==3.4.2


### PR DESCRIPTION
awscli has a requirement of a new version of botocore

moto has a requirement of an old version of boto3, which requires an
old version of botocore

We had to pin boto to an older version, because of the moto issues.
this commit pins awscli to the version currently deployed on prod, so
that it plays nice with that older version of boto/botocore