### PR TITLE
Update validators to use is_message_too_long()

### DIFF
--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -125,10 +125,12 @@ def requires_auth():
         g.service_id = api_key.service_id
         _request_ctx_stack.top.authenticated_service = service
         _request_ctx_stack.top.api_user = api_key
-        current_app.logger.info('API authorised for service {} with api key {}, using issuer {}'.format(
+
+        current_app.logger.info('API authorised for service {} with api key {}, using issuer {} for URL: {}'.format(
             service.id,
             api_key.id,
-            request.headers.get('User-Agent')
+            request.headers.get('User-Agent'),
+            request.base_url
         ))
         return
     else:

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -124,9 +124,10 @@ def validate_and_format_recipient(send_to, key_type, service, notification_type,
         return validate_and_format_email_address(email_address=send_to)
 
 
-def check_sms_content_char_count(content_count):
-    if content_count > SMS_CHAR_COUNT_LIMIT:
-        message = 'Content for template has a character count greater than the limit of {}'.format(SMS_CHAR_COUNT_LIMIT)
+def check_content_char_count(template_with_content):
+    if template_with_content.is_message_too_long():
+        message = f"Text messages cannot be longer than {SMS_CHAR_COUNT_LIMIT} characters. " \
+                  f"Your message is {template_with_content.content_count_without_prefix} characters"
         raise BadRequestError(message=message)
 
 
@@ -151,9 +152,10 @@ def validate_template(template_id, personalisation, service, notification_type):
     check_template_is_active(template)
 
     template_with_content = create_content_for_notification(template, personalisation)
+
     check_notification_content_is_not_empty(template_with_content)
-    if template.template_type == SMS_TYPE:
-        check_sms_content_char_count(template_with_content.content_count)
+
+    check_content_char_count(template_with_content)
 
     return template, template_with_content
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -27,4 +27,4 @@ notifications-python-client==5.5.1
 awscli-cwlogs>=1.4,<1.5
 
 
-git+https://github.com/alphagov/notifications-utils.git@36.6.1#egg=notifications-utils==36.6.1
+git+https://github.com/alphagov/notifications-utils.git@36.6.2#egg=notifications-utils==36.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ notifications-python-client==5.5.1
 awscli-cwlogs>=1.4,<1.5
 
 
-git+https://github.com/alphagov/notifications-utils.git@36.6.1#egg=notifications-utils==36.6.1
+git+https://github.com/alphagov/notifications-utils.git@36.6.2#egg=notifications-utils==36.6.2
 
 ## The following requirements were added by pip freeze:
 alembic==1.4.1

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -99,8 +99,8 @@ def test_send_notification_invalid_template_id(notify_api, sample_template, mock
 
             json_resp = json.loads(response.get_data(as_text=True))
             mocked.assert_not_called()
-            assert response.status_code == 404
-            test_string = 'No result found'
+            assert response.status_code == 400
+            test_string = 'Template not found'
             assert test_string in json_resp['message']
 
 
@@ -315,8 +315,8 @@ def test_should_not_allow_template_from_another_service(notify_api,
 
             json_resp = json.loads(response.get_data(as_text=True))
             mocked.assert_not_called()
-            assert response.status_code == 404
-            test_string = 'No result found'
+            assert response.status_code == 400
+            test_string = 'Template not found'
             assert test_string in json_resp['message']
 
 

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -294,8 +294,8 @@ def test_send_one_off_notification_raises_if_message_too_long(persist_mock, noti
     with pytest.raises(BadRequestError) as e:
         send_one_off_notification(service.id, post_data)
 
-    assert e.value.message == 'Content for template has a character count greater than the limit of {}'.format(
-        SMS_CHAR_COUNT_LIMIT)
+    assert e.value.message == f'Text messages cannot be longer than {SMS_CHAR_COUNT_LIMIT} characters. ' \
+                              f'Your message is {729} characters'
 
 
 def test_send_one_off_notification_fails_if_created_by_other_service(sample_template):


### PR DESCRIPTION
- update check_sms_content_char_count to use the SMSTemplate.is_message_too_long function, and updated the error message to align with the message returned by the admin app.
- Update the the code used by version 1 of the api to use the validate_template method.
  - I did find a couple of services still using the old api, however, this change should not affect them as I checked the messages being sent and they are not too long.
  - We will be sending a message to them to see if they can upgrade.
- Update the log message for authenication to include the URL - makes it easier to track if a service is using version 1 of the api.