### PR TITLE
Return all required information about a user’s organisations and services

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -367,6 +367,13 @@ class Organisation(db.Model):
         nullable=True,
     )
 
+    @property
+    def live_services(self):
+        return [
+            service for service in self.services
+            if service.active and not service.restricted
+        ]
+
     def serialize(self):
         return {
             "id": str(self.id),
@@ -384,6 +391,7 @@ class Organisation(db.Model):
                 domain.domain for domain in self.domains
             ],
             "request_to_go_live_notes": self.request_to_go_live_notes,
+            "count_of_live_services": len(self.live_services),
         }
 
 

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -515,7 +515,11 @@ def get_orgs_and_services(user):
                     }
                     for service in org.services
                     if service.active and service in user.services
-                ]
+                ],
+                'count_of_live_services': len([
+                    service for service in org.services
+                    if service.active and not service.restricted
+                ]),
             }
             for org in user.organisations if org.active
         ],
@@ -534,5 +538,14 @@ def get_orgs_and_services(user):
                     service.organisation not in user.organisations
                 )
             )
+        ],
+        'services': [
+            {
+                'id': service.id,
+                'name': service.name,
+                'restricted': service.restricted,
+                'organisation': service.organisation.id if service.organisation else None,
+            }
+            for service in user.services if service.active
         ]
     }

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -516,10 +516,7 @@ def get_orgs_and_services(user):
                     for service in org.services
                     if service.active and service in user.services
                 ],
-                'count_of_live_services': len([
-                    service for service in org.services
-                    if service.active and not service.restricted
-                ]),
+                'count_of_live_services': len(org.live_services),
             }
             for org in user.organisations if org.active
         ],

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -26,8 +26,10 @@ def test_get_all_organisations(admin_request, notify_db_session):
     assert len(response) == 2
     assert response[0]['name'] == 'active org'
     assert response[0]['active'] is True
+    assert response[0]['count_of_live_services'] == 0
     assert response[1]['name'] == 'inactive org'
     assert response[1]['active'] is False
+    assert response[1]['count_of_live_services'] == 0
 
 
 def test_get_organisation_by_id(admin_request, notify_db_session):
@@ -53,6 +55,7 @@ def test_get_organisation_by_id(admin_request, notify_db_session):
         'email_branding_id',
         'domains',
         'request_to_go_live_notes',
+        'count_of_live_services',
     }
     assert response['id'] == str(org.id)
     assert response['name'] == 'test_org_1'
@@ -66,6 +69,7 @@ def test_get_organisation_by_id(admin_request, notify_db_session):
     assert response['email_branding_id'] is None
     assert response['domains'] == []
     assert response['request_to_go_live_notes'] is None
+    assert response['count_of_live_services'] == 0
 
 
 def test_get_organisation_by_id_returns_domains(admin_request, notify_db_session):


### PR DESCRIPTION
The admin app now needs to know a few extra things about organisations and services in order to list them. At the moment it does this by making multiple API calls. See https://github.com/alphagov/notifications-admin/pull/3008 for more details.

This commit adds extra fields to the existing response. Once the admin app is using this fields we’ll be able to remove:
- `reponse['services_without_organisations']`
- `reponse['organisations']['services']`