### PR TITLE
Update jobs contact list

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -126,6 +126,7 @@ def dao_get_future_scheduled_job_by_id_and_service_id(job_id, service_id):
 def dao_create_job(job):
     if not job.id:
         job.id = uuid.uuid4()
+
     db.session.add(job)
     db.session.commit()
 

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -126,7 +126,6 @@ def dao_get_future_scheduled_job_by_id_and_service_id(job_id, service_id):
 def dao_create_job(job):
     if not job.id:
         job.id = uuid.uuid4()
-
     db.session.add(job)
     db.session.commit()
 

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -141,7 +141,6 @@ def create_job(service_id):
         raise InvalidRequest("Create job is not allowed: service is inactive ", 403)
 
     data = request.get_json()
-
     data.update({
         "service": service_id
     })

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -381,6 +381,7 @@ class JobSchema(BaseSchema):
         ServiceSchema, attribute="service", dump_to="service_name", only=["name"], dump_only=True)
 
     template_type = fields.Method('get_template_type', dump_only=True)
+    contact_list_id = field_for(models.Job, 'contact_list_id')
 
     def get_template_type(self, job):
         return job.template.template_type

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -9,7 +9,7 @@ import pytz
 
 import app.celery.tasks
 from app.dao.templates_dao import dao_update_template
-from app.models import JOB_STATUS_TYPES, JOB_STATUS_PENDING, Job
+from app.models import JOB_STATUS_TYPES, JOB_STATUS_PENDING
 
 from tests import create_authorization_header
 from tests.conftest import set_config


### PR DESCRIPTION
A new feature to allow services to upload emergency contact list has been built. This adds the new contact_list_id to the schema, so it can be updated and returned from the endpoints, to created and get job. 