### PR TITLE
Improve performance of platform stats page

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -144,7 +144,7 @@ def fetch_notification_status_totals_for_all_services(start_date, end_date):
     stats = db.session.query(
         FactNotificationStatus.notification_type.label('notification_type'),
         FactNotificationStatus.notification_status.label('status'),
-        FactNotificationStatus.key_type,
+        FactNotificationStatus.key_type.label('key_type'),
         func.sum(FactNotificationStatus.notification_count).label('count')
     ).filter(
         FactNotificationStatus.bst_date >= start_date,
@@ -174,10 +174,12 @@ def fetch_notification_status_totals_for_all_services(start_date, end_date):
         query = db.session.query(
             all_stats_table.c.notification_type,
             all_stats_table.c.status,
+            all_stats_table.c.key_type,
             func.cast(func.sum(all_stats_table.c.count), Integer).label('count'),
         ).group_by(
             all_stats_table.c.notification_type,
             all_stats_table.c.status,
+            all_stats_table.c.key_type,
         ).order_by(
             all_stats_table.c.notification_type
         )

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from flask import Blueprint, jsonify, request
 
-from app.dao.notifications_dao import fetch_aggregate_stats_by_date_range_for_all_services
+from app.dao.fact_notification_status_dao import fetch_notification_status_totals_for_all_services
 from app.errors import register_errors
 from app.platform_stats.platform_stats_schema import platform_stats_request
 from app.service.statistics import format_admin_stats
@@ -23,7 +23,7 @@ def get_platform_stats():
 
     start_date = datetime.strptime(request.args.get('start_date', today), '%Y-%m-%d').date()
     end_date = datetime.strptime(request.args.get('end_date', today), '%Y-%m-%d').date()
-    data = fetch_aggregate_stats_by_date_range_for_all_services(start_date=start_date, end_date=end_date)
+    data = fetch_notification_status_totals_for_all_services(start_date=start_date, end_date=end_date)
     stats = format_admin_stats(data)
 
     return jsonify(stats)

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 @freeze_time('2018-06-01')
 def test_get_platform_stats_uses_todays_date_if_no_start_or_end_date_is_provided(admin_request, mocker):
     today = datetime.now().date()
-    dao_mock = mocker.patch('app.platform_stats.rest.fetch_aggregate_stats_by_date_range_for_all_services')
+    dao_mock = mocker.patch('app.platform_stats.rest.fetch_notification_status_totals_for_all_services')
     mocker.patch('app.service.rest.statistics.format_statistics')
 
     admin_request.get('platform_stats.get_platform_stats')
@@ -17,7 +17,7 @@ def test_get_platform_stats_uses_todays_date_if_no_start_or_end_date_is_provided
 def test_get_platform_stats_can_filter_by_date(admin_request, mocker):
     start_date = date(2017, 1, 1)
     end_date = date(2018, 1, 1)
-    dao_mock = mocker.patch('app.platform_stats.rest.fetch_aggregate_stats_by_date_range_for_all_services')
+    dao_mock = mocker.patch('app.platform_stats.rest.fetch_notification_status_totals_for_all_services')
     mocker.patch('app.service.rest.statistics.format_statistics')
 
     admin_request.get('platform_stats.get_platform_stats', start_date=start_date, end_date=end_date)

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -2,6 +2,9 @@ from datetime import date, datetime
 
 from freezegun import freeze_time
 
+from app.models import SMS_TYPE, EMAIL_TYPE
+from tests.app.db import create_service, create_template, create_ft_notification_status, create_notification
+
 
 @freeze_time('2018-06-01')
 def test_get_platform_stats_uses_todays_date_if_no_start_or_end_date_is_provided(admin_request, mocker):
@@ -35,3 +38,37 @@ def test_get_platform_stats_validates_the_date(admin_request):
 
     assert response['errors'][0]['message'] == 'start_date time data {} does not match format %Y-%m-%d'.format(
         start_date)
+
+
+@freeze_time('2018-10-31 14:00')
+def test_get_platform_stats_with_real_query(admin_request, notify_db_session):
+    service_1 = create_service(service_name='service_1')
+    sms_template = create_template(service=service_1, template_type=SMS_TYPE)
+    email_template = create_template(service=service_1, template_type=EMAIL_TYPE)
+    create_ft_notification_status(date(2018, 10, 29), 'sms', service_1, count=10)
+    create_ft_notification_status(date(2018, 10, 29), 'email', service_1, count=3)
+
+    create_notification(sms_template, created_at=datetime(2018, 10, 31, 11, 0, 0), key_type='test')
+    create_notification(sms_template, created_at=datetime(2018, 10, 31, 12, 0, 0), status='delivered')
+    create_notification(email_template, created_at=datetime(2018, 10, 31, 13, 0, 0), status='delivered')
+
+    response = admin_request.get(
+        'platform_stats.get_platform_stats', start_date=date(2018, 10, 29),
+    )
+    assert response == {
+        'email': {
+            'failures': {
+                'virus-scan-failed': 0, 'temporary-failure': 0, 'permanent-failure': 0, 'technical-failure': 0},
+            'total': 4, 'test-key': 0
+        },
+        'letter': {
+            'failures': {
+                'virus-scan-failed': 0, 'temporary-failure': 0, 'permanent-failure': 0, 'technical-failure': 0},
+            'total': 0, 'test-key': 0
+        },
+        'sms': {
+            'failures': {
+                'virus-scan-failed': 0, 'temporary-failure': 0, 'permanent-failure': 0, 'technical-failure': 0},
+            'total': 11, 'test-key': 1
+        }
+    }


### PR DESCRIPTION
This change will allow platform admin users to query the platform-admin page for historical data. At the moment the query times out for a big date range.