### PR TITLE
Update the branding of services branding when updating their organisation’s branding

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -80,43 +80,24 @@ def dao_update_organisation(organisation_id, **kwargs):
     organisation = Organisation.query.get(organisation_id)
 
     if 'organisation_type' in kwargs:
-        _update_org_type_for_organisation_services(organisation)
+        _update_organisation_services(organisation, 'organisation_type', only_where_none=False)
 
     if 'email_branding_id' in kwargs:
-        _update_email_branding_for_organisation_services(organisation)
+        _update_organisation_services(organisation, 'email_branding')
 
     if 'letter_branding_id' in kwargs:
-        _update_letter_branding_for_organisation_services(organisation)
+        _update_organisation_services(organisation, 'letter_branding')
 
     return num_updated
 
 
 @version_class(
-    VersionOptions(Service, must_write_history=False)
+    VersionOptions(Service, must_write_history=False),
 )
-def _update_org_type_for_organisation_services(organisation):
+def _update_organisation_services(organisation, attribute, only_where_none=True):
     for service in organisation.services:
-        service.organisation_type = organisation.organisation_type
-        db.session.add(service)
-
-
-@version_class(
-    VersionOptions(Service, must_write_history=False)
-)
-def _update_email_branding_for_organisation_services(organisation):
-    for service in organisation.services:
-        if service.email_branding is None:
-            service.email_branding = organisation.email_branding
-        db.session.add(service)
-
-
-@version_class(
-    VersionOptions(Service, must_write_history=False)
-)
-def _update_letter_branding_for_organisation_services(organisation):
-    for service in organisation.services:
-        if service.letter_branding is None:
-            service.letter_branding = organisation.letter_branding
+        if getattr(service, attribute) is None or not only_where_none:
+            setattr(service, attribute, getattr(organisation, attribute))
         db.session.add(service)
 
 

--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -1,7 +1,7 @@
 from sqlalchemy.sql.expression import func
 
 from app import db
-from app.dao.dao_utils import transactional, version_class
+from app.dao.dao_utils import VersionOptions, transactional, version_class
 from app.models import (
     Organisation,
     Domain,
@@ -77,18 +77,46 @@ def dao_update_organisation(organisation_id, **kwargs):
             for domain in domains
         ])
 
+    organisation = Organisation.query.get(organisation_id)
+
     if 'organisation_type' in kwargs:
-        organisation = Organisation.query.get(organisation_id)
-        if organisation.services:
-            _update_org_type_for_organisation_services(organisation)
+        _update_org_type_for_organisation_services(organisation)
+
+    if 'email_branding_id' in kwargs:
+        _update_email_branding_for_organisation_services(organisation)
+
+    if 'letter_branding_id' in kwargs:
+        _update_letter_branding_for_organisation_services(organisation)
 
     return num_updated
 
 
-@version_class(Service)
+@version_class(
+    VersionOptions(Service, must_write_history=False)
+)
 def _update_org_type_for_organisation_services(organisation):
     for service in organisation.services:
         service.organisation_type = organisation.organisation_type
+        db.session.add(service)
+
+
+@version_class(
+    VersionOptions(Service, must_write_history=False)
+)
+def _update_email_branding_for_organisation_services(organisation):
+    for service in organisation.services:
+        if service.email_branding is None:
+            service.email_branding = organisation.email_branding
+        db.session.add(service)
+
+
+@version_class(
+    VersionOptions(Service, must_write_history=False)
+)
+def _update_letter_branding_for_organisation_services(organisation):
+    for service in organisation.services:
+        if service.letter_branding is None:
+            service.letter_branding = organisation.letter_branding
         db.session.add(service)
 
 


### PR DESCRIPTION
When a service asks for branding I often go and:
- set the branding on the organisation as well
- set the branding on all the organisation’s services

The latter can be quite time consuming, but it does save effort since existing services from the same organisation won’t have to request branding. It also improves the consistency of the communications that users are receiving.

This commit automates that process by applying the branding update to any services belonging to the organisation, if those services don’t already have their own custom branding set up.