### PR TITLE
Switch table in query to Notification from NotificationHistory

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -608,7 +608,7 @@ def dao_get_total_notifications_sent_per_day_for_performance_platform(start_date
     key_type != 'test' AND
     notification_type != 'letter';
     """
-    under_10_secs = NotificationHistory.sent_at - NotificationHistory.created_at <= timedelta(seconds=10)
+    under_10_secs = Notification.sent_at - Notification.created_at <= timedelta(seconds=10)
     sum_column = functions.coalesce(functions.sum(
         case(
             [
@@ -619,14 +619,14 @@ def dao_get_total_notifications_sent_per_day_for_performance_platform(start_date
     ), 0)
 
     return db.session.query(
-        func.count(NotificationHistory.id).label('messages_total'),
+        func.count(Notification.id).label('messages_total'),
         sum_column.label('messages_within_10_secs')
     ).filter(
-        NotificationHistory.created_at >= start_date,
-        NotificationHistory.created_at < end_date,
-        NotificationHistory.api_key_id.isnot(None),
-        NotificationHistory.key_type != KEY_TYPE_TEST,
-        NotificationHistory.notification_type != LETTER_TYPE
+        Notification.created_at >= start_date,
+        Notification.created_at < end_date,
+        Notification.api_key_id.isnot(None),
+        Notification.key_type != KEY_TYPE_TEST,
+        Notification.notification_type != LETTER_TYPE
     ).one()
 
 

--- a/tests/app/dao/notification_dao/test_notification_dao_performance_platform.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_performance_platform.py
@@ -6,11 +6,6 @@ from app.dao.notifications_dao import dao_get_total_notifications_sent_per_day_f
 from app.models import KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST
 
 from tests.app.db import create_notification
-from tests.app.conftest import (
-    sample_notification_history,
-    sample_service,
-    sample_template
-)
 
 BEGINNING_OF_DAY = date(2016, 10, 18)
 END_OF_DAY = date(2016, 10, 19)
@@ -104,32 +99,3 @@ def test_get_total_notifications_returns_zero_if_no_data(notify_db_session):
 
     assert result.messages_total == 0
     assert result.messages_within_10_secs == 0
-
-
-@freeze_time('2016-10-18T10:00')
-def test_get_total_notifications_counts_ignores_research_mode(notify_db, notify_db_session):
-    created_at = datetime.utcnow()
-    service = sample_service(notify_db, notify_db_session, research_mode=True)
-    template = sample_template(notify_db, notify_db_session, service=service)
-
-    create_notification(template, status='created', sent_at=None)
-
-    sample_notification_history(
-        notify_db,
-        notify_db_session,
-        template,
-        notification_type='email',
-        sent_at=created_at + timedelta(seconds=5)
-    )
-    sample_notification_history(
-        notify_db,
-        notify_db_session,
-        template,
-        notification_type='sms',
-        sent_at=created_at + timedelta(seconds=5)
-    )
-
-    result = dao_get_total_notifications_sent_per_day_for_performance_platform(BEGINNING_OF_DAY, END_OF_DAY)
-
-    assert result.messages_total == 2
-    assert result.messages_within_10_secs == 2


### PR DESCRIPTION
Update the query that gets the number of notifications that have been sent under 10 seconds to use Notifications rather than NotificationHistory.

Also removed a test that is not useful