### PR TITLE
Delete old 'process-virus-scan-passed-task'

### DIFF
--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -114,14 +114,6 @@ def move_failed_pdf(source_filename, scan_error_type):
     _move_s3_object(scan_bucket, source_filename, scan_bucket, target_filename)
 
 
-def copy_redaction_failed_pdf(source_filename):
-    scan_bucket = current_app.config['LETTERS_SCAN_BUCKET_NAME']
-
-    target_filename = 'REDACTION_FAILURE/' + source_filename
-
-    _copy_s3_object(scan_bucket, source_filename, scan_bucket, target_filename)
-
-
 def move_error_pdf_to_scan_bucket(source_filename):
     scan_bucket = current_app.config['LETTERS_SCAN_BUCKET_NAME']
     error_file = 'ERROR/' + source_filename
@@ -210,22 +202,6 @@ def _move_s3_object(source_bucket, source_filename, target_bucket, target_filena
     s3.Object(source_bucket, source_filename).delete()
 
     current_app.logger.info("Moved letter PDF: {}/{} to {}/{}".format(
-        source_bucket, source_filename, target_bucket, target_filename))
-
-
-def _copy_s3_object(source_bucket, source_filename, target_bucket, target_filename):
-    s3 = boto3.resource('s3')
-    copy_source = {'Bucket': source_bucket, 'Key': source_filename}
-
-    target_bucket = s3.Bucket(target_bucket)
-    obj = target_bucket.Object(target_filename)
-
-    # Tags are copied across but the expiration time is reset in the destination bucket
-    # e.g. if a file has 5 days left to expire on a ONE_WEEK retention in the source bucket,
-    # in the destination bucket the expiration time will be reset to 7 days left to expire
-    obj.copy(copy_source, ExtraArgs={'ServerSideEncryption': 'AES256'})
-
-    current_app.logger.info("Copied letter PDF: {}/{} to {}/{}".format(
         source_bucket, source_filename, target_bucket, target_filename))
 
 

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -17,7 +17,7 @@ from app import (
     encryption,
     DATETIME_FORMAT
 )
-from app.celery.letters_pdf_tasks import create_letters_pdf, process_virus_scan_passed
+from app.celery.letters_pdf_tasks import create_letters_pdf, sanitise_letter
 from app.celery.research_mode_tasks import create_fake_letter_response_file
 from app.celery.tasks import save_api_email
 from app.clients.document_download import DocumentDownloadError
@@ -407,9 +407,9 @@ def process_precompiled_letter_notifications(*, letter_data, api_key, template, 
         )
     else:
         # stub out antivirus in dev
-        process_virus_scan_passed.apply_async(
-            kwargs={'filename': filename},
-            queue=QueueNames.LETTERS,
+        sanitise_letter.apply_async(
+            [filename],
+            queue=QueueNames.LETTERS
         )
 
     return notification

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -7,7 +7,6 @@ from freezegun import freeze_time
 from moto import mock_s3
 
 from app.letters.utils import (
-    copy_redaction_failed_pdf,
     get_bucket_name_and_prefix_for_notification,
     get_letter_pdf_filename,
     get_letter_pdf_and_metadata,
@@ -292,24 +291,6 @@ def test_move_failed_pdf_scan_failed(notify_api):
 
     assert 'FAILURE/' + filename in [o.key for o in bucket.objects.all()]
     assert filename not in [o.key for o in bucket.objects.all()]
-
-
-@mock_s3
-@freeze_time(FROZEN_DATE_TIME)
-def test_copy_redaction_failed_pdf(notify_api):
-    filename = 'test.pdf'
-    bucket_name = current_app.config['LETTERS_SCAN_BUCKET_NAME']
-
-    conn = boto3.resource('s3', region_name='eu-west-1')
-    bucket = conn.create_bucket(Bucket=bucket_name)
-
-    s3 = boto3.client('s3', region_name='eu-west-1')
-    s3.put_object(Bucket=bucket_name, Key=filename, Body=b'pdf_content')
-
-    copy_redaction_failed_pdf(filename)
-
-    assert 'REDACTION_FAILURE/' + filename in [o.key for o in bucket.objects.all()]
-    assert filename in [o.key for o in bucket.objects.all()]
 
 
 @pytest.mark.parametrize("freeze_date, expected_folder_name",


### PR DESCRIPTION
This has been replaced by a new task, `sanitise-letter`, so this deletes the old task and ensures that when antivirus is not enabled locally we are calling `sanitise-letter`.