### PR TITLE
Add rows in template_redacted where they are missing and help remember to insert them in the future

### DIFF
--- a/migrations/versions/0041_email_template_.py
+++ b/migrations/versions/0041_email_template_.py
@@ -47,6 +47,16 @@ If you didn’t try to register for a GOV.UK Notify account recently, please let
                                datetime.utcnow(), content, service_id,
                                'Your GOV.UK Notify account', user_id))
 
+# If you are copying this migration, please remember about an insert to TemplateRedacted,
+# which was not originally included here either by mistake or because it was before TemplateRedacted existed
+    # op.execute(
+    #     """
+    #         INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
+    #         VALUES ('0880fbb1-a0c6-46f0-9a8e-36c986381ceb', '{}', '{}', '{}')
+    #         ;
+    #     """.format(False, datetime.utcnow(), user_id)
+    # )
+
 
 def downgrade():
     op.execute("delete from notifications where template_id = '0880fbb1-a0c6-46f0-9a8e-36c986381ceb'")

--- a/migrations/versions/0057_change_email_template.py
+++ b/migrations/versions/0057_change_email_template.py
@@ -8,12 +8,12 @@ Create Date: 2016-10-11 09:24:45.669018
 
 # revision identifiers, used by Alembic.
 from datetime import datetime
+from alembic import op
 
 revision = '0057_change_email_template'
 down_revision = '0056_minor_updates'
 
-from alembic import op
-user_id= '6af522d0-2915-4e52-83a3-3690455a5fe6'
+user_id = '6af522d0-2915-4e52-83a3-3690455a5fe6'
 service_id = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'
 template_id = 'eb4d9930-87ab-4aef-9bce-786762687884'
 
@@ -49,7 +49,19 @@ def upgrade():
                                       service_id,
                                       template_name, user_id))
 
+# If you are copying this migration, please remember about an insert to TemplateRedacted,
+# which was not originally included here either by mistake or because it was before TemplateRedacted existed
+    # op.execute(
+    #     """
+    #         INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
+    #         VALUES ('{}', '{}', '{}', '{}')
+    #         ;
+    #     """.format(template_id, False, datetime.utcnow(), user_id)
+    # )
+
 
 def downgrade():
-   op.execute("delete from templates_history where id = '{}'".format(template_id))
-   op.execute("delete from templates where id = '{}'".format(template_id))
+    op.execute("DELETE FROM notifications WHERE template_id = '{}'".format(template_id))
+    op.execute("DELETE FROM notification_history WHERE template_id = '{}'".format(template_id))
+    op.execute("delete from templates_history where id = '{}'".format(template_id))
+    op.execute("delete from templates where id = '{}'".format(template_id))

--- a/migrations/versions/0082_add_golive_template.py
+++ b/migrations/versions/0082_add_golive_template.py
@@ -113,7 +113,19 @@ GOV.UK Notify team
         )
     )
 
+# If you are copying this migration, please remember about an insert to TemplateRedacted,
+# which was not originally included here either by mistake or because it was before TemplateRedacted existed
+    # op.execute(
+    #     """
+    #         INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
+    #         VALUES ('{}', '{}', '{}', '{}')
+    #         ;
+    #     """.format(template_id, False, datetime.utcnow(), current_app.config['NOTIFY_USER_ID'])
+    # )
+
 
 def downgrade():
-   op.execute("DELETE FROM templates_history WHERE id = '{}'".format(template_id))
-   op.execute("DELETE FROM templates WHERE id = '{}'".format(template_id))
+    op.execute("DELETE FROM notifications WHERE template_id = '{}'".format(template_id))
+    op.execute("DELETE FROM notification_history WHERE template_id = '{}'".format(template_id))
+    op.execute("DELETE FROM templates_history WHERE id = '{}'".format(template_id))
+    op.execute("DELETE FROM templates WHERE id = '{}'".format(template_id))

--- a/migrations/versions/0134_add_email_2fa_template_.py
+++ b/migrations/versions/0134_add_email_2fa_template_.py
@@ -65,7 +65,20 @@ def upgrade():
         )
     )
 
+# If you are copying this migration, please remember about an insert to TemplateRedacted,
+# which was not originally included here either by mistake or because it was before TemplateRedacted existed
+    # op.execute(
+    #     """
+    #         INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
+    #         VALUES ('{}', '{}', '{}', '{}')
+    #         ;
+    #     """.format(template_id, False, datetime.utcnow(), current_app.config['NOTIFY_USER_ID'])
+    # )
+
 
 def downgrade():
-   op.execute("DELETE FROM templates_history WHERE id = '{}'".format(template_id))
-   op.execute("DELETE FROM templates WHERE id = '{}'".format(template_id))
+    op.execute("DELETE FROM notifications WHERE template_id = '{}'".format(template_id))
+    op.execute("DELETE FROM notification_history WHERE template_id = '{}'".format(template_id))
+    op.execute("DELETE FROM templates_history WHERE id = '{}'".format(template_id))
+    op.execute("DELETE FROM templates WHERE id = '{}'".format(template_id))
+    op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(template_id))

