### PR TITLE
Ensure notifications have billable units and provider set if sending fails

### DIFF
--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -117,6 +117,7 @@ def test_send_sms_should_switch_providers_on_provider_failure(sample_notificatio
     provider_to_use.return_value.send_sms.side_effect = Exception('Error')
     switch_provider_mock = mocker.patch('app.delivery.send_to_providers.dao_toggle_sms_provider')
     mocker.patch('app.celery.provider_tasks.deliver_sms.retry')
+    mocker.patch('app.delivery.send_to_providers.update_notification_provider')
 
     deliver_sms(sample_notification.id)
 

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -112,18 +112,6 @@ def test_should_retry_and_log_exception(sample_notification, mocker):
     assert sample_notification.status == 'created'
 
 
-def test_send_sms_should_switch_providers_on_provider_failure(sample_notification, mocker):
-    provider_to_use = mocker.patch('app.delivery.send_to_providers.provider_to_use')
-    provider_to_use.return_value.send_sms.side_effect = Exception('Error')
-    switch_provider_mock = mocker.patch('app.delivery.send_to_providers.dao_toggle_sms_provider')
-    mocker.patch('app.celery.provider_tasks.deliver_sms.retry')
-    mocker.patch('app.delivery.send_to_providers.update_notification_provider')
-
-    deliver_sms(sample_notification.id)
-
-    assert switch_provider_mock.called is True
-
-
 def test_send_sms_should_not_switch_providers_on_non_provider_failure(
     sample_notification,
     mocker

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -562,6 +562,25 @@ def test_should_update_billable_units_according_to_research_mode_and_key_type(
     assert sample_notification.billable_units == billable_units
 
 
+def test_should_set_notification_billable_units_and_provider_if_sending_to_provider_fails(
+    notify_db,
+    sample_service,
+    sample_notification,
+    mocker,
+):
+    mocker.patch('app.mmg_client.send_sms', side_effect=Exception())
+    mocker.patch('app.delivery.send_to_providers.dao_toggle_sms_provider')
+
+    sample_notification.billable_units = 0
+    assert sample_notification.sent_by is None
+
+    with pytest.raises(Exception):
+        send_to_providers.send_sms_to_provider(sample_notification)
+
+    assert sample_notification.billable_units == 1
+    assert sample_notification.sent_by == 'mmg'
+
+
 def test_should_send_sms_to_international_providers(
     restore_provider_details,
     sample_sms_template_with_html,

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -569,7 +569,7 @@ def test_should_set_notification_billable_units_and_provider_if_sending_to_provi
     mocker,
 ):
     mocker.patch('app.mmg_client.send_sms', side_effect=Exception())
-    mocker.patch('app.delivery.send_to_providers.dao_toggle_sms_provider')
+    mock_toggle_provider = mocker.patch('app.delivery.send_to_providers.dao_toggle_sms_provider')
 
     sample_notification.billable_units = 0
     assert sample_notification.sent_by is None
@@ -579,6 +579,7 @@ def test_should_set_notification_billable_units_and_provider_if_sending_to_provi
 
     assert sample_notification.billable_units == 1
     assert sample_notification.sent_by == 'mmg'
+    assert mock_toggle_provider.called
 
 
 def test_should_send_sms_to_international_providers(


### PR DESCRIPTION
If we try to send an SMS to the provider and the provider throws an exception
(because they return a 503 status code) the notification should retry. But if
we get a callback from the provider before the notification has been retried, the
notification will have no billable units or provider set.

To avoid this, we now set billable_units and provider even if there has been
an exception from our provider.