### PR TITLE
Use .format instead of concatenation to avoid type issues

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -271,14 +271,20 @@ def check_for_services_with_high_failure_rates_or_sending_to_tv_numbers():
             len(services_with_failures)
         )
         for service in services_with_failures:
-            service_dashboard = current_app.config['ADMIN_BASE_URL'] + "/services/" + service.service_id
+            service_dashboard = "{}/services/{}".format(
+                current_app.config['ADMIN_BASE_URL'],
+                str(service.service_id),
+            )
             message += "service: {} failure rate: {},\n".format(service_dashboard, service.permanent_failure_rate)
     elif services_sending_to_tv_numbers:
         message += "{} service(s) have sent over 100 sms messages to tv numbers in last 24 hours:\n".format(
             len(services_sending_to_tv_numbers)
         )
         for service in services_sending_to_tv_numbers:
-            service_dashboard = current_app.config['ADMIN_BASE_URL'] + "/services/" + service.service_id
+            service_dashboard = "{}/services/{}".format(
+                current_app.config['ADMIN_BASE_URL'],
+                str(service.service_id),
+            )
             message += "service: {} count of sms to tv numbers: {},\n".format(
                 service_dashboard, service.notification_count
             )

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -519,16 +519,16 @@ MockServicesWithHighFailureRate = namedtuple(
         [MockServicesWithHighFailureRate("123", 0.3)],
         [],
         "1 service(s) have had high permanent-failure rates for sms messages in last "
-        "24 hours:\nservice: {} failure rate: 0.3,\n".format(
-            Config.ADMIN_BASE_URL + "/services/" + "123"
+        "24 hours:\nservice: {}/services/{} failure rate: 0.3,\n".format(
+            Config.ADMIN_BASE_URL, "123"
         )
     ],
     [
         [],
         [MockServicesSendingToTVNumbers("123", 300)],
         "1 service(s) have sent over 100 sms messages to tv numbers in last 24 hours:\n"
-        "service: {} count of sms to tv numbers: 300,\n".format(
-            Config.ADMIN_BASE_URL + "/services/" + "123"
+        "service: {}/services/{} count of sms to tv numbers: 300,\n".format(
+            Config.ADMIN_BASE_URL, "123"
         )
     ]
 ])


### PR DESCRIPTION
Trying to concatenate uuid onto a string was throwing an error.