### PR TITLE
fix log line typo

### DIFF
--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -48,19 +48,13 @@ def create_nightly_billing_for_day(process_day):
     transit_data = fetch_billing_data_for_day(process_day=process_day)
     end = datetime.utcnow()
 
-    current_app.logger.info('create-nightly-billing-for-day {} fetched in {} seconds'.format(
-        process_day,
-        (end - start).seconds)
-    )
+    current_app.logger.info(f'create-nightly-billing-for-day {process_day} fetched in {(end - start).seconds} seconds')
 
     for data in transit_data:
         update_fact_billing(data, process_day)
 
     current_app.logger.info(
-        "create-nightly-billing-for-day task complete. {} rows updated for day: {}".format(
-            len(transit_data),
-            process_day
-        )
+        f"create-nightly-billing-for-day task complete. {len(transit_data)} rows updated for day: {process_day}"
     )
 
 
@@ -95,16 +89,14 @@ def create_nightly_notification_status_for_day(process_day, notification_type):
     start = datetime.utcnow()
     transit_data = fetch_notification_status_for_day(process_day=process_day, notification_type=notification_type)
     end = datetime.utcnow()
-    current_app.logger.info('create-nightly-notification-status-for-day {} type {} fetched in {} seconds'.format(
-        process_day,
-        notification_type,
-        (end - start).seconds)
+    current_app.logger.info(
+        f'create-nightly-notification-status-for-day {process_day} type {notification_type} task: '
+        f'data fetched in {(end - start).seconds} seconds'
     )
 
     update_fact_notification_status(transit_data, process_day, notification_type)
 
     current_app.logger.info(
-        "create-nightly-notification-status-for-day task complete: {} rows updated for type {} for day: {}".format(
-            len(transit_data), process_day, notification_type
-        )
+        f'create-nightly-notification-status-for-day {process_day} type {notification_type} task: '
+        f'task complete - {len(transit_data)} rows updated'
     )


### PR DESCRIPTION
log lines didn't make sense because the arguments were the wrong way round.

As an experiment to try and clean up some of our code a bit, this commit adds f-strings. f-strings were added in python 3.6, as a way to clean up, simplify, and improve the performance of `str.format`. They're used by just prefixing a string with `f` (like you would r for raw or b for bytes), and then curly braces work largely like str.format, but looking at all available variables. It's pretty similar to `"...".format(**locals())`. You can still use number formatting just fine with the same colon syntax (eg `{x:04}` to left pad to four characters with zeroes or `{x:,}` to comma separate thousands). You can do complex function calls and operations (eg `f"{foo['x'].get_thing()}"`).

Interested in knowing people's thoughts. A good step? Unnecessary change for the sake of change? looks good/looks bad/who cares?