### PR TITLE
Use ‘organisations‘ table to store info about organisations (not YAML)

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -24,6 +24,20 @@ def dao_get_organisation_by_id(organisation_id):
     return Organisation.query.filter_by(id=organisation_id).one()
 
 
+def dao_get_organisation_by_email_address(email_address):
+
+    email_address = email_address.lower()
+
+    for domain in Domain().query.all():
+        if (
+            email_address.endswith("@{}".format(domain.domain)) or
+            email_address.endswith(".{}".format(domain.domain))
+        ):
+            return Organisation.query.filter_by(id=domain.organisation_id).one()
+
+    return None
+
+
 def dao_get_organisation_by_service_id(service_id):
     return Organisation.query.join(Organisation.services).filter_by(id=service_id).first()
 

--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -59,12 +59,12 @@ def dao_update_organisation(organisation_id, **kwargs):
         kwargs
     )
 
-    if domains:
+    if isinstance(domains, list):
 
         Domain.query.filter_by(organisation_id=organisation_id).delete()
 
         db.session.bulk_save_objects([
-            Domain(domain=domain, organisation_id=organisation_id)
+            Domain(domain=domain.lower(), organisation_id=organisation_id)
             for domain in domains
         ])
 

--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -1,3 +1,5 @@
+from sqlalchemy.sql.expression import func
+
 from app import db
 from app.dao.dao_utils import transactional
 from app.models import (
@@ -28,7 +30,8 @@ def dao_get_organisation_by_email_address(email_address):
 
     email_address = email_address.lower()
 
-    for domain in Domain().query.all():
+    for domain in Domain.query.order_by(func.char_length(Domain.domain).desc()).all():
+
         if (
             email_address.endswith("@{}".format(domain.domain)) or
             email_address.endswith(".{}".format(domain.domain))

--- a/app/models.py
+++ b/app/models.py
@@ -316,6 +316,12 @@ organisation_to_service = db.Table(
 )
 
 
+class Domain(db.Model):
+    __tablename__ = "domain"
+    domain = db.Column(db.String(255), primary_key=True)
+    organisation_id = db.Column('organisation_id', UUID(as_uuid=True), db.ForeignKey('organisation.id'), nullable=False)
+
+
 class Organisation(db.Model):
     __tablename__ = "organisation"
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=False)
@@ -329,14 +335,49 @@ class Organisation(db.Model):
         secondary='organisation_to_service',
         uselist=True)
 
+    agreement_signed = db.Column(db.Boolean, nullable=True)
+    agreement_signed_at = db.Column(db.DateTime, nullable=True)
+    agreement_signed_by_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey('users.id'),
+        nullable=True,
+    )
+    agreement_signed_version = db.Column(db.Float, nullable=True)
+    crown = db.Column(db.Boolean, nullable=True)
+    organisation_type = db.Column(db.String(255), nullable=True)
+
+    domains = db.relationship(
+        'Domain',
+    )
+
+    email_branding = db.relationship('EmailBranding')
+    email_branding_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey('email_branding.id'),
+        nullable=True,
+    )
+
+    letter_branding = db.relationship('LetterBranding')
+    letter_branding_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey('letter_branding.id'),
+        nullable=True,
+    )
+
     def serialize(self):
