### PR TITLE
Add parent id for create template

### DIFF
--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -21,11 +21,16 @@ def dao_create_template(template):
     template.id = uuid.uuid4()  # must be set now so version history model can use same id
     template.archived = False
 
-    template.template_redacted = TemplateRedacted(
-        template=template,
-        redact_personalisation=False,
-        updated_by=template.created_by
-    )
+    redacted_dict = {
+        "template": template,
+        "redact_personalisation": False,
+    }
+    if template.created_by:
+        redacted_dict.update({"updated_by": template.created_by})
+    else:
+        redacted_dict.update({"updated_by_id": template.created_by_id})
+
+    template.template_redacted = TemplateRedacted(**redacted_dict)
 
     db.session.add(template)
 

--- a/app/models.py
+++ b/app/models.py
@@ -888,15 +888,13 @@ class Template(TemplateBase):
     def from_json(cls, data, folder):
         """
         Assumption: data has been validated appropriately.
-
         Returns a Template object based on the provided data.
         """
         fields = data.copy()
 
         fields['created_by_id'] = fields.pop('created_by')
         fields['service_id'] = fields.pop('service')
-        if fields.pop("parent_folder_id"):
-            fields['folder'] = folder
+        fields['folder'] = folder
         return cls(**fields)
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -884,6 +884,20 @@ class Template(TemplateBase):
             _external=True
         )
 
+    @classmethod
+    def from_json(cls, data):
+        """
+        Assumption: data has been validated appropriately.
+
+        Returns a Template object based on the provided data.
+        """
+        fields = data.copy()
+
+        fields['created_by_id'] = fields.pop('created_by')
+        fields['service_id'] = fields.pop('service')
+
+        return cls(**fields)
+
 
 class TemplateRedacted(db.Model):
     __tablename__ = 'template_redacted'

--- a/app/models.py
+++ b/app/models.py
@@ -885,7 +885,7 @@ class Template(TemplateBase):
         )
 
     @classmethod
