### PR TITLE
use original `boto`

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -6,7 +6,7 @@ from datetime import (
     timedelta,
 )
 
-from boto.exception import BotoClientError
+from botocore.exceptions import ClientError
 from flask import current_app
 from notifications_utils.international_billing_rates import INTERNATIONAL_BILLING_RATES
 from notifications_utils.recipients import (
@@ -438,7 +438,7 @@ def _delete_letters_from_s3(
             for s3_object in s3_objects:
                 try:
                     remove_s3_object(bucket_name, s3_object['Key'])
-                except BotoClientError:
+                except ClientError:
                     current_app.logger.exception(
                         "Could not delete S3 object with filename: {}".format(s3_object['Key']))
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,7 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 cffi==1.13.1
-celery==3.1.26.post2 # pyup: <4
+celery[sqs]==3.1.26.post2 # pyup: <4
 docopt==0.6.2
 Flask-Bcrypt==0.7.1
 flask-marshmallow==0.10.1
@@ -30,5 +30,3 @@ awscli-cwlogs>=1.4,<1.5
 itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/notifications-utils.git@36.5.0#egg=notifications-utils==36.5.0
-
-git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # with package version changes made in requirements-app.txt
 
 cffi==1.13.1
-celery==3.1.26.post2 # pyup: <4
+celery[sqs]==3.1.26.post2 # pyup: <4
 docopt==0.6.2
 Flask-Bcrypt==0.7.1
 flask-marshmallow==0.10.1
@@ -33,23 +33,22 @@ itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/notifications-utils.git@36.5.0#egg=notifications-utils==36.5.0
 
-git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
-
 ## The following requirements were added by pip freeze:
-alembic==1.3.3
+alembic==1.4.0
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.3.0
-awscli==1.17.9
+awscli==1.17.15
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.0
+boto==2.49.0
 boto3==1.10.38
-botocore==1.14.9
+botocore==1.14.15
 certifi==2019.11.28
 chardet==3.0.4
 Click==7.0
-colorama==0.4.1
+colorama==0.4.3
 dnspython==1.16.0
 docutils==0.15.2
 flask-redis==0.4.0
@@ -78,11 +77,11 @@ PyYAML==5.2
 redis==3.4.1
 requests==2.22.0
 rsa==3.4.2
-s3transfer==0.3.2
+s3transfer==0.3.3
 six==1.14.0
 smartypants==2.0.1
 statsd==3.3.0
 urllib3==1.25.8
 webencodings==0.5.1
-Werkzeug==0.16.1
-zipp==2.1.0
+Werkzeug==1.0.0
+zipp==2.2.0


### PR DESCRIPTION
    We aren't aware of any reason we need to use our fork of boto anymore.
    We therefore swap to use `celery[sqs]` which brings in the original
    version of boto and we can remove our use of the fork.

    This has been tested by running the celery app and seeing it connect to
    sqs and grab messages off a queue.


    We already use boto3 for our interaction with s3. Therefore if an expection is
    thrown it will be thrown from the botocore library (which boto3 is built
    on top of). This fixes an incorrect catching of a boto exception.

    I have copied
    app/aws/s3.py::file_exists for an example of this exception catching.