### PR TITLE
Upgrade to Pytest 5 😅

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 flake8==3.7.7
 moto==1.3.8
-pytest==3.10.1  # pyup: <4
+pytest==5.2.2
 pytest-env==0.6.2
 pytest-mock==1.10.4
 pytest-cov==2.6.1

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -46,7 +46,7 @@ def test_update_letter_notifications_statuses_raises_for_invalid_format(notify_a
 
     with pytest.raises(DVLAException) as e:
         update_letter_notifications_statuses(filename='NOTIFY-20170823160812-RSP.TXT')
-    assert 'DVLA response file: {} has an invalid format'.format('NOTIFY-20170823160812-RSP.TXT') in str(e)
+    assert 'DVLA response file: {} has an invalid format'.format('NOTIFY-20170823160812-RSP.TXT') in str(e.value)
 
 
 def test_update_letter_notification_statuses_when_notification_does_not_exist_updates_notification_history(
@@ -75,7 +75,7 @@ def test_update_letter_notifications_statuses_raises_dvla_exception(notify_api, 
     failed = ["ref-foo"]
     assert "DVLA response file: {filename} has failed letters with notification.reference {failures}".format(
         filename="failed.txt", failures=failed
-    ) in str(e)
+    ) in str(e.value)
 
 
 def test_update_letter_notifications_statuses_calls_with_correct_bucket_location(notify_api, mocker):
@@ -136,7 +136,7 @@ def test_update_letter_notifications_statuses_persisted(notify_api, mocker, samp
     assert failed_letter.billable_units == 2
     assert failed_letter.updated_at
     assert "DVLA response file: {filename} has failed letters with notification.reference {failures}".format(
-        filename="NOTIFY-20170823160812-RSP.TXT", failures=[format(failed_letter.reference)]) in str(e)
+        filename="NOTIFY-20170823160812-RSP.TXT", failures=[format(failed_letter.reference)]) in str(e.value)
 
 
 def test_update_letter_notifications_does_not_call_send_callback_if_no_db_entry(notify_api, mocker,

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -686,7 +686,7 @@ def test_process_letter_task_check_virus_scan_failed(sample_letter_notification,
     with pytest.raises(VirusScanError) as e:
         process_virus_scan_failed(filename)
 
-    assert "Virus scan failed:" in str(e)
+    assert "Virus scan failed:" in str(e.value)
     mock_move_failed_pdf.assert_called_once_with(filename, ScanErrorType.FAILURE)
     assert sample_letter_notification.status == NOTIFICATION_VIRUS_SCAN_FAILED
 

--- a/tests/app/clients/test_mmg.py
+++ b/tests/app/clients/test_mmg.py
@@ -104,7 +104,7 @@ def test_send_sms_raises_if_mmg_fails_to_return_json(notify_api, mocker):
         request_mock.post('https://example.com/mmg', text=response_dict, status_code=200)
         mmg_client.send_sms(to, content, reference)
 
-    assert 'app.clients.sms.mmg.MMGClientResponseException: Code 200 text NOT AT ALL VALID JSON {"key" : "value"}} exception Expecting value: line 1 column 1 (char 0)' in str(exc)  # noqa
+    assert 'Code 200 text NOT AT ALL VALID JSON {"key" : "value"}} exception Expecting value: line 1 column 1 (char 0)' in str(exc.value)  # noqa
     assert exc.value.status_code == 200
     assert exc.value.text == 'NOT AT ALL VALID JSON {"key" : "value"}}'
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -325,21 +325,23 @@ def sample_trial_letter_template(sample_service_full_permissions):
 
 
 @pytest.fixture(scope='function')
-def sample_email_template_with_placeholders(notify_db, notify_db_session):
-    return sample_email_template(
-        notify_db,
-        notify_db_session,
+def sample_email_template_with_placeholders(sample_service):
+    return create_template(
+        sample_service,
+        template_type=EMAIL_TYPE,
+        subject="((name))",
         content="Hello ((name))\nThis is an email from GOV.UK",
-        subject_line="((name))")
+    )
 
 
 @pytest.fixture(scope='function')
-def sample_email_template_with_html(notify_db, notify_db_session):
-    return sample_email_template(
-        notify_db,
-        notify_db_session,
+def sample_email_template_with_html(sample_service):
+    return create_template(
+        sample_service,
+        template_type=EMAIL_TYPE,
+        subject="((name)) <em>some HTML</em>",
         content="Hello ((name))\nThis is an email from GOV.UK with <em>some HTML</em>",
-        subject_line="((name)) <em>some HTML</em>")
+    )
 
 
 @pytest.fixture(scope='function')
@@ -499,7 +501,7 @@ def sample_notification_with_job(
         key_type=KEY_TYPE_NORMAL
 ):
     if not service:
-        service = create_service()
+        service = create_service(check_if_service_exists=True)
     if not template:
         template = create_template(service=service)
     if job is None:

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -503,7 +503,7 @@ def test_dao_fetch_live_services_data(sample_user):
 def test_get_service_by_id_returns_none_if_no_service(notify_db):
     with pytest.raises(NoResultFound) as e:
         dao_fetch_service_by_id(str(uuid.uuid4()))
-    assert 'No row was found for one()' in str(e)
+    assert 'No row was found for one()' in str(e.value)
 
 
 def test_get_service_by_id_returns_service(notify_db_session):

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -42,9 +42,11 @@ from app.models import (
     ScheduledNotification,
     ServicePermission,
     ServiceSmsSender,
+    ServiceWhitelist,
     Template,
     User,
     EMAIL_TYPE,
+    MOBILE_TYPE,
     SMS_TYPE,
     LETTER_TYPE,
     KEY_TYPE_NORMAL,
@@ -89,7 +91,7 @@ def create_permissions(user, service, *permissions):
         for p in permissions
     ]
 
-    permission_dao.set_user_service_permission(user, service, permissions)
+    permission_dao.set_user_service_permission(user, service, permissions, _commit=True)
 
 
 def create_service(
@@ -736,6 +738,19 @@ def create_ft_notification_status(
     db.session.add(data)
     db.session.commit()
     return data
+
+
+def create_service_whitelist(service, email_address=None, mobile_number=None):
+    if email_address:
+        whitelisted_user = ServiceWhitelist.from_string(service.id, EMAIL_TYPE, email_address)
+    elif mobile_number:
+        whitelisted_user = ServiceWhitelist.from_string(service.id, MOBILE_TYPE, mobile_number)
+    else:
+        whitelisted_user = ServiceWhitelist.from_string(service.id, EMAIL_TYPE, 'whitelisted_user@digital.gov.uk')
+
+    db.session.add(whitelisted_user)
+    db.session.commit()
+    return whitelisted_user
 
 
 def create_complaint(service=None,

--- a/tests/app/invite/test_invite_rest.py
+++ b/tests/app/invite/test_invite_rest.py
@@ -3,6 +3,7 @@ import pytest
 
 from app.models import Notification, SMS_AUTH_TYPE, EMAIL_AUTH_TYPE
 from tests import create_authorization_header
+from tests.app.db import create_invited_user
 
 
 @pytest.mark.parametrize('extra_args, expected_start_of_invite_url', [
@@ -118,16 +119,11 @@ def test_create_invited_user_invalid_email(client, sample_service, mocker, fake_
 
 
 def test_get_all_invited_users_by_service(client, notify_db, notify_db_session, sample_service):
-
-    from tests.app.conftest import sample_invited_user
     invites = []
     for i in range(0, 5):
         email = 'invited_user_{}@service.gov.uk'.format(i)
+        invited_user = create_invited_user(sample_service, to_email_address=email)
 
-        invited_user = sample_invited_user(notify_db,
-                                           notify_db_session,
-                                           sample_service,
-                                           email)
         invites.append(invited_user)
 
     url = '/service/{}/invite'.format(sample_service.id)


### PR DESCRIPTION
Changed the code to be Pytest 5 compatible by
- stopping fixtures being called like functions (almost all of the changes in this PR)
- changing how we check for error messages of exceptions

`conftest.py` can be tidied up as a separate PR - the fixtures there don't need any parameters (since they can't be called as functions anymore). There are also some fixtures in the file which aren't being used anywhere, so can be deleted.