### PR TITLE
[wip] Use supervisord instead of homerolled supervision

### DIFF
--- a/kill_supervisor.py
+++ b/kill_supervisor.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+def write_stdout(s):
+    sys.stdout.write(s)
+    sys.stdout.flush()
+
+def write_stderr(s):
+    sys.stderr.write(s)
+    sys.stderr.flush()
+
+def kill_supervisor():
+    os.system('pkill -15 -f supervisord')
+
+def main():
+    while True:
+        write_stdout('READY\n')
+
+        line = sys.stdin.readline()
+        if 'PROCESS_STATE_FATAL' in line or 'PROCESS_STATE_UNKNOWN' in line:
+            kill_supervisor()
+
+        write_stdout('RESULT 2\nOK')
+
+if __name__ == '__main__':
+    main()

--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -67,9 +67,10 @@ applications:
       NOTIFY_APP_NAME: delivery-worker-research
 
   - name: notify-delivery-worker-sender
-    command: scripts/run_multi_worker_app_paas.sh celery multi start 3 -c 10 -A run_celery.notify_celery --loglevel=INFO -Q send-sms-tasks,send-email-tasks
-    memory: 2G
+    command: scripts/run_multi_worker_app_paas.sh celery multi start 1 -c 10 -A run_celery.notify_celery --loglevel=INFO -Q send-sms-tasks,send-email-tasks
+    memory: 3G
     env:
+      NUM_PROCESSES: '3'
       NOTIFY_APP_NAME: delivery-worker-sender
 
   - name: notify-delivery-worker-periodic

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -32,3 +32,7 @@ itsdangerous==0.24  # pyup: <1.0.0
 git+https://github.com/alphagov/notifications-utils.git@30.7.4#egg=notifications-utils==30.7.4
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
+
+# multiprocess celery workers
+supervisor==3.3.5
+supervisor-stdout==0.1.1


### PR DESCRIPTION
Uses supervisord to supervise celery and awslogs

If any of the processes are stopped it will restart them

If they are stopped > 3 times in < 15s then supervisord will send an
event to kill_supervisor.py which will kill supervisord