### PR TITLE
Cancelled notifications don't show as failures in statistics

### DIFF
--- a/app/service/statistics.py
+++ b/app/service/statistics.py
@@ -86,7 +86,7 @@ def _update_statuses_from_row(update_dict, row):
         update_dict['delivered'] += row.count
     elif row.status in (
             'failed', 'technical-failure', 'temporary-failure',
-            'permanent-failure', 'validation-failed', 'virus-scan-failed', 'cancelled'):
+            'permanent-failure', 'validation-failed', 'virus-scan-failed'):
         update_dict['failed'] += row.count
 
 

--- a/tests/app/service/test_statistics.py
+++ b/tests/app/service/test_statistics.py
@@ -39,7 +39,7 @@ NewStatsRow = collections.namedtuple('row', ('notification_type', 'status', 'key
         StatsRow('letter', 'virus-scan-failed', 1),
         StatsRow('letter', 'permanent-failure', 1),
         StatsRow('letter', 'cancelled', 1),
-    ], [4, 0, 4], [0, 0, 0], [4, 0, 4]),
+    ], [4, 0, 4], [0, 0, 0], [4, 0, 3]),
     'convert_sent_to_delivered': ([
         StatsRow('sms', 'sending', 1),
         StatsRow('sms', 'delivered', 1),


### PR DESCRIPTION
Pivotal ticket: https://www.pivotaltracker.com/story/show/162310324