### PR TITLE
Change content of error messages when letter job can't be cancelled.

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -184,6 +184,6 @@ def can_letter_job_be_cancelled(job):
     if count_cancellable_notifications != job.notification_count or not letter_can_be_cancelled(
         NOTIFICATION_CREATED, job.created_at
     ):
-        return False, "It's too late to cancel sending, these letters have already been sent."
+        return False, "It’s too late to cancel sending, these letters have already been sent."
 
     return True, None

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -177,13 +177,13 @@ def can_letter_job_be_cancelled(job):
     ).all()
     count_notifications = len(notifications)
     if job.job_status != JOB_STATUS_FINISHED or count_notifications != job.notification_count:
-        return False, "This job is still being processed. Wait a couple of minutes and try again."
+        return False, "We are still processing these letters, please try again in a minute."
     count_cancellable_notifications = len([
         n for n in notifications if n.status in CANCELLABLE_JOB_LETTER_STATUSES
     ])
     if count_cancellable_notifications != job.notification_count or not letter_can_be_cancelled(
         NOTIFICATION_CREATED, job.created_at
     ):
-        return False, "Sorry, it's too late, letters have already been sent."
+        return False, "It's too late to cancel sending, these letters have already been sent."
 
     return True, None

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -342,7 +342,7 @@ def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_notifica
     create_notification(template=job.template, job=job, status='created')
     result, errors = can_letter_job_be_cancelled(job)
     assert not result
-    assert errors == "Sorry, it's too late, letters have already been sent."
+    assert errors == "It's too late to cancel sending, these letters have already been sent."
 
 
 def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_letters_already_sent_to_dvla(
@@ -355,7 +355,7 @@ def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_letters_
     with freeze_time('2019-06-13 17:32'):
         result, errors = can_letter_job_be_cancelled(job)
     assert not result
-    assert errors == "Sorry, it's too late, letters have already been sent."
+    assert errors == "It's too late to cancel sending, these letters have already been sent."
     assert letter.status == 'created'
     assert job.job_status == 'finished'
 
@@ -379,7 +379,7 @@ def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_job_not_
     create_notification(template=job.template, job=job, status='created')
     result, errors = can_letter_job_be_cancelled(job)
     assert not result
-    assert errors == "This job is still being processed. Wait a couple of minutes and try again."
+    assert errors == "We are still processing these letters, please try again in a minute."
 
 
 @freeze_time('2019-06-13 13:00')
@@ -390,4 +390,4 @@ def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_notifica
     create_notification(template=job.template, job=job, status='created')
     result, errors = can_letter_job_be_cancelled(job)
     assert not result
-    assert errors == "This job is still being processed. Wait a couple of minutes and try again."
+    assert errors == "We are still processing these letters, please try again in a minute."

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -342,7 +342,7 @@ def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_notifica
     create_notification(template=job.template, job=job, status='created')
     result, errors = can_letter_job_be_cancelled(job)
     assert not result
-    assert errors == "It's too late to cancel sending, these letters have already been sent."
+    assert errors == "It’s too late to cancel sending, these letters have already been sent."
 
 
 def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_letters_already_sent_to_dvla(
@@ -355,7 +355,7 @@ def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_letters_
     with freeze_time('2019-06-13 17:32'):
         result, errors = can_letter_job_be_cancelled(job)
     assert not result
-    assert errors == "It's too late to cancel sending, these letters have already been sent."
+    assert errors == "It’s too late to cancel sending, these letters have already been sent."
     assert letter.status == 'created'
     assert job.job_status == 'finished'
 


### PR DESCRIPTION
This content was first done without help of content designer so now it is improved with the help of one. New content is more in line with the content in the admin app and more human-readable and following GOV.UK standard.