### PR TITLE
Give existing users all folder permissions

### DIFF
--- a/migrations/versions/0292_give_users_folder_perms.py
+++ b/migrations/versions/0292_give_users_folder_perms.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: 0292_give_users_folder_perms
+Revises: 0291_remove_unused_index
+Create Date: 2019-04-01 16:36:53.274394
+
+"""
+from alembic import op
+from sqlalchemy.sql import text
+
+
+revision = '0292_give_users_folder_perms'
+down_revision = '0291_remove_unused_index'
+
+
+def upgrade():
+    op.execute(text(
+        """INSERT INTO user_folder_permissions (user_id, template_folder_id, service_id)
+        SELECT user_to_service.user_id, template_folder.id, user_to_service.service_id from user_to_service, template_folder
+        WHERE template_folder.service_id = user_to_service.service_id
+        ON CONFLICT do nothing"""
+    ))
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
This will be done just before we turn on folder permissions to all services to ensure that all users start with all the permissions.

Pivotal ticket: https://www.pivotaltracker.com/story/show/164051002