### PR TITLE
Only show live services in live services query

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -111,7 +111,9 @@ def dao_fetch_live_services_data():
     ).outerjoin(
         User, Service.go_live_user_id == User.id
     ).filter(
-        Service.count_as_live == True  # noqa
+        Service.count_as_live.is_(True),
+        Service.active.is_(True),
+        Service.restricted.is_(False),
     ).group_by(
         Service.id,
         Organisation.name,

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -391,6 +391,9 @@ def test_dao_fetch_live_services_data(sample_user, mock):
     template = create_template(service=service)
     service_2 = create_service(service_name='second', go_live_user=sample_user, go_live_at='2017-04-20T10:00:00')
     create_service(service_name='third', go_live_at='2016-04-20T10:00:00')
+    # below services should be filtered out:
+    create_service(service_name='restricted', restricted=True)
+    create_service(service_name='not_active', active=False)
     create_service(service_name='not_live', count_as_live=False)
     template2 = create_template(service=service, template_type='email')
     template_letter_1 = create_template(service=service, template_type='letter')


### PR DESCRIPTION
Earlier filter was insufficient so now additional filters checking if service
is not in trial mode and if it's active have been added.