### PR TITLE
Bump utils to add alt text to email branding

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -181,7 +181,8 @@ def get_html_email_options(service):
         'brand_banner': service.email_branding.brand_type == BRANDING_ORG_BANNER,
         'brand_colour': service.email_branding.colour,
         'brand_logo': logo_url,
-        'brand_name': service.email_branding.text,
+        'brand_text': service.email_branding.text,
+        'brand_name': service.email_branding.name,
     }
 
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,6 +29,6 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@32.0.1#egg=notifications-utils==32.0.1
+git+https://github.com/alphagov/notifications-utils.git@33.0.0#egg=notifications-utils==33.0.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@32.0.1#egg=notifications-utils==32.0.1
+git+https://github.com/alphagov/notifications-utils.git@33.0.0#egg=notifications-utils==33.0.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
@@ -40,13 +40,13 @@ alembic==1.0.10
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.1.0
-awscli==1.16.169
-bcrypt==3.1.6
+awscli==1.16.185
+bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.159
-certifi==2019.3.9
+botocore==1.12.175
+certifi==2019.6.16
 chardet==3.0.4
 Click==7.0
 colorama==0.3.9
@@ -59,7 +59,7 @@ idna==2.8
 Jinja2==2.10.1
 jmespath==0.9.4
 kombu==3.0.37
-Mako==1.0.11
+Mako==1.0.12
 MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5
@@ -73,11 +73,11 @@ python-dateutil==2.8.0
 python-editor==1.0.4
 python-json-logger==0.1.11
 pytz==2019.1
-PyYAML==3.13
+PyYAML==4.2b1
 redis==3.2.1
 requests==2.22.0
 rsa==3.4.2
-s3transfer==0.2.0
+s3transfer==0.2.1
 six==1.12.0
 smartypants==2.0.1
 statsd==3.3.0

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -387,6 +387,7 @@ def test_get_html_email_renderer_should_return_for_normal_service(sample_service
     assert options['govuk_banner'] is True
     assert 'brand_colour' not in options.keys()
     assert 'brand_logo' not in options.keys()
+    assert 'brand_text' not in options.keys()
     assert 'brand_name' not in options.keys()
 
 
@@ -412,7 +413,8 @@ def test_get_html_email_renderer_with_branding_details(branding_type, govuk_bann
 
     assert options['govuk_banner'] == govuk_banner
     assert options['brand_colour'] == '#000000'
-    assert options['brand_name'] == 'League of Justice'
+    assert options['brand_text'] == 'League of Justice'
+    assert options['brand_name'] == 'Justice League'
 
     if branding_type == BRANDING_ORG_BANNER:
         assert options['brand_banner'] is True
@@ -470,8 +472,9 @@ def test_get_html_email_renderer_handles_email_branding_without_logo(notify_api)
     assert renderer['govuk_banner'] is False
     assert renderer['brand_banner'] is True
     assert renderer['brand_logo'] is None
-    assert renderer['brand_name'] == 'League of Justice'
+    assert renderer['brand_text'] == 'League of Justice'
     assert renderer['brand_colour'] == '#000000'
+    assert renderer['brand_name'] == 'Justice League'
 
 
 @pytest.mark.parametrize('base_url, expected_url', [


### PR DESCRIPTION
notifications-utils version 33.0.0 adds alt text to email branding - the `HTMLEmailTemplate` now initializes slightly differently as a result (with both `branding_name` and `branding_text`).

[Pivotal story](https://www.pivotaltracker.com/story/show/166089275)