### PR TITLE
Add an endpoint to delete a contact list

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -43,6 +43,13 @@ def get_job_location(service_id, job_id):
     )
 
 
+def get_contact_list_location(service_id, contact_list_id):
+    return (
+        current_app.config['CONTACT_LIST_BUCKET_NAME'],
+        FILE_LOCATION_STRUCTURE.format(service_id, contact_list_id),
+    )
+
+
 def get_job_and_metadata_from_s3(service_id, job_id):
     obj = get_s3_object(*get_job_location(service_id, job_id))
     return obj.get()['Body'].read().decode('utf-8'), obj.get()['Metadata']
@@ -60,6 +67,10 @@ def get_job_metadata_from_s3(service_id, job_id):
 
 def remove_job_from_s3(service_id, job_id):
     return remove_s3_object(*get_job_location(service_id, job_id))
+
+
+def remove_contact_list_from_s3(service_id, contact_list_id):
+    return remove_s3_object(*get_contact_list_location(service_id, contact_list_id))
 
 
 def get_s3_bucket_objects(bucket_name, subfolder=''):

--- a/app/config.py
+++ b/app/config.py
@@ -364,6 +364,7 @@ class Development(Config):
     SQLALCHEMY_ECHO = False
 
     CSV_UPLOAD_BUCKET_NAME = 'development-notifications-csv-upload'
+    CONTACT_LIST_BUCKET_NAME = 'development-contact-list'
     TEST_LETTERS_BUCKET_NAME = 'development-test-letters'
     DVLA_RESPONSE_BUCKET_NAME = 'notify.tools-ftp'
     LETTERS_PDF_BUCKET_NAME = 'development-letters-pdf'
@@ -405,6 +406,7 @@ class Test(Development):
     TESTING = True
 
     CSV_UPLOAD_BUCKET_NAME = 'test-notifications-csv-upload'
+    CONTACT_LIST_BUCKET_NAME = 'test-contact-list'
     TEST_LETTERS_BUCKET_NAME = 'test-test-letters'
     DVLA_RESPONSE_BUCKET_NAME = 'test.notify.com-ftp'
     LETTERS_PDF_BUCKET_NAME = 'test-letters-pdf'
@@ -440,6 +442,7 @@ class Preview(Config):
     NOTIFY_EMAIL_DOMAIN = 'notify.works'
     NOTIFY_ENVIRONMENT = 'preview'
     CSV_UPLOAD_BUCKET_NAME = 'preview-notifications-csv-upload'
+    CONTACT_LIST_BUCKET_NAME = 'preview-contact-list'
     TEST_LETTERS_BUCKET_NAME = 'preview-test-letters'
     DVLA_RESPONSE_BUCKET_NAME = 'notify.works-ftp'
     LETTERS_PDF_BUCKET_NAME = 'preview-letters-pdf'
@@ -456,6 +459,7 @@ class Staging(Config):
     NOTIFY_EMAIL_DOMAIN = 'staging-notify.works'
     NOTIFY_ENVIRONMENT = 'staging'
     CSV_UPLOAD_BUCKET_NAME = 'staging-notifications-csv-upload'
+    CONTACT_LIST_BUCKET_NAME = 'staging-contact-list'
     TEST_LETTERS_BUCKET_NAME = 'staging-test-letters'
     DVLA_RESPONSE_BUCKET_NAME = 'staging-notify.works-ftp'
     LETTERS_PDF_BUCKET_NAME = 'staging-letters-pdf'
@@ -473,6 +477,7 @@ class Live(Config):
     NOTIFY_EMAIL_DOMAIN = 'notifications.service.gov.uk'
     NOTIFY_ENVIRONMENT = 'live'
     CSV_UPLOAD_BUCKET_NAME = 'live-notifications-csv-upload'
