### PR TITLE
Return a useful message if the domain is a duplicate.

### DIFF
--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -34,6 +34,9 @@ def handle_integrity_error(exc):
     if 'ix_organisation_name' in str(exc):
         return jsonify(result="error",
                        message="Organisation name already exists"), 400
+    if 'domain_organisation_id_fkey' in str(exc):
+        return jsonify(result='error',
+                       message='Domain already exists'), 400
 
     current_app.logger.exception(exc)
     return jsonify(result='error', message="Internal server error"), 500

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -326,6 +326,22 @@ def test_post_update_organisation_gives_404_status_if_org_does_not_exist(admin_r
     assert not organisation
 
 
+def test_post_update_organisation_returns_400_if_domain_is_duplicate(admin_request, notify_db_session):
+    org = create_organisation()
+    create_domain('same.com', org.id)
+
+    data = {'domains': ['new.com', 'same.com']}
+
+    response = admin_request.post(
+        'organisation.update_organisation',
+        _data=data,
+        organisation_id='31d42ce6-3dac-45a7-95cb-94423d5ca03c',
+        _expected_status=400
+    )
+
+    assert response['message'] == 'Domain already exists'
+
+
 def test_post_link_service_to_organisation(admin_request, sample_service, sample_organisation):
     data = {
         'service_id': str(sample_service.id)


### PR DESCRIPTION
Previously this error would return a 500. Now we return a 400, with a useful message