### PR TITLE
Usage for all services

### DIFF
--- a/app/dao/date_util.py
+++ b/app/dao/date_util.py
@@ -61,3 +61,10 @@ def get_current_financial_year_start_year():
     if now < start_date:
         financial_year_start = financial_year_start - 1
     return financial_year_start
+
+
+def which_financial_year(start_date):
+    if start_date <= get_april_fools(int(start_date.strftime('%Y'))):
+        return int(start_date.strftime('%Y')) - 1
+    else:
+        return int(start_date.strftime('%Y'))

--- a/tests/app/billing/test_billing.py
+++ b/tests/app/billing/test_billing.py
@@ -408,7 +408,8 @@ def test_populate_free_sms_fragment_limit(notify_db_session):
     assert results[0].service_id == active_service.id
 
 
-def test_populate_free_sms_fragment_limit(notify_db_session):
+def test_populate_free_sms_fragment_limit_when_service_does_not_have_any_annual_billing(notify_db_session):
+    # This should be an unlikely/impossible error
     create_service(active=True)
     with pytest.raises(expected_exception=InvalidRequest):
         populate_free_sms_fragment_limit()

--- a/tests/app/dao/test_date_utils.py
+++ b/tests/app/dao/test_date_utils.py
@@ -2,7 +2,11 @@ from datetime import datetime
 
 import pytest
 
-from app.dao.date_util import get_financial_year, get_april_fools, get_month_start_and_end_date_in_utc
+from app.dao.date_util import (
+    get_financial_year,
+    get_april_fools,
+    get_month_start_and_end_date_in_utc,
+    which_financial_year)
 
 
 def test_get_financial_year():
@@ -29,3 +33,23 @@ def test_get_month_start_and_end_date_in_utc(month, year, expected_start, expect
     result = get_month_start_and_end_date_in_utc(month_year)
     assert result[0] == expected_start
     assert result[1] == expected_end
+
+
+@pytest.mark.parametrize("year, month, expected", [
+    (2019, 1, 2018),
+    (2019, 2, 2018),
+    (2019, 3, 2018),
+    (2019, 4, 2019),
+    (2019, 5, 2019),
+    (2019, 6, 2019),
+    (2019, 7, 2019),
+    (2019, 8, 2019),
+    (2019, 9, 2019),
+    (2019, 10, 2019),
+    (2019, 11, 2019),
+    (2019, 12, 2019),
+])
+def test_which_financial_year(year, month, expected):
+    answer = which_financial_year(datetime(year, month, 1))
+
+    assert answer == expected

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -482,16 +482,34 @@ def test_delete_billing_data(notify_db_session):
     )
 
 
-# def test_fetch_sms_free_allowance_remainder_with_remainder(notify_db_session):
-#     service = create_service(service_name='test thing')
-#     create_annual_billing(service_id=service.id, free_sms_fragment_limit=3, financial_year_start=2016)
-#     create_ft_billing(service=service, bst_date=datetime(2016, 4,20), notification_type='sms', billable_unit=2)
-#     results = fetch_sms_free_allowance_remainder(datetime(2016, 10, 1)).all()
-#
-#     assert results[0].billable_units == 2
-#     assert results[0].free_sms_fragment_limit == 3
-#
-#     assert results[0].sms_remainder == 1
+def test_fetch_sms_free_allowance_remainder_with_remainder(notify_db_session):
+    service = create_service(service_name='a test thing')
+    create_annual_billing(service_id=service.id, free_sms_fragment_limit=3, financial_year_start=2016)
+    create_ft_billing(service=service, bst_date=datetime(2016, 4,20), notification_type='sms', billable_unit=2)
+
+    service_2 = create_service(service_name='b second thing')
+    create_annual_billing(service_id=service_2.id, free_sms_fragment_limit=10, financial_year_start=2016)
+    create_ft_billing(service=service_2, bst_date=datetime(2016, 4, 20), notification_type='sms', billable_unit=4)
+    results = fetch_sms_free_allowance_remainder(datetime(2016, 10, 1)).all()
+
+    assert len(results) == 2
+    service_1_results = None
+    service_2_results = None
+
+    if results[0].service_id == service.id:
+        service_1_results == results[0]
+    else:
+        service_2_results == results[0]
+
+    if results[1].service_id == service.id:
+        service_1_results == results[1]
+    else:
+        service_2_results == results[1]
+
+    assert service_1_results.billable_units == 2
+    assert service_1_results.free_sms_fragment_limit == 3
+
+    assert service_1_results.sms_remainder == 1
 
 
 # def test_fetch_sms_free_allowance_remainder_with_negative_remainder_returns_zero(notify_db_session):
