### PR TITLE
Remove the join on NotificationHistory.

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -344,39 +344,22 @@ def delete_notifications_older_than_retention_by_type(notification_type, qry_lim
 def _delete_notifications(notification_type, date_to_delete_from, service_id, query_limit):
     subquery = db.session.query(
         Notification.id
-    ).join(NotificationHistory, NotificationHistory.id == Notification.id).filter(
-        Notification.notification_type == notification_type,
-        Notification.service_id == service_id,
-        Notification.created_at < date_to_delete_from,
-    ).limit(query_limit).subquery()
-
-    deleted = _delete_for_query(subquery)
-
-    subquery_for_test_keys = db.session.query(
-        Notification.id
     ).filter(
         Notification.notification_type == notification_type,
         Notification.service_id == service_id,
-        Notification.created_at < date_to_delete_from,
-        Notification.key_type == KEY_TYPE_TEST
+        Notification.created_at < date_to_delete_from
     ).limit(query_limit).subquery()
-
-    deleted += _delete_for_query(subquery_for_test_keys)
-
-    return deleted
-
-
-def _delete_for_query(subquery):
-    number_deleted = db.session.query(Notification).filter(
+    number_deleted = 0
+    deleted = db.session.query(Notification).filter(
         Notification.id.in_(subquery)).delete(synchronize_session='fetch')
-    deleted = number_deleted
+    number_deleted += deleted
     db.session.commit()
-    while number_deleted > 0:
-        number_deleted = db.session.query(Notification).filter(
+    while deleted > 0:
+        deleted = db.session.query(Notification).filter(
             Notification.id.in_(subquery)).delete(synchronize_session='fetch')
-        deleted += number_deleted
         db.session.commit()
-    return deleted
+        number_deleted += deleted
+    return number_deleted
 
 
 def insert_update_notification_history(notification_type, date_to_delete_from, service_id, query_limit=10000):

--- a/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
@@ -227,21 +227,6 @@ def test_delete_notifications_does_try_to_delete_from_s3_when_letter_has_not_bee
     mock_get_s3.assert_not_called()
 
 
-@freeze_time("2016-01-10 12:00:00.000000")
-def test_should_not_delete_notification_if_history_does_not_exist(sample_service, mocker):
-    mocker.patch("app.dao.notifications_dao.get_s3_bucket_objects")
-    mocker.patch("app.dao.notifications_dao.insert_update_notification_history")
-    with freeze_time('2016-01-01 12:00'):
-        email_template, letter_template, sms_template = _create_templates(sample_service)
-        create_notification(template=email_template, status='permanent-failure')
-        create_notification(template=sms_template, status='delivered')
-        create_notification(template=letter_template, status='temporary-failure')
-    assert Notification.query.count() == 3
-    delete_notifications_older_than_retention_by_type('sms')
-    assert Notification.query.count() == 3
-    assert NotificationHistory.query.count() == 0
-
-
 def test_delete_notifications_calls_subquery_multiple_times(sample_template):
     create_notification(template=sample_template, created_at=datetime.now() - timedelta(days=8))
     create_notification(template=sample_template, created_at=datetime.now() - timedelta(days=8))


### PR DESCRIPTION
This is saying that we are confident that the NotificationHistory has been records before we delete the Notification.