### PR TITLE
Add missing freezetime to a test

### DIFF
--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -168,6 +168,7 @@ def test_find_services_by_name_handles_no_service_name(notify_db, admin_request,
     mock_get_services_by_partial_name.assert_not_called()
 
 
+@freeze_time('2019-05-02')
 def test_get_live_services_data(sample_user, admin_request):
     org = create_organisation()
 


### PR DESCRIPTION
As new financial year came, this test started failing, because it had no freezetime and billing stopped being for the right year.