### PR TITLE
Ignore gsi in email address when searching for organisation

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -28,7 +28,7 @@ def dao_get_organisation_by_id(organisation_id):
 
 def dao_get_organisation_by_email_address(email_address):
 
-    email_address = email_address.lower()
+    email_address = email_address.lower().replace('.gsi.gov.uk', '.gov.uk')
 
     for domain in Domain.query.order_by(func.char_length(Domain.domain).desc()).all():
 

--- a/tests/app/dao/test_organisation_dao.py
+++ b/tests/app/dao/test_organisation_dao.py
@@ -235,10 +235,9 @@ def test_add_user_to_organisation_when_organisation_does_not_exist(sample_user):
     ('example.gov.uk', True),
 ))
 def test_get_organisation_by_email_address(
-    admin_request,
-    sample_user,
     domain,
     expected_org,
+    notify_db_session
 ):
 
     org = create_organisation()
@@ -255,3 +254,11 @@ def test_get_organisation_by_email_address(
         assert found_org is org
     else:
         assert found_org is None
+
+
+def test_get_organisation_by_email_address_ignores_gsi_gov_uk(notify_db_session):
+    org = create_organisation()
+    create_domain('example.gov.uk', org.id)
+
+    found_org = dao_get_organisation_by_email_address('test_gsi_address@example.gsi.gov.uk')
+    assert org == found_org


### PR DESCRIPTION
Update the dao_get_organisation_by_email_address to ignore `.gsi` in the email address.