-    def from_json(cls, data):
+    def from_json(cls, data, folder):
         """
         Assumption: data has been validated appropriately.
 
@@ -895,7 +895,8 @@ class Template(TemplateBase):
 
         fields['created_by_id'] = fields.pop('created_by')
         fields['service_id'] = fields.pop('service')
-
+        if fields.pop("parent_folder_id"):
+            fields['folder'] = folder
         return cls(**fields)
 
 

--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from uuid import UUID
 
 from iso8601 import iso8601, ParseError
-from jsonschema import (Draft4Validator, ValidationError, FormatChecker)
+from jsonschema import (Draft7Validator, ValidationError, FormatChecker)
 from notifications_utils.recipients import (validate_phone_number, validate_email_address, InvalidPhoneError,
                                             InvalidEmailError)
 
@@ -43,7 +43,7 @@ def validate(json_to_validate, schema):
                                       "https://en.wikipedia.org/wiki/ISO_8601")
         return True
 
-    validator = Draft4Validator(schema, format_checker=format_checker)
+    validator = Draft7Validator(schema, format_checker=format_checker)
     errors = list(validator.iter_errors(json_to_validate))
     if errors.__len__() > 0:
         raise ValidationError(build_error_message(errors))

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -12,6 +12,7 @@ from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.pdf import extract_page_from_pdf
 from notifications_utils.template import SMSMessageTemplate
 from requests import post as requests_post
+from sqlalchemy.orm.exc import NoResultFound
 
 from app.dao.notifications_dao import get_notification_by_id
 from app.dao.services_dao import dao_fetch_service_by_id
@@ -51,8 +52,13 @@ def _content_count_greater_than_limit(content, template_type):
 
 def validate_parent_folder(template_json):
     if template_json.get("parent_folder_id"):
-        return dao_get_template_folder_by_id_and_service_id(template_folder_id=template_json.pop("parent_folder_id"),
-                                                            service_id=template_json['service'])
+        try:
+            return dao_get_template_folder_by_id_and_service_id(
+                template_folder_id=template_json.pop("parent_folder_id"),
+                service_id=template_json['service']
+            )
+        except NoResultFound:
+            raise InvalidRequest("parent_folder_id not found", status_code=400)
     else:
         return None
 

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -15,6 +15,7 @@ from requests import post as requests_post
 
 from app.dao.notifications_dao import get_notification_by_id
 from app.dao.services_dao import dao_fetch_service_by_id
+from app.dao.template_folder_dao import dao_get_template_folder_by_id_and_service_id
 from app.dao.templates_dao import (
     dao_update_template,
     dao_create_template,
@@ -29,7 +30,7 @@ from app.errors import (
     InvalidRequest
 )
 from app.letters.utils import get_letter_pdf
-from app.models import SMS_TYPE, Template, TemplateFolder
+from app.models import SMS_TYPE, Template
 from app.notifications.validators import service_has_permission, check_reply_to
 from app.schema_validation import validate
 from app.schemas import (template_schema, template_history_schema)
@@ -50,10 +51,8 @@ def _content_count_greater_than_limit(content, template_type):
 
 def validate_parent_folder(template_json):
     if template_json.get("parent_folder_id"):
-        return TemplateFolder.query.filter_by(
-            service_id=template_json['service'],
-            id=template_json.pop("parent_folder_id")
-        ).one()
+        return dao_get_template_folder_by_id_and_service_id(template_folder_id=template_json.pop("parent_folder_id"),
+                                                            service_id=template_json['service'])
     else:
         return None
 

--- a/app/template/template_schemas.py
+++ b/app/template/template_schemas.py
@@ -1,0 +1,28 @@
+from app.models import (
+    TEMPLATE_PROCESS_TYPE,
+    TEMPLATE_TYPES,
+)
+from app.schema_validation.definitions import uuid
+
+post_create_template_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "POST create new template",
+    "type": "object",
+    "title": "payload for POST /service/<uuid:service_id>/template",
+    "properties": {
+        "name": {"type": "string"},
+        "template_type": {"enum": TEMPLATE_TYPES},
+        "service": uuid,
+        "process_type": {"emun": TEMPLATE_PROCESS_TYPE},
+        "content": {"type": "string"},
+        "subject": {"type": "string"},
+        "created_by": uuid
+    },
+    "if": {
+        "properties": {
+            "template_type": {"enum": ["email", "letter"]}
+        }
+    },
+    "then": {"required": ["subject"]},
+    "required": ["name", "template_type", "content", "service", "created_by"]
+}

--- a/app/template/template_schemas.py
+++ b/app/template/template_schemas.py
@@ -16,7 +16,8 @@ post_create_template_schema = {
         "process_type": {"emun": TEMPLATE_PROCESS_TYPE},
         "content": {"type": "string"},
         "subject": {"type": "string"},
-        "created_by": uuid
+        "created_by": uuid,
+        "parent_folder_id": uuid
     },
     "if": {
         "properties": {

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -13,7 +13,7 @@ click-datetime==0.2
 eventlet==0.23.0
 gunicorn==19.7.1
 iso8601==0.1.12
-jsonschema==2.6.0
+jsonschema==3.0.0a3
 marshmallow-sqlalchemy==0.14.1
 marshmallow==2.16.0
 psycopg2-binary==2.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ click-datetime==0.2
 eventlet==0.23.0
 gunicorn==19.7.1
 iso8601==0.1.12
-jsonschema==2.6.0
+jsonschema==3.0.0a3
 marshmallow-sqlalchemy==0.14.1
 marshmallow==2.16.0
 psycopg2-binary==2.7.5
@@ -39,6 +39,7 @@ git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 alembic==1.0.2
 amqp==1.4.9
 anyjson==0.3.3
+attrs==18.2.0
 awscli==1.16.49
 bcrypt==3.1.4
 billiard==3.3.0.23
@@ -67,6 +68,7 @@ phonenumbers==8.9.4
 pyasn1==0.4.4
 pycparser==2.19
 PyPDF2==1.26.0
+pyrsistent==0.14.5
 python-dateutil==2.7.5
 python-editor==1.0.3
 python-json-logger==0.1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,6 @@ git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 alembic==1.0.2
 amqp==1.4.9
 anyjson==0.3.3
-attrs==18.2.0
 awscli==1.16.49
 bcrypt==3.1.4
 billiard==3.3.0.23
@@ -68,7 +67,6 @@ phonenumbers==8.9.4
 pyasn1==0.4.4
 pycparser==2.19
 PyPDF2==1.26.0
-pyrsistent==0.14.5
 python-dateutil==2.7.5
 python-editor==1.0.3
 python-json-logger==0.1.8

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -107,7 +107,7 @@ def test_should_create_a_new_template_for_a_service_adds_folder_relationship(
     assert template.folder == parent_folder
 
 
-def test_create_template_should_return_404_if_folder_is_for_a_different_service(
+def test_create_template_should_return_400_if_folder_is_for_a_different_service(
         client, sample_service
 ):
     service2 = create_service(service_name='second service')
@@ -129,10 +129,11 @@ def test_create_template_should_return_404_if_folder_is_for_a_different_service(
         headers=[('Content-Type', 'application/json'), auth_header],
         data=data
     )
-    assert response.status_code == 404
+    assert response.status_code == 400
+    assert json.loads(response.get_data(as_text=True))['message'] == 'parent_folder_id not found'
 
 
-def test_create_template_should_return_404_if_folder_does_not_exist(
+def test_create_template_should_return_400_if_folder_does_not_exist(
         client, sample_service
 ):
     data = {
@@ -151,7 +152,8 @@ def test_create_template_should_return_404_if_folder_does_not_exist(
         headers=[('Content-Type', 'application/json'), auth_header],
         data=data
     )
-    assert response.status_code == 404
+    assert response.status_code == 400
+    assert json.loads(response.get_data(as_text=True))['message'] == 'parent_folder_id not found'
 
 
 def test_should_raise_error_if_service_does_not_exist_on_create(client, sample_user, fake_uuid):

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -12,7 +12,7 @@ from freezegun import freeze_time
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
 
 
-from app.models import Template, SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, TemplateHistory
+from app.models import Template, SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, TemplateHistory, TemplateFolder
 from app.dao.templates_dao import dao_get_template_by_id, dao_redact_template
 
 from tests import create_authorization_header
@@ -21,7 +21,10 @@ from tests.app.conftest import (
     sample_template_without_email_permission,
     sample_template_without_letter_permission,
     sample_template_without_sms_permission)
-from tests.app.db import create_service, create_letter_contact, create_template, create_notification
+from tests.app.db import (
+    create_service, create_letter_contact, create_template, create_notification,
+    create_template_folder,
+)
 from tests.conftest import set_config_values
 
 
@@ -69,6 +72,57 @@ def test_should_create_a_new_template_for_a_service(
     template = Template.query.get(json_resp['data']['id'])
     from app.schemas import template_schema
     assert sorted(json_resp['data']) == sorted(template_schema.dump(template).data)
+
+
+def test_should_create_a_new_template_for_a_service_adds_folder_relationship(
+    client, sample_service
+):
+    parent_folder = create_template_folder(service=sample_service, name='parent folder')
+
+    data = {
+        'name': 'my template',
+        'template_type': 'sms',
+        'content': 'template <b>content</b>',
+        'service': str(sample_service.id),
+        'created_by': str(sample_service.users[0].id),
+        'parent_folder_id': str(parent_folder.id)
+    }
+    data = json.dumps(data)
+    auth_header = create_authorization_header()
+
+    response = client.post(
+        '/service/{}/template'.format(sample_service.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=data
+    )
+    assert response.status_code == 201
+    template = Template.query.filter(Template.name == 'my template').first()
+    assert template.folder == parent_folder
+
+
+def test_create_template_should_return_404_if_folder_is_for_a_different_service(
+        client, sample_service
+):
+    service2 = create_service(service_name='second service')
+    parent_folder = create_template_folder(service=service2)
+
+    data = {
+        'name': 'my template',
+        'template_type': 'sms',
+        'content': 'template <b>content</b>',
+        'service': str(sample_service.id),
+        'created_by': str(sample_service.users[0].id),
+        'parent_folder_id': str(parent_folder.id)
+    }
+    data = json.dumps(data)
+    auth_header = create_authorization_header()
+
+    response = client.post(
+        '/service/{}/template'.format(sample_service.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=data
+    )
+    assert response.status_code == 404
 
 
 def test_should_raise_error_if_service_does_not_exist_on_create(client, sample_user, fake_uuid):

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -302,7 +302,7 @@ def test_must_have_a_subject_on_an_email_or_letter_template(client, sample_user,
 def test_update_should_update_a_template(client, sample_user, sample_template):
     data = {
         'content': 'my template has new content <script type="text/javascript">alert("foo")</script>',
-        'created_by_id': str(sample_user.id)
+        'created_by': str(sample_user.id)
     }
     data = json.dumps(data)
     auth_header = create_authorization_header()

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -172,7 +172,8 @@ def test_should_error_if_created_by_missing(client, sample_user, sample_service)
     )
     json_resp = json.loads(response.get_data(as_text=True))
     assert response.status_code == 400
-    assert json_resp['result'] == 'error'
+    assert json_resp["errors"][0]["error"] == 'ValidationError'
+    assert json_resp["errors"][0]["message"] == 'created_by is a required property'
 
 
 def test_should_be_error_if_service_does_not_exist_on_update(client, fake_uuid):
@@ -211,15 +212,14 @@ def test_must_have_a_subject_on_an_email_or_letter_template(client, sample_user,
         data=data
     )
     json_resp = json.loads(response.get_data(as_text=True))
-    assert response.status_code == 400
-    assert json_resp['result'] == 'error'
-    assert json_resp['message'] == {'subject': ['Invalid template subject']}
+    assert json_resp['errors'][0]['error'] == "ValidationError"
+    assert json_resp['errors'][0]["message"] == 'subject is a required property'
 
 
 def test_update_should_update_a_template(client, sample_user, sample_template):
     data = {
         'content': 'my template has new content <script type="text/javascript">alert("foo")</script>',
-        'created_by': str(sample_user.id)
+        'created_by_id': str(sample_user.id)
     }
     data = json.dumps(data)
     auth_header = create_authorization_header()


### PR DESCRIPTION
- Using jsonschema for create_template. Updated jsonschema to Draft7, this allowed a conditional validation on subject, if template_type == 'email' or 'letter' then subject is required.
This version is backward compatible with Draft4.
When creating TemplateRedacted, I've built the dict depending on if the created_by or created_by_id exists.

- Update model and controller to handle parent_folder_id when creating a template. If the parent_folder_id then check if the folder exists and is for the same service. If it is add the folder to the template model object, the relationship will be persisted when the template is saved. If the folder does not exist or is for a different service, then return a ResultNotFound error.