### PR TITLE
Set default branding for NHS services

### DIFF
--- a/app/dao/email_branding_dao.py
+++ b/app/dao/email_branding_dao.py
@@ -12,7 +12,7 @@ def dao_get_email_branding_by_id(email_branding_id):
 
 
 def dao_get_email_branding_by_name(email_branding_name):
-    return EmailBranding.query.filter_by(name=email_branding_name).one()
+    return EmailBranding.query.filter_by(name=email_branding_name).first()
 
 
 @transactional

--- a/app/dao/letter_branding_dao.py
+++ b/app/dao/letter_branding_dao.py
@@ -7,6 +7,10 @@ def dao_get_letter_branding_by_id(letter_branding_id):
     return LetterBranding.query.filter(LetterBranding.id == letter_branding_id).one()
 
 
+def dao_get_letter_branding_by_name(letter_branding_name):
+    return LetterBranding.query.filter_by(name=letter_branding_name).first()
+
+
 def dao_get_letter_branding_by_domain(domain):
     if not domain:
         return None

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -11,6 +11,8 @@ from app.dao.dao_utils import (
     transactional,
     version_class
 )
+from app.dao.email_branding_dao import dao_get_email_branding_by_name
+from app.dao.letter_branding_dao import dao_get_letter_branding_by_name
 from app.dao.organisation_dao import dao_get_organisation_by_email_address
 from app.dao.service_sms_sender_dao import insert_service_sms_sender
 from app.dao.service_user_dao import dao_get_service_user
@@ -38,7 +40,7 @@ from app.models import (
     SMS_TYPE,
     LETTER_TYPE,
 )
-from app.utils import get_london_midnight_in_utc, midnight_n_days_ago
+from app.utils import email_address_is_nhs, get_london_midnight_in_utc, midnight_n_days_ago
 
 DEFAULT_SERVICE_PERMISSIONS = [
     SMS_TYPE,
@@ -200,6 +202,12 @@ def dao_create_service(
 
         if organisation.letter_branding and not service.letter_branding:
             service.letter_branding = organisation.letter_branding
+
+    if not organisation and (
+        service.organisation_type == 'nhs' or email_address_is_nhs(user.email_address)
+    ):
+        service.email_branding = dao_get_email_branding_by_name('NHS')
+        service.letter_branding = dao_get_letter_branding_by_name('NHS')
 
     db.session.add(service)
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -122,3 +122,9 @@ def escape_special_characters(string):
             r'\{}'.format(special_character)
         )
     return string
+
+
+def email_address_is_nhs(email_address):
+    return email_address.lower().endswith((
+        '@nhs.uk', '@nhs.net', '.nhs.uk', '.nhs.net',
+    ))


### PR DESCRIPTION
The NHS is a special case because it’s not one organisation, but it does have one consistent brand. So anyone working for an NHS organisation should have their default branding set when they create a service, even if we know nothing about their specific organisation.