### PR TITLE
Give new services the upload letters permission

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -48,6 +48,7 @@ from app.models import (
     NOTIFICATION_PERMANENT_FAILURE,
     SMS_TYPE,
     LETTER_TYPE,
+    UPLOAD_LETTERS,
 )
 from app.utils import email_address_is_nhs, escape_special_characters, get_london_midnight_in_utc, midnight_n_days_ago
 
@@ -56,6 +57,7 @@ DEFAULT_SERVICE_PERMISSIONS = [
     EMAIL_TYPE,
     LETTER_TYPE,
     INTERNATIONAL_SMS_TYPE,
+    UPLOAD_LETTERS,
 ]
 
 

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -37,6 +37,7 @@ from app.dao.services_dao import (dao_add_user_to_service, dao_create_service,
 from app.dao.users_dao import create_user_code, save_model_user
 from app.models import (EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, KEY_TYPE_NORMAL,
                         KEY_TYPE_TEAM, KEY_TYPE_TEST, LETTER_TYPE, SMS_TYPE,
+                        UPLOAD_LETTERS,
                         ApiKey, InvitedUser, Job, Notification,
                         NotificationHistory, Organisation, Permission, Service,
                         ServicePermission, ServiceUser, Template,
@@ -488,16 +489,16 @@ def test_create_service_returns_service_with_default_permissions(notify_db_sessi
 
     service = dao_fetch_service_by_id(service.id)
     _assert_service_permissions(service.permissions, (
-        SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE,
+        SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS
     ))
 
 
 @pytest.mark.parametrize("permission_to_remove, permissions_remaining", [
     (SMS_TYPE, (
-        EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE,
+        EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS,
     )),
     (EMAIL_TYPE, (
-        SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE,
+        SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS,
     )),
 ])
 def test_remove_permission_from_service_by_id_returns_service_with_correct_permissions(
@@ -529,14 +530,14 @@ def test_create_service_by_id_adding_and_removing_letter_returns_service_without
 
     service = dao_fetch_service_by_id(service.id)
     _assert_service_permissions(service.permissions, (
-        SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE,
+        SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS,
     ))
 
     dao_remove_service_permission(service_id=service.id, permission=LETTER_TYPE)
     service = dao_fetch_service_by_id(service.id)
 
     _assert_service_permissions(service.permissions, (
-        SMS_TYPE, EMAIL_TYPE, INTERNATIONAL_SMS_TYPE,
+        SMS_TYPE, EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS,
     ))
 
 
@@ -671,7 +672,7 @@ def test_delete_service_and_associated_objects(notify_db_session):
     create_invited_user(service=service)
 
     assert ServicePermission.query.count() == len((
-        SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE,
+        SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS,
     ))
 
     delete_service_and_all_associated_db_objects(service)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -27,7 +27,7 @@ from app.models import (
     KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST,
     EMAIL_TYPE, SMS_TYPE, LETTER_TYPE,
     INTERNATIONAL_SMS_TYPE, INBOUND_SMS_TYPE,
-    NOTIFICATION_RETURNED_LETTER
+    NOTIFICATION_RETURNED_LETTER, UPLOAD_LETTERS,
 )
 from tests import create_authorization_header
 from tests.app.db import (
@@ -255,7 +255,7 @@ def test_get_service_list_has_default_permissions(admin_request, service_factory
         set(
             json['permissions']
         ) == set([
-            EMAIL_TYPE, SMS_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE,
+            EMAIL_TYPE, SMS_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE, UPLOAD_LETTERS,
         ])
         for json in json_resp['data']
     )
@@ -267,7 +267,7 @@ def test_get_service_by_id_has_default_service_permissions(admin_request, sample
     assert set(
         json_resp['data']['permissions']
     ) == set([
-        EMAIL_TYPE, SMS_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE,
+        EMAIL_TYPE, SMS_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE, UPLOAD_LETTERS,
     ])
 
 


### PR DESCRIPTION
This will switch on this feature for new services.

After this we will:
- give existing services this permission with a database migration
- remove this permission from the codebase entirely so that everyone has this feature and can’t switch it off