### PR TITLE
Fix date bug for performance platform

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -157,7 +157,7 @@ def send_daily_performance_platform_stats():
 
 
 def send_total_sent_notifications_to_performance_platform(day):
-    count_dict = total_sent_notifications.get_total_sent_notifications_for_day(day)
+    count_dict = total_sent_notifications.get_total_sent_notifications_for_day(day.date())
     email_sent_count = count_dict.get('email').get('count')
     sms_sent_count = count_dict.get('sms').get('count')
     letter_sent_count = count_dict.get('letter').get('count')

--- a/tests/app/billing/test_billing.py
+++ b/tests/app/billing/test_billing.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 import json
 
 import pytest
+from freezegun import freeze_time
 
 from app.models import FactBilling
 from app.dao.date_util import get_current_financial_year_start_year, get_month_start_and_end_date_in_utc
@@ -156,6 +157,7 @@ def test_update_free_sms_fragment_limit_data(client, sample_service):
     assert annual_billing.free_sms_fragment_limit == 9999
 
 
+@freeze_time('2018-04-21 14:00')
 def test_get_yearly_usage_by_monthly_from_ft_billing_populates_deltas(client, notify_db_session):
     service = create_service()
     sms_template = create_template(service=service, template_type="sms")

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -261,7 +261,7 @@ def test_send_total_sent_notifications_to_performance_platform_calls_with_correc
     perf_mock = mocker.patch(
         'app.celery.nightly_tasks.total_sent_notifications.send_total_notifications_sent_for_day_stats')  # noqa
 
-    today = datetime.utcnow().date()
+    today = datetime.utcnow()
     create_ft_notification_status(bst_date=today, notification_type='sms', service=sample_template.service,
                                   template=sample_template)
     create_ft_notification_status(bst_date=today, notification_type='email', service=sample_email_template.service,
@@ -283,8 +283,9 @@ def test_send_total_sent_notifications_to_performance_platform_calls_with_correc
         send_total_sent_notifications_to_performance_platform(yesterday)
 
         perf_mock.assert_has_calls([
-            call(yesterday, 'sms', 2),
-            call(yesterday, 'email', 3)
+            call(yesterday.date(), 'sms', 2),
+            call(yesterday.date(), 'email', 3),
+            call(yesterday.date(), 'letter', 0)
         ])
 
 


### PR DESCRIPTION
Changed the query to get the performance platform stats from ft_notification_status. But the date used for the query needed to be a date, not datetime so the equality worked.