### PR TITLE
Bump utils to bring in changes to RecipientCSV rows

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -109,7 +109,7 @@ def process_job(job_id, sender_id=None):
             s3.get_job_from_s3(str(service.id), str(job_id)),
             template_type=template.template_type,
             placeholders=template.placeholders
-    ).rows:
+    ).get_rows():
         process_row(row, template, job, service, sender_id=sender_id)
 
     job_complete(job, start=start)
@@ -609,7 +609,7 @@ def process_incomplete_job(job_id):
             s3.get_job_from_s3(str(job.service_id), str(job.id)),
             template_type=template.template_type,
             placeholders=template.placeholders
-    ).rows:
+    ).get_rows():
         if row.index > resume_from_row:
             process_row(row, template, job, job.service)
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,6 +29,6 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@31.2.2#egg=notifications-utils==31.2.2
+git+https://github.com/alphagov/notifications-utils.git@31.2.5#egg=notifications-utils==31.2.5
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@31.2.2#egg=notifications-utils==31.2.2
+git+https://github.com/alphagov/notifications-utils.git@31.2.5#egg=notifications-utils==31.2.5
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
@@ -40,12 +40,12 @@ alembic==1.0.9
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.1.0
-awscli==1.16.141
+awscli==1.16.145
 bcrypt==3.1.6
 billiard==3.3.0.23
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.131
+botocore==1.12.135
 certifi==2019.3.9
 chardet==3.0.4
 Click==7.0
@@ -73,7 +73,7 @@ python-dateutil==2.8.0
 python-editor==1.0.4
 python-json-logger==0.1.10
 pytz==2019.1
-PyYAML==3.12
+PyYAML==3.13
 redis==3.2.1
 requests==2.21.0
 rsa==3.4.2
@@ -81,6 +81,6 @@ s3transfer==0.2.0
 six==1.12.0
 smartypants==2.0.1
 statsd==3.3.0
-urllib3==1.24.1
+urllib3==1.24.2
 webencodings==0.5.1
 Werkzeug==0.15.2


### PR DESCRIPTION
Bumped utils to version 31.2.5, which changes when the rows of a RecipientCSV get created.

Switched to using `.get_rows()` from RecipientCSV (a generator) instead of the `.rows` property (which builds a list of the rows in memory).

Details about the utils change: https://github.com/alphagov/notifications-utils/pull/602

[Pivotal story](https://www.pivotaltracker.com/story/show/165021246)