### PR TITLE
Raise exception if history can’t be written

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -118,8 +118,8 @@ def dao_fetch_all_services_by_user(user_id, only_active=False):
 
 @transactional
 @version_class(Service)
-@version_class(Template, TemplateHistory)
-@version_class(ApiKey)
+@version_class(Template, TemplateHistory, must_write_history=False)
+@version_class(ApiKey, must_write_history=False)
 def dao_archive_service(service_id):
     # have to eager load templates and api keys so that we don't flush when we loop through them
     # to ensure that db.session still contains the models when it comes to creating history objects
@@ -373,7 +373,7 @@ def dao_fetch_todays_stats_for_all_services(include_from_test_key=True, only_act
 
 @transactional
 @version_class(Service)
-@version_class(ApiKey)
+@version_class(ApiKey, must_write_history=False)
 def dao_suspend_service(service_id):
     # have to eager load api keys so that we don't flush when we loop through them
     # to ensure that db.session still contains the models when it comes to creating history objects

--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -11,12 +11,15 @@ from app.models import (
 )
 from app.dao.dao_utils import (
     transactional,
-    version_class
+    version_class,
+    VersionOptions,
 )
 
 
 @transactional
-@version_class(Template, TemplateHistory)
+@version_class(
+    VersionOptions(Template, history_class=TemplateHistory)
+)
 def dao_create_template(template):
     template.id = uuid.uuid4()  # must be set now so version history model can use same id
     template.archived = False
@@ -36,7 +39,9 @@ def dao_create_template(template):
 
 
 @transactional
-@version_class(Template, TemplateHistory)
+@version_class(
+    VersionOptions(Template, history_class=TemplateHistory)
+)
 def dao_update_template(template):
     if template.archived:
         template.folder = None

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -839,6 +839,16 @@ def test_dao_fetch_todays_stats_for_all_services_can_exclude_from_test_key(notif
 
 
 @freeze_time('2001-01-01T23:59:00')
+def test_dao_suspend_service_with_no_api_keys(notify_db_session):
+    service = create_service()
+    dao_suspend_service(service.id)
+    service = Service.query.get(service.id)
+    assert not service.active
+    assert service.name == service.name
+    assert service.api_keys == []
+
+
+@freeze_time('2001-01-01T23:59:00')
 def test_dao_suspend_service_marks_service_as_inactive_and_expires_api_keys(notify_db_session):
     service = create_service()
     api_key = create_api_key(service=service)


### PR DESCRIPTION
This is fiendishly difficult problem to discover on your own.

It’s caused when, during the creation of a row in the database, you run a query on the same table, or a table that joins to the table you’re inserting into. What I think is happening is that the database is forced to flush the session before running the query in order to maintain consistency.

This means that the session is clean by the time the history stuff comes to do its work, so there’s nothing for it to copy into the history table, and it silently fails to record history.

Hopefully raising an exception will:
- prevent this from failing silently
- save whoever comes across this issue in the future a whole load of time