### PR TITLE
Up API health check timeout to 2.5 seconds

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -9,6 +9,7 @@
       'production': ['api.notifications.service.gov.uk'],
     },
     'health-check-type': 'port',
+    'health-check-invocation-timeout': 2.5,
     'instances': {
       'preview': None,
       'staging': None,
@@ -58,6 +59,7 @@ applications:
       {%- endfor%}
       - route: {{ CF_APP }}-{{ environment }}.cloudapps.digital
     health-check-type: {{ app.get('health-check-type', 'process') }}
+    health-check-invocation-timeout: {{ app.get('health-check-invocation-timeout', 1) }}
 
     services:
       - notify-db


### PR DESCRIPTION
This was after we saw an instance of the API failing it's healthcheck
even though it was still healthy enough to serve requests to users.

This follows the change we've also made to template-preview and admin of
upping the health check timeout. Unlike those where we set it to be 10
seconds, we have been less allowing here and only chosen 2.5 seconds.
This was at suggestion of Toby from PaaS as the api should generally
have quicker response times and more annoyance might be created for
users if we let an instance stick around for 10 seconds where it was
unable to serve requests successfully.