### PR TITLE
New index for  notifications

### DIFF
--- a/migrations/versions/0246_notifications_index.py
+++ b/migrations/versions/0246_notifications_index.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: 0246_notifications_index
+Revises: 0245_archived_flag_jobs
+Create Date: 2018-12-12 12:00:09.770775
+
+"""
+from alembic import op
+
+revision = '0246_notifications_index'
+down_revision = '0245_archived_flag_jobs'
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS ix_notifications_service_created_at ON notifications (service_id, created_at)"
+    )
+
+
+def downgrade():
+    conn = op.get_bind()
+    conn.execute(
+        "DROP INDEX IF EXISTS ix_notifications_service_created_at"
+    )
+


### PR DESCRIPTION
Add an index on notifications for (service_id, created_at) to improve the performance of the notification queries.

We've already performed this update on production since you need to create the index concurrently, which is not allowed from the alembic script. For that reason we are checking if the index exists.