### PR TITLE
Update dependencies

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,7 +5,7 @@ cffi==1.12.1
 celery==3.1.26.post2 # pyup: <4
 docopt==0.6.2
 Flask-Bcrypt==0.7.1
-flask-marshmallow==0.9.0
+flask-marshmallow==0.10.0
 Flask-Migrate==2.4.0
 git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262#egg=Flask-SQLAlchemy==2.3.2.dev20190108
 Flask==1.0.2

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -15,7 +15,7 @@ gunicorn==19.7.1
 iso8601==0.1.12
 jsonschema==3.0.1
 marshmallow-sqlalchemy==0.16.1
-marshmallow==2.18.1
+marshmallow==2.19.1
 psycopg2-binary==2.7.7
 PyJWT==1.7.1
 SQLAlchemy==1.2.18

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -14,7 +14,7 @@ eventlet==0.23.0
 gunicorn==19.7.1
 iso8601==0.1.12
 jsonschema==3.0.1
-marshmallow-sqlalchemy==0.16.0
+marshmallow-sqlalchemy==0.16.1
 marshmallow==2.18.1
 psycopg2-binary==2.7.7
 PyJWT==1.7.1

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -13,7 +13,7 @@ click-datetime==0.2
 eventlet==0.23.0
 gunicorn==19.7.1
 iso8601==0.1.12
-jsonschema==3.0.0b3
+jsonschema==3.0.1
 marshmallow-sqlalchemy==0.16.0
 marshmallow==2.18.1
 psycopg2-binary==2.7.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ click-datetime==0.2
 eventlet==0.23.0
 gunicorn==19.7.1
 iso8601==0.1.12
-jsonschema==3.0.0b3
+jsonschema==3.0.1
 marshmallow-sqlalchemy==0.16.0
 marshmallow==2.18.1
 psycopg2-binary==2.7.7
@@ -40,12 +40,12 @@ alembic==1.0.8
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.1.0
-awscli==1.16.125
+awscli==1.16.129
 bcrypt==3.1.6
 billiard==3.3.0.23
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.115
+botocore==1.12.119
 certifi==2019.3.9
 chardet==3.0.4
 Click==7.0
@@ -58,7 +58,7 @@ idna==2.8
 Jinja2==2.10
 jmespath==0.9.4
 kombu==3.0.37
-Mako==1.0.7
+Mako==1.0.8
 MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5
@@ -82,4 +82,4 @@ smartypants==2.0.1
 statsd==3.3.0
 urllib3==1.24.1
 webencodings==0.5.1
-Werkzeug==0.14.1
+Werkzeug==0.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cffi==1.12.1
 celery==3.1.26.post2 # pyup: <4
 docopt==0.6.2
 Flask-Bcrypt==0.7.1
-flask-marshmallow==0.9.0
+flask-marshmallow==0.10.0
 Flask-Migrate==2.4.0
 git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262#egg=Flask-SQLAlchemy==2.3.2.dev20190108
 Flask==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ eventlet==0.23.0
 gunicorn==19.7.1
 iso8601==0.1.12
 jsonschema==3.0.1
-marshmallow-sqlalchemy==0.16.0
+marshmallow-sqlalchemy==0.16.1
 marshmallow==2.18.1
 psycopg2-binary==2.7.7
 PyJWT==1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ gunicorn==19.7.1
 iso8601==0.1.12
 jsonschema==3.0.1
 marshmallow-sqlalchemy==0.16.1
-marshmallow==2.18.1
+marshmallow==2.19.1
 psycopg2-binary==2.7.7
 PyJWT==1.7.1
 SQLAlchemy==1.2.18

--- a/tests/app/delivery/test_rest.py
+++ b/tests/app/delivery/test_rest.py
@@ -21,7 +21,7 @@ def test_should_reject_if_invalid_uuid(notify_api):
             )
         body = json.loads(response.get_data(as_text=True))
         assert response.status_code == 404
-        assert body['message'] == 'The requested URL was not found on the server.  If you entered the URL manually please check your spelling and try again.'  # noqa
+        assert body['message'] == 'The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.'  # noqa
         assert body['result'] == 'error'
 
 


### PR DESCRIPTION
Upgraded
* jsonschema from 3.0.0b3 to 3.0.1 
* pytest-xdist from 1.26.1 to 1.27.0
* marshmallow-sqlalchemy from 0.16.0 to 0.16.1
* marshmallow from 2.18.1 to 2.19.1
* flask-marshmallow from 0.9.0 to 0.10.0

Running `make freeze-requirements` causes Werkzeug to be upgraded from 0.14.1 to 0.15.1, so a test error message needed to be changed as a result.