### PR TITLE
Allow excluding services from live services count

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -179,6 +179,7 @@ def dao_create_service(
     service.active = True
     service.research_mode = False
     service.crown = service.organisation_type == 'central'
+    service.count_as_live = not user.platform_admin
 
     for permission in service_permissions:
         service_permission = ServicePermission(service_id=service.id, permission=permission)

--- a/app/models.py
+++ b/app/models.py
@@ -420,6 +420,7 @@ class Service(db.Model, Versioned):
     volume_email = db.Column(db.Integer(), nullable=True, unique=False)
     volume_letter = db.Column(db.Integer(), nullable=True, unique=False)
     consent_to_research = db.Column(db.Boolean, nullable=True)
+    count_as_live = db.Column(db.Boolean, nullable=False, default=True)
 
     organisation = db.relationship(
         'Organisation',

--- a/migrations/versions/0282_add_count_as_live.py
+++ b/migrations/versions/0282_add_count_as_live.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: 0282_add_count_as_live
+Revises: 0281_non_null_folder_permissions
+Create Date: 2016-10-25 17:37:27.660723
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0282_add_count_as_live'
+down_revision = '0281_non_null_folder_permissions'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('services', sa.Column('count_as_live', sa.Boolean(), nullable=False, server_default=sa.true()))
+    op.add_column('services_history', sa.Column('count_as_live', sa.Boolean(), nullable=False, server_default=sa.true()))
+
+
+def downgrade():
+    op.drop_column('services_history', 'count_as_live')
+    op.drop_column('services', 'count_as_live')

--- a/migrations/versions/0283_platform_admin_not_live.py
+++ b/migrations/versions/0283_platform_admin_not_live.py
@@ -1,0 +1,35 @@
+"""empty message
+
+Revision ID: 0283_platform_admin_not_live
+Revises: 0282_add_count_as_live
+Create Date: 2016-10-25 17:37:27.660723
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0283_platform_admin_not_live'
+down_revision = '0282_add_count_as_live'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+STATEMENT = """
+    UPDATE
+        services
+    SET
+        count_as_live = {count_as_live}
+    FROM
+        users
+    WHERE
+        services.created_by_id = users.id and
+        users.platform_admin is true
+    ;
+"""
+
+
+def upgrade():
+    op.execute(STATEMENT.format(count_as_live='false'))
+
+def downgrade():
+    op.execute(STATEMENT.format(count_as_live='true'))

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -221,7 +221,17 @@ def test_get_service_by_id_should_404_if_no_service_for_user(notify_api, sample_
             assert json_resp['message'] == 'No result found'
 
 
-def test_create_service(admin_request, sample_user):
+@pytest.mark.parametrize('platform_admin, expected_count_as_live', (
+    (True, False),
+    (False, True),
+))
+def test_create_service(
+    admin_request,
+    sample_user,
+    platform_admin,
+    expected_count_as_live,
+):
+    sample_user.platform_admin = platform_admin
     data = {
         'name': 'created service',
         'user_id': str(sample_user.id),
@@ -240,6 +250,7 @@ def test_create_service(admin_request, sample_user):
     assert not json_resp['data']['research_mode']
     assert json_resp['data']['rate_limit'] == 3000
     assert json_resp['data']['letter_branding'] is None
+    assert json_resp['data']['count_as_live'] is expected_count_as_live
 
     service_db = Service.query.get(json_resp['data']['id'])
     assert service_db.name == 'created service'


### PR DESCRIPTION
Sometimes we have to make a few services for what really is one service, for example GOV.UK Pay and GOV.UK Pay Direct Debit. We also have our own test services which aren’t included in the count of live
services. We currently count these as one service by not including them in the beta partners spreadsheet.

This PR
- adds a column to mark such services as ‘not counted’, which can later be used to exclude them from reporting
- marks new and existing services created by a platform admin user as not counted by default (because they’re probably some kind of test service)

***

https://www.pivotaltracker.com/n/projects/1443052