### PR TITLE
Populate returned letters

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,6 +24,7 @@ from app.clients.sms.mmg import MMGClient
 from app.clients.performance_platform.performance_platform_client import PerformancePlatformClient
 from app.encryption import Encryption
 
+DATETIME_FORMAT_NO_TIMEZONE = "%Y-%m-%d %H:%M:%S.%f"
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"
 

--- a/app/dao/returned_letters_dao.py
+++ b/app/dao/returned_letters_dao.py
@@ -54,3 +54,16 @@ def get_returned_letter_summary(service_id):
     ).order_by(
         desc(ReturnedLetter.reported_at)
     ).all()
+
+
+
+def fetch_returned_letters(service_id, report_date):
+    return db.session.query(
+        ReturnedLetter.notification_id,
+        ReturnedLetter.reported_at
+    ).filter(
+        ReturnedLetter.service_id == service_id,
+        func.date(ReturnedLetter.reported_at) == report_date
+    ).order_by(
+        desc(ReturnedLetter.reported_at)
+    ).all()

--- a/app/dao/returned_letters_dao.py
+++ b/app/dao/returned_letters_dao.py
@@ -74,6 +74,8 @@ def fetch_returned_letters(service_id, report_date):
             Template.name.label('template_name'),
             table.template_id,
             table.template_version,
+            Template.hidden,
+            table.api_key_id,
             table.created_by_id,
             User.name.label('user_name'),
             User.email_address,

--- a/app/dao/returned_letters_dao.py
+++ b/app/dao/returned_letters_dao.py
@@ -76,6 +76,7 @@ def fetch_returned_letters(service_id, report_date):
             table.template_version,
             table.created_by_id,
             User.name.label('user_name'),
+            User.email_address,
             Job.original_file_name,
             (table.job_row_number + 1).label('job_row_number')  # row numbers start at 0
         ).outerjoin(

--- a/app/models.py
+++ b/app/models.py
@@ -36,8 +36,8 @@ from app.encryption import (
 from app import (
     db,
     encryption,
-    DATETIME_FORMAT
-)
+    DATETIME_FORMAT,
+    DATETIME_FORMAT_NO_TIMEZONE)
 
 from app.history_meta import Versioned
 
@@ -166,7 +166,7 @@ class User(db.Model):
             'mobile_number': self.mobile_number,
             'organisations': [x.id for x in self.organisations if x.active],
             'password_changed_at': (
-                self.password_changed_at.strftime('%Y-%m-%d %H:%M:%S.%f')
+                self.password_changed_at.strftime(DATETIME_FORMAT_NO_TIMEZONE)
                 if self.password_changed_at
                 else None
             ),

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -22,7 +22,7 @@ from notifications_utils.recipients import (
     validate_and_format_phone_number
 )
 
-from app import ma
+from app import ma, DATETIME_FORMAT_NO_TIMEZONE
 from app import models
 from app.models import ServicePermission
 from app.dao.permissions_dao import permission_dao
@@ -84,8 +84,8 @@ class BaseSchema(ma.ModelSchema):
 class UserSchema(BaseSchema):
 
     permissions = fields.Method("user_permissions", dump_only=True)
-    password_changed_at = field_for(models.User, 'password_changed_at', format='%Y-%m-%d %H:%M:%S.%f')
-    created_at = field_for(models.User, 'created_at', format='%Y-%m-%d %H:%M:%S.%f')
+    password_changed_at = field_for(models.User, 'password_changed_at', format=DATETIME_FORMAT_NO_TIMEZONE)
+    created_at = field_for(models.User, 'created_at', format=DATETIME_FORMAT_NO_TIMEZONE)
     auth_type = field_for(models.User, 'auth_type')
 
     def user_permissions(self, usr):
@@ -210,7 +210,7 @@ class ServiceSchema(BaseSchema):
     organisation = field_for(models.Service, 'organisation')
     override_flag = False
     letter_contact_block = fields.Method(serialize="get_letter_contact")
-    go_live_at = field_for(models.Service, 'go_live_at', format='%Y-%m-%d %H:%M:%S.%f')
+    go_live_at = field_for(models.Service, 'go_live_at', format=DATETIME_FORMAT_NO_TIMEZONE)
 
     def get_letter_logo_filename(self, service):
         return service.letter_branding and service.letter_branding.filename
@@ -345,7 +345,7 @@ class TemplateHistorySchema(BaseSchema):
     reply_to_text = fields.Method("get_reply_to_text", allow_none=True)
 
     created_by = fields.Nested(UserSchema, only=['id', 'name', 'email_address'], dump_only=True)
-    created_at = field_for(models.Template, 'created_at', format='%Y-%m-%d %H:%M:%S.%f')
+    created_at = field_for(models.Template, 'created_at', format=DATETIME_FORMAT_NO_TIMEZONE)
 
     def get_reply_to(self, template):
         return template.reply_to

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -970,8 +970,10 @@ def get_returned_letters(service_id):
          'template_id': x.template_id,
          'template_version': x.template_version,
          'user_name': x.user_name,
+         'email_address': x.email_address,
          'original_file_name': x.original_file_name,
-         'job_row_number': x.job_row_number
+         'job_row_number': x.job_row_number,
+         'uploaded_letter': x.client_reference if x.user_name and not x.original_file_name else None
          } for x in results]
 
     return jsonify(sorted(json_results, key=lambda i: i['created_at'], reverse=True))

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -12,7 +12,7 @@ from notifications_utils.timezones import convert_utc_to_bst
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
-from app import DATE_FORMAT
+from app import DATE_FORMAT, DATETIME_FORMAT
 from app.config import QueueNames
 from app.dao import fact_notification_status_dao, notifications_dao
 from app.dao.dao_utils import dao_rollback
