### PR TITLE
Add columns for on whose behalf agreement signed

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -344,6 +344,8 @@ class Organisation(db.Model):
         db.ForeignKey('users.id'),
         nullable=True,
     )
+    agreement_signed_on_behalf_of_name = db.Column(db.String(255), nullable=True)
+    agreement_signed_on_behalf_of_email_address = db.Column(db.String(255), nullable=True)
     agreement_signed_version = db.Column(db.Float, nullable=True)
     crown = db.Column(db.Boolean, nullable=True)
     organisation_type = db.Column(db.String(255), nullable=True)
@@ -386,6 +388,8 @@ class Organisation(db.Model):
             "agreement_signed": self.agreement_signed,
             "agreement_signed_at": self.agreement_signed_at,
             "agreement_signed_by_id": self.agreement_signed_by_id,
+            "agreement_signed_on_behalf_of_name": self.agreement_signed_on_behalf_of_name,
+            "agreement_signed_on_behalf_of_email_address": self.agreement_signed_on_behalf_of_email_address,
             "agreement_signed_version": self.agreement_signed_version,
             "domains": [
                 domain.domain for domain in self.domains

--- a/migrations/versions/0296_agreement_signed_by_person.py
+++ b/migrations/versions/0296_agreement_signed_by_person.py
@@ -1,0 +1,22 @@
+"""
+
+Revision ID: 0296_agreement_signed_by_person
+Revises: 0295_api_key_constraint
+Create Date: 2019-06-13 16:40:32.982607
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0296_agreement_signed_by_person'
+down_revision = '0295_api_key_constraint'
+
+
+def upgrade():
+    op.add_column('organisation', sa.Column('agreement_signed_on_behalf_of_email_address', sa.String(length=255), nullable=True))
+    op.add_column('organisation', sa.Column('agreement_signed_on_behalf_of_name', sa.String(length=255), nullable=True))
+
+
+def downgrade():
+    op.drop_column('organisation', 'agreement_signed_on_behalf_of_name')
+    op.drop_column('organisation', 'agreement_signed_on_behalf_of_email_address')

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -51,6 +51,8 @@ def test_get_organisation_by_id(admin_request, notify_db_session):
         'agreement_signed_at',
         'agreement_signed_by_id',
         'agreement_signed_version',
+        'agreement_signed_on_behalf_of_name',
+        'agreement_signed_on_behalf_of_email_address',
         'letter_branding_id',
         'email_branding_id',
         'domains',
@@ -70,6 +72,8 @@ def test_get_organisation_by_id(admin_request, notify_db_session):
     assert response['domains'] == []
     assert response['request_to_go_live_notes'] is None
     assert response['count_of_live_services'] == 0
+    assert response['agreement_signed_on_behalf_of_name'] is None
+    assert response['agreement_signed_on_behalf_of_email_address'] is None
 
 
 def test_get_organisation_by_id_returns_domains(admin_request, notify_db_session):
@@ -197,6 +201,8 @@ def test_post_update_organisation_updates_fields(
         'active': False,
         'agreement_signed': agreement_signed,
         'crown': crown,
+        'agreement_signed_on_behalf_of_name': 'Firstname Lastname',
+        'agreement_signed_on_behalf_of_email_address': 'test@example.com',
     }
     assert org.agreement_signed is None
     assert org.crown is None
@@ -217,6 +223,8 @@ def test_post_update_organisation_updates_fields(
     assert organisation[0].agreement_signed == agreement_signed
     assert organisation[0].crown == crown
     assert organisation[0].domains == []
+    assert organisation[0].agreement_signed_on_behalf_of_name == 'Firstname Lastname'
+    assert organisation[0].agreement_signed_on_behalf_of_email_address == 'test@example.com'
 
 
 @pytest.mark.parametrize('domain_list', (


### PR DESCRIPTION
This is changing because we’re going to introduce accepting contracts and MoUs online.

https://www.pivotaltracker.com/story/show/166497058

Previously
---
We had one column for who signed the agreement, which is foreign key’d to the user table. This is still relevant, because there will always be a user who is clicking the button.

Now
---
We add two new fields for the name and email address of the person on whose behalf the agreement is being accepted. This person:
- is different from the one signing the agreement
- won’t necessarily have a Notify account
- is optional – sometimes the person signing the agreement is doing so on their own behalf