### PR TITLE
Enable statsd exporter for production

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -69,13 +69,8 @@ applications:
       AWS_ACCESS_KEY_ID: '{{ AWS_ACCESS_KEY_ID }}'
       AWS_SECRET_ACCESS_KEY: '{{ AWS_SECRET_ACCESS_KEY }}'
 
-      {% if environment in ['preview', 'staging'] %}
       STATSD_HOST: "notify-statsd-exporter-{{ environment }}.apps.internal"
       STATSD_PREFIX: ""
-      {% else %}
-      STATSD_HOST: "statsd.hostedgraphite.com"
-      STATSD_PREFIX: '{{ STATSD_PREFIX }}'
-      {% endif %}
 
       ZENDESK_API_KEY: '{{ ZENDESK_API_KEY }}'
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,6 +29,6 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@33.2.8#egg=notifications-utils==33.2.8
+git+https://github.com/alphagov/notifications-utils.git@33.2.9#egg=notifications-utils==33.2.9
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@33.2.8#egg=notifications-utils==33.2.8
+git+https://github.com/alphagov/notifications-utils.git@33.2.9#egg=notifications-utils==33.2.9
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
@@ -40,12 +40,12 @@ alembic==1.0.11
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.1.0
-awscli==1.16.209
+awscli==1.16.217
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.199
+botocore==1.12.207
 certifi==2019.6.16
 chardet==3.0.4
 Click==7.0
@@ -74,7 +74,7 @@ python-editor==1.0.4
 python-json-logger==0.1.11
 pytz==2019.2
 PyYAML==4.2b1
-redis==3.3.4
+redis==3.3.7
 requests==2.22.0
 rsa==3.4.2
 s3transfer==0.2.1


### PR DESCRIPTION
Also bump the utils version to include a fix on the error handling logic
when we fail to send a metric.