### PR TITLE
Switch providers on slow delivery goes live

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -258,7 +258,7 @@ def switch_current_sms_provider_on_slow_delivery():
     """
     current_provider = get_current_provider('sms')
     if current_provider.updated_at > datetime.utcnow() - timedelta(minutes=10):
-        current_app.logger.info("Slow delivery provider switched less than 10 minutes ago.")
+        current_app.logger.info("Slow delivery notifications provider switched less than 10 minutes ago.")
         return
     slow_delivery_notifications = is_delivery_slow_for_provider(
         provider=current_provider.identifier,

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -37,7 +37,7 @@ from app.dao.notifications_dao import (
 )
 from app.dao.provider_details_dao import (
     get_current_provider,
-    # dao_toggle_sms_provider
+    dao_toggle_sms_provider
 )
 from app.dao.service_callback_api_dao import get_service_delivery_status_callback_api_for_service
 from app.dao.services_dao import (
@@ -274,7 +274,7 @@ def switch_current_sms_provider_on_slow_delivery():
             )
         )
 
-        # dao_toggle_sms_provider(current_provider.identifier)
+        dao_toggle_sms_provider(current_provider.identifier)
 
 
 @notify_celery.task(name="delete-inbound-sms")

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -467,8 +467,13 @@ def is_delivery_slow_for_provider(
 
     counts = {c[0]: c[1] for c in count}
     total_notifications = sum(counts.values())
+    slow_notifications = counts.get(True, 0)
+
     if total_notifications:
-        return counts.get(True, 0) / total_notifications >= threshold
+        current_app.logger.info("Slow delivery notifications count: {} out of {}. Ratio {}".format(
+            slow_notifications, total_notifications, slow_notifications / total_notifications
+        ))
+        return slow_notifications / total_notifications >= threshold
     else:
         return False
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -400,7 +400,6 @@ def test_send_total_sent_notifications_to_performance_platform_calls_with_correc
         ])
 
 
-@pytest.mark.skip(reason="Not switching it on yet")
 def test_switch_providers_on_slow_delivery_switches_once_then_does_not_switch_if_already_switched(
         notify_api,
         mocker,


### PR DESCRIPTION
Work done:
- uncomment the code that actually switches providers
- log the ratio of slow notifications each time it is checked and there are any notifications

This is a 2nd pull request for this story: https://www.pivotaltracker.com/story/show/162170074

This was the 1st PR: https://github.com/alphagov/notifications-api/pull/2250
