### PR TITLE
split create_nightly_notification_status by notification type

### DIFF
--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -12,6 +12,11 @@ from app.dao.fact_billing_dao import (
     update_fact_billing
 )
 from app.dao.fact_notification_status_dao import fetch_notification_status_for_day, update_fact_notification_status
+from app.models import (
+    SMS_TYPE,
+    EMAIL_TYPE,
+    LETTER_TYPE,
+)
 
 
 @notify_celery.task(name="create-nightly-billing")
@@ -72,30 +77,31 @@ def create_nightly_notification_status(day_start=None):
         day_start = datetime.strptime(day_start, "%Y-%m-%d").date()
     for i in range(0, 4):
         process_day = day_start - timedelta(days=i)
-
-        create_nightly_notification_status_for_day.apply_async(
-            kwargs={'process_day': process_day.isoformat()},
-            queue=QueueNames.REPORTING
-        )
+        for notification_type in [SMS_TYPE, EMAIL_TYPE, LETTER_TYPE]:
+            create_nightly_notification_status_for_day.apply_async(
+                kwargs={'process_day': process_day.isoformat(), 'notification_type': notification_type},
+                queue=QueueNames.REPORTING
+            )
 
 
 @notify_celery.task(name="create-nightly-notification-status-for-day")
 @statsd(namespace="tasks")
-def create_nightly_notification_status_for_day(process_day):
+def create_nightly_notification_status_for_day(process_day, notification_type):
     process_day = datetime.strptime(process_day, "%Y-%m-%d").date()
 
     start = datetime.utcnow()
-    transit_data = fetch_notification_status_for_day(process_day=process_day)
+    transit_data = fetch_notification_status_for_day(process_day=process_day, notification_type=notification_type)
     end = datetime.utcnow()
