### PR TITLE
AUTO-413: Point preview statsd at tools

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -70,7 +70,7 @@ applications:
       AWS_SECRET_ACCESS_KEY: '{{ AWS_SECRET_ACCESS_KEY }}'
 
       {% if environment == 'preview' %}
-      STATSD_HOST: "notify-statsd-exporter-{{ environment }}.apps.internal"
+      STATSD_HOST: "statsd.notify.tools"
       STATSD_PREFIX: ""
       {% else %}
       STATSD_HOST: "statsd.hostedgraphite.com"


### PR DESCRIPTION
- We are running a statsd exporter on tools to collect all our statsd
  metrics for scraping by Prometheus
- Update preview to point there instead of at the local one which has
  issues with redeployment and DNS changing