### PR TITLE
Make pyup ignore pytest-xdist

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -6,7 +6,7 @@ pytest-env==0.6.2
 pytest-mock==1.10.4
 pytest-cov==2.6.1
 coveralls==1.7.0
-pytest-xdist==1.27.0
+pytest-xdist==1.27.0  # pyup: ignore, version 1.28.0 requires pytest >= 4.4
 freezegun==0.3.11
 requests-mock==1.5.2
 # optional requirements for jsonschema


### PR DESCRIPTION
The next available version of pytest-xdist is 1.28.0, which [requires pytest>=4.4](https://github.com/pytest-dev/pytest-xdist/blob/master/CHANGELOG.rst#pytest-xdist-1280-2019-04-02). We currently have Pytest pinned to version 3.
