### PR TITLE
update flask-sqlalchemy to 2.4.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,7 +7,7 @@ docopt==0.6.2
 Flask-Bcrypt==0.7.1
 flask-marshmallow==0.10.0
 Flask-Migrate==2.4.0
-git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262#egg=Flask-SQLAlchemy==2.3.2.dev20190108
+Flask-SQLAlchemy==2.4.0
 Flask==1.0.2
 click-datetime==0.2
 eventlet==0.24.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ docopt==0.6.2
 Flask-Bcrypt==0.7.1
 flask-marshmallow==0.10.0
 Flask-Migrate==2.4.0
-git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262#egg=Flask-SQLAlchemy==2.3.2.dev20190108
+Flask-SQLAlchemy==2.4.0
 Flask==1.0.2
 click-datetime==0.2
 eventlet==0.24.1
@@ -40,12 +40,12 @@ alembic==1.0.10
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.1.0
-awscli==1.16.147
+awscli==1.16.150
 bcrypt==3.1.6
 billiard==3.3.0.23
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.137
+botocore==1.12.140
 certifi==2019.3.9
 chardet==3.0.4
 Click==7.0


### PR DESCRIPTION
commit we needed has been released, so we no longer need to pin to a git commit