### PR TITLE
Remove the join to TemplateHistory.

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -32,7 +32,6 @@ from app.models import (
     NotificationHistory,
     ScheduledNotification,
     Template,
-    TemplateHistory,
     KEY_TYPE_TEST,
     LETTER_TYPE,
     NOTIFICATION_CREATED,
@@ -312,7 +311,7 @@ def _filter_query(query, filter_dict=None):
     # filter by template
     template_types = multidict.getlist('template_type')
     if template_types:
-        query = query.join(TemplateHistory).filter(TemplateHistory.template_type.in_(template_types))
+        query = query.filter(Notification.notification_type.in_(template_types))
 
     return query
 


### PR DESCRIPTION
We are adding an index to Notifications to optimize the get_notifications_for_service. We need to build the index concurrently which can not be run inside a transaction block so the index will need to be run on the db directly.

CREATE INDEX CONCURRENTLY ix_notifications_service_created_at ON notifications (service_id, created_at);
DROP INDEX CONCURRENTLY ix_notifications_service_created_at