### PR TITLE
Added a new endpoint to return the last used date for a template.

### DIFF
--- a/app/template_statistics/rest.py
+++ b/app/template_statistics/rest.py
@@ -58,10 +58,10 @@ def get_template_statistics_for_template_id(service_id, template_id):
 
 @template_statistics.route('/last-used/<uuid:template_id>')
 def get_last_used_datetime_for_template(service_id, template_id):
-    template = dao_get_template_by_id_and_service_id(template_id, service_id)
+    # Check the template and service exist
+    dao_get_template_by_id_and_service_id(template_id, service_id)
 
     last_date_used = dao_get_last_date_template_was_used(template_id=template_id,
-                                                         template_type=template.template_type,
                                                          service_id=service_id)
 
     return jsonify(last_date_used=last_date_used.strftime(DATETIME_FORMAT))

--- a/app/template_statistics/rest.py
+++ b/app/template_statistics/rest.py
@@ -1,5 +1,7 @@
 from flask import Blueprint, jsonify, request
-from app.dao.notifications_dao import dao_get_last_template_usage
+
+from app import DATETIME_FORMAT
+from app.dao.notifications_dao import dao_get_last_template_usage, dao_get_last_date_template_was_used
 from app.dao.templates_dao import dao_get_template_by_id_and_service_id
 from app.dao.fact_notification_status_dao import fetch_notification_status_for_service_for_today_and_7_previous_days
 
@@ -52,3 +54,14 @@ def get_template_statistics_for_template_id(service_id, template_id):
         data = notification_with_template_schema.dump(notification).data
 
     return jsonify(data=data)
+
+
+@template_statistics.route('/last-used/<uuid:template_id>')
+def get_last_used_datetime_for_template(service_id, template_id):
+    template = dao_get_template_by_id_and_service_id(template_id, service_id)
+
+    last_date_used = dao_get_last_date_template_was_used(template_id=template_id,
+                                                         template_type=template.template_type,
+                                                         service_id=service_id)
+
+    return jsonify(last_date_used=last_date_used.strftime(DATETIME_FORMAT))

--- a/tests/app/dao/notification_dao/test_notification_dao_template_usage.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_template_usage.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 import pytest
-from app.dao.notifications_dao import dao_get_last_template_usage
-from tests.app.db import create_notification, create_template
+from app.dao.notifications_dao import dao_get_last_template_usage, dao_get_last_date_template_was_used
+from tests.app.db import create_notification, create_template, create_ft_notification_status
 
 
 def test_last_template_usage_should_get_right_data(sample_notification):
@@ -54,3 +54,56 @@ def test_last_template_usage_should_be_able_to_get_no_template_usage_history_if_
         sample_template):
     results = dao_get_last_template_usage(sample_template.id, 'sms', sample_template.service_id)
     assert not results
+
+
+@pytest.mark.parametrize('last_status_date, last_notification_date',
+                         [((datetime.utcnow() - timedelta(days=2)).date(), None),
+                          ((datetime.utcnow() - timedelta(days=2)).date(), datetime.utcnow() - timedelta(days=3))]
+                         )
+def test_dao_get_last_date_template_was_used_returns_bst_date_from_stats_table(
+        sample_template, last_status_date, last_notification_date
+):
+    create_ft_notification_status(bst_date=last_status_date,
+                                  template=sample_template)
+    if last_notification_date:
+        create_notification(template=sample_template, created_at=last_notification_date)
+    last_used_date = dao_get_last_date_template_was_used(template_id=sample_template.id,
+                                                         template_type='sms',
+                                                         service_id=sample_template.service_id)
+    assert last_used_date == last_status_date
+
+
+@pytest.mark.parametrize('last_notification_date, last_status_date',
+                         [(datetime.utcnow() - timedelta(hours=2), None),
+                          (datetime.utcnow() - timedelta(hours=2), (datetime.utcnow() - timedelta(days=2)).date())]
+                         )
+def test_dao_get_last_date_template_was_used_returns_created_at_from_notifications(
+        sample_template, last_status_date, last_notification_date
+):
+    create_notification(template=sample_template, created_at=last_notification_date)
+
+    if last_status_date:
+        create_ft_notification_status(bst_date=last_status_date, template=sample_template)
+    last_used_date = dao_get_last_date_template_was_used(template_id=sample_template.id,
+                                                         template_type='sms',
+                                                         service_id=sample_template.service_id)
+    assert last_used_date == last_notification_date
+
+
+def test_dao_get_last_date_template_was_used_returns_none_if_never_used(sample_template):
+    assert not dao_get_last_date_template_was_used(template_id=sample_template.id,
+                                                   template_type='sms',
+                                                   service_id=sample_template.service_id)
+
+
+def test_dao_get_last_date_template_was_used_correct_date(sample_template):
+    date_from_notification = datetime.utcnow() - timedelta(hours=2)
+    create_notification(template=sample_template, created_at=date_from_notification)
+    date_from_ft_status = (datetime.utcnow() - timedelta(days=2)).date()
+    create_ft_notification_status(bst_date=date_from_ft_status,
+                                  template=sample_template)
+
+    actual_result = dao_get_last_date_template_was_used(template_id=sample_template.id,
+                                                        template_type='sms',
+                                                        service_id=sample_template.service_id)
+    assert actual_result == date_from_notification

--- a/tests/app/dao/notification_dao/test_notification_dao_template_usage.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_template_usage.py
@@ -56,54 +56,31 @@ def test_last_template_usage_should_be_able_to_get_no_template_usage_history_if_
     assert not results
 
 
