### PR TITLE
remove error log from dao_utils

### DIFF
--- a/app/dao/dao_utils.py
+++ b/app/dao/dao_utils.py
@@ -8,13 +8,11 @@ from app.history_meta import create_history
 def transactional(func):
     @wraps(func)
     def commit_or_rollback(*args, **kwargs):
-        from flask import current_app
         try:
             res = func(*args, **kwargs)
             db.session.commit()
             return res
-        except Exception as e:
-            current_app.logger.error(e)
+        except Exception:
             db.session.rollback()
             raise
     return commit_or_rollback


### PR DESCRIPTION
we don't need it here - as exceptions are re-raised, they will be logged additionally by error handlers further up. All this exception logger tells us is that service names are already in use, which isn't something we're really interested in.