@@ -30,7 +30,7 @@ from app.dao.fact_notification_status_dao import (
 )
 from app.dao.inbound_numbers_dao import dao_allocate_number_for_service
 from app.dao.organisation_dao import dao_get_organisation_by_service_id
-from app.dao.returned_letters_dao import get_returned_letter_summary
+from app.dao.returned_letters_dao import get_returned_letter_summary, fetch_returned_letters
 from app.dao.service_data_retention_dao import (
     fetch_service_data_retention,
     fetch_service_data_retention_by_id,
@@ -956,8 +956,19 @@ def returned_letter_summary(service_id):
 
 @service_blueprint.route('/<uuid:service_id>/returned-letters', methods=['GET'])
 def get_returned_letters(service_id):
-    results = get_returned_letter_summary(service_id)
+    results = fetch_returned_letters(service_id=service_id, report_date=request.args.get('reported_at'))
 
-    json_results = [{'returned_letter_count': x.returned_letter_count, 'reported_at': x.reported_at} for x in results]
+    json_results = [
+        {'notification_id': x.notification_id,
+         'client_reference': x.client_reference,
+         'reported_at': x.reported_at.strftime(DATE_FORMAT),
+         'created_at': x.created_at.strftime(DATETIME_FORMAT),
+         'template_name': x.template_name,
+         'template_id': x.template_id,
+         'template_version': x.template_version,
+         'user_name': x.user_name,
+         'original_file_name': x.original_file_name,
+         'job_row_number': x.job_row_number
+         } for x in results]
 
-    return jsonify(json_results)
+    return jsonify(sorted(json_results, key=lambda i: i['created_at'], reverse=True))

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -12,7 +12,7 @@ from notifications_utils.timezones import convert_utc_to_bst
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
-from app import DATE_FORMAT
+from app import DATE_FORMAT, DATETIME_FORMAT_NO_TIMEZONE
 from app.config import QueueNames
 from app.dao import fact_notification_status_dao, notifications_dao
 from app.dao.dao_utils import dao_rollback
@@ -966,7 +966,7 @@ def get_returned_letters(service_id):
          # client reference can only be added on API letters
          'client_reference': x.client_reference if x.api_key_id else None,
          'reported_at': x.reported_at.strftime(DATE_FORMAT),
-         'created_at': x.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+         'created_at': x.created_at.strftime(DATETIME_FORMAT_NO_TIMEZONE),
          # it doesn't make sense to show hidden/precompiled templates
          'template_name': x.template_name if not x.hidden else None,
          'template_id': x.template_id if not x.hidden else None,

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -30,7 +30,10 @@ from app.dao.fact_notification_status_dao import (
 )
 from app.dao.inbound_numbers_dao import dao_allocate_number_for_service
 from app.dao.organisation_dao import dao_get_organisation_by_service_id
-from app.dao.returned_letters_dao import get_returned_letter_summary, fetch_returned_letters
+from app.dao.returned_letters_dao import (
+    fetch_returned_letter_summary,
+    fetch_returned_letters
+)
 from app.dao.service_data_retention_dao import (
     fetch_service_data_retention,
     fetch_service_data_retention_by_id,
@@ -945,7 +948,7 @@ def check_if_reply_to_address_already_in_use(service_id, email_address):
 
 @service_blueprint.route('/<uuid:service_id>/returned-letter-summary', methods=['GET'])
 def returned_letter_summary(service_id):
-    results = get_returned_letter_summary(service_id)
+    results = fetch_returned_letter_summary(service_id)
 
     json_results = [{'returned_letter_count': x.returned_letter_count,
                      'reported_at': x.reported_at.strftime(DATE_FORMAT)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -976,7 +976,7 @@ def get_returned_letters(service_id):
          'original_file_name': x.original_file_name,
          'job_row_number': x.job_row_number,
          # the file name for a letter uploaded via the UI
-         'uploaded_letter': x.client_reference if x.hidden and not x.api_key_id else None
+         'uploaded_letter_file_name': x.client_reference if x.hidden and not x.api_key_id else None
          } for x in results]
 
     return jsonify(sorted(json_results, key=lambda i: i['created_at'], reverse=True))

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -952,3 +952,12 @@ def returned_letter_summary(service_id):
                      } for x in results]
 
     return jsonify(json_results)
