### PR TITLE
Stub out SMS providers on staging for the perf tests

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -74,7 +74,13 @@ applications:
 
       ZENDESK_API_KEY: '{{ ZENDESK_API_KEY }}'
 
+      {% if environment == 'staging' %}
+      MMG_URL: 'https://notify-sms-provider-stub-staging.cloudapps.digital/mmg'
+      FIRETEXT_URL: 'https://notify-sms-provider-stub-staging.cloudapps.digital/firetext'
+      {% else %}
       MMG_URL: '{{ MMG_URL }}'
+      {% endif %}
+
       MMG_API_KEY: '{{ MMG_API_KEY }}'
       MMG_INBOUND_SMS_AUTH: '{{ MMG_INBOUND_SMS_AUTH | tojson }}'
       MMG_INBOUND_SMS_USERNAME: '{{ MMG_INBOUND_SMS_USERNAME | tojson }}'


### PR DESCRIPTION
This points MMG and Firetext on staging to a stub service run on
PaaS to avoid text message costs during the load test.