### PR TITLE
Change name of update method for template folder

### DIFF
--- a/app/template_folder/rest.py
+++ b/app/template_folder/rest.py
@@ -15,7 +15,7 @@ from app.errors import InvalidRequest, register_errors
 from app.models import TemplateFolder
 from app.template_folder.template_folder_schema import (
     post_create_template_folder_schema,
-    post_rename_template_folder_schema,
+    post_update_template_folder_schema,
     post_move_template_folder_schema,
 )
 from app.schema_validation import validate
@@ -67,11 +67,11 @@ def create_template_folder(service_id):
     return jsonify(data=template_folder.serialize()), 201
 
 
-@template_folder_blueprint.route('/<uuid:template_folder_id>/rename', methods=['POST'])
-def rename_template_folder(service_id, template_folder_id):
+@template_folder_blueprint.route('/<uuid:template_folder_id>', methods=['POST'])
+def update_template_folder(service_id, template_folder_id):
     data = request.get_json()
 
-    validate(data, post_rename_template_folder_schema)
+    validate(data, post_update_template_folder_schema)
 
     template_folder = dao_get_template_folder_by_id_and_service_id(template_folder_id, service_id)
     template_folder.name = data['name']

--- a/app/template_folder/template_folder_schema.py
+++ b/app/template_folder/template_folder_schema.py
@@ -11,9 +11,9 @@ post_create_template_folder_schema = {
     "required": ["name", "parent_id"]
 }
 
-post_rename_template_folder_schema = {
+post_update_template_folder_schema = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "POST schema for renaming template_folder",
+    "description": "POST schema for updating template_folder",
     "type": "object",
     "properties": {
         "name": {"type": "string", "minLength": 1},

--- a/tests/app/template_folder/test_template_folder_rest.py
+++ b/tests/app/template_folder/test_template_folder_rest.py
@@ -100,11 +100,11 @@ def test_create_template_folder_fails_if_parent_id_from_different_service(admin_
     assert resp['message'] == 'parent_id not found'
 
 
-def test_rename_template_folder(admin_request, sample_service):
+def test_update_template_folder(admin_request, sample_service):
     existing_folder = create_template_folder(sample_service)
 
     resp = admin_request.post(
-        'template_folder.rename_template_folder',
+        'template_folder.update_template_folder',
         service_id=sample_service.id,
         template_folder_id=existing_folder.id,
         _data={
@@ -121,11 +121,11 @@ def test_rename_template_folder(admin_request, sample_service):
     ({'name': None}, 'name None is not of type string'),
     ({'name': ''}, 'name  is too short'),
 ])
-def test_rename_template_folder_fails_if_missing_name(admin_request, sample_service, data, err):
+def test_update_template_folder_fails_if_missing_name(admin_request, sample_service, data, err):
     existing_folder = create_template_folder(sample_service)
 
     resp = admin_request.post(
-        'template_folder.rename_template_folder',
+        'template_folder.update_template_folder',
         service_id=sample_service.id,
         template_folder_id=existing_folder.id,
         _data=data,


### PR DESCRIPTION
It was initialy called "rename" which does not comply with
RESTful CRUD (create, update, read, delete) naming practice.
We remove the 'rename' operation in favour of template folder
resource update endpoint as it allows us to extend it with other
attributes.