### PR TITLE
Set user permissions when creating a folder

### DIFF
--- a/app/dao/service_user_dao.py
+++ b/app/dao/service_user_dao.py
@@ -1,11 +1,20 @@
 
 from app import db
 from app.dao.dao_utils import transactional
-from app.models import ServiceUser
+from app.models import ServiceUser, User
 
 
 def dao_get_service_user(user_id, service_id):
     return ServiceUser.query.filter_by(user_id=user_id, service_id=service_id).one()
+
+
+def dao_get_active_service_users(service_id):
+    query = ServiceUser.query.join(ServiceUser.user).filter(
+        ServiceUser.service_id == service_id,
+        User.state == 'active'
+    )
+
+    return query.all()
 
 
 @transactional


### PR DESCRIPTION
If the new folder has a parent folder, it inherits user permissions
from its parent. Else if the new folder is at root level, all users
will have a permission to view it.

Pivotal ticket: https://www.pivotaltracker.com/story/show/164050421