### PR TITLE
Fix notification statistics on dashboard

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -95,24 +95,6 @@ def fetch_notification_status_for_service_by_month(start_date, end_date, service
     ).all()
 
 
-def fetch_notification_status_for_service_for_7_days(service_id):
-    start_date = midnight_n_days_ago(7)
-    return db.session.query(
-        FactNotificationStatus.bst_date,
-        FactNotificationStatus.notification_type,
-        FactNotificationStatus.notification_status,
-        func.sum(FactNotificationStatus.notification_count).label('count')
-    ).filter(
-        FactNotificationStatus.service_id == service_id,
-        FactNotificationStatus.bst_date >= start_date,
-        FactNotificationStatus.key_type != KEY_TYPE_TEST
-    ).group_by(
-        FactNotificationStatus.bst_date,
-        FactNotificationStatus.notification_type,
-        FactNotificationStatus.notification_status,
-    ).all()
-
-
 def fetch_notification_status_for_service_for_day(bst_day, service_id):
     return db.session.query(
         # return current month as a datetime so the data has the same shape as the ft_notification_status query
@@ -128,4 +110,40 @@ def fetch_notification_status_for_service_for_day(bst_day, service_id):
     ).group_by(
         Notification.notification_type,
         Notification.status
+    ).all()
+
+
+def fetch_notification_status_for_service_for_today_and_7_previous_days(service_id):
+    start_date = midnight_n_days_ago(7)
+    now = datetime.utcnow()
+    stats_for_7_days = db.session.query(
+        FactNotificationStatus.notification_type.label('notification_type'),
+        FactNotificationStatus.notification_status.label('notification_status'),
+        FactNotificationStatus.notification_count.label('count')
+    ).filter(
+        FactNotificationStatus.service_id == service_id,
+        FactNotificationStatus.bst_date >= start_date,
+        FactNotificationStatus.key_type != KEY_TYPE_TEST
+    )
+
+    stats_for_today = db.session.query(
+        Notification.notification_type.cast(db.Text),
+        Notification.status.label('notification_status'),
+        func.count().label('count')
+    ).filter(
+        Notification.created_at >= get_london_midnight_in_utc(now),
+        Notification.service_id == service_id,
+        Notification.key_type != KEY_TYPE_TEST
+    ).group_by(
+        Notification.notification_type,
+        Notification.status
+    )
+    all_stats_table = stats_for_7_days.union_all(stats_for_today).subquery()
+    return db.session.query(
+        all_stats_table.c.notification_type,
+        all_stats_table.c.notification_status,
+        func.sum(all_stats_table.c.count).label('count')
+    ).group_by(
+        all_stats_table.c.notification_type,
+        all_stats_table.c.notification_status,
     ).all()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -20,7 +20,8 @@ from app.dao.api_key_dao import (
     expire_api_key)
 from app.dao.fact_notification_status_dao import (
     fetch_notification_status_for_service_by_month,
-    fetch_notification_status_for_service_for_day
+    fetch_notification_status_for_service_for_day,
+    fetch_notification_status_for_service_for_today_and_7_previous_days
 )
 from app.dao.inbound_numbers_dao import dao_allocate_number_for_service
 from app.dao.organisation_dao import dao_get_organisation_by_service_id
@@ -433,7 +434,7 @@ def get_service_statistics(service_id, today_only, limit_days=7):
     if today_only:
         stats = dao_fetch_todays_stats_for_service(service_id)
     else:
