### PR TITLE
Added a filter to restrict jobs older than a day from coming back.

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -194,13 +194,16 @@ def find_jobs_with_missing_rows():
     # Jobs can be a maximum of 50,000 rows. It typically takes 5 minutes to create all those notifications.
     # Using 10 minutes as a condition seems reasonable.
     ten_minutes_ago = datetime.utcnow() - timedelta(minutes=10)
+    yesterday = datetime.utcnow() - timedelta(days=1)
     jobs_with_rows_missing = db.session.query(
         func.count(Notification.id).label('actual_count'),
         Job
     ).filter(
         Job.job_status == JOB_STATUS_FINISHED,
         Job.processing_finished < ten_minutes_ago,
-        Job.id == Notification.job_id
+        Job.processing_finished > yesterday,
+        Job.id == Notification.job_id,
+
     ).group_by(
         Job
     ).having(

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -454,6 +454,22 @@ def test_find_jobs_with_missing_rows_returns_nothing_for_a_job_completed_less_th
     assert len(results) == 0
 
 
+def test_find_jobs_with_missing_rows_returns_nothing_for_a_job_completed_more_that_a_day_ago(
+        sample_email_template
+):
+    job = create_job(template=sample_email_template,
+                     notification_count=5,
+                     job_status=JOB_STATUS_FINISHED,
+                     processing_finished=datetime.utcnow() - timedelta(days=1)
+                     )
+    for i in range(0, 4):
+        create_notification(job=job, job_row_number=i)
+
+    results = find_jobs_with_missing_rows()
+
+    assert len(results) == 0
+
+
 @pytest.mark.parametrize('status', ['pending', 'in progress', 'cancelled', 'scheduled'])
 def test_find_jobs_with_missing_rows_doesnt_return_jobs_that_are_not_finished(
         sample_email_template, status


### PR DESCRIPTION
This is only necessary because there is currently a job that is old, but had 1 row created a couple days later. So now there is 1 notifications for the job where the rest have been purged.