### PR TITLE
Add a try/except around the code to get the files.

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -172,15 +172,18 @@ def get_key_and_size_of_letters_to_be_sent_to_print(print_run_deadline):
 
     letter_pdfs = []
     for letter in letters_awaiting_sending:
-        letter_file_name = get_letter_pdf_filename(
-            reference=letter.reference,
-            crown=letter.service.crown,
-            sending_date=letter.created_at,
-            postage=letter.postage
-        )
-
-        letter_head = s3.head_s3_object(current_app.config['LETTERS_PDF_BUCKET_NAME'], letter_file_name)
-        letter_pdfs.append({"Key": letter_file_name, "Size": letter_head['ContentLength']})
+        try:
+            letter_file_name = get_letter_pdf_filename(
+                reference=letter.reference,
+                crown=letter.service.crown,
+                sending_date=letter.created_at,
+                postage=letter.postage
+            )
+            letter_head = s3.head_s3_object(current_app.config['LETTERS_PDF_BUCKET_NAME'], letter_file_name)
+            letter_pdfs.append({"Key": letter_file_name, "Size": letter_head['ContentLength']})
+        except BotoClientError as e:
+            current_app.logger.exception(
+                f"Error getting letter from bucket for notification: {letter.id} with reference: {letter.reference}", e)
 
     return letter_pdfs
 


### PR DESCRIPTION
The idea is to log the exception but keep going. That way the "good" files still get sent and we can investigate why a file failed.