### PR TITLE
Bump utils to 32.0.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,6 +29,6 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@32.0.0#egg=notifications-utils==32.0.0
+git+https://github.com/alphagov/notifications-utils.git@32.0.1#egg=notifications-utils==32.0.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@32.0.0#egg=notifications-utils==32.0.0
+git+https://github.com/alphagov/notifications-utils.git@32.0.1#egg=notifications-utils==32.0.1
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
@@ -40,47 +40,47 @@ alembic==1.0.10
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.1.0
-awscli==1.16.155
+awscli==1.16.169
 bcrypt==3.1.6
 billiard==3.3.0.23
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.145
+botocore==1.12.159
 certifi==2019.3.9
 chardet==3.0.4
 Click==7.0
 colorama==0.3.9
 dnspython==1.16.0
 docutils==0.14
-Flask-Redis==0.3.0
+flask-redis==0.4.0
 future==0.17.1
 greenlet==0.4.15
 idna==2.8
 Jinja2==2.10.1
 jmespath==0.9.4
 kombu==3.0.37
-Mako==1.0.9
+Mako==1.0.11
 MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5
 orderedset==2.0.1
-phonenumbers==8.10.5
+phonenumbers==8.10.13
 pyasn1==0.4.5
 pycparser==2.19
 PyPDF2==1.26.0
-pyrsistent==0.15.1
+pyrsistent==0.15.2
 python-dateutil==2.8.0
 python-editor==1.0.4
-python-json-logger==0.1.10
+python-json-logger==0.1.11
 pytz==2019.1
 PyYAML==3.13
 redis==3.2.1
-requests==2.21.0
+requests==2.22.0
 rsa==3.4.2
 s3transfer==0.2.0
 six==1.12.0
 smartypants==2.0.1
 statsd==3.3.0
-urllib3==1.24.3
+urllib3==1.25.3
 webencodings==0.5.1
-Werkzeug==0.15.2
+Werkzeug==0.15.4


### PR DESCRIPTION
This updates requirements and brings in the change to preserve trailing semicolons on URLs.