### PR TITLE
pin itsdangerous to v0.24

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -27,6 +27,10 @@ awscli==1.15.82  # pyup: ignore
 awscli-cwlogs>=1.4,<1.5
 botocore<1.11.0  # pyup: ignore
 
+
+# Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
+itsdangerous==0.24  # pyup: <1.0.0
+
 git+https://github.com/alphagov/notifications-utils.git@30.5.5#egg=notifications-utils==30.5.5
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,10 @@ awscli==1.15.82  # pyup: ignore
 awscli-cwlogs>=1.4,<1.5
 botocore<1.11.0  # pyup: ignore
 
+
+# Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
+itsdangerous==0.24  # pyup: <1.0.0
+
 git+https://github.com/alphagov/notifications-utils.git@30.5.5#egg=notifications-utils==30.5.5
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
@@ -51,7 +55,6 @@ future==0.16.0
 greenlet==0.4.15
 html5lib==1.0.1
 idna==2.7
-ItsDangerous==1.0.0
 Jinja2==2.10
 jmespath==0.9.3
 kombu==3.0.37


### PR DESCRIPTION
itsdangerous v1 uses sha512 instead of sha1 to sign and unsign its strings. Pin to 0.24 until we figure a migration plan, since it's used in a few places (In the DB, in email tokens, and sending blobs to celery at least).