### PR TITLE
Return recipient for letter uploads

### DIFF
--- a/app/dao/uploads_dao.py
+++ b/app/dao/uploads_dao.py
@@ -30,7 +30,8 @@ def dao_get_uploads_by_service_id(service_id, limit_days=None, page=1, page_size
         Job.scheduled_for.label("scheduled_for"),
         Job.processing_started.label('processing_started'),
         Job.job_status.label("status"),
-        literal('job').label('upload_type')
+        literal('job').label('upload_type'),
+        literal(None).label('recipient'),
     ).join(
         Template, Job.template_id == Template.id
     ).filter(
@@ -58,7 +59,8 @@ def dao_get_uploads_by_service_id(service_id, limit_days=None, page=1, page_size
         # letters don't have a processing_started date but we want created_at to be used for sorting
         Notification.created_at.label('processing_started'),
         Notification.status,
-        literal('letter').label('upload_type')
+        literal('letter').label('upload_type'),
+        Notification.to.label('recipient'),
     ).join(
         Template, Notification.template_id == Template.id
     ).filter(

--- a/app/upload/rest.py
+++ b/app/upload/rest.py
@@ -44,7 +44,7 @@ def get_paginated_uploads(service_id, limit_days, page):
             'created_at': upload.scheduled_for.strftime(
                 "%Y-%m-%d %H:%M:%S") if upload.scheduled_for else upload.created_at.strftime("%Y-%m-%d %H:%M:%S"),
             'upload_type': upload.upload_type,
-            'template_type': None,
+            'template_type': upload.template_type,
             'recipient': upload.recipient,
         }
         if upload.upload_type == 'job':
@@ -60,7 +60,6 @@ def get_paginated_uploads(service_id, limit_days, page):
                 statistics = dao_get_notification_outcomes_for_job(service_id, upload.id)
             upload_dict['statistics'] = [{'status': statistic.status, 'count': statistic.count} for statistic in
                                          statistics]
-            upload_dict['template_type'] = upload.template_type
         else:
             upload_dict['statistics'] = [{'status': upload.status, 'count': 1}]
         data.append(upload_dict)

--- a/app/upload/rest.py
+++ b/app/upload/rest.py
@@ -45,6 +45,7 @@ def get_paginated_uploads(service_id, limit_days, page):
                 "%Y-%m-%d %H:%M:%S") if upload.scheduled_for else upload.created_at.strftime("%Y-%m-%d %H:%M:%S"),
             'upload_type': upload.upload_type,
             'template_type': None,
+            'recipient': upload.recipient,
         }
         if upload.upload_type == 'job':
             start = upload.processing_started

--- a/tests/app/dao/test_uploads_dao.py
+++ b/tests/app/dao/test_uploads_dao.py
@@ -56,6 +56,7 @@ def test_get_uploads_for_service(sample_template):
         letter.created_at,
         letter.status,
         "letter",
+        "file-name",
     )
     assert uploads_from_db[1] == (
         job.id,
@@ -67,6 +68,7 @@ def test_get_uploads_for_service(sample_template):
         job.processing_started,
         job.job_status,
         "job",
+        None,
     )
 
     assert len(other_uploads_from_db) == 2
@@ -78,7 +80,8 @@ def test_get_uploads_for_service(sample_template):
                                         None,
                                         other_letter.created_at,
                                         other_letter.status,
-                                        "letter")
+                                        "letter",
+                                        "file-name")
     assert other_uploads_from_db[1] == (other_job.id,
                                         other_job.original_file_name,
                                         other_job.notification_count,
@@ -86,7 +89,9 @@ def test_get_uploads_for_service(sample_template):
                                         other_job.created_at,
                                         other_job.scheduled_for,
                                         other_job.processing_started,
-                                        other_job.job_status, "job")
+                                        other_job.job_status,
+                                        "job",
+                                        None)
 
     assert uploads_from_db[0] != other_uploads_from_db[0]
     assert uploads_from_db[1] != other_uploads_from_db[1]

--- a/tests/app/upload/test_rest.py
+++ b/tests/app/upload/test_rest.py
@@ -10,7 +10,7 @@ from tests.conftest import set_config
 def create_uploaded_letter(letter_template, service, status='created', created_at=None):
     return create_notification(
         template=letter_template,
-        to_field="file-name",
+        to_field="742 Evergreen Terrace",
         status=status,
         reference="dvla-reference",
         client_reference="file-name",
@@ -55,6 +55,7 @@ def test_get_uploads(admin_request, sample_template):
     assert len(data) == 5
     assert data[0] == {'id': str(upload_5.id),
                        'original_file_name': 'some.csv',
+                       'recipient': None,
                        'notification_count': 10,
                        'template_type': 'sms',
                        'created_at': upload_5.created_at.strftime("%Y-%m-%d %H:%M:%S"),
@@ -62,6 +63,7 @@ def test_get_uploads(admin_request, sample_template):
                        'upload_type': 'job'}
     assert data[1] == {'id': str(upload_4.id),
                        'original_file_name': 'some.csv',
+                       'recipient': None,
                        'notification_count': 1,
                        'template_type': 'sms',
                        'created_at': upload_4.created_at.strftime(
@@ -70,6 +72,7 @@ def test_get_uploads(admin_request, sample_template):
                        'upload_type': 'job'}
     assert data[2] == {'id': str(upload_3.id),
                        'original_file_name': "file-name",
+                       'recipient': '742 Evergreen Terrace',
                        'notification_count': 1,
                        'template_type': None,
                        'created_at': upload_3.created_at.strftime("%Y-%m-%d %H:%M:%S"),
@@ -77,6 +80,7 @@ def test_get_uploads(admin_request, sample_template):
                        'upload_type': 'letter'}
     assert data[3] == {'id': str(upload_2.id),
                        'original_file_name': "some.csv",
+                       'recipient': None,
                        'notification_count': 1,
                        'template_type': 'sms',
                        'created_at': upload_2.created_at.strftime(
@@ -85,6 +89,7 @@ def test_get_uploads(admin_request, sample_template):
                        'upload_type': 'job'}
     assert data[4] == {'id': str(upload_1.id),
                        'original_file_name': "file-name",
+                       'recipient': '742 Evergreen Terrace',
                        'notification_count': 1,
                        'template_type': None,
                        'created_at': upload_1.created_at.strftime("%Y-%m-%d %H:%M:%S"),


### PR DESCRIPTION
If your caseworking system always spits out files with the same name it will be hard to differentiate them when looking at the uploads page.

Seeing who the letter was sent to will help you differentiate them.

We can’t do this until the API returns the recipient.