-@pytest.mark.parametrize('last_status_date, last_notification_date',
-                         [((datetime.utcnow() - timedelta(days=2)).date(), None),
-                          ((datetime.utcnow() - timedelta(days=2)).date(), datetime.utcnow() - timedelta(days=3))]
-                         )
 def test_dao_get_last_date_template_was_used_returns_bst_date_from_stats_table(
-        sample_template, last_status_date, last_notification_date
+        sample_template
 ):
+    last_status_date = (datetime.utcnow() - timedelta(days=2)).date()
     create_ft_notification_status(bst_date=last_status_date,
                                   template=sample_template)
-    if last_notification_date:
-        create_notification(template=sample_template, created_at=last_notification_date)
+
     last_used_date = dao_get_last_date_template_was_used(template_id=sample_template.id,
-                                                         template_type='sms',
                                                          service_id=sample_template.service_id)
     assert last_used_date == last_status_date
 
 
-@pytest.mark.parametrize('last_notification_date, last_status_date',
-                         [(datetime.utcnow() - timedelta(hours=2), None),
-                          (datetime.utcnow() - timedelta(hours=2), (datetime.utcnow() - timedelta(days=2)).date())]
-                         )
 def test_dao_get_last_date_template_was_used_returns_created_at_from_notifications(
-        sample_template, last_status_date, last_notification_date
+        sample_template
 ):
+    last_notification_date = datetime.utcnow() - timedelta(hours=2)
     create_notification(template=sample_template, created_at=last_notification_date)
 
-    if last_status_date:
-        create_ft_notification_status(bst_date=last_status_date, template=sample_template)
+    last_status_date = (datetime.utcnow() - timedelta(days=2)).date()
+    create_ft_notification_status(bst_date=last_status_date, template=sample_template)
     last_used_date = dao_get_last_date_template_was_used(template_id=sample_template.id,
-                                                         template_type='sms',
                                                          service_id=sample_template.service_id)
     assert last_used_date == last_notification_date
 
 
 def test_dao_get_last_date_template_was_used_returns_none_if_never_used(sample_template):
     assert not dao_get_last_date_template_was_used(template_id=sample_template.id,
-                                                   template_type='sms',
                                                    service_id=sample_template.service_id)
-
-
-def test_dao_get_last_date_template_was_used_correct_date(sample_template):
-    date_from_notification = datetime.utcnow() - timedelta(hours=2)
-    create_notification(template=sample_template, created_at=date_from_notification)
-    date_from_ft_status = (datetime.utcnow() - timedelta(days=2)).date()
-    create_ft_notification_status(bst_date=date_from_ft_status,
-                                  template=sample_template)
-
-    actual_result = dao_get_last_date_template_was_used(template_id=sample_template.id,
-                                                        template_type='sms',
-                                                        service_id=sample_template.service_id)
-    assert actual_result == date_from_notification

--- a/tests/app/template_statistics/test_rest.py
+++ b/tests/app/template_statistics/test_rest.py
@@ -221,7 +221,7 @@ def test_get_last_used_datetime_for_template_returns_400_if_service_does_not_exi
     )
 
 
-def test_get_last_used_datetime_for_template_returns_400_if_template_does_not_exist(
+def test_get_last_used_datetime_for_template_returns_404_if_template_does_not_exist(
     admin_request, sample_template
 ):
     admin_request.get(

--- a/tests/app/template_statistics/test_rest.py
+++ b/tests/app/template_statistics/test_rest.py
@@ -1,10 +1,12 @@
 import uuid
+from datetime import datetime, timedelta
 from unittest.mock import Mock
 
 import pytest
 from freezegun import freeze_time
 
-from tests.app.db import create_notification
+from app import DATETIME_FORMAT
+from tests.app.db import create_ft_notification_status, create_notification
 
 
 def set_up_get_all_from_hash(mock_redis, side_effect):
@@ -189,3 +191,42 @@ def test_get_template_statistics_for_template_returns_empty_for_old_notification
     )
 
     assert not json_resp['data']
+
+
+def test_get_last_used_datetime_for_template(
+    admin_request, sample_template
+):
+    date_from_notification = datetime.utcnow() - timedelta(hours=2)
+    create_notification(template=sample_template, created_at=date_from_notification)
+    date_from_ft_status = (datetime.utcnow() - timedelta(days=2)).date()
+    create_ft_notification_status(bst_date=date_from_ft_status,
+                                  template=sample_template)
+
+    json_resp = admin_request.get(
+        'template_statistics.get_last_used_datetime_for_template',
+        service_id=str(sample_template.service_id),
+        template_id=sample_template.id
+    )
+    assert json_resp['last_date_used'] == date_from_notification.strftime(DATETIME_FORMAT)
+
+
+def test_get_last_used_datetime_for_template_returns_400_if_service_does_not_exist(
+    admin_request, sample_template
+):
+    admin_request.get(
+        'template_statistics.get_last_used_datetime_for_template',
+        service_id=uuid.uuid4(),
+        template_id=sample_template.id,
+        _expected_status=404
+    )
+
+
+def test_get_last_used_datetime_for_template_returns_400_if_template_does_not_exist(
+    admin_request, sample_template
+):
+    admin_request.get(
+        'template_statistics.get_last_used_datetime_for_template',
+        service_id=sample_template.service_id,
+        template_id=uuid.uuid4(),
+        _expected_status=404
+    )


### PR DESCRIPTION
The existing endpoint returned a whole notification for the last time the template was used. But this only takes into account data in the last week. This new methods allows us to be specific about when the template was last used if ever but looking into the ft_notification_status table as well.