### PR TITLE
Add fields to record a service’s estimated volumes

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -361,6 +361,9 @@ class Service(db.Model, Versioned):
     crown = db.Column(db.Boolean, index=False, nullable=False, default=True)
     rate_limit = db.Column(db.Integer, index=False, nullable=False, default=3000)
     contact_link = db.Column(db.String(255), nullable=True, unique=False)
+    volume_sms = db.Column(db.String(255), nullable=True, unique=False)
+    volume_email = db.Column(db.String(255), nullable=True, unique=False)
+    volume_letter = db.Column(db.String(255), nullable=True, unique=False)
 
     organisation = db.relationship(
         'Organisation',

--- a/app/models.py
+++ b/app/models.py
@@ -361,9 +361,9 @@ class Service(db.Model, Versioned):
     crown = db.Column(db.Boolean, index=False, nullable=False, default=True)
     rate_limit = db.Column(db.Integer, index=False, nullable=False, default=3000)
     contact_link = db.Column(db.String(255), nullable=True, unique=False)
-    volume_sms = db.Column(db.String(255), nullable=True, unique=False)
-    volume_email = db.Column(db.String(255), nullable=True, unique=False)
-    volume_letter = db.Column(db.String(255), nullable=True, unique=False)
+    volume_sms = db.Column(db.Integer(), nullable=True, unique=False)
+    volume_email = db.Column(db.Integer(), nullable=True, unique=False)
+    volume_letter = db.Column(db.Integer(), nullable=True, unique=False)
 
     organisation = db.relationship(
         'Organisation',

--- a/app/models.py
+++ b/app/models.py
@@ -364,6 +364,7 @@ class Service(db.Model, Versioned):
     volume_sms = db.Column(db.Integer(), nullable=True, unique=False)
     volume_email = db.Column(db.Integer(), nullable=True, unique=False)
     volume_letter = db.Column(db.Integer(), nullable=True, unique=False)
+    consent_to_research = db.Column(db.Boolean, nullable=False, default=False)
 
     organisation = db.relationship(
         'Organisation',

--- a/migrations/versions/0260_service_volumes.py
+++ b/migrations/versions/0260_service_volumes.py
@@ -1,0 +1,30 @@
+"""
+
+Revision ID: 0260_service_volumes
+Revises: 0259_remove_service_postage
+Create Date: 2019-02-13 13:45:00.782500
+
+"""
+from alembic import op
+from itertools import product
+import sqlalchemy as sa
+
+
+revision = '0260_service_volumes'
+down_revision = '0259_remove_service_postage'
+
+
+TABLES_AND_CHANNELS = product(
+    ('services', 'services_history'),
+    ('volume_{}'.format(channel) for channel in ('email', 'letter', 'sms')),
+)
+
+
+def upgrade():
+    for table, channel in TABLES_AND_CHANNELS:
+        op.add_column(table, sa.Column(channel, sa.String(length=255), nullable=True))
+
+
+def downgrade():
+    for table, channel in TABLES_AND_CHANNELS:
+        op.drop_column(table, channel)

--- a/migrations/versions/0260_service_volumes.py
+++ b/migrations/versions/0260_service_volumes.py
@@ -14,17 +14,19 @@ revision = '0260_service_volumes'
 down_revision = '0259_remove_service_postage'
 
 
-TABLES_AND_CHANNELS = product(
-    ('services', 'services_history'),
-    ('volume_{}'.format(channel) for channel in ('email', 'letter', 'sms')),
-)
+TABLES = ['services', 'services_history']
+CHANNELS = ['volume_{}'.format(channel) for channel in ('email', 'letter', 'sms')]
 
 
 def upgrade():
-    for table, channel in TABLES_AND_CHANNELS:
-        op.add_column(table, sa.Column(channel, sa.Integer(), nullable=True))
+    for table in TABLES:
+        op.add_column(table, sa.Column('consent_to_research', sa.Boolean(), nullable=False, server_default=sa.false()))
+        for channel in CHANNELS:
+            op.add_column(table, sa.Column(channel, sa.Integer(), nullable=True))
 
 
 def downgrade():
-    for table, channel in TABLES_AND_CHANNELS:
-        op.drop_column(table, channel)
+    for table in TABLES:
+        op.drop_column(table, 'consent_to_research')
+        for channel in CHANNELS:
+            op.drop_column(table, channel)

--- a/migrations/versions/0260_service_volumes.py
+++ b/migrations/versions/0260_service_volumes.py
@@ -22,7 +22,7 @@ TABLES_AND_CHANNELS = product(
 
 def upgrade():
     for table, channel in TABLES_AND_CHANNELS:
-        op.add_column(table, sa.Column(channel, sa.String(length=255), nullable=True))
+        op.add_column(table, sa.Column(channel, sa.Integer(), nullable=True))
 
 
 def downgrade():

--- a/migrations/versions/0261_service_volumes.py
+++ b/migrations/versions/0261_service_volumes.py
@@ -1,7 +1,7 @@
 """
 
-Revision ID: 0260_service_volumes
-Revises: 0259_remove_service_postage
+Revision ID: 0261_service_volumes
+Revises: 0260_remove_dvla_organisation
 Create Date: 2019-02-13 13:45:00.782500
 
 """
@@ -10,8 +10,8 @@ from itertools import product
 import sqlalchemy as sa
 
 
-revision = '0260_service_volumes'
-down_revision = '0259_remove_service_postage'
+revision = '0261_service_volumes'
+down_revision = '0260_remove_dvla_organisation'
 
 
 TABLES = ['services', 'services_history']

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -644,6 +644,30 @@ def test_update_service_sets_volumes(
     assert getattr(sample_service, field) == expected_persisted
 
 
+@pytest.mark.parametrize('value, expected_status, expected_persisted', (
+    (True, 200, True),
+    (False, 200, False),
+    ('Yes', 400, False),
+))
+def test_update_service_sets_research_consent(
+    admin_request,
+    sample_service,
+    value,
+    expected_status,
+    expected_persisted,
+):
+    assert sample_service.consent_to_research is False
+    admin_request.post(
+        'service.update_service',
+        service_id=sample_service.id,
+        _data={
+            'consent_to_research': value,
+        },
+        _expected_status=expected_status,
+    )
+    assert sample_service.consent_to_research is expected_persisted
+
+
 @pytest.fixture(scope='function')
 def service_with_no_permissions(notify_db, notify_db_session):
     return create_service(service_permissions=[])

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -615,6 +615,32 @@ def test_update_service_sets_crown(client, sample_service, org_type, expected):
     assert result['data']['crown'] is expected
 
 
+@pytest.mark.parametrize('field', (
+    'volume_email',
+    'volume_sms',
+    'volume_letter',
+))
+@pytest.mark.parametrize('value', (
+    'ABC123',
+    None,
+))
+def test_update_service_sets_volumes(
+    admin_request,
+    sample_service,
+    field,
+    value,
+):
+    admin_request.post(
+        'service.update_service',
+        service_id=sample_service.id,
+        _data={
+            field: value,
+        },
+        _expected_status=200,
+    )
+    assert getattr(sample_service, field) == value
+
+
 @pytest.fixture(scope='function')
 def service_with_no_permissions(notify_db, notify_db_session):
     return create_service(service_permissions=[])

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -620,15 +620,18 @@ def test_update_service_sets_crown(client, sample_service, org_type, expected):
     'volume_sms',
     'volume_letter',
 ))
-@pytest.mark.parametrize('value', (
-    'ABC123',
-    None,
+@pytest.mark.parametrize('value, expected_status, expected_persisted', (
+    (1234, 200, 1234),
+    (None, 200, None),
+    ('Aa', 400, None),
 ))
 def test_update_service_sets_volumes(
     admin_request,
     sample_service,
     field,
     value,
+    expected_status,
+    expected_persisted,
 ):
     admin_request.post(
         'service.update_service',
@@ -636,9 +639,9 @@ def test_update_service_sets_volumes(
         _data={
             field: value,
         },
-        _expected_status=200,
+        _expected_status=expected_status,
     )
-    assert getattr(sample_service, field) == value
+    assert getattr(sample_service, field) == expected_persisted
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
When a service go live we ask people for their estimated sending volumes. At the moment we only put this in the ticket, and store it in a spreadsheet.

This means that a service can
- say they want to go live
- say they are sending 100,000 emails per year
- not have created any email templates
- still see ‘create templates’ as ‘completed’ in the go live checklist

If we store this data against the service we can collect it earlier, and then use it to determine automatically what kind of templates the user needs to create before their go live checklist can be considered complete.