### PR TITLE
Letter alert

### DIFF
--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -471,8 +471,8 @@ def test_alert_if_letter_notifications_still_sending_does_nothing_on_the_weekend
 def test_monday_alert_if_letter_notifications_still_sending_reports_thursday_letters(sample_letter_template, mocker):
     thursday = datetime(2018, 1, 11, 13, 30)
     yesterday = datetime(2018, 1, 14, 13, 30)
-    create_notification(template=sample_letter_template, status='sending', sent_at=thursday)
-    create_notification(template=sample_letter_template, status='sending', sent_at=yesterday)
+    create_notification(template=sample_letter_template, status='sending', sent_at=thursday, postage='second')
+    create_notification(template=sample_letter_template, status='sending', sent_at=yesterday, postage='second')
 
     mock_create_ticket = mocker.patch("app.celery.nightly_tasks.zendesk_client.create_ticket")
 
@@ -489,8 +489,10 @@ def test_monday_alert_if_letter_notifications_still_sending_reports_thursday_let
 def test_tuesday_alert_if_letter_notifications_still_sending_reports_friday_letters(sample_letter_template, mocker):
     friday = datetime(2018, 1, 12, 13, 30)
     yesterday = datetime(2018, 1, 14, 13, 30)
-    create_notification(template=sample_letter_template, status='sending', sent_at=friday)
-    create_notification(template=sample_letter_template, status='sending', sent_at=yesterday)
+    create_notification(template=sample_letter_template, status='sending', sent_at=friday, postage='first')
+    create_notification(template=sample_letter_template, status='sending', sent_at=yesterday, postage='first')
+    # doesn't get reported because it's second class, and it's tuesday today
+    create_notification(template=sample_letter_template, status='sending', sent_at=friday, postage='second')
 
     mock_create_ticket = mocker.patch("app.celery.nightly_tasks.zendesk_client.create_ticket")
 

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -394,7 +394,7 @@ def test_delete_dvla_response_files_older_than_seven_days_does_not_remove_files(
     remove_s3_mock.assert_not_called()
 
 
-@freeze_time("2018-01-17 17:00:00")
+@freeze_time("Thursday 17th January 2018 17:00")
 def test_alert_if_letter_notifications_still_sending(sample_letter_template, mocker):
     two_days_ago = datetime(2018, 1, 15, 13, 30)
     create_notification(template=sample_letter_template, status='sending', sent_at=two_days_ago)
@@ -421,7 +421,7 @@ def test_alert_if_letter_notifications_still_sending_a_day_ago_no_alert(sample_l
     assert not mock_create_ticket.called
 
 
-@freeze_time("2018-01-17 17:00:00")
+@freeze_time("Thursday 17th January 2018 17:00")
 def test_alert_if_letter_notifications_still_sending_only_alerts_sending(sample_letter_template, mocker):
     two_days_ago = datetime(2018, 1, 15, 13, 30)
     create_notification(template=sample_letter_template, status='sending', sent_at=two_days_ago)
@@ -439,7 +439,7 @@ def test_alert_if_letter_notifications_still_sending_only_alerts_sending(sample_
     )
 
 
-@freeze_time("2018-01-17 17:00:00")
+@freeze_time("Thursday 17th January 2018 17:00")
 def test_alert_if_letter_notifications_still_sending_alerts_for_older_than_offset(sample_letter_template, mocker):
     three_days_ago = datetime(2018, 1, 14, 13, 30)
     create_notification(template=sample_letter_template, status='sending', sent_at=three_days_ago)
@@ -455,7 +455,7 @@ def test_alert_if_letter_notifications_still_sending_alerts_for_older_than_offse
     )
 
 
-@freeze_time("2018-01-14 17:00:00")
+@freeze_time("Sunday 14th January 2018 17:00")
 def test_alert_if_letter_notifications_still_sending_does_nothing_on_the_weekend(sample_letter_template, mocker):
     yesterday = datetime(2018, 1, 13, 13, 30)
     create_notification(template=sample_letter_template, status='sending', sent_at=yesterday)
@@ -467,7 +467,7 @@ def test_alert_if_letter_notifications_still_sending_does_nothing_on_the_weekend
     assert not mock_create_ticket.called
 
 
-@freeze_time("2018-01-15 17:00:00")
+@freeze_time("Monday 15th January 2018 17:00")
 def test_monday_alert_if_letter_notifications_still_sending_reports_thursday_letters(sample_letter_template, mocker):
     thursday = datetime(2018, 1, 11, 13, 30)
     yesterday = datetime(2018, 1, 14, 13, 30)
@@ -485,7 +485,7 @@ def test_monday_alert_if_letter_notifications_still_sending_reports_thursday_let
     )
 
 
-@freeze_time("2018-01-16 17:00:00")
+@freeze_time("Tuesday 16th January 2018 17:00")
 def test_tuesday_alert_if_letter_notifications_still_sending_reports_friday_letters(sample_letter_template, mocker):
     friday = datetime(2018, 1, 12, 13, 30)
     yesterday = datetime(2018, 1, 14, 13, 30)


### PR DESCRIPTION
this took way longer than it should have.

DVLA now only send second class letters on Mon/Wed/Thurs. we still send to them every day as per previous operation.

This means that a letter sent to DVLA on monday evening might not be sent until weds afternoon, so we shouldn't check for whether it was sent or not on tuesday afternoon.

there's a days grace we put in the query because we found we weren't getting response files in time. I don't know how that'll interact with DVLA skipping days. IE: if they don't send response files on Weds for a weds print run, will they do it on thurs instead, even though they're not doing a print run then? we'll just have to ship it and see