### PR TITLE
Add endpoint and DAO function to archive user

### DIFF
--- a/app/dao/permissions_dao.py
+++ b/app/dao/permissions_dao.py
@@ -38,6 +38,10 @@ class PermissionDAO(DAOClass):
         query = self.Meta.model.query.filter_by(user=user, service=service)
         query.delete()
 
+    def remove_user_service_permissions_for_all_services(self, user):
+        query = self.Meta.model.query.filter_by(user=user)
+        query.delete()
+
     def set_user_service_permission(self, user, service, permissions, _commit=False, replace=False):
         try:
             if replace:
@@ -58,6 +62,10 @@ class PermissionDAO(DAOClass):
     def get_permissions_by_user_id(self, user_id):
         return self.Meta.model.query.filter_by(user_id=user_id)\
                                     .join(Permission.service).filter_by(active=True).all()
+
+    def get_permissions_by_user_id_and_service_id(self, user_id, service_id):
+        return self.Meta.model.query.filter_by(user_id=user_id)\
+                                    .join(Permission.service).filter_by(active=True, id=service_id).all()
 
 
 permission_dao = PermissionDAO()

--- a/app/dao/service_user_dao.py
+++ b/app/dao/service_user_dao.py
@@ -17,6 +17,10 @@ def dao_get_active_service_users(service_id):
     return query.all()
 
 
+def dao_get_service_users_by_user_id(user_id):
+    return ServiceUser.query.filter_by(user_id=user_id).all()
+
+
 @transactional
 def dao_update_service_user(service_user):
     db.session.add(service_user)

--- a/app/models.py
+++ b/app/models.py
@@ -137,8 +137,14 @@ class User(db.Model):
     def check_password(self, password):
         return check_hash(password, self._password)
 
-    def get_permissions(self):
+    def get_permissions(self, service_id=None):
         from app.dao.permissions_dao import permission_dao
+
+        if service_id:
+            return [
+                x.permission for x in permission_dao.get_permissions_by_user_id_and_service_id(self.id, service_id)
+            ]
+
         retval = {}
         for x in permission_dao.get_permissions_by_user_id(self.id):
             service_id = str(x.service_id)

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -21,7 +21,8 @@ from app.dao.users_dao import (
     save_user_attribute,
     update_user_password,
     count_user_verify_codes,
-    get_user_and_accounts
+    get_user_and_accounts,
+    dao_archive_user,
 )
 from app.dao.permissions_dao import permission_dao
 from app.dao.service_user_dao import dao_get_service_user, dao_update_service_user
@@ -126,6 +127,14 @@ def update_user_attribute(user_id):
 
         send_notification_to_queue(saved_notification, False, queue=QueueNames.NOTIFY)
     return jsonify(data=user_to_update.serialize()), 200
+
+
+@user_blueprint.route('/<uuid:user_id>/archive', methods=['POST'])
+def archive_user(user_id):
+    user = get_user_by_id(user_id)
+    dao_archive_user(user)
+
+    return '', 204
 
 
 @user_blueprint.route('/<uuid:user_id>/activate', methods=['POST'])

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -771,33 +771,6 @@ def sample_invited_org_user(
 
 
 @pytest.fixture(scope='function')
-def sample_permission(notify_db,
-                      notify_db_session,
-                      service=None,
-                      user=None,
-                      permission="manage_settings"):
-    if user is None:
-        user = create_user()
-    data = {
-        'user': user,
-        'permission': permission
-    }
-    if service is None:
-        service = create_service(check_if_service_exists=True)
-    if service:
-        data['service'] = service
-    p_model = Permission.query.filter_by(
-        user=user,
-        service=service,
-        permission=permission).first()
-    if not p_model:
-        p_model = Permission(**data)
-        db.session.add(p_model)
-        db.session.commit()
-    return p_model
-
-
-@pytest.fixture(scope='function')
 def sample_user_service_permission(
     notify_db, notify_db_session, service=None, user=None, permission="manage_settings"
 ):

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -13,6 +13,7 @@ from app.dao.notifications_dao import (
     dao_created_scheduled_notification
 )
 from app.dao.organisation_dao import dao_create_organisation
+from app.dao.permissions_dao import permission_dao
 from app.dao.service_callback_api_dao import save_service_callback_api
 from app.dao.service_data_retention_dao import insert_service_data_retention
 from app.dao.service_inbound_api_dao import save_service_inbound_api
@@ -31,6 +32,7 @@ from app.models import (
     EmailBranding,
     LetterRate,
     Organisation,
+    Permission,
     Rate,
     Service,
     ServiceEmailReplyTo,
@@ -79,6 +81,15 @@ def create_user(
         user = User(**data)
     save_model_user(user)
     return user
+
+
+def create_permissions(user, service, *permissions):
+    permissions = [
+        Permission(service_id=service.id, user_id=user.id, permission=p)
+        for p in permissions
+    ]
+
+    permission_dao.set_user_service_permission(user, service, permissions)
 
 
 def create_service(


### PR DESCRIPTION
Added a new `/user/<user_id>/archive` endpoint to allow a user to be archived and a new DAO function to archive a user.

Users can only be archived if all of their services have at least one other active team member with the `manage-settings` permission.

To archive a user we remove them from all services and organisations, remove all their permissions and change some of their details:
- `email_address` will start with `_archived_<date>`
- the `current_session_id` is changed (to sign them out of their current session)
- `mobile_number` is removed (so we also need to switch their auth type to `email_auth`)
- password is changed to a random UUID
- state is changed to `inactive`

If any of the steps fail, we rollback all changes.

[Pivotal story](https://www.pivotaltracker.com/story/show/166027696)