### PR TITLE
Add request_ids to some Celery tasks

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -1,9 +1,9 @@
 import base64
 import functools
 
-import werkzeug
 from flask import request, jsonify, current_app, abort
 from notifications_utils.recipients import try_validate_and_format_phone_number
+from werkzeug.exceptions import BadRequest
 
 from app import api_user, authenticated_service, notify_celery, document_download_client
 from app.celery.letters_pdf_tasks import create_letters_pdf, process_virus_scan_passed
@@ -101,7 +101,7 @@ def post_precompiled_letter_notification():
 def post_notification(notification_type):
     try:
         request_json = request.get_json()
-    except werkzeug.exceptions.BadRequest as e:
+    except BadRequest as e:
         raise BadRequestError(message="Error decoding arguments: {}".format(e.description),
                               status_code=400)
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,6 +29,6 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@34.0.1#egg=notifications-utils==34.0.1
+git+https://github.com/alphagov/notifications-utils.git@36.1.0#egg=notifications-utils==36.1.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,32 +31,32 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@34.0.1#egg=notifications-utils==34.0.1
+git+https://github.com/alphagov/notifications-utils.git@36.1.0#egg=notifications-utils==36.1.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
 ## The following requirements were added by pip freeze:
-alembic==1.1.0
+alembic==1.2.1
 amqp==1.4.9
 anyjson==0.3.3
-attrs==19.1.0
-awscli==1.16.231
+attrs==19.3.0
+awscli==1.16.263
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.0
-boto3==1.6.16
-botocore==1.12.221
-certifi==2019.6.16
+boto3==1.9.221
+botocore==1.12.253
+certifi==2019.9.11
 chardet==3.0.4
 Click==7.0
-colorama==0.3.9
+colorama==0.4.1
 dnspython==1.16.0
 docutils==0.15.2
 flask-redis==0.4.0
-future==0.17.1
+future==0.18.1
 greenlet==0.4.15
 idna==2.8
-Jinja2==2.10.1
+Jinja2==2.10.3
 jmespath==0.9.4
 kombu==3.0.37
 Mako==1.1.0
@@ -64,7 +64,7 @@ MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5
 orderedset==2.0.1
-phonenumbers==8.10.13
+phonenumbers==8.10.17
 pyasn1==0.4.7
 pycparser==2.19
 PyPDF2==1.26.0
@@ -72,15 +72,15 @@ pyrsistent==0.15.4
 python-dateutil==2.8.0
 python-editor==1.0.4
 python-json-logger==0.1.11
-pytz==2019.2
-PyYAML==4.2b1
-redis==3.3.8
+pytz==2019.3
+PyYAML==5.1.2
+redis==3.3.11
 requests==2.22.0
 rsa==3.4.2
 s3transfer==0.2.1
 six==1.12.0
 smartypants==2.0.1
 statsd==3.3.0
-urllib3==1.25.3
+urllib3==1.25.6
 webencodings==0.5.1
-Werkzeug==0.15.5
+Werkzeug==0.16.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -13,4 +13,4 @@ requests-mock==1.5.2
 strict-rfc3339==0.7
 rfc3987==1.3.8
 # used for creating manifest file locally
-jinja2-cli[yaml]==0.6.0
+jinja2-cli[yaml]==0.7.0


### PR DESCRIPTION
**Requirement bumps**
Bumped Utils to bring in changes to logging the request_id (https://github.com/alphagov/notifications-utils/pull/658). Freezing requirements updated a few other dependencies too, including Werkzeug from version 0.15.5 to 0.16.0, which required a small change to an import (https://github.com/pallets/werkzeug/blob/master/CHANGES.rst#version-0160).

**Passing the `request_id` to tasks if available**
We want to pass the `request_id` to Celery tasks if the task is called from an HTTP request, so that we can log it. This change overwrites `apply_async` to add the `request_id` to the kwargs if available. When we call the task, we then add the `request_id` to `g` on Flask's application context.

Tasks called from `send_task` won't have a `request_id` for now, and this change only affects tasks called from HTTP requests (not from other tasks or from Celery Beat).