### PR TITLE
update utils to bring in full welsh diacritics range

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -337,7 +337,7 @@ class Config(object):
     DOCUMENT_DOWNLOAD_API_HOST = os.environ.get('DOCUMENT_DOWNLOAD_API_HOST', 'http://localhost:7000')
     DOCUMENT_DOWNLOAD_API_KEY = os.environ.get('DOCUMENT_DOWNLOAD_API_KEY', 'auth-token')
 
-    MMG_URL = os.environ.get("MMG_URL", "https://api.mmg.co.uk/json/api.php")
+    MMG_URL = os.environ.get("MMG_URL", "https://api.mmg.co.uk/jsonv2a/api.php")
     FIRETEXT_URL = os.environ.get("FIRETEXT_URL", "https://www.firetext.co.uk/api/sendsms/json")
 
     AWS_REGION = 'eu-west-1'

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,6 +29,6 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@36.2.0#egg=notifications-utils==36.2.0
+git+https://github.com/alphagov/notifications-utils.git@36.3.0#egg=notifications-utils==36.3.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@36.2.0#egg=notifications-utils==36.2.0
+git+https://github.com/alphagov/notifications-utils.git@36.3.0#egg=notifications-utils==36.3.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
@@ -40,13 +40,13 @@ alembic==1.3.1
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.3.0
-awscli==1.16.287
+awscli==1.16.292
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.0
 boto3==1.9.221
-botocore==1.13.23
-certifi==2019.9.11
+botocore==1.13.28
+certifi==2019.11.28
 chardet==3.0.4
 Click==7.0
 colorama==0.4.1
@@ -70,7 +70,7 @@ phonenumbers==8.10.17
 pyasn1==0.4.8
 pycparser==2.19
 PyPDF2==1.26.0
-pyrsistent==0.15.5
+pyrsistent==0.15.6
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-json-logger==0.1.11

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -272,10 +272,11 @@ def test_should_not_send_to_provider_when_status_is_not_created(
 
 def test_should_send_sms_with_downgraded_content(notify_db_session, mocker):
     # é, o, and u are in GSM.
-    # á, ï, grapes, tabs, zero width space and ellipsis are not
-    msg = "á é ï o u 🍇 foo\tbar\u200bbaz((misc))…"
+    # ī, grapes, tabs, zero width space and ellipsis are not
+    # ó isn't in GSM, but it is in the welsh alphabet so will still be sent
+    msg = "a é ī o u 🍇 foo\tbar\u200bbaz((misc))…"
     placeholder = '∆∆∆abc'
-    gsm_message = "?odz Housing Service: a é i o u ? foo barbaz???abc..."
+    gsm_message = "?ódz Housing Service: a é i o u ? foo barbaz???abc..."
     service = create_service(service_name='Łódź Housing Service')
     template = create_template(service, content=msg)
     db_notification = create_notification(


### PR DESCRIPTION
note: this includes updating the MMG api url to their v2a api. Their previous API doesn't include support for capital o with grave accent (`Ò`).

MMG have confirmed that there are no other changes to the API endpoint other than the encoding fix for that one character.