### PR TITLE
 Set org_type of a service when adding/updating org org type

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -293,7 +293,6 @@ class Config(object):
     }
     CELERY_QUEUES = []
 
-    NOTIFICATIONS_ALERT = 5  # five mins
     FROM_NUMBER = 'development'
 
     STATSD_HOST = os.getenv('STATSD_HOST')

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -79,14 +79,6 @@ def dao_create_notification(notification):
     db.session.add(notification)
 
 
-def _should_record_notification_in_history_table(notification):
-    if notification.api_key_id and notification.key_type == KEY_TYPE_TEST:
-        return False
-    if notification.service.research_mode:
-        return False
-    return True
-
-
 def _decide_permanent_temporary_failure(current_status, status):
     # Firetext will send pending, then send either succes or fail.
     # If we go from pending to delivered we need to set failure type as temporary-failure


### PR DESCRIPTION
The organisation_type of a service should match the organisation_type of the service's organisation (if there is one). This changes `dao_update_organisation` and `dao_add_service_to_organisation` to set the `organisation_type` of any services when adding / updating an org.

Also removes some unused fixtures and deletes some unused code.

Part of [this story](https://www.pivotaltracker.com/story/show/166293397)