### PR TITLE
Add team key to query

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -351,7 +351,7 @@ def insert_notification_history_delete_notifications(
         WHERE service_id = :service_id
           AND notification_type = :notification_type
           AND created_at < :timestamp_to_delete_backwards_from
-          AND key_type = 'normal'
+          AND key_type in ('normal', 'team')
         limit :qry_limit
         """
     # Insert into NotificationHistory if the row already exists do nothing.

--- a/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
@@ -335,3 +335,31 @@ def test_insert_notification_history_delete_notifications_only_insert_delete_for
     assert len(history_rows) == 1
     assert notifications[0].id == notification_to_stay.id
     assert history_rows[0], id == notification_to_move.id
+
+
+def test_insert_notification_history_delete_notifications_insert_for_key_type(sample_template):
+    create_notification(template=sample_template,
+                        created_at=datetime.utcnow() - timedelta(hours=4),
+                        status='delivered',
+                        key_type='normal')
+    create_notification(template=sample_template,
+                        created_at=datetime.utcnow() - timedelta(hours=4),
+                        status='delivered',
+                        key_type='team')
+    with_test_key = create_notification(template=sample_template,
+                                        created_at=datetime.utcnow() - timedelta(hours=4),
+                                        status='delivered',
+                                        key_type='test')
+
+    del_count = insert_notification_history_delete_notifications(
+        notification_type=sample_template.template_type,
+        service_id=sample_template.service_id,
+        timestamp_to_delete_backwards_from=datetime.utcnow()
+    )
+
+    assert del_count == 2
+    notifications = Notification.query.all()
+    history_rows = NotificationHistory.query.all()
+    assert len(notifications) == 1
+    assert with_test_key.id == notifications[0].id
+    assert len(history_rows) == 2


### PR DESCRIPTION
Add team key to the notifications to delete/insert into notifications/notification_history

notifications created with team keys have not been moved and purged.