### PR TITLE
Update NotificationTechnicalFailureException

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -373,7 +373,7 @@ def update_letter_notifications_to_error(self, notification_references):
     message = "Updated {} letter notifications to technical-failure with references {}".format(
         updated_count, notification_references
     )
-    raise NotificationTechnicalFailureException(message=message)
+    raise NotificationTechnicalFailureException(message)
 
 
 def handle_exception(task, notification, notification_id, exc):

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -4,8 +4,7 @@ class DVLAException(Exception):
 
 
 class NotificationTechnicalFailureException(Exception):
-    def __init__(self, message):
-        self.message = message
+    pass
 
 
 class ArchiveValidationError(Exception):

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -173,9 +173,7 @@ def test_update_letter_notifications_to_sent_to_dvla_updates_based_on_notificati
 
 
 def test_update_letter_notifications_to_error_updates_based_on_notification_references(
-    client,
-    sample_letter_template,
-    mocker
+    sample_letter_template
 ):
     first = create_notification(sample_letter_template, reference='first ref')
     second = create_notification(sample_letter_template, reference='second ref')
@@ -184,7 +182,7 @@ def test_update_letter_notifications_to_error_updates_based_on_notification_refe
     with freeze_time(dt):
         with pytest.raises(NotificationTechnicalFailureException) as e:
             update_letter_notifications_to_error([first.reference])
-    assert first.reference in e.value.message
+            assert first.reference in e.value
 
     assert first.status == NOTIFICATION_TECHNICAL_FAILURE
     assert first.sent_by is None

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -194,7 +194,7 @@ def test_update_status_of_notifications_after_timeout(notify_api, sample_templat
                 seconds=current_app.config.get('SENDING_NOTIFICATIONS_TIMEOUT_PERIOD') + 10))
         with pytest.raises(NotificationTechnicalFailureException) as e:
             timeout_notifications()
-        assert str(not2.id) in e.value.message
+            assert str(not2.id) in e.value
         assert not1.status == 'temporary-failure'
         assert not2.status == 'technical-failure'
         assert not3.status == 'temporary-failure'

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -65,11 +65,11 @@ def test_should_go_into_technical_error_if_exceeds_retries_on_deliver_sms_task(s
 
     with pytest.raises(NotificationTechnicalFailureException) as e:
         deliver_sms(sample_notification.id)
+        assert sample_notification.id in e.value
 
     provider_tasks.deliver_sms.retry.assert_called_with(queue="retry-tasks", countdown=0)
 
     assert sample_notification.status == 'technical-failure'
-    assert str(sample_notification.id) in e.value.message
 
 
 def test_should_go_into_technical_error_if_exceeds_retries_on_deliver_email_task(sample_notification, mocker):
@@ -78,10 +78,10 @@ def test_should_go_into_technical_error_if_exceeds_retries_on_deliver_email_task
 
     with pytest.raises(NotificationTechnicalFailureException) as e:
         deliver_email(sample_notification.id)
+        assert sample_notification.id in e.value
 
     provider_tasks.deliver_email.retry.assert_called_with(queue="retry-tasks")
     assert sample_notification.status == 'technical-failure'
-    assert str(sample_notification.id) in e.value.message
 
 
 def test_should_technical_error_and_not_retry_if_invalid_email(sample_notification, mocker):

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -139,9 +139,9 @@ def test_should_not_send_email_message_when_service_is_inactive_notifcation_is_i
 
     with pytest.raises(NotificationTechnicalFailureException) as e:
         send_to_providers.send_email_to_provider(sample_notification)
+        assert sample_notification.id in e.value
     send_mock.assert_not_called()
     assert Notification.query.get(sample_notification.id).status == 'technical-failure'
-    assert str(sample_notification.id) in e.value.message
 
 
 @pytest.mark.parametrize("client_send", ["app.mmg_client.send_sms", "app.firetext_client.send_sms"])
@@ -152,9 +152,9 @@ def test_should_not_send_sms_message_when_service_is_inactive_notifcation_is_in_
 
     with pytest.raises(NotificationTechnicalFailureException) as e:
         send_to_providers.send_sms_to_provider(sample_notification)
+        assert sample_notification.id in e.value
     send_mock.assert_not_called()
     assert Notification.query.get(sample_notification.id).status == 'technical-failure'
-    assert str(sample_notification.id) in e.value.message
 
 
 def test_send_sms_should_use_template_version_from_notification_not_latest(


### PR DESCRIPTION
- Change the NotificationTechnicalFailureException so that it only inherits from Exception.
- The notify_celery task should create the logging message on failure.
- Fix unit tests
- Remove named parameter when raising exception.