### PR TITLE
Add get_live_services_data endpoint and related query

### DIFF
--- a/app/dao/date_util.py
+++ b/app/dao/date_util.py
@@ -7,8 +7,8 @@ import pytz
 def get_months_for_financial_year(year):
     return [
         convert_bst_to_utc(month) for month in (
-            get_months_for_year(4, 13, year) +
-            get_months_for_year(1, 4, year + 1)
+            get_months_for_year(4, 13, year)
+            + get_months_for_year(1, 4, year + 1)
         )
         if convert_bst_to_utc(month) < datetime.now()
     ]
@@ -20,6 +20,14 @@ def get_months_for_year(start, end, year):
 
 def get_financial_year(year):
     return get_april_fools(year), get_april_fools(year + 1) - timedelta(microseconds=1)
+
+
+def get_current_financial_year():
+    now = datetime.utcnow()
+    current_month = int(now.strftime('%-m'))
+    current_year = int(now.strftime('%Y'))
+    year = current_year if current_month > 3 else current_year - 1
+    return get_financial_year(year)
 
 
 def get_april_fools(year):

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -127,6 +127,8 @@ def dao_fetch_live_services_data():
         Service.volume_email,
         Service.volume_letter,
         this_year_ft_billing.c.notification_type
+    ).order_by(
+        asc(Service.go_live_at)
     ).all()
     results = []
     for row in data:

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -87,6 +87,7 @@ def dao_fetch_live_services_data():
         Service.name.label("service_name"),
         Service.consent_to_research,
         Service.go_live_user_id,
+        Service.count_as_live,
         User.name.label('user_name'),
         User.email_address,
         User.mobile_number,
