### PR TITLE
Choose postage on POST request for precompiled letters

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -307,6 +307,7 @@ def save_letter(
         saved_notification = persist_notification(
             template_id=notification['template'],
             template_version=notification['template_version'],
+            template_postage=template.postage,
             recipient=recipient,
             service=service,
             personalisation=notification['personalisation'],

--- a/app/notifications/process_letter_notifications.py
+++ b/app/notifications/process_letter_notifications.py
@@ -7,6 +7,7 @@ def create_letter_notification(letter_data, template, api_key, status, reply_to_
     notification = persist_notification(
         template_id=template.id,
         template_version=template.version,
+        template_postage=template.postage,
         # we only accept addresses_with_underscores from the API (from CSV we also accept dashes, spaces etc)
         recipient=letter_data['personalisation']['address_line_1'],
         service=template.service,

--- a/app/notifications/process_letter_notifications.py
+++ b/app/notifications/process_letter_notifications.py
@@ -20,6 +20,7 @@ def create_letter_notification(letter_data, template, api_key, status, reply_to_
         client_reference=letter_data.get('reference'),
         status=status,
         reply_to_text=reply_to_text,
-        billable_units=billable_units
+        billable_units=billable_units,
+        postage=letter_data.get('postage')
     )
     return notification

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -75,7 +75,8 @@ def persist_notification(
     created_by_id=None,
     status=NOTIFICATION_CREATED,
     reply_to_text=None,
-    billable_units=None
+    billable_units=None,
+    postage=None
 ):
     notification_created_at = created_at or datetime.utcnow()
     if not notification_id:
@@ -112,11 +113,14 @@ def persist_notification(
     elif notification_type == EMAIL_TYPE:
         notification.normalised_to = format_email_address(notification.to)
     elif notification_type == LETTER_TYPE:
-        template = dao_get_template_by_id(template_id, template_version)
-        if service.has_permission(CHOOSE_POSTAGE) and template.postage:
-            notification.postage = template.postage
+        if postage:
+            notification.postage = postage
         else:
-            notification.postage = service.postage
+            template = dao_get_template_by_id(template_id, template_version)
+            if service.has_permission(CHOOSE_POSTAGE) and template.postage:
+                notification.postage = template.postage
+            else:
+                notification.postage = service.postage
 
     # if simulated create a Notification model to return but do not persist the Notification to the dB
     if not simulated:

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -32,8 +32,6 @@ from app.dao.notifications_dao import (
     dao_created_scheduled_notification
 )
 
-from app.dao.templates_dao import dao_get_template_by_id
-
 from app.v2.errors import BadRequestError
 from app.utils import (
     cache_key_for_service_template_counter,
@@ -76,7 +74,8 @@ def persist_notification(
     status=NOTIFICATION_CREATED,
     reply_to_text=None,
     billable_units=None,
-    postage=None
+    postage=None,
+    template_postage=None
 ):
     notification_created_at = created_at or datetime.utcnow()
     if not notification_id:
@@ -116,9 +115,8 @@ def persist_notification(
         if postage:
             notification.postage = postage
         else:
-            template = dao_get_template_by_id(template_id, template_version)
-            if service.has_permission(CHOOSE_POSTAGE) and template.postage:
-                notification.postage = template.postage
+            if service.has_permission(CHOOSE_POSTAGE) and template_postage:
+                notification.postage = template_postage
             else:
                 notification.postage = service.postage
 

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -124,6 +124,7 @@ def send_notification(notification_type):
     simulated = simulated_recipient(notification_form['to'], notification_type)
     notification_model = persist_notification(template_id=template.id,
                                               template_version=template.version,
+                                              template_postage=template.postage,
                                               recipient=request.get_json()['to'],
                                               service=authenticated_service,
                                               personalisation=notification_form.get('personalisation', None),

--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -29,6 +29,13 @@ def validate(json_to_validate, schema):
             validate_email_address(instance)
         return True
 
+    @format_checker.checks('postage', raises=ValidationError)
+    def validate_schema_postage(instance):
+        if isinstance(instance, str):
+            if instance not in ["first", "second"]:
+                raise ValidationError("invalid. It must be either first or second.")
+        return True
+
     @format_checker.checks('datetime_within_next_day', raises=ValidationError)
     def validate_schema_date_with_hour(instance):
         if isinstance(instance, str):

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -77,6 +77,7 @@ def send_one_off_notification(service_id, post_data):
     notification = persist_notification(
         template_id=template.id,
         template_version=template.version,
+        template_postage=template.postage,
         recipient=post_data['to'],
         service=service,
         personalisation=personalisation,

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -240,7 +240,7 @@ post_precompiled_letter_request = {
     "properties": {
         "reference": {"type": "string"},
         "content": {"type": "string"},
-        "postage": {"type": "string"}
+        "postage": {"type": "string", "format": "postage"}
     },
     "required": ["reference", "content"],
     "additionalProperties": False

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -239,7 +239,8 @@ post_precompiled_letter_request = {
     "title": "POST v2/notifications/letter",
     "properties": {
         "reference": {"type": "string"},
-        "content": {"type": "string"}
+        "content": {"type": "string"},
+        "postage": {"type": "string"}
     },
     "required": ["reference", "content"],
     "additionalProperties": False

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -504,6 +504,7 @@ def test_persist_letter_notification_finds_correct_postage(
     persist_notification(
         template_id=template.id,
         template_version=template.version,
+        template_postage=template.postage,
         recipient="Jane Doe, 10 Downing Street, London",
         service=service,
         personalisation=None,

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -90,6 +90,7 @@ def test_send_one_off_notification_calls_persist_correctly_for_sms(
     persist_mock.assert_called_once_with(
         template_id=template.id,
         template_version=template.version,
+        template_postage=None,
         recipient=post_data['to'],
         service=template.service,
         personalisation={'name': 'foo'},
@@ -127,6 +128,7 @@ def test_send_one_off_notification_calls_persist_correctly_for_email(
     persist_mock.assert_called_once_with(
         template_id=template.id,
         template_version=template.version,
+        template_postage=None,
         recipient=post_data['to'],
         service=template.service,
         personalisation={'name': 'foo'},
@@ -153,6 +155,7 @@ def test_send_one_off_notification_calls_persist_correctly_for_letter(
     template = create_template(
         service=service,
         template_type=LETTER_TYPE,
+        postage='first',
         subject="Test subject",
         content="Hello (( Name))\nYour thing is due soon",
     )
@@ -174,6 +177,7 @@ def test_send_one_off_notification_calls_persist_correctly_for_letter(
     persist_mock.assert_called_once_with(
         template_id=template.id,
         template_version=template.version,
+        template_postage='first',
         recipient=post_data['to'],
         service=template.service,
         personalisation=post_data['personalisation'],

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -469,16 +469,27 @@ def test_post_precompiled_letter_with_invalid_base64(client, notify_user, mocker
     assert not Notification.query.first()
 
 
-@pytest.mark.parametrize('postage', ['first', 'second'])
-def test_post_precompiled_letter_notification_returns_201(client, notify_user, mocker, postage):
+@pytest.mark.parametrize('service_postage, notification_postage, expected_postage', [
+    ('second', 'second', 'second'),
+    ('second', 'first', 'first'),
+    ('second', None, 'second'),
+    ('first', 'first', 'first'),
+    ('first', 'second', 'second'),
+    ('first', None, 'first'),
+])
+def test_post_precompiled_letter_notification_returns_201(
+    client, notify_user, mocker, service_postage, notification_postage, expected_postage
+):
     sample_service = create_service(service_permissions=['letter', 'precompiled_letter'])
-    sample_service.postage = postage
+    sample_service.postage = service_postage
     s3mock = mocker.patch('app.v2.notifications.post_notifications.upload_letter_pdf')
     mocker.patch('app.celery.letters_pdf_tasks.notify_celery.send_task')
     data = {
         "reference": "letter-reference",
         "content": "bGV0dGVyLWNvbnRlbnQ="
     }
+    if notification_postage:
+        data["postage"] = notification_postage
     auth_header = create_authorization_header(service_id=sample_service.id)
     response = client.post(
         path="v2/notifications/letter",
@@ -493,10 +504,10 @@ def test_post_precompiled_letter_notification_returns_201(client, notify_user, m
 
     assert notification.billable_units == 0
     assert notification.status == NOTIFICATION_PENDING_VIRUS_CHECK
-    assert notification.postage == postage
+    assert notification.postage == expected_postage
 
     notification_history = NotificationHistory.query.one()
-    assert notification_history.postage == postage
+    assert notification_history.postage == expected_postage
 
     resp_json = json.loads(response.get_data(as_text=True))
     assert resp_json == {'id': str(notification.id), 'reference': 'letter-reference'}


### PR DESCRIPTION
This PR enables adding optional 'postage' attribute to a POST request to 'post_precompiled_letter_notification' endpoint and sets notification postage based on this attribute if it's present. The attribute value needs to be either 'first' or 'second'.

Pivotal ticket: https://www.pivotaltracker.com/story/show/160231957