### PR TITLE
Let the Notify team invite people to an organisation

### DIFF
--- a/app/organisation/invite_rest.py
+++ b/app/organisation/invite_rest.py
@@ -48,7 +48,11 @@ def invite_user_to_org(organisation_id):
         recipient=invited_org_user.email_address,
         service=template.service,
         personalisation={
-            'user_name': invited_org_user.invited_by.name,
+            'user_name': (
+                'The GOV.UK Notify team'
+                if invited_org_user.invited_by.platform_admin
+                else invited_org_user.invited_by.name
+            ),
             'organisation_name': invited_org_user.organisation.name,
             'url': invited_org_user_url(
                 invited_org_user.id,


### PR DESCRIPTION
We want to start granting access to the org page. But it will be a bit weird if the invites come from us personally, since the people we’re inviting don’t know us.

It makes more sense, and sounds more official if the invites appear to come from the ‘GOV.UK Notify team’ instead.

***

How this will look in the email: 

![image](https://user-images.githubusercontent.com/355079/75982131-c7238a80-5edd-11ea-85dd-7b76b0f1def4.png)
