### PR TITLE
Improve developer experience for zendesk ticket

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -299,11 +299,11 @@ def check_for_services_with_high_failure_rates_or_sending_to_tv_numbers():
             )
 
     if services_with_failures or services_sending_to_tv_numbers:
-        current_app.logger.exception(message)
+        current_app.logger.warning(message)
 
         if current_app.config['NOTIFY_ENVIRONMENT'] in ['live', 'production', 'test']:
-            message += "\nYou can find instructions for this ticket in our manual:\n"
-            "https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#Deal-with-services-with-high-failure-rates-or-sending-sms-to-tv-numbers"  # noqa
+            message += ("\nYou can find instructions for this ticket in our manual:\n"
+                        "https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#Deal-with-services-with-high-failure-rates-or-sending-sms-to-tv-numbers")  # noqa
             zendesk_client.create_ticket(
                 subject="[{}] High failure rates for sms spotted for services".format(
                     current_app.config['NOTIFY_ENVIRONMENT']

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -535,7 +535,7 @@ MockServicesWithHighFailureRate = namedtuple(
 def test_check_for_services_with_high_failure_rates_or_sending_to_tv_numbers(
     mocker, notify_db_session, failure_rates, sms_to_tv_numbers, expected_message
 ):
-    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.exception')
+    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.warning')
     mock_create_ticket = mocker.patch('app.celery.scheduled_tasks.zendesk_client.create_ticket')
     mock_failure_rates = mocker.patch(
         'app.celery.scheduled_tasks.dao_find_services_with_high_failure_rates', return_value=failure_rates
@@ -544,8 +544,7 @@ def test_check_for_services_with_high_failure_rates_or_sending_to_tv_numbers(
         'app.celery.scheduled_tasks.dao_find_services_sending_to_tv_numbers', return_value=sms_to_tv_numbers
     )
 
-    zendesk_actions = "\nYou can find instructions for this ticket in our manual:\n"
-    "https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#Deal-with-services-with-high-failure-rates-or-sending-sms-to-tv-numbers"  # noqa
+    zendesk_actions = "\nYou can find instructions for this ticket in our manual:\nhttps://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#Deal-with-services-with-high-failure-rates-or-sending-sms-to-tv-numbers"  # noqa
 
     check_for_services_with_high_failure_rates_or_sending_to_tv_numbers()
 


### PR DESCRIPTION
We don't need to log this as an exception. It's not an exception, it's
behaviour that is not ideal but is still expected so therefore I've
changed it to warn. Also it removes the email we get for the exception
which is not needed as we get the zendesk ticket instead.

I've also fixed the multiline string meaning the link to the runbook is
included in the zendesk ticket.