### PR TITLE
Validate and format postcode for the API letter sending flow.

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -271,7 +271,7 @@ def process_letter_notification(*, letter_data, api_key, template, reply_to_text
 
     postcode = letter_data['personalisation']['postcode']
     if not is_a_real_uk_postcode(postcode):
-        raise ValidationError(message='A real UK postcode is required.')
+        raise ValidationError(message='Must be a real UK postcode')
 
     test_key = api_key.key_type == KEY_TYPE_TEST
 

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -2,7 +2,9 @@ import base64
 import functools
 
 from flask import request, jsonify, current_app, abort
-from notifications_utils.recipients import try_validate_and_format_phone_number
+from notifications_utils.recipients import (
+    format_postcode_for_printing, is_a_real_uk_postcode, try_validate_and_format_phone_number
+)
 
 from app import api_user, authenticated_service, notify_celery, document_download_client
 from app.celery.letters_pdf_tasks import create_letters_pdf, process_virus_scan_passed
@@ -44,7 +46,7 @@ from app.notifications.validators import (
     validate_template,
 )
 from app.schema_validation import validate
-from app.v2.errors import BadRequestError
+from app.v2.errors import BadRequestError, ValidationError
 from app.v2.notifications import v2_notification_blueprint
 from app.v2.notifications.create_response import (
     create_post_sms_response_from_notification,
@@ -267,11 +269,17 @@ def process_letter_notification(*, letter_data, api_key, template, reply_to_text
                                                         template=template,
                                                         reply_to_text=reply_to_text)
 
+    postcode = letter_data['personalisation']['postcode']
+    if not is_a_real_uk_postcode(postcode):
+        raise ValidationError(message='A real UK postcode is required.')
+
     test_key = api_key.key_type == KEY_TYPE_TEST
 
     # if we don't want to actually send the letter, then start it off in SENDING so we don't pick it up
     status = NOTIFICATION_CREATED if not test_key else NOTIFICATION_SENDING
     queue = QueueNames.CREATE_LETTERS_PDF if not test_key else QueueNames.RESEARCH_MODE
+
+    letter_data['personalisation']['postcode'] = format_postcode_for_printing(postcode)
 
     notification = create_letter_notification(letter_data=letter_data,
                                               template=template,

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -164,7 +164,7 @@ def test_post_letter_notification_throws_error_for_bad_postcode(
     assert error_json['status_code'] == 400
     assert error_json['errors'] == [{
         'error': 'ValidationError',
-        'message': 'A real UK postcode is required.'
+        'message': 'Must be a real UK postcode'
     }]
 
 


### PR DESCRIPTION
Validate and format postcode of a letter that we got through API POST request.

Story ticket: https://www.pivotaltracker.com/story/show/171622677

Should go in after: https://github.com/alphagov/notifications-api/pull/2748 as we are pulling in new version of utils there. Tests will fail until that PR is merged, too.