### PR TITLE
Add user folder permissions

### DIFF
--- a/app/dao/service_user_dao.py
+++ b/app/dao/service_user_dao.py
@@ -1,0 +1,13 @@
+
+from app import db
+from app.dao.dao_utils import transactional
+from app.models import ServiceUser
+
+
+def dao_get_service_user(user_id, service_id):
+    return ServiceUser.query.filter_by(user_id=user_id, service_id=service_id).one()
+
+
+@transactional
+def dao_update_service_user(service_user):
+    db.session.add(service_user)

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -361,7 +361,7 @@ def dao_resume_service(service_id):
 
 def dao_fetch_active_users_for_service(service_id):
     query = User.query.filter(
-        User.user_to_service.any(id=service_id),
+        User.services.any(id=service_id),
         User.state == 'active'
     )
 

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -12,6 +12,7 @@ from app.dao.dao_utils import (
     version_class
 )
 from app.dao.service_sms_sender_dao import insert_service_sms_sender
+from app.dao.service_user_dao import dao_get_service_user
 from app.models import (
     AnnualBilling,
     ApiKey,
@@ -201,8 +202,13 @@ def dao_remove_user_from_service(service, user):
     try:
         from app.dao.permissions_dao import permission_dao
         permission_dao.remove_user_service_permissions(user, service)
+
+        service_user = dao_get_service_user(user.id, service.id)
+        service_user.folders = []
+
         service.users.remove(user)
-        db.session.add(service)
+
+        db.session.add_all([service, service_user])
     except Exception as e:
         db.session.rollback()
         raise e

--- a/app/models.py
+++ b/app/models.py
@@ -754,7 +754,8 @@ class TemplateFolder(db.Model):
             'id': self.id,
             'name': self.name,
             'parent_id': self.parent_id,
-            'service_id': self.service_id
+            'service_id': self.service_id,
+            'users_with_permission': self.get_users_with_permission()
         }
 
     def is_parent_of(self, other):
@@ -763,6 +764,12 @@ class TemplateFolder(db.Model):
                 return True
             other = other.parent
         return False
+
+    def get_users_with_permission(self):
+        service_users = self.users
+        users_with_permission = [str(service_user.user_id) for service_user in service_users]
+
+        return users_with_permission
 
 
 template_folder_map = db.Table(

--- a/app/user/users_schema.py
+++ b/app/user/users_schema.py
@@ -40,3 +40,16 @@ post_send_user_sms_code_schema = {
     'required': [],
     'additionalProperties': False
 }
+
+
+post_set_permissions_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "POST schema for setting user permissions",
+    "type": "object",
+    "properties": {
+        "permissions": {"type": "array", "items": {"type": "object"}},
+        "folder_permissions": {"type": "array", "items": {"type": "string"}}
+    },
+    "required": ["permissions"],
+    "additionalProperties": False
+}

--- a/migrations/versions/0266_user_folder_perms_table.py
+++ b/migrations/versions/0266_user_folder_perms_table.py
@@ -1,0 +1,32 @@
+"""
+
+Revision ID: 0266_user_folder_perms_table
+Revises: 0265_add_confirm_edit_templates
+Create Date: 2019-02-26 17:00:13.247321
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0266_user_folder_perms_table'
+down_revision = '0265_add_confirm_edit_templates'
+
+
+def upgrade():
+    op.create_unique_constraint('ix_id_service_id', 'template_folder', ['id', 'service_id'])
+    op.create_table('user_folder_permissions',
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('template_folder_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('service_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(['template_folder_id', 'service_id'], ['template_folder.id', 'template_folder.service_id'], ),
+        sa.ForeignKeyConstraint(['user_id', 'service_id'], ['user_to_service.user_id', 'user_to_service.service_id'], ),
+        sa.ForeignKeyConstraint(['template_folder_id'], ['template_folder.id'], ),
+        sa.PrimaryKeyConstraint('user_id', 'template_folder_id', 'service_id'),
+    )
+
+
+
+def downgrade():
+    op.drop_table('user_folder_permissions')
+    op.drop_constraint('ix_id_service_id', 'template_folder', type_='unique')

--- a/tests/app/dao/test_template_folder_dao.py
+++ b/tests/app/dao/test_template_folder_dao.py
@@ -1,0 +1,16 @@
+from app import db
+from app.dao.service_user_dao import dao_get_service_user
+from app.dao.template_folder_dao import dao_delete_template_folder, dao_update_template_folder
+from app.models import user_folder_permissions
+from tests.app.db import create_template_folder
+
+
+def test_dao_delete_template_folder_deletes_user_folder_permissions(sample_user, sample_service):
+    folder = create_template_folder(sample_service)
+    service_user = dao_get_service_user(sample_user.id, sample_service.id)
+    folder.users = [service_user]
+    dao_update_template_folder(folder)
+
+    dao_delete_template_folder(folder)
+
+    assert db.session.query(user_folder_permissions).all() == []


### PR DESCRIPTION
* Added a `user_folder_permissions` table which contains the `service_id`, `user_id` and `template_folder_id`. Also changed the `user_to_service` mapping table into a model, `ServiceUser`, since we're often only interested in the users for a given service.
* Allow user folder permissions to be updated
* Include list of `users_with_permission` in all folders response
* Delete user folder permissions when a user is removed from a service

[Pivotal story](https://www.pivotaltracker.com/story/show/164050120)
