### PR TITLE
Add sender email and change date formatting on Notification's serialize_for_csv

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1413,6 +1413,12 @@ class Notification(db.Model):
         else:
             return None
 
+    def get_created_by_email_address(self):
+        if self.created_by:
+            return self.created_by.email_address
+        else:
+            return None
+
     def serialize_for_csv(self):
         created_at_in_bst = convert_utc_to_bst(self.created_at)
         serialized = {
@@ -1424,6 +1430,7 @@ class Notification(db.Model):
             "status": self.formatted_status,
             "created_at": time.strftime('%A %d %B %Y at %H:%M', created_at_in_bst.timetuple()),
             "created_by_name": self.get_created_by_name(),
+            "created_by_email_address": self.get_created_by_email_address(),
         }
 
         return serialized
@@ -1454,6 +1461,7 @@ class Notification(db.Model):
             "subject": self.subject,
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
             "created_by_name": self.get_created_by_name(),
+            "created_by_email_address": self.get_created_by_email_address(),
             "sent_at": self.sent_at.strftime(DATETIME_FORMAT) if self.sent_at else None,
             "completed_at": self.completed_at(),
             "scheduled_for": (

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,4 @@
 import itertools
-import time
 import uuid
 import datetime
 from flask import url_for, current_app
@@ -1428,7 +1427,7 @@ class Notification(db.Model):
             "template_type": self.template.template_type,
             "job_name": self.job.original_file_name if self.job else '',
             "status": self.formatted_status,
-            "created_at": time.strftime('%A %d %B %Y at %H:%M', created_at_in_bst.timetuple()),
+            "created_at": created_at_in_bst.strftime("%Y-%m-%d %H:%M:%S"),
             "created_by_name": self.get_created_by_name(),
             "created_by_email_address": self.get_created_by_email_address(),
         }
@@ -1461,7 +1460,6 @@ class Notification(db.Model):
             "subject": self.subject,
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
             "created_by_name": self.get_created_by_name(),
-            "created_by_email_address": self.get_created_by_email_address(),
             "sent_at": self.sent_at.strftime(DATETIME_FORMAT) if self.sent_at else None,
             "completed_at": self.completed_at(),
             "scheduled_for": (

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -844,5 +844,5 @@ def test_get_all_notifications_for_job_returns_csv_format(
     assert len(resp['notifications']) == 1
     notification = resp['notifications'][0]
     assert set(notification.keys()) == \
-        set(['created_at', 'created_by_name', 'template_type',
+        set(['created_at', 'created_by_name', 'created_by_email_address', 'template_type',
              'template_name', 'job_name', 'status', 'row_number', 'recipient'])

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -146,7 +146,7 @@ def test_notification_for_csv_returns_bst_correctly(sample_template):
     notification = create_notification(sample_template)
 
     serialized = notification.serialize_for_csv()
-    assert serialized['created_at'] == 'Monday 27 March 2017 at 00:01'
+    assert serialized['created_at'] == '2017-03-27 00:01:53'
 
 
 def test_notification_personalisation_getter_returns_empty_dict_from_None():


### PR DESCRIPTION
- Add sender email on `serialize_for_csv` method on Notification class
- change date formatting on the same method so it is more machine-readable while still remaining human-readable
- Update tests accordingly

PR that uses those changes on admin: https://github.com/alphagov/notifications-admin/pull/2565

Pivotal ticket: https://www.pivotaltracker.com/story/show/162310203