+
+
+@service_blueprint.route('/<uuid:service_id>/returned-letters', methods=['GET'])
+def get_returned_letters(service_id):
+    results = get_returned_letter_summary(service_id)
+
+    json_results = [{'returned_letter_count': x.returned_letter_count, 'reported_at': x.reported_at} for x in results]
+
+    return jsonify(json_results)

--- a/migrations/versions/0311_populate_returned_letters.py
+++ b/migrations/versions/0311_populate_returned_letters.py
@@ -1,0 +1,30 @@
+"""
+
+Revision ID: 0311_populate_returned_letters
+Revises: 0310_returned_letters_table
+Create Date: 2019-12-09 12:13:49.432993
+
+"""
+from alembic import op
+
+from app.dao.returned_letters_dao import insert_or_update_returned_letters
+
+revision = '0311_populate_returned_letters'
+down_revision = '0310_returned_letters_table'
+
+
+def upgrade():
+    conn = op.get_bind()
+    sql = """
+        select id, service_id, reference 
+        from notification_history 
+        where notification_type = 'letter'
+        and notification_status = 'returned-letter'"""
+    results = conn.execute(sql)
+    returned_letters = results.fetchall()
+    references = [x.reference for x in returned_letters]
+    insert_or_update_returned_letters(references)
+
+
+def downgrade():
+    pass

--- a/migrations/versions/0311_populate_returned_letters.py
+++ b/migrations/versions/0311_populate_returned_letters.py
@@ -7,8 +7,6 @@ Create Date: 2019-12-09 12:13:49.432993
 """
 from alembic import op
 
-from app.dao.returned_letters_dao import insert_or_update_returned_letters
-
 revision = '0311_populate_returned_letters'
 down_revision = '0310_returned_letters_table'
 
@@ -16,14 +14,20 @@ down_revision = '0310_returned_letters_table'
 def upgrade():
     conn = op.get_bind()
     sql = """
-        select id, service_id, reference 
+        select id, service_id, reference, updated_at
         from notification_history 
         where notification_type = 'letter'
         and notification_status = 'returned-letter'"""
+    insert_sql = """
+        insert into returned_letters(id, reported_at, service_id, notification_id, created_at, updated_at) 
+        values(uuid_in(md5(random()::text)::cstring), '{}', '{}', '{}', now(), null)
+    """
+
     results = conn.execute(sql)
     returned_letters = results.fetchall()
-    references = [x.reference for x in returned_letters]
-    insert_or_update_returned_letters(references)
+    for x in returned_letters:
+        f = insert_sql.format(x.updated_at.date(), x.service_id, x.id)
+        conn.execute(f)
 
 
 def downgrade():

--- a/migrations/versions/0312_populate_returned_letters.py
+++ b/migrations/versions/0312_populate_returned_letters.py
@@ -1,14 +1,14 @@
 """
 
