### PR TITLE
Force sequence of our related nightly tasks

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -223,8 +223,8 @@ class Config(object):
             'options': {'queue': QueueNames.PERIODIC}
         },
         # app/celery/nightly_tasks.py
-        'timeout-sending-notifications': {
-            'task': 'timeout-sending-notifications',
+        'clean-notifications-table-and-create-stats': {
+            'task': 'clean-notifications-table-and-create-stats',
             'schedule': crontab(hour=0, minute=5),
             'options': {'queue': QueueNames.PERIODIC}
         },
@@ -233,32 +233,11 @@ class Config(object):
             'schedule': crontab(hour=0, minute=15),
             'options': {'queue': QueueNames.REPORTING}
         },
-        'create-nightly-notification-status': {
-            'task': 'create-nightly-notification-status',
-            'schedule': crontab(hour=0, minute=30),  # after 'timeout-sending-notifications'
-            'options': {'queue': QueueNames.REPORTING}
-        },
-        'delete-sms-notifications': {
-            'task': 'delete-sms-notifications',
-            'schedule': crontab(hour=4, minute=15),  # after 'create-nightly-notification-status'
-            'options': {'queue': QueueNames.PERIODIC}
-        },
-        'delete-email-notifications': {
-            'task': 'delete-email-notifications',
-            'schedule': crontab(hour=4, minute=30),  # after 'create-nightly-notification-status'
-            'options': {'queue': QueueNames.PERIODIC}
-        },
-        'delete-letter-notifications': {
-            'task': 'delete-letter-notifications',
-            'schedule': crontab(hour=4, minute=45),  # after 'create-nightly-notification-status'
-            'options': {'queue': QueueNames.PERIODIC}
-        },
         'delete-inbound-sms': {
             'task': 'delete-inbound-sms',
             'schedule': crontab(hour=1, minute=40),
             'options': {'queue': QueueNames.PERIODIC}
         },
-
         'send-daily-performance-platform-stats': {
             'task': 'send-daily-performance-platform-stats',
             'schedule': crontab(hour=2, minute=0),


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172062501

We previously sequenced the
`timeout_notifications`, `create_nightly_notification_status` and
`delete_<notification_type>_notifications` tasks by setting
them up with gaps in crontab. This means they would run in
order and likely not conflict however not guaranteed
given that one of them might run for much longer and conflict with the
next task.

If tasks were to conflict, this may cause problems. For example, if
notifications aren't all timed out before creating the
notification_stats data, then the data will be incorrect for the given
day. If that is the case for an SMS retention of 3 days, given we
calculate the past 4 days of stats, we would not naturally recalculate
the stats for the last day if they had incorrect data due to the above
clash. Simiarly, the `delete-email-notifications` and
`delete-sms-notifications` tasks could clash and slow each other down,
we believe because they are both doing a lot of writes to the same
index.

To solve this we also considered using celery chaining, see
http://docs.celeryproject.org/en/latest/userguide/canvas.html#chains.
However the main benefit of chaining is the ability to pass the return value
of the previous task into the next task. We don't need this behaviour.
Apart from that, if an app crashed during an execution of chained tasks,
it would not automatically restart from where it left off. It would
require a human to spot this and kick it off again manually. This is the
same for the approach that we've taken. Therefore we went for the simplest
option of just writing a simple function instead of trying chaining.

I checked to see whether `create-nightly-billing` and
`send-daily-performance-platform-stats` need to be run in sequence too.
It appears not so they can just be run at any time during the middle of
the night. Neither depend on notification_status being in temp failure
rather than sending (which would be done by the timeout task).