### PR TITLE
Use ft_notification_status instead of notification_history

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -394,3 +394,15 @@ def fetch_monthly_template_usage_for_service(start_date, end_date, service_id):
     else:
         query = stats
     return query.all()
+
+
+def get_total_sent_notifications_for_day_and_type(day, notification_type):
+    result = db.session.query(
+        func.sum(FactNotificationStatus.notification_count).label('count')
+    ).filter(
+        FactNotificationStatus.notification_type == notification_type,
+        FactNotificationStatus.key_type != KEY_TYPE_TEST,
+        FactNotificationStatus.bst_date == day,
+    ).scalar()
+
+    return result or 0

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -453,19 +453,6 @@ def dao_timeout_notifications(timeout_period_in_seconds):
     return technical_failure_notifications, temporary_failure_notifications
 
 
-def get_total_sent_notifications_in_date_range(start_date, end_date, notification_type):
-    result = db.session.query(
-        func.count(NotificationHistory.id).label('count')
-    ).filter(
-        NotificationHistory.key_type != KEY_TYPE_TEST,
-        NotificationHistory.created_at >= start_date,
-        NotificationHistory.created_at <= end_date,
-        NotificationHistory.notification_type == notification_type
-    ).scalar()
-
-    return result or 0
-
-
 def is_delivery_slow_for_provider(
         created_at,
         provider,

--- a/app/performance_platform/total_sent_notifications.py
+++ b/app/performance_platform/total_sent_notifications.py
@@ -1,8 +1,5 @@
-from datetime import timedelta
-
 from app import performance_platform_client
-from app.dao.notifications_dao import get_total_sent_notifications_in_date_range
-from app.utils import get_london_midnight_in_utc
+from app.dao.fact_notification_status_dao import get_total_sent_notifications_for_day_and_type
 
 
 def send_total_notifications_sent_for_day_stats(date, notification_type, count):
@@ -18,15 +15,12 @@ def send_total_notifications_sent_for_day_stats(date, notification_type, count):
 
 
 def get_total_sent_notifications_for_day(day):
-    start_date = get_london_midnight_in_utc(day)
-    end_date = start_date + timedelta(days=1)
-
-    email_count = get_total_sent_notifications_in_date_range(start_date, end_date, 'email')
-    sms_count = get_total_sent_notifications_in_date_range(start_date, end_date, 'sms')
-    letter_count = get_total_sent_notifications_in_date_range(start_date, end_date, 'letter')
+    email_count = get_total_sent_notifications_for_day_and_type(day, 'email')
+    sms_count = get_total_sent_notifications_for_day_and_type(day, 'sms')
+    letter_count = get_total_sent_notifications_for_day_and_type(day, 'letter')
 
     return {
-        "start_date": start_date,
+        "start_date": day,
         "email": {
             "count": email_count
         },

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -538,11 +538,11 @@ def test_get_total_sent_notifications_for_day_and_type_returns_right_notificatio
         notification_type, count, sample_template, sample_email_template, sample_letter_template
 ):
     create_ft_notification_status(bst_date="2019-03-27", service=sample_template.service, template=sample_template,
-                                  count=count)
+                                  count=3)
     create_ft_notification_status(bst_date="2019-03-27", service=sample_email_template.service,
-                                  template=sample_email_template, count=count)
+                                  template=sample_email_template, count=5)
     create_ft_notification_status(bst_date="2019-03-27", service=sample_letter_template.service,
-                                  template=sample_letter_template, count=count)
+                                  template=sample_letter_template, count=7)
 
     result = get_total_sent_notifications_for_day_and_type(day='2019-03-27', notification_type=notification_type)
 

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -12,10 +12,12 @@ from app.dao.fact_notification_status_dao import (
     fetch_notification_status_for_service_for_today_and_7_previous_days,
     fetch_notification_status_totals_for_all_services,
     fetch_notification_statuses_for_job,
-    fetch_stats_for_all_services_by_date_range, fetch_monthly_template_usage_for_service
+    fetch_stats_for_all_services_by_date_range, fetch_monthly_template_usage_for_service,
+    get_total_sent_notifications_for_day_and_type
 )
 from app.models import FactNotificationStatus, KEY_TYPE_TEST, KEY_TYPE_TEAM, EMAIL_TYPE, SMS_TYPE, LETTER_TYPE
 from freezegun import freeze_time
+
 from tests.app.db import create_notification, create_service, create_template, create_ft_notification_status, create_job
 
 
@@ -526,3 +528,48 @@ def test_fetch_monthly_template_usage_for_service_does_not_include_test_notifica
     )
 
     assert len(results) == 0
+
+
+@pytest.mark.parametrize("notification_type, count",
+                         [("sms", 3),
+                          ("email", 5),
+                          ("letter", 7)])
+def test_get_total_sent_notifications_for_day_and_type_returns_right_notification_type(
+        notification_type, count, sample_template, sample_email_template, sample_letter_template
+):
+    create_ft_notification_status(bst_date="2019-03-27", service=sample_template.service, template=sample_template,
+                                  count=count)
+    create_ft_notification_status(bst_date="2019-03-27", service=sample_email_template.service,
+                                  template=sample_email_template, count=count)
+    create_ft_notification_status(bst_date="2019-03-27", service=sample_letter_template.service,
+                                  template=sample_letter_template, count=count)
+
+    result = get_total_sent_notifications_for_day_and_type(day='2019-03-27', notification_type=notification_type)
+
+    assert result == count
+
+
+@pytest.mark.parametrize("day",
+                         ["2019-01-27", "2019-04-02"])
+def test_get_total_sent_notifications_for_day_and_type_returns_total_for_right_day(
+    day, sample_template
+):
+    date = datetime.strptime(day, "%Y-%m-%d")
+    create_ft_notification_status(bst_date=date - timedelta(days=1), notification_type=sample_template.template_type,
+                                  service=sample_template.service, template=sample_template, count=1)
+    create_ft_notification_status(bst_date=date, notification_type=sample_template.template_type,
+                                  service=sample_template.service, template=sample_template, count=2)
+    create_ft_notification_status(bst_date=date + timedelta(days=1), notification_type=sample_template.template_type,
+                                  service=sample_template.service, template=sample_template, count=3)
+
+    total = get_total_sent_notifications_for_day_and_type(day, sample_template.template_type)
+
+    assert total == 2
+
+
+def test_get_total_sent_notifications_for_day_and_type_returns_zero_when_no_counts(
+    notify_db_session
+):
+    total = get_total_sent_notifications_for_day_and_type("2019-03-27", "sms")
+
+    assert total == 0


### PR DESCRIPTION
Update the nightly task that send performance platform statistics to use ft_notification_status rather than notification_history.

The previous query was including all notifications regardless of notification_status. This is okay because the performance platform is reporting how many notifications Notify is dealing with. 

I also need to remove the query that's no longer being used.