### PR TITLE
Bump utils to 39.0.0

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -40,6 +40,7 @@ from app.letters.utils import (
     get_file_names_from_error_bucket,
 )
 from app.models import (
+    INTERNATIONAL_LETTERS,
     KEY_TYPE_TEST,
     NOTIFICATION_CREATED,
     NOTIFICATION_DELIVERED,
@@ -227,6 +228,9 @@ def sanitise_letter(self, filename):
             kwargs={
                 'notification_id': str(notification.id),
                 'filename': filename,
+                'allow_international_letters': notification.service.has_permission(
+                    INTERNATIONAL_LETTERS
+                ),
             },
             queue=QueueNames.SANITISE_LETTERS,
         )

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -126,9 +126,7 @@ def get_recipient_csv_and_template_and_sender_id(job):
     template = db_template._as_utils_template()
 
     contents, meta_data = s3.get_job_and_metadata_from_s3(service_id=str(job.service_id), job_id=str(job.id))
-    recipient_csv = RecipientCSV(file_data=contents,
-                                 template_type=template.template_type,
-                                 placeholders=template.placeholders)
+    recipient_csv = RecipientCSV(contents, template=template)
 
     return recipient_csv, template, meta_data.get("sender_id")
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -26,6 +26,6 @@ notifications-python-client==5.5.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@37.3.0#egg=notifications-utils==37.3.0
+git+https://github.com/alphagov/notifications-utils.git@38.0.0#egg=notifications-utils==38.0.0
 
 gds-metrics==0.2.0

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -26,6 +26,6 @@ notifications-python-client==5.5.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@38.1.0#egg=notifications-utils==38.1.0
+git+https://github.com/alphagov/notifications-utils.git@39.0.0#egg=notifications-utils==39.0.0
 
 gds-metrics==0.2.0

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -26,6 +26,6 @@ notifications-python-client==5.5.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@38.0.0#egg=notifications-utils==38.0.0
+git+https://github.com/alphagov/notifications-utils.git@38.1.0#egg=notifications-utils==38.1.0
 
 gds-metrics==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ notifications-python-client==5.5.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@37.3.0#egg=notifications-utils==37.3.0
+git+https://github.com/alphagov/notifications-utils.git@38.0.0#egg=notifications-utils==38.0.0
 
 gds-metrics==0.2.0
 
@@ -37,14 +37,14 @@ alembic==1.4.2
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.3.0
-awscli==1.18.45
+awscli==1.18.46
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.4
 blinker==1.4
 boto==2.49.0
 boto3==1.10.38
-botocore==1.15.45
+botocore==1.15.46
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ notifications-python-client==5.5.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@38.0.0#egg=notifications-utils==38.0.0
+git+https://github.com/alphagov/notifications-utils.git@39.0.0#egg=notifications-utils==39.0.0
 
 gds-metrics==0.2.0
 
@@ -37,17 +37,17 @@ alembic==1.4.2
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.3.0
-awscli==1.18.46
+awscli==1.18.48
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.4
 blinker==1.4
 boto==2.49.0
 boto3==1.10.38
-botocore==1.15.46
+botocore==1.15.48
 certifi==2020.4.5.1
 chardet==3.0.4
-click==7.1.1
+click==7.1.2
 colorama==0.4.3
 dnspython==1.16.0
 docutils==0.15.2
@@ -74,7 +74,7 @@ pyrsistent==0.16.0
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-json-logger==0.1.11
-pytz==2019.3
+pytz==2020.1
 PyYAML==5.3.1
 redis==3.4.1
 requests==2.23.0

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -340,7 +340,7 @@ def test_should_process_letter_job(sample_letter_job, mocker):
 
     row_call = process_row_mock.mock_calls[0][1]
     assert row_call[0].index == 0
-    assert row_call[0].recipient == ['A1', 'A2', 'A3', 'A4', None, None, 'A_POST']
+    assert row_call[0].recipient == ['A1', 'A2', 'A3', 'A4', None, None, 'A_POST', None]
     assert row_call[0].personalisation == {
         'addressline1': 'A1',
         'addressline2': 'A2',
@@ -407,6 +407,7 @@ def test_process_row_sends_letter_task(template_type, research_mode, expected_fu
             recipient_column_headers=['to'],
             placeholders={'foo'},
             template=template,
+            allow_international_letters=True,
         ),
         template,
         job,
@@ -449,6 +450,7 @@ def test_process_row_when_sender_id_is_provided(mocker, fake_uuid):
             recipient_column_headers=['to'],
             placeholders={'foo'},
             template=template,
+            allow_international_letters=True,
         ),
         template,
         job,
@@ -1418,6 +1420,7 @@ def test_get_letter_template_instance(mocker, sample_job):
         'address line 5',
         'address line 6',
         'postcode',
+        'address line 7',
     ]
 
 


### PR DESCRIPTION
Changes:
- code change to how the `RecipientCSV` class should be instantiated
- functional changes to start applying different address validation if letters are allowed to be sent internationally

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/724
- [x] https://github.com/alphagov/notifications-utils/pull/727
- [x] alphagov/notifications-template-preview#445