### PR TITLE
Remove check on permission to upload letters

### DIFF
--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -26,7 +26,6 @@ from app.models import (
     EMAIL_TYPE,
     LETTER_TYPE,
     NOTIFICATION_DELIVERED,
-    UPLOAD_LETTERS,
 )
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.templates_dao import dao_get_template_by_id_and_service_id, get_precompiled_letter_template
@@ -139,7 +138,6 @@ def send_pdf_letter_notification(service_id, post_data):
     service = dao_fetch_service_by_id(service_id)
 
     check_service_has_permission(LETTER_TYPE, service.permissions)
-    check_service_has_permission(UPLOAD_LETTERS, service.permissions)
     check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
     validate_created_by(service, post_data['created_by'])
     validate_and_format_recipient(

--- a/tests/app/service/test_send_pdf_letter_notification.py
+++ b/tests/app/service/test_send_pdf_letter_notification.py
@@ -13,7 +13,6 @@ from tests.app.db import create_service
 
 @pytest.mark.parametrize('permissions', [
     [EMAIL_TYPE],
-    [LETTER_TYPE],
     [UPLOAD_LETTERS],
 ])
 def test_send_pdf_letter_notification_raises_error_if_service_does_not_have_permission(


### PR DESCRIPTION
Soon enough every service will have this permission, and they won’t be able to switch it off. So we should clean up our codebase and make it so there’s no dependancy on a row existing in the permissions table.

This is the first step of that process for the API. Before we can remove it, we have to stop checking from it. Next step will be to stop inserting the permission, then finally remove it from the database.

We can actually ship this before #2726 and #2727 if we want to, the order doesn’t really matter. 