### PR TITLE
Improve platform stats page

### DIFF
--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from flask import Blueprint, jsonify, request
 
-from app.dao.notifications_dao import fetch_aggregate_stats_by_date_range_for_all_services
+from app.dao.fact_notification_status_dao import fetch_notification_status_totals_for_all_services
 from app.errors import register_errors
 from app.platform_stats.platform_stats_schema import platform_stats_request
 from app.service.statistics import format_admin_stats
@@ -23,7 +23,7 @@ def get_platform_stats():
 
     start_date = datetime.strptime(request.args.get('start_date', today), '%Y-%m-%d').date()
     end_date = datetime.strptime(request.args.get('end_date', today), '%Y-%m-%d').date()
-    data = fetch_aggregate_stats_by_date_range_for_all_services(start_date=start_date, end_date=end_date)
+    data = fetch_notification_status_totals_for_all_services(start_date=start_date, end_date=end_date)
     stats = format_admin_stats(data)
 
     return jsonify(stats)

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 @freeze_time('2018-06-01')
 def test_get_platform_stats_uses_todays_date_if_no_start_or_end_date_is_provided(admin_request, mocker):
     today = datetime.now().date()
-    dao_mock = mocker.patch('app.platform_stats.rest.fetch_aggregate_stats_by_date_range_for_all_services')
+    dao_mock = mocker.patch('app.platform_stats.rest.fetch_notification_status_totals_for_all_services')
     mocker.patch('app.service.rest.statistics.format_statistics')
 
     admin_request.get('platform_stats.get_platform_stats')
@@ -17,7 +17,7 @@ def test_get_platform_stats_uses_todays_date_if_no_start_or_end_date_is_provided
 def test_get_platform_stats_can_filter_by_date(admin_request, mocker):
     start_date = date(2017, 1, 1)
     end_date = date(2018, 1, 1)
-    dao_mock = mocker.patch('app.platform_stats.rest.fetch_aggregate_stats_by_date_range_for_all_services')
+    dao_mock = mocker.patch('app.platform_stats.rest.fetch_notification_status_totals_for_all_services')
     mocker.patch('app.service.rest.statistics.format_statistics')
 
     admin_request.get('platform_stats.get_platform_stats', start_date=start_date, end_date=end_date)


### PR DESCRIPTION
Update the platform-stats route to return the data from ft_notification_status, that way the request should not time out for a long date range.

The hope is that after this change you can get the total number of notifications sent by the platform since Notify sent it's first messages. 

Next steps is to update the query for platform admin stats all services (the platform-admin/live-services page)