### PR TITLE
Fix bug on organisation-usage page.

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -554,7 +554,8 @@ def fetch_letter_costs_for_organisation(organisation_id, start_date, end_date):
         FactBilling.bst_date >= start_date,
         FactBilling.bst_date <= end_date,
         FactBilling.notification_type == LETTER_TYPE,
-        Service.organisation_id == organisation_id
+        Service.organisation_id == organisation_id,
+        Service.restricted.is_(False)
     ).group_by(
         Service.id,
         Service.name,
@@ -579,7 +580,8 @@ def fetch_email_usage_for_organisation(organisation_id, start_date, end_date):
         FactBilling.bst_date >= start_date,
         FactBilling.bst_date <= end_date,
         FactBilling.notification_type == EMAIL_TYPE,
-        Service.organisation_id == organisation_id
+        Service.organisation_id == organisation_id,
+        Service.restricted.is_(False)
     ).group_by(
         Service.id,
         Service.name,
@@ -621,7 +623,8 @@ def fetch_sms_billing_for_organisation(organisation_id, start_date, end_date):
         FactBilling.bst_date >= start_date,
         FactBilling.bst_date <= end_date,
         FactBilling.notification_type == SMS_TYPE,
-        Service.organisation_id == organisation_id
+        Service.organisation_id == organisation_id,
+        Service.restricted.is_(False)
     ).group_by(
         Service.id,
         Service.name,

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -71,7 +71,7 @@ def persist_notification(
     billable_units=None,
     postage=None,
     template_postage=None,
-    document_download_count=None,
+    document_download_count=None
 ):
     notification_created_at = created_at or datetime.utcnow()
     if not notification_id:


### PR DESCRIPTION
The dict is initialised for all live services, but if the organisation has trial mode services they cause a key error.