### PR TITLE
Set postage

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -93,6 +93,7 @@ from app.models import (
 from app.notifications.process_notifications import persist_notification, send_notification_to_queue
 from app.schema_validation import validate
 from app.service import statistics
+from app.service.send_pdf_letter_schema import send_pdf_letter_request
 from app.service.service_data_retention_schema import (
     add_service_data_retention_request,
     update_service_data_retention_request
@@ -650,7 +651,8 @@ def create_one_off_notification(service_id):
 
 @service_blueprint.route('/<uuid:service_id>/send-pdf-letter', methods=['POST'])
 def create_pdf_letter(service_id):
-    resp = send_pdf_letter_notification(service_id, request.get_json())
+    data = validate(request.get_json(), send_pdf_letter_request)
+    resp = send_pdf_letter_notification(service_id, data)
     return jsonify(resp), 201
 
 

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -23,7 +23,6 @@ from app.models import (
     SMS_TYPE,
     EMAIL_TYPE,
     LETTER_TYPE,
-    POSTAGE_TYPES,
     NOTIFICATION_DELIVERED,
     UPLOAD_LETTERS,
 )
@@ -149,11 +148,6 @@ def send_pdf_letter_notification(service_id, post_data):
         allow_whitelisted_recipients=False,
     )
 
-    postage = post_data.get('postage')
-    if postage not in POSTAGE_TYPES:
-        message = "postage must be set as 'first' or 'second'"
-        raise BadRequestError(message=message)
-
     template = get_precompiled_letter_template(service.id)
     file_location = 'service-{}/{}.pdf'.format(service.id, post_data['file_id'])
 
@@ -188,7 +182,7 @@ def send_pdf_letter_notification(service_id, post_data):
         client_reference=post_data['filename'],
         created_by_id=post_data['created_by'],
         billable_units=billable_units,
-        postage=postage,
+        postage=post_data['postage'],
     )
 
     upload_filename = get_letter_pdf_filename(

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -23,6 +23,7 @@ from app.models import (
     SMS_TYPE,
     EMAIL_TYPE,
     LETTER_TYPE,
+    POSTAGE_TYPES,
     NOTIFICATION_DELIVERED,
     UPLOAD_LETTERS,
 )
@@ -148,6 +149,11 @@ def send_pdf_letter_notification(service_id, post_data):
         allow_whitelisted_recipients=False,
     )
 
+    postage = post_data.get('postage')
+    if postage not in POSTAGE_TYPES:
+        message = "postage must be set as 'first' or 'second'"
+        raise BadRequestError(message=message)
+
     template = get_precompiled_letter_template(service.id)
     file_location = 'service-{}/{}.pdf'.format(service.id, post_data['file_id'])
 
@@ -167,7 +173,6 @@ def send_pdf_letter_notification(service_id, post_data):
         'address_line_1': post_data['filename']
     }
 
