### PR TITLE
Add endpoint with data for report for the engagement team

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.config import QueueNames
-from app.dao import notifications_dao
+from app.dao import fact_notification_status_dao, notifications_dao
 from app.dao.dao_utils import dao_rollback
 from app.dao.date_util import get_financial_year
 from app.dao.api_key_dao import (
@@ -885,6 +885,16 @@ def modify_service_data_retention(service_id, data_retention_id):
             status_code=404)
 
     return '', 204
+
+
+@service_blueprint.route('/monthly-data-by-service')
+def get_monthly_notification_data_by_service():
+    start_date = request.args.get('start_date')
+    end_date = request.args.get('end_date')
+
+    result = fact_notification_status_dao.fetch_monthly_notification_statuses_per_service(start_date, end_date)
+
+    return jsonify(result)
 
 
 def check_request_args(request):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3275,3 +3275,21 @@ def test_cancel_notification_for_service_updates_letter_if_still_time_to_cancel(
         notification_id=sample_letter_notification.id,
     )
     assert response['status'] == 'cancelled'
+
+
+def test_get_monthly_notification_data_by_service(mocker, admin_request):
+    dao_mock = mocker.patch(
+        'app.service.rest.fact_notification_status_dao.fetch_monthly_notification_statuses_per_service',
+        return_value=[])
+
+    start_date = '2019-01-01'
+    end_date = '2019-06-17'
+
+    response = admin_request.get(
+        'service.get_monthly_notification_data_by_service',
+        start_date=start_date,
+        end_date=end_date
+    )
+
+    dao_mock.assert_called_once_with(start_date, end_date)
+    assert response == []


### PR DESCRIPTION
This adds a dao function and an endpoint to get the data needed for a new report for the engagement team. This report will be added to `/platform-admin/reports` in notifications-admin.

[Pivotal story](https://www.pivotaltracker.com/story/show/166495005)