### PR TITLE
Use created at for sending folder

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -66,8 +66,9 @@ def create_letters_pdf(self, notification_id):
 
         upload_letter_pdf(notification, pdf_data)
 
-        notification.billable_units = billable_units
-        dao_update_notification(notification)
+        if notification.key_type != KEY_TYPE_TEST:
+            notification.billable_units = billable_units
+            dao_update_notification(notification)
 
         current_app.logger.info(
             'Letter notification reference {reference}: billable units set to {billable_units}'.format(

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -253,7 +253,9 @@ def process_virus_scan_passed(self, filename):
         _upload_pdf_to_test_or_live_pdf_bucket(
             new_pdf,
             filename,
-            is_test_letter=is_test_key)
+            is_test_letter=is_test_key,
+            created_at=notification.created_at
+        )
 
         update_letter_pdf_status(
             reference=reference,
@@ -284,10 +286,10 @@ def _move_invalid_letter_and_update_status(notification, filename, scan_pdf_obje
         update_notification_status_by_id(notification.id, NOTIFICATION_TECHNICAL_FAILURE)
 
 
-def _upload_pdf_to_test_or_live_pdf_bucket(pdf_data, filename, is_test_letter):
+def _upload_pdf_to_test_or_live_pdf_bucket(pdf_data, filename, is_test_letter, created_at):
     target_bucket_config = 'TEST_LETTERS_BUCKET_NAME' if is_test_letter else 'LETTERS_PDF_BUCKET_NAME'
     target_bucket_name = current_app.config[target_bucket_config]
-    target_filename = get_folder_name(datetime.utcnow(), is_test_letter) + filename
+    target_filename = get_folder_name(created_at, dont_use_sending_date=is_test_letter) + filename
 
     s3upload(
         filedata=pdf_data,

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -228,7 +228,7 @@ def process_virus_scan_passed(self, filename):
             new_pdf = sanitise_response.content
 
         redaction_failed_message = sanitise_response.get("redaction_failed_message")
-        if redaction_failed_message:
+        if redaction_failed_message and not is_test_key:
             current_app.logger.info('{} for notification id {} ({})'.format(
                 redaction_failed_message, notification.id, filename)
             )

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -407,7 +407,7 @@ def _delete_letters_from_s3(
             prefix = get_letter_pdf_filename(reference=letter.reference,
                                              crown=letter.service.crown,
                                              sending_date=letter.created_at,
-                                             is_scan_letter=letter.key_type == KEY_TYPE_TEST,
+                                             dont_use_sending_date=letter.key_type == KEY_TYPE_TEST,
                                              postage=letter.postage)
             s3_objects = get_s3_bucket_objects(bucket_name=bucket_name, subfolder=prefix)
             for s3_object in s3_objects:

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -25,8 +25,8 @@ LETTERS_PDF_FILE_LOCATION_STRUCTURE = \
 PRECOMPILED_BUCKET_PREFIX = '{folder}NOTIFY.{reference}'
 
 
-def get_folder_name(_now, is_test_or_scan_letter=False):
-    if is_test_or_scan_letter:
+def get_folder_name(_now, dont_use_sending_date=False):
+    if dont_use_sending_date:
         folder_name = ''
     else:
         print_datetime = convert_utc_to_bst(_now)
@@ -36,9 +36,9 @@ def get_folder_name(_now, is_test_or_scan_letter=False):
     return folder_name
 
 
-def get_letter_pdf_filename(reference, crown, sending_date, is_scan_letter=False, postage=SECOND_CLASS):
+def get_letter_pdf_filename(reference, crown, sending_date, dont_use_sending_date=False, postage=SECOND_CLASS):
     upload_file_name = LETTERS_PDF_FILE_LOCATION_STRUCTURE.format(
-        folder=get_folder_name(sending_date, is_scan_letter),
+        folder=get_folder_name(sending_date, dont_use_sending_date),
         reference=reference,
         duplex="D",
         letter_class=RESOLVE_POSTAGE_FOR_FILE_NAME[postage],
@@ -81,7 +81,7 @@ def upload_letter_pdf(notification, pdf_data, precompiled=False):
         reference=notification.reference,
         crown=notification.service.crown,
         sending_date=notification.created_at,
-        is_scan_letter=precompiled or notification.key_type == KEY_TYPE_TEST,
+        dont_use_sending_date=precompiled or notification.key_type == KEY_TYPE_TEST,
         postage=notification.postage
     )
 

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -38,7 +38,7 @@ def get_folder_name(_now, dont_use_sending_date=False):
 
 def get_letter_pdf_filename(reference, crown, sending_date, dont_use_sending_date=False, postage=SECOND_CLASS):
     upload_file_name = LETTERS_PDF_FILE_LOCATION_STRUCTURE.format(
-        folder=get_folder_name(sending_date, dont_use_sending_date),
+        folder=get_folder_name(sending_date, dont_use_sending_date=dont_use_sending_date),
         reference=reference,
         duplex="D",
         letter_class=RESOLVE_POSTAGE_FOR_FILE_NAME[postage],
@@ -57,7 +57,7 @@ def get_bucket_name_and_prefix_for_notification(notification):
         bucket_name = current_app.config['TEST_LETTERS_BUCKET_NAME']
     else:
         bucket_name = current_app.config['LETTERS_PDF_BUCKET_NAME']
-        folder = get_folder_name(notification.created_at, False)
+        folder = get_folder_name(notification.created_at, dont_use_sending_date=False)
 
     upload_file_name = PRECOMPILED_BUCKET_PREFIX.format(
         folder=folder,
@@ -81,7 +81,7 @@ def upload_letter_pdf(notification, pdf_data, precompiled=False):
         reference=notification.reference,
         crown=notification.service.crown,
         sending_date=notification.created_at,
-        dont_use_sending_date=precompiled or notification.key_type == KEY_TYPE_TEST,
+        dont_use_sending_date=precompiled,
         postage=notification.postage
     )
 

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -36,19 +36,16 @@ def get_folder_name(_now, is_test_or_scan_letter=False):
     return folder_name
 
 
-def get_letter_pdf_filename(reference, crown, is_scan_letter=False, postage=SECOND_CLASS):
-    now = datetime.utcnow()
-
+def get_letter_pdf_filename(reference, crown, sending_date, is_scan_letter=False, postage=SECOND_CLASS):
     upload_file_name = LETTERS_PDF_FILE_LOCATION_STRUCTURE.format(
-        folder=get_folder_name(now, is_scan_letter),
+        folder=get_folder_name(sending_date, is_scan_letter),
         reference=reference,
         duplex="D",
         letter_class=RESOLVE_POSTAGE_FOR_FILE_NAME[postage],
         colour="C",
         crown="C" if crown else "N",
-        date=now.strftime('%Y%m%d%H%M%S')
+        date=sending_date.strftime('%Y%m%d%H%M%S')
     ).upper()
-
     return upload_file_name
 
 
@@ -60,12 +57,7 @@ def get_bucket_name_and_prefix_for_notification(notification):
         bucket_name = current_app.config['TEST_LETTERS_BUCKET_NAME']
     else:
         bucket_name = current_app.config['LETTERS_PDF_BUCKET_NAME']
-        if notification.sent_at:
-            folder = "{}/".format(notification.sent_at.date())
-        elif notification.updated_at:
-            folder = get_folder_name(notification.updated_at, False)
-        else:
-            folder = get_folder_name(notification.created_at, False)
+        folder = get_folder_name(notification.created_at, False)
 
     upload_file_name = PRECOMPILED_BUCKET_PREFIX.format(
         folder=folder,
@@ -86,8 +78,9 @@ def upload_letter_pdf(notification, pdf_data, precompiled=False):
         notification.id, notification.reference, notification.created_at, len(pdf_data)))
 
     upload_file_name = get_letter_pdf_filename(
-        notification.reference,
-        notification.service.crown,
+        reference=notification.reference,
+        crown=notification.service.crown,
+        sending_date=notification.created_at,
         is_scan_letter=precompiled or notification.key_type == KEY_TYPE_TEST,
         postage=notification.postage
     )

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -81,7 +81,7 @@ def upload_letter_pdf(notification, pdf_data, precompiled=False):
         reference=notification.reference,
         crown=notification.service.crown,
         sending_date=notification.created_at,
-        dont_use_sending_date=precompiled,
+        dont_use_sending_date=precompiled or notification.key_type == KEY_TYPE_TEST,
         postage=notification.postage
     )
 

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -53,11 +53,10 @@ def get_letter_pdf_filename(reference, crown, is_scan_letter=False, postage=SECO
 
 
 def get_bucket_name_and_prefix_for_notification(notification):
-    is_test_letter = notification.key_type == KEY_TYPE_TEST and notification.template.is_precompiled_letter
     folder = ''
     if notification.status == NOTIFICATION_VALIDATION_FAILED:
         bucket_name = current_app.config['INVALID_PDF_BUCKET_NAME']
-    elif is_test_letter:
+    elif notification.key_type == KEY_TYPE_TEST:
         bucket_name = current_app.config['TEST_LETTERS_BUCKET_NAME']
     else:
         bucket_name = current_app.config['LETTERS_PDF_BUCKET_NAME']
@@ -95,6 +94,8 @@ def upload_letter_pdf(notification, pdf_data, precompiled=False):
 
     if precompiled:
         bucket_name = current_app.config['LETTERS_SCAN_BUCKET_NAME']
+    elif notification.key_type == KEY_TYPE_TEST:
+        bucket_name = current_app.config['TEST_LETTERS_BUCKET_NAME']
     else:
         bucket_name = current_app.config['LETTERS_PDF_BUCKET_NAME']
 

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -88,7 +88,7 @@ def upload_letter_pdf(notification, pdf_data, precompiled=False):
     upload_file_name = get_letter_pdf_filename(
         notification.reference,
         notification.service.crown,
-        is_scan_letter=precompiled,
+        is_scan_letter=precompiled or notification.key_type == KEY_TYPE_TEST,
         postage=notification.postage
     )
 

--- a/app/models.py
+++ b/app/models.py
@@ -1547,7 +1547,7 @@ class Notification(db.Model):
         elif self.status in [NOTIFICATION_DELIVERED, NOTIFICATION_RETURNED_LETTER]:
             return NOTIFICATION_STATUS_LETTER_RECEIVED
         else:
-            # Currently can only be technical-failure
+            # Currently can only be technical-failure OR pending-virus-check OR validation-failed
             return self.status
 
     def get_created_by_name(self):

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -181,7 +181,7 @@ def send_pdf_letter_notification(service_id, post_data):
         reference=notification.reference,
         crown=notification.service.crown,
         sending_date=notification.created_at,
-        is_scan_letter=False,
+        dont_use_sending_date=False,
         postage=notification.postage
     )
 

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -178,8 +178,9 @@ def send_pdf_letter_notification(service_id, post_data):
     )
 
     upload_filename = get_letter_pdf_filename(
-        notification.reference,
-        notification.service.crown,
+        reference=notification.reference,
+        crown=notification.service.crown,
+        sending_date=notification.created_at,
         is_scan_letter=False,
         postage=notification.postage
     )

--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -57,6 +57,11 @@ class BadRequestError(InvalidRequest):
         self.message = message if message else self.message
 
 
+class PDFNotReadyError(BadRequestError):
+    def __init__(self):
+        super().__init__(message='PDF not available yet, try again later', status_code=400)
+
+
 def register_errors(blueprint):
     @blueprint.errorhandler(InvalidEmailError)
     def invalid_format(error):

--- a/app/v2/notifications/get_notifications.py
+++ b/app/v2/notifications/get_notifications.py
@@ -1,9 +1,20 @@
-from flask import jsonify, request, url_for, current_app
+from io import BytesIO
+
+from flask import jsonify, request, url_for, current_app, send_file
+
 from app import api_user, authenticated_service
 from app.dao import notifications_dao
+from app.letters.utils import get_letter_pdf
 from app.schema_validation import validate
+from app.v2.errors import BadRequestError, PDFNotReadyError
 from app.v2.notifications import v2_notification_blueprint
 from app.v2.notifications.notification_schemas import get_notifications_request, notification_by_id
+from app.models import (
+    NOTIFICATION_PENDING_VIRUS_CHECK,
+    NOTIFICATION_VIRUS_SCAN_FAILED,
+    NOTIFICATION_TECHNICAL_FAILURE,
+    LETTER_TYPE,
+)
 
 
 @v2_notification_blueprint.route("/<notification_id>", methods=['GET'])
@@ -13,8 +24,35 @@ def get_notification_by_id(notification_id):
     notification = notifications_dao.get_notification_with_personalisation(
         authenticated_service.id, notification_id, key_type=None
     )
-
     return jsonify(notification.serialize()), 200
+
+
+@v2_notification_blueprint.route('/<notification_id>/pdf', methods=['GET'])
+def get_pdf_for_notification(notification_id):
+    _data = {"notification_id": notification_id}
+    validate(_data, notification_by_id)
+    notification = notifications_dao.get_notification_by_id(
+        notification_id, authenticated_service.id, _raise=True
+    )
+
+    if notification.notification_type != LETTER_TYPE:
+        raise BadRequestError(message="Notification is not a letter")
+
+    if notification.status == NOTIFICATION_VIRUS_SCAN_FAILED:
+        raise BadRequestError(message='Document did not pass the virus scan')
+
+    if notification.status == NOTIFICATION_TECHNICAL_FAILURE:
+        raise BadRequestError(message='PDF not available for letters in status {}'.format(notification.status))
+
+    if notification.status == NOTIFICATION_PENDING_VIRUS_CHECK:
+        raise PDFNotReadyError()
+
+    try:
+        pdf_data = get_letter_pdf(notification)
+    except Exception:
+        raise PDFNotReadyError()
+
+    return send_file(filename_or_fp=BytesIO(pdf_data), mimetype='application/pdf')
 
 
 @v2_notification_blueprint.route("", methods=['GET'])

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -543,10 +543,13 @@ def test_process_letter_task_check_virus_scan_passed_when_redaction_fails(
 
     assert sample_letter_notification.billable_units == 2
     assert sample_letter_notification.status == notification_status
-    mock_copy_s3.assert_called_once_with(
-        bucket_name, filename,
-        bucket_name, 'REDACTION_FAILURE/' + filename
-    )
+    if key_type == KEY_TYPE_NORMAL:
+        mock_copy_s3.assert_called_once_with(
+            bucket_name, filename,
+            bucket_name, 'REDACTION_FAILURE/' + filename
+        )
+    else:
+        mock_copy_s3.assert_not_called()
 
 
 @freeze_time('2018-01-01 18:00')

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -27,7 +27,7 @@ from app.celery.letters_pdf_tasks import (
     _move_invalid_letter_and_update_status,
     _sanitise_precompiled_pdf
 )
-from app.letters.utils import ScanErrorType
+from app.letters.utils import ScanErrorType, get_letter_pdf_filename
 from app.models import (
     KEY_TYPE_NORMAL,
     KEY_TYPE_TEST,
@@ -135,12 +135,12 @@ def test_create_letters_pdf_calls_s3upload(mocker, sample_letter_notification):
 
 
 @freeze_time("2017-12-04 17:31:00")
-def test_create_letters_pdf_calls_s3upload_for_test_letters(mocker, sample_letter_notification):
+def test_create_letters_pdf_calls_s3upload_for_test_letters(mocker, sample_letter_template):
     mocker.patch('app.celery.letters_pdf_tasks.get_letters_pdf', return_value=(b'\x00\x01', '1'))
     mock_s3 = mocker.patch('app.letters.utils.s3upload')
-    sample_letter_notification.key_type = 'test'
+    notification = create_notification(template=sample_letter_template, reference='FOO', key_type='test')
 
-    create_letters_pdf(sample_letter_notification.id)
+    create_letters_pdf(notification.id)
 
     mock_s3.assert_called_with(
         bucket_name=current_app.config['TEST_LETTERS_BUCKET_NAME'],

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -120,9 +120,15 @@ def test_create_letters_pdf_calls_s3upload(mocker, sample_letter_notification):
 
     create_letters_pdf(sample_letter_notification.id)
 
+    filename = get_letter_pdf_filename(
+        reference=sample_letter_notification.reference,
+        crown=sample_letter_notification.service.crown,
+        sending_date=sample_letter_notification.created_at
+    )
+
     mock_s3.assert_called_with(
         bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
-        file_location='2017-12-05/NOTIFY.FOO.D.2.C.C.20171204173100.PDF',
+        file_location=filename,
         filedata=b'\x00\x01',
         region=current_app.config['AWS_REGION']
     )

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -160,7 +160,8 @@ def test_get_letter_pdf_filename_returns_correct_postage_for_filename(
 def test_get_letter_pdf_filename_returns_correct_filename_for_test_letters(
         notify_api, mocker):
     sending_date = datetime(2017, 12, 4, 17, 29)
-    filename = get_letter_pdf_filename(reference='foo', crown='C', sending_date=sending_date, is_scan_letter=True)
+    filename = get_letter_pdf_filename(reference='foo', crown='C',
+                                       sending_date=sending_date, dont_use_sending_date=True)
 
     assert filename == 'NOTIFY.FOO.D.2.C.C.20171204172900.PDF'
 
@@ -215,7 +216,7 @@ def test_upload_letter_pdf_to_correct_bucket(
         reference=sample_letter_notification.reference,
         crown=sample_letter_notification.service.crown,
         sending_date=sample_letter_notification.created_at,
-        is_scan_letter=is_precompiled_letter
+        dont_use_sending_date=is_precompiled_letter
     )
 
     upload_letter_pdf(sample_letter_notification, b'\x00\x01', precompiled=is_precompiled_letter)
@@ -242,7 +243,7 @@ def test_upload_letter_pdf_uses_postage_from_notification(
         reference=letter_notification.reference,
         crown=letter_notification.service.crown,
         sending_date=letter_notification.created_at,
-        is_scan_letter=False,
+        dont_use_sending_date=False,
         postage=letter_notification.postage
     )
 
@@ -329,12 +330,12 @@ def test_copy_redaction_failed_pdf(notify_api):
 def test_get_folder_name_in_british_summer_time(notify_api, freeze_date, expected_folder_name):
     with freeze_time(freeze_date):
         now = datetime.utcnow()
-        folder_name = get_folder_name(_now=now, is_test_or_scan_letter=False)
+        folder_name = get_folder_name(_now=now, dont_use_sending_date=False)
     assert folder_name == expected_folder_name
 
 
 def test_get_folder_name_returns_empty_string_for_test_letter():
-    assert '' == get_folder_name(datetime.utcnow(), is_test_or_scan_letter=True)
+    assert '' == get_folder_name(datetime.utcnow(), dont_use_sending_date=True)
 
 
 @freeze_time('2017-07-07 20:00:00')

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -95,6 +95,16 @@ def test_get_bucket_name_and_prefix_for_notification_precompiled_letter_using_te
 
 
 @freeze_time(FROZEN_DATE_TIME)
+def test_get_bucket_name_and_prefix_for_notification_templated_letter_using_test_key(sample_letter_notification):
+    sample_letter_notification.key_type = KEY_TYPE_TEST
+
+    bucket, bucket_prefix = get_bucket_name_and_prefix_for_notification(sample_letter_notification)
+
+    assert bucket == current_app.config['TEST_LETTERS_BUCKET_NAME']
+    assert bucket_prefix == 'NOTIFY.{}'.format(sample_letter_notification.reference).upper()
+
+
+@freeze_time(FROZEN_DATE_TIME)
 def test_get_bucket_name_and_prefix_for_failed_validation(sample_precompiled_letter_notification):
     sample_precompiled_letter_notification.status = NOTIFICATION_VALIDATION_FAILED
     bucket, bucket_prefix = get_bucket_name_and_prefix_for_notification(sample_precompiled_letter_notification)

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -55,7 +55,7 @@ def test_get_bucket_name_and_prefix_for_notification_valid_notification(sample_n
     ).upper()
 
 
-def test_get_bucket_name_and_prefix_for_notification_get_from_sent_at_date(sample_notification):
+def test_get_bucket_name_and_prefix_for_notification_is_tomorrow_after_17_30(sample_notification):
     sample_notification.created_at = datetime(2019, 8, 1, 17, 35)
     sample_notification.sent_at = datetime(2019, 8, 2, 17, 45)
 
@@ -68,7 +68,7 @@ def test_get_bucket_name_and_prefix_for_notification_get_from_sent_at_date(sampl
     ).upper()
 
 
-def test_get_bucket_name_and_prefix_for_notification_from_created_at_date(sample_notification):
+def test_get_bucket_name_and_prefix_for_notification_is_today_before_17_30(sample_notification):
     sample_notification.created_at = datetime(2019, 8, 1, 12, 00)
     sample_notification.updated_at = datetime(2019, 8, 2, 12, 00)
     sample_notification.sent_at = datetime(2019, 8, 3, 12, 00)
@@ -77,7 +77,7 @@ def test_get_bucket_name_and_prefix_for_notification_from_created_at_date(sample
 
     assert bucket == current_app.config['LETTERS_PDF_BUCKET_NAME']
     assert bucket_prefix == '{folder}/NOTIFY.{reference}'.format(
-        folder='2019-08-03',
+        folder='2019-08-01',
         reference=sample_notification.reference
     ).upper()
 
@@ -137,10 +137,10 @@ def test_get_bucket_name_and_prefix_for_notification_invalid_notification():
     (True, 'C'),
     (False, 'N'),
 ])
-@freeze_time("2017-12-04 17:29:00")
 def test_get_letter_pdf_filename_returns_correct_filename(
         notify_api, mocker, crown_flag, expected_crown_text):
-    filename = get_letter_pdf_filename(reference='foo', crown=crown_flag)
+    sending_date = datetime(2017, 12, 4, 17, 29)
+    filename = get_letter_pdf_filename(reference='foo', crown=crown_flag, sending_date=sending_date)
 
     assert filename == '2017-12-04/NOTIFY.FOO.D.2.C.{}.20171204172900.PDF'.format(expected_crown_text)
 
@@ -149,25 +149,25 @@ def test_get_letter_pdf_filename_returns_correct_filename(
     ('second', 2),
     ('first', 1),
 ])
-@freeze_time("2017-12-04 17:29:00")
 def test_get_letter_pdf_filename_returns_correct_postage_for_filename(
         notify_api, postage, expected_postage):
-    filename = get_letter_pdf_filename(reference='foo', crown=True, postage=postage)
+    sending_date = datetime(2017, 12, 4, 17, 29)
+    filename = get_letter_pdf_filename(reference='foo', crown=True, sending_date=sending_date, postage=postage)
 
     assert filename == '2017-12-04/NOTIFY.FOO.D.{}.C.C.20171204172900.PDF'.format(expected_postage)
 
 
-@freeze_time("2017-12-04 17:29:00")
 def test_get_letter_pdf_filename_returns_correct_filename_for_test_letters(
         notify_api, mocker):
-    filename = get_letter_pdf_filename(reference='foo', crown='C', is_scan_letter=True)
+    sending_date = datetime(2017, 12, 4, 17, 29)
+    filename = get_letter_pdf_filename(reference='foo', crown='C', sending_date=sending_date, is_scan_letter=True)
 
     assert filename == 'NOTIFY.FOO.D.2.C.C.20171204172900.PDF'
 
 
-@freeze_time("2017-12-04 17:31:00")
 def test_get_letter_pdf_filename_returns_tomorrows_filename(notify_api, mocker):
-    filename = get_letter_pdf_filename(reference='foo', crown=True)
+    sending_date = datetime(2017, 12, 4, 17, 31)
+    filename = get_letter_pdf_filename(reference='foo', crown=True, sending_date=sending_date)
 
     assert filename == '2017-12-05/NOTIFY.FOO.D.2.C.C.20171204173100.PDF'
 
@@ -214,6 +214,7 @@ def test_upload_letter_pdf_to_correct_bucket(
     filename = get_letter_pdf_filename(
         reference=sample_letter_notification.reference,
         crown=sample_letter_notification.service.crown,
+        sending_date=sample_letter_notification.created_at,
         is_scan_letter=is_precompiled_letter
     )
 
@@ -240,6 +241,7 @@ def test_upload_letter_pdf_uses_postage_from_notification(
     filename = get_letter_pdf_filename(
         reference=letter_notification.reference,
         crown=letter_notification.service.crown,
+        sending_date=letter_notification.created_at,
         is_scan_letter=False,
         postage=letter_notification.postage
     )

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -122,7 +122,7 @@ def test_post_letter_notification_sets_postage(
     'staging',
     'live',
 ])
-def test_post_letter_notification_with_test_key_set_status_to_delivered(
+def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_delivered(
         notify_api, client, sample_letter_template, mocker, env):
 
     data = {
@@ -148,7 +148,7 @@ def test_post_letter_notification_with_test_key_set_status_to_delivered(
 
     notification = Notification.query.one()
 
-    assert not fake_create_letter_task.called
+    fake_create_letter_task.assert_called_once_with([str(notification.id)], queue='research-mode-tasks')
     assert not fake_create_dvla_response_task.called
     assert notification.status == NOTIFICATION_DELIVERED
 
@@ -157,7 +157,7 @@ def test_post_letter_notification_with_test_key_set_status_to_delivered(
     'development',
     'preview',
 ])
-def test_post_letter_notification_with_test_key_sets_status_to_sending_and_sends_fake_response_file(
+def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_sending_and_sends_fake_response_file(
         notify_api, client, sample_letter_template, mocker, env):
 
     data = {
@@ -183,7 +183,7 @@ def test_post_letter_notification_with_test_key_sets_status_to_sending_and_sends
 
     notification = Notification.query.one()
 
-    assert not fake_create_letter_task.called
+    fake_create_letter_task.assert_called_once_with([str(notification.id)], queue='research-mode-tasks')
     assert fake_create_dvla_response_task.called
     assert notification.status == NOTIFICATION_SENDING
 
@@ -357,7 +357,7 @@ def test_post_letter_notification_doesnt_send_in_trial(client, sample_trial_lett
         {'error': 'BadRequestError', 'message': 'Cannot send letters when service is in trial mode'}]
 
 
-def test_post_letter_notification_is_delivered_if_in_trial_mode_and_using_test_key(
+def test_post_letter_notification_is_delivered_but_still_creates_pdf_if_in_trial_mode_and_using_test_key(
     client,
     sample_trial_letter_template,
     mocker
@@ -373,7 +373,7 @@ def test_post_letter_notification_is_delivered_if_in_trial_mode_and_using_test_k
 
     notification = Notification.query.one()
     assert notification.status == NOTIFICATION_DELIVERED
-    assert not fake_create_letter_task.called
+    fake_create_letter_task.assert_called_once_with([str(notification.id)], queue='research-mode-tasks')
 
 
 def test_post_letter_notification_is_delivered_and_has_pdf_uploaded_to_test_letters_bucket_using_test_key(


### PR DESCRIPTION
### Refactor the code that figures out what folder and filename to use for the letter pdf files.

- Now we consistently use the created_at date, so we can always get the right file location and name.

- The previous updates to this code were trying to solve the problem if a pdf being created at 17:29, but not ready to upload until 17:31 after the antivirus and validation check.
But in those cases we would have trouble finding the file.

- Change the variable name to make a little more sense.