+    CONTACT_LIST_BUCKET_NAME = 'production-contact-list'
     TEST_LETTERS_BUCKET_NAME = 'production-test-letters'
     DVLA_RESPONSE_BUCKET_NAME = 'notifications.service.gov.uk-ftp'
     LETTERS_PDF_BUCKET_NAME = 'production-letters-pdf'
@@ -497,6 +502,7 @@ class Sandbox(CloudFoundryConfig):
     NOTIFY_EMAIL_DOMAIN = 'notify.works'
     NOTIFY_ENVIRONMENT = 'sandbox'
     CSV_UPLOAD_BUCKET_NAME = 'cf-sandbox-notifications-csv-upload'
+    CONTACT_LIST_BUCKET_NAME = 'cf-sandbox-contact-list'
     LETTERS_PDF_BUCKET_NAME = 'cf-sandbox-letters-pdf'
     TEST_LETTERS_BUCKET_NAME = 'cf-sandbox-test-letters'
     DVLA_RESPONSE_BUCKET_NAME = 'notify.works-ftp'

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -135,14 +135,6 @@ def dao_update_job(job):
     db.session.commit()
 
 
-def dao_unlink_jobs_from_contact_list_id(contact_list_id):
-    Job.query.filter(
-        Job.contact_list_id == contact_list_id,
-    ).update({
-        'contact_list_id': None,
-    })
-
-
 def dao_get_jobs_older_than_data_retention(notification_types):
     flexible_data_retention = ServiceDataRetention.query.filter(
         ServiceDataRetention.notification_type.in_(notification_types)

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -135,6 +135,14 @@ def dao_update_job(job):
     db.session.commit()
 
 
+def dao_unlink_jobs_from_contact_list_id(contact_list_id):
+    Job.query.filter(
+        Job.contact_list_id == contact_list_id,
+    ).update({
+        'contact_list_id': None,
+    })
+
+
 def dao_get_jobs_older_than_data_retention(notification_types):
     flexible_data_retention = ServiceDataRetention.query.filter(
         ServiceDataRetention.notification_type.in_(notification_types)

--- a/app/dao/service_contact_list_dao.py
+++ b/app/dao/service_contact_list_dao.py
@@ -5,7 +5,8 @@ from app.models import ServiceContactList
 def dao_get_contact_list_by_id(service_id, contact_list_id):
     contact_list = ServiceContactList.query.filter_by(
         service_id=service_id,
-        id=contact_list_id
+        id=contact_list_id,
+        archived=False,
     ).one()
 
     return contact_list
@@ -13,7 +14,8 @@ def dao_get_contact_list_by_id(service_id, contact_list_id):
 
 def dao_get_contact_lists(service_id):
     contact_lists = ServiceContactList.query.filter_by(
-        service_id=service_id
+        service_id=service_id,
+        archived=False,
     ).order_by(
         ServiceContactList.created_at.desc()
     )
@@ -25,6 +27,7 @@ def save_service_contact_list(service_contact_list):
     db.session.commit()
 
 
-def dao_delete_contact_list(service_contact_list):
-    db.session.delete(service_contact_list)
+def dao_archive_contact_list(service_contact_list):
+    service_contact_list.archived = True
+    db.session.add(service_contact_list)
     db.session.commit()

--- a/app/dao/service_contact_list_dao.py
+++ b/app/dao/service_contact_list_dao.py
@@ -23,3 +23,8 @@ def dao_get_contact_lists(service_id):
 def save_service_contact_list(service_contact_list):
     db.session.add(service_contact_list)
     db.session.commit()
+
+
+def dao_delete_contact_list(service_contact_list):
+    db.session.delete(service_contact_list)
+    db.session.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -2135,6 +2135,7 @@ class ServiceContactList(db.Model):
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), index=True, nullable=True)
     created_at = db.Column(db.DateTime, nullable=False)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    archived = db.Column(db.Boolean, nullable=False, default=False)
 
     def serialize(self):
         created_at_in_bst = convert_utc_to_bst(self.created_at)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -29,6 +29,7 @@ from app.dao.fact_notification_status_dao import (
     fetch_stats_for_all_services_by_date_range, fetch_monthly_template_usage_for_service
 )
 from app.dao.inbound_numbers_dao import dao_allocate_number_for_service
