### PR TITLE
Docs in the db

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1407,6 +1407,8 @@ class Notification(db.Model):
 
     reply_to_text = db.Column(db.String, nullable=True)
 
+    document_download_count = db.Column(db.Integer, nullable=True)
+
     postage = db.Column(db.String, nullable=True)
     CheckConstraint("""
         CASE WHEN notification_type = 'letter' THEN
@@ -1682,6 +1684,8 @@ class NotificationHistory(db.Model, HistoryModel):
             postage is null
         END
     """)
+
+    document_download_count = db.Column(db.Integer, nullable=True)
 
     __table_args__ = (
         db.ForeignKeyConstraint(

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -70,7 +70,8 @@ def persist_notification(
     reply_to_text=None,
     billable_units=None,
     postage=None,
-    template_postage=None
+    template_postage=None,
+    document_download_count=None,
 ):
     notification_created_at = created_at or datetime.utcnow()
     if not notification_id:
@@ -94,7 +95,8 @@ def persist_notification(
         created_by_id=created_by_id,
         status=status,
         reply_to_text=reply_to_text,
-        billable_units=billable_units
+        billable_units=billable_units,
+        document_download_count=document_download_count,
     )
 
     if notification_type == SMS_TYPE:

--- a/migrations/versions/0315_document_download_count.py
+++ b/migrations/versions/0315_document_download_count.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0315_document_download_count
+Revises: 0314_populate_email_access
+Create Date: 2020-02-12 14:19:18.066425
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0315_document_download_count'
+down_revision = '0314_populate_email_access'
+
+
+def upgrade():
+    op.add_column('notifications', sa.Column('document_download_count', sa.Integer(), nullable=True))
+    op.add_column('notification_history', sa.Column('document_download_count', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('notifications', 'document_download_count')
+    op.drop_column('notification_history', 'document_download_count')

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -233,7 +233,8 @@ def create_notification(
         one_off=False,
         reply_to_text=None,
         created_by_id=None,
-        postage=None
+        postage=None,
+        document_download_count=None,
 ):
     assert job or template
     if job:
@@ -287,7 +288,8 @@ def create_notification(
         'normalised_to': normalised_to,
         'reply_to_text': reply_to_text,
         'created_by_id': created_by_id,
-        'postage': postage
+        'postage': postage,
+        'document_download_count': document_download_count,
     }
     notification = Notification(**data)
     dao_create_notification(notification)


### PR DESCRIPTION
create a new `document_count` field in the Notification and NotificationHistory table. When someone posts with a document (or multiple documents), set it to a non-zero value. If someone posts without any documents, keep it set to null

There's an assumption that this will never be set to zero.