### PR TITLE
Fix the folder returned for a pdf letter.

### DIFF
--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -58,7 +58,10 @@ def get_bucket_name_and_prefix_for_notification(notification):
         bucket_name = current_app.config['TEST_LETTERS_BUCKET_NAME']
     else:
         bucket_name = current_app.config['LETTERS_PDF_BUCKET_NAME']
-        folder = get_folder_name(notification.created_at, False)
+        if notification.sent_at:
+            folder = "{}/".format(notification.sent_at.date())
+        else:
+            folder = get_folder_name(notification.updated_at, False)
 
     upload_file_name = PRECOMPILED_BUCKET_PREFIX.format(
         folder=folder,

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -27,6 +27,7 @@ def _sample_precompiled_letter_notification(sample_letter_notification):
     sample_letter_notification.reference = 'foo'
     with freeze_time(FROZEN_DATE_TIME):
         sample_letter_notification.created_at = datetime.utcnow()
+        sample_letter_notification.updated_at = datetime.utcnow()
     return sample_letter_notification
 
 
@@ -42,12 +43,26 @@ def _sample_precompiled_letter_notification_using_test_key(sample_precompiled_le
 ])
 def test_get_bucket_name_and_prefix_for_notification_valid_notification(sample_notification, created_at, folder):
     sample_notification.created_at = created_at
+    sample_notification.updated_at = created_at
 
     bucket, bucket_prefix = get_bucket_name_and_prefix_for_notification(sample_notification)
 
     assert bucket == current_app.config['LETTERS_PDF_BUCKET_NAME']
     assert bucket_prefix == '{folder}/NOTIFY.{reference}'.format(
         folder=folder,
+        reference=sample_notification.reference
+    ).upper()
+
+
+def test_get_bucket_name_and_prefix_for_notification_get_from_sent_at_date(sample_notification):
+    sample_notification.created_at = datetime(2019, 8, 1, 17, 35)
+    sample_notification.sent_at = datetime(2019, 8, 2, 17, 45)
+
+    bucket, bucket_prefix = get_bucket_name_and_prefix_for_notification(sample_notification)
+
+    assert bucket == current_app.config['LETTERS_PDF_BUCKET_NAME']
+    assert bucket_prefix == '{folder}/NOTIFY.{reference}'.format(
+        folder='2019-08-02',
         reference=sample_notification.reference
     ).upper()
 


### PR DESCRIPTION
Using the created at date for the folder is not always going to work because the pdf created_at date could be just before the cut off date but virus scan and validation has yet to happen. By the time the letters is in the created state, the letter goes into the next days bucket.
It can also happen if the letters is stuck in `pending-virus-scan` and we need to restart the task, and the letters is in a different folder.

It might be worth trying to reduce the complexity of these methods. 