### PR TITLE
Catch `TokenAlgorithmError`

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -20,7 +20,7 @@ psycopg2-binary==2.8.4
 PyJWT==1.7.1
 SQLAlchemy==1.3.10
 
-notifications-python-client==5.4.0
+notifications-python-client==5.4.1
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ psycopg2-binary==2.8.4
 PyJWT==1.7.1
 SQLAlchemy==1.3.10
 
-notifications-python-client==5.4.0
+notifications-python-client==5.4.1
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5
@@ -40,12 +40,12 @@ alembic==1.3.1
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.3.0
-awscli==1.16.298
+awscli==1.16.301
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.0
 boto3==1.9.221
-botocore==1.13.34
+botocore==1.13.37
 certifi==2019.11.28
 chardet==3.0.4
 Click==7.0
@@ -56,7 +56,7 @@ flask-redis==0.4.0
 future==0.18.2
 greenlet==0.4.15
 idna==2.8
-importlib-metadata==1.2.0
+importlib-metadata==1.3.0
 Jinja2==2.10.3
 jmespath==0.9.4
 kombu==3.0.37


### PR DESCRIPTION
Instead of letting it go uncaught and causing an error, we now show the
user an appropriate error message.

Requires https://github.com/alphagov/notifications-python-client/pull/155