-        stats = dao_fetch_stats_for_service(service_id, limit_days=limit_days)
+        stats = fetch_notification_status_for_service_for_today_and_7_previous_days(service_id, limit_days=limit_days)
 
     return statistics.format_statistics(stats)
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -48,7 +48,6 @@ from app.dao.services_dao import (
     dao_fetch_all_services_by_user,
     dao_fetch_monthly_historical_usage_by_template_for_service,
     dao_fetch_service_by_id,
-    dao_fetch_stats_for_service,
     dao_fetch_todays_stats_for_service,
     dao_fetch_todays_stats_for_all_services,
     dao_resume_service,

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -200,23 +200,23 @@ def test_fetch_notification_status_for_service_for_today_and_7_previous_days(not
 
     results = sorted(
         fetch_notification_status_for_service_for_today_and_7_previous_days(service_1.id),
-        key=lambda x: (x.notification_type, x.notification_status)
+        key=lambda x: (x.notification_type, x.status)
     )
 
     assert len(results) == 4
 
     assert results[0].notification_type == 'email'
-    assert results[0].notification_status == 'delivered'
+    assert results[0].status == 'delivered'
     assert results[0].count == 4
 
     assert results[1].notification_type == 'letter'
-    assert results[1].notification_status == 'delivered'
+    assert results[1].status == 'delivered'
     assert results[1].count == 5
 
     assert results[2].notification_type == 'sms'
-    assert results[2].notification_status == 'created'
+    assert results[2].status == 'created'
     assert results[2].count == 2
 
     assert results[3].notification_type == 'sms'
-    assert results[3].notification_status == 'delivered'
+    assert results[3].status == 'delivered'
     assert results[3].count == 19

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -154,10 +154,7 @@ def test_fetch_notification_status_for_service_for_7_days(notify_db_session):
     create_ft_notification_status(date(2018, 10, 29), 'sms', service_2)
     # not included - test keys
     create_ft_notification_status(date(2018, 10, 29), 'sms', service_1, key_type=KEY_TYPE_TEST)
-    results = sorted(
-        fetch_notification_status_for_service_for_7_days(service_1.id),
-        key=lambda x: (x.bst_date, x.notification_type, x.notification_status)
-    )
+    results = fetch_notification_status_for_service_for_7_days(service_1.id)
 
     assert len(results) == 5
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -34,6 +34,7 @@ from tests.app.conftest import (
     sample_notification_with_job
 )
 from tests.app.db import (
+    create_ft_notification_status,
     create_service,
     create_service_with_inbound_number,
     create_template,
@@ -1469,8 +1470,7 @@ def test_set_sms_prefixing_for_service_cant_be_none(
 ], ids=['seven_days', 'today'])
 def test_get_detailed_service(notify_db, notify_db_session, notify_api, sample_service, today_only, stats):
     with notify_api.test_request_context(), notify_api.test_client() as client:
-        with freeze_time('2000-01-01T12:00:00'):
-            create_sample_notification(notify_db, notify_db_session, status='delivered')
+        create_ft_notification_status(date(2000, 1, 1), 'sms', sample_service, count=1)
         with freeze_time('2000-01-02T12:00:00'):
             create_sample_notification(notify_db, notify_db_session, status='created')
             resp = client.get(

--- a/tests/app/service/test_statistics_rest.py
+++ b/tests/app/service/test_statistics_rest.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, date
 
 import pytest
 from freezegun import freeze_time
@@ -133,9 +133,8 @@ def test_get_template_usage_by_month_returns_two_templates(admin_request, sample
     (False, {'requested': 2, 'delivered': 1, 'failed': 0}),
     (True, {'requested': 1, 'delivered': 0, 'failed': 0})
 ], ids=['seven_days', 'today'])
-def test_get_service_notification_statistics(admin_request, sample_template, today_only, stats):
-    with freeze_time('2000-01-01T12:00:00'):
-        create_notification(sample_template, status='delivered')
+def test_get_service_notification_statistics(admin_request, sample_service, sample_template, today_only, stats):
+    create_ft_notification_status(date(2000, 1, 1), 'sms', sample_service, count=1)
     with freeze_time('2000-01-02T12:00:00'):
         create_notification(sample_template, status='created')
         resp = admin_request.get(


### PR DESCRIPTION
Pivotal ticket: https://www.pivotaltracker.com/story/show/161176498

We spotted an issue recently: big blue statistics on the service dashboard have been showing numbers that are slightly off for services with default data retention policy (7 days), and completely off if retention policy was changed to a shorter period.

This is because:
- when it comes to retention policy of 7 days or more, the cause is in time zones mix up when querying Notification table. So the query did not cover the first hour of the 7 days period or something like that.
- when it comes to retention policy period shorter than 7 days, querying Notification table would always give us only those notifications that are within the retention period, so less than seven days.

To mitigate those issues, we decided to query FactNotificationStatus table for the statistics for last 7 days. This data is not affected by the retention policy. And then we only query Notification table for the freshest notifications: those created on the day of the query.