### PR TITLE
Update error message to be more descriptive

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -84,7 +84,7 @@ def service_has_permission(notify_type, permissions):
 
 def check_service_has_permission(notify_type, permissions):
     if not service_has_permission(notify_type, permissions):
-        raise BadRequestError(message="Cannot send {}".format(
+        raise BadRequestError(message="Service is not allowed to send {}".format(
             get_public_notify_type_text(notify_type, plural=True)))
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -87,10 +87,14 @@ def cache_key_for_service_template_usage_per_day(service_id, datetime):
 
 
 def get_public_notify_type_text(notify_type, plural=False):
-    from app.models import SMS_TYPE
+    from app.models import (SMS_TYPE, UPLOAD_DOCUMENT, PRECOMPILED_LETTER)
     notify_type_text = notify_type
     if notify_type == SMS_TYPE:
         notify_type_text = 'text message'
+    if notify_type == UPLOAD_DOCUMENT:
+        notify_type_text = 'document'
+    if notify_type == PRECOMPILED_LETTER:
+        notify_type_text = 'precompiled letter'
 
     return '{}{}'.format(notify_type_text, 's' if plural else '')
 

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -314,7 +314,7 @@ def test_post_letter_notification_returns_403_if_not_allowed_to_send_notificatio
     error_json = letter_request(client, data, service_id=service.id, _expected_status=400)
     assert error_json['status_code'] == 400
     assert error_json['errors'] == [
-        {'error': 'BadRequestError', 'message': 'Cannot send letters'}
+        {'error': 'BadRequestError', 'message': 'Service is not allowed to send letters'}
     ]
 
 
@@ -438,7 +438,7 @@ def test_post_precompiled_letter_requires_permission(client, sample_service, not
 
     assert response.status_code == 400, response.get_data(as_text=True)
     resp_json = json.loads(response.get_data(as_text=True))
-    assert resp_json['errors'][0]['message'] == 'Cannot send precompiled_letters'
+    assert resp_json['errors'][0]['message'] == 'Service is not allowed to send precompiled letters'
 
 
 def test_post_precompiled_letter_with_invalid_base64(client, notify_user, mocker):

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -512,8 +512,8 @@ def test_post_sms_notification_with_archived_reply_to_id_returns_400(client, sam
 
 
 @pytest.mark.parametrize('recipient,label,template_factory,expected_error', [
-    ('07700 900000', 'phone_number', sample_template_without_sms_permission, 'Cannot send text messages'),
-    ('someone@test.com', 'email_address', sample_template_without_email_permission, 'Cannot send emails')])
+    ('07700 900000', 'phone_number', sample_template_without_sms_permission, 'text messages'),
+    ('someone@test.com', 'email_address', sample_template_without_email_permission, 'emails')])
 def test_post_sms_notification_returns_400_if_not_allowed_to_send_notification(
         client, template_factory, recipient, label, expected_error, notify_db, notify_db_session):
     sample_template_without_permission = template_factory(notify_db, notify_db_session)
@@ -534,7 +534,7 @@ def test_post_sms_notification_returns_400_if_not_allowed_to_send_notification(
     error_json = json.loads(response.get_data(as_text=True))
     assert error_json['status_code'] == 400
     assert error_json['errors'] == [
-        {"error": "BadRequestError", "message": expected_error}
+        {"error": "BadRequestError", "message": "Service is not allowed to send {}".format(expected_error)}
     ]
 
 


### PR DESCRIPTION
Update the error message when a service does not have permission to send a notification type.