### PR TITLE
Cancel letter job

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -170,20 +170,20 @@ def dao_cancel_letter_job(job):
 def can_letter_job_be_cancelled(job):
     template = dao_get_template_by_id(job.template_id)
     if template.template_type != LETTER_TYPE:
-        return "Only letter jobs can be cancelled through this endpoint. This is not a letter job."
+        return False, "Only letter jobs can be cancelled through this endpoint. This is not a letter job."
 
     notifications = Notification.query.filter(
         Notification.job_id == job.id
     ).all()
     count_notifications = len(notifications)
     if job.job_status != JOB_STATUS_FINISHED or count_notifications != job.notification_count:
-        return "This job is still being processed. Wait a couple of minutes and try again."
+        return False, "This job is still being processed. Wait a couple of minutes and try again."
     count_cancellable_notifications = len([
         n for n in notifications if n.status in CANCELLABLE_JOB_LETTER_STATUSES
     ])
     if count_cancellable_notifications != job.notification_count or not letter_can_be_cancelled(
         NOTIFICATION_CREATED, job.created_at
     ):
-        return "Sorry, it's too late, letters have already been sent."
+        return False, "Sorry, it's too late, letters have already been sent."
 
-    return True
+    return True, None

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -66,12 +66,12 @@ def cancel_job(service_id, job_id):
 @job_blueprint.route('/<job_id>/cancel-letter-job', methods=['POST'])
 def cancel_letter_job(service_id, job_id):
     job = dao_get_job_by_service_id_and_job_id(service_id, job_id)
-    can_we_cancel = can_letter_job_be_cancelled(job)
-    if can_we_cancel is True:
+    can_we_cancel, errors = can_letter_job_be_cancelled(job)
+    if can_we_cancel:
         data = dao_cancel_letter_job(job)
         return jsonify(data), 200
     else:
-        return jsonify(message=can_we_cancel), 400
+        return jsonify(message=errors), 400
 
 
 @job_blueprint.route('/<job_id>/notifications', methods=['GET'])

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -15,7 +15,7 @@ from app.dao.jobs_dao import (
     dao_get_future_scheduled_job_by_id_and_service_id,
     dao_get_notification_outcomes_for_job,
     dao_cancel_letter_job,
-    can_cancel_letter_job
+    can_letter_job_be_cancelled
 )
 from app.dao.fact_notification_status_dao import fetch_notification_statuses_for_job
 from app.dao.services_dao import dao_fetch_service_by_id
@@ -63,17 +63,15 @@ def cancel_job(service_id, job_id):
     return get_job_by_service_and_job_id(service_id, job_id)
 
 
-@job_blueprint.route('/<job_id>/cancel-letter-job')
+@job_blueprint.route('/<job_id>/cancel-letter-job', methods=['POST'])
 def cancel_letter_job(service_id, job_id):
     job = dao_get_job_by_service_id_and_job_id(service_id, job_id)
-    if can_cancel_letter_job(job):
-        dao_cancel_letter_job(job)
-        return jsonify(), 201
+    can_we_cancel = can_letter_job_be_cancelled(job)
+    if can_we_cancel is True:
+        data = dao_cancel_letter_job(job)
+        return jsonify(data), 200
     else:
-        # reasons the letter can't be cancelled:
-        # letters are not yet saved to db  --> can still cancel but later
-        # it's too late
-        return jsonify("CHANGE ME: some error to say the job can't be cancelled"), 400
+        return jsonify(message=can_we_cancel), 400
 
 
 @job_blueprint.route('/<job_id>/notifications', methods=['GET'])

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -5,6 +5,7 @@ from flask import (
     request,
     current_app
 )
+from notifications_utils.letter_timings import letter_can_be_cancelled
 
 from app.aws.s3 import get_job_metadata_from_s3
 from app.dao.jobs_dao import (
@@ -13,7 +14,8 @@ from app.dao.jobs_dao import (
     dao_get_job_by_service_id_and_job_id,
     dao_get_jobs_by_service_id,
     dao_get_future_scheduled_job_by_id_and_service_id,
-    dao_get_notification_outcomes_for_job)
+    dao_get_notification_outcomes_for_job, dao_cancel_letter_job
+)
 from app.dao.fact_notification_status_dao import fetch_notification_statuses_for_job
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.templates_dao import dao_get_template_by_id

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,6 +29,6 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@33.0.0#egg=notifications-utils==33.0.0
+git+https://github.com/alphagov/notifications-utils.git@33.1.0#egg=notifications-utils==33.1.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,21 +31,21 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@33.0.0#egg=notifications-utils==33.0.0
+git+https://github.com/alphagov/notifications-utils.git@33.1.0#egg=notifications-utils==33.1.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
 ## The following requirements were added by pip freeze:
