### PR TITLE
fix constraint name check in service error handler

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -118,7 +118,10 @@ def handle_integrity_error(exc):
     """
     Handle integrity errors caused by the unique constraint on ix_organisation_name
     """
-    if 'services_name_key' or 'services_email_from_key' in str(exc):
+    if any(
+        'duplicate key value violates unique constraint "{}"'.format(constraint) in str(exc)
+        for constraint in {'services_name_key', 'services_email_from_key'}
+    ):
         return jsonify(
             result='error',
             message={'name': ["Duplicate service name '{}'".format(


### PR DESCRIPTION
couldn't think of a good way to test it because the problem was it was suppressing actual 500 internal server errors