### PR TITLE
Look in all parts of a letter template to find placeholders

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -17,7 +17,7 @@ from notifications_utils.statsd_decorators import statsd
 
 from app import db, DATETIME_FORMAT, encryption
 from app.aws import s3
-from app.celery.tasks import record_daily_sorted_counts, get_template_class, process_row
+from app.celery.tasks import record_daily_sorted_counts, process_row
 from app.celery.nightly_tasks import send_total_sent_notifications_to_performance_platform
 from app.celery.service_callback_tasks import send_delivery_status_to_service
 from app.celery.letters_pdf_tasks import create_letters_pdf
@@ -889,8 +889,7 @@ def process_row_from_job(job_id, job_row_number):
     job = dao_get_job_by_id(job_id)
     db_template = dao_get_template_by_id(job.template_id, job.template_version)
 
-    TemplateClass = get_template_class(db_template.template_type)
-    template = TemplateClass(db_template.__dict__)
+    template = db_template._as_utils_template()
 
     for row in RecipientCSV(
             s3.get_job_from_s3(str(job.service_id), str(job.id)),

--- a/app/models.py
+++ b/app/models.py
@@ -983,8 +983,13 @@ class TemplateBase(db.Model):
         if self.template_type == LETTER_TYPE:
             return LetterPrintTemplate(
                 self.__dict__,
-                contact_block=self.service.get_default_letter_contact(),
+                contact_block=self.get_reply_to_text(),
             )
+
+    def _as_utils_template_with_personalisation(self, values):
+        template = self._as_utils_template()
+        template.values = values
+        return template
 
     def serialize(self):
         serialized = {

--- a/app/models.py
+++ b/app/models.py
@@ -977,16 +977,12 @@ class TemplateBase(db.Model):
 
     def _as_utils_template(self):
         if self.template_type == EMAIL_TYPE:
-            return PlainTextEmailTemplate(
-                {'content': self.content, 'subject': self.subject}
-            )
+            return PlainTextEmailTemplate(self.__dict__)
         if self.template_type == SMS_TYPE:
-            return SMSMessageTemplate(
-                {'content': self.content}
-            )
+            return SMSMessageTemplate(self.__dict__)
         if self.template_type == LETTER_TYPE:
             return LetterPrintTemplate(
-                {'content': self.content, 'subject': self.subject},
+                self.__dict__,
                 contact_block=self.service.get_default_letter_contact(),
             )
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -32,11 +32,10 @@ from app.dao.notifications_dao import (
 )
 
 from app.v2.errors import BadRequestError
-from app.utils import get_template_instance
 
 
 def create_content_for_notification(template, personalisation):
-    template_object = get_template_instance(template.__dict__, personalisation)
+    template_object = template._as_utils_template_with_personalisation(personalisation)
     check_placeholders(template_object)
 
     return template_object

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -8,6 +8,7 @@ from flask import request, jsonify, current_app, abort
 from notifications_utils.recipients import (
     format_postcode_for_printing, is_a_real_uk_postcode, try_validate_and_format_phone_number
 )
+from notifications_utils.template import WithSubjectTemplate
 
 from app import (
     api_user,
@@ -166,23 +167,25 @@ def post_notification(notification_type):
     if notification_type == SMS_TYPE:
         create_resp_partial = functools.partial(
             create_post_sms_response_from_notification,
-            from_number=reply_to
+            from_number=reply_to,
+            content=str(template_with_content),
         )
     elif notification_type == EMAIL_TYPE:
         create_resp_partial = functools.partial(
             create_post_email_response_from_notification,
             subject=template_with_content.subject,
-            email_from='{}@{}'.format(authenticated_service.email_from, current_app.config['NOTIFY_EMAIL_DOMAIN'])
+            email_from='{}@{}'.format(authenticated_service.email_from, current_app.config['NOTIFY_EMAIL_DOMAIN']),
+            content=WithSubjectTemplate.__str__(template_with_content),
         )
     elif notification_type == LETTER_TYPE:
         create_resp_partial = functools.partial(
             create_post_letter_response_from_notification,
             subject=template_with_content.subject,
+            content=WithSubjectTemplate.__str__(template_with_content),
         )
 
     resp = create_resp_partial(
         notification=notification,
-        content=str(template_with_content),
         url_root=request.url_root,
         scheduled_for=scheduled_for
     )

--- a/app/v2/template/post_template.py
+++ b/app/v2/template/post_template.py
@@ -3,7 +3,6 @@ from flask import jsonify, request
 from app import authenticated_service
 from app.dao import templates_dao
 from app.schema_validation import validate
-from app.utils import get_template_instance
 from app.v2.errors import BadRequestError
 from app.v2.template import v2_template_blueprint
 from app.v2.template.template_schemas import (
@@ -29,8 +28,9 @@ def post_template_preview(template_id):
     template = templates_dao.dao_get_template_by_id_and_service_id(
         template_id, authenticated_service.id)
 
-    template_object = get_template_instance(
-        template.__dict__, values=data.get('personalisation'))
+    template_object = template._as_utils_template_with_personalisation(
+        data.get('personalisation')
+    )
 
     check_placeholders(template_object)
 

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -29,7 +29,7 @@ from tests.app.db import create_service, create_template
 def test_create_content_for_notification_passes(sample_email_template):
     template = Template.query.get(sample_email_template.id)
     content = create_content_for_notification(template, None)
-    assert str(content) == template.content
+    assert str(content) == template.content + '\n'
 
 
 def test_create_content_for_notification_with_placeholders_passes(sample_template_with_placeholders):


### PR DESCRIPTION
Text messages have placeholders in their body.

Emails have them in their subject line too.

Letters have them in their body, subject line and contact block.

We were only looking in the the body and subject when processing a job, therefore the thing assembling the letter was not looking in all the CSV columns it needed to, because it hadn’t been told about any placeholders in the contact block.

Fixing this means always making sure we use the correct `Template` instance for the type of template we’re dealing with. Which we were already doing in a different part of the codebase. So it makes sense to reuse that.

Turns out we fixed the same bug for email subjects over 3 years ago: 3ed9715

---

This commit also updates the API to check the contact block when validating the placeholders for creating a notification or preview of a template. 

---

Fixes https://www.pivotaltracker.com/story/show/172171068