### PR TITLE
Don't insert notification history

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -344,7 +344,8 @@ def _delete_notifications(
     ).filter(
         Notification.notification_type == notification_type,
         Notification.service_id == service_id,
-        Notification.created_at < date_to_delete_from
+        Notification.created_at < date_to_delete_from,
+        NotificationHistory.id == Notification.id
     ).limit(query_limit).subquery()
 
     number_deleted = db.session.query(Notification).filter(

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -336,21 +336,35 @@ def delete_notifications_older_than_retention_by_type(notification_type, qry_lim
     return deleted
 
 
-def _delete_notifications(
-        deleted, notification_type, date_to_delete_from, service_id, query_limit):
-
+def _delete_notifications(deleted, notification_type, date_to_delete_from, service_id, query_limit):
     subquery = db.session.query(
+        Notification.id
+    ).join(NotificationHistory, NotificationHistory.id == Notification.id).filter(
+        Notification.notification_type == notification_type,
+        Notification.service_id == service_id,
+        Notification.created_at < date_to_delete_from,
+    ).limit(query_limit).subquery()
+
+    deleted += _delete_for_query(subquery)
+
+    subquery_for_test_keys = db.session.query(
         Notification.id
     ).filter(
         Notification.notification_type == notification_type,
         Notification.service_id == service_id,
         Notification.created_at < date_to_delete_from,
-        NotificationHistory.id == Notification.id
+        Notification.key_type == KEY_TYPE_TEST
     ).limit(query_limit).subquery()
 
+    deleted += _delete_for_query(subquery_for_test_keys)
+
+    return deleted
+
+
+def _delete_for_query(subquery):
     number_deleted = db.session.query(Notification).filter(
         Notification.id.in_(subquery)).delete(synchronize_session='fetch')
-    deleted += number_deleted
+    deleted = number_deleted
     db.session.commit()
     while number_deleted > 0:
         number_deleted = db.session.query(Notification).filter(

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -27,7 +27,7 @@ from app.models import (
 )
 from app.dao.notifications_dao import (
     dao_create_notification,
-    dao_delete_notifications_and_history_by_id,
+    dao_delete_notifications_by_id,
     dao_created_scheduled_notification
 )
 
@@ -142,7 +142,7 @@ def send_notification_to_queue(notification, research_mode, queue=None):
     try:
         deliver_task.apply_async([str(notification.id)], queue=queue)
     except Exception:
-        dao_delete_notifications_and_history_by_id(notification.id)
+        dao_delete_notifications_by_id(notification.id)
         raise
 
     current_app.logger.debug(

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -7,7 +7,6 @@ from flask import current_app
 
 from app.exceptions import DVLAException, NotificationTechnicalFailureException
 from app.models import (
-    Notification,
     NotificationHistory,
     NOTIFICATION_CREATED,
     NOTIFICATION_DELIVERED,
@@ -28,7 +27,7 @@ from app.celery.tasks import (
 )
 from app.dao.daily_sorted_letter_dao import dao_get_daily_sorted_letter_by_billing_day
 
-from tests.app.db import create_notification, create_service_callback_api
+from tests.app.db import create_notification, create_service_callback_api, create_notification_history
 from tests.conftest import set_config
 
 
@@ -56,9 +55,8 @@ def test_update_letter_notification_statuses_when_notification_does_not_exist_up
 ):
     valid_file = 'ref-foo|Sent|1|Unsorted'
     mocker.patch('app.celery.tasks.s3.get_s3_file', return_value=valid_file)
-    notification = create_notification(sample_letter_template, reference='ref-foo', status=NOTIFICATION_SENDING,
-                                       billable_units=1)
-    Notification.query.filter_by(id=notification.id).delete()
+    notification = create_notification_history(sample_letter_template, reference='ref-foo', status=NOTIFICATION_SENDING,
+                                               billable_units=1)
 
     update_letter_notifications_statuses(filename="NOTIFY-20170823160812-RSP.TXT")
 

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -14,7 +14,6 @@ from notifications_utils.columns import Row
 
 from app import (
     DATETIME_FORMAT,
-    db,
     encryption
 )
 from app.celery import provider_tasks
@@ -60,6 +59,7 @@ from tests.app.db import (
     create_user,
     create_reply_to_email,
     create_service_with_defined_sms_sender,
+    create_notification_history
 )
 from tests.conftest import set_config_values
 
@@ -1601,11 +1601,9 @@ def test_process_returned_letters_list(sample_letter_template):
 def test_process_returned_letters_list_updates_history_if_notification_is_already_purged(
         sample_letter_template
 ):
-    create_notification(sample_letter_template, reference='ref1')
-    create_notification(sample_letter_template, reference='ref2')
+    create_notification_history(sample_letter_template, reference='ref1')
+    create_notification_history(sample_letter_template, reference='ref2')
 
-    Notification.query.delete()
-    db.session.commit()
     process_returned_letters_list(['ref1', 'ref2', 'unknown-ref'])
 
     notifications = NotificationHistory.query.all()

--- a/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
@@ -181,6 +181,14 @@ def test_delete_notifications_keep_data_for_days_of_retention_is_longer(sample_s
         mock_get_s3.assert_not_called()
 
 
+def test_delete_notifications_with_test_keys(sample_template, mocker):
+    mocker.patch("app.dao.notifications_dao.get_s3_bucket_objects")
+    create_notification(template=sample_template, key_type='test', created_at=datetime.utcnow() - timedelta(days=8))
+    assert len(Notification.query.all()) == 1
+    delete_notifications_older_than_retention_by_type('sms')
+    assert len(Notification.query.filter_by().all()) == 0
+
+
 def test_delete_notifications_delete_notification_type_for_default_time_if_no_days_of_retention_for_type(
         sample_service, mocker
 ):
@@ -212,7 +220,7 @@ def test_delete_notifications_does_try_to_delete_from_s3_when_letter_has_not_bee
     mock_get_s3.assert_not_called()
 
 
-@pytest.mark.parametrize('notification_type', ['sms', 'email', 'letter'])
+@pytest.mark.parametrize('notification_type', ['sms'])
 @freeze_time("2016-01-10 12:00:00.000000")
 def test_should_not_delete_notification_if_history_does_not_exist(sample_service, notification_type, mocker):
     mocker.patch("app.dao.notifications_dao.get_s3_bucket_objects")

--- a/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
@@ -212,6 +212,23 @@ def test_delete_notifications_does_try_to_delete_from_s3_when_letter_has_not_bee
     mock_get_s3.assert_not_called()
 
 
+@pytest.mark.parametrize('notification_type', ['sms', 'email', 'letter'])
+@freeze_time("2016-01-10 12:00:00.000000")
+def test_should_not_delete_notification_if_history_does_not_exist(sample_service, notification_type, mocker):
+    mocker.patch("app.dao.notifications_dao.get_s3_bucket_objects")
+    mocker.patch("app.dao.notifications_dao.insert_update_notification_history")
+    with freeze_time('2016-01-01 12:00'):
+        email_template, letter_template, sms_template = _create_templates(sample_service)
+        create_notification(template=email_template, status='permanent-failure')
+        create_notification(template=sms_template, status='delivered')
+        create_notification(template=letter_template, status='temporary-failure')
+    assert Notification.query.count() == 3
+    assert NotificationHistory.query.count() == 0
+    delete_notifications_older_than_retention_by_type(notification_type)
+    assert Notification.query.count() == 3
+    assert NotificationHistory.query.count() == 0
+
+
 def test_delete_notifications_calls_subquery(
         notify_db_session, mocker
 ):

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -28,7 +28,8 @@ from tests.app.db import (
     create_template,
     create_notification,
     create_rate,
-    create_letter_rate
+    create_letter_rate,
+    create_notification_history
 )
 
 
@@ -95,6 +96,7 @@ def test_fetch_billing_data_for_today_includes_data_with_the_right_key_type(noti
     assert results[0].notifications_sent == 2
 
 
+@freeze_time('2018-04-02 01:20:00')
 def test_fetch_billing_data_for_today_includes_data_with_the_right_date(notify_db_session):
     process_day = datetime(2018, 4, 1, 13, 30, 0)
     service = create_service()
@@ -235,8 +237,10 @@ def test_fetch_billing_data_for_day_returns_empty_list(notify_db_session):
 def test_fetch_billing_data_for_day_uses_notification_history(notify_db_session):
     service = create_service()
     sms_template = create_template(service=service, template_type='sms')
-    create_notification(template=sms_template, status='delivered', created_at=datetime.utcnow() - timedelta(days=8))
-    create_notification(template=sms_template, status='delivered', created_at=datetime.utcnow() - timedelta(days=8))
+    create_notification_history(template=sms_template, status='delivered',
+                                created_at=datetime.utcnow() - timedelta(days=8))
+    create_notification_history(template=sms_template, status='delivered',
+                                created_at=datetime.utcnow() - timedelta(days=8))
 
     Notification.query.delete()
     db.session.commit()

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -73,6 +73,7 @@ from tests.app.db import (
     create_invited_user,
     create_email_branding,
     create_letter_branding,
+    create_notification_history
 )
 
 
@@ -713,16 +714,13 @@ def test_fetch_stats_filters_on_service(notify_db_session):
     assert len(stats) == 0
 
 
-def test_fetch_stats_ignores_historical_notification_data(notify_db_session):
-    notification = create_notification(template=create_template(service=create_service()))
-    service_id = notification.service.id
-
-    db.session.delete(notification)
+def test_fetch_stats_ignores_historical_notification_data(sample_template):
+    create_notification_history(template=sample_template)
 
     assert Notification.query.count() == 0
     assert NotificationHistory.query.count() == 1
 
-    stats = dao_fetch_stats_for_service(service_id, 7)
+    stats = dao_fetch_stats_for_service(sample_template.service_id, 7)
     assert len(stats) == 0
 
 

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -73,27 +73,24 @@ def test_persist_notification_creates_and_save_to_db(sample_template, sample_api
         reply_to_text=sample_template.service.get_default_sms_sender())
 
     assert Notification.query.get(notification.id) is not None
-    assert NotificationHistory.query.get(notification.id) is not None
 
     notification_from_db = Notification.query.one()
-    notification_history_from_db = NotificationHistory.query.one()
 
-    assert notification_from_db.id == notification_history_from_db.id
-    assert notification_from_db.template_id == notification_history_from_db.template_id
-    assert notification_from_db.template_version == notification_history_from_db.template_version
-    assert notification_from_db.api_key_id == notification_history_from_db.api_key_id
-    assert notification_from_db.key_type == notification_history_from_db.key_type
-    assert notification_from_db.key_type == notification_history_from_db.key_type
-    assert notification_from_db.billable_units == notification_history_from_db.billable_units
-    assert notification_from_db.notification_type == notification_history_from_db.notification_type
-    assert notification_from_db.created_at == notification_history_from_db.created_at
+    assert notification_from_db.id == notification.id
+    assert notification_from_db.template_id == notification.template_id
+    assert notification_from_db.template_version == notification.template_version
+    assert notification_from_db.api_key_id == notification.api_key_id
+    assert notification_from_db.key_type == notification.key_type
+    assert notification_from_db.key_type == notification.key_type
+    assert notification_from_db.billable_units == notification.billable_units
+    assert notification_from_db.notification_type == notification.notification_type
+    assert notification_from_db.created_at == notification.created_at
     assert not notification_from_db.sent_at
-    assert not notification_history_from_db.sent_at
-    assert notification_from_db.updated_at == notification_history_from_db.updated_at
-    assert notification_from_db.status == notification_history_from_db.status
-    assert notification_from_db.reference == notification_history_from_db.reference
-    assert notification_from_db.client_reference == notification_history_from_db.client_reference
-    assert notification_from_db.created_by_id == notification_history_from_db.created_by_id
+    assert notification_from_db.updated_at == notification.updated_at
+    assert notification_from_db.status == notification.status
+    assert notification_from_db.reference == notification.reference
+    assert notification_from_db.client_reference == notification.client_reference
+    assert notification_from_db.created_by_id == notification.created_by_id
     assert notification_from_db.reply_to_text == sample_template.service.get_default_sms_sender()
 
     mocked_redis.assert_called_once_with(str(sample_template.service_id) + "-2016-01-01-count")
@@ -187,7 +184,7 @@ def test_persist_notification_with_optionals(sample_job, sample_api_key, mocker)
         created_by_id=sample_job.created_by_id
     )
     assert Notification.query.count() == 1
-    assert NotificationHistory.query.count() == 1
+    assert NotificationHistory.query.count() == 0
     persisted_notification = Notification.query.all()[0]
     assert persisted_notification.id == n_id
     persisted_notification.job_id == sample_job.id

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -9,7 +9,6 @@ from app.config import QueueNames
 from app.models import (
     Job,
     Notification,
-    NotificationHistory,
     EMAIL_TYPE,
     KEY_TYPE_NORMAL,
     KEY_TYPE_TEAM,
@@ -474,9 +473,6 @@ def test_post_precompiled_letter_notification_returns_201(
     assert notification.billable_units == 0
     assert notification.status == NOTIFICATION_PENDING_VIRUS_CHECK
     assert notification.postage == expected_postage
-
-    notification_history = NotificationHistory.query.one()
-    assert notification_history.postage == expected_postage
 
     resp_json = json.loads(response.get_data(as_text=True))
     assert resp_json == {'id': str(notification.id), 'reference': 'letter-reference', 'postage': expected_postage}


### PR DESCRIPTION
This PR is the final step to make NotificationHistory truly an archive table. 

After this NotificationHistory is only inserted when the Notification is deleted. A join to NotificationHistory on id is added to the delete query to insure we have the history row before deleting the Notification. 

