### PR TITLE
Return postage from the monthly-usage endpoint

### DIFF
--- a/app/billing/billing_schemas.py
+++ b/app/billing/billing_schemas.py
@@ -22,6 +22,7 @@ def serialize_ft_billing_remove_emails(data):
             "notification_type": notification.notification_type,
             "billing_units": notification.billable_units,
             "rate": float(notification.rate),
+            "postage": notification.postage,
         }
         results.append(json_result)
     return results

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -87,7 +87,8 @@ def fetch_monthly_billing_for_year(service_id, year):
         func.sum(FactBilling.notifications_sent).label("notifications_sent"),
         func.sum(FactBilling.notifications_sent).label("billable_units"),
         FactBilling.rate.label('rate'),
-        FactBilling.notification_type.label('notification_type')
+        FactBilling.notification_type.label('notification_type'),
+        FactBilling.postage
     ).filter(
         FactBilling.service_id == service_id,
         FactBilling.bst_date >= year_start_date,
@@ -96,7 +97,8 @@ def fetch_monthly_billing_for_year(service_id, year):
     ).group_by(
         'month',
         FactBilling.rate,
-        FactBilling.notification_type
+        FactBilling.notification_type,
+        FactBilling.postage
     )
 
     sms = db.session.query(
@@ -104,7 +106,8 @@ def fetch_monthly_billing_for_year(service_id, year):
         func.sum(FactBilling.notifications_sent).label("notifications_sent"),
         func.sum(FactBilling.billable_units * FactBilling.rate_multiplier).label("billable_units"),
         FactBilling.rate,
-        FactBilling.notification_type
+        FactBilling.notification_type,
+        FactBilling.postage
     ).filter(
         FactBilling.service_id == service_id,
         FactBilling.bst_date >= year_start_date,
@@ -113,7 +116,8 @@ def fetch_monthly_billing_for_year(service_id, year):
     ).group_by(
         'month',
         FactBilling.rate,
-        FactBilling.notification_type
+        FactBilling.notification_type,
+        FactBilling.postage
     )
 
     yearly_data = email_and_letters.union_all(sms).order_by(

--- a/tests/app/billing/test_billing.py
+++ b/tests/app/billing/test_billing.py
@@ -214,12 +214,14 @@ def test_get_yearly_usage_by_monthly_from_ft_billing(client, notify_db_session):
     expected_sms_april = {"month": "April",
                           "notification_type": "sms",
                           "billing_units": 30,
-                          "rate": 0.162
+                          "rate": 0.162,
+                          "postage": "none"
                           }
     expected_letter_april = {"month": "April",
                              "notification_type": "letter",
                              "billing_units": 30,
-                             "rate": 0.33
+                             "rate": 0.33,
+                             "postage": "second"
                              }
 
     for k in keys:
@@ -321,26 +323,31 @@ def test_get_yearly_usage_by_monthly_from_ft_billing_all_cases(client, notify_db
     assert json_response[0]['notification_type'] == 'letter'
     assert json_response[0]['rate'] == 0.33
     assert json_response[0]['billing_units'] == 1
+    assert json_response[0]['postage'] == 'second'
 
     assert json_response[1]['month'] == 'May'
     assert json_response[1]['notification_type'] == 'letter'
     assert json_response[1]['rate'] == 0.36
     assert json_response[1]['billing_units'] == 1
+    assert json_response[1]['postage'] == 'second'
 
     assert json_response[2]['month'] == 'May'
     assert json_response[2]['notification_type'] == 'letter'
     assert json_response[2]['rate'] == 0.39
     assert json_response[2]['billing_units'] == 1
+    assert json_response[2]['postage'] == 'first'
 
     assert json_response[3]['month'] == 'May'
     assert json_response[3]['notification_type'] == 'sms'
     assert json_response[3]['rate'] == 0.0150
     assert json_response[3]['billing_units'] == 4
+    assert json_response[3]['postage'] == 'none'
 
     assert json_response[4]['month'] == 'May'
     assert json_response[4]['notification_type'] == 'sms'
     assert json_response[4]['rate'] == 0.162
     assert json_response[4]['billing_units'] == 5
+    assert json_response[4]['postage'] == 'none'
 
 
 def test_get_yearly_billing_usage_summary_from_ft_billing_all_cases(client, notify_db_session):
@@ -452,5 +459,5 @@ def set_up_data_for_all_cases():
                       rate=0.39,
                       billable_unit=3,
                       notifications_sent=1,
-                      postage='second')
+                      postage='first')
     return service

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -329,12 +329,14 @@ def test_fetch_monthly_billing_for_year(notify_db_session):
     assert results[0].billable_units == Decimal('60')
     assert results[0].rate == Decimal('0.162')
     assert results[0].notification_type == 'sms'
+    assert results[0].postage == 'none'
 
     assert str(results[1].month) == "2018-07-01"
     assert results[1].notifications_sent == 31
     assert results[1].billable_units == Decimal('31')
     assert results[1].rate == Decimal('0.158')
     assert results[1].notification_type == 'sms'
+    assert results[1].postage == 'none'
 
 
 @freeze_time('2018-08-01 13:30:00')


### PR DESCRIPTION
We were already returning the month, notification_type, billing_units and rate from the /monthly-usage billing endpoint. This adds in the postage too so that we can display postage details on the usage page of notifications-admin.

[Pivotal story](https://www.pivotaltracker.com/story/show/160660570)