### PR TITLE
Look at all previous days when sending letters

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -56,7 +56,7 @@ def remove_job_from_s3(service_id, job_id):
     return remove_s3_object(*get_job_location(service_id, job_id))
 
 
-def get_s3_bucket_objects(bucket_name, subfolder='', older_than=7, limit_days=2):
+def get_s3_bucket_objects(bucket_name, subfolder=''):
     boto_client = client('s3', current_app.config['AWS_REGION'])
     paginator = boto_client.get_paginator('list_objects_v2')
     page_iterator = paginator.paginate(

--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -19,6 +19,12 @@ def get_s3_object(bucket_name, file_location):
     return s3.Object(bucket_name, file_location)
 
 
+def head_s3_object(bucket_name, file_location):
+    # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.head_object
+    boto_client = client('s3', current_app.config['AWS_REGION'])
+    return boto_client.head_object(Bucket=bucket_name, Key=file_location)
+
+
 def file_exists(bucket_name, file_location):
     try:
         # try and access metadata of object

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -25,7 +25,6 @@ from app.dao.notifications_dao import (
     update_notification_status_by_id,
     dao_update_notification,
     dao_get_notification_by_reference,
-    dao_get_notifications_by_references,
     dao_update_notifications_by_reference,
     dao_get_letters_to_be_printed,
 )
@@ -180,10 +179,6 @@ def get_key_and_size_of_letters_to_be_sent_to_print(print_run_date):
             postage=letter.postage
         )
 
-        current_app.logger.info(
-            f'Found notification {letter.id} to send to DVLA to print: {letter_file_name}'
-        )
-
         letter_head = s3.head_s3_object(current_app.config['LETTERS_PDF_BUCKET_NAME'], letter_file_name)
         letter_pdfs.append({"Key": letter_file_name, "Size": letter_head['ContentLength']})
 
@@ -199,7 +194,7 @@ def group_letters(letter_pdfs):
     running_filesize = 0
     list_of_files = []
     for letter in letter_pdfs:
