### PR TITLE
Only add overlay for pages which are invalid for precompiled letters uploaded via the API

### DIFF
--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -248,12 +248,9 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
         page_number = page if page else "1"
         content = base64.b64encode(pdf_file).decode('utf-8')
         content_outside_printable_area = metadata.get("message") == "content-outside-printable-area"
+        page_is_in_invalid_pages = page_number in metadata.get('invalid_pages', '[]')
 
-        show_overlay_for_page = False
-        if content_outside_printable_area and page_number in metadata.get('invalid_pages', '[]'):
-            show_overlay_for_page = True
-
-        if show_overlay_for_page or (content_outside_printable_area and file_type == "pdf"):
+        if content_outside_printable_area and (file_type == "pdf" or page_is_in_invalid_pages):
             path = '/precompiled/overlay.{}'.format(file_type)
             query_string = '?page_number={}'.format(page_number) if file_type == 'png' else ''
             content = pdf_file
@@ -266,7 +263,7 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
         if file_type == 'png':
             try:
                 pdf_page = extract_page_from_pdf(BytesIO(pdf_file), int(page_number) - 1)
-                content = pdf_page if show_overlay_for_page else base64.b64encode(pdf_page).decode('utf-8')
+                content = pdf_page if page_is_in_invalid_pages else base64.b64encode(pdf_page).decode('utf-8')
             except PdfReadError as e:
                 raise InvalidRequest(
                     'Error extracting requested page from PDF file for notification_id {} type {} {}'.format(

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1143,13 +1143,13 @@ def test_preview_letter_template_precompiled_s3_error(
 
 
 @pytest.mark.parametrize(
-    "filetype, post_url, message, requested_page", 
+    "requested_page, filetype, message, expected_post_url",
     [
-        ('png', 'precompiled-preview.png', "", ""),
-        ('png', 'precompiled/overlay.png?page_number=1', "content-outside-printable-area", "1"),
-        ('png', 'precompiled/overlay.png?page_number=2', "content-outside-printable-area", "2"),
-        ('png', 'precompiled/overlay.png?page_number=3', "content-outside-printable-area", "3"),
-        ('pdf', 'precompiled/overlay.pdf', "content-outside-printable-area", "")
+        ("", 'png', "", 'precompiled-preview.png'),
+        ("1", 'png', "content-outside-printable-area", 'precompiled/overlay.png?page_number=1'),
+        ("2", 'png', "content-outside-printable-area", 'precompiled/overlay.png?page_number=2'),
+        ("3", 'png', "content-outside-printable-area", 'precompiled/overlay.png?page_number=3'),
+        ("", 'pdf', "content-outside-printable-area", 'precompiled/overlay.pdf')
     ]
 )
 def test_preview_letter_template_precompiled_png_file_type_or_pdf_with_overlay(
@@ -1158,10 +1158,10 @@ def test_preview_letter_template_precompiled_png_file_type_or_pdf_with_overlay(
         admin_request,
         sample_service,
         mocker,
-        filetype,
-        post_url,
-        message,
         requested_page,
+        filetype,
+        message,
+        expected_post_url,
 ):
 
     template = create_template(sample_service,
@@ -1195,7 +1195,7 @@ def test_preview_letter_template_precompiled_png_file_type_or_pdf_with_overlay(
             mocker.patch('app.template.rest.extract_page_from_pdf', return_value=pdf_content)
 
             mock_post = request_mock.post(
-                'http://localhost/notifications-template-preview/{}'.format(post_url),
+                'http://localhost/notifications-template-preview/{}'.format(expected_post_url),
                 content=expected_returned_content,
                 headers={'X-pdf-page-count': '4'},
                 status_code=200


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171130095

## Design decision
As suggested by the story, 'The code path for the notifications page goes via the API (whereas the upload page goes straight to the template preview app). We should probably investigate if it still needs to do this. It would be nice if the viewnotification page called the TemplatePreview.from(in)valid_pdf functions. '

I did look into this here which is a very rough draft:
https://github.com/alphagov/notifications-admin/compare/template-preview-page?expand=1

I managed to get it working but it seemed like it would be more work and this is all fairly complex already so didn't want to change too much in one go. Would potentially involve moving a bunch of functionality into utils or having things not very DRY. This PR instead seems like a much smaller change that isn't massively making things worse so that's why I'm suggesting this approach.

## How to review
I suggest reviewing commit by commit (but may not be necessary)


![image](https://user-images.githubusercontent.com/7228605/76226810-4da9d600-6216-11ea-971d-5334e128f3e8.png)

![image](https://user-images.githubusercontent.com/7228605/76226827-539fb700-6216-11ea-8b5a-13e1994d8ce3.png)
