### PR TITLE
Catch the TERM signal in the run_app_*paas scripts

### DIFF
--- a/scripts/run_app_paas.sh
+++ b/scripts/run_app_paas.sh
@@ -81,7 +81,7 @@ echo "Run script pid: $$"
 
 check_params
 
-trap "on_exit" EXIT
+trap "on_exit" EXIT TERM
 
 configure_aws_logs
 

--- a/scripts/run_multi_worker_app_paas.sh
+++ b/scripts/run_multi_worker_app_paas.sh
@@ -143,7 +143,7 @@ echo "Run script pid: $$"
 
 check_params
 
-trap "on_exit" EXIT
+trap "on_exit" EXIT TERM
 
 configure_aws_logs
 


### PR DESCRIPTION
What
----

When Cloud Foundry applications are to be rescheduled from one cell to
another, or they are stopped, they are sent a SIGTERM signal and 10
seconds later, a SIGKILL signal.

Currently the scripts trap the POSIX defined EXIT handler, rather than
the signal directly.

In order for the signal to properly be propagated to celery, and the
celery workers, the script should call the on_exit function when
receiving a TERM signal.

How to review
----

- [link to helpful page](https://www.linuxjournal.com/content/bash-trap-command)

- `cf t -s preview`
- `cf v3-ssh notify-delivery-worker-letters`
- `ps auxf | grep run_app_paas.sh`
- `kill -15 PID` using PID from above
- Observe that `Terminating application process with pid` is printed to the logs in Kibana/AWS

Work done by
----

Becca, Toby