### PR TITLE
Optimise platform admin live services

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -8,7 +8,7 @@ from sqlalchemy.sql.expression import literal
 from sqlalchemy.types import DateTime, Integer
 
 from app import db
-from app.models import Notification, NotificationHistory, FactNotificationStatus, KEY_TYPE_TEST
+from app.models import Notification, NotificationHistory, FactNotificationStatus, KEY_TYPE_TEST, Service
 from app.utils import get_london_midnight_in_utc, midnight_n_days_ago
 
 
@@ -197,3 +197,95 @@ def fetch_notification_statuses_for_job(job_id):
     ).group_by(
         FactNotificationStatus.notification_status
     ).all()
+
+
+def fetch_stats_for_all_services_by_date_range(start_date, end_date,include_from_test_key=True):
+    stats = db.session.query(
+        FactNotificationStatus.service_id.label('service_id'),
+        Service.name.label('name'),
+        Service.restricted.label('restricted'),
+        Service.research_mode.label('research_mode'),
+        Service.active.label('active'),
+        Service.created_at.label('created_at'),
+        FactNotificationStatus.notification_type.label('notification_type'),
+        FactNotificationStatus.notification_status.label('status'),
+        func.sum(FactNotificationStatus.notification_count).label('count')
+    ).filter(
+        FactNotificationStatus.bst_date >= start_date,
+        FactNotificationStatus.bst_date <= end_date,
+        FactNotificationStatus.service_id == Service.id,
+    ).group_by(
+        FactNotificationStatus.service_id.label('service_id'),
+        Service.name,
+        Service.restricted,
+        Service.research_mode,
+        Service.active,
+        Service.created_at,
+        FactNotificationStatus.notification_type,
+        FactNotificationStatus.notification_status,
+    ).order_by(
+        FactNotificationStatus.service_id,
+        FactNotificationStatus.notification_type
+    )
+    if not include_from_test_key:
+        stats = stats.filter(FactNotificationStatus.key_type != KEY_TYPE_TEST)
+
+    today = get_london_midnight_in_utc(datetime.utcnow())
+    if start_date <= today.date() <= end_date:
+        subquery = db.session.query(
+            Notification.notification_type.cast(db.Text).label('notification_type'),
+            Notification.status.label('status'),
+            Notification.service_id.label('service_id'),
+            func.count(Notification.id).label('count')
+        ).filter(
+            Notification.created_at >= today
+        ).group_by(
+            Notification.notification_type,
+            Notification.status,
+            Notification.service_id
+        )
+        if not include_from_test_key:
+            subquery = subquery.filter(FactNotificationStatus.key_type != KEY_TYPE_TEST)
+        subquery = subquery.subquery()
+
+        stats_for_today = db.session.query(
+            Service.id.label('service_id'),
+            Service.name.label('name'),
+            Service.restricted.label('restricted'),
+            Service.research_mode.label('research_mode'),
+            Service.active.label('active'),
+            Service.created_at.label('created_at'),
+            subquery.c.notification_type.label('notification_type'),
+            subquery.c.status.label('status'),
+            subquery.c.count.label('count')
+        ).outerjoin(
+            subquery,
+            subquery.c.service_id == Service.id
+        ).order_by(Service.id)
+
+        all_stats_table = stats.union_all(stats_for_today).subquery()
+        query = db.session.query(
+            all_stats_table.c.service_id,
+            all_stats_table.c.name,
+            all_stats_table.c.restricted,
+            all_stats_table.c.research_mode,
+            all_stats_table.c.active,
+            all_stats_table.c.created_at,
+            all_stats_table.c.notification_type,
+            all_stats_table.c.status,
+            func.cast(func.sum(all_stats_table.c.count), Integer).label('count'),
+        ).group_by(
+            all_stats_table.c.service_id,
+            all_stats_table.c.name,
+            all_stats_table.c.restricted,
+            all_stats_table.c.research_mode,
+            all_stats_table.c.active,
+            all_stats_table.c.created_at,
+            all_stats_table.c.notification_type,
+            all_stats_table.c.status,
+        ).order_by(
+            all_stats_table.c.service_id
+        )
+    else:
+        query = stats
+    return query.all()

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -199,7 +199,7 @@ def fetch_notification_statuses_for_job(job_id):
     ).all()
 
 
