### PR TITLE
bump utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ docs/_build/
 # PyBuilder
 target/
 .idea/
+.vscode
 
 # Mac
 *.DS_Store

--- a/app/commands.py
+++ b/app/commands.py
@@ -836,7 +836,7 @@ def populate_go_live(file_name):
     print("Populate go live user and date")
     with open(file_name, 'r') as f:
         rows = csv.reader(
-            f.read().splitlines(),
+            f,
             quoting=csv.QUOTE_MINIMAL,
             skipinitialspace=True,
         )

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ env =
     LOADTESTING_API_KEY=loadtesting
     FIRETEXT_API_KEY=Firetext
     NOTIFICATION_QUEUE_PREFIX=testing
+addopts = -n 4 -v -p no:warnings

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,6 +29,6 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@33.2.4#egg=notifications-utils==33.2.4
+git+https://github.com/alphagov/notifications-utils.git@33.2.8#egg=notifications-utils==33.2.8
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@33.2.4#egg=notifications-utils==33.2.4
+git+https://github.com/alphagov/notifications-utils.git@33.2.8#egg=notifications-utils==33.2.8
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
@@ -40,12 +40,12 @@ alembic==1.0.11
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.1.0
-awscli==1.16.199
+awscli==1.16.209
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.189
+botocore==1.12.199
 certifi==2019.6.16
 chardet==3.0.4
 Click==7.0
@@ -59,22 +59,22 @@ idna==2.8
 Jinja2==2.10.1
 jmespath==0.9.4
 kombu==3.0.37
-Mako==1.0.13
+Mako==1.1.0
 MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5
 orderedset==2.0.1
 phonenumbers==8.10.13
-pyasn1==0.4.5
+pyasn1==0.4.6
 pycparser==2.19
 PyPDF2==1.26.0
-pyrsistent==0.15.3
+pyrsistent==0.15.4
 python-dateutil==2.8.0
 python-editor==1.0.4
 python-json-logger==0.1.11
-pytz==2019.1
+pytz==2019.2
 PyYAML==4.2b1
-redis==3.2.1
+redis==3.3.4
 requests==2.22.0
 rsa==3.4.2
 s3transfer==0.2.1


### PR DESCRIPTION
also remove the `read().splitlines()` pattern from csv.reader usage, as it's redundant. also add .vscode to gitignore to accomodate my hipster IDE choices, and add some lines to pytest.ini so just running `py.test` uses some useful flags