-        if letter['Key'].lower().endswith('.pdf') and letter_in_created_state(letter['Key']):
+        if letter['Key'].lower().endswith('.pdf'):
             if (
                 running_filesize + letter['Size'] > current_app.config['MAX_LETTER_PDF_ZIP_FILESIZE'] or
                 len(list_of_files) >= current_app.config['MAX_LETTER_PDF_COUNT_PER_ZIP']
@@ -213,22 +208,6 @@ def group_letters(letter_pdfs):
 
     if list_of_files:
         yield list_of_files
-
-
-def letter_in_created_state(filename):
-    # filename looks like '2018-01-13/NOTIFY.ABCDEF1234567890.D.2.C.C.20180113120000.PDF'
-    subfolder = filename.split('/')[0]
-    ref = get_reference_from_filename(filename)
-    notifications = dao_get_notifications_by_references([ref])
-    if notifications:
-        if notifications[0].status == NOTIFICATION_CREATED:
-            return True
-        current_app.logger.info('Collating letters for {} but notification with reference {} already in {}'.format(
-            subfolder,
-            ref,
-            notifications[0].status
-        ))
-    return False
 
 
 @notify_celery.task(bind=True, name='process-virus-scan-passed', max_retries=15, default_retry_delay=300)

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -132,8 +132,6 @@ def collate_letter_pdfs_to_be_sent():
     if print_run_date.time() < LETTER_PROCESSING_DEADLINE:
         print_run_date = print_run_date - timedelta(days=1)
 
-    # We can truncate the datetime to a date and add our own time (5:30pm) because UTC to BST does not
-    # make a difference to the date since it is triggered mid afternoon.
     print_run_deadline = print_run_date.replace(
         hour=17, minute=30, second=0, microsecond=0
     )

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -118,9 +118,9 @@ def get_letters_pdf(template, contact_block, filename, values):
     return resp.content, billable_units
 
 
-@notify_celery.task(name='collate-letter-pdfs-for-day')
-@cronitor("collate-letter-pdfs-for-day")
-def collate_letter_pdfs_for_day():
+@notify_celery.task(name='collate-letter-pdfs-to-be-sent')
+@cronitor("collate-letter-pdfs-to-be-sent")
+def collate_letter_pdfs_to_be_sent():
     """
     Finds all letters which are still waiting to be sent to DVLA for printing
 

--- a/app/config.py
+++ b/app/config.py
@@ -296,8 +296,8 @@ class Config(object):
         },
         # The collate-letter-pdf does assume it is called in an hour that BST does not make a
         # difference to the truncate date which translates to the filename to process
-        'collate-letter-pdfs-for-day': {
-            'task': 'collate-letter-pdfs-for-day',
+        'collate-letter-pdfs-to-be-sent': {
+            'task': 'collate-letter-pdfs-to-be-sent',
             'schedule': crontab(hour=17, minute=50),
             'options': {'queue': QueueNames.PERIODIC}
         },

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -731,6 +731,24 @@ def notifications_not_yet_sent(should_be_sending_after_seconds, notification_typ
     return notifications
 
 
+def dao_get_letters_to_be_printed(print_run_date):
+    """
+    Given a date for a print run, Return all letters created before 5:30pm that day that have not yet been sent
+    """
+    last_processing_deadline = datetime.strptime(print_run_date, "%Y-%m-%d").replace(
+        hour=17, minute=30, second=0, microsecond=0
+    )
+
+    notifications = Notification.query.filter(
+        Notification.created_at < convert_bst_to_utc(last_processing_deadline),
+        Notification.notification_type == LETTER_TYPE,
+        Notification.status == NOTIFICATION_CREATED
+    ).order_by(
+        Notification.created_at
+    ).all()
+    return notifications
+
+
 def dao_old_letters_with_created_status():
     yesterday_bst = convert_utc_to_bst(datetime.utcnow()) - timedelta(days=1)
     last_processing_deadline = yesterday_bst.replace(hour=17, minute=30, second=0, microsecond=0)

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -731,16 +731,12 @@ def notifications_not_yet_sent(should_be_sending_after_seconds, notification_typ
     return notifications
 
 
-def dao_get_letters_to_be_printed(print_run_date):
+def dao_get_letters_to_be_printed(print_run_deadline):
     """
-    Given a date for a print run, Return all letters created before 5:30pm that day that have not yet been sent
+    Return all letters created before the print run deadline that have not yet been sent
     """
-    last_processing_deadline = datetime.strptime(print_run_date, "%Y-%m-%d").replace(
-        hour=17, minute=30, second=0, microsecond=0
-    )
-
     notifications = Notification.query.filter(
-        Notification.created_at < convert_bst_to_utc(last_processing_deadline),
+        Notification.created_at < convert_bst_to_utc(print_run_deadline),
         Notification.notification_type == LETTER_TYPE,
         Notification.status == NOTIFICATION_CREATED,
         Notification.key_type == KEY_TYPE_NORMAL

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -742,7 +742,8 @@ def dao_get_letters_to_be_printed(print_run_date):
     notifications = Notification.query.filter(
         Notification.created_at < convert_bst_to_utc(last_processing_deadline),
         Notification.notification_type == LETTER_TYPE,
-        Notification.status == NOTIFICATION_CREATED
+        Notification.status == NOTIFICATION_CREATED,
+        Notification.key_type == KEY_TYPE_NORMAL
     ).order_by(
         Notification.created_at
     ).all()

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -19,7 +19,7 @@ from app.exceptions import NotificationTechnicalFailureException
 from app.celery.letters_pdf_tasks import (
     create_letters_pdf,
     get_letters_pdf,
-    collate_letter_pdfs_for_day,
+    collate_letter_pdfs_to_be_sent,
     get_key_and_size_of_letters_to_be_sent_to_print,
     group_letters,
     process_sanitised_letter,
@@ -52,7 +52,7 @@ from tests.conftest import set_config_values
 
 def test_should_have_decorated_tasks_functions():
     assert create_letters_pdf.__wrapped__.__name__ == 'create_letters_pdf'
-    assert collate_letter_pdfs_for_day.__wrapped__.__name__ == 'collate_letter_pdfs_for_day'
+    assert collate_letter_pdfs_to_be_sent.__wrapped__.__name__ == 'collate_letter_pdfs_to_be_sent'
     assert process_virus_scan_passed.__wrapped__.__name__ == 'process_virus_scan_passed'
     assert process_virus_scan_failed.__wrapped__.__name__ == 'process_virus_scan_failed'
     assert process_virus_scan_error.__wrapped__.__name__ == 'process_virus_scan_error'
@@ -316,7 +316,7 @@ def test_get_key_and_size_of_letters_to_be_sent_to_print(notify_api, mocker, sam
 
 
 @freeze_time('2020-02-17 18:00:00')
-def test_collate_letter_pdfs_for_day(notify_api, sample_letter_template, mocker):
+def test_collate_letter_pdfs_to_be_sent(notify_api, sample_letter_template, mocker):
     create_notification(
         template=sample_letter_template,
         status='created',
@@ -349,7 +349,7 @@ def test_collate_letter_pdfs_for_day(notify_api, sample_letter_template, mocker)
     ])
     mock_celery = mocker.patch('app.celery.letters_pdf_tasks.notify_celery.send_task')
 
-    collate_letter_pdfs_for_day()
+    collate_letter_pdfs_to_be_sent()
 
     assert len(mock_celery.call_args_list) == 2
     assert mock_celery.call_args_list[0] == call(
@@ -373,8 +373,8 @@ def test_collate_letter_pdfs_for_day(notify_api, sample_letter_template, mocker)
 
 
 @freeze_time('2020-02-18 02:00:00')
-def test_collate_letter_pdfs_for_day_when_run_after_midnight(notify_api, sample_letter_template, mocker):
-    # created_at times for notifications choosen to match times in above test test_collate_letter_pdfs_for_day
+def test_collate_letter_pdfs_to_be_sent_when_run_after_midnight(notify_api, sample_letter_template, mocker):
+    # created_at times for notifications choosen to match times in above test test_collate_letter_pdfs_to_be_sent
     create_notification(
         template=sample_letter_template,
         status='created',
@@ -407,7 +407,7 @@ def test_collate_letter_pdfs_for_day_when_run_after_midnight(notify_api, sample_
     ])
     mock_celery = mocker.patch('app.celery.letters_pdf_tasks.notify_celery.send_task')
 
-    collate_letter_pdfs_for_day()
+    collate_letter_pdfs_to_be_sent()
 
     assert len(mock_celery.call_args_list) == 2
     assert mock_celery.call_args_list[0] == call(

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -296,7 +296,7 @@ def test_get_key_and_size_of_letters_to_be_sent_to_print(notify_api, mocker, sam
         {'ContentLength': 3},
     ])
 
-    results = get_key_and_size_of_letters_to_be_sent_to_print('2020-02-17')
+    results = get_key_and_size_of_letters_to_be_sent_to_print(datetime.now() - timedelta(minutes=30))
 
     assert mock_s3.call_count == 3
     mock_s3.assert_has_calls(

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -343,20 +343,21 @@ def test_collate_letter_pdfs_to_be_sent(notify_api, sample_letter_template, mock
         {'ContentLength': 1},
         {'ContentLength': 3},
     ])
-    mocker.patch('app.celery.letters_pdf_tasks.group_letters', return_value=[
-        [{'Key': '2020-02-16/A.PDF', 'Size': 1}, {'Key': '2020-02-17/B.PDF', 'Size': 2}],
-        [{'Key': '2020-02-17/C.PDF', 'Size': 3}]
-    ])
+
     mock_celery = mocker.patch('app.celery.letters_pdf_tasks.notify_celery.send_task')
 
-    collate_letter_pdfs_to_be_sent()
+    with set_config_values(notify_api, {'MAX_LETTER_PDF_COUNT_PER_ZIP': 2}):
+        collate_letter_pdfs_to_be_sent()
 
     assert len(mock_celery.call_args_list) == 2
     assert mock_celery.call_args_list[0] == call(
         name='zip-and-send-letter-pdfs',
         kwargs={
-            'filenames_to_zip': ['2020-02-16/A.PDF', '2020-02-17/B.PDF'],
-            'upload_filename': 'NOTIFY.2020-02-17.001.pneY1OU2TUq7KfFSrJ2Q.ZIP'
+            'filenames_to_zip': [
+                '2020-02-16/NOTIFY.REF2.D.2.C.C.20200215180000.PDF',
+                '2020-02-17/NOTIFY.REF1.D.2.C.C.20200217150000.PDF'
+            ],
+            'upload_filename': 'NOTIFY.2020-02-17.001.k3x_WqC5KhB6e2DWv9Ma.ZIP'
         },
         queue='process-ftp-tasks',
         compression='zlib'
@@ -364,8 +365,10 @@ def test_collate_letter_pdfs_to_be_sent(notify_api, sample_letter_template, mock
     assert mock_celery.call_args_list[1] == call(
         name='zip-and-send-letter-pdfs',
         kwargs={
-            'filenames_to_zip': ['2020-02-17/C.PDF'],
-            'upload_filename': 'NOTIFY.2020-02-17.002.Wy0jBtrnVzWeGqLXhE_f.ZIP'
+            'filenames_to_zip': [
+                '2020-02-17/NOTIFY.REF0.D.2.C.C.20200217160000.PDF'
+            ],
+            'upload_filename': 'NOTIFY.2020-02-17.002.J85cUw-FWlKuAIOcwdLS.ZIP'
         },
         queue='process-ftp-tasks',
         compression='zlib'
@@ -401,20 +404,20 @@ def test_collate_letter_pdfs_to_be_sent_when_run_after_midnight(notify_api, samp
         {'ContentLength': 1},
         {'ContentLength': 3},
     ])
-    mocker.patch('app.celery.letters_pdf_tasks.group_letters', return_value=[
-        [{'Key': '2020-02-16/A.PDF', 'Size': 1}, {'Key': '2020-02-17/B.PDF', 'Size': 2}],
-        [{'Key': '2020-02-17/C.PDF', 'Size': 3}]
-    ])
     mock_celery = mocker.patch('app.celery.letters_pdf_tasks.notify_celery.send_task')
 
-    collate_letter_pdfs_to_be_sent()
+    with set_config_values(notify_api, {'MAX_LETTER_PDF_COUNT_PER_ZIP': 2}):
+        collate_letter_pdfs_to_be_sent()
 
     assert len(mock_celery.call_args_list) == 2
     assert mock_celery.call_args_list[0] == call(
         name='zip-and-send-letter-pdfs',
         kwargs={
-            'filenames_to_zip': ['2020-02-16/A.PDF', '2020-02-17/B.PDF'],
-            'upload_filename': 'NOTIFY.2020-02-17.001.pneY1OU2TUq7KfFSrJ2Q.ZIP'
+            'filenames_to_zip': [
+                '2020-02-16/NOTIFY.REF2.D.2.C.C.20200215180000.PDF',
+                '2020-02-17/NOTIFY.REF1.D.2.C.C.20200217150000.PDF'
+            ],
+            'upload_filename': 'NOTIFY.2020-02-17.001.k3x_WqC5KhB6e2DWv9Ma.ZIP'
         },
         queue='process-ftp-tasks',
         compression='zlib'
@@ -422,8 +425,10 @@ def test_collate_letter_pdfs_to_be_sent_when_run_after_midnight(notify_api, samp
     assert mock_celery.call_args_list[1] == call(
         name='zip-and-send-letter-pdfs',
         kwargs={
-            'filenames_to_zip': ['2020-02-17/C.PDF'],
-            'upload_filename': 'NOTIFY.2020-02-17.002.Wy0jBtrnVzWeGqLXhE_f.ZIP'
+            'filenames_to_zip': [
+                '2020-02-17/NOTIFY.REF0.D.2.C.C.20200217160000.PDF'
+            ],
+            'upload_filename': 'NOTIFY.2020-02-17.002.J85cUw-FWlKuAIOcwdLS.ZIP'
         },
         queue='process-ftp-tasks',
         compression='zlib'

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -335,8 +335,8 @@ def test_collate_letter_pdfs_for_day(notify_api, sample_letter_template, mocker)
         {'ContentLength': 3},
     ])
     mocker.patch('app.celery.letters_pdf_tasks.group_letters', return_value=[
-        [{'Key': '2020-02-16/A.PDF', 'Size': 1}, {'Key': '2020-02-17/B.pDf', 'Size': 2}],
-        [{'Key': '2020-02-17/C.pdf', 'Size': 3}]
+        [{'Key': '2020-02-16/A.PDF', 'Size': 1}, {'Key': '2020-02-17/B.PDF', 'Size': 2}],
+        [{'Key': '2020-02-17/C.PDF', 'Size': 3}]
     ])
     mock_celery = mocker.patch('app.celery.letters_pdf_tasks.notify_celery.send_task')
 
@@ -346,8 +346,8 @@ def test_collate_letter_pdfs_for_day(notify_api, sample_letter_template, mocker)
     assert mock_celery.call_args_list[0] == call(
         name='zip-and-send-letter-pdfs',
         kwargs={
-            'filenames_to_zip': ['2020-02-16/A.PDF', '2020-02-17/B.pDf'],
-            'upload_filename': 'NOTIFY.2020-02-17.001.fGRjtoP1V9XUrng24Zzq.ZIP'
+            'filenames_to_zip': ['2020-02-16/A.PDF', '2020-02-17/B.PDF'],
+            'upload_filename': 'NOTIFY.2020-02-17.001.pneY1OU2TUq7KfFSrJ2Q.ZIP'
         },
         queue='process-ftp-tasks',
         compression='zlib'
@@ -355,8 +355,8 @@ def test_collate_letter_pdfs_for_day(notify_api, sample_letter_template, mocker)
     assert mock_celery.call_args_list[1] == call(
         name='zip-and-send-letter-pdfs',
         kwargs={
-            'filenames_to_zip': ['2020-02-17/C.pdf'],
-            'upload_filename': 'NOTIFY.2020-02-17.002.Ay8mP80pe12NH46clM08.ZIP'
+            'filenames_to_zip': ['2020-02-17/C.PDF'],
+            'upload_filename': 'NOTIFY.2020-02-17.002.Wy0jBtrnVzWeGqLXhE_f.ZIP'
         },
         queue='process-ftp-tasks',
         compression='zlib'
@@ -393,8 +393,8 @@ def test_collate_letter_pdfs_for_day_when_run_after_midnight(notify_api, sample_
         {'ContentLength': 3},
     ])
     mocker.patch('app.celery.letters_pdf_tasks.group_letters', return_value=[
-        [{'Key': '2020-02-16/A.PDF', 'Size': 1}, {'Key': '2020-02-17/B.pDf', 'Size': 2}],
-        [{'Key': '2020-02-17/C.pdf', 'Size': 3}]
+        [{'Key': '2020-02-16/A.PDF', 'Size': 1}, {'Key': '2020-02-17/B.PDF', 'Size': 2}],
+        [{'Key': '2020-02-17/C.PDF', 'Size': 3}]
     ])
     mock_celery = mocker.patch('app.celery.letters_pdf_tasks.notify_celery.send_task')
 
@@ -404,8 +404,8 @@ def test_collate_letter_pdfs_for_day_when_run_after_midnight(notify_api, sample_
     assert mock_celery.call_args_list[0] == call(
         name='zip-and-send-letter-pdfs',
         kwargs={
-            'filenames_to_zip': ['2020-02-16/A.PDF', '2020-02-17/B.pDf'],
-            'upload_filename': 'NOTIFY.2020-02-17.001.fGRjtoP1V9XUrng24Zzq.ZIP'
+            'filenames_to_zip': ['2020-02-16/A.PDF', '2020-02-17/B.PDF'],
+            'upload_filename': 'NOTIFY.2020-02-17.001.pneY1OU2TUq7KfFSrJ2Q.ZIP'
         },
         queue='process-ftp-tasks',
         compression='zlib'
@@ -413,8 +413,8 @@ def test_collate_letter_pdfs_for_day_when_run_after_midnight(notify_api, sample_
     assert mock_celery.call_args_list[1] == call(
         name='zip-and-send-letter-pdfs',
         kwargs={
-            'filenames_to_zip': ['2020-02-17/C.pdf'],
-            'upload_filename': 'NOTIFY.2020-02-17.002.Ay8mP80pe12NH46clM08.ZIP'
+            'filenames_to_zip': ['2020-02-17/C.PDF'],
+            'upload_filename': 'NOTIFY.2020-02-17.002.Wy0jBtrnVzWeGqLXhE_f.ZIP'
         },
         queue='process-ftp-tasks',
         compression='zlib'
@@ -504,12 +504,19 @@ def test_group_letters_splits_on_file_size_and_file_count(notify_api):
         assert next(x, None) is None
 
 
-def test_group_letters_ignores_non_pdfs(notify_api, mocker):
-    letters = [{'Key': 'A.zip'}]
+@pytest.mark.parametrize('key', ["A.ZIP", "B.zip"])
+def test_group_letters_ignores_non_pdfs(key):
+    letters = [{'Key': key, 'Size': 1}]
     assert list(group_letters(letters)) == []
 
 
-def test_group_letters_with_no_letters(notify_api, mocker):
+@pytest.mark.parametrize('key', ["A.PDF", "B.pdf", "C.PdF"])
+def test_group_letters_includes_pdf_files(key):
+    letters = [{'Key': key, 'Size': 1}]
+    assert list(group_letters(letters)) == [[{'Key': key, 'Size': 1}]]
+
+
+def test_group_letters_with_no_letters():
     assert list(group_letters([])) == []
 
 

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -22,7 +22,6 @@ from app.celery.letters_pdf_tasks import (
     collate_letter_pdfs_for_day,
     get_key_and_size_of_letters_to_be_sent_to_print,
     group_letters,
-    letter_in_created_state,
     process_sanitised_letter,
     process_virus_scan_passed,
     process_virus_scan_failed,
@@ -41,7 +40,6 @@ from app.models import (
     NOTIFICATION_CREATED,
     NOTIFICATION_DELIVERED,
     NOTIFICATION_PENDING_VIRUS_CHECK,
-    NOTIFICATION_SENDING,
     NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_VALIDATION_FAILED,
     NOTIFICATION_VIRUS_SCAN_FAILED,
@@ -423,8 +421,7 @@ def test_collate_letter_pdfs_for_day_when_run_after_midnight(notify_api, sample_
     )
 
 
-def test_group_letters_splits_on_file_size(notify_api, mocker):
-    mocker.patch('app.celery.letters_pdf_tasks.letter_in_created_state', return_value=True)
+def test_group_letters_splits_on_file_size(notify_api):
     letters = [
         # ends under max but next one is too big
         {'Key': 'A.pdf', 'Size': 1}, {'Key': 'B.pdf', 'Size': 2},
@@ -450,8 +447,7 @@ def test_group_letters_splits_on_file_size(notify_api, mocker):
         assert next(x, None) is None
 
 
-def test_group_letters_splits_on_file_count(notify_api, mocker):
-    mocker.patch('app.celery.letters_pdf_tasks.letter_in_created_state', return_value=True)
+def test_group_letters_splits_on_file_count(notify_api):
     letters = [
         {'Key': 'A.pdf', 'Size': 1},
         {'Key': 'B.pdf', 'Size': 2},
@@ -474,8 +470,7 @@ def test_group_letters_splits_on_file_count(notify_api, mocker):
         assert next(x, None) is None
 
 
-def test_group_letters_splits_on_file_size_and_file_count(notify_api, mocker):
-    mocker.patch('app.celery.letters_pdf_tasks.letter_in_created_state', return_value=True)
+def test_group_letters_splits_on_file_size_and_file_count(notify_api):
     letters = [
         # ends under max file size but next file is too big
         {'Key': 'A.pdf', 'Size': 1},
@@ -510,41 +505,12 @@ def test_group_letters_splits_on_file_size_and_file_count(notify_api, mocker):
 
 
 def test_group_letters_ignores_non_pdfs(notify_api, mocker):
-    mocker.patch('app.celery.letters_pdf_tasks.letter_in_created_state', return_value=True)
     letters = [{'Key': 'A.zip'}]
     assert list(group_letters(letters)) == []
 
 
-def test_group_letters_ignores_notifications_already_sent(notify_api, mocker):
-    mock = mocker.patch('app.celery.letters_pdf_tasks.letter_in_created_state', return_value=False)
-    letters = [{'Key': 'A.pdf'}]
-    assert list(group_letters(letters)) == []
-    mock.assert_called_once_with('A.pdf')
-
-
 def test_group_letters_with_no_letters(notify_api, mocker):
-    mocker.patch('app.celery.letters_pdf_tasks.letter_in_created_state', return_value=True)
     assert list(group_letters([])) == []
-
-
-def test_letter_in_created_state(sample_notification):
-    sample_notification.reference = 'ABCDEF1234567890'
-    filename = '2018-01-13/NOTIFY.ABCDEF1234567890.D.2.C.C.20180113120000.PDF'
-
-    assert letter_in_created_state(filename) is True
-
-
-def test_letter_in_created_state_fails_if_notification_not_in_created(sample_notification):
-    sample_notification.reference = 'ABCDEF1234567890'
-    sample_notification.status = NOTIFICATION_SENDING
-    filename = '2018-01-13/NOTIFY.ABCDEF1234567890.D.2.C.C.20180113120000.PDF'
-    assert letter_in_created_state(filename) is False
-
-
-def test_letter_in_created_state_fails_if_notification_doesnt_exist(sample_notification):
-    sample_notification.reference = 'QWERTY1234567890'
-    filename = '2018-01-13/NOTIFY.ABCDEF1234567890.D.2.C.C.20180113120000.PDF'
-    assert letter_in_created_state(filename) is False
 
 
 @freeze_time('2018-01-01 18:00')

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -281,6 +281,15 @@ def test_get_key_and_size_of_letters_to_be_sent_to_print(notify_api, mocker, sam
         created_at=(datetime.now() - timedelta(minutes=1)).isoformat()
     )
 
+    # test notification we don't expect to get sent
+    create_notification(
+        template=sample_letter_template,
+        status='created',
+        reference='ref4',
+        created_at=(datetime.now() - timedelta(days=1)).isoformat(),
+        key_type=KEY_TYPE_TEST
+    )
+
     mock_s3 = mocker.patch('app.celery.tasks.s3.head_s3_object', side_effect=[
         {'ContentLength': 2},
         {'ContentLength': 1},

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -247,21 +247,21 @@ def test_get_key_and_size_of_letters_to_be_sent_to_print(notify_api, mocker, sam
         template=sample_letter_template,
         status='created',
         reference='ref0',
-        created_at=(datetime.now() - timedelta(hours=2)).isoformat()
+        created_at=(datetime.now() - timedelta(hours=2))
     )
 
     create_notification(
         template=sample_letter_template,
         status='created',
         reference='ref1',
-        created_at=(datetime.now() - timedelta(hours=3)).isoformat()
+        created_at=(datetime.now() - timedelta(hours=3))
     )
 
     create_notification(
         template=sample_letter_template,
         status='created',
         reference='ref2',
-        created_at=(datetime.now() - timedelta(days=2)).isoformat()
+        created_at=(datetime.now() - timedelta(days=2))
     )
 
     # notifications we don't expect to get sent to print as they are in the wrong status
@@ -270,7 +270,7 @@ def test_get_key_and_size_of_letters_to_be_sent_to_print(notify_api, mocker, sam
             template=sample_letter_template,
             status=status,
             reference='ref3',
-            created_at=(datetime.now() - timedelta(days=2)).isoformat()
+            created_at=(datetime.now() - timedelta(days=2))
         )
 
     # notification we don't expect to get sent as instead will make into this evenings print run
@@ -278,7 +278,7 @@ def test_get_key_and_size_of_letters_to_be_sent_to_print(notify_api, mocker, sam
         template=sample_letter_template,
         status='created',
         reference='ref4',
-        created_at=(datetime.now() - timedelta(minutes=1)).isoformat()
+        created_at=(datetime.now() - timedelta(minutes=1))
     )
 
     # test notification we don't expect to get sent
@@ -286,7 +286,7 @@ def test_get_key_and_size_of_letters_to_be_sent_to_print(notify_api, mocker, sam
         template=sample_letter_template,
         status='created',
         reference='ref4',
-        created_at=(datetime.now() - timedelta(days=1)).isoformat(),
+        created_at=(datetime.now() - timedelta(days=1)),
         key_type=KEY_TYPE_TEST
     )
 
@@ -325,21 +325,21 @@ def test_collate_letter_pdfs_to_be_sent(notify_api, sample_letter_template, mock
             template=sample_letter_template,
             status='created',
             reference='ref0',
-            created_at=(datetime.now() - timedelta(hours=2)).isoformat()
+            created_at=(datetime.now() - timedelta(hours=2))
         )
 
         create_notification(
             template=sample_letter_template,
             status='created',
             reference='ref1',
-            created_at=(datetime.now() - timedelta(hours=3)).isoformat()
+            created_at=(datetime.now() - timedelta(hours=3))
         )
 
         create_notification(
             template=sample_letter_template,
             status='created',
             reference='ref2',
-            created_at=(datetime.now() - timedelta(days=2)).isoformat()
+            created_at=(datetime.now() - timedelta(days=2))
         )
 
     mocker.patch('app.celery.tasks.s3.head_s3_object', side_effect=[


### PR DESCRIPTION
## What
https://www.pivotaltracker.com/n/projects/1443052

Previously, when running the `collate_letter_pdfs_for_day` task, we
would only send letters that were created between 5:30pm yesterday and
5:30 today.

Now we send letters that were created before 5:30pm today and that are
still waiting to be sent. This will help us automatically attempt to
send letters that may have fallen through the gaps and not been sent the
previous day when they should have been.

Previously we solved the problem of letters that had fallen the gap by
having to run the task with a date parameter for example
`collate_letter_pdfs_for_day('2020-02-18'). We no longer need this date
parameter as we will always look back across previous days too for
letters that still need sending.

Note, we have to change from using the pagination `list_objects_v2` to
instead getting each individual notification from s3. We reduce load by
using `HEAD` rather than `GET` but this will still greatly increase the
number of API calls. We acknowledge there will be a small cost to this,
say 50p for 5000 letters and think this is tolerable. Boto3 also handles
retries itself so if when making one of the many HEAD requests, there is
a networking blip then it should be retried automatically for us.

## How to test locally
Make sure you have sent a letter before 5:30pm that exists in the `development-letters-pdf` bucket for yesterdays print run.
Make sure you have sent a letter before 5:30pm that exists in  `development-letters-pdf` bucket for the print run 2 days ago.

Note, you can likely set this up by uploading two letters today. And then:
- change their created at date in your database
- move the file in the s3 bucket to the relevant days sending folder
- change the filename of the file you are moving in s3 to match your new created_at timestamp

```
source environment.sh
flask shell
from app.celery.letters_pdf_tasks import collate_letter_pdfs_for_day
collate_letter_pdfs_for_day()
```