### PR TITLE
Ensure dao_create_template doesn't clash with new trigger

### DIFF
--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -24,16 +24,19 @@ def dao_create_template(template):
     template.id = uuid.uuid4()  # must be set now so version history model can use same id
     template.archived = False
 
-    redacted_dict = {
-        "template": template,
-        "redact_personalisation": False,
-    }
-    if template.created_by:
-        redacted_dict.update({"updated_by": template.created_by})
-    else:
-        redacted_dict.update({"updated_by_id": template.created_by_id})
+    # The template redacted is now being inserted via a trigger
+    # this will catch any Notify templates being added by a db migration
+    if not TemplateRedacted.query.filter(TemplateRedacted.template_id == template.id).first():
+        redacted_dict = {
+            "template": template,
+            "redact_personalisation": False,
+        }
+        if template.created_by:
+            redacted_dict.update({"updated_by": template.created_by})
+        else:
+            redacted_dict.update({"updated_by_id": template.created_by_id})
 
-    template.template_redacted = TemplateRedacted(**redacted_dict)
+        template.template_redacted = TemplateRedacted(**redacted_dict)
 
     db.session.add(template)
 

--- a/tests/app/v2/template/test_get_template.py
+++ b/tests/app/v2/template/test_get_template.py
@@ -17,7 +17,7 @@ valid_version_params = [None, 1]
 ])
 @pytest.mark.parametrize("version", valid_version_params)
 def test_get_template_by_id_returns_200(
-    client, sample_service, tmp_type, expected_name, expected_subject, version, postage
+    client, sample_service, mock, tmp_type, expected_name, expected_subject, version, postage
 ):
     template = create_template(sample_service, template_type=tmp_type)
     auth_header = create_authorization_header(service_id=sample_service.id)
@@ -36,7 +36,7 @@ def test_get_template_by_id_returns_200(
         'id': '{}'.format(template.id),
         'type': '{}'.format(template.template_type),
         'created_at': template.created_at.strftime(DATETIME_FORMAT),
-        'updated_at': None,
+        'updated_at': mock.ANY,
         'version': template.version,
         'created_by': template.created_by.email_address,
         'body': template.content,


### PR DESCRIPTION
New trigger creates template_redacted row after insert to template
table

This here PR needs to be deployed before following PR: https://github.com/alphagov/notifications-api/pull/2537
