### PR TITLE
Fix automatic inheritance of org’s branding

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -194,11 +194,11 @@ def dao_create_service(
 
         service.organisation = organisation
 
-        if organisation.email_branding_id:
-            service.email_branding = organisation.email_branding_id
+        if organisation.email_branding:
+            service.email_branding = organisation.email_branding
 
-        if organisation.letter_branding_id and not service.letter_branding:
-            service.letter_branding = organisation.letter_branding_id
+        if organisation.letter_branding and not service.letter_branding:
+            service.letter_branding = organisation.letter_branding
 
     db.session.add(service)
 


### PR DESCRIPTION
When creating a service it should inherit it’s organisation’s branding, if that organisation has branding.

This wasn’t working because we were referring to the ID of the branding when making the association, not the branding itself.