### PR TITLE
downgrade error to info for notification not found for callback

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -113,7 +113,7 @@ def update_notification_status_by_id(notification_id, status, sent_by=None):
     notification = Notification.query.with_for_update().filter(Notification.id == notification_id).first()
 
     if not notification:
-        current_app.logger.error('notification not found for id {} (update to status {})'.format(
+        current_app.logger.info('notification not found for id {} (update to status {})'.format(
             notification_id,
             status
         ))


### PR DESCRIPTION
When we get a callback from SES, we identify the notification by the SES reference that we set on the notification after sending. When we wrote the log message, we assumed that we'd always have a notification for every callback, so if one couldn't be found we would raise an error log. This isn't the case for a few reasons:

* We might receive a callback before the sender worker has persisted the reference to the database.
* We might have deleted the notification, especially if the service has a short data retention period
* We sometimes receive callbacks for references that we have no record of whatsoever (this is quite alarming but we don't know why this happens)

The error logs were happening pretty frequently, and we don't have a real way to solve them at the moment, so lets cut down on noise and downgrade them to info level for now.