### PR TITLE
Precompiled request preview with overlay when validation fails

### DIFF
--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -136,7 +136,6 @@ def get_letter_pdf(notification):
 
     s3 = boto3.resource('s3')
     bucket = s3.Bucket(bucket_name)
-
     item = next(x for x in bucket.objects.filter(Prefix=prefix))
 
     obj = s3.Object(

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -240,11 +240,10 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
 
         if overlay:
             path = '/precompiled/overlay.{}'.format(file_type)
-            query_string = '?invert=1'
             content = pdf_file
         elif file_type == 'png':
-            path = '/precompiled-preview.png'
             query_string = '?hide_notify=true' if page_number == '1' else ''
+            path = '/precompiled-preview.png' + query_string
         else:
             path = None
 
@@ -260,7 +259,7 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
                 )
 
         if path:
-            url = current_app.config['TEMPLATE_PREVIEW_API_HOST'] + path + query_string
+            url = current_app.config['TEMPLATE_PREVIEW_API_HOST'] + path
             response_content = _get_png_preview_or_overlaid_pdf(url, content, notification.id, json=False)
         else:
             response_content = content

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -251,10 +251,9 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
 
             if request.args.get('overlay'):
                 content = pdf_page
-                url = '{}/precompiled/overlay.png{}{}'.format(
+                url = '{}/precompiled/overlay.png{}'.format(
                     current_app.config['TEMPLATE_PREVIEW_API_HOST'],
                     '?invert=1',
-                    '&hide_notify=true' if page_number == '1' else ''
                 )
             else:
                 url = '{}/precompiled-preview.png{}'.format(
@@ -262,7 +261,14 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
                     '?hide_notify=true' if page_number == '1' else ''
                 )
 
-            content = _get_png_preview(url, content, notification.id, json=False)
+            content = _get_png_preview_or_overlaid_pdf(url, content, notification.id, json=False)
+        elif file_type == 'pdf' and request.args.get('overlay'):
+            content = pdf_file
+            url = '{}/precompiled/overlay.pdf{}'.format(
+                current_app.config['TEMPLATE_PREVIEW_API_HOST'],
+                '?invert=1',
+            )
+            content = _get_png_preview_or_overlaid_pdf(url, content, notification.id, json=False)
     else:
 
         template_for_letter_print = {
@@ -287,12 +293,12 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
             file_type,
             '?page={}'.format(page) if page else ''
         )
-        content = _get_png_preview(url, data, notification.id, json=True)
+        content = _get_png_preview_or_overlaid_pdf(url, data, notification.id, json=True)
 
     return jsonify({"content": content})
 
 
-def _get_png_preview(url, data, notification_id, json=True):
+def _get_png_preview_or_overlaid_pdf(url, data, notification_id, json=True):
     if json:
         resp = requests_post(
             url,

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -249,10 +249,18 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
                     status_code=500
                 )
 
-            url = '{}/precompiled-preview.png{}'.format(
-                current_app.config['TEMPLATE_PREVIEW_API_HOST'],
-                '?hide_notify=true' if page_number == '1' else ''
-            )
+            if request.args.get('overlay'):
+                content = pdf_page
+                url = '{}/precompiled/overlay.png{}{}'.format(
+                    current_app.config['TEMPLATE_PREVIEW_API_HOST'],
+                    '?invert=1',
+                    '&hide_notify=true' if page_number == '1' else ''
+                )
+            else:
+                url = '{}/precompiled-preview.png{}'.format(
+                    current_app.config['TEMPLATE_PREVIEW_API_HOST'],
+                    '?hide_notify=true' if page_number == '1' else ''
+                )
 
             content = _get_png_preview(url, content, notification.id, json=False)
     else:

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1192,7 +1192,7 @@ def test_preview_letter_template_precompiled_png_file_type_hide_notify_tag_only_
 
         mocker.patch('app.template.rest.get_letter_pdf', return_value=pdf_content)
         mocker.patch('app.template.rest.extract_page_from_pdf', return_value=png_content)
-        mock_get_png_preview = mocker.patch('app.template.rest._get_png_preview', return_value=encoded)
+        mock_get_png_preview = mocker.patch('app.template.rest._get_png_preview_or_overlaid_pdf', return_value=encoded)
 
         admin_request.get(
             'template.preview_letter_template_by_notification_id',

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1098,12 +1098,18 @@ def test_preview_letter_template_precompiled_s3_error(
                                          "when calling the GetObject operation: Unauthorized".format(notification.id)
 
 
+@pytest.mark.parametrize(
+    "post_url, overlay",
+    [('precompiled-preview.png', None), ('precompiled/overlay.png?invert=1', 1)]
+)
 def test_preview_letter_template_precompiled_png_file_type(
         notify_api,
         client,
         admin_request,
         sample_service,
-        mocker
+        mocker,
+        post_url,
+        overlay
 ):
 
     template = create_template(sample_service,
@@ -1128,7 +1134,7 @@ def test_preview_letter_template_precompiled_png_file_type(
             mocker.patch('app.template.rest.extract_page_from_pdf', return_value=pdf_content)
 
             mock_post = request_mock.post(
-                'http://localhost/notifications-template-preview/precompiled-preview.png',
+                'http://localhost/notifications-template-preview/{}'.format(post_url),
                 content=png_content,
                 headers={'X-pdf-page-count': '1'},
                 status_code=200
@@ -1138,7 +1144,8 @@ def test_preview_letter_template_precompiled_png_file_type(
                 'template.preview_letter_template_by_notification_id',
                 service_id=notification.service_id,
                 notification_id=notification.id,
-                file_type='png'
+                file_type='png',
+                overlay=overlay,
             )
 
             with pytest.raises(ValueError):

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1102,8 +1102,8 @@ def test_preview_letter_template_precompiled_s3_error(
     "filetype, post_url, overlay",
     [
         ('png', 'precompiled-preview.png', None),
-        ('png', 'precompiled/overlay.png?invert=1', 1),
-        ('pdf', 'precompiled/overlay.pdf?invert=1', 1)
+        ('png', 'precompiled/overlay.png', 1),
+        ('pdf', 'precompiled/overlay.pdf', 1)
     ]
 )
 def test_preview_letter_template_precompiled_png_file_type_or_pdf_with_overlay(


### PR DESCRIPTION
Has to go after this template-preview PR: https://github.com/alphagov/notifications-template-preview/pull/315

Part of this story: https://www.pivotaltracker.com/story/show/164798738