@@ -109,11 +110,14 @@ def dao_fetch_live_services_data():
         this_year_ft_billing, Service.id == this_year_ft_billing.c.service_id
     ).outerjoin(
         User, Service.go_live_user_id == User.id
+    ).filter(
+        Service.count_as_live == True  # noqa
     ).group_by(
         Service.id,
         Organisation.name,
         Service.name,
         Service.consent_to_research,
+        Service.count_as_live,
         Service.go_live_user_id,
         User.name,
         User.email_address,

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date, datetime, timedelta
 
 from notifications_utils.statsd_decorators import statsd
-from sqlalchemy import asc, func
+from sqlalchemy import asc, func, case
 from sqlalchemy.orm import joinedload
 from flask import current_app
 
@@ -21,11 +21,13 @@ from app.dao.template_folder_dao import dao_get_valid_template_folders_by_id
 from app.models import (
     AnnualBilling,
     ApiKey,
+    FactBilling,
     InboundNumber,
     InvitedUser,
     Job,
     Notification,
     NotificationHistory,
+    Organisation,
     Permission,
     Service,
     ServicePermission,
@@ -70,6 +72,84 @@ def dao_count_live_services():
         restricted=False,
         count_as_live=True,
     ).count()
+
+
+def dao_fetch_live_services_data():
+    data = db.session.query(
+        Service.id,
+        Organisation.name.label("organisation_name"),
+        Service.name.label("service_name"),
+        Service.consent_to_research,
+        Service.go_live_user_id,
+        User.name.label('user_name'),
+        User.email_address,
+        User.mobile_number,
+        Service.go_live_at.label("live_date"),
+        Service.volume_sms,
+        Service.volume_email,
+        Service.volume_letter,
+        case([
+            (FactBilling.notification_type == 'email', func.sum(FactBilling.notifications_sent))
+        ], else_=0).label("email_totals"),
+        case([
+            (FactBilling.notification_type == 'sms', func.sum(FactBilling.notifications_sent))
+        ], else_=0).label("sms_totals"),
+        case([
+            (FactBilling.notification_type == 'letter', func.sum(FactBilling.notifications_sent))
+        ], else_=0).label("letter_totals"),
+    ).outerjoin(
+        Service.organisation
+    ).outerjoin(
+        FactBilling, Service.id == FactBilling.service_id
+    ).outerjoin(
+        User, Service.go_live_user_id == User.id
+    ).group_by(
+        Service.id,
+        Organisation.name,
+        Service.name,
+        Service.consent_to_research,
+        Service.go_live_user_id,
+        User.name,
+        User.email_address,
+        User.mobile_number,
+        Service.go_live_at,
+        Service.volume_sms,
+        Service.volume_email,
+        Service.volume_letter,
+        FactBilling.notification_type
+    ).all()
+    results = []
+    for row in data:
+        is_service_in_list = None
+        i = 0
+        while i < len(results):
+            if results[i]["service_id"] == row.id:
+                is_service_in_list = i
+                break
+            else:
+                i += 1
+        if is_service_in_list is not None:
+            results[is_service_in_list]["email_totals"] += row.email_totals
+            results[is_service_in_list]["sms_totals"] += row.sms_totals
+            results[is_service_in_list]["letter_totals"] += row.letter_totals
+        else:
+            results.append({
+                "service_id": row.id,
+                "service_name": row.service_name,
+                "organisation_name": row.organisation_name,
+                "consent_to_research": row.consent_to_research,
+                "contact_name": row.user_name,
+                "contact_email": row.email_address,
+                "contact_mobile": row.mobile_number,
+                "live_date": row.live_date,
+                "sms_volume_intent": row.volume_sms,
+                "email_volume_intent": row.volume_email,
+                "letter_volume_intent": row.volume_letter,
+                "sms_totals": row.sms_totals,
+                "email_totals": row.email_totals,
+                "letter_totals": row.letter_totals,
+            })
+    return results
 
 
 def dao_fetch_service_by_id(service_id, only_active=False):

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -49,6 +49,7 @@ from app.dao.services_dao import (
     dao_create_service,
     dao_fetch_all_services,
     dao_fetch_all_services_by_user,
+    dao_fetch_live_services_data,
     dao_fetch_service_by_id,
     dao_fetch_todays_stats_for_service,
     dao_fetch_todays_stats_for_all_services,
@@ -155,6 +156,12 @@ def get_services():
     else:
         services = dao_fetch_all_services(only_active)
     data = service_schema.dump(services, many=True).data
+    return jsonify(data=data)
+
+
+@service_blueprint.route('/live-services-data', methods=['GET'])
+def get_live_services_data():
+    data = dao_fetch_live_services_data()
     return jsonify(data=data)
 
 

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -387,10 +387,10 @@ def test_get_all_user_services_should_return_empty_list_if_no_services_for_user(
 @freeze_time('2019-04-23T10:00:00')
 def test_dao_fetch_live_services_data(sample_user, mock):
     org = create_organisation()
-    service = create_service(go_live_user=sample_user)
+    service = create_service(go_live_user=sample_user, go_live_at='2014-04-20T10:00:00')
     template = create_template(service=service)
-    service_2 = create_service(service_name='second', go_live_user=sample_user)
-    create_service(service_name='third')
+    service_2 = create_service(service_name='second', go_live_user=sample_user, go_live_at='2017-04-20T10:00:00')
+    create_service(service_name='third', go_live_at='2016-04-20T10:00:00')
     create_service(service_name='not_live', count_as_live=False)
     template2 = create_template(service=service, template_type='email')
     template_letter_1 = create_template(service=service, template_type='letter')
@@ -410,21 +410,24 @@ def test_dao_fetch_live_services_data(sample_user, mock):
 
     results = dao_fetch_live_services_data()
     assert len(results) == 3
-    assert {'service_id': mock.ANY, 'service_name': 'Sample service', 'organisation_name': 'test_org_1',
+    # checks the results and that they are ordered by date:
+    assert results == [
+        {'service_id': mock.ANY, 'service_name': 'Sample service', 'organisation_name': 'test_org_1',
             'consent_to_research': None, 'contact_name': 'Test User',
             'contact_email': 'notify@digital.cabinet-office.gov.uk', 'contact_mobile': '+447700900986',
-            'live_date': None, 'sms_volume_intent': None, 'email_volume_intent': None,
-            'letter_volume_intent': None, 'sms_totals': 2, 'email_totals': 1, 'letter_totals': 1} in results
-    assert {'service_id': mock.ANY, 'service_name': 'second', 'organisation_name': None, 'consent_to_research': None,
-            'contact_name': 'Test User', 'contact_email': 'notify@digital.cabinet-office.gov.uk',
-            'contact_mobile': '+447700900986', 'live_date': None, 'sms_volume_intent': None,
-            'email_volume_intent': None, 'letter_volume_intent': None,
-            'sms_totals': 0, 'email_totals': 0, 'letter_totals': 1} in results
-    assert {'service_id': mock.ANY, 'service_name': 'third', 'organisation_name': None, 'consent_to_research': None,
+            'live_date': datetime(2014, 4, 20, 10, 0), 'sms_volume_intent': None, 'email_volume_intent': None,
+            'letter_volume_intent': None, 'sms_totals': 2, 'email_totals': 1, 'letter_totals': 1},
+        {'service_id': mock.ANY, 'service_name': 'third', 'organisation_name': None, 'consent_to_research': None,
             'contact_name': None, 'contact_email': None,
-            'contact_mobile': None, 'live_date': None, 'sms_volume_intent': None,
+            'contact_mobile': None, 'live_date': datetime(2016, 4, 20, 10, 0), 'sms_volume_intent': None,
             'email_volume_intent': None, 'letter_volume_intent': None,
-            'sms_totals': 0, 'email_totals': 0, 'letter_totals': 0} in results
+            'sms_totals': 0, 'email_totals': 0, 'letter_totals': 0},
+        {'service_id': mock.ANY, 'service_name': 'second', 'organisation_name': None, 'consent_to_research': None,
+            'contact_name': 'Test User', 'contact_email': 'notify@digital.cabinet-office.gov.uk',
+            'contact_mobile': '+447700900986', 'live_date': datetime(2017, 4, 20, 10, 0), 'sms_volume_intent': None,
+            'email_volume_intent': None, 'letter_volume_intent': None,
+            'sms_totals': 0, 'email_totals': 0, 'letter_totals': 1}
+    ]
 
 
 def test_get_service_by_id_returns_none_if_no_service(notify_db):

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -391,15 +391,21 @@ def test_dao_fetch_live_services_data(sample_user, mock):
     template = create_template(service=service)
     service_2 = create_service(service_name='second', go_live_user=sample_user)
     create_service(service_name='third')
+    create_service(service_name='not_live', count_as_live=False)
     template2 = create_template(service=service, template_type='email')
     template_letter_1 = create_template(service=service, template_type='letter')
     template_letter_2 = create_template(service=service_2, template_type='letter')
     dao_add_service_to_organisation(service=service, organisation_id=org.id)
+    # two sms billing records for 1st service within current financial year:
     create_ft_billing(bst_date='2019-04-20', notification_type='sms', template=template, service=service)
     create_ft_billing(bst_date='2019-04-21', notification_type='sms', template=template, service=service)
+    # one sms billing record for 1st service from previous financial year, should not appear in the result:
     create_ft_billing(bst_date='2018-04-20', notification_type='sms', template=template, service=service)
+    # one email billing record for 1st service within current financial year:
     create_ft_billing(bst_date='2019-04-20', notification_type='email', template=template2, service=service)
+    # one letter billing record for 1st service within current financial year:
     create_ft_billing(bst_date='2019-04-15', notification_type='letter', template=template_letter_1, service=service)
+    # one letter billing record for 2nd service within current financial year:
     create_ft_billing(bst_date='2019-04-16', notification_type='letter', template=template_letter_2, service=service_2)
 
     results = dao_fetch_live_services_data()

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -35,6 +35,7 @@ from tests.app.conftest import (
     sample_notification_with_job
 )
 from tests.app.db import (
+    create_ft_billing,
     create_ft_notification_status,
     create_service,
     create_service_with_inbound_number,
@@ -136,8 +137,28 @@ def test_get_service_list_should_return_empty_list_if_no_services(admin_request)
     assert len(json_resp['data']) == 0
 
 
-def test_get_live_services_data():
-    pass
+def test_get_live_services_data(sample_user, admin_request, mock):
+    org = create_organisation()
+    service = create_service(go_live_user=sample_user)
+    template = create_template(service=service)
+    create_service(service_name='second', go_live_user=sample_user)
+    template2 = create_template(service=service, template_type='email')
+    dao_add_service_to_organisation(service=service, organisation_id=org.id)
+    create_ft_billing(bst_date='2019-04-20', notification_type='sms', template=template, service=service)
+    create_ft_billing(bst_date='2019-04-20', notification_type='email', template=template2,
+                      service=service)
+    response = admin_request.get('service.get_live_services_data')["data"]
+    assert len(response) == 2
+    assert {'consent_to_research': None, 'contact_email': 'notify@digital.cabinet-office.gov.uk',
+            'contact_mobile': '+447700900986', 'contact_name': 'Test User', 'email_totals': 0,
+            'email_volume_intent': None, 'letter_totals': 0, 'letter_volume_intent': None, 'live_date': None,
+            'organisation_name': None, 'service_id': mock.ANY, 'service_name': 'second', 'sms_totals': 0,
+            'sms_volume_intent': None} in response
+    assert {'consent_to_research': None, 'contact_email': 'notify@digital.cabinet-office.gov.uk',
+            'contact_mobile': '+447700900986', 'contact_name': 'Test User', 'email_totals': 1,
+            'email_volume_intent': None, 'letter_totals': 0, 'letter_volume_intent': None, 'live_date': None,
+            'organisation_name': 'test_org_1', 'service_id': mock.ANY, 'service_name': 'Sample service',
+            'sms_totals': 1, 'sms_volume_intent': None} in response
 
 
 def test_get_service_by_id(admin_request, sample_service):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -136,6 +136,10 @@ def test_get_service_list_should_return_empty_list_if_no_services(admin_request)
     assert len(json_resp['data']) == 0
 
 
+def test_get_live_services_data():
+    pass
+
+
 def test_get_service_by_id(admin_request, sample_service):
     json_resp = admin_request.get('service.get_service_by_id', service_id=sample_service.id)
     assert json_resp['data']['name'] == sample_service.name


### PR DESCRIPTION
Adds get_live_services_data endpoint to services rest and a related query to services_dao.

The query gets data about live services from multiple tables (Service, User, Organisation, FactBilling) and then serialises it so it can be pulled by admin app to create a csv report for our platform admins.

Needed for this story: https://www.pivotaltracker.com/story/show/164829877

Needs to be deployed before this PR: https://github.com/alphagov/notifications-admin/pull/2934