### PR TITLE
Set default branding for all organisations

### DIFF
--- a/migrations/versions/0285_default_org_branding.py
+++ b/migrations/versions/0285_default_org_branding.py
@@ -1,0 +1,47 @@
+"""empty message
+
+Revision ID: 0285_default_org_branding
+Revises: 0284_0283_retry
+Create Date: 2016-10-25 17:37:27.660723
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0285_default_org_branding'
+down_revision = '0284_0283_retry'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+BRANDING_TABLES = ('email_branding', 'letter_branding')
+
+
+def upgrade():
+    for branding in BRANDING_TABLES:
+        op.execute("""
+            UPDATE
+                organisation
+            SET
+                {branding}_id = {branding}.id
+            FROM
+                {branding}
+            WHERE
+                {branding}.domain in (
+                    SELECT
+                        domain
+                    FROM
+                        domain
+                    WHERE
+                        domain.organisation_id = organisation.id
+                )
+        """.format(branding=branding))
+
+def downgrade():
+    for branding in BRANDING_TABLES:
+        op.execute("""
+            UPDATE
+                organisation
+            SET
+                {branding}_id = null
+        """.format(branding=branding))


### PR DESCRIPTION
Currently when someone creates a service we match them to an organisation. Then if the organisation has a default branding set, their service gets that branding.

However none of the organisations yet have a default branding set up. This commit migrates the data about the relationship between an organisation and its branding from being inferred from the `domain`
field on the branding, to being a proper database relationship.