### PR TITLE
Don't log address redaction failure when letter sent with test key

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -228,7 +228,7 @@ def process_virus_scan_passed(self, filename):
             new_pdf = sanitise_response.content
 
         redaction_failed_message = sanitise_response.get("redaction_failed_message")
-        if redaction_failed_message:
+        if redaction_failed_message and not is_test_key:
             current_app.logger.info('{} for notification id {} ({})'.format(
                 redaction_failed_message, notification.id, filename)
             )

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -532,10 +532,13 @@ def test_process_letter_task_check_virus_scan_passed_when_redaction_fails(
 
     assert sample_letter_notification.billable_units == 2
     assert sample_letter_notification.status == notification_status
-    mock_copy_s3.assert_called_once_with(
-        bucket_name, filename,
-        bucket_name, 'REDACTION_FAILURE/' + filename
-    )
+    if key_type == KEY_TYPE_NORMAL:
+        mock_copy_s3.assert_called_once_with(
+            bucket_name, filename,
+            bucket_name, 'REDACTION_FAILURE/' + filename
+        )
+    else:
+        mock_copy_s3.assert_not_called()
 
 
 @freeze_time('2018-01-01 18:00')


### PR DESCRIPTION
People send test letters with name only in address block, and then our redaction tool finds too many matches. Yet those redaction failures do not matter as they are not representative of real letters.

So it would be good to only log real letters that failed redaction.