### PR TITLE
[DO NOT MERGE] Stop passing dvla_org_id to template preview

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -53,7 +53,6 @@ def create_letters_pdf(self, notification_id):
         pdf_data, billable_units = get_letters_pdf(
             notification.template,
             contact_block=notification.reply_to_text,
-            org_id=notification.service.dvla_organisation.id,
             filename=notification.service.dvla_organisation.filename,
             values=notification.personalisation
         )
@@ -80,7 +79,7 @@ def create_letters_pdf(self, notification_id):
             update_notification_status_by_id(notification_id, 'technical-failure')
 
 
-def get_letters_pdf(template, contact_block, org_id, filename, values):
+def get_letters_pdf(template, contact_block, filename, values):
     template_for_letter_print = {
         "subject": template.subject,
         "content": template.content
@@ -91,7 +90,6 @@ def get_letters_pdf(template, contact_block, org_id, filename, values):
         'template': template_for_letter_print,
         'values': values,
         'filename': filename,
-        'dvla_org_id': org_id,
     }
     resp = requests_post(
         '{}/print.pdf'.format(

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -248,7 +248,6 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
             'values': notification.personalisation,
             'date': notification.created_at.isoformat(),
             'filename': service.dvla_organisation.filename,
-            'dvla_org_id': service.dvla_organisation_id,
         }
 
         url = '{}/preview.{}{}'.format(

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -49,7 +49,6 @@ def test_should_have_decorated_tasks_functions():
 def test_get_letters_pdf_calls_notifications_template_preview_service_correctly(
         notify_api, mocker, client, sample_letter_template, personalisation):
     contact_block = 'Mr Foo,\n1 Test Street,\nLondon\nN1'
-    dvla_org_id = '002'
     filename = 'opg'
 
     with set_config_values(notify_api, {
@@ -63,14 +62,12 @@ def test_get_letters_pdf_calls_notifications_template_preview_service_correctly(
             get_letters_pdf(
                 sample_letter_template,
                 contact_block=contact_block,
-                org_id=dvla_org_id,
                 filename=filename,
                 values=personalisation)
 
     assert mock_post.last_request.json() == {
         'values': personalisation,
         'letter_contact_block': contact_block,
-        'dvla_org_id': dvla_org_id,
         'filename': filename,
         'template': {
             'subject': sample_letter_template.subject,
@@ -87,7 +84,6 @@ def test_get_letters_pdf_calls_notifications_template_preview_service_correctly(
 def test_get_letters_pdf_calculates_billing_units(
         notify_api, mocker, client, sample_letter_template, page_count, expected_billable_units):
     contact_block = 'Mr Foo,\n1 Test Street,\nLondon\nN1'
-    dvla_org_id = '002'
     filename = 'opg'
 
     with set_config_values(notify_api, {
@@ -103,7 +99,7 @@ def test_get_letters_pdf_calculates_billing_units(
             )
 
             _, billable_units = get_letters_pdf(
-                sample_letter_template, contact_block=contact_block, org_id=dvla_org_id, filename=filename, values=None)
+                sample_letter_template, contact_block=contact_block, filename=filename, values=None)
 
     assert billable_units == expected_billable_units
 


### PR DESCRIPTION
We were passing both `dvla_org_id` and `filename` to template-preview
temporarily while we switch to only using filename. Now that
template-preview is set up to use `filename`, we can stop sending the
`dvla_org_id too`.

[Pivotal story](https://www.pivotaltracker.com/story/show/159991865)

_Needs https://github.com/alphagov/notifications-template-preview/pull/229 to be merged first_