### PR TITLE
AUTO: Get gunicorn stats

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -7,6 +7,8 @@ worker_class = "eventlet"
 worker_connections = 256
 errorlog = "/home/vcap/logs/gunicorn_error.log"
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
+statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
+statsd_prefix = os.getenv("STATSD_PREFIX")
 
 
 def on_starting(server):


### PR DESCRIPTION
- Gunicorn can give us some interestings stats about what it is doing
  that might prove useful when trying to work out the
gunicorn/eventlet/sqlalchemy kind of bottlenecking issues
- We already ship these env vars to the app so this is a pretty easy
  change to make
- Uses statsd which is UDP so it shouldn't have any performance impact
  on gunicorn