### PR TITLE
Add email and letter branding to the add organisation command 

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -42,7 +42,9 @@ from app.dao.users_dao import delete_model_user, delete_user_verify_codes, get_u
 from app.models import (
     PROVIDERS, User, Notification, Organisation, Domain, Service, SMS_TYPE,
     NOTIFICATION_CREATED,
-    KEY_TYPE_TEST
+    KEY_TYPE_TEST,
+    EmailBranding,
+    LetterBranding
 )
 from app.performance_platform.processing_time import send_processing_time_for_start_and_end
 from app.utils import get_london_midnight_in_utc, get_midnight_for_day_before
@@ -697,6 +699,8 @@ def populate_organisations_from_file(file_name):
     # [2] crown:: TRUE | FALSE only
     # [3] argeement_signed:: TRUE | FALSE
     # [4] domains:: comma separated list of domains related to the organisation
+    # [5] email branding name: name of the default email branding for the org
+    # [6] letter branding name: name of the default letter branding for the org
 
     # The expectation is that the organisation, organisation_to_service
     # and user_to_organisation will be cleared before running this command.
@@ -713,12 +717,23 @@ def populate_organisations_from_file(file_name):
         for line in itertools.islice(f, 1, None):
             columns = line.split('|')
             print(columns)
+            email_branding = None
+            email_branding_column = columns[5]
+            if len(email_branding_column) > 0:
+                email_branding = EmailBranding.query.filter(EmailBranding.name == email_branding_column).one()
+            letter_branding = None
+            letter_branding_column = columns[6].strip()
+            if len(letter_branding_column) > 0:
+                letter_branding = LetterBranding.query.filter(LetterBranding.name == letter_branding_column).one()
             data = {
                 'name': columns[0],
                 'active': True,
                 'agreement_signed': boolean_or_none(columns[3]),
                 'crown': boolean_or_none(columns[2]),
-                'organisation_type': columns[1].lower()
+                'organisation_type': columns[1].lower(),
+                'email_branding_id': email_branding.id if email_branding else None,
+                'letter_branding_id': letter_branding.id if letter_branding else None
+
             }
             org = Organisation(**data)
             try:
@@ -729,7 +744,7 @@ def populate_organisations_from_file(file_name):
                 db.session.rollback()
             domains = columns[4].split(',')
             for d in domains:
-                if d != '\n':
+                if len(d.strip()) > 0:
                     domain = Domain(domain=d.strip(), organisation_id=org.id)
                     try:
                         db.session.add(domain)

--- a/app/commands.py
+++ b/app/commands.py
@@ -718,7 +718,7 @@ def populate_organisations_from_file(file_name):
             columns = line.split('|')
             print(columns)
             email_branding = None
-            email_branding_column = columns[5]
+            email_branding_column = columns[5].strip()
             if len(email_branding_column) > 0:
                 email_branding = EmailBranding.query.filter(EmailBranding.name == email_branding_column).one()
             letter_branding = None


### PR DESCRIPTION
Updated the `populate-organisations-from-file` command to include a default email and letter branding column. The name of brand is used to look up the brand id and set it in the Organisation model. Also works if the columns are empty.