### PR TITLE
Don't unbind the non-existent notify-api-db-migration service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,9 +247,6 @@ cf-deploy: scripts/statsd_exporter ## Deploys the app to Cloud Foundry
 cf-deploy-api-db-migration:
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
 	cf target -o ${CF_ORG} -s ${CF_SPACE}
-	cf unbind-service notify-api-db-migration notify-db
-	cf unbind-service notify-api-db-migration notify-config
-	cf unbind-service notify-api-db-migration notify-aws
 	cf push notify-api-db-migration -f <(make -s CF_APP=notify-api-db-migration generate-manifest)
 	cf run-task notify-api-db-migration "flask db upgrade" --name api_db_migration
 


### PR DESCRIPTION
- Things were failing to deploy because it was trying to unbind a
  service that didn't exist (they were removed in the upgrade to
  `cflinuxfs3` and come up on deploy).

Questions:
- The temporary app for the migration should go away at the end of the deploy, how do we achieve this?
- Can we integrate this with the task below it, "check status", so that if the migration succeeds it deletes the app?
- There doesn't seem to be a `flask db downgrade` step for rolling back the migration?