### PR TITLE
Allow the admin app to send one-off letters

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -12,6 +12,7 @@ from notifications_utils.recipients import (
 
 from app import redis_store
 from app.celery import provider_tasks
+from app.celery.letters_pdf_tasks import create_letters_pdf
 from app.config import QueueNames
 
 from app.models import (
@@ -149,6 +150,10 @@ def send_notification_to_queue(notification, research_mode, queue=None):
         if not queue:
             queue = QueueNames.SEND_EMAIL
         deliver_task = provider_tasks.deliver_email
+    if notification.notification_type == LETTER_TYPE:
+        if not queue:
+            queue = QueueNames.CREATE_LETTERS_PDF
+        deliver_task = create_letters_pdf
 
     try:
         deliver_task.apply_async([str(notification.id)], queue=queue)

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.config import QueueNames
+from app.dao.notifications_dao import _update_notification_status
 from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_id
 from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id
 from app.notifications.validators import (
@@ -17,6 +18,8 @@ from app.models import (
     PRIORITY,
     SMS_TYPE,
     EMAIL_TYPE,
+    LETTER_TYPE,
+    NOTIFICATION_DELIVERED,
 )
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.templates_dao import dao_get_template_by_id_and_service_id
@@ -78,11 +81,18 @@ def send_one_off_notification(service_id, post_data):
     )
 
     queue_name = QueueNames.PRIORITY if template.process_type == PRIORITY else None
-    send_notification_to_queue(
-        notification=notification,
-        research_mode=service.research_mode,
-        queue=queue_name
-    )
+
+    if template.template_type == LETTER_TYPE and service.research_mode:
+        _update_notification_status(
+            notification,
+            NOTIFICATION_DELIVERED,
+        )
+    else:
+        send_notification_to_queue(
+            notification=notification,
+            research_mode=service.research_mode,
+            queue=queue_name,
+        )
 
     return {'id': str(notification.id)}
 

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -258,6 +258,22 @@ def test_send_one_off_letter_notification_should_use_template_reply_to_text(samp
     assert notification.reply_to_text == "Edinburgh, ED1 1AA"
 
 
+def test_send_one_off_letter_should_not_make_pdf_in_research_mode(sample_letter_template):
+
+    sample_letter_template.service.research_mode = True
+
+    data = {
+        'to': 'A. Name',
+        'template_id': str(sample_letter_template.id),
+        'created_by': str(sample_letter_template.service.created_by_id)
+    }
+
+    notification = send_one_off_notification(service_id=sample_letter_template.service.id, post_data=data)
+    notification = Notification.query.get(notification['id'])
+
+    assert notification.status == "delivered"
+
+
 def test_send_one_off_sms_notification_should_use_sms_sender_reply_to_text(sample_service, celery_mock):
     template = create_template(service=sample_service, template_type=SMS_TYPE)
     sms_sender = create_service_sms_sender(


### PR DESCRIPTION
This pull request modifies the code paths the admin app uses to send one off emails and text messages to also accept letters.

It seems to work running locally, but I could do with some help to:
- check it’s doing all the required tasks/database updates
- write some good tests (all I’ve done is modify the existing ones so they pass)