-    current_app.logger.info('create-nightly-notification-status-for-day {} fetched in {} seconds'.format(
+    current_app.logger.info('create-nightly-notification-status-for-day {} type {} fetched in {} seconds'.format(
         process_day,
+        notification_type,
         (end - start).seconds)
     )
 
-    update_fact_notification_status(transit_data, process_day)
+    update_fact_notification_status(transit_data, process_day, notification_type)
 
     current_app.logger.info(
-        "create-nightly-notification-status-for-day task complete: {} rows updated for day: {}".format(
-            len(transit_data), process_day
+        "create-nightly-notification-status-for-day task complete: {} rows updated for type {} for day: {}".format(
+            len(transit_data), process_day, notification_type
         )
     )

--- a/app/commands.py
+++ b/app/commands.py
@@ -21,6 +21,7 @@ from app.celery.tasks import record_daily_sorted_counts, get_template_class, pro
 from app.celery.nightly_tasks import send_total_sent_notifications_to_performance_platform
 from app.celery.service_callback_tasks import send_delivery_status_to_service
 from app.celery.letters_pdf_tasks import create_letters_pdf
+from app.celery.reporting_tasks import create_nightly_notification_status_for_day
 from app.config import QueueNames
 from app.dao.annual_billing_dao import dao_create_or_update_annual_billing_for_year
 from app.dao.fact_billing_dao import (
@@ -491,52 +492,14 @@ def rebuild_ft_billing_for_day(service_id, day):
 @click.option('-e', '--end_date', required=True, help="end date inclusive", type=click_dt(format='%Y-%m-%d'))
 @statsd(namespace="tasks")
 def migrate_data_to_ft_notification_status(start_date, end_date):
-
-    print('Notification statuses migration from date {} to {}'.format(start_date, end_date))
-
-    process_date = start_date
-    total_updated = 0
-
-    while process_date < end_date:
-        start_time = datetime.now()
-        # migrate data into ft_notification_status and update if record already exists
-
-        db.session.execute(
-            'delete from ft_notification_status where bst_date = :process_date',
-            {"process_date": process_date}
+    start_date = start_date.date()
+    for day_diff in range((end_date - start_date).days):
+        process_day = start_date + timedelta(days=day_diff)
+        print('create_nightly_notification_status_for_day triggered for {}'.format(process_day))
+        create_nightly_notification_status_for_day.apply_async(
+            kwargs={'process_day': process_day.strftime('%Y-%m-%d')},
+            queue=QueueNames.REPORTING
         )
-
-        sql = \
-            """
-            insert into ft_notification_status (bst_date, template_id, service_id, job_id, notification_type, key_type,
-                notification_status, created_at, notification_count)
-                select
-                    (n.created_at at time zone 'UTC' at time zone 'Europe/London')::timestamp::date as bst_date,
-                    coalesce(n.template_id, '00000000-0000-0000-0000-000000000000') as template_id,
-                    n.service_id,
-                    coalesce(n.job_id, '00000000-0000-0000-0000-000000000000') as job_id,
-                    n.notification_type,
-                    n.key_type,
-                    n.notification_status,
-                    now() as created_at,
-                    count(*) as notification_count
-                from notification_history n
-                where n.created_at >= (date :start + time '00:00:00') at time zone 'Europe/London' at time zone 'UTC'
-                    and n.created_at < (date :end + time '00:00:00') at time zone 'Europe/London' at time zone 'UTC'
-                group by bst_date, template_id, service_id, job_id, notification_type, key_type, notification_status
-                order by bst_date
-            """
-        result = db.session.execute(sql, {"start": process_date, "end": process_date + timedelta(days=1)})
-        db.session.commit()
-        print('ft_notification_status: --- Completed took {}ms. Migrated {} rows for {}.'.format(
-            datetime.now() - start_time,
-            result.rowcount,
-            process_date
-        ))
-        process_date += timedelta(days=1)
-
-        total_updated += result.rowcount
-    print('Total inserted/updated records = {}'.format(total_updated))
 
 
 @notify_command(name='bulk-invite-user-to-service')

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -63,7 +63,6 @@ def query_for_fact_status_data(table, start_date, end_date, notification_type, s
         table.template_id,
         table.service_id,
         func.coalesce(table.job_id, '00000000-0000-0000-0000-000000000000').label('job_id'),
-        table.notification_type,
         table.key_type,
         table.status,
         func.count().label('notification_count')
@@ -77,7 +76,6 @@ def query_for_fact_status_data(table, start_date, end_date, notification_type, s
         table.template_id,
         table.service_id,
         'job_id',
-        table.notification_type,
         table.key_type,
         table.status
     )
@@ -98,7 +96,7 @@ def update_fact_notification_status(data, process_day, notification_type):
             template_id=row.template_id,
             service_id=row.service_id,
             job_id=row.job_id,
-            notification_type=row.notification_type,
+            notification_type=notification_type,
             key_type=row.key_type,
             notification_status=row.status,
             notification_count=row.notification_count,

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -66,8 +66,9 @@ def test_update_fact_notification_status(notify_db_session):
         create_notification_history(template=second_template)
         create_notification(template=third_template)
 
-    data = fetch_notification_status_for_day(process_day=process_day)
-    update_fact_notification_status(data=data, process_day=process_day)
+    for notification_type in ('letter', 'sms', 'email'):
+        data = fetch_notification_status_for_day(process_day=process_day, notification_type=notification_type)
+        update_fact_notification_status(data=data, process_day=process_day, notification_type=notification_type)
 
     new_fact_data = FactNotificationStatus.query.order_by(FactNotificationStatus.bst_date,
                                                           FactNotificationStatus.notification_type
@@ -105,8 +106,8 @@ def test__update_fact_notification_status_updates_row(notify_db_session):
     create_notification(template=first_template, status='delivered')
 
     process_day = date.today()
-    data = fetch_notification_status_for_day(process_day=process_day)
-    update_fact_notification_status(data=data, process_day=process_day)
+    data = fetch_notification_status_for_day(process_day=process_day, notification_type='sms')
+    update_fact_notification_status(data=data, process_day=process_day, notification_type='sms')
 
     new_fact_data = FactNotificationStatus.query.order_by(FactNotificationStatus.bst_date,
                                                           FactNotificationStatus.notification_type
@@ -116,8 +117,8 @@ def test__update_fact_notification_status_updates_row(notify_db_session):
 
     create_notification(template=first_template, status='delivered')
 
-    data = fetch_notification_status_for_day(process_day=process_day)
-    update_fact_notification_status(data=data, process_day=process_day)
+    data = fetch_notification_status_for_day(process_day=process_day, notification_type='sms')
+    update_fact_notification_status(data=data, process_day=process_day, notification_type='sms')
 
     updated_fact_data = FactNotificationStatus.query.order_by(FactNotificationStatus.bst_date,
                                                               FactNotificationStatus.notification_type

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -664,8 +664,10 @@ def test_update_service_permission_creates_a_history_record_with_current_data(no
         EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE,
     ))
 
-    assert len(Service.get_history_model().query.filter_by(name='service_name').all()) == 3
-    assert Service.get_history_model().query.filter_by(name='service_name').all()[2].version == 3
+    history = Service.get_history_model().query.filter_by(name='service_name').order_by('version').all()
+
+    assert len(history) == 3
+    assert history[2].version == 3
 
 
 def test_create_service_and_history_is_transactional(notify_db_session):


### PR DESCRIPTION
Separate this refactoring PR from the actual logic change that is coming soon™ (to make it rebuild for letters more often). Just splitting up the task by notification_type - it now requires type all the time. This is fine to merge provided that the task isn't running as it deploys, but given that it runs nightly at 4am or something that's probably fine

This also allows us to rebuild historical data by type, rather than for all three notification types.

And it makes the command just call through to the task, rather than re-implementing it.