### PR TITLE
Add new tasks for processing letters which have passed virus scan

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -29,6 +29,7 @@ class QueueNames(object):
     CALLBACKS = 'service-callbacks'
     LETTERS = 'letter-tasks'
     ANTIVIRUS = 'antivirus-tasks'
+    SANITISE_LETTERS = 'sanitise-letter-tasks'
 
     @staticmethod
     def all_queues():
@@ -53,6 +54,7 @@ class TaskNames(object):
     PROCESS_INCOMPLETE_JOBS = 'process-incomplete-jobs'
     ZIP_AND_SEND_LETTER_PDFS = 'zip-and-send-letter-pdfs'
     SCAN_FILE = 'scan-file'
+    SANITISE_LETTER = 'sanitise-and-upload-letter'
 
 
 class Config(object):
@@ -375,6 +377,7 @@ class Development(Config):
     LETTERS_SCAN_BUCKET_NAME = 'development-letters-scan'
     INVALID_PDF_BUCKET_NAME = 'development-letters-invalid-pdf'
     TRANSIENT_UPLOADED_LETTERS = 'development-transient-uploaded-letters'
+    LETTER_SANITISE_BUCKET_NAME = 'development-letters-sanitise'
 
     ADMIN_CLIENT_SECRET = 'dev-notify-secret-key'
     SECRET_KEY = 'dev-notify-secret-key'
@@ -415,6 +418,7 @@ class Test(Development):
     LETTERS_SCAN_BUCKET_NAME = 'test-letters-scan'
     INVALID_PDF_BUCKET_NAME = 'test-letters-invalid-pdf'
     TRANSIENT_UPLOADED_LETTERS = 'test-transient-uploaded-letters'
+    LETTER_SANITISE_BUCKET_NAME = 'test-letters-sanitise'
 
     # this is overriden in jenkins and on cloudfoundry
     SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI', 'postgresql://localhost/test_notification_api')
@@ -449,6 +453,7 @@ class Preview(Config):
     LETTERS_SCAN_BUCKET_NAME = 'preview-letters-scan'
     INVALID_PDF_BUCKET_NAME = 'preview-letters-invalid-pdf'
     TRANSIENT_UPLOADED_LETTERS = 'preview-transient-uploaded-letters'
+    LETTER_SANITISE_BUCKET_NAME = 'preview-letters-sanitise'
     FROM_NUMBER = 'preview'
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = False
@@ -464,6 +469,7 @@ class Staging(Config):
     LETTERS_SCAN_BUCKET_NAME = 'staging-letters-scan'
     INVALID_PDF_BUCKET_NAME = 'staging-letters-invalid-pdf'
     TRANSIENT_UPLOADED_LETTERS = 'staging-transient-uploaded-letters'
+    LETTER_SANITISE_BUCKET_NAME = 'staging-letters-sanitise'
     FROM_NUMBER = 'stage'
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = True
@@ -480,6 +486,7 @@ class Live(Config):
     LETTERS_SCAN_BUCKET_NAME = 'production-letters-scan'
     INVALID_PDF_BUCKET_NAME = 'production-letters-invalid-pdf'
     TRANSIENT_UPLOADED_LETTERS = 'production-transient-uploaded-letters'
+    LETTER_SANITISE_BUCKET_NAME = 'production-letters-sanitise'
     FROM_NUMBER = 'GOVUK'
     PERFORMANCE_PLATFORM_ENABLED = True
     API_RATE_LIMIT_ENABLED = True

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -156,6 +156,19 @@ def move_uploaded_pdf_to_letters_bucket(source_filename, upload_filename):
     )
 
 
+def move_sanitised_letter_to_test_or_live_pdf_bucket(filename, is_test_letter, created_at):
+    target_bucket_config = 'TEST_LETTERS_BUCKET_NAME' if is_test_letter else 'LETTERS_PDF_BUCKET_NAME'
+    target_bucket_name = current_app.config[target_bucket_config]
+    target_filename = get_folder_name(created_at, dont_use_sending_date=is_test_letter) + filename
+
+    _move_s3_object(
+        source_bucket=current_app.config['LETTER_SANITISE_BUCKET_NAME'],
+        source_filename=filename,
+        target_bucket=target_bucket_name,
+        target_filename=target_filename,
+    )
+
+
 def get_file_names_from_error_bucket():
     s3 = boto3.resource('s3')
     scan_bucket = current_app.config['LETTERS_SCAN_BUCKET_NAME']


### PR DESCRIPTION
The current `process_virus_scan_passed` task will be split into three separate tasks so that we can validate letters asynchronously. These new tasks are, in order:

#### 1. `sanitise_letter`
Added in this PR. This calls the template preview task with details of the letter to be sanitised.
#### 2. `sanitise_and_upload_letter`
Added to template preview [here](https://github.com/alphagov/notifications-template-preview/pull/399). This sanitises the letter and calls the third task with the results.
#### 3. `process_sanitised_letter`
Added in this PR. This moves the files into the relevant S3 buckets and update the notification

Once deployed, the new tasks won't be used until notifications-antivirus is updated to call `sanitise_letter` instead of `process_virus_scan_passed`.

[Pivotal story](https://www.pivotaltracker.com/story/show/169148522)