-    # TODO: stop hard-coding postage as 'second' once we get postage from the admin
     notification = persist_notification(
         notification_id=post_data['file_id'],
         template_id=template.id,
@@ -183,7 +188,7 @@ def send_pdf_letter_notification(service_id, post_data):
         client_reference=post_data['filename'],
         created_by_id=post_data['created_by'],
         billable_units=billable_units,
-        postage='second',
+        postage=postage,
     )
 
     upload_filename = get_letter_pdf_filename(

--- a/app/service/send_pdf_letter_schema.py
+++ b/app/service/send_pdf_letter_schema.py
@@ -4,11 +4,10 @@ send_pdf_letter_request = {
     "type": "object",
     "title": "Send an uploaded pdf letter",
     "properties": {
-        "postage": {"enum": ["first", "second"]},
+        "postage": {"type": "string", "format": "postage"},
         "filename": {"type": "string"},
         "created_by": {"type": "string"},
         "file_id": {"type": "string"},
     },
-
     "required": ["postage", "filename", "created_by", "file_id"]
 }

--- a/app/service/send_pdf_letter_schema.py
+++ b/app/service/send_pdf_letter_schema.py
@@ -1,0 +1,14 @@
+send_pdf_letter_request = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "POST send uploaded pdf letter",
+    "type": "object",
+    "title": "Send an uploaded pdf letter",
+    "properties": {
+        "postage": {"enum": ["first", "second"]},
+        "filename": {"type": "string"},
+        "created_by": {"type": "string"},
+        "file_id": {"type": "string"},
+    },
+
+    "required": ["postage", "filename", "created_by", "file_id"]
+}

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2282,7 +2282,8 @@ def test_create_pdf_letter(mocker, sample_service_full_permissions, client, fake
     data = json.dumps({
         'filename': 'valid.pdf',
         'created_by': str(user.id),
-        'file_id': fake_uuid
+        'file_id': fake_uuid,
+        'postage': 'second'
     })
 
     response = client.post(

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2297,6 +2297,23 @@ def test_create_pdf_letter(mocker, sample_service_full_permissions, client, fake
     assert json_resp == {'id': fake_uuid}
 
 
+def test_create_pdf_letter_validates_against_json_schema(sample_service_full_permissions, client):
+    response = client.post(
+        url_for('service.create_pdf_letter', service_id=sample_service_full_permissions.id),
+        data=json.dumps({}),
+        headers=[('Content-Type', 'application/json'), create_authorization_header()]
+    )
+    json_resp = json.loads(response.get_data(as_text=True))
+
+    assert response.status_code == 400
+    assert json_resp['errors'] == [
+        {'error': 'ValidationError', 'message': 'postage is a required property'},
+        {'error': 'ValidationError', 'message': 'filename is a required property'},
+        {'error': 'ValidationError', 'message': 'created_by is a required property'},
+        {'error': 'ValidationError', 'message': 'file_id is a required property'}
+    ]
+
+
 def test_get_notification_for_service_includes_template_redacted(admin_request, sample_notification):
     resp = admin_request.get(
         'service.get_notification_for_service',

--- a/tests/app/service/test_send_pdf_letter_notification.py
+++ b/tests/app/service/test_send_pdf_letter_notification.py
@@ -51,26 +51,6 @@ def test_send_pdf_letter_notification_validates_created_by(
         send_pdf_letter_notification(sample_service_full_permissions.id, post_data)
 
 
-def test_send_pdf_letter_notification_validates_postage(
-    sample_service_full_permissions, fake_uuid, notify_user
-):
-    user = sample_service_full_permissions.users[0]
-    post_data = {'filename': 'valid.pdf', 'created_by': user.id, 'file_id': fake_uuid, 'postage': 'third'}
-
-    with pytest.raises(BadRequestError):
-        send_pdf_letter_notification(sample_service_full_permissions.id, post_data)
-
-
-def test_send_pdf_letter_notification_requires_postage(
-    sample_service_full_permissions, fake_uuid, notify_user
-):
-    user = sample_service_full_permissions.users[0]
-    post_data = {'filename': 'valid.pdf', 'created_by': user.id, 'file_id': fake_uuid}
-
-    with pytest.raises(BadRequestError):
-        send_pdf_letter_notification(sample_service_full_permissions.id, post_data)
-
-
 def test_send_pdf_letter_notification_raises_error_if_service_in_trial_mode(
     mocker,
     sample_service_full_permissions,

--- a/tests/app/service/test_send_pdf_letter_notification.py
+++ b/tests/app/service/test_send_pdf_letter_notification.py
@@ -22,7 +22,7 @@ def test_send_pdf_letter_notification_raises_error_if_service_does_not_have_perm
     permissions,
 ):
     service = create_service(service_permissions=permissions)
-    post_data = {'filename': 'valid.pdf', 'created_by': fake_uuid, 'file_id': fake_uuid}
+    post_data = {'filename': 'valid.pdf', 'created_by': fake_uuid, 'file_id': fake_uuid, 'postage': 'first'}
 
     with pytest.raises(BadRequestError):
         send_pdf_letter_notification(service.id, post_data)
@@ -36,7 +36,7 @@ def test_send_pdf_letter_notification_raises_error_if_service_is_over_daily_mess
     mocker.patch(
         'app.service.send_notification.check_service_over_daily_message_limit',
         side_effect=TooManyRequestsError(10))
-    post_data = {'filename': 'valid.pdf', 'created_by': fake_uuid, 'file_id': fake_uuid}
+    post_data = {'filename': 'valid.pdf', 'created_by': fake_uuid, 'file_id': fake_uuid, 'postage': 'first'}
 
     with pytest.raises(TooManyRequestsError):
         send_pdf_letter_notification(sample_service_full_permissions.id, post_data)
@@ -45,7 +45,27 @@ def test_send_pdf_letter_notification_raises_error_if_service_is_over_daily_mess
 def test_send_pdf_letter_notification_validates_created_by(
     sample_service_full_permissions, fake_uuid, sample_user
 ):
-    post_data = {'filename': 'valid.pdf', 'created_by': sample_user.id, 'file_id': fake_uuid}
+    post_data = {'filename': 'valid.pdf', 'created_by': sample_user.id, 'file_id': fake_uuid, 'postage': 'first'}
+
+    with pytest.raises(BadRequestError):
+        send_pdf_letter_notification(sample_service_full_permissions.id, post_data)
+
+
+def test_send_pdf_letter_notification_validates_postage(
+    sample_service_full_permissions, fake_uuid, notify_user
+):
+    user = sample_service_full_permissions.users[0]
+    post_data = {'filename': 'valid.pdf', 'created_by': user.id, 'file_id': fake_uuid, 'postage': 'third'}
+
+    with pytest.raises(BadRequestError):
+        send_pdf_letter_notification(sample_service_full_permissions.id, post_data)
+
+
+def test_send_pdf_letter_notification_requires_postage(
+    sample_service_full_permissions, fake_uuid, notify_user
+):
+    user = sample_service_full_permissions.users[0]
+    post_data = {'filename': 'valid.pdf', 'created_by': user.id, 'file_id': fake_uuid}
 
     with pytest.raises(BadRequestError):
         send_pdf_letter_notification(sample_service_full_permissions.id, post_data)
@@ -72,7 +92,7 @@ def test_send_pdf_letter_notification_raises_error_when_pdf_is_not_in_transient_
     notify_user,
 ):
     user = sample_service_full_permissions.users[0]
-    post_data = {'filename': 'valid.pdf', 'created_by': user.id, 'file_id': fake_uuid}
+    post_data = {'filename': 'valid.pdf', 'created_by': user.id, 'file_id': fake_uuid, 'postage': 'first'}
     mocker.patch('app.service.send_notification.utils_s3download', side_effect=S3ObjectNotFound({}, ''))
 
     with pytest.raises(S3ObjectNotFound):
@@ -88,7 +108,7 @@ def test_send_pdf_letter_notification_creates_notification_and_moves_letter(
     user = sample_service_full_permissions.users[0]
     filename = 'valid.pdf'
     file_id = uuid.uuid4()
-    post_data = {'filename': filename, 'created_by': user.id, 'file_id': file_id}
+    post_data = {'filename': filename, 'created_by': user.id, 'file_id': file_id, 'postage': 'second'}
 
     mocker.patch('app.service.send_notification.utils_s3download')
     mocker.patch('app.service.send_notification.get_page_count', return_value=1)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/167534014

- Require postage key for API calls to send an uploaded PDF letter
- Set postage in the DB as sent from API call
- Use JSON schema validation for requests to this endpoint

This will lay the groundwork for https://github.com/alphagov/notifications-admin/pull/3144 to be finished off

I've tested this against 
- https://github.com/alphagov/notifications-admin/pull/3144
- notifications-admin master