### PR TITLE
ensure cronitor decorator is inside the notify_task wrapper

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -111,8 +111,8 @@ def get_letters_pdf(template, contact_block, filename, values):
     return resp.content, billable_units
 
 
-@cronitor("collate-letter-pdfs-for-day")
 @notify_celery.task(name='collate-letter-pdfs-for-day')
+@cronitor("collate-letter-pdfs-for-day")
 def collate_letter_pdfs_for_day(date=None):
     if not date:
         # Using the truncated date is ok because UTC to BST does not make a difference to the date,


### PR DESCRIPTION
the celery decorator should always be on the outside so that all other decorators will be captured within the celery task. We had problems with cronitor not reporting, and only for this task.