### PR TITLE
AUTO: Enable statsd exporter on staging

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -69,7 +69,7 @@ applications:
       AWS_ACCESS_KEY_ID: '{{ AWS_ACCESS_KEY_ID }}'
       AWS_SECRET_ACCESS_KEY: '{{ AWS_SECRET_ACCESS_KEY }}'
 
-      {% if environment == 'preview' %}
+      {% if environment in ['preview', 'staging'] %}
       STATSD_HOST: "statsd.notify.tools"
       STATSD_PREFIX: ""
       {% else %}


### PR DESCRIPTION
- We want to do some load testing so we want to use the Prometheus
  metrics for observing the system
- Roll out the statsd exporter work to staging too