### PR TITLE
Increase default query limit to 50,000 from 10,000

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -372,19 +372,14 @@ def insert_notification_history_delete_notifications(
         "timestamp_to_delete_backwards_from": timestamp_to_delete_backwards_from,
         "qry_limit": qry_limit
     }
-    current_app.logger.info(
-        f"Start executing insert_notification_history_delete_notifications for input params {input_params}"
-    )
+
     db.session.execute(drop_table_if_exists)
-    current_app.logger.info('Start executing select into temp table')
     db.session.execute(select_into_temp_table, input_params)
 
     result = db.session.execute("select * from NOTIFICATION_ARCHIVE")
 
-    current_app.logger.info('Start executing insert into history')
     db.session.execute(insert_query)
 
-    current_app.logger.info('Start executing deleting notifications')
     db.session.execute(delete_query)
 
     db.session.execute("DROP TABLE NOTIFICATION_ARCHIVE")

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -297,7 +297,7 @@ def _filter_query(query, filter_dict=None):
 
 
 @statsd(namespace="dao")
-def delete_notifications_older_than_retention_by_type(notification_type, qry_limit=10000):
+def delete_notifications_older_than_retention_by_type(notification_type, qry_limit=50000):
     current_app.logger.info(
         'Deleting {} notifications for services with flexible data retention'.format(notification_type))
 


### PR DESCRIPTION
The original intention was to increase the limit to 50K, which takes about 48seconds. 
10K rows takes 11 seconds.
