### PR TITLE
Bump utils to bring in new fragment count for unicode SMS

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,6 +29,6 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@31.2.5#egg=notifications-utils==31.2.5
+git+https://github.com/alphagov/notifications-utils.git@32.0.0#egg=notifications-utils==32.0.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@31.2.5#egg=notifications-utils==31.2.5
+git+https://github.com/alphagov/notifications-utils.git@32.0.0#egg=notifications-utils==32.0.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 


### PR DESCRIPTION
Version 32.0.0 of notifications-utils changes how SMS fragment count is calculated. Certain Welsh characters will cause the SMS to be encoded in unicode encoding (instead of GSM) so the fragment counts will be lower.

[Pivotal story](https://www.pivotaltracker.com/story/show/165672985)

Needs to be merged after:
- [x] https://github.com/alphagov/notifications-utils/pull/606