### PR TITLE
Distribute sms between providers

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -35,7 +35,7 @@ from app.dao.notifications_dao import (
 )
 from app.dao.provider_details_dao import (
     get_current_provider,
-    dao_toggle_sms_provider
+    dao_reduce_sms_provider_priority
 )
 from app.dao.users_dao import delete_codes_older_created_more_than_a_day_ago
 from app.models import (
@@ -129,7 +129,7 @@ def switch_current_sms_provider_on_slow_delivery():
             )
         )
 
-        dao_toggle_sms_provider(current_provider.identifier)
+        dao_reduce_sms_provider_priority(current_provider.identifier)
 
 
 @notify_celery.task(name='check-job-status')

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -35,7 +35,6 @@ from app.dao.notifications_dao import (
 )
 from app.dao.provider_details_dao import dao_reduce_sms_provider_priority
 from app.dao.users_dao import delete_codes_older_created_more_than_a_day_ago
-from app.dao.provider_details_dao import get_provider_details_by_notification_type
 from app.models import (
     Job,
     JOB_STATUS_IN_PROGRESS,
@@ -111,13 +110,6 @@ def switch_current_sms_provider_on_slow_delivery():
     in the last ten minutes. If both providers are slow, don't do anything. If we changed the providers in the
     last ten minutes, then don't update them again either.
     """
-    providers = get_provider_details_by_notification_type('sms')
-    # if something updated recently, don't update again. If the updated_at is null, set it to min time
-    # just to prevent errors
-    if any((provider.updated_at or datetime.min) > datetime.utcnow() - timedelta(minutes=10) for provider in providers):
-        current_app.logger.info("Slow delivery notifications provider switched less than 10 minutes ago.")
-        return
-
     slow_delivery_notifications = is_delivery_slow_for_providers(
         threshold=0.3,
         created_at=datetime.utcnow() - timedelta(minutes=10),

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -122,7 +122,7 @@ def switch_current_sms_provider_on_slow_delivery():
         for provider_name, is_slow in slow_delivery_notifications.items():
             if is_slow:
                 current_app.logger.warning('Slow delivery notifications detected for provider {}'.format(provider_name))
-                dao_reduce_sms_provider_priority(provider_name)
+                dao_reduce_sms_provider_priority(provider_name, time_threshold=timedelta(minutes=10))
 
 
 @notify_celery.task(name='check-job-status')

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -25,19 +25,17 @@ from app.dao.jobs_dao import (
 )
 from app.dao.jobs_dao import dao_update_job
 from app.dao.notifications_dao import (
-    is_delivery_slow_for_provider,
     dao_get_scheduled_notifications,
     set_scheduled_notification_to_processed,
     notifications_not_yet_sent,
     dao_precompiled_letters_still_pending_virus_check,
     dao_old_letters_with_created_status,
-    letters_missing_from_sending_bucket
+    letters_missing_from_sending_bucket,
+    is_delivery_slow_for_providers,
 )
-from app.dao.provider_details_dao import (
-    get_current_provider,
-    dao_reduce_sms_provider_priority
-)
+from app.dao.provider_details_dao import dao_reduce_sms_provider_priority
 from app.dao.users_dao import delete_codes_older_created_more_than_a_day_ago
+from app.dao.provider_details_dao import get_provider_details_by_notification_type
 from app.models import (
     Job,
     JOB_STATUS_IN_PROGRESS,
@@ -109,27 +107,30 @@ def delete_invitations():
 @statsd(namespace="tasks")
 def switch_current_sms_provider_on_slow_delivery():
     """
-    Switch providers if at least 30% of notifications took more than four minutes to be delivered
-    in the last ten minutes. Search from the time we last switched to the current provider.
+    Reduce provider's priority if at least 30% of notifications took more than four minutes to be delivered
+    in the last ten minutes. If both providers are slow, don't do anything. If we changed the providers in the
+    last ten minutes, then don't update them again either.
     """
-    current_provider = get_current_provider('sms')
-    if current_provider.updated_at > datetime.utcnow() - timedelta(minutes=10):
+    providers = get_provider_details_by_notification_type('sms')
+    # if something updated recently, don't update again. If the updated_at is null, set it to min time
+    # just to prevent errors
+    if any((provider.updated_at or datetime.min) > datetime.utcnow() - timedelta(minutes=10) for provider in providers):
         current_app.logger.info("Slow delivery notifications provider switched less than 10 minutes ago.")
         return
+
     slow_delivery_notifications = is_delivery_slow_for_providers(
         threshold=0.3,
         created_at=datetime.utcnow() - timedelta(minutes=10),
         delivery_time=timedelta(minutes=4),
     )
 
-    if slow_delivery_notifications[current_provider]:
-        current_app.logger.warning(
-            'Slow delivery notifications detected for provider {}'.format(
-                current_provider.identifier
-            )
-        )
-
-        dao_reduce_sms_provider_priority(current_provider.identifier)
+    # only adjust if some values are true and some are false - ie, don't adjust if all providers are fast or
+    # all providers are slow
+    if len(set(slow_delivery_notifications.values())) != 1:
+        for provider_name, is_slow in slow_delivery_notifications.items():
+            if is_slow:
+                current_app.logger.warning('Slow delivery notifications detected for provider {}'.format(provider_name))
+                dao_reduce_sms_provider_priority(provider_name)
 
 
 @notify_celery.task(name='check-job-status')

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -116,14 +116,13 @@ def switch_current_sms_provider_on_slow_delivery():
     if current_provider.updated_at > datetime.utcnow() - timedelta(minutes=10):
         current_app.logger.info("Slow delivery notifications provider switched less than 10 minutes ago.")
         return
-    slow_delivery_notifications = is_delivery_slow_for_provider(
-        provider=current_provider.identifier,
+    slow_delivery_notifications = is_delivery_slow_for_providers(
         threshold=0.3,
         created_at=datetime.utcnow() - timedelta(minutes=10),
         delivery_time=timedelta(minutes=4),
     )
 
-    if slow_delivery_notifications:
+    if slow_delivery_notifications[current_provider]:
         current_app.logger.warning(
             'Slow delivery notifications detected for provider {}'.format(
                 current_provider.identifier

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -42,7 +42,7 @@ from app.dao.notifications_dao import (
     update_notification_status_by_reference,
     dao_get_notification_history_by_reference,
 )
-from app.dao.provider_details_dao import get_current_provider
+from app.dao.provider_details_dao import get_provider_details_by_notification_type
 from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_id
 from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
 from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id
@@ -352,7 +352,7 @@ def save_letter(
 @statsd(namespace="tasks")
 def update_letter_notifications_to_sent_to_dvla(self, notification_references):
     # This task will be called by the FTP app to update notifications as sent to DVLA
-    provider = get_current_provider(LETTER_TYPE)
+    provider = get_provider_details_by_notification_type(LETTER_TYPE)[0]
 
     updated_count, _ = dao_update_notifications_by_reference(
         notification_references,

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -1,5 +1,7 @@
 import functools
 import string
+from itertools import groupby
+from operator import attrgetter
 from datetime import (
     datetime,
     timedelta,
@@ -15,7 +17,7 @@ from notifications_utils.recipients import (
 )
 from notifications_utils.statsd_decorators import statsd
 from notifications_utils.timezones import convert_bst_to_utc, convert_utc_to_bst
-from sqlalchemy import (desc, func, asc)
+from sqlalchemy import (desc, func, asc, and_)
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import functions
@@ -31,6 +33,7 @@ from app.letters.utils import get_letter_pdf_filename
 from app.models import (
     Notification,
     NotificationHistory,
+    ProviderDetails,
     ScheduledNotification,
     KEY_TYPE_NORMAL,
     KEY_TYPE_TEST,
@@ -486,40 +489,63 @@ def dao_timeout_notifications(timeout_period_in_seconds):
     return technical_failure_notifications, temporary_failure_notifications
 
 
-def is_delivery_slow_for_provider(
+def is_delivery_slow_for_providers(
         created_at,
-        provider,
         threshold,
         delivery_time,
 ):
-    count = db.session.query(
+    """
+    Returns a dict of providers and whether they are currently slow or not. eg:
+    {
+        'mmg': True,
+        'firetext': False
+    }
+    """
+    slow_notification_counts = db.session.query(
+        ProviderDetails.identifier,
         case(
             [(
                 Notification.status == NOTIFICATION_DELIVERED,
                 (Notification.updated_at - Notification.sent_at) >= delivery_time
             )],
             else_=(datetime.utcnow() - Notification.sent_at) >= delivery_time
-        ).label("slow"), func.count()
-
+        ).label("slow"),
+        func.count().label('count')
+    ).select_from(
+        ProviderDetails
+    ).outerjoin(
+        Notification, and_(
+            Notification.sent_by == ProviderDetails.identifier,
+            Notification.created_at >= created_at,
+            Notification.sent_at.isnot(None),
+            Notification.status.in_([NOTIFICATION_DELIVERED, NOTIFICATION_PENDING, NOTIFICATION_SENDING]),
+            Notification.key_type != KEY_TYPE_TEST
+        )
     ).filter(
-        Notification.created_at >= created_at,
-        Notification.sent_at.isnot(None),
-        Notification.status.in_([NOTIFICATION_DELIVERED, NOTIFICATION_PENDING, NOTIFICATION_SENDING]),
-        Notification.sent_by == provider,
-        Notification.key_type != KEY_TYPE_TEST
-    ).group_by("slow").all()
+        ProviderDetails.notification_type == 'sms',
+        ProviderDetails.active
+    ).order_by(
+        ProviderDetails.identifier
+    ).group_by(
+        ProviderDetails.identifier,
+        "slow"
+    )
+    print(slow_notification_counts)
+    print([x for x in slow_notification_counts])
 
-    counts = {c[0]: c[1] for c in count}
-    total_notifications = sum(counts.values())
-    slow_notifications = counts.get(True, 0)
+    slow_providers = {}
+    for provider, rows in groupby(slow_notification_counts, key=attrgetter('identifier')):
+        rows = list(rows)
+        total_notifications = sum(row.count for row in rows)
+        slow_notifications = sum(row.count for row in rows if row.slow)
 
-    if total_notifications:
+        slow_providers[provider] = (slow_notifications / total_notifications >= threshold)
+
         current_app.logger.info("Slow delivery notifications count for provider {}: {} out of {}. Ratio {}".format(
             provider, slow_notifications, total_notifications, slow_notifications / total_notifications
         ))
-        return slow_notifications / total_notifications >= threshold
-    else:
-        return False
+
+    return slow_providers
 
 
 @statsd(namespace="dao")

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -530,8 +530,6 @@ def is_delivery_slow_for_providers(
         ProviderDetails.identifier,
         "slow"
     )
-    print(slow_notification_counts)
-    print([x for x in slow_notification_counts])
 
     slow_providers = {}
     for provider, rows in groupby(slow_notification_counts, key=attrgetter('identifier')):

--- a/app/dao/provider_details_dao.py
+++ b/app/dao/provider_details_dao.py
@@ -29,15 +29,6 @@ def get_alternative_sms_provider(identifier):
     raise ValueError('Unrecognised sms provider {}'.format(identifier))
 
 
-def get_current_provider(notification_type):
-    return ProviderDetails.query.filter_by(
-        notification_type=notification_type,
-        active=True
-    ).order_by(
-        asc(ProviderDetails.priority)
-    ).first()
-
-
 def dao_get_provider_versions(provider_id):
     return ProviderDetailsHistory.query.filter_by(
         id=provider_id
@@ -60,11 +51,6 @@ def dao_reduce_sms_provider_priority(identifier):
     # always keep values between 0 and 100
     providers[identifier].priority = max(0, providers[identifier].priority - 10)
     providers[other].priority = min(100, providers[other].priority + 10)
-
-
-def dao_toggle_sms_provider(*args, **kwargs):
-    raise NotImplementedError
-
 
 def get_provider_details_by_notification_type(notification_type, supports_international=False):
 

--- a/app/dao/provider_details_dao.py
+++ b/app/dao/provider_details_dao.py
@@ -4,11 +4,6 @@ from notifications_utils.timezones import convert_utc_to_bst
 from sqlalchemy import asc, desc, func
 
 from app.dao.dao_utils import transactional
-from app.provider_details.switch_providers import (
-    provider_is_inactive,
-    provider_is_primary,
-    switch_providers
-)
 from app.models import FactBilling, ProviderDetails, ProviderDetailsHistory, SMS_TYPE, User
 from app import db
 
@@ -51,6 +46,7 @@ def dao_reduce_sms_provider_priority(identifier):
     # always keep values between 0 and 100
     providers[identifier].priority = max(0, providers[identifier].priority - 10)
     providers[other].priority = min(100, providers[other].priority + 10)
+
 
 def get_provider_details_by_notification_type(notification_type, supports_international=False):
 

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -1,6 +1,6 @@
 import random
 from urllib import parse
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from flask import current_app
 from notifications_utils.recipients import (
@@ -66,7 +66,7 @@ def send_sms_to_provider(notification):
             except Exception as e:
                 notification.billable_units = template.fragment_count
                 dao_update_notification(notification)
-                dao_reduce_sms_provider_priority(provider.get_name())
+                dao_reduce_sms_provider_priority(provider.get_name(), time_threshold=timedelta(minutes=1))
                 raise e
             else:
                 notification.billable_units = template.fragment_count

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -1,3 +1,4 @@
+import random
 from urllib import parse
 from datetime import datetime
 
@@ -39,7 +40,7 @@ def send_sms_to_provider(notification):
         return
 
     if notification.status == 'created':
-        provider = provider_to_use(SMS_TYPE, notification.id, notification.international)
+        provider = provider_to_use(SMS_TYPE, notification.international)
 
         template_model = dao_get_template_by_id(notification.template_id, notification.template_version)
 
@@ -81,7 +82,7 @@ def send_email_to_provider(notification):
         technical_failure(notification=notification)
         return
     if notification.status == 'created':
-        provider = provider_to_use(EMAIL_TYPE, notification.id)
+        provider = provider_to_use(EMAIL_TYPE)
 
         template_dict = dao_get_template_by_id(notification.template_id, notification.template_version).__dict__
 
@@ -128,18 +129,20 @@ def update_notification_to_sending(notification, provider):
     dao_update_notification(notification)
 
 
-def provider_to_use(notification_type, notification_id, international=False):
-    active_providers_in_order = [
+def provider_to_use(notification_type, international=False):
+    active_providers = [
         p for p in get_provider_details_by_notification_type(notification_type, international) if p.active
     ]
 
-    if not active_providers_in_order:
+    if not active_providers:
         current_app.logger.error(
-            "{} {} failed as no active providers".format(notification_type, notification_id)
+            "{} failed as no active providers".format(notification_type)
         )
         raise Exception("No active {} providers".format(notification_type))
 
-    return clients.get_client_by_name_and_type(active_providers_in_order[0].identifier, notification_type)
+    chosen_provider = random.choices(active_providers, weights=[p.priority for p in active_providers])[0]
+
+    return clients.get_client_by_name_and_type(chosen_provider.identifier, notification_type)
 
 
 def get_logo_url(base_url, logo_file):

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -15,7 +15,7 @@ from app.dao.notifications_dao import (
 )
 from app.dao.provider_details_dao import (
     get_provider_details_by_notification_type,
-    dao_toggle_sms_provider
+    dao_reduce_sms_provider_priority
 )
 from app.celery.research_mode_tasks import send_sms_response, send_email_response
 from app.dao.templates_dao import dao_get_template_by_id
@@ -66,7 +66,7 @@ def send_sms_to_provider(notification):
             except Exception as e:
                 notification.billable_units = template.fragment_count
                 dao_update_notification(notification)
-                dao_reduce_sms_provider_priority(provider)
+                dao_reduce_sms_provider_priority(provider.get_name())
                 raise e
             else:
                 notification.billable_units = template.fragment_count

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -66,7 +66,7 @@ def send_sms_to_provider(notification):
             except Exception as e:
                 notification.billable_units = template.fragment_count
                 dao_update_notification(notification)
-                dao_toggle_sms_provider(provider.name)
+                dao_reduce_sms_provider_priority(provider)
                 raise e
             else:
                 notification.billable_units = template.fragment_count

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -120,9 +120,11 @@ def test_send_sms_should_not_switch_providers_on_non_provider_failure(
         'app.delivery.send_to_providers.send_sms_to_provider',
         side_effect=Exception("Non Provider Exception")
     )
-    switch_provider_mock = mocker.patch('app.delivery.send_to_providers.dao_toggle_sms_provider')
+    mock_dao_reduce_sms_provider_priority = mocker.patch(
+        'app.delivery.send_to_providers.dao_reduce_sms_provider_priority'
+    )
     mocker.patch('app.celery.provider_tasks.deliver_sms.retry')
 
     deliver_sms(sample_notification.id)
 
-    assert switch_provider_mock.called is False
+    assert mock_dao_reduce_sms_provider_priority.called is False

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -58,7 +58,7 @@ def test_should_call_delete_codes_on_delete_verify_codes_task(notify_db_session,
     assert scheduled_tasks.delete_codes_older_created_more_than_a_day_ago.call_count == 1
 
 
-def test_should_call_delete_invotations_on_delete_invitations_task(notify_api, mocker):
+def test_should_call_delete_invotations_on_delete_invitations_task(notify_db_session, mocker):
     mocker.patch('app.celery.scheduled_tasks.delete_invitations_created_more_than_two_days_ago')
     delete_invitations()
     assert scheduled_tasks.delete_invitations_created_more_than_two_days_ago.call_count == 1
@@ -119,7 +119,7 @@ def test_switch_current_sms_provider_on_slow_delivery_switches_when_one_provider
         created_at=datetime(2017, 5, 1, 13, 50),
         delivery_time=timedelta(minutes=4)
     )
-    mock_reduce.assert_called_once_with('firetext')
+    mock_reduce.assert_called_once_with('firetext', time_threshold=timedelta(minutes=10))
 
 
 @freeze_time('2017-05-01 14:00:00')

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -21,7 +21,7 @@ from app.celery.scheduled_tasks import (
 from app.config import QueueNames, TaskNames
 from app.dao.jobs_dao import dao_get_job_by_id
 from app.dao.notifications_dao import dao_get_scheduled_notifications
-from app.dao.provider_details_dao import get_provider_details_by_notification_type, get_provider_details_by_identifier
+from app.dao.provider_details_dao import get_provider_details_by_identifier
 from app.models import (
     JOB_STATUS_IN_PROGRESS,
     JOB_STATUS_ERROR,
@@ -123,21 +123,6 @@ def test_switch_current_sms_provider_on_slow_delivery_switches_when_one_provider
 
 
 @freeze_time('2017-05-01 14:00:00')
-def test_switch_current_sms_provider_on_slow_delivery_does_nothing_if_recent_changes(
-    mocker,
-    restore_provider_details,
-):
-    mock_is_slow = mocker.patch('app.celery.scheduled_tasks.is_delivery_slow_for_providers')
-    mock_reduce = mocker.patch('app.celery.scheduled_tasks.dao_reduce_sms_provider_priority')
-    get_provider_details_by_identifier('mmg').updated_at = datetime(2017, 5, 1, 13, 51)
-
-    switch_current_sms_provider_on_slow_delivery()
-
-    assert mock_is_slow.called is False
-    assert mock_reduce.called is False
-
-
-@freeze_time('2017-05-01 14:00:00')
 @pytest.mark.parametrize('is_slow_dict', [
     {'mmg': False, 'firetext': False},
     {'mmg': True, 'firetext': True},
@@ -150,7 +135,6 @@ def test_switch_current_sms_provider_on_slow_delivery_does_nothing_if_no_need(
     mocker.patch('app.celery.scheduled_tasks.is_delivery_slow_for_providers', return_value=is_slow_dict)
     mock_reduce = mocker.patch('app.celery.scheduled_tasks.dao_reduce_sms_provider_priority')
     get_provider_details_by_identifier('mmg').updated_at = datetime(2017, 5, 1, 13, 51)
-
 
     switch_current_sms_provider_on_slow_delivery()
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -5,7 +5,6 @@ import pytest
 from freezegun import freeze_time
 from mock import mock
 
-from app import db
 from app.celery import scheduled_tasks
 from app.celery.scheduled_tasks import (
     check_job_status,
@@ -13,7 +12,6 @@ from app.celery.scheduled_tasks import (
     delete_verify_codes,
     run_scheduled_jobs,
     send_scheduled_notifications,
-    switch_current_sms_provider_on_slow_delivery,
     replay_created_notifications,
     check_precompiled_letter_state,
     check_templated_letter_state,

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -15,11 +15,13 @@ from app.celery.scheduled_tasks import (
     replay_created_notifications,
     check_precompiled_letter_state,
     check_templated_letter_state,
-    check_for_missing_rows_in_completed_jobs
+    check_for_missing_rows_in_completed_jobs,
+    switch_current_sms_provider_on_slow_delivery,
 )
 from app.config import QueueNames, TaskNames
 from app.dao.jobs_dao import dao_get_job_by_id
 from app.dao.notifications_dao import dao_get_scheduled_notifications
+from app.dao.provider_details_dao import get_provider_details_by_notification_type, get_provider_details_by_identifier
 from app.models import (
     JOB_STATUS_IN_PROGRESS,
     JOB_STATUS_ERROR,
@@ -98,13 +100,61 @@ def test_should_update_all_scheduled_jobs_and_put_on_queue(sample_template, mock
     ])
 
 
-def test_switch_providers_on_slow_delivery_switches_once_then_does_not_switch_if_already_switched(
-        notify_api,
-        mocker,
-        sample_user,
-        sample_template
+@freeze_time('2017-05-01 14:00:00')
+def test_switch_current_sms_provider_on_slow_delivery_switches_when_one_provider_is_slow(
+    mocker,
+    restore_provider_details,
 ):
-    raise NotImplementedError  # TODO
+    is_slow_dict = {'mmg': False, 'firetext': True}
+    mock_is_slow = mocker.patch('app.celery.scheduled_tasks.is_delivery_slow_for_providers', return_value=is_slow_dict)
+    mock_reduce = mocker.patch('app.celery.scheduled_tasks.dao_reduce_sms_provider_priority')
+    # updated_at times are older than the 10 minute window
+    get_provider_details_by_identifier('mmg').updated_at = datetime(2017, 5, 1, 13, 49)
+    get_provider_details_by_identifier('firetext').updated_at = None
+
+    switch_current_sms_provider_on_slow_delivery()
+
+    mock_is_slow.assert_called_once_with(
+        threshold=0.3,
+        created_at=datetime(2017, 5, 1, 13, 50),
+        delivery_time=timedelta(minutes=4)
+    )
+    mock_reduce.assert_called_once_with('firetext')
+
+
+@freeze_time('2017-05-01 14:00:00')
+def test_switch_current_sms_provider_on_slow_delivery_does_nothing_if_recent_changes(
+    mocker,
+    restore_provider_details,
+):
+    mock_is_slow = mocker.patch('app.celery.scheduled_tasks.is_delivery_slow_for_providers')
+    mock_reduce = mocker.patch('app.celery.scheduled_tasks.dao_reduce_sms_provider_priority')
+    get_provider_details_by_identifier('mmg').updated_at = datetime(2017, 5, 1, 13, 51)
+
+    switch_current_sms_provider_on_slow_delivery()
+
+    assert mock_is_slow.called is False
+    assert mock_reduce.called is False
+
+
+@freeze_time('2017-05-01 14:00:00')
+@pytest.mark.parametrize('is_slow_dict', [
+    {'mmg': False, 'firetext': False},
+    {'mmg': True, 'firetext': True},
+])
+def test_switch_current_sms_provider_on_slow_delivery_does_nothing_if_no_need(
+    mocker,
+    restore_provider_details,
+    is_slow_dict
+):
+    mocker.patch('app.celery.scheduled_tasks.is_delivery_slow_for_providers', return_value=is_slow_dict)
+    mock_reduce = mocker.patch('app.celery.scheduled_tasks.dao_reduce_sms_provider_priority')
+    get_provider_details_by_identifier('mmg').updated_at = datetime(2017, 5, 1, 13, 51)
+
+
+    switch_current_sms_provider_on_slow_delivery()
+
+    assert mock_reduce.called is False
 
 
 @freeze_time("2017-05-01 14:00:00")

--- a/tests/app/dao/test_provider_details_dao.py
+++ b/tests/app/dao/test_provider_details_dao.py
@@ -185,6 +185,21 @@ def test_reduce_sms_provider_priority_adds_rows_to_history_table(
     assert updated_provider_history_rows[0].priority == 90
 
 
+@freeze_time('2017-05-01 14:00:00')
+def test_reduce_sms_provider_priority_does_nothing_if_providers_have_recently_changed(
+    mocker,
+    restore_provider_details,
+):
+    mock_is_slow = mocker.patch('app.celery.scheduled_tasks.is_delivery_slow_for_providers')
+    mock_reduce = mocker.patch('app.celery.scheduled_tasks.dao_reduce_sms_provider_priority')
+    get_provider_details_by_identifier('mmg').updated_at = datetime(2017, 5, 1, 13, 51)
+
+    dao_reduce_sms_provider_priority('firetext')
+
+    assert mock_is_slow.called is False
+    assert mock_reduce.called is False
+
+
 @freeze_time('2018-06-28 12:00')
 def test_dao_get_provider_stats(notify_db_session):
     service_1 = create_service(service_name='1')

--- a/tests/app/dao/test_provider_details_dao.py
+++ b/tests/app/dao/test_provider_details_dao.py
@@ -32,32 +32,32 @@ def set_primary_sms_provider(identifier):
     dao_update_provider_details(secondary_provider)
 
 
-def test_can_get_sms_non_international_providers(restore_provider_details):
+def test_can_get_sms_non_international_providers(notify_db_session):
     sms_providers = get_provider_details_by_notification_type('sms')
     assert len(sms_providers) == 2
     assert all('sms' == prov.notification_type for prov in sms_providers)
 
 
-def test_can_get_sms_international_providers(restore_provider_details):
+def test_can_get_sms_international_providers(notify_db_session):
     sms_providers = get_provider_details_by_notification_type('sms', True)
     assert len(sms_providers) == 1
     assert all('sms' == prov.notification_type for prov in sms_providers)
     assert all(prov.supports_international for prov in sms_providers)
 
 
-def test_can_get_sms_providers_in_order_of_priority(restore_provider_details):
+def test_can_get_sms_providers_in_order_of_priority(notify_db_session):
     providers = get_provider_details_by_notification_type('sms', False)
 
     assert providers[0].priority < providers[1].priority
 
 
-def test_can_get_email_providers_in_order_of_priority(restore_provider_details):
+def test_can_get_email_providers_in_order_of_priority(notify_db_session):
     providers = get_provider_details_by_notification_type('email')
 
     assert providers[0].identifier == "ses"
 
 
-def test_can_get_email_providers(restore_provider_details):
+def test_can_get_email_providers(notify_db_session):
     assert len(get_provider_details_by_notification_type('email')) == 1
     types = [provider.notification_type for provider in get_provider_details_by_notification_type('email')]
     assert all('email' == notification_type for notification_type in types)
@@ -136,7 +136,7 @@ def test_get_alternative_sms_provider_fails_if_unrecognised():
     ({'mmg': 50, 'firetext': -100}, {'mmg': 40, 'firetext': -90}),
 ])
 def test_reduce_sms_provider_priority_switches_provider(
-    restore_provider_details,
+    notify_db_session,
     starting_priorities,
     expected_priorities
 ):
@@ -156,21 +156,20 @@ def test_reduce_sms_provider_priority_switches_provider(
 def test_reduce_sms_provider_priority_adds_rows_to_history_table(
     mocker,
     restore_provider_details,
-    current_sms_provider,
     sample_user
 ):
     raise NotImplementedError
     # mocker.patch('app.provider_details.switch_providers.get_user_by_id', return_value=sample_user)
     # provider_history_rows = ProviderDetailsHistory.query.filter(
-    #     ProviderDetailsHistory.id == current_sms_provider.id
+    #     ProviderDetailsHistory.id == mmg.id
     # ).order_by(
     #     desc(ProviderDetailsHistory.version)
     # ).all()
 
-    # dao_toggle_sms_provider(current_sms_provider.identifier)
+    # dao_toggle_sms_provider(mmg.identifier)
 
     # updated_provider_history_rows = ProviderDetailsHistory.query.filter(
-    #     ProviderDetailsHistory.id == current_sms_provider.id
+    #     ProviderDetailsHistory.id == mmg.id
     # ).order_by(
     #     desc(ProviderDetailsHistory.version)
     # ).all()
@@ -196,8 +195,8 @@ def test_reduce_sms_provider_priority_records_notify_user(
     # assert new_provider.created_by_id == sample_user.id
 
 
-def test_can_get_all_provider_history(restore_provider_details, current_sms_provider):
-    assert len(dao_get_provider_versions(current_sms_provider.id)) == 1
+def test_can_get_all_provider_history(notify_db_session):
+    assert len(dao_get_provider_versions('mmg')) == 1
 
 
 @freeze_time('2018-06-28 12:00')

--- a/tests/app/dao/test_provider_details_dao.py
+++ b/tests/app/dao/test_provider_details_dao.py
@@ -224,17 +224,17 @@ def test_dao_get_provider_stats(notify_db_session):
     assert result[0].created_by_name is None
     assert result[0].current_month_billable_sms == 0
 
-    assert result[1].identifier == 'mmg'
-    assert result[1].display_name == 'MMG'
-    assert result[1].supports_international is True
+    assert result[1].identifier == 'firetext'
+    assert result[1].notification_type == 'sms'
+    assert result[1].supports_international is False
     assert result[1].active is True
-    assert result[1].current_month_billable_sms == 4
+    assert result[1].current_month_billable_sms == 5
 
-    assert result[2].identifier == 'firetext'
-    assert result[2].notification_type == 'sms'
-    assert result[2].supports_international is False
+    assert result[2].identifier == 'mmg'
+    assert result[2].display_name == 'MMG'
+    assert result[2].supports_international is True
     assert result[2].active is True
-    assert result[2].current_month_billable_sms == 5
+    assert result[2].current_month_billable_sms == 4
 
     assert result[3].identifier == 'dvla'
     assert result[3].current_month_billable_sms == 0

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -40,7 +40,7 @@ def test_should_return_highest_priority_active_provider(restore_provider_details
     first = providers[0]
     second = providers[1]
 
-    assert send_to_providers.provider_to_use('sms', '1234').name == first.identifier
+    assert send_to_providers.provider_to_use('sms').name == first.identifier
 
     first.priority = 20
     second.priority = 10
@@ -48,7 +48,7 @@ def test_should_return_highest_priority_active_provider(restore_provider_details
     provider_details_dao.dao_update_provider_details(first)
     provider_details_dao.dao_update_provider_details(second)
 
-    assert send_to_providers.provider_to_use('sms', '1234').name == second.identifier
+    assert send_to_providers.provider_to_use('sms').name == second.identifier
 
     first.priority = 10
     first.active = False
@@ -57,12 +57,12 @@ def test_should_return_highest_priority_active_provider(restore_provider_details
     provider_details_dao.dao_update_provider_details(first)
     provider_details_dao.dao_update_provider_details(second)
 
-    assert send_to_providers.provider_to_use('sms', '1234').name == second.identifier
+    assert send_to_providers.provider_to_use('sms').name == second.identifier
 
     first.active = True
     provider_details_dao.dao_update_provider_details(first)
 
-    assert send_to_providers.provider_to_use('sms', '1234').name == first.identifier
+    assert send_to_providers.provider_to_use('sms').name == first.identifier
 
 
 def test_should_send_personalised_template_to_correct_sms_provider_and_persist(

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -553,7 +553,7 @@ def test_should_set_notification_billable_units_if_sending_to_provider_fails(
     mocker,
 ):
     mocker.patch('app.mmg_client.send_sms', side_effect=Exception())
-    mock_toggle_provider = mocker.patch('app.delivery.send_to_providers.dao_toggle_sms_provider')
+    mocker.patch('app.delivery.send_to_providers.dao_reduce_sms_provider_priority')
 
     sample_notification.billable_units = 0
     assert sample_notification.sent_by is None
@@ -562,7 +562,6 @@ def test_should_set_notification_billable_units_if_sending_to_provider_fails(
         send_to_providers.send_sms_to_provider(sample_notification)
 
     assert sample_notification.billable_units == 1
-    assert mock_toggle_provider.called
 
 
 def test_should_send_sms_to_international_providers(

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -565,7 +565,6 @@ def test_should_set_notification_billable_units_if_sending_to_provider_fails(
 
 
 def test_should_send_sms_to_international_providers(
-    restore_provider_details,
     sample_template,
     sample_user,
     mocker

--- a/tests/app/provider_details/test_rest.py
+++ b/tests/app/provider_details/test_rest.py
@@ -8,7 +8,7 @@ from tests import create_authorization_header
 from tests.app.db import create_ft_billing
 
 
-def test_get_provider_details_returns_all_providers(admin_request, db_session):
+def test_get_provider_details_returns_all_providers(admin_request, notify_db_session):
     json_resp = admin_request.get('provider_details.get_providers')['provider_details']
 
     assert len(json_resp) == 4

--- a/tests/app/provider_details/test_rest.py
+++ b/tests/app/provider_details/test_rest.py
@@ -8,19 +8,11 @@ from tests import create_authorization_header
 from tests.app.db import create_ft_billing
 
 
-def test_get_provider_details_in_type_and_identifier_order(client, notify_db):
-    response = client.get(
-        '/provider-details',
-        headers=[create_authorization_header()]
-    )
-    assert response.status_code == 200
-    json_resp = json.loads(response.get_data(as_text=True))['provider_details']
-    assert len(json_resp) == 4
+def test_get_provider_details_returns_all_providers(admin_request, db_session):
+    json_resp = admin_request.get('provider_details.get_providers')['provider_details']
 
-    assert json_resp[0]['identifier'] == 'ses'
-    assert json_resp[1]['identifier'] == 'mmg'
-    assert json_resp[2]['identifier'] == 'firetext'
-    assert json_resp[3]['identifier'] == 'dvla'
+    assert len(json_resp) == 4
+    assert {x['identifier'] for x in json_resp} == {'ses', 'firetext', 'mmg', 'dvla'}
 
 
 def test_get_provider_details_by_id(client, notify_db):

--- a/tests/app/test_schemas.py
+++ b/tests/app/test_schemas.py
@@ -2,7 +2,7 @@ import pytest
 from marshmallow import ValidationError
 from sqlalchemy import desc
 
-from app.dao.provider_details_dao import dao_update_provider_details
+from app.dao.provider_details_dao import dao_update_provider_details, get_provider_details_by_identifier
 from app.models import ProviderDetailsHistory
 from tests.app.db import create_api_key
 
@@ -101,9 +101,10 @@ def test_user_update_schema_rejects_disallowed_attribute_keys(user_attribute):
 def test_provider_details_schema_returns_user_details(
     mocker,
     sample_user,
-    current_sms_provider
+    restore_provider_details
 ):
     from app.schemas import provider_details_schema
+    current_sms_provider = get_provider_details_by_identifier('mmg')
     mocker.patch('app.provider_details.switch_providers.get_user_by_id', return_value=sample_user)
     current_sms_provider.created_by = sample_user
     data = provider_details_schema.dump(current_sms_provider).data
@@ -115,10 +116,10 @@ def test_provider_details_history_schema_returns_user_details(
     mocker,
     sample_user,
     restore_provider_details,
-    current_sms_provider
 ):
     from app.schemas import provider_details_schema
     mocker.patch('app.provider_details.switch_providers.get_user_by_id', return_value=sample_user)
+    current_sms_provider = get_provider_details_by_identifier('mmg')
     current_sms_provider.created_by_id = sample_user.id
     data = provider_details_schema.dump(current_sms_provider).data
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 import sqlalchemy
 
 from app import create_app, db
+from app.dao.provider_details_dao import get_provider_details_by_identifier
 
 
 @pytest.fixture(scope='session')
@@ -90,7 +91,18 @@ def notify_db(notify_api, worker_id):
 
 
 @pytest.fixture(scope='function')
-def notify_db_session(notify_db):
+def sms_providers(notify_db):
+    """
+    In production we randomly choose which provider to use based on their priority. To guarantee tests run the same each
+    time, make sure we always choose mmg. You'll need to override them in your tests if you wish to do something
+    different.
+    """
+    get_provider_details_by_identifier('mmg').priority = 100
+    get_provider_details_by_identifier('firetext').priority = 0
+
+
+@pytest.fixture(scope='function')
+def notify_db_session(notify_db, sms_providers):
     yield notify_db
 
     notify_db.session.remove()


### PR DESCRIPTION
## Previous (one provider at a time)

* exclusively use one provider at a time
* if a provider has been "slow" over a recent period of time, switch to the other one
* if a provider returns 5xx or times out, switch to the other one
* if we accidentally DOS a provider with high load, we'll switch and then we might accidentally DOS the other provider (this actually happened and was the reason we prioritised this story)

## Now (share the load, frodo)

* randomly pick a provider when sending an sms, taking the `priority` field as a weighting
* if a provider has been "slow", reduce its weight (and bump up the other weight to make it easier to read/reason about)
* if a provider has a 500, reduce its weight and bump the other
* don't adjust weights if they've been changed in the last 10 minutes (to stop 10 500s at once taking something from working to switched off instantly)

## Thoughts/risks/concerns

* we try and constrain the numbers to 0<=x<=100 to keep them sensible and easy to read, but they won't always add up to 100. they don't need to for our code to work (if one is positive and one is negative the positive one will always be selected, but other than that all values work, even `NaN`)
* should we gradually tend the providers back to 50/50 (eg, by 1 pt every minute or something)?
* should manual adjustments be handled differently to automated overrides?
* to turn off a provider, set their priority to 0. you don't need to adjust the other one. 100 doesn't mean 100%, it's just arbitrary.
* if both providers have a priority of 0, the random choice will always select the same arbitrary one (based on the order returned from the DB)
* mmg is the active provider in all tests now, with a priority of 100 and firetext having a priority of 0.

^ these are probably problems to be solved in future PRs though, this PR is big enough already