### PR TITLE
Make invited_users folder_permissions column non-nullable

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1693,7 +1693,7 @@ class InvitedUser(db.Model):
         nullable=False,
         default=SMS_AUTH_TYPE
     )
-    folder_permissions = db.Column(JSONB(none_as_null=True), nullable=True, default=[])
+    folder_permissions = db.Column(JSONB(none_as_null=True), nullable=False, default=[])
 
     # would like to have used properties for this but haven't found a way to make them
     # play nice with marshmallow yet

--- a/migrations/versions/0281_non_null_folder_permissions.py
+++ b/migrations/versions/0281_non_null_folder_permissions.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: 0281_non_null_folder_permissions
+Revises: 0280_invited_user_folder_perms
+Create Date: 2019-03-20 10:12:24.927129
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0281_non_null_folder_permissions'
+down_revision = '0280_invited_user_folder_perms'
+
+
+def upgrade():
+    op.execute("UPDATE invited_users SET folder_permissions = '[]' WHERE folder_permissions IS null")
+    op.alter_column('invited_users', 'folder_permissions',
+               existing_type=postgresql.JSONB(astext_type=sa.Text()),
+               nullable=False)
+
+
+def downgrade():
+    op.alter_column('invited_users', 'folder_permissions',
+               existing_type=postgresql.JSONB(astext_type=sa.Text()),
+               nullable=True)


### PR DESCRIPTION
Now that notifications-admin is always sending through
folder_permissions, the folder_permissions column of the `invited_user`
table can be made non-nullable. The migration also backfills the column
(to `[]`) to account for existing null values.

Needs to be merged after https://github.com/alphagov/notifications-admin/pull/2850

[Pivotal story](https://www.pivotaltracker.com/story/show/163756170)