### PR TITLE
bump gunicorn to v20

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -11,7 +11,7 @@ git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd
 Flask==1.1.1
 click-datetime==0.2
 eventlet==0.25.1
-gunicorn==19.7.1  # pyup: ignore, >19.8 breaks eventlet patching
+gunicorn==20.0.4
 iso8601==0.1.12
 jsonschema==3.1.1
 marshmallow-sqlalchemy==0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd
 Flask==1.1.1
 click-datetime==0.2
 eventlet==0.25.1
-gunicorn==19.7.1  # pyup: ignore, >19.8 breaks eventlet patching
+gunicorn==20.0.4
 iso8601==0.1.12
 jsonschema==3.1.1
 marshmallow-sqlalchemy==0.19.0
@@ -40,12 +40,12 @@ alembic==1.3.3
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.3.0
-awscli==1.17.8
+awscli==1.17.9
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.0
 boto3==1.10.38
-botocore==1.14.8
+botocore==1.14.9
 certifi==2019.11.28
 chardet==3.0.4
 Click==7.0
@@ -56,15 +56,14 @@ flask-redis==0.4.0
 future==0.18.2
 greenlet==0.4.15
 idna==2.8
-importlib-metadata==1.4.0
-Jinja2==2.10.3
+importlib-metadata==1.5.0
+Jinja2==2.11.1
 jmespath==0.9.4
 kombu==3.0.37
 Mako==1.1.1
 MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5
-more-itertools==8.1.0
 orderedset==2.0.1
 phonenumbers==8.11.1
 pyasn1==0.4.8
@@ -76,7 +75,7 @@ python-editor==1.0.4
 python-json-logger==0.1.11
 pytz==2019.3
 PyYAML==5.2
-redis==3.3.11
+redis==3.4.1
 requests==2.22.0
 rsa==3.4.2
 s3transfer==0.3.2
@@ -85,5 +84,5 @@ smartypants==2.0.1
 statsd==3.3.0
 urllib3==1.25.8
 webencodings==0.5.1
-Werkzeug==0.16.0
-zipp==2.0.1
+Werkzeug==0.16.1
+zipp==2.1.0


### PR DESCRIPTION
v20 brings in a host of changes, including a fix for https://github.com/benoitc/gunicorn/issues/1847, which was stopping us upgrading before.

TODO: understand a bit more about what the issue was before with eventlet, and go through the rest of the changelog to understand the risk.