### PR TITLE
Return org_type in list of all organisations

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -427,6 +427,7 @@ class Organisation(db.Model):
             'active': self.active,
             'count_of_live_services': len(self.live_services),
             'domains': self.domain_list,
+            'organisation_type': self.organisation_type,
         }
 
 

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -15,7 +15,7 @@ from tests.app.db import (
 
 
 def test_get_all_organisations(admin_request, notify_db_session):
-    create_organisation(name='inactive org', active=False)
+    create_organisation(name='inactive org', active=False, organisation_type='nhs_central')
     create_organisation(name='active org', domains=['example.com'])
 
     response = admin_request.get(
@@ -24,14 +24,24 @@ def test_get_all_organisations(admin_request, notify_db_session):
     )
 
     assert len(response) == 2
+    assert set(response[0].keys()) == set(response[1].keys()) == {
+        'name',
+        'id',
+        'active',
+        'count_of_live_services',
+        'domains',
+        'organisation_type',
+    }
     assert response[0]['name'] == 'active org'
     assert response[0]['active'] is True
     assert response[0]['count_of_live_services'] == 0
     assert response[0]['domains'] == ['example.com']
+    assert response[0]['organisation_type'] is None
     assert response[1]['name'] == 'inactive org'
     assert response[1]['active'] is False
     assert response[1]['count_of_live_services'] == 0
     assert response[1]['domains'] == []
+    assert response[1]['organisation_type'] == 'nhs_central'
 
 
 def test_get_organisation_by_id(admin_request, notify_db_session):


### PR DESCRIPTION
This will let us do some filtering of this list in the admin. It’s better to do it there because it means the admin can use the same cached response from Redis each time.

***

Will require flushing the Redis cache after deploying.