### PR TITLE
Fix serialisation error

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -205,7 +205,7 @@ def replay_created_notifications():
 
         current_app.logger.info(msg)
         for letter in letters:
-            create_letters_pdf.apply_async([letter.id], queue=QueueNames.LETTERS)
+            create_letters_pdf.apply_async([str(letter.id)], queue=QueueNames.LETTERS)
 
 
 @notify_celery.task(name='check-precompiled-letter-state')

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -329,8 +329,8 @@ def test_replay_created_notifications_create_letters_pdf_tasks_for_letters_not_r
 
     replay_created_notifications()
 
-    calls = [call([notification_1.id], queue=QueueNames.LETTERS),
-             call([notification_2.id], queue=QueueNames.LETTERS),
+    calls = [call([str(notification_1.id)], queue=QueueNames.LETTERS),
+             call([str(notification_2.id)], queue=QueueNames.LETTERS),
              ]
     mock_task.assert_has_calls(calls, any_order=True)
 


### PR DESCRIPTION
Fix serialisation error when creating the `create_letters_pdf` in `resend_created_notifications_older_than`