### PR TITLE
don't define MMG_URL and FIRETEXT_URL in manifest

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -337,6 +337,7 @@ class Config(object):
     DOCUMENT_DOWNLOAD_API_HOST = os.environ.get('DOCUMENT_DOWNLOAD_API_HOST', 'http://localhost:7000')
     DOCUMENT_DOWNLOAD_API_KEY = os.environ.get('DOCUMENT_DOWNLOAD_API_KEY', 'auth-token')
 
+    # these environment vars aren't defined in the manifest so to set them on paas use `cf set-env`
     MMG_URL = os.environ.get("MMG_URL", "https://api.mmg.co.uk/jsonv2a/api.php")
     FIRETEXT_URL = os.environ.get("FIRETEXT_URL", "https://www.firetext.co.uk/api/sendsms/json")
 

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -92,12 +92,10 @@ applications:
 
       ZENDESK_API_KEY: '{{ ZENDESK_API_KEY }}'
 
-      MMG_URL: '{{ MMG_URL }}'
       MMG_API_KEY: '{{ MMG_API_KEY }}'
       MMG_INBOUND_SMS_AUTH: '{{ MMG_INBOUND_SMS_AUTH | tojson }}'
       MMG_INBOUND_SMS_USERNAME: '{{ MMG_INBOUND_SMS_USERNAME | tojson }}'
 
-      FIRETEXT_URL: '{{ FIRETEXT_URL }}'
       FIRETEXT_API_KEY: '{{ FIRETEXT_API_KEY }}'
       FIRETEXT_INBOUND_SMS_AUTH: '{{ FIRETEXT_INBOUND_SMS_AUTH | tojson }}'
 


### PR DESCRIPTION
these URLs never change, and it lead to surprising issues where an updated default MMG_URL wasn't actually respected on PaaS. These urls aren't private and don't need to be stored in credentials.

By not defining them in the manifest, we expect them to use the default unless `cf set-env` has been specifically used to modify them in an app.