--- a/migrations/versions/0134_add_email_2fa_template_.py
+++ b/migrations/versions/0134_add_email_2fa_template_.py
@@ -79,6 +79,6 @@ def upgrade():
 def downgrade():
     op.execute("DELETE FROM notifications WHERE template_id = '{}'".format(template_id))
     op.execute("DELETE FROM notification_history WHERE template_id = '{}'".format(template_id))
+    op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(template_id))
     op.execute("DELETE FROM templates_history WHERE id = '{}'".format(template_id))
     op.execute("DELETE FROM templates WHERE id = '{}'".format(template_id))
-    op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(template_id))

--- a/migrations/versions/0171_add_org_invite_template.py
+++ b/migrations/versions/0171_add_org_invite_template.py
@@ -89,7 +89,7 @@ def upgrade():
 def downgrade():
     op.execute("DELETE FROM notifications WHERE template_id = '{}'".format(template_id))
     op.execute("DELETE FROM notification_history WHERE template_id = '{}'".format(template_id))
+    op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(template_id))
     op.execute("DELETE FROM templates_history WHERE id = '{}'".format(template_id))
     op.execute("DELETE FROM templates WHERE id = '{}'".format(template_id))
-    op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(template_id))
     op.create_unique_constraint('organisation_to_service_service_id_organisation_id_key', 'organisation_to_service', ['service_id', 'organisation_id'])

--- a/migrations/versions/0265_add_confirm_edit_templates.py
+++ b/migrations/versions/0265_add_confirm_edit_templates.py
@@ -108,10 +108,34 @@ def upgrade():
         )
     )
 
+# If you are copying this migration, please remember about an insert to TemplateRedacted,
+# which was not originally included here either by mistake or because it was before TemplateRedacted existed
+    # op.execute(
+    #     """
+    #         INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
+    #         VALUES ('{}', '{}', '{}', '{}')
+    #         ;
+    #     """.format(email_template_id, False, datetime.utcnow(), current_app.config['NOTIFY_USER_ID'])
+    # )
+
+    # op.execute(
+    #     """
+    #         INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
+    #         VALUES ('{}', '{}', '{}', '{}')
+    #         ;
+    #     """.format(mobile_template_id, False, datetime.utcnow(), current_app.config['NOTIFY_USER_ID'])
+    # )
+
 
 def downgrade():
+    op.execute("DELETE FROM notifications WHERE template_id = '{}'".format(email_template_id))
+    op.execute("DELETE FROM notification_history WHERE template_id = '{}'".format(email_template_id))
     op.execute("DELETE FROM templates_history WHERE id = '{}'".format(email_template_id))
     op.execute("DELETE FROM templates WHERE id = '{}'".format(email_template_id))
+    op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(email_template_id))
 
+    op.execute("DELETE FROM notifications WHERE template_id = '{}'".format(mobile_template_id))
+    op.execute("DELETE FROM notification_history WHERE template_id = '{}'".format(mobile_template_id))
     op.execute("DELETE FROM templates_history WHERE id = '{}'".format(mobile_template_id))
     op.execute("DELETE FROM templates WHERE id = '{}'".format(mobile_template_id))
+    op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(mobile_template_id))

--- a/migrations/versions/0265_add_confirm_edit_templates.py
+++ b/migrations/versions/0265_add_confirm_edit_templates.py
@@ -130,12 +130,12 @@ def upgrade():
 def downgrade():
     op.execute("DELETE FROM notifications WHERE template_id = '{}'".format(email_template_id))
     op.execute("DELETE FROM notification_history WHERE template_id = '{}'".format(email_template_id))
+    op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(email_template_id))
     op.execute("DELETE FROM templates_history WHERE id = '{}'".format(email_template_id))
     op.execute("DELETE FROM templates WHERE id = '{}'".format(email_template_id))
-    op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(email_template_id))
 
     op.execute("DELETE FROM notifications WHERE template_id = '{}'".format(mobile_template_id))
     op.execute("DELETE FROM notification_history WHERE template_id = '{}'".format(mobile_template_id))
+    op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(mobile_template_id))
     op.execute("DELETE FROM templates_history WHERE id = '{}'".format(mobile_template_id))
     op.execute("DELETE FROM templates WHERE id = '{}'".format(mobile_template_id))
-    op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(mobile_template_id))

--- a/migrations/versions/0294_add_verify_reply_to_.py
+++ b/migrations/versions/0294_add_verify_reply_to_.py
@@ -90,6 +90,6 @@ def upgrade():
 def downgrade():
     op.execute("DELETE FROM notifications WHERE template_id = '{}'".format(email_template_id))
     op.execute("DELETE FROM notification_history WHERE template_id = '{}'".format(email_template_id))
-    op.execute("DELETE FROM templates WHERE id = '{}'".format(email_template_id))
-    op.execute("DELETE FROM templates_history WHERE id = '{}'".format(email_template_id))
     op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(email_template_id))
