### PR TITLE
Use Notification's serialize method for .get_all_notifications_for_service endpoint

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1446,7 +1446,7 @@ class Notification(db.Model):
 
         return serialized
 
-    def serialize(self):
+    def serialize(self, for_service=False):
         template_dict = {
             'version': self.template.version,
             'id': self.template.id,
@@ -1483,8 +1483,7 @@ class Notification(db.Model):
             ),
             "postage": self.postage
         }
-
-        if self.notification_type == LETTER_TYPE:
+        if for_service is False and self.notification_type == LETTER_TYPE:
             col = Columns(self.personalisation)
             serialized['line_1'] = col.get('address_line_1')
             serialized['line_2'] = col.get('address_line_2')
@@ -1497,6 +1496,15 @@ class Notification(db.Model):
                 get_letter_timings(serialized['created_at'], postage=self.postage)\
                 .earliest_delivery\
                 .strftime(DATETIME_FORMAT)
+        if for_service:
+            serialized['to'] = self.to
+            serialized['personalisation'] = self.personalisation
+            template_dict['name'] = self.template.name
+            template_dict['template_type'] = self.template.template_type
+            template_dict['content'] = self.template.content
+            template_dict['subject'] = self.template.subject
+            template_dict['redact_personalisation'] = self.template.redact_personalisation
+            template_dict['is_precompiled_letter'] = self.template.is_precompiled_letter
 
         return serialized
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -361,7 +361,7 @@ def get_all_notifications_for_service(service_id):
     if data.get('format_for_csv'):
         notifications = [notification.serialize_for_csv() for notification in pagination.items]
     else:
-        notifications = [notification.serialize() for notification in pagination.items]
+        notifications = [notification.serialize(for_service=True) for notification in pagination.items]
     return jsonify(
         notifications=notifications,
         page_size=page_size,

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -361,7 +361,7 @@ def get_all_notifications_for_service(service_id):
     if data.get('format_for_csv'):
         notifications = [notification.serialize_for_csv() for notification in pagination.items]
     else:
-        notifications = notification_with_template_schema.dump(pagination.items, many=True).data
+        notifications = [notification.serialize() for notification in pagination.items]
     return jsonify(
         notifications=notifications,
         page_size=page_size,


### PR DESCRIPTION
This PR supersedes the call to marshmallow schema with a call to Notification's serialize method. This is because:
1. we are trying to go away from using the schemas
2. we want to adjust letter notification statuses and Notification's serialize does it for us

As a part of this work a `for_service` flag has been added to serialize method so unnecessary fields are not returned when not needed.

Pivotal ticket: https://www.pivotaltracker.com/story/show/162950719