### PR TITLE
Send letter filename to template preview

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -54,6 +54,7 @@ def create_letters_pdf(self, notification_id):
             notification.template,
             contact_block=notification.reply_to_text,
             org_id=notification.service.dvla_organisation.id,
+            filename=notification.service.dvla_organisation.filename,
             values=notification.personalisation
         )
 
@@ -79,7 +80,7 @@ def create_letters_pdf(self, notification_id):
             update_notification_status_by_id(notification_id, 'technical-failure')
 
 
-def get_letters_pdf(template, contact_block, org_id, values):
+def get_letters_pdf(template, contact_block, org_id, filename, values):
     template_for_letter_print = {
         "subject": template.subject,
         "content": template.content
@@ -89,6 +90,7 @@ def get_letters_pdf(template, contact_block, org_id, values):
         'letter_contact_block': contact_block,
         'template': template_for_letter_print,
         'values': values,
+        'filename': filename,
         'dvla_org_id': org_id,
     }
     resp = requests_post(

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -247,6 +247,7 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
             'template': template_for_letter_print,
             'values': notification.personalisation,
             'date': notification.created_at.isoformat(),
+            'filename': service.dvla_organisation.filename,
             'dvla_org_id': service.dvla_organisation_id,
         }
 

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -50,6 +50,7 @@ def test_get_letters_pdf_calls_notifications_template_preview_service_correctly(
         notify_api, mocker, client, sample_letter_template, personalisation):
     contact_block = 'Mr Foo,\n1 Test Street,\nLondon\nN1'
     dvla_org_id = '002'
+    filename = 'opg'
 
     with set_config_values(notify_api, {
         'TEMPLATE_PREVIEW_API_HOST': 'http://localhost/notifications-template-preview',
@@ -60,12 +61,17 @@ def test_get_letters_pdf_calls_notifications_template_preview_service_correctly(
                 'http://localhost/notifications-template-preview/print.pdf', content=b'\x00\x01', status_code=200)
 
             get_letters_pdf(
-                sample_letter_template, contact_block=contact_block, org_id=dvla_org_id, values=personalisation)
+                sample_letter_template,
+                contact_block=contact_block,
+                org_id=dvla_org_id,
+                filename=filename,
+                values=personalisation)
 
     assert mock_post.last_request.json() == {
         'values': personalisation,
         'letter_contact_block': contact_block,
         'dvla_org_id': dvla_org_id,
+        'filename': filename,
         'template': {
             'subject': sample_letter_template.subject,
             'content': sample_letter_template.content
@@ -82,6 +88,7 @@ def test_get_letters_pdf_calculates_billing_units(
         notify_api, mocker, client, sample_letter_template, page_count, expected_billable_units):
     contact_block = 'Mr Foo,\n1 Test Street,\nLondon\nN1'
     dvla_org_id = '002'
+    filename = 'opg'
 
     with set_config_values(notify_api, {
         'TEMPLATE_PREVIEW_API_HOST': 'http://localhost/notifications-template-preview',
@@ -96,7 +103,7 @@ def test_get_letters_pdf_calculates_billing_units(
             )
 
             _, billable_units = get_letters_pdf(
-                sample_letter_template, contact_block=contact_block, org_id=dvla_org_id, values=None)
+                sample_letter_template, contact_block=contact_block, org_id=dvla_org_id, filename=filename, values=None)
 
     assert billable_units == expected_billable_units
 


### PR DESCRIPTION
We now pass `filename`, the filename of the letter logo to use, through
to Template Preview in addition to the `dvla_org_id`. Once Template
Preview has been updated to only use the `filename` we will stop
sending the `dvla_org_id`.

[Pivotal story](https://www.pivotaltracker.com/story/show/159991865)