### PR TITLE
Make Firetext URL configurable through the application environment

### DIFF
--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -47,7 +47,7 @@ class FiretextClient(SmsClient):
         self.api_key = current_app.config.get('FIRETEXT_API_KEY')
         self.from_number = current_app.config.get('FROM_NUMBER')
         self.name = 'firetext'
-        self.url = "https://www.firetext.co.uk/api/sendsms/json"
+        self.url = current_app.config.get('FIRETEXT_URL')
         self.statsd_client = statsd_client
 
     def get_name(self):

--- a/app/config.py
+++ b/app/config.py
@@ -320,7 +320,9 @@ class Config(object):
     DOCUMENT_DOWNLOAD_API_HOST = os.environ.get('DOCUMENT_DOWNLOAD_API_HOST', 'http://localhost:7000')
     DOCUMENT_DOWNLOAD_API_KEY = os.environ.get('DOCUMENT_DOWNLOAD_API_KEY', 'auth-token')
 
-    MMG_URL = "https://api.mmg.co.uk/json/api.php"
+    MMG_URL = os.environ.get("MMG_URL", "https://api.mmg.co.uk/json/api.php")
+    FIRETEXT_URL = os.environ.get("FIRETEXT_URL", "https://www.firetext.co.uk/api/sendsms/json")
+
     AWS_REGION = 'eu-west-1'
 
 
@@ -401,6 +403,9 @@ class Test(Development):
     SMS_INBOUND_WHITELIST = ['203.0.113.195']
     FIRETEXT_INBOUND_SMS_AUTH = ['testkey']
     TEMPLATE_PREVIEW_API_HOST = 'http://localhost:9999'
+
+    MMG_URL = 'https://example.com/mmg'
+    FIRETEXT_URL = 'https://example.com/firetext'
 
 
 class Preview(Config):

--- a/tests/app/clients/test_firetext.py
+++ b/tests/app/clients/test_firetext.py
@@ -36,7 +36,7 @@ def test_send_sms_successful_returns_firetext_response(mocker, mock_firetext_cli
     }
 
     with requests_mock.Mocker() as request_mock:
-        request_mock.post('https://www.firetext.co.uk/api/sendsms/json', json=response_dict, status_code=200)
+        request_mock.post('https://example.com/firetext', json=response_dict, status_code=200)
         response = mock_firetext_client.send_sms(to, content, reference)
 
     response_json = response.json()
@@ -54,11 +54,11 @@ def test_send_sms_calls_firetext_correctly(mocker, mock_firetext_client):
     }
 
     with requests_mock.Mocker() as request_mock:
-        request_mock.post('https://www.firetext.co.uk/api/sendsms/json', json=response_dict, status_code=200)
+        request_mock.post('https://example.com/firetext', json=response_dict, status_code=200)
         mock_firetext_client.send_sms(to, content, reference)
 
     assert request_mock.call_count == 1
-    assert request_mock.request_history[0].url == 'https://www.firetext.co.uk/api/sendsms/json'
+    assert request_mock.request_history[0].url == 'https://example.com/firetext'
     assert request_mock.request_history[0].method == 'POST'
 
     request_args = parse_qs(request_mock.request_history[0].text)
@@ -79,7 +79,7 @@ def test_send_sms_raises_if_firetext_rejects(mocker, mock_firetext_client):
     }
 
     with pytest.raises(SmsClientResponseException) as exc, requests_mock.Mocker() as request_mock:
-        request_mock.post('https://www.firetext.co.uk/api/sendsms/json', json=response_dict, status_code=200)
+        request_mock.post('https://example.com/firetext', json=response_dict, status_code=200)
         mock_firetext_client.send_sms(to, content, reference)
 
     assert exc.value.status_code == 200
