### PR TITLE
Choose postage on template

### DIFF
--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -203,7 +203,7 @@ def get_template_versions(service_id, template_id):
 def _template_has_not_changed(current_data, updated_template):
     return all(
         current_data[key] == updated_template[key]
-        for key in ('name', 'content', 'subject', 'archived', 'process_type')
+        for key in ('name', 'content', 'subject', 'archived', 'process_type', 'postage')
     )
 
 

--- a/app/template/template_schemas.py
+++ b/app/template/template_schemas.py
@@ -17,7 +17,8 @@ post_create_template_schema = {
         "content": {"type": "string"},
         "subject": {"type": "string"},
         "created_by": uuid,
-        "parent_folder_id": uuid
+        "parent_folder_id": uuid,
+        "postage": {"type": "string"},
     },
     "if": {
         "properties": {

--- a/app/v2/template/template_schemas.py
+++ b/app/v2/template/template_schemas.py
@@ -37,6 +37,7 @@ get_template_by_id_response = {
         "body": {"type": "string"},
         "subject": {"type": ["string", "null"]},
         "name": {"type": "string"},
+        "postage": {"type": "string"}
     },
     "required": ["id", "type", "created_at", "updated_at", "version", "created_by", "body", "name"],
 }
@@ -63,7 +64,8 @@ post_template_preview_response = {
         "type": {"enum": TEMPLATE_TYPES},
         "version": {"type": "integer"},
         "body": {"type": "string"},
-        "subject": {"type": ["string", "null"]}
+        "subject": {"type": ["string", "null"]},
+        "postage": {"type": "string"}
     },
     "required": ["id", "type", "version", "body"]
 }
@@ -77,5 +79,6 @@ def create_post_template_preview_response(template, template_object):
         "type": template.template_type,
         "version": template.version,
         "body": str(template_object),
-        "subject": subject
+        "subject": subject,
+        "postage": template.postage
     }

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -158,6 +158,7 @@ def sample_service(
     email_from=None,
     permissions=None,
     research_mode=None,
+    postage="second",
 ):
     if user is None:
         user = create_user()
@@ -170,6 +171,7 @@ def sample_service(
         'restricted': restricted,
         'email_from': email_from,
         'created_by': user,
+        "postage": postage,
     }
     service = Service.query.filter_by(name=service_name).first()
     if not service:

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -153,7 +153,7 @@ def test_dao_update_template_reply_to_none_to_some(sample_service, sample_user):
     assert template_history.updated_at == updated.updated_at
 
 
-def test_dao_update_tempalte_reply_to_some_to_some(sample_service, sample_user):
+def test_dao_update_template_reply_to_some_to_some(sample_service, sample_user):
     letter_contact = create_letter_contact(sample_service, 'Edinburgh, ED1 1AA')
     letter_contact_2 = create_letter_contact(sample_service, 'London, N1 1DE')
 

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -81,6 +81,7 @@ def create_service(
         prefix_sms=True,
         message_limit=1000,
         organisation_type='central',
+        postage='second'
 ):
     service = Service(
         name=service_name,
@@ -90,6 +91,7 @@ def create_service(
         created_by=user or create_user(email='{}@digital.cabinet-office.gov.uk'.format(uuid.uuid4())),
         prefix_sms=prefix_sms,
         organisation_type=organisation_type,
+        postage=postage
     )
 
     dao_create_service(service, service.created_by, service_id, service_permissions=service_permissions)

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -140,6 +140,7 @@ def create_template(
         hidden=False,
         archived=False,
         folder=None,
+        postage=None,
 ):
     data = {
         'name': template_name or '{} Template Name'.format(template_type),
@@ -150,6 +151,7 @@ def create_template(
         'reply_to': reply_to,
         'hidden': hidden,
         'folder': folder,
+        'postage': postage,
     }
     if template_type != SMS_TYPE:
         data['subject'] = subject

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -17,6 +17,7 @@ from app.models import (
     EMAIL_TYPE,
     LETTER_TYPE,
     SMS_TYPE,
+    CHOOSE_POSTAGE,
     Template,
     TemplateHistory
 )
@@ -210,6 +211,34 @@ def test_should_raise_error_on_create_if_no_permission(
     assert json_resp['message'] == expected_error
 
 
+def test_should_raise_error_on_create_if_no_choose_postage_permission(client, sample_user):
+    service = create_service(service_permissions=[LETTER_TYPE])
+    data = {
+        'name': 'my template',
+        'template_type': LETTER_TYPE,
+        'content': 'template content',
+        'service': str(service.id),
+        'created_by': str(sample_user.id),
+        'subject': "Some letter",
+        'postage': 'first',
+    }
+
+    data = json.dumps(data)
+    auth_header = create_authorization_header()
+
+    response = client.post(
+        '/service/{}/template'.format(service.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=data
+    )
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert response.status_code == 403
+    assert json_resp['result'] == 'error'
+    assert json_resp['message'] == {
+        "template_postage": ["Setting postage on templates is not enabled for this service."]
+    }
+
+
 @pytest.mark.parametrize('template_factory, expected_error', [
     (sample_template_without_sms_permission, {'template_type': ['Updating text message templates is not allowed']}),
     (sample_template_without_email_permission, {'template_type': ['Updating email templates is not allowed']}),
@@ -237,6 +266,33 @@ def test_should_be_error_on_update_if_no_permission(
     assert update_response.status_code == 403
     assert json_resp['result'] == 'error'
     assert json_resp['message'] == expected_error
+
+
+def test_should_be_error_on_update_if_no_choose_postage_permission(client, sample_user):
+    service = create_service(service_name='some_service', service_permissions=[LETTER_TYPE])
+    template = create_template(service, template_type=LETTER_TYPE)
+    data = {
+        'content': 'new template content',
+        'created_by': str(sample_user.id),
+        'postage': 'first'
+    }
+
+    data = json.dumps(data)
+    auth_header = create_authorization_header()
+
+    update_response = client.post(
+        '/service/{}/template/{}'.format(
+            template.service_id, template.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=data
+    )
+
+    json_resp = json.loads(update_response.get_data(as_text=True))
+    assert update_response.status_code == 403
+    assert json_resp['result'] == 'error'
+    assert json_resp['message'] == {
+        "template_postage": ["Setting postage on templates is not enabled for this service."]
+    }
 
 
 def test_should_error_if_created_by_missing(client, sample_user, sample_service):

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -17,7 +17,6 @@ from app.models import (
     EMAIL_TYPE,
     LETTER_TYPE,
     SMS_TYPE,
-    CHOOSE_POSTAGE,
     Template,
     TemplateHistory
 )


### PR DESCRIPTION
Work done:
- Don't allow to set postage per template if no service permission
- Choose postage when persisting a notification
- Update v2 template schema to include postage
- Include postage in checking if template changed

Pivotal ticket: https://www.pivotaltracker.com/story/show/160231772