### PR TITLE
Bump utils to 33.2.3

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,6 +29,6 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@33.2.2#egg=notifications-utils==33.2.2
+git+https://github.com/alphagov/notifications-utils.git@33.2.3#egg=notifications-utils==33.2.3
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@33.2.2#egg=notifications-utils==33.2.2
+git+https://github.com/alphagov/notifications-utils.git@33.2.3#egg=notifications-utils==33.2.3
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
@@ -40,12 +40,12 @@ alembic==1.0.11
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.1.0
-awscli==1.16.198
+awscli==1.16.199
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.188
+botocore==1.12.189
 certifi==2019.6.16
 chardet==3.0.4
 Click==7.0
@@ -83,4 +83,4 @@ smartypants==2.0.1
 statsd==3.3.0
 urllib3==1.25.3
 webencodings==0.5.1
-Werkzeug==0.15.4
+Werkzeug==0.15.5


### PR DESCRIPTION
This brings in validation for the length of the local part of email addresses.

[Pivotal story](https://www.pivotaltracker.com/story/show/167170104)