### PR TITLE
fix typo in config

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -267,7 +267,12 @@ class Config(object):
         'check-templated-letter-state': {
             'task': 'check-templated-letter-state',
             'schedule': crontab(day_of_week='mon-fri', hour=9, minute=0),
-            'options': {'queue', QueueNames.PERIODIC}
+            'options': {'queue': QueueNames.PERIODIC}
+        },
+        'check-precompiled-letter-state': {
+            'task': 'check-precompiled-letter-state',
+            'schedule': crontab(day_of_week='mon-fri', hour='9,15', minute=0),
+            'options': {'queue': QueueNames.PERIODIC}
         },
         'raise-alert-if-letter-notifications-still-sending': {
             'task': 'raise-alert-if-letter-notifications-still-sending',
@@ -285,11 +290,6 @@ class Config(object):
             'task': 'raise-alert-if-no-letter-ack-file',
             'schedule': crontab(hour=23, minute=00),
             'options': {'queue': QueueNames.PERIODIC}
-        },
-        'check-precompiled-letter-state': {
-            'task': 'check-precompiled-letter-state',
-            'schedule': crontab(day_of_week='mon-fri', hour='9,15', minute=0),
-            'options': {'queue', QueueNames.PERIODIC}
         },
     }
     CELERY_QUEUES = []


### PR DESCRIPTION
was a `,`, not a `:`, so 'options' was a set rather than a dictionary, causing beat to crash