### PR TITLE
Go live data recorded for service

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -402,8 +402,8 @@ class Service(db.Model, Versioned):
     restricted = db.Column(db.Boolean, index=False, unique=False, nullable=False)
     research_mode = db.Column(db.Boolean, index=False, unique=False, nullable=False, default=False)
     email_from = db.Column(db.Text, index=False, unique=True, nullable=False)
-    created_by = db.relationship('User')
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=False)
+    created_by = db.relationship('User', foreign_keys=[created_by_id])
     prefix_sms = db.Column(db.Boolean, nullable=False, default=True)
     organisation_type = db.Column(
         db.String(255),
@@ -417,6 +417,9 @@ class Service(db.Model, Versioned):
     volume_letter = db.Column(db.Integer(), nullable=True, unique=False)
     consent_to_research = db.Column(db.Boolean, nullable=True)
     count_as_live = db.Column(db.Boolean, nullable=False, default=True)
+    go_live_user_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), nullable=True)
+    go_live_user = db.relationship('User', foreign_keys=[go_live_user_id])
+    go_live_at = db.Column(db.DateTime, nullable=True)
 
     organisation = db.relationship(
         'Organisation',
@@ -434,6 +437,8 @@ class Service(db.Model, Versioned):
         secondary=service_letter_branding,
         uselist=False,
         backref=db.backref('services', lazy='dynamic'))
+
+
 
     @classmethod
     def from_json(cls, data):

--- a/app/models.py
+++ b/app/models.py
@@ -438,8 +438,6 @@ class Service(db.Model, Versioned):
         uselist=False,
         backref=db.backref('services', lazy='dynamic'))
 
-
-
     @classmethod
     def from_json(cls, data):
         """

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -210,6 +210,7 @@ class ServiceSchema(BaseSchema):
     organisation = field_for(models.Service, 'organisation')
     override_flag = False
     letter_contact_block = fields.Method(serialize="get_letter_contact")
+    go_live_at = field_for(models.Service, 'go_live_at', format='%Y-%m-%d %H:%M:%S.%f')
 
     def get_letter_logo_filename(self, service):
         return service.letter_branding and service.letter_branding.filename

--- a/migrations/versions/0287_add_go_live_user.py
+++ b/migrations/versions/0287_add_go_live_user.py
@@ -1,0 +1,29 @@
+"""
+
+Revision ID: 0287_add_go_live_user
+Revises: 0286_add_unique_email_name
+Create Date: 2019-04-15 16:50:22.275673
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0287_add_go_live_user'
+down_revision = '0286_add_unique_email_name'
+
+
+def upgrade():
+    op.add_column('services', sa.Column('go_live_at', sa.DateTime(), nullable=True))
+    op.add_column('services', sa.Column('go_live_user_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key('fk_services_go_live_user', 'services', 'users', ['go_live_user_id'], ['id'])
+    op.add_column('services_history', sa.Column('go_live_at', sa.DateTime(), nullable=True))
+    op.add_column('services_history', sa.Column('go_live_user_id', postgresql.UUID(as_uuid=True), nullable=True))
+
+
+def downgrade():
+    op.drop_column('services_history', 'go_live_user_id')
+    op.drop_column('services_history', 'go_live_at')
+    op.drop_constraint('fk_services_go_live_user', 'services', type_='foreignkey')
+    op.drop_column('services', 'go_live_user_id')
+    op.drop_column('services', 'go_live_at')

--- a/migrations/versions/0288_add_go_live_user.py
+++ b/migrations/versions/0288_add_go_live_user.py
@@ -1,7 +1,7 @@
 """
 
-Revision ID: 0287_add_go_live_user
-Revises: 0286_add_unique_email_name
+Revision ID: 0288_add_go_live_user
+Revises: 0287_drop_branding_domains
 Create Date: 2019-04-15 16:50:22.275673
 
 """
@@ -9,8 +9,8 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
-revision = '0287_add_go_live_user'
-down_revision = '0286_add_unique_email_name'
+revision = '0288_add_go_live_user'
+down_revision = '0287_drop_branding_domains'
 
 
 def upgrade():

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -93,7 +93,9 @@ def create_service(
         prefix_sms=True,
         message_limit=1000,
         organisation_type='central',
-        check_if_service_exists=False
+        check_if_service_exists=False,
+        go_live_user=None,
+        go_live_at=None
 ):
     if check_if_service_exists:
         service = Service.query.filter_by(name=service_name).first()
@@ -105,7 +107,9 @@ def create_service(
             email_from=email_from if email_from else service_name.lower().replace(' ', '.'),
             created_by=user if user else create_user(email='{}@digital.cabinet-office.gov.uk'.format(uuid.uuid4())),
             prefix_sms=prefix_sms,
-            organisation_type=organisation_type
+            organisation_type=organisation_type,
+            go_live_user=go_live_user,
+            go_live_at=go_live_at
         )
         dao_create_service(service, service.created_by, service_id, service_permissions=service_permissions)
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -221,6 +221,14 @@ def test_get_service_by_id_should_404_if_no_service_for_user(notify_api, sample_
             assert json_resp['message'] == 'No result found'
 
 
+def test_get_service_by_id_returns_go_live_user_and_go_live_at(admin_request, sample_user):
+    now = datetime.utcnow()
+    service = create_service(user=sample_user, go_live_user=sample_user, go_live_at=now)
+    json_resp = admin_request.get('service.get_service_by_id', service_id=service.id)
+    assert json_resp['data']['go_live_user'] == str(sample_user.id)
+    assert json_resp['data']['go_live_at'] == str(now)
+
+
 @pytest.mark.parametrize('platform_admin, expected_count_as_live', (
     (True, False),
     (False, True),


### PR DESCRIPTION
Adding go_live_user and go_live_at columns to Services table. 

When the `request to go live` link is clicked, we will record the user that requested to go live. 
When the service is marked live we will record that date. 

Include the new columns in the return for get service.