### PR TITLE
Add folder permissions to invited users

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -14,6 +14,7 @@ from app.dao.dao_utils import (
 from app.dao.organisation_dao import dao_get_organisation_by_email_address
 from app.dao.service_sms_sender_dao import insert_service_sms_sender
 from app.dao.service_user_dao import dao_get_service_user
+from app.dao.template_folder_dao import dao_get_valid_template_folders_by_id
 from app.models import (
     AnnualBilling,
     ApiKey,
@@ -208,13 +209,21 @@ def dao_update_service(service):
     db.session.add(service)
 
 
-def dao_add_user_to_service(service, user, permissions=None):
+def dao_add_user_to_service(service, user, permissions=None, folder_permissions=None):
     permissions = permissions or []
+    folder_permissions = folder_permissions or []
+
     try:
         from app.dao.permissions_dao import permission_dao
         service.users.append(user)
         permission_dao.set_user_service_permission(user, service, permissions, _commit=False)
         db.session.add(service)
+
+        service_user = dao_get_service_user(user.id, service.id)
+        valid_template_folders = dao_get_valid_template_folders_by_id(folder_permissions)
+        service_user.folders = valid_template_folders
+        db.session.add(service_user)
+
     except Exception as e:
         db.session.rollback()
         raise e

--- a/app/dao/template_folder_dao.py
+++ b/app/dao/template_folder_dao.py
@@ -10,6 +10,10 @@ def dao_get_template_folder_by_id_and_service_id(template_folder_id, service_id)
     ).one()
 
 
+def dao_get_valid_template_folders_by_id(folder_ids):
+    return TemplateFolder.query.filter(TemplateFolder.id.in_(folder_ids)).all()
+
+
 @transactional
 def dao_create_template_folder(template_folder):
     db.session.add(template_folder)

--- a/app/models.py
+++ b/app/models.py
@@ -8,7 +8,8 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.dialects.postgresql import (
     UUID,
-    JSON
+    JSON,
+    JSONB,
 )
 from sqlalchemy import UniqueConstraint, CheckConstraint, Index
 from notifications_utils.columns import Columns
@@ -1692,6 +1693,7 @@ class InvitedUser(db.Model):
         nullable=False,
         default=SMS_AUTH_TYPE
     )
+    folder_permissions = db.Column(JSONB(none_as_null=True), nullable=True, default=[])
 
     # would like to have used properties for this but haven't found a way to make them
     # play nice with marshmallow yet

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -539,24 +539,6 @@ class InvitedUserSchema(BaseSchema):
             raise ValidationError(str(e))
 
 
-class PermissionSchema(BaseSchema):
-
-    # Override generated fields
-    user = field_for(models.Permission, 'user', dump_only=True)
-    service = field_for(models.Permission, 'service', dump_only=True)
-    permission = field_for(models.Permission, 'permission')
-
-    __envelope__ = {
-        'single': 'permission',
-        'many': 'permissions',
-    }
-
-    class Meta:
-        model = models.Permission
-        exclude = ("created_at",)
-        strict = True
-
-
 class EmailDataSchema(ma.Schema):
 
     class Meta:
@@ -692,7 +674,6 @@ notification_schema = NotificationModelSchema()
 notification_with_template_schema = NotificationWithTemplateSchema()
 notification_with_personalisation_schema = NotificationWithPersonalisationSchema()
 invited_user_schema = InvitedUserSchema()
-permission_schema = PermissionSchema()
 email_data_request_schema = EmailDataSchema()
 partial_email_data_request_schema = EmailDataSchema(partial_email=True)
 notifications_filter_schema = NotificationsFilterSchema()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -83,7 +83,7 @@ from app.errors import (
     register_errors
 )
 from app.letters.utils import letter_print_day
