### PR TITLE
Billing for all services

### DIFF
--- a/app/billing/rest.py
+++ b/app/billing/rest.py
@@ -14,9 +14,6 @@ from app.dao.annual_billing_dao import (
 from app.dao.date_util import get_current_financial_year_start_year
 from app.dao.fact_billing_dao import (
     fetch_monthly_billing_for_year, fetch_billing_totals_for_year,
-    fetch_sms_billing_for_all_services,
-    fetch_letter_costs_for_all_services,
-    fetch_letter_line_items_for_all_services
 )
 
 from app.errors import InvalidRequest
@@ -31,19 +28,6 @@ billing_blueprint = Blueprint(
 
 
 register_errors(billing_blueprint)
-
-
-@billing_blueprint.route('usage-for-all-services')
-def get_usage_for_all_services():
-    start_date = request.args.get('start_date')
-    end_date = request.args.get('end_date')
-
-    sms_totals = fetch_sms_billing_for_all_services(start_date, end_date)
-    letter_totals = fetch_letter_costs_for_all_services(start_date, end_date)
-    letter_breakdown = fetch_letter_line_items_for_all_services(start_date, end_date)
-
-
-
 
 
 @billing_blueprint.route('/ft-monthly-usage')

--- a/app/billing/rest.py
+++ b/app/billing/rest.py
@@ -12,7 +12,12 @@ from app.dao.annual_billing_dao import (
     dao_update_annual_billing_for_future_years
 )
 from app.dao.date_util import get_current_financial_year_start_year
-from app.dao.fact_billing_dao import fetch_monthly_billing_for_year, fetch_billing_totals_for_year
+from app.dao.fact_billing_dao import (
+    fetch_monthly_billing_for_year, fetch_billing_totals_for_year,
+    fetch_sms_billing_for_all_services,
+    fetch_letter_costs_for_all_services,
+    fetch_letter_line_items_for_all_services
+)
 
 from app.errors import InvalidRequest
 from app.errors import register_errors
@@ -26,6 +31,19 @@ billing_blueprint = Blueprint(
 
 
 register_errors(billing_blueprint)
+
+
+@billing_blueprint.route('usage-for-all-services')
+def get_usage_for_all_services():
+    start_date = request.args.get('start_date')
+    end_date = request.args.get('end_date')
+
+    sms_totals = fetch_sms_billing_for_all_services(start_date, end_date)
+    letter_totals = fetch_letter_costs_for_all_services(start_date, end_date)
+    letter_breakdown = fetch_letter_line_items_for_all_services(start_date, end_date)
+
+
+
 
 
 @billing_blueprint.route('/ft-monthly-usage')

--- a/app/commands.py
+++ b/app/commands.py
@@ -278,8 +278,6 @@ def populate_annual_billing(year):
                                                      free_sms_fragment_limit=free_allowance[0],
                                                      financial_year_start=int(year))
 
-    db.session.commit()
-
 
 @notify_command(name='list-routes')
 def list_routes():

--- a/app/commands.py
+++ b/app/commands.py
@@ -21,6 +21,7 @@ from app.celery.nightly_tasks import send_total_sent_notifications_to_performanc
 from app.celery.service_callback_tasks import send_delivery_status_to_service
 from app.celery.letters_pdf_tasks import create_letters_pdf
 from app.config import QueueNames
+from app.dao.annual_billing_dao import dao_create_or_update_annual_billing_for_year
 from app.dao.fact_billing_dao import (
     delete_billing_data_for_service_for_day,
     fetch_billing_data_for_day,
@@ -248,29 +249,38 @@ def backfill_processing_time(start_date, end_date):
         send_processing_time_for_start_and_end(process_start_date, process_end_date)
 
 
-@notify_command()
-def populate_annual_billing():
+@notify_command(name='latest_annual_billing')
+@click.option('-y', '--year', required=True,
+              help="""The year to populate the annual billing data for, i.e. 2019""")
+def populate_annual_billing(year):
     """
-    add annual_billing for 2016, 2017 and 2018.
+    add annual_billing for given year.
     """
-    financial_year = [2016, 2017, 2018]
+    sql = """
+        Select id from services where active = true
+        except
+        select service_id
+        from annual_billing
+        where financial_year_start = :year
+    """
+    services_without_annual_billing = db.session.execute(sql, {"year": int(year)})
+    for row in services_without_annual_billing:
+        latest_annual_billing = """
+            Select free_sms_fragment_limit
+            from annual_billing
+            where service_id = :service_id
+            order by financial_year_start limit 1
+        """
+        print(row.id)
+        free_allowance_rows = db.session.execute(latest_annual_billing, {"service_id": row.id})
+        free_allowance = [x[0]for x in free_allowance_rows]
+        print(free_allowance)
+        print("create free limit of {} for service: {}".format(free_allowance[0], row.id))
+        dao_create_or_update_annual_billing_for_year(service_id=row.id,
+                                                     free_sms_fragment_limit=free_allowance[0],
+                                                     financial_year_start=int(year))
 
-    for fy in financial_year:
-        populate_data = """
-        INSERT INTO annual_billing(id, service_id, free_sms_fragment_limit, financial_year_start,
-                created_at, updated_at)
-            SELECT uuid_in(md5(random()::text || now()::text)::cstring), id, 250000, {}, '{}', '{}'
-            FROM services
-            WHERE id NOT IN(
-                SELECT service_id
-                FROM annual_billing
-                WHERE financial_year_start={})
-        """.format(fy, datetime.utcnow(), datetime.utcnow(), fy)
-
-        services_result1 = db.session.execute(populate_data)
-        db.session.commit()
-
-        print("Populated annual billing {} for {} services".format(fy, services_result1.rowcount))
+    db.session.commit()
 
 
 @notify_command(name='list-routes')

--- a/app/dao/date_util.py
+++ b/app/dao/date_util.py
@@ -63,8 +63,9 @@ def get_current_financial_year_start_year():
     return financial_year_start
 
 
-def which_financial_year(start_date):
-    if start_date <= get_april_fools(int(start_date.strftime('%Y'))):
-        return int(start_date.strftime('%Y')) - 1
+def get_financial_year_for_datetime(start_date):
+    year = int(start_date.strftime('%Y'))
+    if start_date < get_april_fools(year):
+        return year - 1
     else:
-        return int(start_date.strftime('%Y'))
+        return year

--- a/app/dao/date_util.py
+++ b/app/dao/date_util.py
@@ -61,3 +61,10 @@ def get_current_financial_year_start_year():
     if now < start_date:
         financial_year_start = financial_year_start - 1
     return financial_year_start
+
+
+def which_financial_year(start_date):
+    if start_date <= get_april_fools(int(start_date.strftime('%Y'))):
+        return int(start_date.strftime('%Y')) - 1
+    else:
+        return int(start_date.strftime('%Y'))

--- a/app/dao/date_util.py
+++ b/app/dao/date_util.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date, time
 
 from notifications_utils.timezones import convert_bst_to_utc
 import pytz
@@ -64,6 +64,9 @@ def get_current_financial_year_start_year():
 
 
 def get_financial_year_for_datetime(start_date):
+    if type(start_date) == date:
+        start_date = datetime.combine(start_date, time.min)
+
     year = int(start_date.strftime('%Y'))
     if start_date < get_april_fools(year):
         return year - 1

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -27,7 +27,6 @@ from app.models import (
     NOTIFICATION_STATUS_TYPES_BILLABLE_FOR_LETTERS,
     AnnualBilling,
     Organisation,
-    organisation_to_service
 )
 from app.utils import get_london_midnight_in_utc
 
@@ -116,8 +115,8 @@ def fetch_letter_costs_for_all_services(start_date, end_date):
     query = db.session.query(
         Organisation.name.label("organisation_name"),
         Organisation.id.label("organisation_id"),
-        FactBilling.service_id.label("service_id"),
         Service.name.label("service_name"),
+        FactBilling.service_id.label("service_id"),
         func.sum(FactBilling.notifications_sent * FactBilling.rate).label("letter_cost")
     ).outerjoin(
         Organisation, Service.organisation_id == Organisation.id
@@ -143,11 +142,11 @@ def fetch_letter_line_items_for_all_services(start_date, end_date):
     query = db.session.query(
         Organisation.name.label("organisation_name"),
         Organisation.id.label("organisation_id"),
-        FactBilling.service_id.label("service_id"),
         Service.name.label("service_name"),
-        FactBilling.billable_units.label('sheet_count'),
+        FactBilling.service_id.label("service_id"),
+        FactBilling.billable_units.label("sheet_count"),
         FactBilling.rate.label("letter_rate"),
-        FactBilling.postage('postage'),
+        FactBilling.postage.label("postage"),
         func.sum(FactBilling.notifications_sent).label("letters_sent"),
     ).outerjoin(
         Organisation, Service.organisation_id == Organisation.id
@@ -156,7 +155,7 @@ def fetch_letter_line_items_for_all_services(start_date, end_date):
         FactBilling.bst_date >= start_date,
         FactBilling.bst_date <= end_date,
         FactBilling.notification_type == LETTER_TYPE,
-    ).group_by(
+        ).group_by(
         Organisation.name,
         Organisation.id,
         FactBilling.service_id,
@@ -167,10 +166,9 @@ def fetch_letter_line_items_for_all_services(start_date, end_date):
     ).order_by(
         Organisation.name,
         Service.name,
-        FactBilling.billable_units,
-        FactBilling.postage
+        FactBilling.postage.desc(),
+        FactBilling.rate,
     )
-
     return query.all()
 
 

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -161,7 +161,6 @@ def fetch_letter_line_items_for_all_services(start_date, end_date):
     ).join(
         FactBilling, FactBilling.service_id == Service.id,
     ).filter(
-        FactBilling.service_id == Service.id,
         FactBilling.bst_date >= start_date,
         FactBilling.bst_date <= end_date,
         FactBilling.notification_type == LETTER_TYPE,

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -75,8 +75,8 @@ def fetch_sms_billing_for_all_services(start_date, end_date):
     query = db.session.query(
         Organisation.name.label('organisation_name'),
         Organisation.id.label('organisation_id'),
-        FactBilling.service_id.label("service_id"),
         Service.name.label("service_name"),
+        FactBilling.service_id.label("service_id"),
         AnnualBilling.free_sms_fragment_limit,
         FactBilling.rate.label('sms_rate'),
         sms_remainder.label("sms_remainder"),
@@ -155,7 +155,7 @@ def fetch_letter_line_items_for_all_services(start_date, end_date):
         FactBilling.bst_date >= start_date,
         FactBilling.bst_date <= end_date,
         FactBilling.notification_type == LETTER_TYPE,
-        ).group_by(
+    ).group_by(
         Organisation.name,
         Organisation.id,
         FactBilling.service_id,

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -42,9 +42,9 @@ def fetch_sms_free_allowance_remainder(start_date):
         func.greatest((AnnualBilling.free_sms_fragment_limit -
                        func.sum(FactBilling.billable_units * FactBilling.rate_multiplier)
                        ).cast(Integer), 0).label('sms_remainder')
+    ).join(
+        AnnualBilling, FactBilling.service_id == AnnualBilling.service_id,
     ).filter(
-        FactBilling.service_id == Service.id,
-        FactBilling.service_id == AnnualBilling.service_id,
         FactBilling.bst_date >= start_of_year,
         FactBilling.bst_date < start_date,
         FactBilling.notification_type == SMS_TYPE,

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -9,7 +9,7 @@ from app import db
 from app.dao.date_util import (
     get_april_fools as financial_year_start,
     get_financial_year,
-    which_financial_year
+    get_financial_year_for_datetime
 )
 
 from app.models import (
@@ -33,7 +33,7 @@ from app.utils import get_london_midnight_in_utc
 
 def fetch_sms_free_allowance_remainder(start_date):
     # ASSUMPTION: AnnualBilling has been populated for year.
-    billing_year = which_financial_year(start_date)
+    billing_year = get_financial_year_for_datetime(start_date)
     print(billing_year)
     start_of_year = convert_utc_to_bst(financial_year_start(billing_year))
     query = db.session.query(
@@ -60,7 +60,7 @@ def fetch_sms_free_allowance_remainder(start_date):
 def fetch_sms_billing_for_all_services(start_date, end_date):
 
     # ASSUMPTION: AnnualBilling has been populated for year.
-    billing_year = which_financial_year(start_date)
+    billing_year = get_financial_year_for_datetime(start_date)
     free_allowance_remainder = fetch_sms_free_allowance_remainder(start_date).subquery()
     sms_billable_units = func.sum(FactBilling.billable_units * FactBilling.rate_multiplier)
     sms_remainder = func.coalesce(free_allowance_remainder.c.sms_remainder, AnnualBilling.free_sms_fragment_limit)

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -64,11 +64,13 @@ def fetch_sms_free_allowance_remainder(start_date):
 def fetch_sms_billing_for_all_services(start_date, end_date):
 
     # ASSUMPTION: AnnualBilling has been populated for year.
-    billing_year = get_financial_year_for_datetime(start_date)
     free_allowance_remainder = fetch_sms_free_allowance_remainder(start_date).subquery()
 
     sms_billable_units = func.sum(FactBilling.billable_units * FactBilling.rate_multiplier)
-    sms_remainder = func.coalesce(free_allowance_remainder.c.sms_remainder, AnnualBilling.free_sms_fragment_limit)
+    sms_remainder = func.coalesce(
+        free_allowance_remainder.c.sms_remainder,
+        free_allowance_remainder.c.free_sms_fragment_limit
+    )
     chargeable_sms = func.greatest(sms_billable_units - sms_remainder, 0)
     sms_cost = chargeable_sms * FactBilling.rate
 
@@ -77,30 +79,30 @@ def fetch_sms_billing_for_all_services(start_date, end_date):
         Organisation.id.label('organisation_id'),
         Service.name.label("service_name"),
         FactBilling.service_id.label("service_id"),
-        AnnualBilling.free_sms_fragment_limit,
+        free_allowance_remainder.c.free_sms_fragment_limit,
         FactBilling.rate.label('sms_rate'),
         sms_remainder.label("sms_remainder"),
         sms_billable_units.label('sms_billable_units'),
         chargeable_sms.label("chargeable_billable_sms"),
         sms_cost.label('sms_cost'),
-    ).join(
-        Service.annual_billing,
+    ).select_from(
+        Service
     ).outerjoin(
         free_allowance_remainder, Service.id == free_allowance_remainder.c.service_id
     ).outerjoin(
-        Organisation, Service.organisation_id == Organisation.id
+        Service.organisation
+    ).join(
+        FactBilling, FactBilling.service_id == Service.id,
     ).filter(
-        FactBilling.service_id == Service.id,
         FactBilling.bst_date >= start_date,
         FactBilling.bst_date <= end_date,
         FactBilling.notification_type == SMS_TYPE,
-        AnnualBilling.financial_year_start == billing_year,
     ).group_by(
         Organisation.name,
         Organisation.id,
         FactBilling.service_id,
         Service.name,
-        AnnualBilling.free_sms_fragment_limit,
+        free_allowance_remainder.c.free_sms_fragment_limit,
         free_allowance_remainder.c.sms_remainder,
         FactBilling.rate,
     ).order_by(

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -78,7 +78,7 @@ def fetch_sms_billing_for_all_services(start_date, end_date):
         Organisation.name.label('organisation_name'),
         Organisation.id.label('organisation_id'),
         Service.name.label("service_name"),
-        FactBilling.service_id.label("service_id"),
+        Service.id.label("service_id"),
         free_allowance_remainder.c.free_sms_fragment_limit,
         FactBilling.rate.label('sms_rate'),
         sms_remainder.label("sms_remainder"),
@@ -100,7 +100,7 @@ def fetch_sms_billing_for_all_services(start_date, end_date):
     ).group_by(
         Organisation.name,
         Organisation.id,
-        FactBilling.service_id,
+        Service.id,
         Service.name,
         free_allowance_remainder.c.free_sms_fragment_limit,
         free_allowance_remainder.c.sms_remainder,
@@ -118,10 +118,14 @@ def fetch_letter_costs_for_all_services(start_date, end_date):
         Organisation.name.label("organisation_name"),
         Organisation.id.label("organisation_id"),
         Service.name.label("service_name"),
-        FactBilling.service_id.label("service_id"),
+        Service.id.label("service_id"),
         func.sum(FactBilling.notifications_sent * FactBilling.rate).label("letter_cost")
+    ).select_from(
+        Service
     ).outerjoin(
-        Organisation, Service.organisation_id == Organisation.id
+        Service.organisation
+    ).join(
+        FactBilling, FactBilling.service_id == Service.id,
     ).filter(
         FactBilling.service_id == Service.id,
         FactBilling.bst_date >= start_date,
@@ -130,7 +134,7 @@ def fetch_letter_costs_for_all_services(start_date, end_date):
     ).group_by(
         Organisation.name,
         Organisation.id,
-        FactBilling.service_id,
+        Service.id,
         Service.name,
     ).order_by(
         Organisation.name,
@@ -145,13 +149,17 @@ def fetch_letter_line_items_for_all_services(start_date, end_date):
         Organisation.name.label("organisation_name"),
         Organisation.id.label("organisation_id"),
         Service.name.label("service_name"),
-        FactBilling.service_id.label("service_id"),
+        Service.id.label("service_id"),
         FactBilling.billable_units.label("sheet_count"),
         FactBilling.rate.label("letter_rate"),
         FactBilling.postage.label("postage"),
         func.sum(FactBilling.notifications_sent).label("letters_sent"),
+    ).select_from(
+        Service
     ).outerjoin(
-        Organisation, Service.organisation_id == Organisation.id
+        Service.organisation
+    ).join(
+        FactBilling, FactBilling.service_id == Service.id,
     ).filter(
         FactBilling.service_id == Service.id,
         FactBilling.bst_date >= start_date,
@@ -160,7 +168,7 @@ def fetch_letter_line_items_for_all_services(start_date, end_date):
     ).group_by(
         Organisation.name,
         Organisation.id,
-        FactBilling.service_id,
+        Service.id,
         Service.name,
         FactBilling.billable_units,
         FactBilling.rate,

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, time
+from datetime import datetime, timedelta, time, date
 
 from flask import current_app
 from notifications_utils.timezones import convert_bst_to_utc, convert_utc_to_bst
@@ -7,7 +7,6 @@ from sqlalchemy import func, case, desc, Date, Integer, and_
 
 from app import db
 from app.dao.date_util import (
-    get_april_fools as financial_year_start,
     get_financial_year,
     get_financial_year_for_datetime
 )
@@ -34,7 +33,7 @@ from app.utils import get_london_midnight_in_utc
 def fetch_sms_free_allowance_remainder(start_date):
     # ASSUMPTION: AnnualBilling has been populated for year.
     billing_year = get_financial_year_for_datetime(start_date)
-    start_of_year = convert_utc_to_bst(financial_year_start(billing_year))
+    start_of_year = date(billing_year, 4, 1)
 
     billable_units = func.coalesce(func.sum(FactBilling.billable_units * FactBilling.rate_multiplier), 0)
 

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -34,6 +34,7 @@ from app.utils import get_london_midnight_in_utc
 def fetch_sms_free_allowance_remainder(start_date):
     # ASSUMPTION: AnnualBilling has been populated for year.
     billing_year = which_financial_year(start_date)
+    print(billing_year)
     start_of_year = convert_utc_to_bst(financial_year_start(billing_year))
     query = db.session.query(
         FactBilling.service_id.label("service_id"),
@@ -62,7 +63,7 @@ def fetch_sms_billing_for_all_services(start_date, end_date):
     billing_year = which_financial_year(start_date)
     free_allowance_remainder = fetch_sms_free_allowance_remainder(start_date).subquery()
     sms_billable_units = func.sum(FactBilling.billable_units * FactBilling.rate_multiplier)
-    sms_remainder = func.coalesce(free_allowance_remainder.c.sms_remainder, 0)
+    sms_remainder = func.coalesce(free_allowance_remainder.c.sms_remainder, AnnualBilling.free_sms_fragment_limit)
     chargeable_sms = case([(sms_remainder == 0, sms_billable_units),
                            (sms_billable_units - sms_remainder <= 0, 0),
                            (sms_billable_units - sms_remainder > 0,

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -80,11 +80,11 @@ def get_usage_for_all_services():
             "letter_cost": 0,
             "letter_breakdown": ""
         }
-        combined[str(s.service_id)] = entry
+        combined[s.service_id] = entry
 
     for l in letter_costs:
         if l.service_id in combined:
-            combined[str(l.service_id)].update({'letter_cost': l.letter_cost})
+            combined[l.service_id].update({'letter_cost': l.letter_cost})
         else:
             letter_entry = {
                 "organisation_id": str(l.organisation_id) if l.organisation_id else "",
@@ -96,8 +96,8 @@ def get_usage_for_all_services():
                 "letter_cost": float(l.letter_cost),
                 "letter_breakdown": ""
             }
-            combined[str(l.service_id)] = letter_entry
+            combined[l.service_id] = letter_entry
     for service_id, breakdown in lb_by_service:
-        combined[str(service_id)]['letter_breakdown'] += (breakdown + '\n')
+        combined[service_id]['letter_breakdown'] += (breakdown + '\n')
 
     return jsonify(list(combined.values()))

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -2,8 +2,13 @@ from datetime import datetime
 
 from flask import Blueprint, jsonify, request
 
+from app.dao.date_util import get_financial_year
+from app.dao.fact_billing_dao import (
+    fetch_sms_billing_for_all_services, fetch_letter_costs_for_all_services,
+    fetch_letter_line_items_for_all_services
+)
 from app.dao.fact_notification_status_dao import fetch_notification_status_totals_for_all_services
-from app.errors import register_errors
+from app.errors import register_errors, InvalidRequest
 from app.platform_stats.platform_stats_schema import platform_stats_request
 from app.service.statistics import format_admin_stats
 from app.schema_validation import validate
@@ -27,3 +32,71 @@ def get_platform_stats():
     stats = format_admin_stats(data)
 
     return jsonify(stats)
+
+
+def validate_date_range_is_within_a_financial_year(start_date, end_date):
+    try:
+        start_date = datetime.strptime(start_date, "%Y-%m-%d").date()
+        end_date = datetime.strptime(end_date, "%Y-%m-%d").date()
+    except ValueError:
+        raise InvalidRequest(message="Input must be a date in the format: YYYY-MM-DD", status_code=400)
+    if end_date < start_date:
+        raise InvalidRequest(message="Start date must be before end date", status_code=400)
+    if 4 <= int(start_date.strftime("%m")) <= 12:
+        year_start, year_end = get_financial_year(year=int(start_date.strftime("%Y")))
+    else:
+        year_start, year_end = get_financial_year(year=int(start_date.strftime("%Y")) - 1)
+    year_start = year_start.date()
+    year_end = year_end.date()
+    if year_start <= start_date <= year_end and year_start <= end_date <= year_end:
+        return True
+    else:
+        raise InvalidRequest(message="Date must be in a single financial year.", status_code=400)
+
+
+@platform_stats_blueprint.route('usage-for-all-services')
+def get_usage_for_all_services():
+    start_date = request.args.get('start_date')
+    end_date = request.args.get('end_date')
+
+    validate_date_range_is_within_a_financial_year(start_date, end_date)
+    start_date = datetime.strptime(start_date, "%Y-%m-%d")
+    end_date = datetime.strptime(end_date, "%Y-%m-%d")
+
+    sms_costs = fetch_sms_billing_for_all_services(start_date, end_date)
+    letter_costs = fetch_letter_costs_for_all_services(start_date, end_date)
+    letter_breakdown = fetch_letter_line_items_for_all_services(start_date, end_date)
+
+    lb_by_service = [(lb.service_id, "{} {} class letters at {}p".format(lb.letters_sent, lb.postage, lb.letter_rate))
+                     for lb in letter_breakdown]
+    combined = {}
+    for s in sms_costs:
+        entry = {
+            "Organisation_id": str(s.organisation_id) if s.organisation_id else "",
+            "Organisation_name": s.organisation_name or "",
+            "service_id": str(s.service_id),
+            "service_name": s.service_name,
+            "sms_cost": str(s.sms_cost),
+            "letter_cost": 0,
+            "letter_breakdown": ""
+        }
+        combined[str(s.service_id)] = entry
+
+    for l in letter_costs:
+        if l.service_id in combined:
+            combined[str(l.service_id)].update({'letter_cost': l.letter_cost})
+        else:
+            letter_entry = {
+                "Organisation_id": str(l.organisation_id) if l.organisation_id else "",
+                "Organisation_name": l.organisation_name or "",
+                "service_id": str(l.service_id),
+                "service_name": l.service_name,
+                "sms_cost": 0,
+                "letter_cost": str(l.letter_cost),
+                "letter_breakdown": ""
+            }
+            combined[str(l.service_id)] = letter_entry
+    for service_id, breakdown in lb_by_service:
+        combined[str(service_id)]['letter_breakdown'] += (breakdown + '\n')
+
+    return jsonify(list(combined.values()))

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -67,16 +67,19 @@ def get_usage_for_all_services():
     letter_costs = fetch_letter_costs_for_all_services(start_date, end_date)
     letter_breakdown = fetch_letter_line_items_for_all_services(start_date, end_date)
 
-    lb_by_service = [(lb.service_id, "{} {} class letters at {}p".format(lb.letters_sent, lb.postage, lb.letter_rate))
-                     for lb in letter_breakdown]
+    lb_by_service = [
+        (lb.service_id, "{} {} class letters at {}p".format(lb.letters_sent, lb.postage, int(lb.letter_rate * 100)))
+        for lb in letter_breakdown
+    ]
     combined = {}
     for s in sms_costs:
         entry = {
-            "Organisation_id": str(s.organisation_id) if s.organisation_id else "",
-            "Organisation_name": s.organisation_name or "",
+            "organisation_id": str(s.organisation_id) if s.organisation_id else "",
+            "organisation_name": s.organisation_name or "",
             "service_id": str(s.service_id),
             "service_name": s.service_name,
-            "sms_cost": str(s.sms_cost),
+            "sms_cost": float(s.sms_cost),
+            "sms_fragments": s.chargeable_billable_sms,
             "letter_cost": 0,
             "letter_breakdown": ""
         }
@@ -87,12 +90,13 @@ def get_usage_for_all_services():
             combined[str(l.service_id)].update({'letter_cost': l.letter_cost})
         else:
             letter_entry = {
-                "Organisation_id": str(l.organisation_id) if l.organisation_id else "",
-                "Organisation_name": l.organisation_name or "",
+                "organisation_id": str(l.organisation_id) if l.organisation_id else "",
+                "organisation_name": l.organisation_name or "",
                 "service_id": str(l.service_id),
                 "service_name": l.service_name,
                 "sms_cost": 0,
-                "letter_cost": str(l.letter_cost),
+                "sms_fragments": 0,
+                "letter_cost": float(l.letter_cost),
                 "letter_breakdown": ""
             }
             combined[str(l.service_id)] = letter_entry

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -100,4 +100,9 @@ def get_usage_for_all_services():
     for service_id, breakdown in lb_by_service:
         combined[service_id]['letter_breakdown'] += (breakdown + '\n')
 
-    return jsonify(list(combined.values()))
+    # sorting first by name == '' means that blank orgs will be sorted last.
+    return jsonify(sorted(combined.values(), key=lambda x: (
+        x['organisation_name'] == '',
+        x['organisation_name'],
+        x['service_name']
+    )))

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -50,15 +50,15 @@ def validate_date_range_is_within_a_financial_year(start_date, end_date):
     if start_fy != end_fy:
         raise InvalidRequest(message="Date must be in a single financial year.", status_code=400)
 
+    return start_date, end_date
+
 
 @platform_stats_blueprint.route('usage-for-all-services')
 def get_usage_for_all_services():
     start_date = request.args.get('start_date')
     end_date = request.args.get('end_date')
 
-    validate_date_range_is_within_a_financial_year(start_date, end_date)
-    start_date = datetime.strptime(start_date, "%Y-%m-%d")
-    end_date = datetime.strptime(end_date, "%Y-%m-%d")
+    start_date, end_date = validate_date_range_is_within_a_financial_year(start_date, end_date)
 
     sms_costs = fetch_sms_billing_for_all_services(start_date, end_date)
     letter_costs = fetch_letter_costs_for_all_services(start_date, end_date)

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -84,7 +84,7 @@ def get_usage_for_all_services():
 
     for l in letter_costs:
         if l.service_id in combined:
-            combined[l.service_id].update({'letter_cost': l.letter_cost})
+            combined[l.service_id].update({'letter_cost': float(l.letter_cost)})
         else:
             letter_entry = {
                 "organisation_id": str(l.organisation_id) if l.organisation_id else "",

--- a/tests/app/dao/test_date_utils.py
+++ b/tests/app/dao/test_date_utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date
 
 import pytest
 
@@ -40,7 +40,8 @@ def test_get_month_start_and_end_date_in_utc(month, year, expected_start, expect
     (datetime(2018, 3, 31, 23, 0, 0), 2018),
     (datetime(2019, 3, 31, 22, 59, 59), 2018),
     (datetime(2019, 3, 31, 23, 0, 0), 2019),
-    (datetime(2020, 3, 31, 22, 59, 0), 2019),
+    (date(2019, 3, 31), 2018),
+    (date(2019, 4, 1), 2019),
 ])
 def test_get_financial_year_for_datetime(dt, fy):
     assert get_financial_year_for_datetime(dt) == fy

--- a/tests/app/dao/test_date_utils.py
+++ b/tests/app/dao/test_date_utils.py
@@ -2,7 +2,12 @@ from datetime import datetime
 
 import pytest
 
-from app.dao.date_util import get_financial_year, get_april_fools, get_month_start_and_end_date_in_utc
+from app.dao.date_util import (
+    get_financial_year,
+    get_april_fools,
+    get_month_start_and_end_date_in_utc,
+    get_financial_year_for_datetime,
+)
 
 
 def test_get_financial_year():
@@ -29,3 +34,13 @@ def test_get_month_start_and_end_date_in_utc(month, year, expected_start, expect
     result = get_month_start_and_end_date_in_utc(month_year)
     assert result[0] == expected_start
     assert result[1] == expected_end
+
+
+@pytest.mark.parametrize("dt, fy", [
+    (datetime(2018, 3, 31, 23, 0, 0), 2018),
+    (datetime(2019, 3, 31, 22, 59, 59), 2018),
+    (datetime(2019, 3, 31, 23, 0, 0), 2019),
+    (datetime(2020, 3, 31, 22, 59, 0), 2019),
+])
+def test_get_financial_year_for_datetime(dt, fy):
+    assert get_financial_year_for_datetime(dt) == fy

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -537,7 +537,6 @@ def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
                       billable_unit=12, rate=0.11)
     create_ft_billing(service=service_2, template=template_2, bst_date=datetime(2019, 5, 20), notification_type='sms',
                       billable_unit=3, rate=0.11)
-    
     service_3 = create_service(service_name='c - partial allowance')
     template_3 = create_template(service=service_3)
     org_3 = create_organisation(name="Org for {}".format(service_3.name))
@@ -558,27 +557,13 @@ def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
 
     results = fetch_sms_billing_for_all_services(datetime(2019, 5, 1), datetime(2019, 5, 31))
     assert len(results) == 3
-
-    assert results[0].organisation_id == org.id
-    assert results[0].service_id == service.id
-    assert results[0].sms_billable_units == 3
-    assert results[0].sms_remainder == 8
-    assert results[0].chargeable_billable_sms == 0
-    assert results[0].sms_cost == Decimal('0')
-
-    assert results[1].organisation_id == org_2.id
-    assert results[1].service_id == service_2.id
-    assert results[1].sms_billable_units == 3
-    assert results[1].sms_remainder == 0
-    assert results[1].chargeable_billable_sms == 3
-    assert results[1].sms_cost == Decimal('0.33')
-
-    assert results[2].organisation_id == org_3.id
-    assert results[2].service_id == service_3.id
-    assert results[2].sms_billable_units == 7
-    assert results[2].sms_remainder == 5
-    assert results[2].chargeable_billable_sms == 2
-    assert results[2].sms_cost == Decimal('0.22')
+    # (organisation_name, organisation_id, service_name, free_sms_fragment_limit, sms_rate,
+    #  sms_remainder, sms_billable_units, chargeable_billable_sms, sms_cost)
+    assert results[0] == (org.name, org.id, service.name, service.id, 10, Decimal('0.11'), 8, 3, 0, Decimal('0'))
+    assert results[1] == (org_2.name, org_2.id, service_2.name, service_2.id, 10, Decimal('0.11'), 0, 3, 3,
+                          Decimal('0.33'))
+    assert results[2] == (org_3.name, org_3.id, service_3.name, service_3.id, 10, Decimal('0.11'), 5, 7, 2,
+                          Decimal('0.22'))
 
 
 def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(notify_db_session):

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -16,7 +16,10 @@ from app.dao.fact_billing_dao import (
     fetch_monthly_billing_for_year,
     get_rate,
     get_rates_for_billing,
-)
+    fetch_sms_free_allowance_remainder,
+    fetch_sms_billing_for_all_services,
+    fetch_letter_costs_for_all_services, fetch_letter_line_items_for_all_services)
+from app.dao.organisation_dao import dao_add_service_to_organisation
 from app.models import (
     FactBilling,
     Notification,
@@ -29,7 +32,9 @@ from tests.app.db import (
     create_notification,
     create_rate,
     create_letter_rate,
-    create_notification_history
+    create_notification_history,
+    create_annual_billing,
+    create_organisation
 )
 
 
@@ -478,3 +483,193 @@ def test_delete_billing_data(notify_db_session):
     assert sorted(x.billable_units for x in current_rows) == sorted(
         [other_day.billable_units, other_service.billable_units]
     )
+
+
+def test_fetch_sms_free_allowance_remainder_with_two_services(notify_db_session):
+    service = create_service(service_name='has free allowance')
+    template = create_template(service=service)
+    org = create_organisation(name="Org for {}".format(service.name))
+    dao_add_service_to_organisation(service=service, organisation_id=org.id)
+    create_annual_billing(service_id=service.id, free_sms_fragment_limit=10, financial_year_start=2016)
+    create_ft_billing(service=service, template=template,
+                      bst_date=datetime(2016, 4, 20), notification_type='sms', billable_unit=2, rate=0.11)
+    create_ft_billing(service=service, template=template, bst_date=datetime(2016, 5, 20), notification_type='sms',
+                      billable_unit=3, rate=0.11)
+
+    service_2 = create_service(service_name='used free allowance')
+    template_2 = create_template(service=service_2)
+    org_2 = create_organisation(name="Org for {}".format(service_2.name))
+    dao_add_service_to_organisation(service=service_2, organisation_id=org_2.id)
+    create_annual_billing(service_id=service_2.id, free_sms_fragment_limit=20, financial_year_start=2016)
+    create_ft_billing(service=service_2, template=template_2, bst_date=datetime(2016, 4, 20), notification_type='sms',
+                      billable_unit=12, rate=0.11)
+    create_ft_billing(service=service_2, template=template_2, bst_date=datetime(2016, 4, 22), notification_type='sms',
+                      billable_unit=10, rate=0.11)
+    create_ft_billing(service=service_2, template=template_2, bst_date=datetime(2016, 5, 20), notification_type='sms',
+                      billable_unit=3, rate=0.11)
+    results = fetch_sms_free_allowance_remainder(datetime(2016, 5, 1)).all()
+    assert len(results) == 2
+    service_result = [row for row in results if row[0] == service.id]
+    assert service_result[0] == (service.id, 10, 2, 8)
+    service_2_result = [row for row in results if row[0] == service_2.id]
+    assert service_2_result[0] == (service_2.id, 20, 22, 0)
+
+
+def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
+    service = create_service(service_name='a - has free allowance')
+    template = create_template(service=service)
+    org = create_organisation(name="Org for {}".format(service.name))
+    dao_add_service_to_organisation(service=service, organisation_id=org.id)
+    create_annual_billing(service_id=service.id, free_sms_fragment_limit=10, financial_year_start=2019)
+    create_ft_billing(service=service, template=template,
+                      bst_date=datetime(2019, 4, 20), notification_type='sms', billable_unit=2, rate=0.11)
+    create_ft_billing(service=service, template=template, bst_date=datetime(2019, 5, 20), notification_type='sms',
+                      billable_unit=2, rate=0.11)
+    create_ft_billing(service=service, template=template, bst_date=datetime(2019, 5, 22), notification_type='sms',
+                      billable_unit=1, rate=0.11)
+
+    service_2 = create_service(service_name='b - used free allowance')
+    template_2 = create_template(service=service_2)
+    org_2 = create_organisation(name="Org for {}".format(service_2.name))
+    dao_add_service_to_organisation(service=service_2, organisation_id=org_2.id)
+    create_annual_billing(service_id=service_2.id, free_sms_fragment_limit=10, financial_year_start=2019)
+    create_ft_billing(service=service_2, template=template_2, bst_date=datetime(2019, 4, 20), notification_type='sms',
+                      billable_unit=12, rate=0.11)
+    create_ft_billing(service=service_2, template=template_2, bst_date=datetime(2019, 5, 20), notification_type='sms',
+                      billable_unit=3, rate=0.11)
+    
+    service_3 = create_service(service_name='c - partial allowance')
+    template_3 = create_template(service=service_3)
+    org_3 = create_organisation(name="Org for {}".format(service_3.name))
+    dao_add_service_to_organisation(service=service_3, organisation_id=org_3.id)
+    create_annual_billing(service_id=service_3.id, free_sms_fragment_limit=10, financial_year_start=2019)
+    create_ft_billing(service=service_3, template=template_3, bst_date=datetime(2019, 4, 20), notification_type='sms',
+                      billable_unit=5, rate=0.11)
+    create_ft_billing(service=service_3, template=template_3, bst_date=datetime(2019, 5, 20), notification_type='sms',
+                      billable_unit=7, rate=0.11)
+
+    service_4 = create_service(service_name='d - email only')
+    email_template = create_template(service=service_4, template_type='email')
+    org_4 = create_organisation(name="Org for {}".format(service_4.name))
+    dao_add_service_to_organisation(service=service_4, organisation_id=org_4.id)
+    create_annual_billing(service_id=service_4.id, free_sms_fragment_limit=10, financial_year_start=2019)
+    create_ft_billing(service=service_4, template=email_template, bst_date=datetime(2019, 5, 22), notifications_sent=5,
+                      notification_type='email', billable_unit=0, rate=0)
+
+    results = fetch_sms_billing_for_all_services(datetime(2019, 5, 1), datetime(2019, 5, 31))
+    assert len(results) == 3
+
+    assert results[0].organisation_id == org.id
+    assert results[0].service_id == service.id
+    assert results[0].sms_billable_units == 3
+    assert results[0].sms_remainder == 8
+    assert results[0].chargeable_billable_sms == 0
+    assert results[0].sms_cost == Decimal('0')
+
+    assert results[1].organisation_id == org_2.id
+    assert results[1].service_id == service_2.id
+    assert results[1].sms_billable_units == 3
+    assert results[1].sms_remainder == 0
+    assert results[1].chargeable_billable_sms == 3
+    assert results[1].sms_cost == Decimal('0.33')
+
+    assert results[2].organisation_id == org_3.id
+    assert results[2].service_id == service_3.id
+    assert results[2].sms_billable_units == 7
+    assert results[2].sms_remainder == 5
+    assert results[2].chargeable_billable_sms == 2
+    assert results[2].sms_cost == Decimal('0.22')
+
+
+def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(notify_db_session):
+    service = create_service(service_name='a - has free allowance')
+    template = create_template(service=service)
+    org = create_organisation(name="Org for {}".format(service.name))
+    service.organisation = org
+    create_annual_billing(service_id=service.id, free_sms_fragment_limit=10, financial_year_start=2019)
+    create_ft_billing(service=service, template=template,
+                      bst_date=datetime(2019, 4, 20), notification_type='sms', billable_unit=2, rate=0.11)
+    create_ft_billing(service=service, template=template, bst_date=datetime(2019, 5, 20), notification_type='sms',
+                      billable_unit=2, rate=0.11)
+    create_ft_billing(service=service, template=template, bst_date=datetime(2019, 5, 22), notification_type='sms',
+                      billable_unit=1, rate=0.11)
+
+    service_2 = create_service(service_name='b - used free allowance')
+    template_2 = create_template(service=service_2)
+
+    create_annual_billing(service_id=service_2.id, free_sms_fragment_limit=10, financial_year_start=2019)
+    create_ft_billing(service=service_2, template=template_2, bst_date=datetime(2019, 4, 20), notification_type='sms',
+                      billable_unit=12, rate=0.11)
+    create_ft_billing(service=service_2, template=template_2, bst_date=datetime(2019, 5, 20), notification_type='sms',
+                      billable_unit=3, rate=0.11)
+    results = fetch_sms_billing_for_all_services(datetime(2019, 5, 1), datetime(2019, 5, 31))
+    assert len(results) == 2
+
+    assert results[0].organisation_name == org.name
+    assert results[0].service_id == service.id
+    assert results[0].sms_billable_units == 3
+    assert results[0].sms_remainder == 8
+    assert results[0].chargeable_billable_sms == 0
+    assert results[0].sms_cost == Decimal('0')
+
+    assert not results[1].organisation_name
+    assert results[1].service_id == service_2.id
+    assert results[1].sms_billable_units == 3
+    assert results[1].sms_remainder == 0
+    assert results[1].chargeable_billable_sms == 3
+    assert results[1].sms_cost == Decimal('0.33')
+
+
+def test_fetch_letter_costs_for_all_services(notify_db_session):
+    org, org_3, service, service_3 = set_up_letter_data()
+
+    results = fetch_letter_costs_for_all_services(datetime(2019, 6, 1), datetime(2019, 9, 30))
+
+    assert len(results) == 2
+    assert results[0].organisation_id == org.id
+    assert results[0].organisation_name == org.name
+    assert results[0].service_id == service.id
+    assert results[0].service_name == service.name
+    assert results[0].letter_cost == Decimal('3.40')
+
+    assert results[1].organisation_id == org_3.id
+    assert results[1].organisation_name == org_3.name
+    assert results[1].service_id == service_3.id
+    assert results[1].service_name == service_3.name
+    assert results[1].letter_cost == Decimal('6.20')
+
+
+def test_fetch_letter_line_items_for_all_service(notify_db_session):
+    set_up_letter_data()
+    results = fetch_letter_line_items_for_all_services(datetime(2019, 6, 1), datetime(2019, 9, 30))
+    print(results)
+    assert len(results) == 4
+
+
+def set_up_letter_data():
+    service = create_service(service_name='a - first service')
+    letter_template = create_template(service=service, template_type='letter')
+    org = create_organisation(name="Org for {}".format(service.name))
+    dao_add_service_to_organisation(service=service, organisation_id=org.id)
+    service_2 = create_service(service_name='b - second service')
+    sms_template = create_template(service=service, template_type='sms')
+    dao_add_service_to_organisation(service=service_2, organisation_id=org.id)
+    service_3 = create_service(service_name='c - third service')
+    template_3 = create_template(service=service_3)
+    org_3 = create_organisation(name="Org for {}".format(service_3.name))
+    dao_add_service_to_organisation(service=service_3, organisation_id=org_3.id)
+    create_ft_billing(bst_date=datetime(2019, 8, 12), service=service_2, notification_type='sms',
+                      template=sms_template)
+    create_ft_billing(bst_date=datetime(2019, 8, 15), service=service, notification_type='letter',
+                      template=letter_template,
+                      notifications_sent=2, billable_unit=1, rate=.35, postage='first')
+    create_ft_billing(bst_date=datetime(2019, 8, 20), service=service, notification_type='letter',
+                      template=letter_template,
+                      notifications_sent=6, billable_unit=2, rate=.45, postage='second')
+    create_ft_billing(bst_date=datetime(2019, 9, 1), service=service_3, notification_type='letter',
+                      template=template_3,
+                      notifications_sent=2, billable_unit=3, rate=.50, postage='first')
+    create_ft_billing(bst_date=datetime(2019, 9, 20), service=service_3, notification_type='letter',
+                      template=template_3,
+                      notifications_sent=8, billable_unit=5, rate=.65, postage='second')
+    return org, org_3, service, service_3

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -108,7 +108,8 @@ def create_service(
         check_if_service_exists=False,
         go_live_user=None,
         go_live_at=None,
-        crown=True
+        crown=True,
+        organisation=None
 ):
     if check_if_service_exists:
         service = Service.query.filter_by(name=service_name).first()

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -126,7 +126,6 @@ def test_get_usage_for_all_services(notify_db_session, admin_request):
     response = admin_request.get("platform_stats.get_usage_for_all_services",
                                  start_date='2019-05-01',
                                  end_date='2019-06-30')
-    print(response)
     assert len(response) == 4
     assert response[0]["organisation_id"] == str(org.id)
     assert response[0]["service_id"] == str(service.id)

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -1,9 +1,15 @@
 from datetime import date, datetime
 
+import pytest
 from freezegun import freeze_time
 
+from app.errors import InvalidRequest
 from app.models import SMS_TYPE, EMAIL_TYPE
-from tests.app.db import create_service, create_template, create_ft_notification_status, create_notification
+from app.platform_stats.rest import validate_date_range_is_within_a_financial_year
+from tests.app.db import (
+    create_service, create_template, create_ft_notification_status, create_notification,
+    set_up_usage_data
+)
 
 
 @freeze_time('2018-06-01')
@@ -72,3 +78,53 @@ def test_get_platform_stats_with_real_query(admin_request, notify_db_session):
             'total': 11, 'test-key': 1
         }
     }
+
+
+@pytest.mark.parametrize('start_date, end_date',
+                         [('2019-04-01', '2019-06-30'),
+                          ('2019-08-01', '2019-09-30'),
+                          ('2019-01-01', '2019-03-31'),
+                          ('2019-12-01', '2020-02-28')])
+def test_validate_date_range_is_within_a_financial_year_returns_true(start_date, end_date):
+    assert validate_date_range_is_within_a_financial_year(start_date, end_date)
+
+
+@pytest.mark.parametrize('start_date, end_date',
+                         [('2019-04-01', '2020-06-30'),
+                          ('2019-01-01', '2019-04-30'),
+                          ('2019-12-01', '2020-04-30'),
+                          ('2019-03-31', '2019-04-01')])
+def test_validate_date_range_is_within_a_financial_year_returns_false(start_date, end_date):
+    with pytest.raises(expected_exception=InvalidRequest) as e:
+        validate_date_range_is_within_a_financial_year(start_date, end_date)
+        assert e.message == 'Date must be in a single financial year.'
+        assert e.code == 400
+
+
+def test_validate_date_is_within_a_financial_year_raises_validation_error():
+    start_date = '2019-08-01'
+    end_date = '2019-06-01'
+
+    with pytest.raises(expected_exception=InvalidRequest) as e:
+        validate_date_range_is_within_a_financial_year(start_date, end_date)
+        assert e.message == 'Start date must be before end date'
+        assert e.code == 400
+
+
+@pytest.mark.parametrize('start_date, end_date',
+                         [('22-01-2019', '2019-08-01'),
+                          ('2019-07-01', 'not-date')])
+def test_validate_date_is_within_a_financial_year_when_input_is_not_a_date(start_date, end_date):
+    with pytest.raises(expected_exception=InvalidRequest) as e:
+        assert validate_date_range_is_within_a_financial_year(start_date, end_date)
+        assert e.message == 'Input must be a date in the format: YYYY-MM-DD'
+        assert e.code == 400
+
+
+def test_get_usage_for_all_services(notify_db_session, admin_request):
+    org, org_2, service, service_2, service_3, service_sms_only = set_up_usage_data(datetime(2019, 5, 1))
+    response = admin_request.get("platform_stats.get_usage_for_all_services",
+                                 start_date='2019-05-01',
+                                 end_date='2019-06-30')
+    print(response)
+    assert 1 == 0

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -127,4 +127,30 @@ def test_get_usage_for_all_services(notify_db_session, admin_request):
                                  start_date='2019-05-01',
                                  end_date='2019-06-30')
     print(response)
-    assert 1 == 0
+    assert len(response) == 4
+    assert response[0]["organisation_id"] == str(org.id)
+    assert response[0]["service_id"] == str(service.id)
+    assert response[0]["sms_cost"] == 0
+    assert response[0]["sms_fragments"] == 0
+    assert response[0]["letter_cost"] == 3.40
+    assert response[0]["letter_breakdown"] == "6 second class letters at 45p\n2 first class letters at 35p\n"
+    assert response[1]["organisation_id"] == ""
+    assert response[1]["service_id"] == str(service_sms_only.id)
+    assert response[1]["sms_cost"] == 0.33
+    assert response[1]["sms_fragments"] == 3
+    assert response[1]["letter_cost"] == 0
+    assert response[1]["letter_breakdown"] == ""
+
+    assert response[2]["organisation_id"] == str(org_2.id)
+    assert response[2]["service_id"] == str(service_2.id)
+    assert response[2]["sms_cost"] == 0
+    assert response[2]["sms_fragments"] == 0
+    assert response[2]["letter_cost"] == 14
+    assert response[2]["letter_breakdown"] == "20 second class letters at 65p\n2 first class letters at 50p\n"
+
+    assert response[3]["organisation_id"] == ""
+    assert response[3]["service_id"] == str(service_3.id)
+    assert response[3]["sms_cost"] == 0
+    assert response[3]["sms_fragments"] == 0
+    assert response[3]["letter_cost"] == 8.25
+    assert response[3]["letter_breakdown"] == "15 second class letters at 55p\n"

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -85,8 +85,8 @@ def test_get_platform_stats_with_real_query(admin_request, notify_db_session):
                           ('2019-08-01', '2019-09-30'),
                           ('2019-01-01', '2019-03-31'),
                           ('2019-12-01', '2020-02-28')])
-def test_validate_date_range_is_within_a_financial_year_returns_true(start_date, end_date):
-    assert validate_date_range_is_within_a_financial_year(start_date, end_date)
+def test_validate_date_range_is_within_a_financial_year(start_date, end_date):
+    validate_date_range_is_within_a_financial_year(start_date, end_date)
 
 
 @pytest.mark.parametrize('start_date, end_date',
@@ -94,7 +94,7 @@ def test_validate_date_range_is_within_a_financial_year_returns_true(start_date,
                           ('2019-01-01', '2019-04-30'),
                           ('2019-12-01', '2020-04-30'),
                           ('2019-03-31', '2019-04-01')])
-def test_validate_date_range_is_within_a_financial_year_returns_false(start_date, end_date):
+def test_validate_date_range_is_within_a_financial_year_raises(start_date, end_date):
     with pytest.raises(expected_exception=InvalidRequest) as e:
         validate_date_range_is_within_a_financial_year(start_date, end_date)
         assert e.message == 'Date must be in a single financial year.'

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -133,19 +133,20 @@ def test_get_usage_for_all_services(notify_db_session, admin_request):
     assert response[0]["sms_fragments"] == 0
     assert response[0]["letter_cost"] == 3.40
     assert response[0]["letter_breakdown"] == "6 second class letters at 45p\n2 first class letters at 35p\n"
-    assert response[1]["organisation_id"] == ""
-    assert response[1]["service_id"] == str(service_sms_only.id)
-    assert response[1]["sms_cost"] == 0.33
-    assert response[1]["sms_fragments"] == 3
-    assert response[1]["letter_cost"] == 0
-    assert response[1]["letter_breakdown"] == ""
 
-    assert response[2]["organisation_id"] == str(org_2.id)
-    assert response[2]["service_id"] == str(service_2.id)
-    assert response[2]["sms_cost"] == 0
-    assert response[2]["sms_fragments"] == 0
-    assert response[2]["letter_cost"] == 14
-    assert response[2]["letter_breakdown"] == "20 second class letters at 65p\n2 first class letters at 50p\n"
+    assert response[1]["organisation_id"] == str(org_2.id)
+    assert response[1]["service_id"] == str(service_2.id)
+    assert response[1]["sms_cost"] == 0
+    assert response[1]["sms_fragments"] == 0
+    assert response[1]["letter_cost"] == 14
+    assert response[1]["letter_breakdown"] == "20 second class letters at 65p\n2 first class letters at 50p\n"
+
+    assert response[2]["organisation_id"] == ""
+    assert response[2]["service_id"] == str(service_sms_only.id)
+    assert response[2]["sms_cost"] == 0.33
+    assert response[2]["sms_fragments"] == 3
+    assert response[2]["letter_cost"] == 0
+    assert response[2]["letter_breakdown"] == ""
 
     assert response[3]["organisation_id"] == ""
     assert response[3]["service_id"] == str(service_3.id)


### PR DESCRIPTION
New billing report for all services. 

There is a command to populate the missing annual billing - the report will miss wrong for those missing rows. You'll need to run the `flask command populate-annual-billing -y 2019`

After the task is done the count of active services should match the count of services in annual billing for 2019.
`select count(*) from services where active=true`
equals
`select count(*) from annual_billing where financial_year_start=2019`