### PR TITLE
Restore provider resting points

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -140,8 +140,8 @@ class Config(object):
 
     # these should always add up to 100%
     SMS_PROVIDER_RESTING_POINTS = {
-        'mmg': 0,
-        'firetext': 100
+        'mmg': 70,
+        'firetext': 30
     }
 
     NOTIFY_SERVICE_ID = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'


### PR DESCRIPTION
We temporarily updated the provider resting points in https://github.com/alphagov/notifications-api/pull/2804. This puts the provider resting points back to their original value now that both providers seem to be functioning well.