### PR TITLE
Remove, cache or hardcode anything that could be cached when sending an email

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -976,15 +976,10 @@ class TemplateBase(db.Model):
         pass
 
     def _as_utils_template(self):
-        if self.template_type == EMAIL_TYPE:
-            return PlainTextEmailTemplate(self.__dict__)
-        if self.template_type == SMS_TYPE:
-            return SMSMessageTemplate(self.__dict__)
-        if self.template_type == LETTER_TYPE:
-            return LetterPrintTemplate(
-                self.__dict__,
-                contact_block=self.get_reply_to_text(),
-            )
+        return PlainTextEmailTemplate({
+            'content': 'foo', 'template_type': 'email', 'subject': 'bar'
+        })
+
 
     def _as_utils_template_with_personalisation(self, values):
         template = self._as_utils_template()

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from sqlalchemy.orm.exc import NoResultFound
 from flask import current_app
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
@@ -138,9 +139,17 @@ def check_notification_content_is_not_empty(template_with_content):
         raise BadRequestError(message=message)
 
 
+@lru_cache(maxsize=None)
+def get_template(template_id, service_id):
+    return templates_dao.dao_get_template_by_id_and_service_id(
+        template_id=template_id,
+        service_id=service_id
+    )
+
+
 def validate_template(template_id, personalisation, service, notification_type):
     try:
-        template = templates_dao.dao_get_template_by_id_and_service_id(
+        template = get_template(
             template_id=template_id,
             service_id=service.id
         )

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -158,9 +158,6 @@ def validate_template(template_id, personalisation, service, notification_type):
         raise BadRequestError(message=message,
                               fields=[{'template': message}])
 
-    check_template_is_for_notification_type(notification_type, template.template_type)
-    check_template_is_active(template)
-
     template_with_content = create_content_for_notification(template, personalisation)
 
     check_notification_content_is_not_empty(template_with_content)

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -235,7 +235,7 @@ def process_sms_or_email_notification(*, form, notification_type, api_key, templ
     if scheduled_for:
         persist_scheduled_notification(notification.id, form["scheduled_for"])
     else:
-        if not simulated:
+        if not True:
             queue_name = QueueNames.PRIORITY if template.process_type == PRIORITY else None
             send_notification_to_queue(
                 notification=notification,

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -143,7 +143,7 @@ def post_notification(notification_type):
             form=form,
             notification_type=notification_type,
             api_key=api_user,
-            template=template,
+            template_id=form['template_id'],
             service=authenticated_service,
             reply_to_text=reply_to
         )
@@ -170,7 +170,7 @@ def post_notification(notification_type):
     return jsonify(resp), 201
 
 
-def process_sms_or_email_notification(*, form, notification_type, api_key, template, service, reply_to_text=None):
+def process_sms_or_email_notification(*, form, notification_type, api_key, template_id, service, reply_to_text=None):
     notification_id = None
     form_send_to = form['email_address'] if notification_type == EMAIL_TYPE else form['phone_number']
 
@@ -217,8 +217,8 @@ def process_sms_or_email_notification(*, form, notification_type, api_key, templ
 
     notification = persist_notification(
         notification_id=notification_id,
-        template_id=template.id,
-        template_version=template.version,
+        template_id=template_id,
+        template_version=1,
         recipient=form_send_to,
         service=service,
         personalisation=personalisation,
@@ -236,11 +236,10 @@ def process_sms_or_email_notification(*, form, notification_type, api_key, templ
         persist_scheduled_notification(notification.id, form["scheduled_for"])
     else:
         if not True:
-            queue_name = QueueNames.PRIORITY if template.process_type == PRIORITY else None
             send_notification_to_queue(
                 notification=notification,
                 research_mode=service.research_mode,
-                queue=queue_name
+                queue=None
             )
         else:
             current_app.logger.debug("POST simulated notification for id: {}".format(notification.id))


### PR DESCRIPTION
Probably shouldn’t deploy this to production 😅

This is a pull request so I can show exactly what I removed, bodged and hardcoded to test what the performance implications of caching a bunch of stuff might look like.

Test command for all these examples:
```bash
python -m timeit -v -n 100 -s "import notifications_python_client; c = notifications_python_client.notifications.NotificationsAPIClient('🤫', base_url='http://localhost:6011')" "c.send_email_notification(email_address='sender@something.com', template_id='be433bfc-fe31-464b-9f2c-5be11abf2176')"
```

Running against current master branch (e366fc5f)
```
raw times: 12.1 11.9 11.8
100 loops, best of 3: 118 msec per loop
```

With the changes in 3d9f173
```
raw times: 11.2 10.7 10.1
100 loops, best of 3: 101 msec per loop
```

Not a big improvement… So I was curious what it was doing in those ~100ms

Let’s go back to master and comment out the bit of code that persists the notification to the database:
```
raw times: 12.3 10.5 10.5
100 loops, best of 3: 105 msec per loop
```
(saves about 13ms)

If we comment out sending to the queue instead:
```
raw times: 3.43 3.24 4.88
100 loops, best of 3: 32.4 msec per loop
```
(saves about 85ms)

This means most of our request time is spent waiting for SQS.

If we check out this branch while sending to the queue is commented out we get a clearer picture of the potential improvements:
```
raw times: 2.13 1.84 2.18
100 loops, best of 3: 18.4 msec per loop
```

This is a saving of 14ms, from a baseline of 32.4ms, so 56%.

A typical call to fetch a service from Redis from the admin app takes about 0.6ms, for context.

It’s also worth thinking about whether we’re holding a database connection longer than we need to if we still have it while talking to SQS.