### PR TITLE
add routes for all apps

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -1,9 +1,10 @@
 {%- set app_vars = {
   'notify-api': {'NOTIFY_APP_NAME': 'api', 'disk_quota': '2G', 'sqlalchemy_pool_size': 20, 'routes': {
-      'preview': ['notify-api-preview.cloudapps.digital', 'api.notify.works'],
-      'staging': ['notify-api-staging.cloudapps.digital', 'api.staging-notify.works'],
-      'production': ['notify-api-production.cloudapps.digital', 'api.notifications.service.gov.uk'],
-    }
+      'preview': ['api.notify.works'],
+      'staging': ['api.staging-notify.works'],
+      'production': ['api.notifications.service.gov.uk'],
+    },
+    'healthcheck-endpoint': '/_status?simple=true',
   },
   'notify-api-db-migration': {'NOTIFY_APP_NAME': 'api', 'instances': 0},
 
@@ -33,24 +34,24 @@ applications:
     memory: {{ app.get('memory', '1G') }}
     disk_quota: {{ app.get('disk_quota', '1G')}}
 
-    {% if 'routes' in app -%}
     routes:
-      {%- for route in app['routes'][environment] %}
+      {%- for route in app.get('routes', {}).get(environment, []) %}
       - route: {{ route }}
-      {%- endfor -%}
-    {%- elif environment in app.get('local_statsd', []) -%}
-    health-check-type: none
-    routes:
+      {%- endfor%}
       - route: {{ CF_APP }}-{{ environment }}.cloudapps.digital
-    {%- else -%}
-    health-check-type: none
-    no-route: true
+    {% if 'healthcheck-endpoint' in app %}
+    health-check-type: http
+    health-check-http-endpoint: {{ app['healthcheck-endpoint'] }}
+    {% else %}
+    health-check-type: process
     {% endif %}
 
     services:
       - notify-db
       - logit-ssl-syslog-drain
-      {% if environment in app.get('local_statsd', []) %}- notify-prometheus{% endif %}
+      {% if environment in app.get('local_statsd', []) -%}
+      - notify-prometheus
+      {% endif %}
 
     env:
       NOTIFY_APP_NAME: {{ app.get('NOTIFY_APP_NAME', CF_APP.replace('notify-', '')) }}


### PR DESCRIPTION
If not specified, healthcheck is set to `port` by cloudfoundry - we've seen some issues with upgrading the deployment from v2 to v3 when using port - it adds apps to load balancer when they're not ready, which can result in 404s. by setting healthcheck to http it'll wait for the `/status` endpoint to return 200, which will wait for flask to get everything up and running properly