### PR TITLE
Removing the foreign from to users from Notification_history.

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1574,8 +1574,7 @@ class NotificationHistory(db.Model, HistoryModel):
     phone_prefix = db.Column(db.String, nullable=True)
     rate_multiplier = db.Column(db.Float(asdecimal=False), nullable=True)
 
-    created_by = db.relationship('User')
-    created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), nullable=True)
+    created_by_id = db.Column(UUID(as_uuid=True), nullable=True)
 
     postage = db.Column(db.String, nullable=True)
     CheckConstraint("""

--- a/migrations/versions/0278_remove_fk_to_users.py
+++ b/migrations/versions/0278_remove_fk_to_users.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 0278_remove_fk_to_users
+Revises: 0277_consent_to_research_null
+Create Date: 2019-03-06 16:49:28.674498
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0278_remove_fk_to_users'
+down_revision = '0277_consent_to_research_null'
+
+
+def upgrade():
+    op.drop_constraint('notification_history_created_by_id_fkey', 'notification_history', type_='foreignkey')
+
+
+def downgrade():
+    op.create_foreign_key('notification_history_created_by_id_fkey', 'notification_history', 'users', ['created_by_id'], ['id'])

--- a/migrations/versions/0279_remove_fk_to_users.py
+++ b/migrations/versions/0279_remove_fk_to_users.py
@@ -1,16 +1,14 @@
 """
 
-Revision ID: 0278_remove_fk_to_users
-Revises: 0277_consent_to_research_null
+Revision ID: 0279_remove_fk_to_users
+Revises: 0278_add_more_stuff_to_orgs
 Create Date: 2019-03-06 16:49:28.674498
 
 """
 from alembic import op
-import sqlalchemy as sa
 
-
-revision = '0278_remove_fk_to_users'
-down_revision = '0277_consent_to_research_null'
+revision = '0279_remove_fk_to_users'
+down_revision = '0278_add_more_stuff_to_orgs'
 
 
 def upgrade():


### PR DESCRIPTION
The relationship is not used and it prevents us from deleting users. It would be good to delete users that are never activated.