-from app.models import LETTER_TYPE, NOTIFICATION_CANCELLED, Service, EmailBranding, LetterBranding
+from app.models import LETTER_TYPE, NOTIFICATION_CANCELLED, Permission, Service, EmailBranding, LetterBranding
 from app.schema_validation import validate
 from app.service import statistics
 from app.service.service_data_retention_schema import (
@@ -101,11 +101,11 @@ from app.service.send_notification import send_one_off_notification
 from app.schemas import (
     service_schema,
     api_key_schema,
-    permission_schema,
     notification_with_template_schema,
     notifications_filter_schema,
     detailed_service_schema
 )
+from app.user.users_schema import post_set_permissions_schema
 from app.utils import pagination_links
 
 service_blueprint = Blueprint('service', __name__)
@@ -286,12 +286,13 @@ def add_user_to_service(service_id, user_id):
         raise InvalidRequest(error, status_code=400)
 
     data = request.get_json()
-    if 'permissions' in data:
-        user_permissions = data['permissions']
-    else:
-        user_permissions = data
+    validate(data, post_set_permissions_schema)
 
-    permissions = permission_schema.load(user_permissions, many=True).data
+    permissions = [
+        Permission(service_id=service_id, user_id=user_id, permission=p['permission'])
+        for p in data['permissions']
+    ]
+
     dao_add_user_to_service(service, user, permissions)
     data = service_schema.dump(service).data
     return jsonify(data=data), 201

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -292,8 +292,9 @@ def add_user_to_service(service_id, user_id):
         Permission(service_id=service_id, user_id=user_id, permission=p['permission'])
         for p in data['permissions']
     ]
+    folder_permissions = data.get('folder_permissions', [])
 
-    dao_add_user_to_service(service, user, permissions)
+    dao_add_user_to_service(service, user, permissions, folder_permissions)
     data = service_schema.dump(service).data
     return jsonify(data=data), 201
 

--- a/migrations/versions/0280_invited_user_folder_perms.py
+++ b/migrations/versions/0280_invited_user_folder_perms.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 0280_invited_user_folder_perms
+Revises: 0279_remove_fk_to_users
+Create Date: 2019-03-11 14:38:28.010082
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0280_invited_user_folder_perms'
+down_revision = '0279_remove_fk_to_users'
+
+
+def upgrade():
+    op.add_column('invited_users', sa.Column('folder_permissions', postgresql.JSONB(none_as_null=True, astext_type=sa.Text()), nullable=True))
+
+
+def downgrade():
+    op.drop_column('invited_users', 'folder_permissions')

--- a/tests/app/accept_invite/test_accept_invite_rest.py
+++ b/tests/app/accept_invite/test_accept_invite_rest.py
@@ -45,6 +45,7 @@ def test_validate_invitation_token_returns_200_when_token_valid(
         assert json_resp['data']['service'] == str(sample_invited_user.service_id)
         assert json_resp['data']['status'] == sample_invited_user.status
         assert json_resp['data']['permissions'] == sample_invited_user.permissions
+        assert json_resp['data']['folder_permissions'] == sample_invited_user.folder_permissions
     if invitation_type == 'organisation':
         assert json_resp['data'] == sample_invited_org_user.serialize()
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -752,7 +752,8 @@ def sample_invited_user(notify_db,
         'service': service,
         'email_address': to_email_address,
         'from_user': from_user,
-        'permissions': 'send_messages,manage_service,manage_api_keys'
+        'permissions': 'send_messages,manage_service,manage_api_keys',
+        'folder_permissions': ['folder_1_id', 'folder_2_id'],
     }
     invited_user = InvitedUser(**data)
     save_invited_user(invited_user)

--- a/tests/app/dao/test_invited_user_dao.py
+++ b/tests/app/dao/test_invited_user_dao.py
@@ -26,7 +26,8 @@ def test_create_invited_user(notify_db, notify_db_session, sample_service):
         'service': sample_service,
         'email_address': email_address,
         'from_user': invite_from,
-        'permissions': 'send_messages,manage_service'
+        'permissions': 'send_messages,manage_service',
+        'folder_permissions': []
     }
 
     invited_user = InvitedUser(**data)
@@ -39,6 +40,29 @@ def test_create_invited_user(notify_db, notify_db_session, sample_service):
     assert len(permissions) == 2
     assert 'send_messages' in permissions
     assert 'manage_service' in permissions
