### PR TITLE
 Get and use sender_id from S3 metadata

### DIFF
--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -150,8 +150,10 @@ def create_job(service_id):
 
     dao_create_job(job)
 
+    sender_id = data.get('sender_id')
+
     if job.job_status == JOB_STATUS_PENDING:
-        process_job.apply_async([str(job.id)], queue=QueueNames.JOBS)
+        process_job.apply_async([str(job.id)], {'sender_id': sender_id}, queue=QueueNames.JOBS)
 
     job_json = job_schema.dump(job).data
     job_json['statistics'] = []


### PR DESCRIPTION
The `save_email` and `save_sms` jobs were updated previously to take an
optional `sender_id` and to use this if it was available. This commit
now gets the `sender_id` from the S3 metadata if it exists and passes it
through the the tasks which save the job notifications. This means SMS
and emails sent through jobs can use a specified `sender_id` instead of
the default.

[Pivotal story](https://www.pivotaltracker.com/story/show/161176428)