-        serialized = {
+        return {
             "id": str(self.id),
             "name": self.name,
             "active": self.active,
+            "crown": self.crown,
+            "organisation_type": self.organisation_type,
+            "letter_branding_id": self.letter_branding_id,
+            "email_branding_id": self.email_branding_id,
+            "agreement_signed": self.agreement_signed,
+            "agreement_signed_at": self.agreement_signed_at,
+            "agreement_signed_by_id": self.agreement_signed_by_id,
+            "agreement_signed_version": self.agreement_signed_version,
         }
-
-        return serialized
 
 
 class Service(db.Model, Versioned):

--- a/migrations/versions/0278_add_more_stuff_to_orgs.py
+++ b/migrations/versions/0278_add_more_stuff_to_orgs.py
@@ -1,0 +1,57 @@
+"""
+
+Revision ID: 0278_add_more_stuff_to_orgs
+Revises: 0277_consent_to_research_null
+Create Date: 2019-02-26 10:15:22.430340
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0278_add_more_stuff_to_orgs'
+down_revision = '0277_consent_to_research_null'
+
+
+def upgrade():
+    op.create_table(
+        'domain',
+        sa.Column('domain', sa.String(length=255), nullable=False),
+        sa.Column('organisation_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(['organisation_id'], ['organisation.id'], ),
+        sa.PrimaryKeyConstraint('domain')
+    )
+    op.create_index(op.f('ix_domain_domain'), 'domain', ['domain'], unique=True)
+
+    op.add_column('organisation', sa.Column('email_branding_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key('fk_organisation_email_branding_id', 'organisation', 'email_branding', ['email_branding_id'], ['id'])
+
+    op.add_column('organisation', sa.Column('letter_branding_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key('fk_organisation_letter_branding_id', 'organisation', 'letter_branding', ['letter_branding_id'], ['id'])
+
+    op.add_column('organisation', sa.Column('agreement_signed', sa.Boolean(), nullable=True))
+    op.add_column('organisation', sa.Column('agreement_signed_at', sa.DateTime(), nullable=True))
+    op.add_column('organisation', sa.Column('agreement_signed_by_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column('organisation', sa.Column('agreement_signed_version', sa.Float(), nullable=True))
+    op.add_column('organisation', sa.Column('crown', sa.Boolean(), nullable=True))
+    op.add_column('organisation', sa.Column('organisation_type', sa.String(length=255), nullable=True))
+    op.create_foreign_key('fk_organisation_agreement_user_id', 'organisation', 'users', ['agreement_signed_by_id'], ['id'])
+
+
+def downgrade():
+    op.drop_constraint('fk_organisation_agreement_user_id', 'organisation', type_='foreignkey')
+    op.drop_column('organisation', 'organisation_type')
+    op.drop_column('organisation', 'crown')
+    op.drop_column('organisation', 'agreement_signed_version')
+    op.drop_column('organisation', 'agreement_signed_by_id')
+    op.drop_column('organisation', 'agreement_signed_at')
+    op.drop_column('organisation', 'agreement_signed')
+
+    op.drop_column('organisation', 'email_branding_id')
+    op.drop_constraint('fk_organisation_email_branding_id', 'organisation', type_='foreignkey')
+
+    op.drop_column('organisation', 'letter_branding_id')
+    op.drop_constraint('fk_organisation_letter_branding_id', 'organisation', type_='foreignkey')
+
+    op.drop_index(op.f('ix_domain_domain'), table_name='domain')
+    op.drop_table('domain')

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import pytest
 from freezegun import freeze_time
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm.exc import FlushError, NoResultFound
+from sqlalchemy.orm.exc import NoResultFound
 
 from app import db
 from app.dao.inbound_numbers_dao import (
@@ -167,9 +167,9 @@ def test_cannot_create_service_with_no_user(notify_db_session):
                       message_limit=1000,
                       restricted=False,
                       created_by=user)
-    with pytest.raises(FlushError) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         dao_create_service(service, None)
-    assert "Can't flush None value found in collection Service.users" in str(excinfo.value)
+    assert "Can't create a service without a user" in str(excinfo.value)
 
 
 def test_should_add_user_to_service(notify_db_session):

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -51,7 +51,8 @@ from app.models import (
     Complaint,
     InvitedUser,
     TemplateFolder,
-    LetterBranding
+    LetterBranding,
+    Domain,
 )
 
 
@@ -495,6 +496,16 @@ def create_annual_billing(
     db.session.commit()
 
     return annual_billing
+
+
+def create_domain(domain, organisation_id):
+
+    domain = Domain(domain=domain, organisation_id=organisation_id)
+
+    db.session.add(domain)
+    db.session.commit()
+
+    return domain
 
 
 def create_organisation(name='test_org_1', active=True):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -271,6 +271,10 @@ def test_create_service_with_domain_sets_organisation(
     expected_org,
 ):
 
+    red_herring_org = create_organisation(name='Sub example')
+    create_domain('specific.example.gov.uk', red_herring_org.id)
+    create_domain('aaaaaaaa.example.gov.uk', red_herring_org.id)
+
     org = create_organisation()
     create_domain('example.gov.uk', org.id)
     create_domain('test.gov.uk', org.id)


### PR DESCRIPTION
Currently we have
- a thing in the database called an ‘organisation’ which we don’t use
- the idea of an organisation which we derive from the user’s email address and is used to set the default branding for their service and determine whether they’ve signed the MOU

We should make these two things into one thing, by storing everything we know about an organisation against that organisation in the database. This will be much less laborious than storing it in a YAML file that needs a deploy every time it’s updated.

An organisation can now have:
- domains which we can use to automatically associate services with it (eg anyone whose email address ends in `dwp.gsi.gov.uk` gets services they create associated to the DWP organisation)
- default letter branding for any new services
- default email branding for any new services

***

Migrating the data into these tables will be a separate exercise…
