### PR TITLE
Change permissions endpoint to accept data in new format

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -338,7 +338,14 @@ def set_permissions(user_id, service_id):
     # who is making this request has permission to make the request.
     user = get_user_by_id(user_id=user_id)
     service = dao_fetch_service_by_id(service_id=service_id)
-    permissions, errors = permission_schema.load(request.get_json(), many=True)
+
+    data = request.get_json()
+    if 'permissions' in data:
+        user_permissions = data['permissions']
+    else:
+        user_permissions = data
+
+    permissions, errors = permission_schema.load(user_permissions, many=True)
 
     for p in permissions:
         p.user = user

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -347,6 +347,33 @@ def test_set_user_permissions_multiple(client, sample_user, sample_service):
     assert permission.permission == MANAGE_TEMPLATES
 
 
+def test_set_user_permissions_multiple_with_new_data_format(client, sample_user, sample_service):
+    permissions_data = {
+        'permissions': [{'permission': MANAGE_SETTINGS}, {'permission': MANAGE_TEMPLATES}]
+    }
+
+    data = json.dumps(permissions_data)
+    header = create_authorization_header()
+    headers = [('Content-Type', 'application/json'), header]
+    response = client.post(
+        url_for(
+            'user.set_permissions',
+            user_id=str(sample_user.id),
+            service_id=str(sample_service.id)),
+        headers=headers,
+        data=data)
+
+    assert response.status_code == 204
+    permission = Permission.query.filter_by(permission=MANAGE_SETTINGS).first()
+    assert permission.user == sample_user
+    assert permission.service == sample_service
+    assert permission.permission == MANAGE_SETTINGS
+    permission = Permission.query.filter_by(permission=MANAGE_TEMPLATES).first()
+    assert permission.user == sample_user
+    assert permission.service == sample_service
+    assert permission.permission == MANAGE_TEMPLATES
+
+
 def test_set_user_permissions_remove_old(client, sample_user, sample_service):
     data = json.dumps([{'permission': MANAGE_SETTINGS}])
     header = create_authorization_header()


### PR DESCRIPTION
The data posted to the `set_permissions` endpoint is currently sent as a list of permissions:
`[{'permission': MANAGE_SETTINGS}, {'permission': MANAGE_TEMPLATES}]`.

This endpoint is going to also be used for both `permissions` and `user_folder_permissions`, so the data now needs to be nested:

`{'permissions': [{'permission': MANAGE_SETTINGS}, {'permission': MANAGE_TEMPLATES}]}`

This changes the `set_permissions` endpoint to accept data in either format. Once admin is sending data in the new format, the code here can be updated to only accept data in the new format.