@@ -92,7 +92,7 @@ def test_send_sms_raises_if_firetext_rejects_with_unexpected_data(mocker, mock_f
     response_dict = {"something": "gone bad"}
 
     with pytest.raises(SmsClientResponseException) as exc, requests_mock.Mocker() as request_mock:
-        request_mock.post('https://www.firetext.co.uk/api/sendsms/json', json=response_dict, status_code=400)
+        request_mock.post('https://example.com/firetext', json=response_dict, status_code=400)
         mock_firetext_client.send_sms(to, content, reference)
 
     assert exc.value.status_code == 400
@@ -110,7 +110,7 @@ def test_send_sms_override_configured_shortcode_with_sender(mocker, mock_firetex
     sender = 'fromservice'
 
     with requests_mock.Mocker() as request_mock:
-        request_mock.post('https://www.firetext.co.uk/api/sendsms/json', json=response_dict, status_code=200)
+        request_mock.post('https://example.com/firetext', json=response_dict, status_code=200)
         mock_firetext_client.send_sms(to, content, reference, sender=sender)
 
     request_args = parse_qs(request_mock.request_history[0].text)
@@ -121,7 +121,7 @@ def test_send_sms_raises_if_firetext_rejects_with_connect_timeout(rmock, mock_fi
     to = content = reference = 'foo'
 
     with pytest.raises(FiretextClientResponseException) as exc:
-        rmock.register_uri('POST', 'https://www.firetext.co.uk/api/sendsms/json', exc=ConnectTimeout)
+        rmock.register_uri('POST', 'https://example.com/firetext', exc=ConnectTimeout)
         mock_firetext_client.send_sms(to, content, reference)
 
     assert exc.value.status_code == 504
@@ -132,7 +132,7 @@ def test_send_sms_raises_if_firetext_rejects_with_read_timeout(rmock, mock_firet
     to = content = reference = 'foo'
 
     with pytest.raises(FiretextClientResponseException) as exc:
-        rmock.register_uri('POST', 'https://www.firetext.co.uk/api/sendsms/json', exc=ReadTimeout)
+        rmock.register_uri('POST', 'https://example.com/firetext', exc=ReadTimeout)
         mock_firetext_client.send_sms(to, content, reference)
 
     assert exc.value.status_code == 504

--- a/tests/app/clients/test_mmg.py
+++ b/tests/app/clients/test_mmg.py
@@ -33,7 +33,7 @@ def test_send_sms_successful_returns_mmg_response(notify_api, mocker):
     response_dict = {'Reference': 12345678}
 
     with requests_mock.Mocker() as request_mock:
-        request_mock.post('https://api.mmg.co.uk/json/api.php', json=response_dict, status_code=200)
+        request_mock.post('https://example.com/mmg', json=response_dict, status_code=200)
         response = mmg_client.send_sms(to, content, reference)
 
     response_json = response.json()
@@ -48,11 +48,11 @@ def test_send_sms_calls_mmg_correctly(notify_api, mocker):
     response_dict = {'Reference': 12345678}
 
     with requests_mock.Mocker() as request_mock:
-        request_mock.post('https://api.mmg.co.uk/json/api.php', json=response_dict, status_code=200)
+        request_mock.post('https://example.com/mmg', json=response_dict, status_code=200)
         mmg_client.send_sms(to, content, reference)
 
     assert request_mock.call_count == 1
-    assert request_mock.request_history[0].url == 'https://api.mmg.co.uk/json/api.php'
+    assert request_mock.request_history[0].url == 'https://example.com/mmg'
     assert request_mock.request_history[0].method == 'POST'
 
     request_args = request_mock.request_history[0].json()
@@ -72,7 +72,7 @@ def test_send_sms_raises_if_mmg_rejects(notify_api, mocker):
     }
 
     with pytest.raises(SmsClientResponseException) as exc, requests_mock.Mocker() as request_mock:
-        request_mock.post('https://api.mmg.co.uk/json/api.php', json=response_dict, status_code=400)
+        request_mock.post('https://example.com/mmg', json=response_dict, status_code=400)
         mmg_client.send_sms(to, content, reference)
 
     assert exc.value.status_code == 400
@@ -89,7 +89,7 @@ def test_send_sms_override_configured_shortcode_with_sender(notify_api, mocker):
     sender = 'fromservice'
 
     with requests_mock.Mocker() as request_mock:
-        request_mock.post('https://api.mmg.co.uk/json/api.php', json=response_dict, status_code=200)
+        request_mock.post('https://example.com/mmg', json=response_dict, status_code=200)
         mmg_client.send_sms(to, content, reference, sender=sender)
 
     request_args = request_mock.request_history[0].json()
@@ -101,7 +101,7 @@ def test_send_sms_raises_if_mmg_fails_to_return_json(notify_api, mocker):
     response_dict = 'NOT AT ALL VALID JSON {"key" : "value"}}'
 
     with pytest.raises(SmsClientResponseException) as exc, requests_mock.Mocker() as request_mock:
-        request_mock.post('https://api.mmg.co.uk/json/api.php', text=response_dict, status_code=200)
+        request_mock.post('https://example.com/mmg', text=response_dict, status_code=200)
         mmg_client.send_sms(to, content, reference)
 
     assert 'app.clients.sms.mmg.MMGClientResponseException: Code 200 text NOT AT ALL VALID JSON {"key" : "value"}} exception Expecting value: line 1 column 1 (char 0)' in str(exc)  # noqa
@@ -113,7 +113,7 @@ def test_send_sms_raises_if_mmg_rejects_with_connect_timeout(rmock):
     to = content = reference = 'foo'
 
     with pytest.raises(MMGClientResponseException) as exc:
-        rmock.register_uri('POST', 'https://api.mmg.co.uk/json/api.php', exc=ConnectTimeout)
+        rmock.register_uri('POST', 'https://example.com/mmg', exc=ConnectTimeout)
         mmg_client.send_sms(to, content, reference)
 
     assert exc.value.status_code == 504
@@ -124,7 +124,7 @@ def test_send_sms_raises_if_mmg_rejects_with_read_timeout(rmock):
     to = content = reference = 'foo'
 
     with pytest.raises(MMGClientResponseException) as exc:
-        rmock.register_uri('POST', 'https://api.mmg.co.uk/json/api.php', exc=ReadTimeout)
+        rmock.register_uri('POST', 'https://example.com/mmg', exc=ReadTimeout)
         mmg_client.send_sms(to, content, reference)
 
     assert exc.value.status_code == 504

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -855,6 +855,7 @@ def mock_firetext_client(mocker, statsd_client=None):
     client = FiretextClient()
     statsd_client = statsd_client or mocker.Mock()
     current_app = mocker.Mock(config={
+        'FIRETEXT_URL': 'https://example.com/firetext',
         'FIRETEXT_API_KEY': 'foo',
         'FROM_NUMBER': 'bar'
     })


### PR DESCRIPTION
Similar to MMG, there's a new env variable FIRETEXT_URL that can be
used to override the Firetext api URL.

This will be used to stub out both providers during the load test or
can be used to run a local API against a fake provider endpoint.