### PR TITLE
Degrade MaxRetriesExceededError to warning status in logger

### DIFF
--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -96,7 +96,7 @@ def _send_data_to_service_callback_api(self, data, service_callback_url, token, 
             try:
                 self.retry(queue=QueueNames.RETRY)
             except self.MaxRetriesExceededError:
-                current_app.logger.error(
+                current_app.logger.warning(
                     "Retry: {} has retried the max num of times for callback url {} and notification_id: {}".format(
                         function_name,
                         service_callback_url,


### PR DESCRIPTION
This is because that error is caused by our providers and we
cannot do anything about it but it can make our logs hard to read
and actionable errors harder to spot