### PR TITLE
Enable pessimistic DB connection disconnect handling

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ import string
 import uuid
 
 from flask import _request_ctx_stack, request, g, jsonify
-from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy as _SQLAlchemy
 from flask_marshmallow import Marshmallow
 from flask_migrate import Migrate
 from time import monotonic
@@ -26,6 +26,13 @@ from app.encryption import Encryption
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"
+
+
+class SQLAlchemy(_SQLAlchemy):
+    def apply_pool_defaults(self, app, options):
+        _SQLAlchemy.apply_pool_defaults(self, app, options)
+        options["pool_pre_ping"] = True
+
 
 db = SQLAlchemy()
 migrate = Migrate()


### PR DESCRIPTION
By default, SQLAlchemy will start a transaction with an
existing connection without checking that the connection
is still valid.

Enabling "pre-ping" makes the ORM send a `SELECT 1` when
acquiring a connection, which should help avoid some errors
caused by connections breaking during a DB failover.

The added statement has a constant overhead for all transactions,
so we should only keep it enabled when we're planning to switch
or upgrade the database server.

https://docs.sqlalchemy.org/en/latest/core/pooling.html#disconnect-handling-pessimistic