### PR TITLE
Allow add_user_to_service endpoint to accept new data format

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -285,7 +285,13 @@ def add_user_to_service(service_id, user_id):
         error = 'User id: {} already part of service id: {}'.format(user_id, service_id)
         raise InvalidRequest(error, status_code=400)
 
-    permissions = permission_schema.load(request.get_json(), many=True).data
+    data = request.get_json()
+    if 'permissions' in data:
+        user_permissions = data['permissions']
+    else:
+        user_permissions = data
+
+    permissions = permission_schema.load(user_permissions, many=True).data
     dao_add_user_to_service(service, user, permissions)
     data = service_schema.dump(service).data
     return jsonify(data=data), 201


### PR DESCRIPTION
The data posted to the `add_user_to_service` endpoint is currently sent as a list of permissions:
`[{'permission': MANAGE_SETTINGS}, {'permission': MANAGE_TEMPLATES}]`.

This endpoint is going to also be used for folder permissions, so the data now needs to be nested:
`{'permissions': [{'permission': MANAGE_SETTINGS}, {'permission': MANAGE_TEMPLATES}]}`

This changes the `add_user_to_service` endpoint to accept data in either format. Once admin is sending data in the new format, the code can be simplified.

Part 1 of this [Pivotal story](https://www.pivotaltracker.com/story/show/163756170)