### PR TITLE
Provide feedback on incorrect Content-Type

### DIFF
--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -56,6 +56,8 @@ def validate_schema_date_with_hour(instance):
 
 
 def validate(json_to_validate, schema):
+    if json_to_validate == None:
+        raise ValidationError("Request body arguments not JSON or incorrect Content-Type header supplied.")
     validator = Draft7Validator(schema, format_checker=format_checker)
     errors = list(validator.iter_errors(json_to_validate))
     if errors.__len__() > 0:


### PR DESCRIPTION
When calling the API with a Content-Type that isn't `application/json` (even if there is a JSON body), calls to `request.get_json()` return None, and this isn't caught very well- you get a ValidationError with "None is not of type object" as the message.

This PR catches the bad API call and returns a more helpful error message.

### To test
Bring up the API and attempt to call endpoint with a Content-Type of, say `application/x-www-form-urlencoded`, with or without JSON in the body. With the PR applied, you should still get a ValidationError, but with a message reading "Request body arguments not JSON or incorrect Content-Type header supplied."