+from app.dao.jobs_dao import dao_unlink_jobs_from_contact_list_id
 from app.dao.organisation_dao import dao_get_organisation_by_service_id
 from app.dao.returned_letters_dao import (
     fetch_most_recent_returned_letter,
@@ -36,8 +37,12 @@ from app.dao.returned_letters_dao import (
     fetch_returned_letter_summary,
     fetch_returned_letters,
 )
-from app.dao.service_contact_list_dao import dao_get_contact_lists, save_service_contact_list, \
-    dao_get_contact_list_by_id
+from app.dao.service_contact_list_dao import (
+    dao_get_contact_lists,
+    save_service_contact_list,
+    dao_get_contact_list_by_id,
+    dao_delete_contact_list,
+)
 from app.dao.service_data_retention_dao import (
     fetch_service_data_retention,
     fetch_service_data_retention_by_id,
@@ -1032,6 +1037,18 @@ def get_contact_list_by_id(service_id, contact_list_id):
     )
 
     return jsonify(contact_list.serialize())
+
+
+@service_blueprint.route('/<uuid:service_id>/contact-list/<uuid:contact_list_id>', methods=['DELETE'])
+def delete_contact_list_by_id(service_id, contact_list_id):
+    contact_list = dao_get_contact_list_by_id(
+        service_id=service_id,
+        contact_list_id=contact_list_id,
+    )
+    dao_unlink_jobs_from_contact_list_id(contact_list.id)
+    dao_delete_contact_list(contact_list)
+
+    return '', 204
 
 
 @service_blueprint.route('/<uuid:service_id>/contact-list', methods=['POST'])

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -13,6 +13,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import DATE_FORMAT, DATETIME_FORMAT_NO_TIMEZONE
+from app.aws import s3
 from app.config import QueueNames
 from app.dao import fact_notification_status_dao, notifications_dao
 from app.dao.dao_utils import dao_rollback
@@ -1047,6 +1048,7 @@ def delete_contact_list_by_id(service_id, contact_list_id):
     )
     dao_unlink_jobs_from_contact_list_id(contact_list.id)
     dao_delete_contact_list(contact_list)
+    s3.remove_contact_list_from_s3(service_id, contact_list_id)
 
     return '', 204
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -30,7 +30,6 @@ from app.dao.fact_notification_status_dao import (
     fetch_stats_for_all_services_by_date_range, fetch_monthly_template_usage_for_service
 )
 from app.dao.inbound_numbers_dao import dao_allocate_number_for_service
