### PR TITLE
Add Cronitor decorator collate-letter-pdfs-for-day

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -47,6 +47,7 @@ from app.models import (
     NOTIFICATION_VALIDATION_FAILED,
     NOTIFICATION_VIRUS_SCAN_FAILED,
 )
+from app.cronitor import cronitor
 
 
 @notify_celery.task(bind=True, name="create-letters-pdf", max_retries=15, default_retry_delay=300)
@@ -110,6 +111,7 @@ def get_letters_pdf(template, contact_block, filename, values):
     return resp.content, billable_units
 
 
+@cronitor("collate-letter-pdfs-for-day")
 @notify_celery.task(name='collate-letter-pdfs-for-day')
 def collate_letter_pdfs_for_day(date=None):
     if not date:


### PR DESCRIPTION
```
This celery task was not decorated with the cronitor decorator so never
checked in with cronitor.

Adding the decorator will ensure this task is monitored.

The requisite cronitor key is in the credentials repository already.

Signed-off-by: Toby Lorne <toby.lornewelch-richards@digital.cabinet-office.gov.uk>
```

What
---

Ensure that the `collate-letter-pdfs-for-day` task checks in with Cronitor

How to review
---

- Code review
- Ensure that the `collate-letter-pdfs-for-day` cronitor key is in the production paas environment variables credentials file in the creds repo.