@@ -507,66 +525,93 @@ def test_delete_billing_data(notify_db_session):
 
 
 def test_fetch_billing_for_all_services_with_remainder(notify_db_session):
-    service = create_service(service_name='test thing')
+    service = create_service(service_name='has free allowance')
     org = create_organisation(name="Org for {}".format(service.name))
     dao_add_service_to_organisation(service=service, organisation_id=org.id)
     create_annual_billing(service_id=service.id, free_sms_fragment_limit=10, financial_year_start=2016)
-    create_ft_billing(service=service, bst_date=datetime(2016, 4, 20), notification_type='sms', billable_unit=2)
-    create_ft_billing(service=service, bst_date=datetime(2016, 5, 20), notification_type='sms', billable_unit=2)
+    create_ft_billing(service=service, bst_date=datetime(2016, 4, 20), notification_type='sms', billable_unit=2,
+                      rate=0.1)
+    create_ft_billing(service=service, bst_date=datetime(2016, 5, 20), notification_type='sms', billable_unit=2,
+                      rate=0.1)
+
+    service_2 = create_service(service_name='used free allowance')
+    org2 = create_organisation(name="Org for {}".format(service_2.name))
+    dao_add_service_to_organisation(service=service_2, organisation_id=org.id)
+    create_annual_billing(service_id=service_2.id, free_sms_fragment_limit=10, financial_year_start=2016)
+    create_ft_billing(service=service_2, bst_date=datetime(2016, 4, 20), notification_type='sms', billable_unit=12,
+                      rate=0.11)
+    create_ft_billing(service=service_2, bst_date=datetime(2016, 5, 20), notification_type='sms', billable_unit=3,
+                      rate=0.11)
     results = fetch_billing_for_all_services(datetime(2016, 5, 1), datetime(2016, 5, 31))
-    assert len(results) == 1
-
-
-def test_fetch_billing_for_all_services(notify_db_session):
-    set_up_quarterly_data()
-    set_up_quarterly_data(service_name='Second Service')
-
-    results = fetch_billing_for_all_services(datetime(2016, 4, 1), datetime(2016, 6, 30))
     print(results)
     assert len(results) == 2
 
-    assert results[0].organisation_name == 'Org for First service'
-    assert results[0].service_name == 'First service'
-    assert results[0].free_sms_fragment_limit == 25000
-    assert results[1].organisation_name == 'Org for Second Service'
-    assert results[1].service_name == 'Second Service'
-    assert results[1].free_sms_fragment_limit == 25000
+    assert results[0].organisation_id == org.id
+    assert results[0].service_id == service.id
+    assert results[0].sms_billable_units == 2
+    assert results[0].sms_remainder == 8
+    assert results[0].remainder_minus_billable_units == 0
+    assert results[0].sms_cost == 0
 
+    # assert results[1].organisation_id == org2.id
+    # assert results[1].service_id == service_2.id
+    # assert results[1].sms_billable_units == 3
+    # assert results[1].sms_remainder == 0
+    # assert results[1].remainder_minus_billable_units == 3
+    # assert results[1].sms_cost == 0.2
 
