### PR TITLE
Add client reference to notification reponse

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1569,6 +1569,7 @@ class Notification(db.Model):
         serialized = {
             "row_number": '' if self.job_row_number is None else self.job_row_number + 1,
             "recipient": self.to,
+            "client_reference": self.client_reference or '',
             "template_name": self.template.name,
             "template_type": self.template.template_type,
             "job_name": self.job.original_file_name if self.job else '',

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -794,7 +794,8 @@ def test_get_all_notifications_for_job_returns_csv_format(admin_request, sample_
         'job_name',
         'status',
         'row_number',
-        'recipient'
+        'recipient',
+        'client_reference'
     }
 
 


### PR DESCRIPTION
Add client_reference to the serialised notification returned for the CSV reports.

We want to add the client reference to the report, precompiled letters require a client reference. 