### PR TITLE
Fix bug in precompiled preview with overlay

### DIFF
--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -240,10 +240,11 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
 
         if overlay:
             path = '/precompiled/overlay.{}'.format(file_type)
+            query_string = '?page_number={}'.format(page_number) if file_type == 'png' else ''
             content = pdf_file
         elif file_type == 'png':
             query_string = '?hide_notify=true' if page_number == '1' else ''
-            path = '/precompiled-preview.png' + query_string
+            path = '/precompiled-preview.png'
         else:
             path = None
 
@@ -259,7 +260,7 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
                 )
 
         if path:
-            url = current_app.config['TEMPLATE_PREVIEW_API_HOST'] + path
+            url = current_app.config['TEMPLATE_PREVIEW_API_HOST'] + path + query_string
             response_content = _get_png_preview_or_overlaid_pdf(url, content, notification.id, json=False)
         else:
             response_content = content

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1102,7 +1102,7 @@ def test_preview_letter_template_precompiled_s3_error(
     "filetype, post_url, overlay",
     [
         ('png', 'precompiled-preview.png', None),
-        ('png', 'precompiled/overlay.png', 1),
+        ('png', 'precompiled/overlay.png?page_number=1', 1),
         ('pdf', 'precompiled/overlay.pdf', 1)
     ]
 )


### PR DESCRIPTION
The bug treated all pages of png preview as if they were all first
page, showing overlay for address bar.

has to go after: https://github.com/alphagov/notifications-template-preview/pull/326

Pivotal ticket: https://www.pivotaltracker.com/story/show/165569388

Preview after fixing:
![Screen Shot 2019-04-24 at 18 20 31](https://user-images.githubusercontent.com/20957548/56680353-062e6000-66bf-11e9-8f2b-96a39b9bc819.png)
