### PR TITLE
Some minor refactoring

### DIFF
--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -97,8 +97,9 @@ def _send_data_to_service_callback_api(self, data, service_callback_url, token, 
                 self.retry(queue=QueueNames.RETRY)
             except self.MaxRetriesExceededError:
                 current_app.logger.error(
-                    "Retry: {} has retried the max num of times for notification: {}".format(
+                    "Retry: {} has retried the max num of times for callback url {} and notification_id: {}".format(
                         function_name,
+                        service_callback_url,
                         notification_id
                     )
                 )

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -143,7 +143,7 @@ def _update_notification_status(notification, status):
 
 @statsd(namespace="dao")
 @transactional
-def update_notification_status_by_id(notification_id, status):
+def update_notification_status_by_id(notification_id, status, sent_by=None):
     notification = Notification.query.with_lockmode("update").filter(
         Notification.id == notification_id,
         or_(
@@ -158,7 +158,8 @@ def update_notification_status_by_id(notification_id, status):
 
     if notification.international and not country_records_delivery(notification.phone_prefix):
         return None
-
+    if not notification.sent_by and sent_by:
+        notification.sent_by = sent_by
     return _update_notification_status(
         notification=notification,
         status=status

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -141,6 +141,14 @@ def test_should_update_status_by_id_if_created(notify_db, notify_db_session):
     assert updated.status == 'failed'
 
 
+def test_should_update_status_by_id_and_set_sent_by(notify_db, notify_db_session):
+    notification = sample_notification(notify_db, notify_db_session, status='sending')
+
+    updated = update_notification_status_by_id(notification.id, 'delivered', sent_by='mmg')
+    assert updated.status == 'delivered'
+    assert updated.sent_by == 'mmg'
+
+
 def test_should_not_update_status_by_reference_if_from_country_with_no_delivery_receipts(sample_template):
     notification = create_notification(
         sample_template,

--- a/tests/app/notifications/test_process_client_response.py
+++ b/tests/app/notifications/test_process_client_response.py
@@ -89,6 +89,13 @@ def test_process_sms_response_return_success_for_send_sms_code_reference(mocker)
     assert error is None
 
 
+def test_process_sms_response_does_not_send_status_update_for_pending(sample_notification, mocker):
+    send_mock = mocker.patch('app.celery.service_callback_tasks.send_delivery_status_to_service.apply_async')
+    process_sms_client_response(
+        status='2', provider_reference=str(sample_notification.id), client_name='firetext')
+    send_mock.assert_not_called()
+
+
 def test_process_sms_updates_sent_by_with_client_name_if_not_in_noti(notify_db, sample_notification):
     sample_notification.sent_by = None
     success, error = process_sms_client_response(


### PR DESCRIPTION
- Updated notifications_dao.update_notification_status_by_id with an optional parameter to set the sent_by, this will eliminate a separate update to notifcaitons.
- Added the callback url to the log message, that way we can see if it's the same url failing.
- Stop sending the status callbacks for PENDING status.