-def set_up_quarterly_data(service_name='First service'):
-    year = 2016
-    org = create_organisation(name="Org for {}".format(service_name))
-    service = create_service(service_name=service_name)
-    dao_add_service_to_organisation(service=service, organisation_id=org.id)
-    create_annual_billing(service_id=service.id, free_sms_fragment_limit=25000, financial_year_start=year)
-    sms_template = create_template(service=service, template_type="sms")
-    email_template = create_template(service=service, template_type="email")
-    letter_template = create_template(service=service, template_type="letter")
-    for month in range(4, 6):
-        mon = str(month).zfill(2)
-        for day in range(1, 3):
-            d = str(day).zfill(2)
-            create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
-                              service=service,
-                              template=sms_template,
-                              notification_type='sms',
-                              rate=0.162)
-            create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
-                              service=service,
-                              template=email_template,
-                              notification_type='email',
-                              rate=0)
-            create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
-                              service=service,
-                              template=letter_template,
-                              notification_type='letter',
-                              rate=0.33,
-                              postage='second')
-            create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
-                              service=service,
-                              template=letter_template,
-                              notification_type='letter',
-                              rate=0.30,
-                              billable_unit=2,
-                              postage='first')
-    return service
+#
+#
+# def test_fetch_billing_for_all_services(notify_db_session):
+#     set_up_quarterly_data()
+#     set_up_quarterly_data(service_name='Second Service')
+#
+#     results = fetch_billing_for_all_services(datetime(2016, 4, 1), datetime(2016, 6, 30))
+#     print(results)
+#     assert len(results) == 2
+#
+#     assert results[0].organisation_name == 'Org for First service'
+#     assert results[0].service_name == 'First service'
+#     assert results[0].free_sms_fragment_limit == 25000
+#     assert results[1].organisation_name == 'Org for Second Service'
+#     assert results[1].service_name == 'Second Service'
+#     assert results[1].free_sms_fragment_limit == 25000
+#
+#
+# def set_up_quarterly_data(service_name='First service'):
+#     year = 2016
+#     org = create_organisation(name="Org for {}".format(service_name))
+#     service = create_service(service_name=service_name)
+#     dao_add_service_to_organisation(service=service, organisation_id=org.id)
+#     create_annual_billing(service_id=service.id, free_sms_fragment_limit=25000, financial_year_start=year)
+#     sms_template = create_template(service=service, template_type="sms")
+#     email_template = create_template(service=service, template_type="email")
+#     letter_template = create_template(service=service, template_type="letter")
+#     for month in range(4, 6):
+#         mon = str(month).zfill(2)
+#         for day in range(1, 3):
+#             d = str(day).zfill(2)
+#             create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
+#                               service=service,
+#                               template=sms_template,
+#                               notification_type='sms',
+#                               rate=0.162)
+#             create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
+#                               service=service,
+#                               template=email_template,
+#                               notification_type='email',
+#                               rate=0)
+#             create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
+#                               service=service,
+#                               template=letter_template,
+#                               notification_type='letter',
+#                               rate=0.33,
+#                               postage='second')
+#             create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
+#                               service=service,
+#                               template=letter_template,
+#                               notification_type='letter',
+#                               rate=0.30,
+#                               billable_unit=2,
+#                               postage='first')
+#     return service

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -482,136 +482,79 @@ def test_delete_billing_data(notify_db_session):
     )
 
 
-def test_fetch_sms_free_allowance_remainder_with_remainder(notify_db_session):
-    service = create_service(service_name='a test thing')
-    create_annual_billing(service_id=service.id, free_sms_fragment_limit=3, financial_year_start=2016)
-    create_ft_billing(service=service, bst_date=datetime(2016, 4,20), notification_type='sms', billable_unit=2)
+def test_fetch_sms_free_allowance_remainder_with_two_services(notify_db_session):
+    service = create_service(service_name='has free allowance')
+    template = create_template(service=service)
+    org = create_organisation(name="Org for {}".format(service.name))
+    dao_add_service_to_organisation(service=service, organisation_id=org.id)
+    create_annual_billing(service_id=service.id, free_sms_fragment_limit=10, financial_year_start=2016)
+    create_ft_billing(service=service, template=template,
+                      bst_date=datetime(2016, 4, 20), notification_type='sms', billable_unit=2, rate=0.11)
+    create_ft_billing(service=service, template=template, bst_date=datetime(2016, 5, 20), notification_type='sms',
+                      billable_unit=3, rate=0.11)
 
