### PR TITLE
Cache template when posting a notification

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -140,9 +140,10 @@ def check_notification_content_is_not_empty(template_with_content):
 
 def validate_template(template_id, personalisation, service, notification_type):
     try:
-        template = templates_dao.dao_get_template_by_id_and_service_id(
+        template = templates_dao.dao_get_template_by_id_and_service_id_and_version(
             template_id=template_id,
-            service_id=service.id
+            service_id=service.id,
+            version=templates_dao.dao_get_template_version(template_id),
         )
     except NoResultFound:
         message = 'Template not found'


### PR DESCRIPTION
This commit proposes two types of caching to speed up the post notification processing time.

Since every notification needs a template, if we can avoid going to the database to get the template then we should save some time.

The first cache is an LRU cache, which means that, for a given `template_id`, `service_id` and `version` the app will go to memory rather than the database to get the template. This should be much faster, and we should be guaranteed that a combination of those three parameters should always return the same result.

But, we don’t know the template version at the time of making the call. So this commit also adds another layer of caching to find the most recent version number of a template. Since this can be changed by other instances we need to cache it externally, so this cache uses Redis. Redis will be a lot slower than going to memory, but hopefully quicker than going to the database. By only caching the minimal amount of data possible in Redis (just the version as a number) we’re hopefully minimising the performance hit from going to an external service.

***

Questions:
- will this work?
- will this make things faster?
- is this massive increase in traffic to Redis a problem?