### PR TITLE
All services can send files by email if they have set contact_link

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -89,10 +89,12 @@ def check_service_has_permission(notify_type, permissions):
         ))
 
 
-def check_if_service_can_send_files_by_email(service_contact_link):
+def check_if_service_can_send_files_by_email(service_contact_link, service_id):
     if not service_contact_link:
+
         raise BadRequestError(
-            message="Send files by email has not been set up. Go to your Settings page to manage Send files by email."
+            message=f"Send files by email has not been set up - add contact details for your service at "
+                    f"{current_app.config['ADMIN_BASE_URL']}/services/{service_id}/service-settings/send-files-by-email"
         )
 
 

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -91,7 +91,9 @@ def check_service_has_permission(notify_type, permissions):
 
 def check_if_service_can_send_files_by_email(service_contact_link):
     if not service_contact_link:
-        raise BadRequestError(message="Go to Service Settings to turn on sending files by email")
+        raise BadRequestError(
+            message="Send files by email is not set up yet. Go to your settings page to manage send files by email"
+        )
 
 
 def check_service_can_schedule_notification(permissions, scheduled_for):

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -92,7 +92,7 @@ def check_service_has_permission(notify_type, permissions):
 def check_if_service_can_send_files_by_email(service_contact_link):
     if not service_contact_link:
         raise BadRequestError(
-            message="Send files by email is not set up yet. Go to your settings page to manage send files by email"
+            message="Send files by email has not been set up. Go to your Settings page to manage Send files by email."
         )
 
 

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -85,7 +85,13 @@ def service_has_permission(notify_type, permissions):
 def check_service_has_permission(notify_type, permissions):
     if not service_has_permission(notify_type, permissions):
         raise BadRequestError(message="Service is not allowed to send {}".format(
-            get_public_notify_type_text(notify_type, plural=True)))
+            get_public_notify_type_text(notify_type, plural=True)
+        ))
+
+
+def check_if_service_can_send_files_by_email(service_contact_link):
+    if not service_contact_link:
+        raise BadRequestError(message="Go to Service Settings to turn on sending files by email")
 
 
 def check_service_can_schedule_notification(permissions, scheduled_for):

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -16,7 +16,6 @@ from app.models import (
     SMS_TYPE,
     EMAIL_TYPE,
     LETTER_TYPE,
-    UPLOAD_DOCUMENT,
     PRIORITY,
     KEY_TYPE_TEST,
     KEY_TYPE_TEAM,
@@ -35,13 +34,14 @@ from app.notifications.process_notifications import (
     simulated_recipient
 )
 from app.notifications.validators import (
-    validate_and_format_recipient,
+    check_if_service_can_send_files_by_email,
     check_rate_limiting,
     check_service_can_schedule_notification,
-    check_service_has_permission,
-    validate_template,
     check_service_email_reply_to_id,
-    check_service_sms_sender_id
+    check_service_has_permission,
+    check_service_sms_sender_id,
+    validate_and_format_recipient,
+    validate_template,
 )
 from app.schema_validation import validate
 from app.v2.errors import BadRequestError
@@ -235,7 +235,7 @@ def process_document_uploads(personalisation_data, service, simulated=False):
 
     personalisation_data = personalisation_data.copy()
 
-    check_service_has_permission(UPLOAD_DOCUMENT, authenticated_service.permissions)
+    check_if_service_can_send_files_by_email(authenticated_service.contact_link)
 
     for key in file_keys:
         if simulated:

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -235,7 +235,10 @@ def process_document_uploads(personalisation_data, service, simulated=False):
 
     personalisation_data = personalisation_data.copy()
 
-    check_if_service_can_send_files_by_email(authenticated_service.contact_link)
+    check_if_service_can_send_files_by_email(
+        service_contact_link=authenticated_service.contact_link,
+        service_id=authenticated_service.id
+    )
 
     for key in file_keys:
         if simulated:

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -534,8 +534,10 @@ def test_check_reply_to_letter_type(sample_service):
 def test_check_if_service_can_send_files_by_email_raises_if_no_contact_link_set(sample_service):
     with pytest.raises(BadRequestError) as e:
         check_if_service_can_send_files_by_email(sample_service.contact_link)
+
+    expected_message = "Send files by email is not set up yet. Go to your settings page to manage send files by email"
     assert e.value.status_code == 400
-    assert e.value.message == "Go to Service Settings to turn on sending files by email"
+    assert e.value.message == expected_message
 
 
 def test_check_if_service_can_send_files_by_email_passes_if_contact_link_set(sample_service):

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -533,13 +533,20 @@ def test_check_reply_to_letter_type(sample_service):
 
 def test_check_if_service_can_send_files_by_email_raises_if_no_contact_link_set(sample_service):
     with pytest.raises(BadRequestError) as e:
-        check_if_service_can_send_files_by_email(sample_service.contact_link)
+        check_if_service_can_send_files_by_email(
+            service_contact_link=sample_service.contact_link,
+            service_id=sample_service.id
+        )
 
-    message = "Send files by email has not been set up. Go to your Settings page to manage Send files by email."
+    message = f"Send files by email has not been set up - add contact details for your service at " \
+              f"http://localhost:6012/services/{sample_service.id}/service-settings/send-files-by-email"
     assert e.value.status_code == 400
     assert e.value.message == message
 
 
 def test_check_if_service_can_send_files_by_email_passes_if_contact_link_set(sample_service):
     sample_service.contact_link = 'contact.me@gov.uk'
-    check_if_service_can_send_files_by_email(sample_service.contact_link)
+    check_if_service_can_send_files_by_email(
+        service_contact_link=sample_service.contact_link,
+        service_id=sample_service.id
+    )

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -8,6 +8,7 @@ from app.dao import templates_dao
 from app.models import SMS_TYPE, EMAIL_TYPE, LETTER_TYPE
 from app.notifications.process_notifications import create_content_for_notification
 from app.notifications.validators import (
+    check_if_service_can_send_files_by_email,
     check_notification_content_is_not_empty,
     check_service_over_daily_message_limit,
     check_template_is_for_notification_type,
@@ -528,3 +529,15 @@ def test_check_reply_to_sms_type(sample_service):
 def test_check_reply_to_letter_type(sample_service):
     letter_contact = create_letter_contact(service=sample_service, contact_block='123456')
     assert check_reply_to(sample_service.id, letter_contact.id, LETTER_TYPE) == '123456'
+
+
+def test_check_if_service_can_send_files_by_email_raises_if_no_contact_link_set(sample_service):
+    with pytest.raises(BadRequestError) as e:
+        check_if_service_can_send_files_by_email(sample_service.contact_link)
+    assert e.value.status_code == 400
+    assert e.value.message == "Go to Service Settings to turn on sending files by email"
+
+
+def test_check_if_service_can_send_files_by_email_passes_if_contact_link_set(sample_service):
+    sample_service.contact_link = 'contact.me@gov.uk'
+    check_if_service_can_send_files_by_email(sample_service.contact_link)

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -535,9 +535,9 @@ def test_check_if_service_can_send_files_by_email_raises_if_no_contact_link_set(
     with pytest.raises(BadRequestError) as e:
         check_if_service_can_send_files_by_email(sample_service.contact_link)
 
-    expected_message = "Send files by email is not set up yet. Go to your settings page to manage send files by email"
+    message = "Send files by email has not been set up. Go to your Settings page to manage Send files by email."
     assert e.value.status_code == 400
-    assert e.value.message == expected_message
+    assert e.value.message == message
 
 
 def test_check_if_service_can_send_files_by_email_passes_if_contact_link_set(sample_service):

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -11,7 +11,6 @@ from app.models import (
     NOTIFICATION_CREATED,
     SCHEDULE_NOTIFICATIONS,
     SMS_TYPE,
-    UPLOAD_DOCUMENT,
     INTERNATIONAL_SMS_TYPE
 )
 from flask import json, current_app
@@ -775,7 +774,8 @@ def test_post_email_notification_with_archived_reply_to_id_returns_400(client, s
 
 
 def test_post_notification_with_document_upload(client, notify_db_session, mocker):
-    service = create_service(service_permissions=[EMAIL_TYPE, UPLOAD_DOCUMENT])
+    service = create_service(service_permissions=[EMAIL_TYPE])
+    service.contact_link = 'contact.me@gov.uk'
     template = create_template(
         service=service,
         template_type='email',
@@ -822,7 +822,8 @@ def test_post_notification_with_document_upload(client, notify_db_session, mocke
 
 
 def test_post_notification_with_document_upload_simulated(client, notify_db_session, mocker):
-    service = create_service(service_permissions=[EMAIL_TYPE, UPLOAD_DOCUMENT])
+    service = create_service(service_permissions=[EMAIL_TYPE])
+    service.contact_link = 'contact.me@gov.uk'
     template = create_template(
         service=service,
         template_type='email',


### PR DESCRIPTION
This PR changes validation away from `upload_document` service permission and towards checking if service has provided contact details for the feature.

Connected to PR: https://github.com/alphagov/notifications-admin/pull/3307 (they should go out around the same time)

Story ticket: https://www.pivotaltracker.com/story/show/171254127