### PR TITLE
Retry making services created by platform admin users not counted in the list of live services

### DIFF
--- a/migrations/versions/0284_0283_retry.py
+++ b/migrations/versions/0284_0283_retry.py
@@ -1,0 +1,39 @@
+"""empty message
+
+Revision ID: 0284_0283_retry
+Revises: 0283_platform_admin_not_live
+Create Date: 2016-10-25 17:37:27.660723
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0284_0283_retry'
+down_revision = '0283_platform_admin_not_live'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.execute("""
+        UPDATE
+            services
+        SET
+            count_as_live = not users.platform_admin
+        FROM
+            users, services_history
+        WHERE
+            services_history.id = services.id and
+            services_history.version = 1 and
+            services_history.created_by_id = users.id
+        ;
+    """)
+
+def downgrade():
+    op.execute("""
+        UPDATE
+            services
+        SET
+            count_as_live = true
+        ;
+    """)


### PR DESCRIPTION
The [previous migration](https://github.com/alphagov/notifications-api/pull/2417) didn’t work because the `created_by_id` column in services references the user who created the _version_ of the service, not who created the service originally. 

For most live services the user who created the most recent version will be the one who made the service live, ie the a platform admin user.

This commit runs another migration to wipe all the data, and replace it using an operation that looks at the first version of the service in the history table, which will reference the user who actually created the service.