### PR TITLE
[do not merge] Change API get_notifications endpoint to return jobs

### DIFF
--- a/app/v2/notifications/get_notifications.py
+++ b/app/v2/notifications/get_notifications.py
@@ -29,9 +29,6 @@ def get_notifications():
     if 'reference' in _data:
         _data['reference'] = _data['reference'][0]
 
-    if 'include_jobs' in _data:
-        _data['include_jobs'] = _data['include_jobs'][0]
-
     data = validate(_data, get_notifications_request)
 
     paginated_notifications = notifications_dao.get_notifications_for_service(
@@ -42,7 +39,7 @@ def get_notifications():
         older_than=data.get('older_than'),
         client_reference=data.get('reference'),
         page_size=current_app.config.get('API_PAGE_SIZE'),
-        include_jobs=data.get('include_jobs')
+        include_jobs=True
     )
 
     def _build_links(notifications):

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -86,7 +86,6 @@ get_notifications_request = {
                 "enum": TEMPLATE_TYPES
             }
         },
-        "include_jobs": {"enum": ["true", "True"]},
         "older_than": uuid
     },
     "additionalProperties": False,

--- a/tests/app/v2/notifications/test_notification_schemas.py
+++ b/tests/app/v2/notifications/test_notification_schemas.py
@@ -20,7 +20,6 @@ valid_get_with_optionals_json = {
     "reference": "test reference",
     "status": [NOTIFICATION_CREATED],
     "template_type": [EMAIL_TYPE],
-    "include_jobs": "true",
     "older_than": "a5149c32-f03b-4711-af49-ad6993797d45"
 }
 


### PR DESCRIPTION
Updated the v2/notifications endpoint to always include notifications sent via a job.

[Pivotal story](https://www.pivotaltracker.com/story/show/160757291)