-alembic==1.0.10
+alembic==1.0.11
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.1.0
-awscli==1.16.185
+awscli==1.16.188
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.175
+botocore==1.12.178
 certifi==2019.6.16
 chardet==3.0.4
 Click==7.0

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -6,14 +6,16 @@ import pytest
 from freezegun import freeze_time
 
 from app.dao.jobs_dao import (
-    dao_get_job_by_service_id_and_job_id,
+    can_letter_job_be_cancelled,
+    dao_cancel_letter_job,
     dao_create_job,
-    dao_update_job,
-    dao_get_jobs_by_service_id,
-    dao_set_scheduled_jobs_to_pending,
     dao_get_future_scheduled_job_by_id_and_service_id,
+    dao_get_job_by_service_id_and_job_id,
+    dao_get_jobs_by_service_id,
+    dao_get_jobs_older_than_data_retention,
     dao_get_notification_outcomes_for_job,
-    dao_get_jobs_older_than_data_retention
+    dao_set_scheduled_jobs_to_pending,
+    dao_update_job,
 )
 from app.models import (
     Job,
@@ -308,3 +310,84 @@ def assert_job_stat(job, result, sent, delivered, failed):
     assert result.sent == sent
     assert result.delivered == delivered
     assert result.failed == failed
+
+
+@freeze_time('2019-06-13 13:00')
+def test_dao_cancel_letter_job_cancels_job_and_returns_number_of_cancelled_notifications(
+    sample_letter_template, admin_request
+):
+    job = create_job(template=sample_letter_template, notification_count=1, job_status='finished')
+    notification = create_notification(template=job.template, job=job, status='created')
+    result = dao_cancel_letter_job(job)
+    assert result == 1
+    assert notification.status == 'cancelled'
+    assert job.job_status == 'cancelled'
+
+
+@freeze_time('2019-06-13 13:00')
+def test_can_letter_job_be_cancelled_returns_true_if_job_can_be_cancelled(sample_letter_template, admin_request):
+    job = create_job(template=sample_letter_template, notification_count=1, job_status='finished')
+    create_notification(template=job.template, job=job, status='created')
+    result, errors = can_letter_job_be_cancelled(job)
+    assert result
+    assert not errors
+
+
+@freeze_time('2019-06-13 13:00')
+def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_notification_status_sending(
+    sample_letter_template, admin_request
+):
+    job = create_job(template=sample_letter_template, notification_count=2, job_status='finished')
+    create_notification(template=job.template, job=job, status='sending')
+    create_notification(template=job.template, job=job, status='created')
+    result, errors = can_letter_job_be_cancelled(job)
+    assert not result
+    assert errors == "Sorry, it's too late, letters have already been sent."
+
+
+def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_letters_already_sent_to_dvla(
+    sample_letter_template, admin_request
+):
+    with freeze_time('2019-06-13 13:00'):
+        job = create_job(template=sample_letter_template, notification_count=1, job_status='finished')
+        letter = create_notification(template=job.template, job=job, status='created')
+
+    with freeze_time('2019-06-13 17:32'):
+        result, errors = can_letter_job_be_cancelled(job)
+    assert not result
+    assert errors == "Sorry, it's too late, letters have already been sent."
+    assert letter.status == 'created'
+    assert job.job_status == 'finished'
+
+
+@freeze_time('2019-06-13 13:00')
+def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_not_a_letter_job(
+    sample_template, admin_request
+):
+    job = create_job(template=sample_template, notification_count=1, job_status='finished')
+    create_notification(template=job.template, job=job, status='created')
+    result, errors = can_letter_job_be_cancelled(job)
+    assert not result
+    assert errors == "Only letter jobs can be cancelled through this endpoint. This is not a letter job."
+
+
+@freeze_time('2019-06-13 13:00')
+def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_job_not_finished(
+    sample_letter_template, admin_request
+):
+    job = create_job(template=sample_letter_template, notification_count=1, job_status="in progress")
+    create_notification(template=job.template, job=job, status='created')
+    result, errors = can_letter_job_be_cancelled(job)
+    assert not result
+    assert errors == "This job is still being processed. Wait a couple of minutes and try again."
+
+
+@freeze_time('2019-06-13 13:00')
+def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_notifications_not_in_db_yet(
+    sample_letter_template, admin_request
+):
+    job = create_job(template=sample_letter_template, notification_count=2, job_status='finished')
+    create_notification(template=job.template, job=job, status='created')
+    result, errors = can_letter_job_be_cancelled(job)
+    assert not result
+    assert errors == "This job is still being processed. Wait a couple of minutes and try again."

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -311,15 +311,24 @@ def assert_job_stat(job, result, sent, delivered, failed):
     assert result.failed == failed
 
 
-def test_dao_cancel_letter_job_does_not_allow_cancel_if_notification_in_sending(sample_job):
-    create_notification(template=sample_job.template, job=sample_job, status='sending')
-    create_notification(template=sample_job.template, job=sample_job, status='created')
-    assert not dao_cancel_letter_job(service_id=sample_job.service_id, job_id=sample_job.id)
+def test_dao_cancel_letter_job_does_not_allow_cancel_if_notification_in_sending(sample_letter_template):
+    job = create_job(template=sample_letter_template, notification_count=2)
+    create_notification(template=job.template, job=job, status='sending')
+    create_notification(template=job.template, job=job, status='created')
+    assert not dao_cancel_letter_job(job)
 
 
 def test_dao_cancel_letter_job_updates_notifications_and_job_to_cancelled(sample_job):
     notification = create_notification(template=sample_job.template, job=sample_job, status='created')
-    assert dao_cancel_letter_job(service_id=sample_job.service_id, job_id=sample_job.id) == 1
+    assert dao_cancel_letter_job(sample_job) == 1
     assert notification.status == 'cancelled'
     assert sample_job.job_status == 'cancelled'
+
+
+def test_dao_cancel_letter_job_returns_false_if_too_late():
+    pass
+
+
+def test_dao_cancel_letter_returns_false_if_not_a_letter_job():
+    pass
 

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -86,7 +86,9 @@ def test_dao_cancel_letter_job_updates_notifications_and_job_to_cancelled(sample
 
 
 @freeze_time('2019-06-13 13:00')
-def test_dao_cancel_letter_job_does_not_allow_cancel_if_notification_in_sending(sample_letter_template, admin_request):
+def test_dao_cancel_letter_job_does_not_allow_cancel_if_notification_status_sending(
+    sample_letter_template, admin_request
+):
     job = create_job(template=sample_letter_template, notification_count=2, job_status='finished')
     letter_1 = create_notification(template=job.template, job=job, status='sending')
     letter_2 = create_notification(template=job.template, job=job, status='created')
@@ -96,7 +98,7 @@ def test_dao_cancel_letter_job_does_not_allow_cancel_if_notification_in_sending(
         job_id=job.id,
         _expected_status=400
     )
-    assert response == "This job is still being processed. Wait a couple of minutes and try again."
+    assert response["message"] == "Sorry, it's too late, letters have already been sent."
     assert letter_1.status == 'sending'
     assert letter_2.status == 'created'
     assert job.job_status == 'finished'
@@ -116,7 +118,7 @@ def test_dao_cancel_letter_job_does_not_allow_cancel_if_letters_already_sent_to_
             job_id=job.id,
             _expected_status=400
         )
-    assert response == "Sorry, it's too late, letters have already been sent."
+    assert response["message"] == "Sorry, it's too late, letters have already been sent."
     assert letter.status == 'created'
     assert job.job_status == 'finished'
 
@@ -131,7 +133,7 @@ def test_dao_cancel_letter_job_does_not_allow_cancel_if_not_a_letter_job(sample_
         job_id=job.id,
         _expected_status=400
     )
-    assert response == "Only letter jobs can be cancelled through this endpoint. This is not a letter job."
+    assert response["message"] == "Only letter jobs can be cancelled through this endpoint. This is not a letter job."
     assert notification.status == 'created'
     assert job.job_status == 'finished'
 
@@ -146,7 +148,7 @@ def test_dao_cancel_letter_job_does_not_allow_cancel_if_job_not_finished(sample_
         job_id=job.id,
         _expected_status=400
     )
-    assert response == "This job is still being processed. Wait a couple of minutes and try again."
+    assert response["message"] == "This job is still being processed. Wait a couple of minutes and try again."
     assert letter.status == 'created'
     assert job.job_status == 'in progress'
 
@@ -163,7 +165,7 @@ def test_dao_cancel_letter_job_does_not_allow_cancel_if_notifications_not_in_db_
         job_id=job.id,
         _expected_status=400
     )
-    assert response == "This job is still being processed. Wait a couple of minutes and try again."
+    assert response["message"] == "This job is still being processed. Wait a couple of minutes and try again."
     assert letter.status == 'created'
     assert job.job_status == 'finished'
 


### PR DESCRIPTION
In this PR:
- create a rest endpoint cancel_letter_job
- check if letter job can be cancelled
- if yes, cancel letter job and return how many notifications have been cancelled
- if not, return a 'forbidden' error and a message explaining why the letter job can't be cancelled

Others in this series :)
utils: https://github.com/alphagov/notifications-utils/pull/621
admin: https://github.com/alphagov/notifications-admin/pull/3026