### PR TITLE
Move provider resting balance as temporary measure

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -140,8 +140,8 @@ class Config(object):
 
     # these should always add up to 100%
     SMS_PROVIDER_RESTING_POINTS = {
-        'mmg': 70,
-        'firetext': 30
+        'mmg': 0,
+        'firetext': 100
     }
 
     NOTIFY_SERVICE_ID = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'


### PR DESCRIPTION
We are seeing issues with one of our providers. Move all traffic to the
other. We have done this with the provider load balancer, however this
will be reverted back 10 percent every hour to these resting points,
which we want to stop happening until we are confident our provider has
fixed their issues.

In the long run, we should add functionality to pause our load balancer
behaviour.