### PR TITLE
Change to the _status endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ production: ## Set environment to production
 
 .PHONY: generate-version-file
 generate-version-file: ## Generates the app version file
-	@echo -e "__travis_commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"\n__travis_job_number__ = \"${BUILD_NUMBER}\"\n__travis_job_url__ = \"${BUILD_URL}\"" > ${APP_VERSION_FILE}
+	@echo -e "__git_commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"\n__jenkins_job_number__ = \"${BUILD_NUMBER}\"\n__jenkins_job_url__ = \"${BUILD_URL}\"" > ${APP_VERSION_FILE}
 
 .PHONY: build-paas-artifact
 build-paas-artifact:  ## Build the deploy artifact for PaaS

--- a/app/status/healthcheck.py
+++ b/app/status/healthcheck.py
@@ -4,7 +4,10 @@ from flask import (
     request
 )
 
-from app import version
+from app import (
+    db,
+    version
+)
 from app.dao.services_dao import dao_count_live_services
 from app.dao.organisation_dao import dao_count_organsations_with_live_services
 
@@ -31,3 +34,10 @@ def live_service_and_organisation_counts():
         organisations=dao_count_organsations_with_live_services(),
         services=dao_count_live_services(),
     ), 200
+
+
+@status.route('/_status/db-version')
+def get_db_version():
+    query = 'SELECT version_num FROM alembic_version'
+    full_name = db.session.execute(query).fetchone()[0]
+    return jsonify(db_version=full_name)

--- a/app/status/healthcheck.py
+++ b/app/status/healthcheck.py
@@ -4,7 +4,7 @@ from flask import (
     request
 )
 
-from app import db, version
+from app import version
 from app.dao.services_dao import dao_count_live_services
 from app.dao.organisation_dao import dao_count_organsations_with_live_services
 
@@ -19,10 +19,10 @@ def show_status():
     else:
         return jsonify(
             status="ok",  # This should be considered part of the public API
-            travis_commit=version.__travis_commit__,
-            travis_build_number=version.__travis_job_number__,
-            build_time=version.__time__,
-            db_version=get_db_version()), 200
+            git_commit=version.__git_commit__,
+            jenkins_build_number=version.__jenkins_job_number__,
+            build_time=version.__time__
+        )
 
 
 @status.route('/_status/live-service-and-organisation-counts')
@@ -31,9 +31,3 @@ def live_service_and_organisation_counts():
         organisations=dao_count_organsations_with_live_services(),
         services=dao_count_live_services(),
     ), 200
-
-
-def get_db_version():
-    query = 'SELECT version_num FROM alembic_version'
-    full_name = db.session.execute(query).fetchone()[0]
-    return full_name

--- a/app/version.py.dist
+++ b/app/version.py.dist
@@ -1,4 +1,4 @@
-__travis_commit__ = ""
+__git_commit__ = ""
 __time__ = ""
-__travis_job_number__ = ""
-__travis_job_url__ = ""
+__jenkins_job_number__ = ""
+__jenkins_job_url__ = ""

--- a/scripts/check_if_new_migration.py
+++ b/scripts/check_if_new_migration.py
@@ -14,7 +14,7 @@ def get_latest_db_migration_to_apply():
 
 
 def get_current_db_version():
-    api_status_url = '{}/_status'.format(os.getenv('API_HOST_NAME'))
+    api_status_url = '{}/_status/db-version'.format(os.getenv('API_HOST_NAME'))
     response = requests.get(api_status_url)
 
     if response.status_code != 200:

--- a/tests/app/status/test_status.py
+++ b/tests/app/status/test_status.py
@@ -10,9 +10,8 @@ def test_get_status_all_ok(client, notify_db_session, path):
     assert response.status_code == 200
     resp_json = json.loads(response.get_data(as_text=True))
     assert resp_json['status'] == 'ok'
-    assert resp_json['db_version']
-    assert resp_json['travis_commit']
-    assert resp_json['travis_build_number']
+    assert resp_json['git_commit']
+    assert resp_json['jenkins_build_number']
     assert resp_json['build_time']
 
 


### PR DESCRIPTION
The _status endpoint returns data about the deployed build which includes the dB version. The dB is queried to get the alembic_version, this is a quick query but is a query none the less.
I'm not convinced that this endpoint needs to use a dB connection to return this data.
I also renamed the attributes of the json to stop referring to travis.

Sound like a good idea?