-def fetch_stats_for_all_services_by_date_range(start_date, end_date,include_from_test_key=True):
+def fetch_stats_for_all_services_by_date_range(start_date, end_date, include_from_test_key=True):
     stats = db.session.query(
         FactNotificationStatus.service_id.label('service_id'),
         Service.name.label('name'),
@@ -230,8 +230,8 @@ def fetch_stats_for_all_services_by_date_range(start_date, end_date,include_from
     if not include_from_test_key:
         stats = stats.filter(FactNotificationStatus.key_type != KEY_TYPE_TEST)
 
-    today = get_london_midnight_in_utc(datetime.utcnow())
-    if start_date <= today.date() <= end_date:
+    if start_date <= datetime.utcnow().date() <= end_date:
+        today = get_london_midnight_in_utc(datetime.utcnow())
         subquery = db.session.query(
             Notification.notification_type.cast(db.Text).label('notification_type'),
             Notification.status.label('status'),
@@ -284,7 +284,9 @@ def fetch_stats_for_all_services_by_date_range(start_date, end_date,include_from
             all_stats_table.c.notification_type,
             all_stats_table.c.status,
         ).order_by(
-            all_stats_table.c.service_id
+            all_stats_table.c.name,
+            all_stats_table.c.notification_type,
+            all_stats_table.c.status
         )
     else:
         query = stats

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -23,8 +23,8 @@ from app.dao.api_key_dao import (
 from app.dao.fact_notification_status_dao import (
     fetch_notification_status_for_service_by_month,
     fetch_notification_status_for_service_for_day,
-    fetch_notification_status_for_service_for_today_and_7_previous_days
-)
+    fetch_notification_status_for_service_for_today_and_7_previous_days,
+    fetch_stats_for_all_services_by_date_range)
 from app.dao.inbound_numbers_dao import dao_allocate_number_for_service
 from app.dao.organisation_dao import dao_get_organisation_by_service_id
 from app.dao.service_data_retention_dao import (
@@ -56,7 +56,6 @@ from app.dao.services_dao import (
     dao_remove_user_from_service,
     dao_suspend_service,
     dao_update_service,
-    fetch_stats_by_date_range_for_all_services
 )
 from app.dao.service_whitelist_dao import (
     dao_fetch_service_whitelist,
@@ -472,10 +471,10 @@ def get_detailed_services(start_date, end_date, only_active=False, include_from_
                                                         only_active=only_active)
     else:
 
-        stats = fetch_stats_by_date_range_for_all_services(start_date=start_date,
+        stats = fetch_stats_for_all_services_by_date_range(start_date=start_date,
                                                            end_date=end_date,
                                                            include_from_test_key=include_from_test_key,
-                                                           only_active=only_active)
+                                                           )
     results = []
     for service_id, rows in itertools.groupby(stats, lambda x: x.service_id):
         rows = list(rows)

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -11,7 +11,7 @@ from app.dao.fact_notification_status_dao import (
     fetch_notification_status_for_service_for_today_and_7_previous_days,
     fetch_notification_status_totals_for_all_services,
     fetch_notification_statuses_for_job,
-)
+    fetch_stats_for_all_services_by_date_range)
 from app.models import FactNotificationStatus, KEY_TYPE_TEST, KEY_TYPE_TEAM, EMAIL_TYPE, SMS_TYPE, LETTER_TYPE
 from freezegun import freeze_time
 from tests.app.db import create_notification, create_service, create_template, create_ft_notification_status, create_job
@@ -304,3 +304,12 @@ def test_fetch_notification_statuses_for_job(sample_template):
         'created': 5,
         'delivered': 2
     }
+
+
+@freeze_time('2018-10-31 14:00')
+def test_fetch_stats_for_all_services_by_date_range(notify_db_session):
+    set_up_data()
+    results = fetch_stats_for_all_services_by_date_range( start_date=date(2018, 10, 29),
+                                                          end_date=date(2018, 10, 31))
+    print(results)
+    assert len(results) == 2

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -289,6 +289,7 @@ def set_up_data():
     create_notification(sms_template, created_at=datetime(2018, 10, 31, 11, 0, 0))
     create_notification(sms_template, created_at=datetime(2018, 10, 31, 12, 0, 0), status='delivered')
     create_notification(email_template, created_at=datetime(2018, 10, 31, 13, 0, 0), status='delivered')
+    return service_1, service_2
 
 
 def test_fetch_notification_statuses_for_job(sample_template):
@@ -308,8 +309,32 @@ def test_fetch_notification_statuses_for_job(sample_template):
 
 @freeze_time('2018-10-31 14:00')
 def test_fetch_stats_for_all_services_by_date_range(notify_db_session):
-    set_up_data()
-    results = fetch_stats_for_all_services_by_date_range( start_date=date(2018, 10, 29),
-                                                          end_date=date(2018, 10, 31))
-    print(results)
-    assert len(results) == 2
+    service_1, service_2 = set_up_data()
+    results = fetch_stats_for_all_services_by_date_range(start_date=date(2018, 10, 29),
+                                                         end_date=date(2018, 10, 31))
+    assert len(results) == 5
+
+    assert results[0].service_id == service_1.id
+    assert results[0].notification_type == 'email'
+    assert results[0].status == 'delivered'
+    assert results[0].count == 4
+
+    assert results[1].service_id == service_1.id
+    assert results[1].notification_type == 'sms'
+    assert results[1].status == 'created'
+    assert results[1].count == 2
+
+    assert results[2].service_id == service_1.id
+    assert results[2].notification_type == 'sms'
+    assert results[2].status == 'delivered'
+    assert results[2].count == 11
+
+    assert results[3].service_id == service_2.id
+    assert results[3].notification_type == 'letter'
+    assert results[3].status == 'delivered'
+    assert results[3].count == 10
+
+    assert results[4].service_id == service_2.id
+    assert not results[4].notification_type
+    assert not results[4].status
+    assert not results[4].count


### PR DESCRIPTION
At the moment you can not use the `platform-admin/live-services` page for a long date range. This PR aims to fix that. 
 
- Created a query to get the notification status counts per notification type and service for all service for a given date range. The query follows the same pattern as the other queries, getting the statistics from the fact_notification_status table for dates older than today and union that with today.
Tests required.
- Optimise the query for getting the platform statistics for all services. The page should render for all time after this change.
- Removed unused query
- This is one step closer to eliminating the need to read from NotificationHistory.
