### PR TITLE
Check parent folder belongs to the same service

### DIFF
--- a/app/dao/template_folder_dao.py
+++ b/app/dao/template_folder_dao.py
@@ -3,8 +3,11 @@ from app.dao.dao_utils import transactional
 from app.models import TemplateFolder
 
 
-def dao_get_template_folder_by_id(template_folder_id):
-    return TemplateFolder.query.filter(TemplateFolder.id == template_folder_id).one()
+def dao_get_template_folder_by_id_and_service_id(template_folder_id, service_id):
+    return TemplateFolder.query.filter(
+        TemplateFolder.id == template_folder_id,
+        TemplateFolder.service_id == service_id
+    ).one()
 
 
 @transactional

--- a/app/template_folder/rest.py
+++ b/app/template_folder/rest.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from app.dao.template_folder_dao import (
     dao_create_template_folder,
-    dao_get_template_folder_by_id,
+    dao_get_template_folder_by_id_and_service_id,
     dao_update_template_folder,
     dao_delete_template_folder
 )
@@ -49,12 +49,9 @@ def create_template_folder(service_id):
 
     if data.get('parent_id') is not None:
         try:
-            parent_folder = dao_get_template_folder_by_id(data['parent_id'])
+            dao_get_template_folder_by_id_and_service_id(data['parent_id'], service_id)
         except NoResultFound:
             raise InvalidRequest("parent_id not found", status_code=400)
-
-        if parent_folder.service_id != service_id:
-            raise InvalidRequest("parent_id belongs to a different service", status_code=400)
 
     template_folder = TemplateFolder(
         service_id=service_id,
@@ -73,7 +70,7 @@ def rename_template_folder(service_id, template_folder_id):
 
     validate(data, post_rename_template_folder_schema)
 
-    template_folder = dao_get_template_folder_by_id(template_folder_id)
+    template_folder = dao_get_template_folder_by_id_and_service_id(template_folder_id, service_id)
     template_folder.name = data['name']
 
     dao_update_template_folder(template_folder)
@@ -83,7 +80,7 @@ def rename_template_folder(service_id, template_folder_id):
 
 @template_folder_blueprint.route('/<uuid:template_folder_id>', methods=['DELETE'])
 def delete_template_folder(service_id, template_folder_id):
-    template_folder = dao_get_template_folder_by_id(template_folder_id)
+    template_folder = dao_get_template_folder_by_id_and_service_id(template_folder_id, service_id)
 
     # don't allow deleting if there's anything in the folder (even if it's just more empty subfolders)
     if template_folder.subfolders or template_folder.templates:

--- a/tests/app/template_folder/test_template_folder_rest.py
+++ b/tests/app/template_folder/test_template_folder_rest.py
@@ -74,9 +74,6 @@ def test_create_template_folder_fails_if_missing_fields(admin_request, sample_se
 
 
 def test_create_template_folder_fails_if_unknown_parent_id(admin_request, sample_service):
-    # create existing folder
-    create_template_folder(sample_service)
-
     resp = admin_request.post(
         'template_folder.create_template_folder',
         service_id=sample_service.id,
@@ -86,6 +83,21 @@ def test_create_template_folder_fails_if_unknown_parent_id(admin_request, sample
 
     assert resp['result'] == 'error'
     assert resp['message'] == 'parent_id not found'
+
+
+def test_create_template_folder_fails_if_parent_id_from_different_service(admin_request, sample_service):
+    s1 = create_service(service_name='a')
+    parent_folder_id = create_template_folder(s1).id
+
+    resp = admin_request.post(
+        'template_folder.create_template_folder',
+        service_id=sample_service.id,
+        _data={'name': 'bar', 'parent_id': str(parent_folder_id)},
+        _expected_status=400
+    )
+
+    assert resp['result'] == 'error'
+    assert resp['message'] == 'parent_id belongs to a different service'
 
 
 def test_rename_template_folder(admin_request, sample_service):

--- a/tests/app/template_folder/test_template_folder_rest.py
+++ b/tests/app/template_folder/test_template_folder_rest.py
@@ -97,7 +97,7 @@ def test_create_template_folder_fails_if_parent_id_from_different_service(admin_
     )
 
     assert resp['result'] == 'error'
-    assert resp['message'] == 'parent_id belongs to a different service'
+    assert resp['message'] == 'parent_id not found'
 
 
 def test_rename_template_folder(admin_request, sample_service):


### PR DESCRIPTION
### Ensure that new template folder belongs to the same service as parent

Since template folders are only linked by ID to their parent we need to check that the parent folder belongs to the same service as the one being created. Otherwise, admin users could modify parent ID to create a folder outside their service.

Ideally, this check would be performed by a DB constraint, but since parent_id can be nullable this is only possible to express using DB triggers.

Instead, we perform the check in the API endpoint code.

### Always use both folder and service ID when getting template folder

Currently there aren't any permission checks based on folder IDs in the admin app or the API, so it's possible for a user to modify the folder ID to perform operations on folders outside their service.

Our usual way to avoid this is to always use service_id filter when fetching objects from the database.
