### PR TITLE
Up threshold for sms to telephone numbers

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -286,7 +286,7 @@ def check_for_services_with_high_failure_rates_or_sending_to_tv_numbers():
             )
             message += "service: {} failure rate: {},\n".format(service_dashboard, service.permanent_failure_rate)
     elif services_sending_to_tv_numbers:
-        message += "{} service(s) have sent over 100 sms messages to tv numbers in last 24 hours:\n".format(
+        message += "{} service(s) have sent over 500 sms messages to tv numbers in last 24 hours:\n".format(
             len(services_sending_to_tv_numbers)
         )
         for service in services_sending_to_tv_numbers:

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -525,7 +525,7 @@ def dao_fetch_active_users_for_service(service_id):
     return query.all()
 
 
-def dao_find_services_sending_to_tv_numbers(start_date, end_date, threshold=100):
+def dao_find_services_sending_to_tv_numbers(start_date, end_date, threshold=500):
     return db.session.query(
         Notification.service_id.label('service_id'),
         func.count(Notification.id).label('notification_count')

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -526,7 +526,7 @@ MockServicesWithHighFailureRate = namedtuple(
     [
         [],
         [MockServicesSendingToTVNumbers("123", 300)],
-        "1 service(s) have sent over 100 sms messages to tv numbers in last 24 hours:\n"
+        "1 service(s) have sent over 500 sms messages to tv numbers in last 24 hours:\n"
         "service: {}/services/{} count of sms to tv numbers: 300,\n".format(
             Config.ADMIN_BASE_URL, "123"
         )


### PR DESCRIPTION
We were just ignoring the errors and our users were not fixing things.

Given that 500 texts cost approx £8 it's not the end of the world.

In the long run we may decide to just stop letting people try and send
messages to TV numbers but this is a quick fix to stop emails coming in
which we ignore.