### PR TITLE
Remove relationship to folder when archiving a template

### DIFF
--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -38,6 +38,9 @@ def dao_create_template(template):
 @transactional
 @version_class(Template, TemplateHistory)
 def dao_update_template(template):
+    if template.archived:
+        template.folder = None
+
     db.session.add(template)
 
 

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -15,6 +15,7 @@ from app.dao.templates_dao import (
 )
 from app.models import (
     Template,
+    TemplateFolder,
     TemplateHistory,
     TemplateRedacted
 )
@@ -91,6 +92,35 @@ def test_update_template(sample_service, sample_user):
     created.name = 'new name'
     dao_update_template(created)
     assert dao_get_all_templates_for_service(sample_service.id)[0].name == 'new name'
+
+
+def test_update_template_in_a_folder_to_archived(sample_service, sample_user):
+    template_data = {
+        'name': 'Sample Template',
+        'template_type': "sms",
+        'content': "Template content",
+        'service': sample_service,
+        'created_by': sample_user
+    }
+    template = Template(**template_data)
+
+    template_folder_data = {
+        'name': 'My Folder',
+        'service_id': sample_service.id,
+    }
+    template_folder = TemplateFolder(**template_folder_data)
+
+    template.folder = template_folder
+    dao_create_template(template)
+
+    template.archived = True
+    dao_update_template(template)
+
+    template_folder = TemplateFolder.query.one()
+    archived_template = Template.query.one()
+
+    assert template_folder
+    assert not archived_template.folder
 
 
 def test_dao_update_template_reply_to_none_to_some(sample_service, sample_user):


### PR DESCRIPTION
When a template is archived, it should no longer belong to any folder.

If we don’t do this it will make it very hard to delete folders later
(because folders can only be deleted if they have no templates or folders
inside them).

We originally tried to check if the link between a template and folder
should be removed with

`if template.archived and template.folder:`

instead of using `if template.archived:`. However, this caused issues
because checking `template.folder` flushes the session. Since the
session is no longer dirty, the versioning decorator doesn't work as
expected and doesn't create a new row in `TemplateHistory`.