### PR TITLE
Make `consent_to_research` nullable

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -374,7 +374,7 @@ class Service(db.Model, Versioned):
     volume_sms = db.Column(db.Integer(), nullable=True, unique=False)
     volume_email = db.Column(db.Integer(), nullable=True, unique=False)
     volume_letter = db.Column(db.Integer(), nullable=True, unique=False)
-    consent_to_research = db.Column(db.Boolean, nullable=False, default=False)
+    consent_to_research = db.Column(db.Boolean, nullable=True)
 
     organisation = db.relationship(
         'Organisation',

--- a/migrations/versions/0277_consent_to_research_null.py
+++ b/migrations/versions/0277_consent_to_research_null.py
@@ -1,0 +1,71 @@
+"""
+
+Revision ID: 0277_consent_to_research_null
+Revises: 0266_user_folder_perms_table
+Create Date: 2019-03-01 13:47:15.720238
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0277_consent_to_research_null'
+down_revision = '0266_user_folder_perms_table'
+
+
+def upgrade():
+    op.alter_column(
+        'services',
+        'consent_to_research',
+        existing_type=sa.BOOLEAN(),
+        nullable=True,
+        server_default=sa.null(),
+    )
+    op.alter_column(
+        'services_history',
+        'consent_to_research',
+        existing_type=sa.BOOLEAN(),
+        nullable=True,
+        server_default=sa.null(),
+    )
+    op.execute("""
+        UPDATE
+            services
+        SET
+            consent_to_research = null
+    """)
+    op.execute("""
+        UPDATE
+            services_history
+        SET
+            consent_to_research = null
+    """)
+
+
+def downgrade():
+    op.execute("""
+        UPDATE
+            services
+        SET
+            consent_to_research = false
+    """)
+    op.execute("""
+        UPDATE
+            services_history
+        SET
+            consent_to_research = false
+    """)
+    op.alter_column(
+        'services_history',
+        'consent_to_research',
+        existing_type=sa.BOOLEAN(),
+        nullable=False,
+        server_default=sa.false(),
+    )
+    op.alter_column(
+        'services',
+        'consent_to_research',
+        existing_type=sa.BOOLEAN(),
+        nullable=False,
+        server_default=sa.false(),
+    )

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -647,7 +647,7 @@ def test_update_service_sets_volumes(
 @pytest.mark.parametrize('value, expected_status, expected_persisted', (
     (True, 200, True),
     (False, 200, False),
-    ('Yes', 400, False),
+    ('Yes', 400, None),
 ))
 def test_update_service_sets_research_consent(
     admin_request,
@@ -656,7 +656,7 @@ def test_update_service_sets_research_consent(
     expected_status,
     expected_persisted,
 ):
-    assert sample_service.consent_to_research is False
+    assert sample_service.consent_to_research is None
     admin_request.post(
         'service.update_service',
         service_id=sample_service.id,


### PR DESCRIPTION
It should be nullable so we can tell whether someone has answered the question already or not.

No real users have entered data into this column yet, so it’s fine to wipe it.