+    op.execute("DELETE FROM templates_history WHERE id = '{}'".format(email_template_id))
+    op.execute("DELETE FROM templates WHERE id = '{}'".format(email_template_id))

--- a/migrations/versions/0294_add_verify_reply_to_.py
+++ b/migrations/versions/0294_add_verify_reply_to_.py
@@ -76,9 +76,20 @@ def upgrade():
         )
     )
 
+# If you are copying this migration, please remember about an insert to TemplateRedacted,
+# which was not originally included here either by mistake or because it was before TemplateRedacted existed
+    # op.execute(
+    #     """
+    #         INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
+    #         VALUES ('{}', '{}', '{}', '{}')
+    #         ;
+    #     """.format(email_template_id, False, datetime.utcnow(), current_app.config['NOTIFY_USER_ID'])
+    # )
+
 
 def downgrade():
     op.execute("DELETE FROM notifications WHERE template_id = '{}'".format(email_template_id))
     op.execute("DELETE FROM notification_history WHERE template_id = '{}'".format(email_template_id))
     op.execute("DELETE FROM templates WHERE id = '{}'".format(email_template_id))
     op.execute("DELETE FROM templates_history WHERE id = '{}'".format(email_template_id))
+    op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(email_template_id))

--- a/migrations/versions/0296_template_redacted_fix.py
+++ b/migrations/versions/0296_template_redacted_fix.py
@@ -21,6 +21,32 @@ def upgrade():
         ;
     """)
 
+    op.execute("""
+        create or replace function insert_redacted()
+            returns trigger AS
+        $$
+        BEGIN
+            INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
+            SELECT templates.id, FALSE, now(), templates.created_by_id
+            FROM templates
+            WHERE templates.id NOT IN (SELECT template_id FROM template_redacted WHERE template_id = templates.id);
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+    """)
+
+    op.execute("""
+        CREATE TRIGGER insert_template_redacted AFTER INSERT ON templates
+        FOR EACH ROW
+        EXECUTE PROCEDURE insert_redacted();
+    """)
+
 
 def downgrade():
-    pass
+    op.execute("""
+        drop trigger insert_template_redacted ON templates
+    """)
+
+    op.execute("""
+        drop function insert_redacted();
+    """)

--- a/migrations/versions/0296_template_redacted_fix.py
+++ b/migrations/versions/0296_template_redacted_fix.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: 0296_template_redacted_fix
+Revises: 0295_api_key_constraint
+Create Date: 2019-06-07 17:02:14.350064
+
+"""
+from alembic import op
+
+
+revision = '0296_template_redacted_fix'
+down_revision = '0295_api_key_constraint'
+
+
+def upgrade():
+    op.execute("""
+        INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
+        SELECT templates.id, FALSE, now(), templates.created_by_id
+        FROM templates
+        WHERE templates.id NOT IN (SELECT template_id FROM template_redacted WHERE template_id = templates.id)
+        ;
+    """)
+
+
+def downgrade():
+    pass

--- a/migrations/versions/0297_template_redacted_fix.py
+++ b/migrations/versions/0297_template_redacted_fix.py
@@ -21,32 +21,6 @@ def upgrade():
         ;
     """)
 
-    op.execute("""
-        create or replace function insert_redacted()
-            returns trigger AS
-        $$
-        BEGIN
-            INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
-            SELECT templates.id, FALSE, now(), templates.created_by_id
-            FROM templates
-            WHERE templates.id NOT IN (SELECT template_id FROM template_redacted WHERE template_id = templates.id);
-            RETURN NEW;
-        END;
-        $$ LANGUAGE plpgsql;
-    """)
-
-    op.execute("""
-        CREATE TRIGGER insert_template_redacted AFTER INSERT ON templates
-        FOR EACH ROW
-        EXECUTE PROCEDURE insert_redacted();
-    """)
-
 
 def downgrade():
-    op.execute("""
-        drop trigger insert_template_redacted ON templates
-    """)
-
-    op.execute("""
-        drop function insert_redacted();
-    """)
+    pass

--- a/migrations/versions/0297_template_redacted_fix.py
+++ b/migrations/versions/0297_template_redacted_fix.py
@@ -1,15 +1,15 @@
 """
 
-Revision ID: 0296_template_redacted_fix
-Revises: 0295_api_key_constraint
-Create Date: 2019-06-07 17:02:14.350064
+Revision ID: 0297_template_redacted_fix
+Revises: 0296_agreement_signed_by_person
+Create Date: 2019-06-25 17:02:14.350064
 
 """
 from alembic import op
 
 
-revision = '0296_template_redacted_fix'
-down_revision = '0295_api_key_constraint'
+revision = '0297_template_redacted_fix'
+down_revision = '0296_agreement_signed_by_person'
 
 
 def upgrade():


### PR DESCRIPTION
- Create template_redacted rows for templates created by migration, so that we can edit those templates

- Add commented out code to past migrations so when somebody is copying those migrations they remember about template_redacted insert

- Add missing statements to downgrades for past migrations