### PR TITLE
Fix a bug introduced when refactoring some code. 

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -51,8 +51,8 @@ def send_sms_to_provider(notification):
         )
 
         if service.research_mode or notification.key_type == KEY_TYPE_TEST:
-            send_sms_response(provider.get_name(), str(notification.id), notification.to)
             update_notification_to_sending(notification, provider)
+            send_sms_response(provider.get_name(), str(notification.id), notification.to)
 
         else:
             try:


### PR DESCRIPTION
The notification status happened in the wrong order - this resolved that.

This meant notifications sent with a test key never got a 'delivered' status.