### PR TITLE
Fix bug where preview for templated letters would not show

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -89,7 +89,8 @@ def create_letters_pdf(self, notification_id):
 def get_letters_pdf(template, contact_block, filename, values):
     template_for_letter_print = {
         "subject": template.subject,
-        "content": template.content
+        "content": template.content,
+        "template_type": template.template_type
     }
 
     data = {

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -288,7 +288,8 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
             "id": str(notification.template_id),
             "subject": template.subject,
             "content": template.content,
-            "version": str(template.version)
+            "version": str(template.version),
+            "template_type": template.template_type
         }
 
         service = dao_fetch_service_by_id(service_id)

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -82,7 +82,8 @@ def test_get_letters_pdf_calls_notifications_template_preview_service_correctly(
         'filename': filename,
         'template': {
             'subject': sample_letter_template.subject,
-            'content': sample_letter_template.content
+            'content': sample_letter_template.content,
+            'template_type': sample_letter_template.template_type
         }
     }
 


### PR DESCRIPTION
We bumped version of utils here: https://github.com/alphagov/notifications-template-preview/pull/441

What we did not realise is that now template preview would require more information from API.

This PR fixes that omission.

Before:
![Screenshot 2020-04-20 at 15 24 03](https://user-images.githubusercontent.com/20957548/79762698-ffaae680-831a-11ea-8418-c456f04242b2.png)

After:
![Screenshot 2020-04-20 at 15 23 37](https://user-images.githubusercontent.com/20957548/79762713-033e6d80-831b-11ea-9fdf-29ffe0bb7557.png)
