### PR TITLE
remove unnecessary unique index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ cf-deploy: scripts/statsd_exporter ## Deploys the app to Cloud Foundry
 cf-deploy-api-db-migration:
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
 	cf target -o ${CF_ORG} -s ${CF_SPACE}
-	cf push notify-api-db-migration -f <(make -s CF_APP=notify-api-db-migration generate-manifest)
+	cf push notify-api-db-migration --no-start --no-route -f <(make -s CF_APP=notify-api-db-migration generate-manifest)
 	cf run-task notify-api-db-migration "flask db upgrade" --name api_db_migration
 
 .PHONY: cf-check-api-db-migration-task

--- a/app/commands.py
+++ b/app/commands.py
@@ -10,7 +10,7 @@ import itertools
 from click_datetime import Datetime as click_dt
 from flask import current_app, json
 from notifications_utils.template import SMSMessageTemplate
-from psycopg2._psycopg import IntegrityError
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 from notifications_utils.statsd_decorators import statsd
 

--- a/migrations/versions/0291_remove_unused_index.py
+++ b/migrations/versions/0291_remove_unused_index.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 0291_remove_unused_index
+Revises: 0290_org_go_live_notes
+Create Date: 2019-05-16 14:05:18.104274
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0291_remove_unused_index'
+down_revision = '0290_org_go_live_notes'
+
+
+def upgrade():
+    op.drop_index('ix_domain_domain', table_name='domain')
+
+
+def downgrade():
+    op.create_index('ix_domain_domain', 'domain', ['domain'], unique=True)


### PR DESCRIPTION
primary key provides the same control. also catch the right exception in the related command

mainly opening this PR to make sure zdt deploy flow doesn't go weird with migrations. It shouldn't, because we're still using the old `cf push` command for migrations, but make sure we don't create instances or map routes.