### PR TITLE
Add request_to_go_live_notes column to Organisation table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -341,6 +341,7 @@ class Organisation(db.Model):
     agreement_signed_version = db.Column(db.Float, nullable=True)
     crown = db.Column(db.Boolean, nullable=True)
     organisation_type = db.Column(db.String(255), nullable=True)
+    request_to_go_live_notes = db.Column(db.Text)
 
     domains = db.relationship(
         'Domain',
@@ -376,6 +377,7 @@ class Organisation(db.Model):
             "domains": [
                 domain.domain for domain in self.domains
             ],
+            "request_to_go_live_notes": self.request_to_go_live_notes,
         }
 
 

--- a/migrations/versions/0290_org_go_live_notes.py
+++ b/migrations/versions/0290_org_go_live_notes.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 0290_org_go_live_notes
+Revises: 0289_precompiled_for_all
+Create Date: 2019-05-13 14:55:10.291781
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0290_org_go_live_notes'
+down_revision = '0289_precompiled_for_all'
+
+
+def upgrade():
+    op.add_column('organisation', sa.Column('request_to_go_live_notes', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('organisation', 'request_to_go_live_notes')

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -52,6 +52,7 @@ def test_get_organisation_by_id(admin_request, notify_db_session):
         'letter_branding_id',
         'email_branding_id',
         'domains',
+        'request_to_go_live_notes',
     }
     assert response['id'] == str(org.id)
     assert response['name'] == 'test_org_1'
@@ -64,6 +65,7 @@ def test_get_organisation_by_id(admin_request, notify_db_session):
     assert response['letter_branding_id'] is None
     assert response['email_branding_id'] is None
     assert response['domains'] == []
+    assert response['request_to_go_live_notes'] is None
 
 
 def test_get_organisation_by_id_returns_domains(admin_request, notify_db_session):


### PR DESCRIPTION
This column will be used to stores extra notes that should go in the
Zendesk ticket when a service belonging to that organisation requests to
go live.

[Pivotal story](https://www.pivotaltracker.com/story/show/165790477)