### PR TITLE
Lower the max dvla zip size from 500mb to 40mb

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -132,7 +132,8 @@ class Config(object):
     ONE_OFF_MESSAGE_FILENAME = 'Report'
     MAX_VERIFY_CODE_COUNT = 10
 
-    MAX_LETTER_PDF_ZIP_FILESIZE = 500 * 1024 * 1024  # 500mb
+    # be careful increasing this size without being sure that we won't see slowness in pysftp
+    MAX_LETTER_PDF_ZIP_FILESIZE = 40 * 1024 * 1024  # 40mb
     MAX_LETTER_PDF_COUNT_PER_ZIP = 500
 
     CHECK_PROXY_HEADER = False


### PR DESCRIPTION
There's a bug in pysftp that appears to cause quadratic performance loss. See https://github.com/paramiko/paramiko/issues/1141 for more details.

As a temporary band-aid fix, lower the size of the files we're sending.