### PR TITLE
Put pdf letter validation failed message in S3 metadata

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -209,9 +209,8 @@ def process_virus_scan_passed(self, filename):
     old_pdf = scan_pdf_object.get()['Body'].read()
 
     sanitise_response, result = _sanitise_precompiled_pdf(self, notification, old_pdf)
-    if result == "validation_failed":
-        new_pdf = None
-    else:
+    new_pdf = None
+    if result == 'validation_passed':
         new_pdf = base64.b64decode(sanitise_response["file"].encode())
 
         redaction_failed_message = sanitise_response.get("redaction_failed_message")
@@ -228,7 +227,7 @@ def process_virus_scan_passed(self, filename):
         # Check your state pension submit letters with good addresses and notify tags, so just use their supplied pdf
         new_pdf = old_pdf
 
-    if not new_pdf:
+    if result == 'validation_failed' and not new_pdf:
         current_app.logger.info('Invalid precompiled pdf received {} ({})'.format(notification.id, filename))
         _move_invalid_letter_and_update_status(
             notification=notification,
@@ -239,9 +238,6 @@ def process_virus_scan_passed(self, filename):
             page_count=sanitise_response.get("page_count")
         )
         return
-    else:
-        current_app.logger.info(
-            "Validation was successful for precompiled pdf {} ({})".format(notification.id, filename))
 
     current_app.logger.info('notification id {} ({}) sanitised and ready to send'.format(notification.id, filename))
 

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -49,7 +49,6 @@ from app.models import (
     NOTIFICATION_VIRUS_SCAN_FAILED,
 )
 from app.cronitor import cronitor
-from json import JSONDecodeError
 
 
 @notify_celery.task(bind=True, name="create-letters-pdf", max_retries=15, default_retry_delay=300)
@@ -214,18 +213,16 @@ def process_virus_scan_passed(self, filename):
         billable_units = get_page_count(old_pdf)
     except PdfReadError:
         current_app.logger.exception(msg='Invalid PDF received for notification_id: {}'.format(notification.id))
-        _move_invalid_letter_and_update_status(notification, filename, scan_pdf_object)
+        _move_invalid_letter_and_update_status(
+            notification=notification, filename=filename, scan_pdf_object=scan_pdf_object
+        )
         return
 
     sanitise_response = _sanitise_precompiled_pdf(self, notification, old_pdf)
-    if not sanitise_response:
+    if sanitise_response["message"]:  # is response without message attribute possible now? I think not?
         new_pdf = None
     else:
-        sanitise_response = sanitise_response.json()
-        try:
-            new_pdf = base64.b64decode(sanitise_response["file"].encode())
-        except JSONDecodeError:
-            new_pdf = sanitise_response.content
+        new_pdf = base64.b64decode(sanitise_response["file"].encode())
 
         redaction_failed_message = sanitise_response.get("redaction_failed_message")
         if redaction_failed_message and not is_test_key:
@@ -241,7 +238,14 @@ def process_virus_scan_passed(self, filename):
 
     if not new_pdf:
         current_app.logger.info('Invalid precompiled pdf received {} ({})'.format(notification.id, filename))
-        _move_invalid_letter_and_update_status(notification, filename, scan_pdf_object)
+        _move_invalid_letter_and_update_status(
+            notification=notification,
+            filename=filename,
+            scan_pdf_object=scan_pdf_object,
+            message=sanitise_response["message"],
+            invalid_pages=sanitise_response.get("invalid_pages"),
+            page_count=sanitise_response.get("page_count")
+        )
         return
     else:
         current_app.logger.info(
@@ -270,9 +274,16 @@ def process_virus_scan_passed(self, filename):
         update_notification_status_by_id(notification.id, NOTIFICATION_TECHNICAL_FAILURE)
 
 
-def _move_invalid_letter_and_update_status(notification, filename, scan_pdf_object):
+def _move_invalid_letter_and_update_status(
+    *, notification, filename, scan_pdf_object, message=None, invalid_pages=None, page_count=None
+):
     try:
-        move_scan_to_invalid_pdf_bucket(filename)
+        move_scan_to_invalid_pdf_bucket(
+            source_filename=filename,
+            message=message,
+            invalid_pages=invalid_pages,
+            page_count=page_count
+        )
         scan_pdf_object.delete()
 
         update_letter_pdf_status(
@@ -311,17 +322,19 @@ def _sanitise_precompiled_pdf(self, notification, precompiled_pdf):
                      'Notification-ID': str(notification.id)}
         )
         response.raise_for_status()
-        return response
+        return response.json()
     except RequestException as ex:
         if ex.response is not None and ex.response.status_code == 400:
             message = "sanitise_precompiled_pdf validation error for notification: {}. ".format(notification.id)
             if "message" in response.json():
                 message += response.json()["message"]
