### PR TITLE
Lower service rate limit log level to INFO

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -29,7 +29,7 @@ def check_service_over_api_rate_limit(service, api_key):
         rate_limit = service.rate_limit
         interval = 60
         if redis_store.exceeded_rate_limit(cache_key, rate_limit, interval):
-            current_app.logger.error("service {} has been rate limited for throughput".format(service.id))
+            current_app.logger.info("service {} has been rate limited for throughput".format(service.id))
             raise RateLimitError(rate_limit, interval, api_key.key_type)
 
 
@@ -41,7 +41,7 @@ def check_service_over_daily_message_limit(key_type, service):
             service_stats = services_dao.fetch_todays_total_message_count(service.id)
             redis_store.set(cache_key, service_stats, ex=3600)
         if int(service_stats) >= service.message_limit:
-            current_app.logger.error(
+            current_app.logger.info(
                 "service {} has been rate limited for daily use sent {} limit {}".format(
                     service.id, int(service_stats), service.message_limit)
             )

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,6 +29,6 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@30.7.0#egg=notifications-utils==30.7.0
+git+https://github.com/alphagov/notifications-utils.git@30.7.1#egg=notifications-utils==30.7.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@30.7.0#egg=notifications-utils==30.7.0
+git+https://github.com/alphagov/notifications-utils.git@30.7.1#egg=notifications-utils==30.7.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
@@ -40,12 +40,12 @@ alembic==1.0.3
 amqp==1.4.9
 anyjson==0.3.3
 attrs==18.2.0
-awscli==1.16.61
+awscli==1.16.62
 bcrypt==3.1.4
 billiard==3.3.0.23
 bleach==2.1.3
 boto3==1.6.16
-botocore==1.12.51
+botocore==1.12.52
 certifi==2018.10.15
 chardet==3.0.4
 Click==7.0


### PR DESCRIPTION
### Update utils to 30.7.1 to silence 'Header missing' warnings

Brings in changes from https://github.com/alphagov/notifications-utils/pull/553

### Lower service rate limit log level to INFO

Services reaching rate limits are triggering our alerts and make it hard to find actual exceptions in the logs.

As far as the API is concerned this is not an exceptional state, so we shouldn't log it as such.
