### PR TITLE
Add a filter to exclude services that do not count_as_live

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -555,7 +555,8 @@ def fetch_letter_costs_for_organisation(organisation_id, start_date, end_date):
         FactBilling.bst_date <= end_date,
         FactBilling.notification_type == LETTER_TYPE,
         Service.organisation_id == organisation_id,
-        Service.restricted.is_(False)
+        Service.restricted.is_(False),
+        Service.count_as_live.is_(True)
     ).group_by(
         Service.id,
         Service.name,
@@ -581,7 +582,8 @@ def fetch_email_usage_for_organisation(organisation_id, start_date, end_date):
         FactBilling.bst_date <= end_date,
         FactBilling.notification_type == EMAIL_TYPE,
         Service.organisation_id == organisation_id,
-        Service.restricted.is_(False)
+        Service.restricted.is_(False),
+        Service.count_as_live.is_(True)
     ).group_by(
         Service.id,
         Service.name,
@@ -624,7 +626,8 @@ def fetch_sms_billing_for_organisation(organisation_id, start_date, end_date):
         FactBilling.bst_date <= end_date,
         FactBilling.notification_type == SMS_TYPE,
         Service.organisation_id == organisation_id,
-        Service.restricted.is_(False)
+        Service.restricted.is_(False),
+        Service.count_as_live.is_(True)
     ).group_by(
         Service.id,
         Service.name,

--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -34,8 +34,9 @@ def dao_get_organisation_services(organisation_id):
 def dao_get_organisation_live_services(organisation_id):
     return Service.query.filter_by(
         organisation_id=organisation_id,
-        restricted=False
-    ).all()
+        restricted=False,
+        count_as_live=True
+    ).order_by(Service.name).all()
 
 
 def dao_get_organisation_by_id(organisation_id):

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -709,3 +709,34 @@ def test_fetch_usage_year_for_organisation_only_returns_data_for_live_services(n
     assert len(results) == 1
     assert results[str(live_service.id)]['sms_billable_units'] == 19
     assert results[str(live_service.id)]['emails_sent'] == 0
+
+
+@freeze_time('2020-02-27 13:30')
+def test_fetch_usage_year_for_organisation_does_not_return_data_for_service_where_count_as_live_is_false(
+        notify_db_session
+):
+    org = create_organisation(name='Organisation without live services')
+    live_service = create_service(restricted=False)
+    sms_template = create_template(service=live_service)
+    dont_count_as_live_service = create_service(
+        service_name='count_as_live_is_false', restricted=False, count_as_live=False
+    )
+    email_template = create_template(service=dont_count_as_live_service, template_type='email')
+    trial_sms_template = create_template(service=dont_count_as_live_service, template_type='sms')
+    trial_letter_template = create_template(service=dont_count_as_live_service, template_type='letter')
+    dao_add_service_to_organisation(service=live_service, organisation_id=org.id)
+    dao_add_service_to_organisation(service=dont_count_as_live_service, organisation_id=org.id)
+    create_ft_billing(bst_date=datetime.utcnow().date(), template=sms_template, rate=0.0158,
+                      billable_unit=19, notifications_sent=19)
+    create_ft_billing(bst_date=datetime.utcnow().date(), template=email_template, billable_unit=0,
+                      notifications_sent=100)
+    create_ft_billing(bst_date=datetime.utcnow().date(), template=trial_sms_template, billable_unit=200, rate=0.0158,
+                      notifications_sent=100)
+    create_ft_billing(bst_date=datetime.utcnow().date(), template=trial_letter_template, billable_unit=40, rate=0.30,
+                      notifications_sent=20)
+
+    results = fetch_usage_year_for_organisation(organisation_id=org.id, year=2019)
+
+    assert len(results) == 1
+    assert results[str(live_service.id)]['sms_billable_units'] == 19
+    assert results[str(live_service.id)]['emails_sent'] == 0


### PR DESCRIPTION
This will exclude any test services, this query is used for the organistion usage page.