### PR TITLE
move slow sms provider threshold from 10% to 20%

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -106,7 +106,7 @@ def switch_current_sms_provider_on_slow_delivery():
         return
     slow_delivery_notifications = is_delivery_slow_for_provider(
         provider=current_provider.identifier,
-        threshold=0.1,
+        threshold=0.2,
         created_at=datetime.utcnow() - timedelta(minutes=10),
         delivery_time=timedelta(minutes=4),
     )

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -494,8 +494,8 @@ def is_delivery_slow_for_provider(
     slow_notifications = counts.get(True, 0)
 
     if total_notifications:
-        current_app.logger.info("Slow delivery notifications count: {} out of {}. Ratio {}".format(
-            slow_notifications, total_notifications, slow_notifications / total_notifications
+        current_app.logger.info("Slow delivery notifications count for provider {}: {} out of {}. Ratio {}".format(
+            provider, slow_notifications, total_notifications, slow_notifications / total_notifications
         ))
         return slow_notifications / total_notifications >= threshold
     else:


### PR DESCRIPTION
provider switching is a process that can happen as often as we like without disrupting the flow of the system - however, there are some reasons why we might not want to switch. One problem we've seen is when a provider is having an issue, we might switch away from them manually only for the app to automatically switch back to them again and again.

Long term we'd like to have a system better suited for sharing the load equally between our two sms providers, but short term, by increasing the threshold for switching from 10% (of messages sent are slow) to 20%, we hope to make switching happen less often.

A notification is considered slow if it was sent in the last ten minutes, on the current provider, and is either

* still in sending or pending after 4 minutes
* in delivered, but took at least 4 minutes to send