### PR TITLE
remove gunicorn server header from responses

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import traceback
+import gunicorn
 
 workers = 4
 worker_class = "eventlet"
@@ -9,6 +10,7 @@ errorlog = "/home/vcap/logs/gunicorn_error.log"
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
 statsd_prefix = os.getenv("STATSD_PREFIX")
+gunicorn.SERVER_SOFTWARE = 'None'
 
 
 def on_starting(server):


### PR DESCRIPTION
All our requests identify the web server they were served with via the `server` response header. This opens us up to potential attackers who might be crawling the internet looking for specific versions with known vulnerabilities. As our dependencies are open source, this doesn't affect any targeted attacks as they can just look at our repos on github, but this theoretically will marginally improve security.

Regardless, the header isn't useful [1], we're not the first people to want to get rid of it, and gunicorn are in the process of at least amending it to remove the version information [2].

This shouldn't have any impact on us, though an empty string will be passed through to debug information in event of a crash. That's fine though, as we already know what version we're running.

[1] https://www.fastly.com/blog/headers-we-dont-want
[2] https://github.com/benoitc/gunicorn/issues/825