### PR TITLE
Allow retry exception to propagate from ses callback task

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 import iso8601
+from celery.exceptions import Retry
 from flask import current_app, json
 from notifications_utils.statsd_decorators import statsd
 from sqlalchemy.orm.exc import NoResultFound
@@ -74,6 +75,9 @@ def process_ses_results(self, response):
         _check_and_queue_callback_task(notification)
 
         return True
+
+    except Retry:
+        raise
 
     except Exception as e:
         current_app.logger.exception('Error processing SES results: {}'.format(type(e)))


### PR DESCRIPTION
Celery `self.retry` raises an exception to communicate that the task
needs to be retried. Since our ses task is wrapped in a catch-all
except block it logs that exception as an error before retrying.

Handling Retry class separately allows us to raise it without logging
the traceback.