-Revision ID: 0311_populate_returned_letters
-Revises: 0310_returned_letters_table
+Revision ID: 0312_populate_returned_letters
+Revises: 0311_add_inbound_sms_history
 Create Date: 2019-12-09 12:13:49.432993
 
 """
 from alembic import op
 
-revision = '0311_populate_returned_letters'
-down_revision = '0310_returned_letters_table'
+revision = '0312_populate_returned_letters'
+down_revision = '0311_add_inbound_sms_history'
 
 
 def upgrade():

--- a/tests/app/dao/test_returned_letters_dao.py
+++ b/tests/app/dao/test_returned_letters_dao.py
@@ -3,7 +3,8 @@ from datetime import datetime, timedelta, date
 from freezegun import freeze_time
 
 from app.dao.returned_letters_dao import (
-    insert_or_update_returned_letters, get_returned_letter_summary,
+    insert_or_update_returned_letters,
+    fetch_returned_letter_summary,
     fetch_returned_letters
 )
 from app.models import ReturnedLetter, NOTIFICATION_RETURNED_LETTER
@@ -94,7 +95,7 @@ def test_get_returned_letter_summary(sample_service):
     create_returned_letter(sample_service, reported_at=now)
     create_returned_letter(sample_service, reported_at=now)
 
-    results = get_returned_letter_summary(sample_service.id)
+    results = fetch_returned_letter_summary(sample_service.id)
 
     assert len(results) == 1
 
@@ -112,7 +113,7 @@ def test_get_returned_letter_summary_orders_by_reported_at(sample_service):
     create_returned_letter(sample_service, reported_at=last_month)
     create_returned_letter()  # returned letter for a different service
 
-    results = get_returned_letter_summary(sample_service.id)
+    results = fetch_returned_letter_summary(sample_service.id)
 
     assert len(results) == 2
     assert results[0].reported_at == now.date()
@@ -163,7 +164,7 @@ def test_fetch_returned_letters_with_jobs(sample_letter_job):
     assert len(results) == 1
     assert results[0] == (letter_1.id, returned_letter_1.reported_at, letter_1.client_reference, letter_1.created_at,
                           sample_letter_job.template.name, letter_1.template_id, letter_1.template_version,
-                          letter_1.created_by_id, None, sample_letter_job.original_file_name, letter_1.job_row_number)
+                          letter_1.created_by_id, None, sample_letter_job.original_file_name, 21)
 
 
 def test_fetch_returned_letters_with_create_by_user(sample_letter_template):

--- a/tests/app/dao/test_returned_letters_dao.py
+++ b/tests/app/dao/test_returned_letters_dao.py
@@ -145,10 +145,10 @@ def test_fetch_returned_letters_from_notifications_and_notification_history(samp
     assert len(results) == 2
     assert results[0] == (letter_2.id, returned_letter_2.reported_at, letter_2.client_reference, letter_2.created_at,
                           sample_letter_template.name, letter_2.template_id, letter_2.template_version,
-                          letter_2.created_by_id, None, None, None)
+                          None, None, None, None, None)
     assert results[1] == (letter_1.id, returned_letter_1.reported_at, letter_1.client_reference, letter_1.created_at,
                           sample_letter_template.name, letter_1.template_id, letter_1.template_version,
-                          letter_1.created_by_id, None, None, None)
+                          None, None, None, None, None)
 
 
 def test_fetch_returned_letters_with_jobs(sample_letter_job):
@@ -164,7 +164,7 @@ def test_fetch_returned_letters_with_jobs(sample_letter_job):
     assert len(results) == 1
     assert results[0] == (letter_1.id, returned_letter_1.reported_at, letter_1.client_reference, letter_1.created_at,
                           sample_letter_job.template.name, letter_1.template_id, letter_1.template_version,
-                          letter_1.created_by_id, None, sample_letter_job.original_file_name, 21)
+                          None, None, None, sample_letter_job.original_file_name, 21)
 
 
 def test_fetch_returned_letters_with_create_by_user(sample_letter_template):
@@ -180,4 +180,5 @@ def test_fetch_returned_letters_with_create_by_user(sample_letter_template):
     assert len(results) == 1
     assert results[0] == (letter_1.id, returned_letter_1.reported_at, letter_1.client_reference, letter_1.created_at,
                           sample_letter_template.name, letter_1.template_id, letter_1.template_version,
-                          letter_1.created_by_id, sample_letter_template.service.users[0].name, None, None)
+                          letter_1.created_by_id, sample_letter_template.service.users[0].name,
+                          sample_letter_template.service.users[0].email_address, None, None)

--- a/tests/app/dao/test_returned_letters_dao.py
+++ b/tests/app/dao/test_returned_letters_dao.py
@@ -6,7 +6,7 @@ from app.dao.returned_letters_dao import (
     insert_or_update_returned_letters, get_returned_letter_summary,
     fetch_returned_letters
 )
-from app.models import ReturnedLetter
+from app.models import ReturnedLetter, NOTIFICATION_RETURNED_LETTER
 from tests.app.db import create_notification, create_notification_history, create_returned_letter
 
 
@@ -121,14 +121,62 @@ def test_get_returned_letter_summary_orders_by_reported_at(sample_service):
     assert results[1].returned_letter_count == 2
 
 
-def test_fetch_returned_letters(sample_service):
+def test_fetch_returned_letters_from_notifications_and_notification_history(sample_letter_template):
     today = datetime.now()
     last_month = datetime.now() - timedelta(days=30)
 
-    create_returned_letter(service=sample_service, reported_at=today)
-    create_returned_letter(service=sample_service, reported_at=today)
-    create_returned_letter(service=sample_service, reported_at=last_month)
+    letter_1 = create_notification(template=sample_letter_template, client_reference='letter_1',
+                                   status=NOTIFICATION_RETURNED_LETTER,
+                                   created_at=datetime.utcnow() - timedelta(days=1))
+    returned_letter_1 = create_returned_letter(service=sample_letter_template.service, reported_at=today,
+                                               notification_id=letter_1.id)
+    letter_2 = create_notification_history(template=sample_letter_template, client_reference='letter_2',
+                                           status=NOTIFICATION_RETURNED_LETTER, created_at=datetime.utcnow())
+    returned_letter_2 = create_returned_letter(service=sample_letter_template.service, reported_at=today,
+                                               notification_id=letter_2.id)
+    letter_3 = create_notification_history(template=sample_letter_template, client_reference='letter_3',
+                                           status=NOTIFICATION_RETURNED_LETTER)
+    create_returned_letter(service=sample_letter_template.service, reported_at=last_month,
+                           notification_id=letter_3.id)
 
-    results = fetch_returned_letters(service_id=sample_service.id, report_date=today.date())
+    results = fetch_returned_letters(service_id=sample_letter_template.service_id, report_date=today.date())
 
     assert len(results) == 2
+    assert results[0] == (letter_2.id, returned_letter_2.reported_at, letter_2.client_reference, letter_2.created_at,
+                          sample_letter_template.name, letter_2.template_id, letter_2.template_version,
+                          letter_2.created_by_id, None, None, None)
+    assert results[1] == (letter_1.id, returned_letter_1.reported_at, letter_1.client_reference, letter_1.created_at,
+                          sample_letter_template.name, letter_1.template_id, letter_1.template_version,
+                          letter_1.created_by_id, None, None, None)
+
+
+def test_fetch_returned_letters_with_jobs(sample_letter_job):
+    today = datetime.now()
+    letter_1 = create_notification_history(template=sample_letter_job.template, client_reference='letter_1',
+                                           status=NOTIFICATION_RETURNED_LETTER,
+                                           job=sample_letter_job, job_row_number=20,
+                                           created_at=datetime.utcnow() - timedelta(minutes=1))
+    returned_letter_1 = create_returned_letter(service=sample_letter_job.service, reported_at=today,
+                                               notification_id=letter_1.id)
+
+    results = fetch_returned_letters(service_id=sample_letter_job.service_id, report_date=today.date())
+    assert len(results) == 1
+    assert results[0] == (letter_1.id, returned_letter_1.reported_at, letter_1.client_reference, letter_1.created_at,
+                          sample_letter_job.template.name, letter_1.template_id, letter_1.template_version,
+                          letter_1.created_by_id, None, sample_letter_job.original_file_name, letter_1.job_row_number)
+
+
+def test_fetch_returned_letters_with_create_by_user(sample_letter_template):
+    today = datetime.now()
+    letter_1 = create_notification_history(template=sample_letter_template, client_reference='letter_1',
+                                           status=NOTIFICATION_RETURNED_LETTER,
+                                           created_at=datetime.utcnow() - timedelta(minutes=1),
+                                           created_by_id=sample_letter_template.service.users[0].id)
+    returned_letter_1 = create_returned_letter(service=sample_letter_template.service, reported_at=today,
+                                               notification_id=letter_1.id)
+
+    results = fetch_returned_letters(service_id=sample_letter_template.service_id, report_date=today.date())
+    assert len(results) == 1
+    assert results[0] == (letter_1.id, returned_letter_1.reported_at, letter_1.client_reference, letter_1.created_at,
+                          sample_letter_template.name, letter_1.template_id, letter_1.template_version,
+                          letter_1.created_by_id, sample_letter_template.service.users[0].name, None, None)

--- a/tests/app/dao/test_returned_letters_dao.py
+++ b/tests/app/dao/test_returned_letters_dao.py
@@ -2,7 +2,10 @@ from datetime import datetime, timedelta, date
 
 from freezegun import freeze_time
 
-from app.dao.returned_letters_dao import insert_or_update_returned_letters, get_returned_letter_summary
+from app.dao.returned_letters_dao import (
+    insert_or_update_returned_letters, get_returned_letter_summary,
+    fetch_returned_letters
+)
 from app.models import ReturnedLetter
 from tests.app.db import create_notification, create_notification_history, create_returned_letter
 
@@ -116,3 +119,16 @@ def test_get_returned_letter_summary_orders_by_reported_at(sample_service):
     assert results[0].returned_letter_count == 3
     assert results[1].reported_at == last_month.date()
     assert results[1].returned_letter_count == 2
+
+
+def test_fetch_returned_letters(sample_service):
+    today = datetime.now()
+    last_month = datetime.now() - timedelta(days=30)
+
+    create_returned_letter(service=sample_service, reported_at=today)
+    create_returned_letter(service=sample_service, reported_at=today)
+    create_returned_letter(service=sample_service, reported_at=last_month)
+
+    results = fetch_returned_letters(service_id=sample_service.id, report_date=today.date())
+
+    assert len(results) == 2

--- a/tests/app/dao/test_returned_letters_dao.py
+++ b/tests/app/dao/test_returned_letters_dao.py
@@ -144,11 +144,11 @@ def test_fetch_returned_letters_from_notifications_and_notification_history(samp
 
     assert len(results) == 2
     assert results[0] == (letter_2.id, returned_letter_2.reported_at, letter_2.client_reference, letter_2.created_at,
-                          sample_letter_template.name, letter_2.template_id, letter_2.template_version,
+                          sample_letter_template.name, letter_2.template_id, letter_2.template_version, False, None,
                           None, None, None, None, None)
     assert results[1] == (letter_1.id, returned_letter_1.reported_at, letter_1.client_reference, letter_1.created_at,
-                          sample_letter_template.name, letter_1.template_id, letter_1.template_version,
-                          None, None, None, None, None)
+                          sample_letter_template.name, letter_1.template_id, letter_1.template_version, False,
+                          letter_1.api_key_id, None, None, None, None, None)
 
 
 def test_fetch_returned_letters_with_jobs(sample_letter_job):
@@ -163,7 +163,7 @@ def test_fetch_returned_letters_with_jobs(sample_letter_job):
     results = fetch_returned_letters(service_id=sample_letter_job.service_id, report_date=today.date())
     assert len(results) == 1
     assert results[0] == (letter_1.id, returned_letter_1.reported_at, letter_1.client_reference, letter_1.created_at,
-                          sample_letter_job.template.name, letter_1.template_id, letter_1.template_version,
+                          sample_letter_job.template.name, letter_1.template_id, letter_1.template_version, False, None,
                           None, None, None, sample_letter_job.original_file_name, 21)
 
 
@@ -179,6 +179,6 @@ def test_fetch_returned_letters_with_create_by_user(sample_letter_template):
     results = fetch_returned_letters(service_id=sample_letter_template.service_id, report_date=today.date())
     assert len(results) == 1
     assert results[0] == (letter_1.id, returned_letter_1.reported_at, letter_1.client_reference, letter_1.created_at,
-                          sample_letter_template.name, letter_1.template_id, letter_1.template_version,
+                          sample_letter_template.name, letter_1.template_id, letter_1.template_version, False, None,
                           letter_1.created_by_id, sample_letter_template.service.users[0].name,
                           sample_letter_template.service.users[0].email_address, None, None)

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -685,7 +685,7 @@ def create_ft_billing(bst_date,
                       rate=0,
                       billable_unit=1,
                       notifications_sent=1,
-                      postage='none',
+                      postage='none'
                       ):
     data = FactBilling(bst_date=bst_date,
                        service_id=template.service_id,

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -60,7 +60,6 @@ from app.models import (
     LetterBranding,
     Domain,
     NotificationHistory,
-    NOTIFICATION_RETURNED_LETTER,
     ReturnedLetter
 )
 
@@ -944,15 +943,13 @@ def set_up_usage_data(start_date):
     return org, org_3, service, service_3, service_4, service_sms_only
 
 
-def create_returned_letter(service=None, reported_at=None):
+def create_returned_letter(service=None, reported_at=None, notification_id=None):
     if not service:
         service = create_service(service_name='a - with sms and letter')
-    template = create_template(service=service, template_type=LETTER_TYPE)
-    notification = create_notification(template=template, status=NOTIFICATION_RETURNED_LETTER)
     returned_letter = ReturnedLetter(
         service_id=service.id,
         reported_at=reported_at or datetime.utcnow(),
-        notification_id=notification.id,
+        notification_id=notification_id or uuid.uuid4(),
         created_at=datetime.utcnow(),
     )
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3394,12 +3394,15 @@ def test_get_returned_letter_summary(admin_request, sample_service):
 
 @freeze_time('2019-12-11 13:30')
 def test_get_returned_letter(admin_request, sample_letter_template):
-    letter_1 = create_notification_history(template=sample_letter_template, client_reference='letter_1',
-                                           status=NOTIFICATION_RETURNED_LETTER,
-                                           created_at=datetime.utcnow() - timedelta(minutes=1),
-                                           created_by_id=sample_letter_template.service.users[0].id)
+    letter_from_previous_report = create_notification_history(
+        template=sample_letter_template,
+        client_reference='letter_from_previous_report',
+        status=NOTIFICATION_RETURNED_LETTER,
+        created_at=datetime.utcnow() - timedelta(minutes=1),
+        created_by_id=sample_letter_template.service.users[0].id
+    )
     create_returned_letter(service=sample_letter_template.service, reported_at=datetime.utcnow() - timedelta(days=3),
-                           notification_id=letter_1.id)
+                           notification_id=letter_from_previous_report.id)
 
     job = create_job(template=sample_letter_template)
     letter_from_job = create_notification(template=sample_letter_template, client_reference='letter_from_job',
@@ -3439,11 +3442,11 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     create_returned_letter(service=sample_letter_template.service, reported_at=datetime.utcnow(),
                            notification_id=uploaded_letter.id)
 
-    not_included_in_results = create_template(service=create_service(service_name='not included in results'),
-                                              template_type='letter')
-    letter_4 = create_notification_history(template=not_included_in_results,
+    not_included_in_results_template = create_template(service=create_service(service_name='not included in results'),
+                                                       template_type='letter')
+    letter_4 = create_notification_history(template=not_included_in_results_template,
                                            status=NOTIFICATION_RETURNED_LETTER)
-    create_returned_letter(service=not_included_in_results.service, reported_at=datetime.utcnow(),
+    create_returned_letter(service=not_included_in_results_template.service, reported_at=datetime.utcnow(),
                            notification_id=letter_4.id)
     response = admin_request.get('service.get_returned_letters', service_id=sample_letter_template.service_id,
                                  reported_at='2019-12-11')
@@ -3452,7 +3455,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[0]['notification_id'] == str(letter_from_job.id)
     assert not response[0]['client_reference']
     assert response[0]['reported_at'] == '2019-12-11'
-    assert response[0]['created_at'] == '2019-12-10 13:30:00'
+    assert response[0]['created_at'] == '2019-12-10 13:30:00.000000'
     assert response[0]['template_name'] == sample_letter_template.name
     assert response[0]['template_id'] == str(sample_letter_template.id)
     assert response[0]['template_version'] == sample_letter_template.version
@@ -3464,7 +3467,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[1]['notification_id'] == str(one_off_letter.id)
     assert not response[1]['client_reference']
     assert response[1]['reported_at'] == '2019-12-11'
-    assert response[1]['created_at'] == '2019-12-09 13:30:00'
+    assert response[1]['created_at'] == '2019-12-09 13:30:00.000000'
     assert response[1]['template_name'] == sample_letter_template.name
     assert response[1]['template_id'] == str(sample_letter_template.id)
     assert response[1]['template_version'] == sample_letter_template.version
@@ -3476,7 +3479,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[2]['notification_id'] == str(api_letter.id)
     assert response[2]['client_reference'] == 'api_letter'
     assert response[2]['reported_at'] == '2019-12-11'
-    assert response[2]['created_at'] == '2019-12-08 13:30:00'
+    assert response[2]['created_at'] == '2019-12-08 13:30:00.000000'
     assert response[2]['template_name'] == sample_letter_template.name
     assert response[2]['template_id'] == str(sample_letter_template.id)
     assert response[2]['template_version'] == sample_letter_template.version
@@ -3488,7 +3491,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[3]['notification_id'] == str(precompiled_letter.id)
     assert response[3]['client_reference'] == 'precompiled letter'
     assert response[3]['reported_at'] == '2019-12-11'
-    assert response[3]['created_at'] == '2019-12-07 13:30:00'
+    assert response[3]['created_at'] == '2019-12-07 13:30:00.000000'
     assert not response[3]['template_name']
     assert not response[3]['template_id']
     assert not response[3]['template_version']
@@ -3500,7 +3503,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[4]['notification_id'] == str(uploaded_letter.id)
     assert not response[4]['client_reference']
     assert response[4]['reported_at'] == '2019-12-11'
-    assert response[4]['created_at'] == '2019-12-06 13:30:00'
+    assert response[4]['created_at'] == '2019-12-06 13:30:00.000000'
     assert not response[4]['template_name']
     assert not response[4]['template_id']
     assert not response[4]['template_version']

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3394,16 +3394,6 @@ def test_get_returned_letter_summary(admin_request, sample_service):
 
 @freeze_time('2019-12-11 13:30')
 def test_get_returned_letter(admin_request, sample_letter_template):
-    letter_from_previous_report = create_notification_history(
-        template=sample_letter_template,
-        client_reference='letter_from_previous_report',
-        status=NOTIFICATION_RETURNED_LETTER,
-        created_at=datetime.utcnow() - timedelta(minutes=1),
-        created_by_id=sample_letter_template.service.users[0].id
-    )
-    create_returned_letter(service=sample_letter_template.service, reported_at=datetime.utcnow() - timedelta(days=3),
-                           notification_id=letter_from_previous_report.id)
-
     job = create_job(template=sample_letter_template)
     letter_from_job = create_notification(template=sample_letter_template, client_reference='letter_from_job',
                                           status=NOTIFICATION_RETURNED_LETTER,
@@ -3462,7 +3452,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[0]['user_name'] == sample_letter_template.service.users[0].name
     assert response[0]['original_file_name'] == job.original_file_name
     assert response[0]['job_row_number'] == 3
-    assert not response[0]['uploaded_letter']
+    assert not response[0]['uploaded_letter_file_name']
 
     assert response[1]['notification_id'] == str(one_off_letter.id)
     assert not response[1]['client_reference']
@@ -3474,7 +3464,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[1]['user_name'] == sample_letter_template.service.users[0].name
     assert not response[1]['original_file_name']
     assert not response[1]['job_row_number']
-    assert not response[1]['uploaded_letter']
+    assert not response[1]['uploaded_letter_file_name']
 
     assert response[2]['notification_id'] == str(api_letter.id)
     assert response[2]['client_reference'] == 'api_letter'
@@ -3486,7 +3476,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[2]['user_name'] == 'API'
     assert not response[2]['original_file_name']
     assert not response[2]['job_row_number']
-    assert not response[2]['uploaded_letter']
+    assert not response[2]['uploaded_letter_file_name']
 
     assert response[3]['notification_id'] == str(precompiled_letter.id)
     assert response[3]['client_reference'] == 'precompiled letter'
@@ -3498,7 +3488,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[3]['user_name'] == 'API'
     assert not response[3]['original_file_name']
     assert not response[3]['job_row_number']
-    assert not response[3]['uploaded_letter']
+    assert not response[3]['uploaded_letter_file_name']
 
     assert response[4]['notification_id'] == str(uploaded_letter.id)
     assert not response[4]['client_reference']
@@ -3511,4 +3501,4 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[4]['email_address'] == sample_letter_template.service.users[0].email_address
     assert not response[4]['original_file_name']
     assert not response[4]['job_row_number']
-    assert response[4]['uploaded_letter'] == 'filename.pdf'
+    assert response[4]['uploaded_letter_file_name'] == 'filename.pdf'

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -48,7 +48,8 @@ from tests.app.db import (
     create_domain,
     create_email_branding,
     create_annual_billing,
-    create_returned_letter, create_notification_history,
+    create_returned_letter,
+    create_notification_history,
     create_job
 )
 from tests.app.db import create_user
@@ -3443,4 +3444,4 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[1]['template_version'] == sample_letter_template.version
     assert not response[1]['user_name']
     assert response[1]['original_file_name'] == job.original_file_name
-    assert response[1]['job_row_number'] == 2
+    assert response[1]['job_row_number'] == 3


### PR DESCRIPTION
# Context

Once a month the postal provider sends a report of all the returned letters. At the moment, the services do not have a way to consume this information. 

# What

This PR has a db migration script to populate a new table called `returned_letters` which captures the notification id of the letter that has been returned. 

There is a new query to get a summary of the data and an endpoint to show each report for a given service. 
There is a new query and endpoint to return the report for a given service and report date. 
