### PR TITLE
Update EmailBranding.name to be not null and unique.

### DIFF
--- a/app/email_branding/email_branding_schema.py
+++ b/app/email_branding/email_branding_schema.py
@@ -6,13 +6,13 @@ post_create_email_branding_schema = {
     "type": "object",
     "properties": {
         "colour": {"type": ["string", "null"]},
-        "name": {"type": ["string", "null"]},
+        "name": {"type": "string"},
         "text": {"type": ["string", "null"]},
         "logo": {"type": ["string", "null"]},
         "domain": {"type": ["string", "null"]},
         "brand_type": {"enum": BRANDING_TYPES},
     },
-    "required": []
+    "required": ["name"]
 }
 
 post_update_email_branding_schema = {

--- a/app/models.py
+++ b/app/models.py
@@ -219,7 +219,7 @@ class EmailBranding(db.Model):
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     colour = db.Column(db.String(7), nullable=True)
     logo = db.Column(db.String(255), nullable=True)
-    name = db.Column(db.String(255), nullable=True)
+    name = db.Column(db.String(255), unique=True, nullable=False)
     text = db.Column(db.String(255), nullable=True)
     domain = db.Column(db.Text, unique=True, nullable=True)
     brand_type = db.Column(

--- a/migrations/versions/0093_data_gov_uk.py
+++ b/migrations/versions/0093_data_gov_uk.py
@@ -22,7 +22,7 @@ def upgrade():
         '{}',
         '',
         'data_gov_uk_x2.png',
-        ''
+        'data gov.uk'
     )""".format(DATA_GOV_UK_ID))
 
 

--- a/migrations/versions/0099_tfl_dar.py
+++ b/migrations/versions/0099_tfl_dar.py
@@ -22,7 +22,7 @@ def upgrade():
         '{}',
         '',
         'tfl_dar_x2.png',
-        ''
+        'tfl'
     )""".format(TFL_DAR_ID))
 
 

--- a/migrations/versions/0101_een_logo.py
+++ b/migrations/versions/0101_een_logo.py
@@ -20,7 +20,7 @@ def upgrade():
         '{}',
         '',
         'een_x2.png',
-        ''
+        'een'
     )""".format(ENTERPRISE_EUROPE_NETWORK_ID))
 
 

--- a/migrations/versions/0286_add_unique_email_name.py
+++ b/migrations/versions/0286_add_unique_email_name.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: 0286_add_unique_email_name
+Revises: 0285_default_org_branding
+Create Date: 2019-04-09 13:01:13.892249
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0286_add_unique_email_name'
+down_revision = '0285_default_org_branding'
+
+
+def upgrade():
+    op.alter_column('email_branding', 'name',
+                    existing_type=sa.VARCHAR(length=255),
+                    nullable=False)
+    op.create_unique_constraint('uq_email_branding_name', 'email_branding', ['name'])
+
+
+def downgrade():
+    op.drop_constraint('uq_email_branding_name', 'email_branding', type_='unique')
+    op.alter_column('email_branding', 'name',
+                    existing_type=sa.VARCHAR(length=255),
+                    nullable=True)


### PR DESCRIPTION
Needed to update old migration scripts so that the email_branding name is not null when creating the test dbs.
This should no affect the migrations elsewhere.