### PR TITLE
Make name and filename fields of DVLAOrganisation non-nullable

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -246,8 +246,8 @@ DVLA_ORG_LAND_REGISTRY = '500'
 class DVLAOrganisation(db.Model):
     __tablename__ = 'dvla_organisation'
     id = db.Column(db.String, primary_key=True)
-    name = db.Column(db.String(255), nullable=True)
-    filename = db.Column(db.String(255), nullable=True)
+    name = db.Column(db.String(255), nullable=False)
+    filename = db.Column(db.String(255), nullable=False)
 
 
 INTERNATIONAL_SMS_TYPE = 'international_sms'

--- a/migrations/versions/0240_dvla_org_non_nullable.py
+++ b/migrations/versions/0240_dvla_org_non_nullable.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0240_dvla_org_non_nullable
+Revises: 0239_add_edit_folder_permission
+Create Date: 2018-10-25 09:16:54.602182
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0240_dvla_org_non_nullable'
+down_revision = '0239_add_edit_folder_permission'
+
+
+def upgrade():
+    op.alter_column('dvla_organisation', 'filename', existing_type=sa.VARCHAR(length=255), nullable=False)
+    op.alter_column('dvla_organisation', 'name', existing_type=sa.VARCHAR(length=255), nullable=False)
+
+
+def downgrade():
+    op.alter_column('dvla_organisation', 'name', existing_type=sa.VARCHAR(length=255), nullable=True)
+    op.alter_column('dvla_organisation', 'filename', existing_type=sa.VARCHAR(length=255), nullable=True)


### PR DESCRIPTION
If either of these fields are null, previewing a letter template now won't work.

[Pivotal story](https://www.pivotaltracker.com/story/show/159991865)