### PR TITLE
Increase the queue pool size to 30.

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -2,7 +2,7 @@
   'notify-api': {
     'NOTIFY_APP_NAME': 'api',
     'disk_quota': '2G',
-    'sqlalchemy_pool_size': 20,
+    'sqlalchemy_pool_size': 30,
     'routes': {
       'preview': ['api.notify.works'],
       'staging': ['api.staging-notify.works'],


### PR DESCRIPTION
This should add an extra 1000 connections maximum, which will not tip us over the allowable 5000 db connections. And it may help with the queue pool connection errors.