### PR TITLE
REP-340: Use PaaS statsd exporter

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -70,7 +70,7 @@ applications:
       AWS_SECRET_ACCESS_KEY: '{{ AWS_SECRET_ACCESS_KEY }}'
 
       {% if environment in ['preview', 'staging'] %}
-      STATSD_HOST: "statsd.notify.tools"
+      STATSD_HOST: "notify-statsd-exporter-{{ environment }}.apps.internal"
       STATSD_PREFIX: ""
       {% else %}
       STATSD_HOST: "statsd.hostedgraphite.com"


### PR DESCRIPTION
- We are running the statsd-exporter on the PaaS now so we can use the
  internal UDP route to talk to it
- Only update in preview and staging still so that we can get the
  dashboards fully up to date before switching prod