+    assert invited_user.folder_permissions == []
+
+
+def test_create_invited_user_sets_default_folder_permissions_of_empty_list(
+    notify_db,
+    notify_db_session,
+    sample_service,
+):
+    assert InvitedUser.query.count() == 0
+    invite_from = sample_service.users[0]
+
+    data = {
+        'service': sample_service,
+        'email_address': 'invited_user@service.gov.uk',
+        'from_user': invite_from,
+        'permissions': 'send_messages,manage_service',
+    }
+
+    invited_user = InvitedUser(**data)
+    save_invited_user(invited_user)
+
+    assert InvitedUser.query.count() == 1
+    assert invited_user.folder_permissions == []
 
 
 def test_get_invited_user_by_service_and_id(notify_db, notify_db_session, sample_invited_user):
@@ -124,7 +148,8 @@ def make_invitation(user, service, age=timedelta(hours=0), email_address="test@t
         service=service,
         status='pending',
         created_at=datetime.utcnow() - age,
-        permissions='manage_settings'
+        permissions='manage_settings',
+        folder_permissions=[str(uuid.uuid4())]
     )
     db.session.add(verify_code)
     db.session.commit()

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -739,7 +739,8 @@ def create_invited_user(service=None,
         'service': service,
         'email_address': to_email_address,
         'from_user': from_user,
-        'permissions': 'send_messages,manage_service,manage_api_keys'
+        'permissions': 'send_messages,manage_service,manage_api_keys',
+        'folder_permissions': [str(uuid.uuid4()), str(uuid.uuid4())]
     }
     invited_user = InvitedUser(**data)
     save_invited_user(invited_user)

--- a/tests/app/invite/test_invite_rest.py
+++ b/tests/app/invite/test_invite_rest.py
@@ -33,6 +33,7 @@ def test_create_invited_user(
         from_user=str(invite_from.id),
         permissions='send_messages,manage_service,manage_api_keys',
         auth_type=EMAIL_AUTH_TYPE,
+        folder_permissions=['folder_1', 'folder_2', 'folder_3'],
         **extra_args
     )
 
