### PR TITLE
More logging and retrying for letters

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -259,6 +259,11 @@ class Config(object):
             # since we mark jobs as archived
             'options': {'queue': QueueNames.PERIODIC},
         },
+        'check-templated-letter-state': {
+            'task': 'check-templated-letter-state',
+            'schedule': crontab(day_of_week='mon-fri', hour=9, minute=0),
+            'options': {'queue', QueueNames.PERIODIC}
+        },
         'raise-alert-if-letter-notifications-still-sending': {
             'task': 'raise-alert-if-letter-notifications-still-sending',
             'schedule': crontab(hour=16, minute=30),

--- a/app/config.py
+++ b/app/config.py
@@ -276,6 +276,11 @@ class Config(object):
             'schedule': crontab(hour=23, minute=00),
             'options': {'queue': QueueNames.PERIODIC}
         },
+        'check-precompiled-letter-state': {
+            'task': 'check-precompiled-letter-state',
+            'schedule': crontab(day_of_week='mon-fri', hour='9,15', minute=0),
+            'options': {'queue', QueueNames.PERIODIC}
+        },
     }
     CELERY_QUEUES = []
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -692,6 +692,18 @@ def notifications_not_yet_sent(should_be_sending_after_seconds, notification_typ
     return notifications
 
 
+def dao_precompiled_letters_still_pending_virus_check():
+    ninety_minutes_ago = datetime.utcnow() - timedelta(seconds=5400)
+
+    notifications = Notification.query.filter(
+        Notification.created_at < ninety_minutes_ago,
+        Notification.status == NOTIFICATION_PENDING_VIRUS_CHECK
+    ).order_by(
+        Notification.created_at
+    ).all()
+    return notifications
+
+
 def guess_notification_type(search_term):
     if set(search_term) & set(string.ascii_letters + '@'):
         return EMAIL_TYPE

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -15,6 +15,7 @@ from app.celery.scheduled_tasks import (
     switch_current_sms_provider_on_slow_delivery,
     replay_created_notifications,
     check_precompiled_letter_state,
+    check_templated_letter_state,
 )
 from app.config import QueueNames, TaskNames
 from app.dao.jobs_dao import dao_get_job_by_id
@@ -362,4 +363,42 @@ def test_check_precompiled_letter_state(mocker, sample_letter_template):
         "2 precompiled letters have been pending-virus-check for over 90 minutes. Notifications: ['{}', '{}']".format(
             noti_2.id,
             noti_1.id)
+    )
+
+
+@freeze_time("2019-05-30 14:00:00")
+def test_check_templated_letter_state_during_bst(mocker, sample_letter_template):
+    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.exception')
+
+    noti_1 = create_notification(template=sample_letter_template, created_at=datetime(2019, 5, 1, 12, 0))
+    noti_2 = create_notification(template=sample_letter_template, created_at=datetime(2019, 5, 29, 16, 29))
+    create_notification(template=sample_letter_template, created_at=datetime(2019, 5, 29, 16, 30))
+    create_notification(template=sample_letter_template, created_at=datetime(2019, 5, 29, 17, 29))
+    create_notification(template=sample_letter_template, status='delivered', created_at=datetime(2019, 5, 28, 10, 0))
+    create_notification(template=sample_letter_template, created_at=datetime(2019, 5, 30, 10, 0))
+
+    check_templated_letter_state()
+
+    mock_logger.assert_called_once_with(
+        "2 letters were created before 17.30 yesterday and still have 'created' state. "
+        "Notifications: ['{}', '{}']".format(noti_1.id, noti_2.id)
+    )
+
+
+@freeze_time("2019-01-30 14:00:00")
+def test_check_templated_letter_state_during_utc(mocker, sample_letter_template):
+    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.exception')
+
+    noti_1 = create_notification(template=sample_letter_template, created_at=datetime(2018, 12, 1, 12, 0))
+    noti_2 = create_notification(template=sample_letter_template, created_at=datetime(2019, 1, 29, 17, 29))
+    create_notification(template=sample_letter_template, created_at=datetime(2019, 1, 29, 17, 30))
+    create_notification(template=sample_letter_template, created_at=datetime(2019, 1, 29, 18, 29))
+    create_notification(template=sample_letter_template, status='delivered', created_at=datetime(2019, 1, 29, 10, 0))
+    create_notification(template=sample_letter_template, created_at=datetime(2019, 1, 30, 10, 0))
+
+    check_templated_letter_state()
+
+    mock_logger.assert_called_once_with(
+        "2 letters were created before 17.30 yesterday and still have 'created' state. "
+        "Notifications: ['{}', '{}']".format(noti_1.id, noti_2.id)
     )


### PR DESCRIPTION
Added logging for letters which have been in `pending-virus-check` or `created` state for too long.

### Log an exception and set notification status to 'technical-failure' if there's an S3 error during the 'process_virus_scan_passed' task
The `process_virus_scan_passed` task now catches S3 errors - if these occur, it logs an exception and puts the letter in a `technical-failure` state. We don't retry the task, because the most common reason for failure would be the letter not being in the expected S3 bucket, in which case retrying would make no difference.

### Add scheduled task to find precompiled letters in wrong state
Added a task which runs twice a day on weekdays and checks for letters that have been in the state of `pending-virus-check` for over 90 minutes. This is just logging an exception for now, not trying to fix things, since we will need to manually check where the issue was.

### Add scheduled task to find old letters which still have 'created' status
Added a scheduled task to run once a day and check if there were any letters from before 17.30 that still have a status of 'created'. This logs an exception instead of trying to fix the error because the fix
will be different depending on which bucket the letter is in.

### Create a Zendesk ticket for letters in the wrong state 
This creates a Zendesk ticket if either the `check_precompiled_letter_state` or `check_templated_letter_state` tasks fail.

[Pivotal story](https://www.pivotaltracker.com/story/show/166160483)