### PR TITLE
Ensure correct object renders V2 template preview

### DIFF
--- a/app/v2/template/template_schemas.py
+++ b/app/v2/template/template_schemas.py
@@ -1,3 +1,5 @@
+from notifications_utils.template import WithSubjectTemplate
+
 from app.models import SMS_TYPE, TEMPLATE_TYPES
 from app.schema_validation.definitions import uuid, personalisation
 from app.utils import get_html_email_body_from_template
@@ -75,13 +77,18 @@ post_template_preview_response = {
 
 
 def create_post_template_preview_response(template, template_object):
-    subject = template_object.subject if template.template_type != SMS_TYPE else None
+    if template.template_type == SMS_TYPE:
+        subject = None
+        body = str(template_object)
+    else:
+        subject = template_object.subject
+        body = WithSubjectTemplate.__str__(template_object)
 
     return {
         "id": template.id,
         "type": template.template_type,
         "version": template.version,
-        "body": str(template_object),
+        "body": body,
         "html": get_html_email_body_from_template(template_object),
         "subject": subject,
         "postage": template.postage


### PR DESCRIPTION
The `body` field of the ‘preview a template’ endpoint should contain the content of the template with the placeholders replaced.

It should not be rendered into a plain text email, which does stuff like normalising newlines (so `\r\n` becomes `\n`). However the object that the `create_post_template_preview_response` function receives is an instance of `PlainTextEmailTemplate`. So we can’t just call `str()` on
it. Instead we need to call the `__str__` method of `WithSubjectTemplate` which gives us the result we want.

We were already doing this the right way in the V1 endpoint<sup>1</sup> but forgot to do it here too.

***

1. https://github.com/alphagov/notifications-api/blob/0108749daa9885e000ad0ea222692b799ff59338/app/template/rest.py#L181-L184