### PR TITLE
Bump available disk space for API, sender and receipts workers

### DIFF
--- a/manifest-api-base.yml
+++ b/manifest-api-base.yml
@@ -54,6 +54,7 @@ env:
 
 instances: 1
 memory: 1G
+disk_quota: 2G
 
 applications:
   - name: notify-api

--- a/manifest-delivery-base.yml
+++ b/manifest-delivery-base.yml
@@ -69,6 +69,7 @@ applications:
   - name: notify-delivery-worker-sender
     command: scripts/run_multi_worker_app_paas.sh celery multi start 3 -c 10 -A run_celery.notify_celery --loglevel=INFO -Q send-sms-tasks,send-email-tasks
     memory: 3G
+    disk_quota: 2G
     env:
       NOTIFY_APP_NAME: delivery-worker-sender
 
@@ -101,5 +102,6 @@ applications:
 
   - name: notify-delivery-worker-service-callbacks
     command: scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 -Q service-callbacks 2> /dev/null
+    disk_quota: 2G
     env:
       NOTIFY_APP_NAME: delivery-worker-service-callbacks


### PR DESCRIPTION
They are the busiest services and if we don't deploy often to rotate
them they tend to fill their disk space.