### PR TITLE
Send the alert for `letters-still-sending` an hour earlier.

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -296,7 +296,7 @@ class Config(object):
         },
         'raise-alert-if-letter-notifications-still-sending': {
             'task': 'raise-alert-if-letter-notifications-still-sending',
-            'schedule': crontab(hour=16, minute=30),
+            'schedule': crontab(hour=15, minute=30),
             'options': {'queue': QueueNames.PERIODIC}
         },
         # The collate-letter-pdf does assume it is called in an hour that BST does not make a


### PR DESCRIPTION
These alerts are sent to our postal provider. And it usually arrives as they are getting ready to go home for the day or the weekend.
Which means they get missed/overlooked. They have agreed to get the alert an hour earlier, perhaps that will improved the response time.