-    service_2 = create_service(service_name='b second thing')
-    create_annual_billing(service_id=service_2.id, free_sms_fragment_limit=10, financial_year_start=2016)
-    create_ft_billing(service=service_2, bst_date=datetime(2016, 4, 20), notification_type='sms', billable_unit=4)
+    service_2 = create_service(service_name='used free allowance')
+    template_2 = create_template(service=service_2)
+    org_2 = create_organisation(name="Org for {}".format(service_2.name))
+    dao_add_service_to_organisation(service=service_2, organisation_id=org_2.id)
+    create_annual_billing(service_id=service_2.id, free_sms_fragment_limit=20, financial_year_start=2016)
+    create_ft_billing(service=service_2, template=template_2, bst_date=datetime(2016, 4, 20), notification_type='sms',
+                      billable_unit=12, rate=0.11)
+    create_ft_billing(service=service_2, template=template_2, bst_date=datetime(2016, 4, 22), notification_type='sms',
+                      billable_unit=10, rate=0.11)
+    create_ft_billing(service=service_2, template=template_2, bst_date=datetime(2016, 5, 20), notification_type='sms',
+                      billable_unit=3, rate=0.11)
+    results = fetch_sms_free_allowance_remainder(datetime(2016, 5, 1)).all()
+    assert len(results) == 2
+    service_result = [row for row in results if row[0] == service.id]
+    assert service_result[0] == (service.id, 10, 2, 8)
+    service_2_result = [row for row in results if row[0] == service_2.id]
+    assert service_2_result[0] == (service_2.id, 20, 22, 0)
+
+
+def test_fetch_sms_free_allowance_remainder_with_negative_remainder_returns_zero(notify_db_session):
+    service = create_service(service_name='test remainder')
+    create_annual_billing(service_id=service.id, free_sms_fragment_limit=3, financial_year_start=2016)
+    create_ft_billing(service=service, bst_date=datetime(2016, 4,20), notification_type='sms', billable_unit=12)
     results = fetch_sms_free_allowance_remainder(datetime(2016, 10, 1)).all()
 
-    assert len(results) == 2
-    service_1_results = None
-    service_2_results = None
-
-    if results[0].service_id == service.id:
-        service_1_results == results[0]
-    else:
-        service_2_results == results[0]
-
-    if results[1].service_id == service.id:
-        service_1_results == results[1]
-    else:
-        service_2_results == results[1]
-
-    assert service_1_results.billable_units == 2
-    assert service_1_results.free_sms_fragment_limit == 3
-
-    assert service_1_results.sms_remainder == 1
-
-
-# def test_fetch_sms_free_allowance_remainder_with_negative_remainder_returns_zero(notify_db_session):
-#     service = create_service(service_name='test thing')
-#     create_annual_billing(service_id=service.id, free_sms_fragment_limit=3, financial_year_start=2016)
-#     create_ft_billing(service=service, bst_date=datetime(2016, 4,20), notification_type='sms', billable_unit=12)
-#     results = fetch_sms_free_allowance_remainder(datetime(2016, 10, 1)).all()
-#
-#     assert results[0].service_id == service.id
-#     assert results[0].billable_units == 12
-#     assert results[0].free_sms_fragment_limit == 3
-#     assert results[0].sms_remainder == 0
+    assert results[0].service_id == service.id
+    assert results[0].billable_units == 12
+    assert results[0].free_sms_fragment_limit == 3
+    assert results[0].sms_remainder == 0
 
 
 def test_fetch_billing_for_all_services_with_remainder(notify_db_session):
     service = create_service(service_name='has free allowance')
+    template = create_template(service=service)
     org = create_organisation(name="Org for {}".format(service.name))
     dao_add_service_to_organisation(service=service, organisation_id=org.id)
     create_annual_billing(service_id=service.id, free_sms_fragment_limit=10, financial_year_start=2016)
-    create_ft_billing(service=service, bst_date=datetime(2016, 4, 20), notification_type='sms', billable_unit=2,
-                      rate=0.1)
-    create_ft_billing(service=service, bst_date=datetime(2016, 5, 20), notification_type='sms', billable_unit=2,
-                      rate=0.1)
+    create_ft_billing(service=service, template=template,
+                      bst_date=datetime(2016, 4, 20), notification_type='sms', billable_unit=2, rate=0.11)
+    create_ft_billing(service=service, template=template, bst_date=datetime(2016, 5, 20), notification_type='sms',
+                      billable_unit=2, rate=0.11)
 
     service_2 = create_service(service_name='used free allowance')
-    org2 = create_organisation(name="Org for {}".format(service_2.name))
-    dao_add_service_to_organisation(service=service_2, organisation_id=org.id)
+    template_2 = create_template(service=service_2)
+    org_2 = create_organisation(name="Org for {}".format(service_2.name))
+    dao_add_service_to_organisation(service=service_2, organisation_id=org_2.id)
     create_annual_billing(service_id=service_2.id, free_sms_fragment_limit=10, financial_year_start=2016)
