### PR TITLE
Revert "Change email status to permanent-failure if SES raises InvalidParameterValue"

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -9,7 +9,7 @@ from app.dao import notifications_dao
 from app.dao.notifications_dao import update_notification_status_by_id
 from app.delivery import send_to_providers
 from app.exceptions import NotificationTechnicalFailureException
-from app.models import NOTIFICATION_PERMANENT_FAILURE, NOTIFICATION_TECHNICAL_FAILURE
+from app.models import NOTIFICATION_TECHNICAL_FAILURE
 
 
 @notify_celery.task(bind=True, name="deliver_sms", max_retries=48, default_retry_delay=300)
@@ -47,8 +47,8 @@ def deliver_email(self, notification_id):
             raise NoResultFound()
         send_to_providers.send_email_to_provider(notification)
     except InvalidEmailError as e:
-        current_app.logger.info(e)
-        update_notification_status_by_id(notification_id, NOTIFICATION_PERMANENT_FAILURE)
+        current_app.logger.exception(e)
+        update_notification_status_by_id(notification_id, 'technical-failure')
     except Exception:
         try:
             current_app.logger.exception(

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -84,14 +84,14 @@ def test_should_go_into_technical_error_if_exceeds_retries_on_deliver_email_task
     assert str(sample_notification.id) in e.value.message
 
 
-def test_should_go_into_permanent_failure_and_not_retry_if_invalid_email(sample_notification, mocker):
+def test_should_technical_error_and_not_retry_if_invalid_email(sample_notification, mocker):
     mocker.patch('app.delivery.send_to_providers.send_email_to_provider', side_effect=InvalidEmailError('bad email'))
     mocker.patch('app.celery.provider_tasks.deliver_email.retry')
 
     deliver_email(sample_notification.id)
 
     assert provider_tasks.deliver_email.retry.called is False
-    assert sample_notification.status == 'permanent-failure'
+    assert sample_notification.status == 'technical-failure'
 
 
 def test_should_retry_and_log_exception(sample_notification, mocker):


### PR DESCRIPTION
This reverts commit 51716fbaf8364aa41d34aac91d17d7c4a979507b.

Instead of relying on catching SES errors we will convert all email addresses to punycode before sending instead.