### PR TITLE
Return rendered HTML when previewing a template

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import pytz
 from flask import url_for
 from sqlalchemy import func
-from notifications_utils.template import SMSMessageTemplate, WithSubjectTemplate
+from notifications_utils.template import SMSMessageTemplate, WithSubjectTemplate, get_html_email_body
 from notifications_utils.timezones import convert_utc_to_bst
 
 local_timezone = pytz.timezone("Europe/London")
@@ -33,6 +33,18 @@ def get_template_instance(template, values):
     return {
         SMS_TYPE: SMSMessageTemplate, EMAIL_TYPE: WithSubjectTemplate, LETTER_TYPE: WithSubjectTemplate
     }[template['template_type']](template, values)
+
+
+def get_html_email_body_from_template(template_instance):
+    from app.models import EMAIL_TYPE
+
+    if template_instance.template_type != EMAIL_TYPE:
+        return None
+
+    return get_html_email_body(
+        template_instance.content,
+        template_instance.values,
+    )
 
 
 def get_london_midnight_in_utc(date):

--- a/app/v2/template/template_schemas.py
+++ b/app/v2/template/template_schemas.py
@@ -66,9 +66,11 @@ post_template_preview_response = {
         "version": {"type": "integer"},
         "body": {"type": "string"},
         "subject": {"type": ["string", "null"]},
-        "postage": {"type": "string"}
+        "postage": {"type": "string"},
+        "html": {"type": ["string", "null"]},
     },
-    "required": ["id", "type", "version", "body"]
+    "required": ["id", "type", "version", "body"],
+    "additionalProperties": False,
 }
 
 

--- a/app/v2/template/template_schemas.py
+++ b/app/v2/template/template_schemas.py
@@ -1,5 +1,6 @@
 from app.models import SMS_TYPE, TEMPLATE_TYPES
 from app.schema_validation.definitions import uuid, personalisation
+from app.utils import get_html_email_body_from_template
 
 
 get_template_by_id_request = {
@@ -79,6 +80,7 @@ def create_post_template_preview_response(template, template_object):
         "type": template.template_type,
         "version": template.version,
         "body": str(template_object),
+        "html": get_html_email_body_from_template(template_object),
         "subject": subject,
         "postage": template.postage
     }

--- a/tests/app/v2/template/test_template_schemas.py
+++ b/tests/app/v2/template/test_template_schemas.py
@@ -71,17 +71,16 @@ valid_json_post_response = {
     'id': str(uuid.uuid4()),
     'type': 'email',
     'version': 1,
-    'created_by': 'someone@test.com',
-    'body': 'some body'
+    'body': 'some body',
 }
 
 valid_json_post_response_with_optionals = {
     'id': str(uuid.uuid4()),
     'type': 'email',
     'version': 1,
-    'created_by': 'someone@test.com',
     'body': "some body",
-    'subject': 'some subject'
+    'subject': 'some subject',
+    'html': '<p>some body</p>',
 }
 
 


### PR DESCRIPTION
If you’re trying to show what a Notify email will look like in your caseworking system all the API gives you at the moment is raw markdown (with the placeholders replaced).

This isn’t that useful if your caseworkers have no idea what markdown is. If we also give teams the HTML then they can embed this in their systems, and the people using those systems will be able to see how headings, bulleted lists, etc. look.

***

The first users of this are working in Java. They’ve said they’re happy to update the client to add this new field.