### PR TITLE
fix new services being assigned to wrong letter branding

### DIFF
--- a/app/dao/letter_branding_dao.py
+++ b/app/dao/letter_branding_dao.py
@@ -8,6 +8,8 @@ def dao_get_letter_branding_by_id(letter_branding_id):
 
 
 def dao_get_letter_branding_by_domain(domain):
+    if not domain:
+        return None
     return LetterBranding.query.filter(
         LetterBranding.domain == domain
     ).first()


### PR DESCRIPTION
when creating a service, the api accepts a `service_domain` field that it uses to populate the letter branding - if the service domain is known to match an existing letter branding option, use that
automatically. However, the admin currently doesn't know about this field yet so doesn't pass anything through - the api erroneously searches the DB for letter branding with a domain of None - which they currently all have.

This meant that when services were created, their letter branding was set to the most recent row in the DB (that matched None).