-    create_ft_billing(service=service_2, bst_date=datetime(2016, 4, 20), notification_type='sms', billable_unit=12,
-                      rate=0.11)
-    create_ft_billing(service=service_2, bst_date=datetime(2016, 5, 20), notification_type='sms', billable_unit=3,
-                      rate=0.11)
+    create_ft_billing(service=service_2, template=template_2, bst_date=datetime(2016, 4, 20), notification_type='sms',
+                      billable_unit=12, rate=0.11)
+    create_ft_billing(service=service_2, template=template_2, bst_date=datetime(2016, 5, 20), notification_type='sms',
+                      billable_unit=3, rate=0.11)
     results = fetch_billing_for_all_services(datetime(2016, 5, 1), datetime(2016, 5, 31))
-    print(results)
     assert len(results) == 2
 
     assert results[0].organisation_id == org.id
     assert results[0].service_id == service.id
     assert results[0].sms_billable_units == 2
     assert results[0].sms_remainder == 8
-    assert results[0].remainder_minus_billable_units == 0
-    assert results[0].sms_cost == 0
+    assert results[0].sms_rate == Decimal('0.11')
 
-    # assert results[1].organisation_id == org2.id
-    # assert results[1].service_id == service_2.id
-    # assert results[1].sms_billable_units == 3
-    # assert results[1].sms_remainder == 0
-    # assert results[1].remainder_minus_billable_units == 3
-    # assert results[1].sms_cost == 0.2
-
-#
-#
-# def test_fetch_billing_for_all_services(notify_db_session):
-#     set_up_quarterly_data()
-#     set_up_quarterly_data(service_name='Second Service')
-#
-#     results = fetch_billing_for_all_services(datetime(2016, 4, 1), datetime(2016, 6, 30))
-#     print(results)
-#     assert len(results) == 2
-#
-#     assert results[0].organisation_name == 'Org for First service'
-#     assert results[0].service_name == 'First service'
-#     assert results[0].free_sms_fragment_limit == 25000
-#     assert results[1].organisation_name == 'Org for Second Service'
-#     assert results[1].service_name == 'Second Service'
-#     assert results[1].free_sms_fragment_limit == 25000
-#
-#
-# def set_up_quarterly_data(service_name='First service'):
-#     year = 2016
-#     org = create_organisation(name="Org for {}".format(service_name))
-#     service = create_service(service_name=service_name)
-#     dao_add_service_to_organisation(service=service, organisation_id=org.id)
-#     create_annual_billing(service_id=service.id, free_sms_fragment_limit=25000, financial_year_start=year)
-#     sms_template = create_template(service=service, template_type="sms")
-#     email_template = create_template(service=service, template_type="email")
-#     letter_template = create_template(service=service, template_type="letter")
-#     for month in range(4, 6):
-#         mon = str(month).zfill(2)
-#         for day in range(1, 3):
-#             d = str(day).zfill(2)
-#             create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
-#                               service=service,
-#                               template=sms_template,
-#                               notification_type='sms',
-#                               rate=0.162)
-#             create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
-#                               service=service,
-#                               template=email_template,
-#                               notification_type='email',
-#                               rate=0)
-#             create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
-#                               service=service,
-#                               template=letter_template,
-#                               notification_type='letter',
-#                               rate=0.33,
-#                               postage='second')
-#             create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
-#                               service=service,
-#                               template=letter_template,
-#                               notification_type='letter',
-#                               rate=0.30,
-#                               billable_unit=2,
-#                               postage='first')
-#     return service
+    assert results[1].organisation_id == org_2.id
+    assert results[1].service_id == service_2.id
+    assert results[1].sms_billable_units == 3
+    assert results[1].sms_remainder == 0
+    assert results[1].sms_rate == Decimal('0.11')


### PR DESCRIPTION
Every quarter we need to get the usage data for all services. The ultimate goal for this work is to have a button on the front end that takes a start and end date (which must be in a single financial year) and return all the appropriate billing data. 

- Query to get all the usage data for all services.
- Task to populate AnnualBilling (contains free sms allowance) for all active services.

Still outstanding:

- [ ] Change the query so we can calculate billing with the free allowance.
- [ ] Add config to run the `populate-free-sms-fragment-limit` task once a financial year. 
- [ ] End point to return all the aggregated data.



