### PR TITLE
Change how the bash script is started.

### DIFF
--- a/scripts/paas_app_wrapper.sh
+++ b/scripts/paas_app_wrapper.sh
@@ -2,55 +2,55 @@
 case $NOTIFY_APP_NAME in
   api)
     unset GUNICORN_CMD_ARGS
-    scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py application
+    exec scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py application
     ;;
   delivery-worker-retry-tasks)
-    scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
+    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
     -Q retry-tasks 2> /dev/null
     ;;
   delivery-worker-letters)
-    scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
+    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
     -Q create-letters-pdf-tasks,letter-tasks 2> /dev/null
     ;;
   delivery-worker-jobs)
-    scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
+    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
     -Q database-tasks,job-tasks 2> /dev/null
     ;;
   delivery-worker-research)
-    scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5 \
+    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5 \
     -Q research-mode-tasks 2> /dev/null
     ;;
   delivery-worker-sender)
-    scripts/run_multi_worker_app_paas.sh celery multi start 3 -c 10 -A run_celery.notify_celery --loglevel=INFO \
+    exec scripts/run_multi_worker_app_paas.sh celery multi start 3 -c 10 -A run_celery.notify_celery --loglevel=INFO \
     -Q send-sms-tasks,send-email-tasks
     ;;
   delivery-worker-periodic)
-    scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=2 \
+    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=2 \
     -Q periodic-tasks 2> /dev/null
     ;;
   delivery-worker-reporting)
-    scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
+    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
     -Q reporting-tasks 2> /dev/null
     ;;
   delivery-worker-priority)
-    scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5 \
+    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5 \
     -Q priority-tasks 2> /dev/null
     ;;
   # Only consume the notify-internal-tasks queue on this app so that Notify messages are processed as a priority
   delivery-worker-internal)
-    scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
+    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
     -Q notify-internal-tasks 2> /dev/null
     ;;
   delivery-worker-receipts)
-    scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
+    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
     -Q ses-callbacks 2> /dev/null
     ;;
   delivery-worker-service-callbacks)
-    scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
+    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
     -Q service-callbacks 2> /dev/null
     ;;
   delivery-celery-beat)
-    scripts/run_app_paas.sh celery -A run_celery.notify_celery beat --loglevel=INFO
+    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery beat --loglevel=INFO
     ;;
   *)
     echo "Unknown notify_app_name $NOTIFY_APP_NAME"

--- a/scripts/run_app_paas.sh
+++ b/scripts/run_app_paas.sh
@@ -81,7 +81,7 @@ echo "Run script pid: $$"
 
 check_params
 
-trap "on_exit" EXIT TERM
+trap "on_exit" EXIT
 
 configure_aws_logs
 


### PR DESCRIPTION
By adding `exec` to the entrypoint bash script for the application, we can trap an EXIT from the script and execute our custom `on_exit` method with checks if the application process is busy before terminating, waiting up to 10 seconds. We don't need to trap `TERM` so that's been removed again.

Written by:
@servingupaces
@tlwr