### PR TITLE
Remove unused statsd_prefix variable

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -80,9 +80,6 @@ class Config(object):
     # Firetext API Key
     FIRETEXT_API_KEY = os.getenv("FIRETEXT_API_KEY")
 
-    # Hosted graphite statsd prefix
-    STATSD_PREFIX = os.getenv('STATSD_PREFIX')
-
     # Prefix to identify queues in SQS
     NOTIFICATION_QUEUE_PREFIX = os.getenv('NOTIFICATION_QUEUE_PREFIX')
 

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -9,7 +9,6 @@ worker_connections = 256
 errorlog = "/home/vcap/logs/gunicorn_error.log"
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
-statsd_prefix = os.getenv("STATSD_PREFIX")
 gunicorn.SERVER_SOFTWARE = 'None'
 
 

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -90,7 +90,6 @@ applications:
       AWS_SECRET_ACCESS_KEY: '{{ AWS_SECRET_ACCESS_KEY }}'
 
       STATSD_HOST: "notify-statsd-exporter-{{ environment }}.apps.internal"
-      STATSD_PREFIX: ""
 
       ZENDESK_API_KEY: '{{ ZENDESK_API_KEY }}'
 


### PR DESCRIPTION
We moved from sending statsd metrics to hosted graphite to sending to
one that is running on the paas. Therefore we no longer need to send
statsd metrics to a particular prefix at the statsd app as it is only
receiving statsd metrics from our apps (not other users like would have
been the case with HostedGraphite).

This should change no behaviour as the only place the environment
variable was being used was in the gunicorn config and it was an empty
string which is the default behaviour anyway as per:
https://docs.gunicorn.org/en/stable/settings.html#statsd-prefix

Will test by deploying to preview and then checking metrics are being sent to statsd OK and no errors in logs