### PR TITLE
Format postcode for CSV letter rows

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -4,6 +4,7 @@ from collections import namedtuple, defaultdict
 
 from flask import current_app
 from notifications_utils.recipients import (
+    format_postcode_for_printing,
     RecipientCSV
 )
 from notifications_utils.statsd_decorators import statsd
@@ -304,6 +305,10 @@ def save_letter(
 
     # we store the recipient as just the first item of the person's address
     recipient = notification['personalisation']['addressline1']
+
+    notification['personalisation']['postcode'] = format_postcode_for_printing(
+        notification['personalisation']['postcode']
+    )
 
     service = dao_fetch_service_by_id(service_id)
     template = dao_get_template_by_id(notification['template'], version=notification['template_version'])

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -27,4 +27,4 @@ notifications-python-client==5.5.1
 awscli-cwlogs>=1.4,<1.5
 
 
-git+https://github.com/alphagov/notifications-utils.git@36.8.0#egg=notifications-utils==36.8.0
+git+https://github.com/alphagov/notifications-utils.git@36.9.0#egg=notifications-utils==36.9.0

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -27,4 +27,4 @@ notifications-python-client==5.5.1
 awscli-cwlogs>=1.4,<1.5
 
 
-git+https://github.com/alphagov/notifications-utils.git@36.6.2#egg=notifications-utils==36.6.2
+git+https://github.com/alphagov/notifications-utils.git@36.8.0#egg=notifications-utils==36.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,23 +29,23 @@ notifications-python-client==5.5.1
 awscli-cwlogs>=1.4,<1.5
 
 
-git+https://github.com/alphagov/notifications-utils.git@36.6.2#egg=notifications-utils==36.6.2
+git+https://github.com/alphagov/notifications-utils.git@36.9.0#egg=notifications-utils==36.9.0
 
 ## The following requirements were added by pip freeze:
 alembic==1.4.1
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.3.0
-awscli==1.18.16
+awscli==1.18.20
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.1
 boto==2.49.0
 boto3==1.10.38
-botocore==1.15.16
+botocore==1.15.20
 certifi==2019.11.28
 chardet==3.0.4
-click==7.1
+click==7.1.1
 colorama==0.4.3
 dnspython==1.16.0
 docutils==0.15.2


### PR DESCRIPTION
Story ticket: https://www.pivotaltracker.com/story/show/171622677

We are formatting the postcode here, because if we did it in template
preview, that could break flows like API and admin one-off, since
we are not validating postcode there yet, and format_postcode
needs a nice validated postcode.

We are not doing it in admin, as then we would have to either
rewrite the CSV file or pass data differently to API. First would
be nasty, second is a lot of overhead.

In the long run we might want to move postcode formatting to
template preview so that the postcode in letter preview looks the same
before and after user sends it, but now to get it out quickly it's better
to format the postcode here in the task (if we did it in template preview now,
it would also try to format postcode for API flow and one-off flow, where it is
not being validated yet, and so if the postcode data is shorter than 4 characters
it would throw an exception, as postcode formatter relies on data being a real UK postcode)

Requires 
- https://github.com/alphagov/notifications-utils/pull/704
- a PR on admin be released which validates postcodes for CSV uploads