### PR TITLE
Fix grouping on the usage for all services report

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -149,7 +149,6 @@ def fetch_letter_line_items_for_all_services(start_date, end_date):
         Organisation.id.label("organisation_id"),
         Service.name.label("service_name"),
         Service.id.label("service_id"),
-        FactBilling.billable_units.label("sheet_count"),
         FactBilling.rate.label("letter_rate"),
         FactBilling.postage.label("postage"),
         func.sum(FactBilling.notifications_sent).label("letters_sent"),
@@ -168,7 +167,6 @@ def fetch_letter_line_items_for_all_services(start_date, end_date):
         Organisation.id,
         Service.id,
         Service.name,
-        FactBilling.billable_units,
         FactBilling.rate,
         FactBilling.postage
     ).order_by(

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -612,8 +612,8 @@ def test_fetch_letter_line_items_for_all_service(notify_db_session):
     results = fetch_letter_line_items_for_all_services(datetime(2019, 6, 1), datetime(2019, 9, 30))
 
     assert len(results) == 5
-    assert results[0] == (org_1.name, org_1.id, service_1.name, service_1.id, 2, Decimal('0.45'), 'second', 6)
-    assert results[1] == (org_1.name, org_1.id, service_1.name, service_1.id, 1, Decimal("0.35"), 'first', 2)
-    assert results[2] == (org_2.name, org_2.id, service_2.name, service_2.id, 5, Decimal("0.65"), 'second', 20)
-    assert results[3] == (org_2.name, org_2.id, service_2.name, service_2.id, 3, Decimal("0.50"), 'first', 2)
-    assert results[4] == (None, None, service_3.name, service_3.id, 4, Decimal("0.55"), 'second', 15)
+    assert results[0] == (org_1.name, org_1.id, service_1.name, service_1.id, Decimal('0.45'), 'second', 6)
+    assert results[1] == (org_1.name, org_1.id, service_1.name, service_1.id, Decimal("0.35"), 'first', 2)
+    assert results[2] == (org_2.name, org_2.id, service_2.name, service_2.id, Decimal("0.65"), 'second', 20)
+    assert results[3] == (org_2.name, org_2.id, service_2.name, service_2.id, Decimal("0.50"), 'first', 2)
+    assert results[4] == (None, None, service_3.name, service_3.id, Decimal("0.55"), 'second', 15)

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -912,7 +912,10 @@ def set_up_usage_data(start_date):
                       notifications_sent=2, billable_unit=1, rate=.35, postage='first')
     create_ft_billing(bst_date=one_month_later, service=service, notification_type='letter',
                       template=letter_template,
-                      notifications_sent=6, billable_unit=2, rate=.45, postage='second')
+                      notifications_sent=4, billable_unit=2, rate=.45, postage='second')
+    create_ft_billing(bst_date=one_week_later, service=service, notification_type='letter',
+                      template=letter_template,
+                      notifications_sent=2, billable_unit=2, rate=.45, postage='second')
 
     create_ft_billing(bst_date=one_week_earlier, service=service_sms_only, notification_type='sms',
                       template=sms_template, rate=0.11, billable_unit=12)


### PR DESCRIPTION
The sheet count was not calculated properly (it should be billable_units/notifications_sent).

And it turns out the sheet count is not required for the report. This PR takes out the columns to resolve the group by error.