-from app.dao.jobs_dao import dao_unlink_jobs_from_contact_list_id
 from app.dao.organisation_dao import dao_get_organisation_by_service_id
 from app.dao.returned_letters_dao import (
     fetch_most_recent_returned_letter,
@@ -39,10 +38,10 @@ from app.dao.returned_letters_dao import (
     fetch_returned_letters,
 )
 from app.dao.service_contact_list_dao import (
+    dao_archive_contact_list,
     dao_get_contact_lists,
-    save_service_contact_list,
     dao_get_contact_list_by_id,
-    dao_delete_contact_list,
+    save_service_contact_list,
 )
 from app.dao.service_data_retention_dao import (
     fetch_service_data_retention,
@@ -1046,8 +1045,7 @@ def delete_contact_list_by_id(service_id, contact_list_id):
         service_id=service_id,
         contact_list_id=contact_list_id,
     )
-    dao_unlink_jobs_from_contact_list_id(contact_list.id)
-    dao_delete_contact_list(contact_list)
+    dao_archive_contact_list(contact_list)
     s3.remove_contact_list_from_s3(service_id, contact_list_id)
 
     return '', 204

--- a/migrations/versions/0319_contact_list_archived.py
+++ b/migrations/versions/0319_contact_list_archived.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: 0319_contact_list_archived
+Revises: 0318_service_contact_list
+Create Date: 2020-03-26 11:16:12.389524
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0319_contact_list_archived'
+down_revision = '0318_service_contact_list'
+
+
+def upgrade():
+    op.add_column(
+        'service_contact_list',
+        sa.Column('archived', sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade():
+    op.drop_column(
+        'service_contact_list',
+        'archived',
+    )

--- a/tests/app/dao/test_service_contact_list_dao.py
+++ b/tests/app/dao/test_service_contact_list_dao.py
@@ -4,6 +4,11 @@ from tests.app.db import create_service_contact_list
 
 def test_dao_get_contact_lists(notify_db_session):
     contact_list = create_service_contact_list()
+    create_service_contact_list(
+        service=contact_list.service,
+        archived=True,
+    )
+
     fetched_list = dao_get_contact_lists(contact_list.service_id)
 
     assert len(fetched_list) == 1

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -976,7 +976,8 @@ def create_service_contact_list(
     original_file_name='EmergencyContactList.xls',
     row_count=100,
     template_type='email',
-    created_by_id=None
+    created_by_id=None,
+    archived=False,
 ):
     if not service:
         service = create_service(service_name='service for contact list', user=create_user())
@@ -988,6 +989,7 @@ def create_service_contact_list(
         template_type=template_type,
         created_by_id=created_by_id or service.users[0].id,
         created_at=datetime.utcnow(),
+        archived=archived,
     )
     db.session.add(contact_list)
     db.session.commit()

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -384,7 +384,8 @@ def create_job(
         processing_started=None,
         processing_finished=None,
         original_file_name='some.csv',
-        archived=False
+        archived=False,
+        contact_list_id=None,
 ):
     data = {
         'id': uuid.uuid4(),
@@ -400,7 +401,8 @@ def create_job(
         'scheduled_for': scheduled_for,
         'processing_started': processing_started,
         'processing_finished': processing_finished,
-        'archived': archived
+        'archived': archived,
+        'contact_list_id': contact_list_id,
     }
     job = Job(**data)
     dao_create_job(job)

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -238,12 +238,21 @@ def test_create_scheduled_job(client, sample_template, mocker, fake_uuid):
     assert resp_json['data']['notification_count'] == 1
 
 
-def test_create_job_with_contact_list_id(client, mocker, sample_template, fake_uuid):
+@pytest.mark.parametrize('contact_list_archived', (
+    True, False,
+))
+def test_create_job_with_contact_list_id(
+    client,
+    mocker,
+    sample_template,
+    fake_uuid,
+    contact_list_archived,
+):
     mocker.patch('app.celery.tasks.process_job.apply_async')
     mocker.patch('app.job.rest.get_job_metadata_from_s3', return_value={
         'template_id': str(sample_template.id)
     })
-    contact_list = create_service_contact_list()
+    contact_list = create_service_contact_list(archived=contact_list_archived)
     data = {
         'id': fake_uuid,
         'valid': 'True',

--- a/tests/app/service/test_service_contact_list_rest.py
+++ b/tests/app/service/test_service_contact_list_rest.py
@@ -138,7 +138,9 @@ def test_archive_contact_list_by_id(mocker, admin_request, sample_service):
     expected_list = create_service_contact_list(service=service_1)
     other_list = create_service_contact_list(service=service_1)
 
+    # Job linked to the contact list we’re deleting
     job_1 = create_job(template=template_1, contact_list_id=expected_list.id)
+    # Other jobs and lists shouldn’t be affected
     job_2 = create_job(template=template_1, contact_list_id=other_list.id)
     job_3 = create_job(template=template_1)
 


### PR DESCRIPTION
This was one of things we de-scoped when we first shipped this feature.

In order to safely delete a list, we first need to make sure any jobs aren’t referencing it.

Then we can remove the CSV file itself from S3.