### PR TITLE
Alert if a letter doesn't make it past created status

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -191,7 +191,7 @@ def replay_created_notifications():
         for n in notifications_to_resend:
             send_notification_to_queue(notification=n, research_mode=n.service.research_mode)
 
-    # if the letter has not be send after 4 hours + 15 minutes, then create a zendesk ticket
+    # if the letter has not be send after an hour, then create a zendesk ticket
     letters = letters_missing_from_sending_bucket(resend_created_notifications_older_than)
 
     if len(letters) > 0:

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -175,8 +175,8 @@ def check_job_status():
 @notify_celery.task(name='replay-created-notifications')
 @statsd(namespace="tasks")
 def replay_created_notifications():
-    # if the notification has not be send after 4 hours + 15 minutes, then try to resend.
-    resend_created_notifications_older_than = (60 * 60 * 4) + (60 * 15)
+    # if the notification has not be send after 1 hour, then try to resend.
+    resend_created_notifications_older_than = (60 * 60)
     for notification_type in (EMAIL_TYPE, SMS_TYPE):
         notifications_to_resend = notifications_not_yet_sent(
             resend_created_notifications_older_than,
@@ -195,7 +195,7 @@ def replay_created_notifications():
     letters = letters_missing_from_sending_bucket(resend_created_notifications_older_than)
 
     if len(letters) > 0:
-        msg = "{} letters were created four hours and 15 minutes ago, " \
+        msg = "{} letters were created over an hour ago, " \
               "but do not have an updated_at timestamp or billable units. " \
               "\n Creating app.celery.letters_pdf_tasks.create_letters tasks to upload letter to S3 " \
               "and update notifications for the following notification ids: " \

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -710,11 +710,11 @@ def dao_old_letters_with_created_status():
 
 def letters_missing_from_sending_bucket(seconds_to_subtract):
     older_than_date = datetime.utcnow() - timedelta(seconds=seconds_to_subtract)
-
+    # We expect letters to have a `created` status, updated_at timestamp and billable units greater than zero.
     notifications = Notification.query.filter(
+        Notification.billable_units == 0,
         Notification.updated_at == None,  # noqa
         Notification.status == NOTIFICATION_CREATED,
-        Notification.billable_units == 0,
         Notification.created_at <= older_than_date,
         Notification.notification_type == LETTER_TYPE,
         Notification.key_type == KEY_TYPE_NORMAL

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -32,6 +32,7 @@ from app.models import (
     Notification,
     NotificationHistory,
     ScheduledNotification,
+    KEY_TYPE_NORMAL,
     KEY_TYPE_TEST,
     LETTER_TYPE,
     NOTIFICATION_CREATED,
@@ -46,7 +47,7 @@ from app.models import (
     SMS_TYPE,
     EMAIL_TYPE,
     ServiceDataRetention,
-    Service
+    Service,
 )
 from app.utils import get_london_midnight_in_utc
 from app.utils import midnight_n_days_ago, escape_special_characters
@@ -698,12 +699,29 @@ def dao_old_letters_with_created_status():
     last_processing_deadline = yesterday_bst.replace(hour=17, minute=30, second=0, microsecond=0)
 
     notifications = Notification.query.filter(
-        Notification.updated_at < convert_bst_to_utc(last_processing_deadline),
+        Notification.created_at < convert_bst_to_utc(last_processing_deadline),
         Notification.notification_type == LETTER_TYPE,
         Notification.status == NOTIFICATION_CREATED
     ).order_by(
-        Notification.updated_at
+        Notification.created_at
     ).all()
+    return notifications
+
+
+def letters_missing_from_sending_bucket(seconds_to_subtract):
+    older_than_date = datetime.utcnow() - timedelta(seconds=seconds_to_subtract)
+
+    notifications = Notification.query.filter(
+        Notification.updated_at == None,  # noqa
+        Notification.status == NOTIFICATION_CREATED,
+        Notification.billable_units == 0,
+        Notification.created_at <= older_than_date,
+        Notification.notification_type == LETTER_TYPE,
+        Notification.key_type == KEY_TYPE_NORMAL
+    ).order_by(
+        Notification.created_at
+    ).all()
+
     return notifications
 
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -285,7 +285,7 @@ def test_replay_created_notifications(notify_db_session, sample_service, mocker)
 
     sms_template = create_template(service=sample_service, template_type='sms')
     email_template = create_template(service=sample_service, template_type='email')
-    older_than = (60 * 60 * 4) + (60 * 15)  # 4 hours 15 minutes
+    older_than = (60 * 60) + (60 * 15)  # 1 hour 15 minutes
     # notifications expected to be resent
     old_sms = create_notification(template=sms_template, created_at=datetime.utcnow() - timedelta(seconds=older_than),
                                   status='created')
@@ -316,8 +316,10 @@ def test_replay_created_notifications_create_letters_pdf_tasks_for_letters_not_r
     create_notification(template=sample_letter_template, billable_units=0,
                         created_at=datetime.utcnow() - timedelta(hours=4))
 
+    create_notification(template=sample_letter_template, billable_units=0,
+                        created_at=datetime.utcnow() - timedelta(minutes=20))
     notification_1 = create_notification(template=sample_letter_template, billable_units=0,
-                                         created_at=datetime.utcnow() - timedelta(hours=4, minutes=20))
+                                         created_at=datetime.utcnow() - timedelta(hours=1, minutes=20))
     notification_2 = create_notification(template=sample_letter_template, billable_units=0,
                                          created_at=datetime.utcnow() - timedelta(hours=5))
 


### PR DESCRIPTION
Add an alert when a letter is created but doesn't have a file in S3 for sending. We can tell this is the case because there is no updated_at and billable units are still 0.

It is safe to run the app.celery.letters_pdf_tasks.create_letters_pdf task again even if the letter is already in the S3 bucket. Which also means we could shorten the time we wait before check the letter. 

I've reduced the amount of time that we wait before replaying the task to send or create pdf for the notification. This is possible because the tasks can be run twice without harm.