### PR TITLE
Don’t require a domain when updating the letter branding

### DIFF
--- a/app/letter_branding/letter_branding_schema.py
+++ b/app/letter_branding/letter_branding_schema.py
@@ -7,5 +7,5 @@ post_letter_branding_schema = {
         "filename": {"type": ["string", "null"]},
         "domain": {"type": ["string", "null"]},
     },
-    "required": ("name", "filename", "domain")
+    "required": ("name", "filename")
 }


### PR DESCRIPTION
So the admin is free to stop passing it in.