@@ -49,6 +50,7 @@ def test_create_invited_user(
     assert json_resp['data']['permissions'] == 'send_messages,manage_service,manage_api_keys'
     assert json_resp['data']['auth_type'] == EMAIL_AUTH_TYPE
     assert json_resp['data']['id']
+    assert json_resp['data']['folder_permissions'] == ['folder_1', 'folder_2', 'folder_3']
 
     notification = Notification.query.first()
 
@@ -73,6 +75,7 @@ def test_create_invited_user_without_auth_type(admin_request, sample_service, mo
         'email_address': email_address,
         'from_user': str(invite_from.id),
         'permissions': 'send_messages,manage_service,manage_api_keys',
+        'folder_permissions': []
     }
 
     json_resp = admin_request.post(
@@ -85,7 +88,7 @@ def test_create_invited_user_without_auth_type(admin_request, sample_service, mo
     assert json_resp['data']['auth_type'] == SMS_AUTH_TYPE
 
 
-def test_create_invited_user_invalid_email(client, sample_service, mocker):
+def test_create_invited_user_invalid_email(client, sample_service, mocker, fake_uuid):
     mocked = mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
     email_address = 'notanemail'
     invite_from = sample_service.users[0]
@@ -94,7 +97,8 @@ def test_create_invited_user_invalid_email(client, sample_service, mocker):
         'service': str(sample_service.id),
         'email_address': email_address,
         'from_user': str(invite_from.id),
-        'permissions': 'send_messages,manage_service,manage_api_keys'
+        'permissions': 'send_messages,manage_service,manage_api_keys',
+        'folder_permissions': [fake_uuid, fake_uuid]
     }
 
     data = json.dumps(data)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1080,81 +1080,7 @@ def test_default_permissions_are_added_for_user_service(notify_api,
             assert sorted(default_service_permissions) == sorted(service_permissions)
 
 
-def test_add_existing_user_to_another_service_with_all_permissions(notify_api,
-                                                                   notify_db,
-                                                                   notify_db_session,
-                                                                   sample_service,
-                                                                   sample_user):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            # check which users part of service
-            user_already_in_service = sample_service.users[0]
-            auth_header = create_authorization_header()
-
-            resp = client.get(
-                '/service/{}/users'.format(sample_service.id),
-                headers=[('Content-Type', 'application/json'), auth_header]
-            )
-
-            assert resp.status_code == 200
-            result = resp.json
-            assert len(result['data']) == 1
-            assert result['data'][0]['email_address'] == user_already_in_service.email_address
-
-            # add new user to service
-            user_to_add = User(
-                name='Invited User',
-                email_address='invited@digital.cabinet-office.gov.uk',
-                password='password',
-                mobile_number='+4477123456'
-            )
-            # they must exist in db first
-            save_model_user(user_to_add)
-
-            data = [{"permission": "send_emails"},
-                    {"permission": "send_letters"},
-                    {"permission": "send_texts"},
-                    {"permission": "manage_users"},
-                    {"permission": "manage_settings"},
-                    {"permission": "manage_api_keys"},
-                    {"permission": "manage_templates"},
-                    {"permission": "view_activity"}]
-
-            auth_header = create_authorization_header()
-
-            resp = client.post(
-                '/service/{}/users/{}'.format(sample_service.id, user_to_add.id),
-                headers=[('Content-Type', 'application/json'), auth_header],
-                data=json.dumps(data)
-            )
-
-            assert resp.status_code == 201
-
-            # check new user added to service
-            auth_header = create_authorization_header()
-
-            resp = client.get(
-                '/service/{}'.format(sample_service.id),
-                headers=[('Content-Type', 'application/json'), auth_header],
-            )
-            assert resp.status_code == 200
-            json_resp = resp.json
-            assert str(user_to_add.id) in json_resp['data']['users']
-
-            # check user has all permissions
-            auth_header = create_authorization_header()
-            resp = client.get(url_for('user.get_user', user_id=user_to_add.id),
-                              headers=[('Content-Type', 'application/json'), auth_header])
-
-            assert resp.status_code == 200
-            json_resp = resp.json
-            permissions = json_resp['data']['permissions'][str(sample_service.id)]
-            expected_permissions = ['send_texts', 'send_emails', 'send_letters', 'manage_users',
-                                    'manage_settings', 'manage_templates', 'manage_api_keys', 'view_activity']
-            assert sorted(expected_permissions) == sorted(permissions)
-
-
-def test_add_existing_user_to_another_service_with_all_permissions_with_new_data_format(
+def test_add_existing_user_to_another_service_with_all_permissions(
     notify_api,
     notify_db,
     notify_db_session,
@@ -1250,9 +1176,13 @@ def test_add_existing_user_to_another_service_with_send_permissions(notify_api,
             )
             save_model_user(user_to_add)
 
-            data = [{"permission": "send_emails"},
+            data = {
+                "permissions": [
+                    {"permission": "send_emails"},
                     {"permission": "send_letters"},
-                    {"permission": "send_texts"}]
+                    {"permission": "send_texts"},
+                ]
+            }
 
             auth_header = create_authorization_header()
 
@@ -1293,9 +1223,13 @@ def test_add_existing_user_to_another_service_with_manage_permissions(notify_api
             )
             save_model_user(user_to_add)
 
-            data = [{"permission": "manage_users"},
+            data = {
+                "permissions": [
+                    {"permission": "manage_users"},
                     {"permission": "manage_settings"},
-                    {"permission": "manage_templates"}]
+                    {"permission": "manage_templates"},
+                ]
+            }
 
             auth_header = create_authorization_header()
 
@@ -1336,7 +1270,7 @@ def test_add_existing_user_to_another_service_with_manage_api_keys(notify_api,
             )
             save_model_user(user_to_add)
 
-            data = [{"permission": "manage_api_keys"}]
+            data = {"permissions": [{"permission": "manage_api_keys"}]}
 
             auth_header = create_authorization_header()
 


### PR DESCRIPTION
#### Added a new `folder_permissions` column  to the `invited_users` table
This is a JSONB column that is currently nullable, but will be backfilled and made non-nullable at a later stage.

#### Updated the `add_user_to_service` endpoint
This was expecting data in either of 2 formats until the [relevant changes were made to admin](https://github.com/alphagov/notifications-admin/pull/2846). We can simplify this now to only expect data in the new format. This also allows us to remove a Marshmallow schema.

#### Set folder permissions when adding a user to a service
This sets the folder permissions for a user when adding them to a service. If a user is being added to a service after accepting an invite, we need to account for the possibility that the folders we are trying to add them to have been deleted before they accepted the invite.

[Pivotal story](https://www.pivotaltracker.com/story/show/163756170)