### PR TITLE
Copy original file to redaction_failure folder when redaction fails

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -31,6 +31,7 @@ from app.dao.notifications_dao import (
 )
 from app.errors import VirusScanError
 from app.letters.utils import (
+    copy_redaction_failed_pdf,
     get_reference_from_filename,
     get_folder_name,
     upload_letter_pdf,
@@ -219,10 +220,19 @@ def process_virus_scan_passed(self, filename):
     if not sanitise_response:
         new_pdf = None
     else:
+        sanitise_response = sanitise_response.json()
         try:
-            new_pdf = base64.b64decode(sanitise_response.json()["file"].encode())
+            new_pdf = base64.b64decode(sanitise_response["file"].encode())
         except JSONDecodeError:
             new_pdf = sanitise_response.content
+
+        redaction_failed_message = sanitise_response.get("redaction_failed_message")
+        if redaction_failed_message:
+            current_app.logger.info('{} for notification id {} ({})'.format(
+                redaction_failed_message, notification.id, filename)
+            )
+            copy_redaction_failed_pdf(filename)
+
     # TODO: Remove this once CYSP update their template to not cross over the margins
     if notification.service_id == UUID('fe44178f-3b45-4625-9f85-2264a36dd9ec'):  # CYSP
         # Check your state pension submit letters with good addresses and notify tags, so just use their supplied pdf

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -7,6 +7,7 @@ from freezegun import freeze_time
 from moto import mock_s3
 
 from app.letters.utils import (
+    copy_redaction_failed_pdf,
     get_bucket_name_and_prefix_for_notification,
     get_letter_pdf_filename,
     get_letter_pdf,
@@ -263,6 +264,24 @@ def test_move_failed_pdf_scan_failed(notify_api):
 
     assert 'FAILURE/' + filename in [o.key for o in bucket.objects.all()]
     assert filename not in [o.key for o in bucket.objects.all()]
+
+
+@mock_s3
+@freeze_time(FROZEN_DATE_TIME)
+def test_copy_redaction_failed_pdf(notify_api):
+    filename = 'test.pdf'
+    bucket_name = current_app.config['LETTERS_SCAN_BUCKET_NAME']
+
+    conn = boto3.resource('s3', region_name='eu-west-1')
+    bucket = conn.create_bucket(Bucket=bucket_name)
+
+    s3 = boto3.client('s3', region_name='eu-west-1')
+    s3.put_object(Bucket=bucket_name, Key=filename, Body=b'pdf_content')
+
+    copy_redaction_failed_pdf(filename)
+
+    assert 'REDACTION_FAILURE/' + filename in [o.key for o in bucket.objects.all()]
+    assert filename in [o.key for o in bucket.objects.all()]
 
 
 @pytest.mark.parametrize("freeze_date, expected_folder_name",


### PR DESCRIPTION
This is done so that we can see why no matches are found sometimes during the redaction procedure

Needs this PR to work: https://github.com/alphagov/notifications-template-preview/pull/369 