### PR TITLE
Check service is not in trial mode for uploaded letters

### DIFF
--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -140,6 +140,13 @@ def send_pdf_letter_notification(service_id, post_data):
     check_service_has_permission(UPLOAD_LETTERS, service.permissions)
     check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
     validate_created_by(service, post_data['created_by'])
+    validate_and_format_recipient(
+        send_to=post_data['filename'],
+        key_type=KEY_TYPE_NORMAL,
+        service=service,
+        notification_type=LETTER_TYPE,
+        allow_whitelisted_recipients=False,
+    )
 
     template = get_precompiled_letter_template(service.id)
     file_location = 'service-{}/{}.pdf'.format(service.id, post_data['file_id'])

--- a/tests/app/service/test_send_pdf_letter_notification.py
+++ b/tests/app/service/test_send_pdf_letter_notification.py
@@ -51,6 +51,20 @@ def test_send_pdf_letter_notification_validates_created_by(
         send_pdf_letter_notification(sample_service_full_permissions.id, post_data)
 
 
+def test_send_pdf_letter_notification_raises_error_if_service_in_trial_mode(
+    mocker,
+    sample_service_full_permissions,
+    fake_uuid,
+):
+    sample_service_full_permissions.restricted = True
+    user = sample_service_full_permissions.users[0]
+    post_data = {'filename': 'valid.pdf', 'created_by': user.id, 'file_id': fake_uuid}
+
+    with pytest.raises(BadRequestError) as e:
+        send_pdf_letter_notification(sample_service_full_permissions.id, post_data)
+    assert 'trial mode' in e.value.message
+
+
 def test_send_pdf_letter_notification_raises_error_when_pdf_is_not_in_transient_letter_bucket(
     mocker,
     sample_service_full_permissions,


### PR DESCRIPTION
This adds an api check that the service is not in trial mode when someone tries to send an uploaded letter.