### PR TITLE
Validate email access based on code_type and not auth_type

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -114,7 +114,9 @@ class User(db.Model):
     platform_admin = db.Column(db.Boolean, nullable=False, default=False)
     current_session_id = db.Column(UUID(as_uuid=True), nullable=True)
     auth_type = db.Column(db.String, db.ForeignKey('auth_type.name'), index=True, nullable=False, default=SMS_AUTH_TYPE)
-    email_access_validated_at = db.Column(db.DateTime, index=False, unique=False, nullable=False)
+    email_access_validated_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow
+    )
 
     # either email auth or a mobile number must be provided
     CheckConstraint("auth_type = 'email_auth' or mobile_number is not null")
@@ -163,15 +165,11 @@ class User(db.Model):
             'auth_type': self.auth_type,
             'current_session_id': self.current_session_id,
             'failed_login_count': self.failed_login_count,
-            'email_access_validated_at': self.email_access_validated_at,
+            'email_access_validated_at': self.email_access_validated_at.strftime(DATETIME_FORMAT),
             'logged_in_at': self.logged_in_at.strftime(DATETIME_FORMAT) if self.logged_in_at else None,
             'mobile_number': self.mobile_number,
             'organisations': [x.id for x in self.organisations if x.active],
-            'password_changed_at': (
-                self.password_changed_at.strftime(DATETIME_FORMAT_NO_TIMEZONE)
-                if self.password_changed_at
-                else None
-            ),
+            'password_changed_at': self.password_changed_at.strftime(DATETIME_FORMAT_NO_TIMEZONE),
             'permissions': self.get_permissions(),
             'platform_admin': self.platform_admin,
             'services': [x.id for x in self.services if x.active],

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -197,7 +197,7 @@ def verify_user_code(user_id):
 
     user_to_verify.current_session_id = str(uuid.uuid4())
     user_to_verify.logged_in_at = datetime.utcnow()
-    if user_to_verify.auth_type == 'email_auth':
+    if data['code_type'] == 'email':
         user_to_verify.email_access_validated_at = datetime.utcnow()
     user_to_verify.failed_login_count = 0
     save_model_user(user_to_verify)


### PR DESCRIPTION
when verifying the code is correct. This way if user has sms_auth
and we send them verification code to validate their email access,
and they click the link in the email, their access will be validated
correctly.

### More changes added in that PR:
- Format email_access_validated_at when serializing
This is to bring it in line with other serialized dates in User
model, like logged_in_at and password_changed_at.

- Also get rid of check if password_changed_at has value, as
it is a non-nullable column, so it needs to always have value.

- Also set a default value for email_access_validated_at, to bring
it in line with other non-nullable columns.