### PR TITLE
Fix performance platform date bug

### DIFF
--- a/app/clients/performance_platform/performance_platform_client.py
+++ b/app/clients/performance_platform/performance_platform_client.py
@@ -46,17 +46,17 @@ class PerformancePlatformClient:
                 resp.raise_for_status()
 
     @staticmethod
-    def format_payload(*, dataset, date, group_name, group_value, count, period='day'):
+    def format_payload(*, dataset, start_time, group_name, group_value, count, period='day'):
         """
         :param dataset - the name of the overall graph, as referred to in the endpoint.
-        :param date - the date we're sending stats for
+        :param start_time - UTC midnight of the day we're sending stats for
         :param group_name - the name of the individual groups of data, eg "channel" or "status"
         :param group_value - the value of the group, eg "sms" or "email" for group_name=channel
         :param count - the actual numeric value to send
         :param period - the period that this data covers - "day", "week", "month", "quarter".
         """
         payload = {
-            '_timestamp': convert_utc_to_bst(date).isoformat(),
+            '_timestamp': convert_utc_to_bst(start_time).isoformat(),
             'service': 'govuk-notify',
             'dataType': dataset,
             'period': period,

--- a/app/performance_platform/processing_time.py
+++ b/app/performance_platform/processing_time.py
@@ -9,29 +9,29 @@ from app import performance_platform_client
 
 def send_processing_time_to_performance_platform():
     today = datetime.utcnow()
-    start_date = get_midnight_for_day_before(today)
-    end_date = get_london_midnight_in_utc(today)
+    start_time = get_midnight_for_day_before(today)
+    end_time = get_london_midnight_in_utc(today)
 
-    send_processing_time_for_start_and_end(start_date, end_date)
+    send_processing_time_for_start_and_end(start_time, end_time)
 
 
-def send_processing_time_for_start_and_end(start_date, end_date):
-    result = dao_get_total_notifications_sent_per_day_for_performance_platform(start_date, end_date)
+def send_processing_time_for_start_and_end(start_time, end_time):
+    result = dao_get_total_notifications_sent_per_day_for_performance_platform(start_time, end_time)
 
     current_app.logger.info(
         'Sending processing-time to performance platform for date {}. Total: {}, under 10 secs {}'.format(
-            start_date, result.messages_total, result.messages_within_10_secs
+            start_time, result.messages_total, result.messages_within_10_secs
         )
     )
 
-    send_processing_time_data(start_date, 'messages-total', result.messages_total)
-    send_processing_time_data(start_date, 'messages-within-10-secs', result.messages_within_10_secs)
+    send_processing_time_data(start_time, 'messages-total', result.messages_total)
+    send_processing_time_data(start_time, 'messages-within-10-secs', result.messages_within_10_secs)
 
 
-def send_processing_time_data(date, status, count):
+def send_processing_time_data(start_time, status, count):
     payload = performance_platform_client.format_payload(
         dataset='processing-time',
-        date=date,
+        start_time=start_time,
         group_name='status',
         group_value=status,
         count=count

--- a/app/performance_platform/total_sent_notifications.py
+++ b/app/performance_platform/total_sent_notifications.py
@@ -1,5 +1,6 @@
 from app import performance_platform_client
 from app.dao.fact_notification_status_dao import get_total_sent_notifications_for_day_and_type
+from app.utils import get_london_midnight_in_utc
 
 
 def send_total_notifications_sent_for_day_stats(date, notification_type, count):
@@ -19,8 +20,10 @@ def get_total_sent_notifications_for_day(day):
     sms_count = get_total_sent_notifications_for_day_and_type(day, 'sms')
     letter_count = get_total_sent_notifications_for_day_and_type(day, 'letter')
 
+    start_date = get_london_midnight_in_utc(day)
+
     return {
-        "start_date": day,
+        "start_date": start_date,
         "email": {
             "count": email_count
         },

--- a/app/performance_platform/total_sent_notifications.py
+++ b/app/performance_platform/total_sent_notifications.py
@@ -1,12 +1,11 @@
 from app import performance_platform_client
 from app.dao.fact_notification_status_dao import get_total_sent_notifications_for_day_and_type
-from app.utils import get_london_midnight_in_utc
 
 
-def send_total_notifications_sent_for_day_stats(date, notification_type, count):
+def send_total_notifications_sent_for_day_stats(start_time, notification_type, count):
     payload = performance_platform_client.format_payload(
         dataset='notifications',
-        date=date,
+        start_time=start_time,
         group_name='channel',
         group_value=notification_type,
         count=count
@@ -20,17 +19,8 @@ def get_total_sent_notifications_for_day(day):
     sms_count = get_total_sent_notifications_for_day_and_type(day, 'sms')
     letter_count = get_total_sent_notifications_for_day_and_type(day, 'letter')
 
-    start_date = get_london_midnight_in_utc(day)
-
     return {
-        "start_date": start_date,
-        "email": {
-            "count": email_count
-        },
-        "sms": {
-            "count": sms_count
-        },
-        "letter": {
-            "count": letter_count
-        },
+        "email": email_count,
+        "sms": sms_count,
+        "letter": letter_count,
     }

--- a/tests/app/performance_platform/test_processing_time.py
+++ b/tests/app/performance_platform/test_processing_time.py
@@ -29,7 +29,7 @@ def test_send_processing_time_to_performance_platform_creates_correct_call_to_pe
     send_stats = mocker.patch('app.performance_platform.total_sent_notifications.performance_platform_client.send_stats_to_performance_platform')  # noqa
 
     send_processing_time_data(
-        date=datetime(2016, 10, 15, 23, 0, 0),
+        start_time=datetime(2016, 10, 15, 23, 0, 0),
         status='foo',
         count=142
     )

--- a/tests/app/performance_platform/test_total_sent_notifications.py
+++ b/tests/app/performance_platform/test_total_sent_notifications.py
@@ -53,15 +53,11 @@ def test_get_total_sent_notifications_yesterday_returns_expected_totals_dict(sam
 
     total_count_dict = get_total_sent_notifications_for_day(yesterday)
 
-    assert total_count_dict == {
-        "start_date": yesterday,
-        "email": {
-            "count": 3
-        },
-        "sms": {
-            "count": 2
-        },
-        "letter": {
-            "count": 1
-        }
-    }
+    assert total_count_dict["email"] == {"count": 3}
+    assert total_count_dict["sms"] == {"count": 2}
+    assert total_count_dict["letter"] == {"count": 1}
+
+    # Should return a time around midnight depending on timezones
+    expected_start = datetime.combine(yesterday, datetime.min.time())
+    time_diff = abs(expected_start - total_count_dict["start_date"])
+    assert time_diff <= timedelta(minutes=60)

--- a/tests/app/performance_platform/test_total_sent_notifications.py
+++ b/tests/app/performance_platform/test_total_sent_notifications.py
@@ -1,4 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import datetime, date
+
+from freezegun import freeze_time
 
 from app.performance_platform.total_sent_notifications import (
     send_total_notifications_sent_for_day_stats,
@@ -12,7 +14,7 @@ def test_send_total_notifications_sent_for_day_stats_stats_creates_correct_call(
     send_stats = mocker.patch('app.performance_platform.total_sent_notifications.performance_platform_client.send_stats_to_performance_platform')  # noqa
 
     send_total_notifications_sent_for_day_stats(
-        date=datetime(2016, 10, 15, 23, 0, 0),
+        start_time=datetime(2016, 10, 15, 23, 0, 0),
         notification_type='sms',
         count=142
     )
@@ -30,34 +32,29 @@ def test_send_total_notifications_sent_for_day_stats_stats_creates_correct_call(
     assert request_args['_id'] == expected_base64_id
 
 
+@freeze_time('2018-06-10 01:00')
 def test_get_total_sent_notifications_yesterday_returns_expected_totals_dict(sample_service):
     sms = create_template(sample_service, template_type='sms')
     email = create_template(sample_service, template_type='email')
     letter = create_template(sample_service, template_type='letter')
 
-    today = datetime.utcnow().date()
-    yesterday = today - timedelta(days=1)
-    create_ft_notification_status(bst_date=today, notification_type='sms',
-                                  service=sms.service, template=sms)
-    create_ft_notification_status(bst_date=today, notification_type='email',
-                                  service=email.service, template=email)
-    create_ft_notification_status(bst_date=today, notification_type='letter',
-                                  service=letter.service, template=letter)
+    today = date(2018, 6, 10)
+    yesterday = date(2018, 6, 9)
 
-    create_ft_notification_status(bst_date=yesterday, notification_type='sms',
-                                  service=sms.service, template=sms, count=2)
-    create_ft_notification_status(bst_date=yesterday, notification_type='email',
-                                  service=email.service, template=email, count=3)
-    create_ft_notification_status(bst_date=yesterday, notification_type='letter',
-                                  service=letter.service, template=letter, count=1)
+    # todays is excluded
+    create_ft_notification_status(bst_date=today, template=sms)
+    create_ft_notification_status(bst_date=today, template=email)
+    create_ft_notification_status(bst_date=today, template=letter)
+
+    # yesterdays is included
+    create_ft_notification_status(bst_date=yesterday, template=sms, count=2)
+    create_ft_notification_status(bst_date=yesterday, template=email, count=3)
+    create_ft_notification_status(bst_date=yesterday, template=letter, count=1)
 
     total_count_dict = get_total_sent_notifications_for_day(yesterday)
 
-    assert total_count_dict["email"] == {"count": 3}
-    assert total_count_dict["sms"] == {"count": 2}
-    assert total_count_dict["letter"] == {"count": 1}
-
-    # Should return a time around midnight depending on timezones
-    expected_start = datetime.combine(yesterday, datetime.min.time())
-    time_diff = abs(expected_start - total_count_dict["start_date"])
-    assert time_diff <= timedelta(minutes=60)
+    assert total_count_dict == {
+        "email": 3,
+        "sms": 2,
+        "letter": 1
+    }

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date
 
 import pytest
 from freezegun import freeze_time
@@ -15,6 +15,9 @@ from app.utils import (
     (datetime(2016, 1, 15, 0, 30), datetime(2016, 1, 15, 0, 0)),
     (datetime(2016, 6, 15, 0, 0), datetime(2016, 6, 14, 23, 0)),
     (datetime(2016, 9, 15, 11, 59), datetime(2016, 9, 14, 23, 0)),
+    # works for both dates and datetimes
+    (date(2016, 1, 15), datetime(2016, 1, 15, 0, 0)),
+    (date(2016, 6, 15), datetime(2016, 6, 14, 23, 0)),
 ])
 def test_get_london_midnight_in_utc_returns_expected_date(date, expected_date):
     assert get_london_midnight_in_utc(date) == expected_date


### PR DESCRIPTION
We had a bug caused by passing a date object in to a function that expected a datetime.

To help reduce confusion around this, we've cleaned up usage of dates/datetimes in performance platform tasks:

* call variables less ambiguous things like `start_time` or `bst_date` to reduce risk of passing in the wrong thing
* simplify the count_dict object - remove nested dict and start_date fields as superfluous
* use static datetime objects in tests rather than calculating them each time


![image](https://user-images.githubusercontent.com/5020841/55398872-80951580-5541-11e9-8534-3bbbc4ae3914.png)
