### PR TITLE
Remove the organisation_to_service table.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -70,7 +70,6 @@ def create_app(application):
     application.config.from_object(configs[notify_environment])
 
     application.config['NOTIFY_APP_NAME'] = application.name
-    print(application.config['SQLALCHEMY_DATABASE_URI'])
     init_app(application)
     request_helper.init_app(application)
     db.init_app(application)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -70,7 +70,7 @@ def create_app(application):
     application.config.from_object(configs[notify_environment])
 
     application.config['NOTIFY_APP_NAME'] = application.name
-
+    print(application.config['SQLALCHEMY_DATABASE_URI'])
     init_app(application)
     request_helper.init_app(application)
     db.init_app(application)

--- a/app/models.py
+++ b/app/models.py
@@ -311,15 +311,6 @@ class ServicePermissionTypes(db.Model):
     name = db.Column(db.String(255), primary_key=True)
 
 
-organisation_to_service = db.Table(
-    'organisation_to_service',
-    db.Model.metadata,
-    # service_id is a primary key as you can only have one organisation per service
-    db.Column('service_id', UUID(as_uuid=True), db.ForeignKey('services.id'), primary_key=True, nullable=False),
-    db.Column('organisation_id', UUID(as_uuid=True), db.ForeignKey('organisation.id'), nullable=False),
-)
-
-
 class Domain(db.Model):
     __tablename__ = "domain"
     domain = db.Column(db.String(255), primary_key=True)

--- a/migrations/versions/0304_remove_org_to_service.py
+++ b/migrations/versions/0304_remove_org_to_service.py
@@ -1,0 +1,29 @@
+"""
+
+Revision ID: 0304_remove_org_to_service
+Revises: 0303_populate_services_org_id
+Create Date: 2019-08-15 14:49:00.754390
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0304_remove_org_to_service'
+down_revision = '0303_populate_services_org_id'
+
+
+def upgrade():
+    op.drop_table('organisation_to_service')
+
+
+def downgrade():
+    op.create_table('organisation_to_service',
+                    sa.Column('service_id', postgresql.UUID(), autoincrement=False, nullable=False),
+                    sa.Column('organisation_id', postgresql.UUID(), autoincrement=False, nullable=False),
+                    sa.ForeignKeyConstraint(['organisation_id'], ['organisation.id'],
+                                            name='organisation_to_service_organisation_id_fkey'),
+                    sa.ForeignKeyConstraint(['service_id'], ['services.id'],
+                                            name='organisation_to_service_service_id_fkey'),
+                    sa.PrimaryKeyConstraint('service_id', name='organisation_to_service_pkey')
+                    )


### PR DESCRIPTION
This table is no longer used or referenced in the code.
We can remove this mapping table now that the organisation to service relationship is handled by the foreign key in Services.