### PR TITLE
Change error code for duplicate reply-to address to 409 meaning conflict

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -953,7 +953,7 @@ def check_if_reply_to_address_already_in_use(service_id, email_address):
     existing_reply_to_addresses = dao_get_reply_to_by_service_id(service_id)
     if email_address in [i.email_address for i in existing_reply_to_addresses]:
         raise InvalidRequest(
-            "Your service already uses ‘{}’ as an email reply-to address.".format(email_address), status_code=400
+            "Your service already uses ‘{}’ as an email reply-to address.".format(email_address), status_code=409
         )
 
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2622,7 +2622,7 @@ def test_verify_reply_to_email_address_doesnt_allow_duplicates(admin_request, no
         'service.verify_reply_to_email_address',
         service_id=service.id,
         _data=data,
-        _expected_status=400
+        _expected_status=409
     )
     assert response["message"] == "Your service already uses ‘reply-here@example.gov.uk’ as an email reply-to address."
 
@@ -2651,7 +2651,7 @@ def test_add_service_reply_to_email_address_doesnt_allow_duplicates(
         'service.add_service_reply_to_email_address',
         service_id=service.id,
         _data=data,
-        _expected_status=400
+        _expected_status=409
     )
     assert response["message"] == "Your service already uses ‘reply-here@example.gov.uk’ as an email reply-to address."
 


### PR DESCRIPTION
This is a more accurate error code. It also means we are sure that we get the right error in admin without checking the error message first.

Needs this PR to go in first: https://github.com/alphagov/notifications-admin/pull/3389

Story ticket: https://www.pivotaltracker.com/story/show/171785534