### PR TITLE
Set healthcheck timeout as integer

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -9,7 +9,7 @@
       'production': ['api.notifications.service.gov.uk'],
     },
     'health-check-type': 'port',
-    'health-check-invocation-timeout': 2.5,
+    'health-check-invocation-timeout': 3,
     'instances': {
       'preview': None,
       'staging': None,


### PR DESCRIPTION
Not allowed to be a non integer so have upped to 3 rather than going to
2 (fairly arbitrary choice).