### PR TITLE
Update service schema to add letter_logo_filename

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -205,11 +205,15 @@ class ServiceSchema(BaseSchema):
     created_by = field_for(models.Service, 'created_by', required=True)
     organisation_type = field_for(models.Service, 'organisation_type')
     dvla_organisation = field_for(models.Service, 'dvla_organisation')
+    letter_logo_filename = fields.Method(method_name='get_letter_logo_filename')
     permissions = fields.Method("service_permissions")
     email_branding = field_for(models.Service, 'email_branding')
     organisation = field_for(models.Service, 'organisation')
     override_flag = False
     letter_contact_block = fields.Method(method_name="get_letter_contact")
+
+    def get_letter_logo_filename(self, service):
+        return service.dvla_organisation.filename
 
     def service_permissions(self, service):
         return [p.permission for p in service.permissions]

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -139,6 +139,7 @@ def test_get_service_by_id(admin_request, sample_service):
     assert json_resp['data']['dvla_organisation'] == '001'
     assert json_resp['data']['prefix_sms'] is True
     assert json_resp['data']['postage'] == 'second'
+    assert json_resp['data']['letter_logo_filename'] == 'hm-government'
 
 
 @pytest.mark.parametrize('detailed', [True, False])


### PR DESCRIPTION
Added the filename of a service's letter logo to the service schema. We want
this in the schema so that it is possible to call `current_service.letter_logo_filename`
from notifications-admin and to pass this value through to template-preview.

[Pivotal story](https://www.pivotaltracker.com/story/show/159991865)