### PR TITLE
Don’t let admin specify branding for new service

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -168,7 +168,6 @@ def dao_create_service(
     user,
     service_id=None,
     service_permissions=None,
-    letter_branding=None,
 ):
     # the default property does not appear to work when there is a difference between the sqlalchemy schema and the
     # db schema (ie: during a migration), so we have to set sms_sender manually here. After the GOVUK sms_sender
@@ -198,9 +197,6 @@ def dao_create_service(
     # do we just add the default - or will we get a value from FE?
     insert_service_sms_sender(service, current_app.config['FROM_NUMBER'])
 
-    if letter_branding:
-        service.letter_branding = letter_branding
-
     if organisation:
 
         service.organisation = organisation
@@ -211,9 +207,8 @@ def dao_create_service(
         if organisation.letter_branding and not service.letter_branding:
             service.letter_branding = organisation.letter_branding
 
-    if not organisation and (
-        service.organisation_type == 'nhs' or email_address_is_nhs(user.email_address)
-    ):
+    elif service.organisation_type == 'nhs' or email_address_is_nhs(user.email_address):
+
         service.email_branding = dao_get_email_branding_by_name('NHS')
         service.letter_branding = dao_get_letter_branding_by_name('NHS')
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -195,8 +195,7 @@ def create_service():
     # unpack valid json into service object
     valid_service = Service.from_json(data)
 
-    letter_branding = dao_get_letter_branding_by_domain(domain)
-    dao_create_service(valid_service, user, letter_branding=letter_branding)
+    dao_create_service(valid_service, user)
 
     return jsonify(data=service_schema.dump(valid_service).data), 201
 

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -102,25 +102,6 @@ def test_create_service(notify_db_session):
     assert not service.letter_branding
 
 
-def test_create_service_with_letter_branding(notify_db_session):
-    user = create_user()
-    create_letter_branding()
-    letter_branding = create_letter_branding(
-        name='test domain', filename='test-domain', domain='test.domain'
-    )
-    assert Service.query.count() == 0
-    service = Service(name="service_name",
-                      email_from="email_from",
-                      message_limit=1000,
-                      restricted=False,
-                      organisation_type='central',
-                      created_by=user)
-    dao_create_service(service, user, letter_branding=letter_branding)
-    service_db = Service.query.one()
-    assert service_db.id == service.id
-    assert service.letter_branding == letter_branding
-
-
 @pytest.mark.parametrize('email_address, organisation_type', (
     ("test@example.gov.uk", 'nhs'),
     ("test@nhs.net", 'nhs'),
@@ -155,7 +136,7 @@ def test_create_nhs_service_get_default_branding_based_on_email_address(
         organisation_type=organisation_type,
         created_by=user,
     )
-    dao_create_service(service, user, letter_branding=letter_branding)
+    dao_create_service(service, user)
     service_db = Service.query.one()
 
     if expected_branding:

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -341,6 +341,7 @@ def test_create_service_inherits_branding_from_organisation(
             'active': False,
             'email_from': 'created.service',
             'created_by': str(sample_user.id),
+            'letter_branding': 'blahblahblah',  # this should be ignored
         },
         _expected_status=201
     )


### PR DESCRIPTION
It doesn’t need to because the API code works it all out now by looking at the organisation.