### PR TITLE
Optimise nightly task to calculate monthly template stats.

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -149,6 +149,8 @@ def fetch_billing_data_for_day(process_day, service_id=None):
     # this is useful if we need to rebuild the ft_billing table for a date older than 7 days ago.
     current_app.logger.info("Populate ft_billing for {} to {}".format(start_date, end_date))
     table = Notification
+    # If we decide to delete the data before inserting then we need to go to the NotificationHistory
+    # table we need to consider when a service has data retention that is less than 7 days.
     if start_date < datetime.utcnow() - timedelta(days=7):
         table = NotificationHistory
     transit_data = []

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -11,7 +11,7 @@ from app.dao.dao_utils import (
     transactional,
     version_class
 )
-from app.dao.date_util import get_financial_year, get_month_start_and_end_date_in_utc
+from app.dao.date_util import get_financial_year
 from app.dao.service_sms_sender_dao import insert_service_sms_sender
 from app.dao.stats_template_usage_by_month_dao import dao_get_template_usage_stats_by_service
 from app.models import (
@@ -414,17 +414,11 @@ def dao_fetch_active_users_for_service(service_id):
 
 
 @statsd(namespace="dao")
-def dao_fetch_monthly_historical_stats_by_template():
+def dao_fetch_monthly_historical_stats_by_template(start_date, end_date):
     # Test notifications are not saved to the NotificationHistory
     # table so we don't need to filter out test key notifications.
     month = get_london_month_from_utc_column(NotificationHistory.created_at)
     year = func.date_trunc("year", NotificationHistory.created_at)
-
-    # We want to record this months and last months if we are in the beginning of the month.
-    today = datetime.combine(date.today(), time.min)
-    delta = today - timedelta(days=10)
-    _, end_date = get_month_start_and_end_date_in_utc(today)
-    start_date, _ = get_month_start_and_end_date_in_utc(delta)
 
     return db.session.query(
         NotificationHistory.template_id,

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -11,7 +11,7 @@ from app.dao.dao_utils import (
     transactional,
     version_class
 )
-from app.dao.date_util import get_financial_year
+from app.dao.date_util import get_financial_year, get_month_start_and_end_date_in_utc
 from app.dao.service_sms_sender_dao import insert_service_sms_sender
 from app.dao.stats_template_usage_by_month_dao import dao_get_template_usage_stats_by_service
 from app.models import (
@@ -417,7 +417,12 @@ def dao_fetch_active_users_for_service(service_id):
 def dao_fetch_monthly_historical_stats_by_template():
     month = get_london_month_from_utc_column(NotificationHistory.created_at)
     year = func.date_trunc("year", NotificationHistory.created_at)
-    end_date = datetime.combine(date.today(), time.min)
+
+    # We want to record this months and last months if we are in the beginning of the month.
+    today = datetime.combine(date.today(), time.min)
+    delta = today - timedelta(days=10)
+    _, end_date = get_month_start_and_end_date_in_utc(today)
+    start_date, _ = get_month_start_and_end_date_in_utc(delta)
 
     return db.session.query(
         NotificationHistory.template_id,
@@ -425,6 +430,7 @@ def dao_fetch_monthly_historical_stats_by_template():
         extract('year', year).label('year'),
         func.count().label('count')
     ).filter(
+        NotificationHistory.created_at >= start_date,
         NotificationHistory.created_at < end_date
     ).group_by(
         NotificationHistory.template_id,

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -415,6 +415,8 @@ def dao_fetch_active_users_for_service(service_id):
 
 @statsd(namespace="dao")
 def dao_fetch_monthly_historical_stats_by_template():
+    # Test notifications are not saved to the NotificationHistory
+    # table so we don't need to filter out test key notifications.
     month = get_london_month_from_utc_column(NotificationHistory.created_at)
     year = func.date_trunc("year", NotificationHistory.created_at)
 

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -969,7 +969,7 @@ def test_dao_fetch_monthly_historical_stats_by_template(notify_db_session):
     create_notification(created_at=datetime(2017, 10, 3), template=template_two, status='delivered')
     create_notification(created_at=datetime.now(), template=template_two, status='delivered')
 
-    result = sorted(dao_fetch_monthly_historical_stats_by_template(),
+    result = sorted(dao_fetch_monthly_historical_stats_by_template(start_date='2017-09-01', end_date='2017-10-31'),
                     key=lambda x: (x.month, x.template_id == template_one.id))
 
     assert len(result) == 3

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -50,6 +50,7 @@ from app.models import (
     Complaint,
     InvitedUser,
     TemplateFolder,
+    StatsTemplateUsageByMonth
 )
 
 
@@ -724,3 +725,18 @@ def create_template_folder(service, name='foo', parent=None):
     db.session.add(tf)
     db.session.commit()
     return tf
+
+
+def create_stats_template_usage_by_month(
+        template_id,
+        month,
+        year,
+        count
+):
+    stat = StatsTemplateUsageByMonth(
+        template_id=template_id,
+        month=month,
+        year=year,
+        count=count
+    )
+    db.session.add(stat)


### PR DESCRIPTION
The daily_stats_template_usage_by_month scheduled tasks was calling a query that took 17 minutes.

Turns out it was calculating monthly usage for all services going back to start of Notify.
This ensures we calculate this months and if we are 10 days into this month we re-calculate last months.
By the way, 10 days is a bit arbitrary and could probably be 2.