+            if "invalid_pages" in response.json():
+                message += (" on pages: " + ", ".join(map(str, response.json()["invalid_pages"])))
 
             current_app.logger.info(
                 message
             )
-            return None
+            return response.json()
 
         try:
             current_app.logger.exception(

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -132,9 +132,10 @@ def move_scan_to_invalid_pdf_bucket(source_filename, message=None, invalid_pages
     if message:
         metadata["validation_failed_message"] = message
     if invalid_pages:
-        metadata["invalid_pages"] = [str(p) for p in invalid_pages]
+        metadata["invalid_pages"] = "-".join(map(str, invalid_pages))
     if page_count:
         metadata["page_count"] = str(page_count)
+
     _move_s3_object(
         source_bucket=current_app.config['LETTERS_SCAN_BUCKET_NAME'],
         source_filename=source_filename,
@@ -187,7 +188,8 @@ def _move_s3_object(source_bucket, source_filename, target_bucket, target_filena
     # in the destination bucket the expiration time will be reset to 7 days left to expire
     put_args = {'ServerSideEncryption': 'AES256'}
     if metadata:
-        metadata = put_args['Metadata'] = metadata
+        put_args['Metadata'] = metadata
+        put_args["MetadataDirective"] = "REPLACE"
     obj.copy(copy_source, ExtraArgs=put_args)
 
     s3.Object(source_bucket, source_filename).delete()

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -30,6 +30,7 @@ from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.templates_dao import dao_get_template_by_id_and_service_id, get_precompiled_letter_template
 from app.dao.users_dao import get_user_by_id
 from app.letters.utils import (
+    get_billable_units_for_letter_page_count,
     get_letter_pdf_filename,
     get_page_count,
     move_uploaded_pdf_to_letters_bucket,
@@ -152,7 +153,8 @@ def send_pdf_letter_notification(service_id, post_data):
         raise e
 
     # Getting the page count won't raise an error since admin has already checked the PDF is valid
-    billable_units = get_page_count(letter.read())
+    page_count = get_page_count(letter.read())
+    billable_units = get_billable_units_for_letter_page_count(page_count)
 
     personalisation = {
         'address_line_1': post_data['filename']

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -482,7 +482,7 @@ def test_process_letter_task_check_virus_scan_passed_when_sanitise_fails(
         "file": base64.b64encode(b"nyan").decode("utf-8"),
         "validation_passed": False,
         "message": "content-outside-printable-area",
-        "invalid_pages": [1],
+        "invalid_pages": [1, 2],
         "page_count": 1
     }
     mock_sanitise = mocker.patch(
@@ -503,7 +503,7 @@ def test_process_letter_task_check_virus_scan_passed_when_sanitise_fails(
         source_bucket=source_bucket_name, source_filename=filename,
         target_bucket=target_bucket_name, target_filename=filename, metadata={
             "validation_failed_message": "content-outside-printable-area",
-            "invalid_pages": ["1"],
+            "invalid_pages": "1-2",
             "page_count": "1"
         }
     )

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -2,7 +2,6 @@ from unittest.mock import Mock, call, ANY
 
 import base64
 import boto3
-from PyPDF2.utils import PdfReadError
 from moto import mock_s3
 from flask import current_app
 from freezegun import freeze_time
@@ -426,7 +425,6 @@ def test_process_letter_task_check_virus_scan_passed(
     s3 = boto3.client('s3', region_name='eu-west-1')
     s3.put_object(Bucket=source_bucket_name, Key=filename, Body=b'old_pdf')
 
-    mock_get_page_count = mocker.patch('app.celery.letters_pdf_tasks.get_page_count', return_value=1)
     mock_s3upload = mocker.patch('app.celery.letters_pdf_tasks.s3upload')
     endpoint = 'http://localhost:9999/precompiled/sanitise'
     with requests_mock.mock() as rmock:
@@ -455,7 +453,6 @@ def test_process_letter_task_check_virus_scan_passed(
         file_location=destination_folder + filename,
         region='eu-west-1',
     )
-    mock_get_page_count.assert_called_once_with(b'old_pdf')
 
 
 @freeze_time('2018-01-01 18:00')
@@ -486,9 +483,8 @@ def test_process_letter_task_check_virus_scan_passed_when_sanitise_fails(
         "page_count": 1
     }
     mock_sanitise = mocker.patch(
-        'app.celery.letters_pdf_tasks._sanitise_precompiled_pdf', return_value=sanitise_response
+        'app.celery.letters_pdf_tasks._sanitise_precompiled_pdf', return_value=(sanitise_response, "validation_failed")
     )
-    mock_get_page_count = mocker.patch('app.celery.letters_pdf_tasks.get_page_count', return_value=2)
 
     process_virus_scan_passed(filename)
 
@@ -502,13 +498,11 @@ def test_process_letter_task_check_virus_scan_passed_when_sanitise_fails(
     mock_move_s3.assert_called_once_with(
         source_bucket=source_bucket_name, source_filename=filename,
         target_bucket=target_bucket_name, target_filename=filename, metadata={
-            "validation_failed_message": "content-outside-printable-area",
-            "invalid_pages": "1-2",
+            "message": "content-outside-printable-area",
+            "invalid_pages": "[1, 2]",
             "page_count": "1"
         }
     )
-
-    mock_get_page_count.assert_called_once_with(b'pdf_content')
 
 
 @freeze_time('2018-01-01 18:00')
@@ -534,7 +528,6 @@ def test_process_letter_task_check_virus_scan_passed_when_redaction_fails(
     sample_letter_notification.status = NOTIFICATION_PENDING_VIRUS_CHECK
     sample_letter_notification.key_type = key_type
     mock_copy_s3 = mocker.patch('app.letters.utils._copy_s3_object')
-    mocker.patch('app.celery.letters_pdf_tasks.get_page_count', return_value=2)
 
     endpoint = 'http://localhost:9999/precompiled/sanitise'
     with requests_mock.mock() as rmock:
@@ -547,7 +540,7 @@ def test_process_letter_task_check_virus_scan_passed_when_redaction_fails(
                 "redaction_failed_message": "No matches for address block during redaction procedure",
                 "message": "",
                 "invalid_pages": "",
-                "page_count": 2
+                "page_count": 3
             },
             status_code=200
         )
@@ -585,16 +578,25 @@ def test_process_letter_task_check_virus_scan_passed_when_file_cannot_be_opened(
     sample_letter_notification.key_type = key_type
     mock_move_s3 = mocker.patch('app.letters.utils._move_s3_object')
 
-    mock_get_page_count = mocker.patch('app.celery.letters_pdf_tasks.get_page_count', side_effect=PdfReadError)
-    mock_sanitise = mocker.patch('app.celery.letters_pdf_tasks._sanitise_precompiled_pdf')
+    endpoint = 'http://localhost:9999/precompiled/sanitise'
+    with requests_mock.mock() as rmock:
+        rmock.request(
+            "POST",
+            endpoint,
+            json={
+                "page_count": None,
+                "recipient_address": None,
+                "message": 'unable-to-read-the-file',
+                "invalid_pages": None,
+                "file": None
+            },
+            status_code=400
+        )
+        process_virus_scan_passed(filename)
 
-    process_virus_scan_passed(filename)
-
-    mock_sanitise.assert_not_called()
-    mock_get_page_count.assert_called_once_with(b'pdf_content')
     mock_move_s3.assert_called_once_with(
         source_bucket=source_bucket_name, source_filename=filename,
-        target_bucket=target_bucket_name, target_filename=filename, metadata={}
+        target_bucket=target_bucket_name, target_filename=filename, metadata={'message': 'unable-to-read-the-file'}
     )
     assert sample_letter_notification.status == NOTIFICATION_VALIDATION_FAILED
     assert sample_letter_notification.billable_units == 0
@@ -616,8 +618,6 @@ def test_process_virus_scan_passed_logs_error_and_sets_tech_failure_if_s3_error_
 
     s3 = boto3.client('s3', region_name='eu-west-1')
     s3.put_object(Bucket=source_bucket_name, Key=filename, Body=b'pdf_content')
-
-    mocker.patch('app.celery.letters_pdf_tasks.get_page_count', return_value=1)
 
     error_response = {
         'Error': {
@@ -741,10 +741,11 @@ def test_sanitise_precompiled_pdf_returns_data_from_template_preview(rmock, samp
             status_code=200
         )
         mock_celery = Mock(**{'retry.side_effect': Retry})
-        response = _sanitise_precompiled_pdf(mock_celery, sample_letter_notification, b'old_pdf')
+        response, result = _sanitise_precompiled_pdf(mock_celery, sample_letter_notification, b'old_pdf')
         assert rmock.called
         assert rmock.request_history[0].url == endpoint
 
+    assert result == "validation_passed"
     assert base64.b64decode(response["file"].encode()) == b"new_pdf"
     assert rmock.last_request.text == 'old_pdf'
 
@@ -768,10 +769,11 @@ def test_sanitise_precompiled_pdf_return_validation_error(rmock, sample_letter_n
             status_code=400
         )
         mock_celery = Mock(**{'retry.side_effect': Retry})
-        response = _sanitise_precompiled_pdf(mock_celery, sample_letter_notification, b'old_pdf')
+        response, result = _sanitise_precompiled_pdf(mock_celery, sample_letter_notification, b'old_pdf')
         assert rmock.called
         assert rmock.request_history[0].url == endpoint
 
+    assert result == "validation_failed"
     assert response == response_json
 
 


### PR DESCRIPTION
So it can be used by admin app to tell the user why the letter has failed validation.

Attention! This PR can only be merged when Katie's PR in admin is ready so we can make sure our approaches to metadata are harmonised