### PR TITLE
Send extra headers to Template Preview /precompiled/sanitise endpoint

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -261,7 +261,9 @@ def _sanitise_precompiled_pdf(self, notification, precompiled_pdf):
                 current_app.config['TEMPLATE_PREVIEW_API_HOST']
             ),
             data=precompiled_pdf,
-            headers={'Authorization': 'Token {}'.format(current_app.config['TEMPLATE_PREVIEW_API_KEY'])}
+            headers={'Authorization': 'Token {}'.format(current_app.config['TEMPLATE_PREVIEW_API_KEY']),
+                     'Service-ID': str(notification.service_id),
+                     'Notification-ID': str(notification.id)}
         )
         resp.raise_for_status()
         return resp.content


### PR DESCRIPTION
We want to send two new headers, `ServiceId` and `NotificationId` to the
template preview `/precompiled/sanitise` endpoint. This is to allow us to log
errors from this endpoint in template preview with all the information needed,
instead of needing to pass the information back to notifications-api and
to log it there.

Part of [this pivotal story](https://www.pivotaltracker.com/story/show/162310239)