### PR TITLE
Bump utils to 30.5.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -27,6 +27,6 @@ awscli==1.15.82
 awscli-cwlogs>=1.4,<1.5
 botocore<1.11.0
 
-git+https://github.com/alphagov/notifications-utils.git@30.4.0#egg=notifications-utils==30.4.0
+git+https://github.com/alphagov/notifications-utils.git@30.5.1#egg=notifications-utils==30.5.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ awscli==1.15.82
 awscli-cwlogs>=1.4,<1.5
 botocore<1.11.0
 
-git+https://github.com/alphagov/notifications-utils.git@30.4.0#egg=notifications-utils==30.4.0
+git+https://github.com/alphagov/notifications-utils.git@30.5.1#egg=notifications-utils==30.5.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
@@ -79,4 +79,3 @@ statsd==3.2.2
 urllib3==1.23
 webencodings==0.5.1
 Werkzeug==0.14.1
-wheel==0.24.0


### PR DESCRIPTION
Brings in some fixes for HTML validation problems with the email template:

https://github.com/alphagov/notifications-utils/pull/538