### PR TITLE
handle document download errors properly

### DIFF
--- a/app/v2/notifications/get_notifications.py
+++ b/app/v2/notifications/get_notifications.py
@@ -39,7 +39,7 @@ def get_pdf_for_notification(notification_id):
         raise BadRequestError(message="Notification is not a letter")
 
     if notification.status == NOTIFICATION_VIRUS_SCAN_FAILED:
-        raise BadRequestError(message='Document did not pass the virus scan')
+        raise BadRequestError(message='File did not pass the virus scan')
 
     if notification.status == NOTIFICATION_TECHNICAL_FAILURE:
         raise BadRequestError(message='PDF not available for letters in status {}'.format(notification.status))

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -250,7 +250,7 @@ def create_notification(
         updated_at = updated_at or datetime.utcnow()
 
     if not one_off and (job is None and api_key is None):
-        # we didn't specify in test - lets create it
+        # we did not specify in test - lets create it
         api_key = ApiKey.query.filter(ApiKey.service == template.service, ApiKey.key_type == key_type).first()
         if not api_key:
             api_key = create_api_key(template.service, key_type=key_type)

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -703,7 +703,7 @@ def test_get_pdf_for_notification_returns_400_if_pdf_not_found(
 
 
 @pytest.mark.parametrize('status, expected_message', [
-    ('virus-scan-failed', 'Document did not pass the virus scan'),
+    ('virus-scan-failed', 'File did not pass the virus scan'),
     ('technical-failure', 'PDF not available for letters in status technical-failure'),
 ])
 def test_get_pdf_for_notification_only_returns_pdf_content_if_right_status(


### PR DESCRIPTION
if doc download returns a 403, that's a screw-up on our side. it's not helpful to a notify user for that to be passed on. the only thing they should care about is if it's a 400, because they uploaded a filetype we don't allow.

Everything else should return 500 internal server error.