### PR TITLE
Add edit_folders service permission

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -257,6 +257,7 @@ EMAIL_AUTH = 'email_auth'
 LETTERS_AS_PDF = 'letters_as_pdf'
 PRECOMPILED_LETTER = 'precompiled_letter'
 UPLOAD_DOCUMENT = 'upload_document'
+EDIT_FOLDERS = 'edit_folders'
 
 SERVICE_PERMISSION_TYPES = [
     EMAIL_TYPE,
@@ -269,6 +270,7 @@ SERVICE_PERMISSION_TYPES = [
     LETTERS_AS_PDF,
     PRECOMPILED_LETTER,
     UPLOAD_DOCUMENT,
+    EDIT_FOLDERS,
 ]
 
 

--- a/migrations/versions/0239_add_edit_folder_permission.py
+++ b/migrations/versions/0239_add_edit_folder_permission.py
@@ -1,0 +1,22 @@
+"""
+
+Revision ID: 0239_add_edit_folder_permission
+Revises: 0238_add_validation_failed
+Create Date: 2018-09-03 11:24:58.773824
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0239_add_edit_folder_permission'
+down_revision = '0238_add_validation_failed'
+
+
+def upgrade():
+    op.execute("INSERT INTO service_permission_types VALUES ('edit_folders')")
+
+
+def downgrade():
+    op.execute("DELETE FROM service_permissions WHERE permission = 'edit_folders'")
+    op.execute("DELETE FROM service_permission_types WHERE name = 'edit_folders'")


### PR DESCRIPTION
This is a temporary permission to allow some services to see and edit folders before the feature is turned on for everyone.

[Pivotal story](https://www.pivotaltracker.com/story/show/161176936)