### PR TITLE
Give existing services upload letters permission

### DIFF
--- a/migrations/versions/0317_uploads_for_all.py
+++ b/migrations/versions/0317_uploads_for_all.py
@@ -1,0 +1,41 @@
+"""
+
+Revision ID: 0317_uploads_for_all
+Revises: 0316_int_letters_permission
+Create Date: 2019-05-13 10:44:51.867661
+
+"""
+from alembic import op
+from app.models import UPLOAD_LETTERS
+
+
+revision = '0317_uploads_for_all'
+down_revision = '0316_int_letters_permission'
+
+
+def upgrade():
+    op.execute("""
+        INSERT INTO
+            service_permissions (service_id, permission, created_at)
+        SELECT
+            id, '{permission}', now()
+        FROM
+            services
+        WHERE
+            NOT EXISTS (
+                SELECT
+                FROM
+                    service_permissions
+                WHERE
+                    service_id = services.id and
+                    permission = '{permission}'
+           )
+    """.format(
+        permission=UPLOAD_LETTERS
+    ))
+
+
+def downgrade():
+    op.execute("DELETE from service_permissions where permission = '{}'".format(
+        UPLOAD_LETTERS
+    ))


### PR DESCRIPTION
This gives the feature to all existing users.

Depends on: 
- [x] https://github.com/alphagov/notifications-api/pull/2726

After this we will:
- remove this permission from the codebase entirely so that everyone has this feature and can’t switch it off