### PR TITLE
Change dao_remove_user_from_service query to avoid IntegrityError

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -228,11 +228,7 @@ def dao_remove_user_from_service(service, user):
         permission_dao.remove_user_service_permissions(user, service)
 
         service_user = dao_get_service_user(user.id, service.id)
-        service_user.folders = []
-
-        service.users.remove(user)
-
-        db.session.add_all([service, service_user])
+        db.session.delete(service_user)
     except Exception as e:
         db.session.rollback()
         raise e


### PR DESCRIPTION
When triggered by an admin request `dao_remove_user_from_service`
raised an IntegrityError since the user_to_service delete query was
issued before the folder permissions one, violating the foreign key
constraint on the folder permissions table.

For some reason this isn't caught by the tests in test_services_dao
that check that folder permissions are removed properly.