### PR TITLE
Add ‘GP’ as an org type

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -42,6 +42,7 @@ from app.models import (
     EMAIL_TYPE,
     INTERNATIONAL_SMS_TYPE,
     KEY_TYPE_TEST,
+    NHS_ORGANISATION_TYPES,
     NON_CROWN_ORGANISATION_TYPES,
     SMS_TYPE,
     LETTER_TYPE,
@@ -306,7 +307,7 @@ def dao_create_service(
         if organisation.letter_branding and not service.letter_branding:
             service.letter_branding = organisation.letter_branding
 
-    elif service.organisation_type in ['nhs_central', 'nhs_local'] or email_address_is_nhs(user.email_address):
+    elif service.organisation_type in NHS_ORGANISATION_TYPES or email_address_is_nhs(user.email_address):
         service.email_branding = dao_get_email_branding_by_name('NHS')
         service.letter_branding = dao_get_letter_branding_by_name('NHS')
     if organisation:

--- a/app/models.py
+++ b/app/models.py
@@ -326,11 +326,11 @@ class Domain(db.Model):
 
 
 ORGANISATION_TYPES = [
-    "central", "local", "nhs_central", "nhs_local", "emergency_service", "school_or_college", "other",
+    "central", "local", "nhs_central", "nhs_local", "gp", "emergency_service", "school_or_college", "other",
 ]
 
 CROWN_ORGANISATION_TYPES = ["nhs_central"]
-NON_CROWN_ORGANISATION_TYPES = ["local", "nhs_local", "emergency_service", "school_or_college"]
+NON_CROWN_ORGANISATION_TYPES = ["local", "nhs_local", "gp", "emergency_service", "school_or_college"]
 
 
 class OrganisationTypes(db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -326,11 +326,11 @@ class Domain(db.Model):
 
 
 ORGANISATION_TYPES = [
-    "central", "local", "nhs_central", "nhs_local", "gp", "emergency_service", "school_or_college", "other",
+    "central", "local", "nhs_central", "nhs_local", "nhs_gp", "emergency_service", "school_or_college", "other",
 ]
 
 CROWN_ORGANISATION_TYPES = ["nhs_central"]
-NON_CROWN_ORGANISATION_TYPES = ["local", "nhs_local", "gp", "emergency_service", "school_or_college"]
+NON_CROWN_ORGANISATION_TYPES = ["local", "nhs_local", "nhs_gp", "emergency_service", "school_or_college"]
 
 
 class OrganisationTypes(db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -331,6 +331,7 @@ ORGANISATION_TYPES = [
 
 CROWN_ORGANISATION_TYPES = ["nhs_central"]
 NON_CROWN_ORGANISATION_TYPES = ["local", "nhs_local", "nhs_gp", "emergency_service", "school_or_college"]
+NHS_ORGANISATION_TYPES = ["nhs_central", "nhs_local", "nhs_gp"]
 
 
 class OrganisationTypes(db.Model):

--- a/migrations/versions/0305_add_gp_org_type.py
+++ b/migrations/versions/0305_add_gp_org_type.py
@@ -1,0 +1,42 @@
+import os
+
+"""
+
+Revision ID: 0305_add_gp_org_type
+Revises: 0304_remove_org_to_service
+Create Date: 2019-07-24 16:18:27.467361
+
+"""
+from alembic import op
+
+
+revision = '0305_add_gp_org_type'
+down_revision = '0304_remove_org_to_service'
+GP_ORG_TYPE_NAME = 'gp'
+
+
+def upgrade():
+    op.execute("""
+        INSERT INTO
+            organisation_types
+            (name, is_crown, annual_free_sms_fragment_limit)
+        VALUES
+            ('{}', false, 25000)
+    """.format(GP_ORG_TYPE_NAME))
+
+
+def downgrade():
+    op.execute("""
+        UPDATE
+            organisation
+        SET
+            organisation_type = 'nhs_local'
+        WHERE
+            organisation_type = '{}'
+    """.format(GP_ORG_TYPE_NAME))
+    op.execute("""
+        DELETE FROM
+            organisation_types
+        WHERE
+            name = '{}'
+    """.format(GP_ORG_TYPE_NAME))

--- a/migrations/versions/0305_add_gp_org_type.py
+++ b/migrations/versions/0305_add_gp_org_type.py
@@ -12,7 +12,7 @@ from alembic import op
 
 revision = '0305_add_gp_org_type'
 down_revision = '0304_remove_org_to_service'
-GP_ORG_TYPE_NAME = 'gp'
+GP_ORG_TYPE_NAME = 'nhs_gp'
 
 
 def upgrade():

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -143,6 +143,8 @@ def test_create_service_with_organisation(notify_db_session):
 
 @pytest.mark.parametrize('email_address, organisation_type', (
     ("test@example.gov.uk", 'nhs_central'),
+    ("test@example.gov.uk", 'nhs_local'),
+    ("test@example.gov.uk", 'nhs_gp'),
     ("test@nhs.net", 'nhs_local'),
     ("test@nhs.net", 'local'),
     ("test@nhs.net", 'central'),

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -206,7 +206,7 @@ def test_post_create_organisation_existing_name_raises_400(admin_request, sample
         'organisation_type': 'foo',
     }, (
         'organisation_type foo is not one of '
-        '[central, local, nhs_central, nhs_local, gp, emergency_service, school_or_college, other]'
+        '[central, local, nhs_central, nhs_local, nhs_gp, emergency_service, school_or_college, other]'
     )),
 ))
 def test_post_create_organisation_with_missing_data_gives_validation_error(

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -204,7 +204,10 @@ def test_post_create_organisation_existing_name_raises_400(admin_request, sample
         'name': 'Service name',
         'crown': False,
         'organisation_type': 'foo',
-    }, 'organisation_type foo is not one of [central, local, nhs_central, nhs_local, emergency_service, school_or_college, other]'),  # noqa
+    }, (
+        'organisation_type foo is not one of '
+        '[central, local, nhs_central, nhs_local, gp, emergency_service, school_or_college, other]'
+    )),
 ))
 def test_post_create_organisation_with_missing_data_gives_validation_error(
     admin_request,


### PR DESCRIPTION
Although their allowances are the same as what we call `nhs_local` it makes more sense to store them separately because:
- we already present them as two separate choices to the user
- we may want to handle them differently in the future, eg in terms of what branding choices are available to them