### PR TITLE
Use firetext response code to see if temporary or permanent failure if available

### DIFF
--- a/app/celery/process_sms_client_response_tasks.py
+++ b/app/celery/process_sms_client_response_tasks.py
@@ -7,7 +7,7 @@ from notifications_utils.template import SMSMessageTemplate
 
 from app import notify_celery, statsd_client
 from app.clients import ClientException
-from app.clients.sms.firetext import get_firetext_responses, get_message_status_from_firetext_code
+from app.clients.sms.firetext import get_firetext_responses
 from app.clients.sms.mmg import get_mmg_responses
 from app.celery.service_callback_tasks import send_delivery_status_to_service, create_delivery_status_callback_data
 from app.config import QueueNames
@@ -51,16 +51,18 @@ def process_sms_client_response(self, status, provider_reference, client_name, c
     _process_for_status(
         notification_status=notification_status,
         client_name=client_name,
-        provider_reference=provider_reference
+        provider_reference=provider_reference,
+        code=code
     )
 
 
-def _process_for_status(notification_status, client_name, provider_reference):
+def _process_for_status(notification_status, client_name, provider_reference, code=None):
     # record stats
     notification = notifications_dao.update_notification_status_by_id(
         notification_id=provider_reference,
         status=notification_status,
-        sent_by=client_name.lower()
+        sent_by=client_name.lower(),
+        code=code
     )
     if not notification:
         return

--- a/app/celery/process_sms_client_response_tasks.py
+++ b/app/celery/process_sms_client_response_tasks.py
@@ -7,7 +7,7 @@ from notifications_utils.template import SMSMessageTemplate
 
 from app import notify_celery, statsd_client
 from app.clients import ClientException
-from app.clients.sms.firetext import get_firetext_responses
+from app.clients.sms.firetext import get_firetext_responses, get_message_status_from_firetext_code
 from app.clients.sms.mmg import get_mmg_responses
 from app.celery.service_callback_tasks import send_delivery_status_to_service, create_delivery_status_callback_data
 from app.config import QueueNames
@@ -24,7 +24,7 @@ sms_response_mapper = {
 
 @notify_celery.task(bind=True, name="process-sms-client-response", max_retries=5, default_retry_delay=300)
 @statsd(namespace="tasks")
-def process_sms_client_response(self, status, provider_reference, client_name):
+def process_sms_client_response(self, status, provider_reference, client_name, code=None):
     # validate reference
     try:
         uuid.UUID(provider_reference, version=4)

--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -20,15 +20,15 @@ firetext_responses = {
 }
 
 firetext_codes = {
-    '101': 'permanent-failure',  # Unknown Subscriber
-    '102': 'temporary-failure',  # Absent Subscriber
-    '103': 'temporary-failure',  # Subscriber Busy
-    '104': 'temporary-failure',  # No Subscriber Memory
-    '201': 'permanent-failure',  # Invalid Number
-    '301': 'permanent-failure',  # SMS Not Supported
-    '302': 'temporary-failure',  # SMS Not Supported
-    '401': 'permanent-failure',  # Message Rejected
-    '900': 'temporary-failure',  # Routing Error
+    '101': {'status': 'permanent-failure', 'reason': 'Unknown Subscriber'},
+    '102': {'status': 'temporary-failure', 'reason': 'Absent Subscriber'},
+    '103': {'status': 'temporary-failure', 'reason': 'Subscriber Busy'},
+    '104': {'status': 'temporary-failure', 'reason': 'No Subscriber Memory'},
+    '201': {'status': 'permanent-failure', 'reason': 'Invalid Number'},
+    '301': {'status': 'permanent-failure', 'reason': 'SMS Not Supported'},
+    '302': {'status': 'temporary-failure', 'reason': 'SMS Not Supported'},
+    '401': {'status': 'permanent-failure', 'reason': 'Message Rejected'},
+    '900': {'status': 'temporary-failure', 'reason': 'Routing Error'},
 }
 
 
@@ -36,8 +36,8 @@ def get_firetext_responses(status):
     return firetext_responses[status]
 
 
-def get_message_status_from_firetext_code(code):
-    return firetext_codes[code]
+def get_message_status_and_reason_from_firetext_code(code):
+    return firetext_codes[code]['status'], firetext_codes[code]['reason']
 
 
 class FiretextClientResponseException(SmsClientResponseException):

--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -19,9 +19,25 @@ firetext_responses = {
     '2': 'pending'
 }
 
+firetext_codes = {
+    '101': 'permanent-failure',  # Unknown Subscriber
+    '102': 'temporary-failure',  # Absent Subscriber
+    '103': 'temporary-failure',  # Subscriber Busy
+    '104': 'temporary-failure',  # No Subscriber Memory
+    '201': 'permanent-failure',  # Invalid Number
+    '301': 'permanent-failure',  # SMS Not Supported
+    '302': 'temporary-failure',  # SMS Not Supported
+    '401': 'permanent-failure',  # Message Rejected
+    '900': 'temporary-failure',  # Routing Error
+}
+
 
 def get_firetext_responses(status):
     return firetext_responses[status]
+
+
+def get_message_status_from_firetext_code(code):
+    return firetext_codes[code]
 
 
 class FiretextClientResponseException(SmsClientResponseException):

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -92,8 +92,8 @@ def dao_create_notification(notification):
 
 def _decide_permanent_temporary_failure(current_status, status, code=None):
     # Firetext will send pending, then send either succes or fail.
-    # If we go from pending to failure we need to set failure type as temporary-failure
-    # if we get a detailed code from firetext, we should use that code to set status instead
+    # If we go from pending to failure we need to set failure type as temporary-failure,
+    # unless we get a detailed code from firetext. Then we should use that code to set status instead.
     if current_status == NOTIFICATION_PENDING and status == NOTIFICATION_PERMANENT_FAILURE:
         if code:
             status = get_message_status_from_firetext_code(code)

--- a/app/notifications/notifications_sms_callback.py
+++ b/app/notifications/notifications_sms_callback.py
@@ -48,6 +48,7 @@ def process_firetext_response():
         raise InvalidRequest(errors, status_code=400)
 
     status = request.form.get('status')
+    code = request.form.get('code')
     provider_reference = request.form.get('reference')
 
     safe_to_log = dict(request.form).copy()
@@ -57,7 +58,7 @@ def process_firetext_response():
     )
 
     process_sms_client_response.apply_async(
-        [status, provider_reference, client_name],
+        [status, provider_reference, client_name, code],
         queue=QueueNames.SMS_CALLBACKS,
     )
 

--- a/tests/app/notifications/rest/test_callbacks.py
+++ b/tests/app/notifications/rest/test_callbacks.py
@@ -147,7 +147,7 @@ def test_firetext_callback_should_return_200_and_call_task_with_valid_data(clien
     assert json_resp['result'] == 'success'
 
     mock_celery.assert_called_once_with(
-        ['0', 'notification_id', 'Firetext'],
+        ['0', 'notification_id', 'Firetext', None],
         queue='sms-callbacks',
     )
 

--- a/tests/app/notifications/test_process_client_response.py
+++ b/tests/app/notifications/test_process_client_response.py
@@ -57,6 +57,23 @@ def test_process_sms_client_response_updates_notification_status(
     assert sample_notification.status == expected_notification_status
 
 
+@pytest.mark.parametrize('code, expected_notification_status', [
+    ('101', 'permanent-failure'),
+    ('102', 'temporary-failure'),
+])
+def test_process_sms_client_response_updates_notification_status_when_called_second_time(
+    sample_notification,
+    mocker,
+    code,
+    expected_notification_status,
+):
+    sample_notification.status = 'sending'
+    process_sms_client_response('2', str(sample_notification.id), 'Firetext')
+    process_sms_client_response('1', str(sample_notification.id), 'Firetext', code)
+
+    assert sample_notification.status == expected_notification_status
+
+
 def test_sms_response_does_not_send_callback_if_notification_is_not_in_the_db(sample_service, mocker):
     mocker.patch(
         'app.celery.process_sms_client_response_tasks.get_service_delivery_status_callback_api_for_service',


### PR DESCRIPTION
Currently, when we get first pending status, then permanent failure status from Firetext, we class it as temporary failure. But this is not always right. 

Hence, when we receive that succession of statuses, we will check for a code that tells us exactly what happened, so we know the status for sure.

Story ticket: https://www.pivotaltracker.com/story/show/171742892

Questions:
- maybe we would like to defer to the code every time we receive a failure from firetext?
- Since each code has a detailed explanation for failure, how about exposing those to our users? They often ask why messages failed, so more detailed explanation might help them with their work.