### PR TITLE
don't log exception info for retries

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -74,7 +74,7 @@ def create_letters_pdf(self, notification_id):
             )
             self.retry(queue=QueueNames.RETRY)
         except MaxRetriesExceededError:
-            current_app.logger.exception(
+            current_app.logger.error(
                 "RETRY FAILED: task create_letters_pdf failed for notification {}".format(notification_id),
             )
             update_notification_status_by_id(notification_id, 'technical-failure')
@@ -259,7 +259,7 @@ def _sanitise_precompiled_pdf(self, notification, precompiled_pdf):
             )
             self.retry(queue=QueueNames.RETRY)
         except MaxRetriesExceededError:
-            current_app.logger.exception(
+            current_app.logger.error(
                 "RETRY FAILED: sanitise_precompiled_pdf failed for notification {}".format(notification.id),
             )
 

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -96,9 +96,11 @@ def _send_data_to_service_callback_api(self, data, service_callback_url, token, 
             try:
                 self.retry(queue=QueueNames.RETRY)
             except self.MaxRetriesExceededError:
-                current_app.logger.exception(
-                    """Retry: {} has retried the max num of times
-                     for notification: {}""".format(function_name, notification_id)
+                current_app.logger.error(
+                    "Retry: {} has retried the max num of times for notification: {}".format(
+                        function_name,
+                        notification_id
+                    )
                 )
 
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -386,7 +386,7 @@ def handle_exception(task, notification, notification_id, exc):
         try:
             task.retry(queue=QueueNames.RETRY, exc=exc)
         except task.MaxRetriesExceededError:
-            current_app.logger.exception('Retry' + retry_msg)
+            current_app.logger.error('Max retry failed' + retry_msg)
 
 
 def get_template_class(template_type):
@@ -546,7 +546,11 @@ def send_inbound_sms_to_service(self, inbound_sms_id, service_id):
             try:
                 self.retry(queue=QueueNames.RETRY)
             except self.MaxRetriesExceededError:
-                current_app.logger.exception('Retry: send_inbound_sms_to_service has retried the max number of times')
+                current_app.logger.error(
+                    'Retry: send_inbound_sms_to_service has retried the max number of times for inbound_sms {}'.format(
+                        inbound_sms_id
+                    )
+                )
 
 
 @notify_celery.task(name='process-incomplete-jobs')


### PR DESCRIPTION
it includes task args, which might contain PII. And we don't need to know where the retry exception came from - it came from the line above