### PR TITLE
Check failure code on failure only.

### DIFF
--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -20,6 +20,7 @@ firetext_responses = {
 }
 
 firetext_codes = {
+    # code '000' means 'No errors reported'
     '101': {'status': 'permanent-failure', 'reason': 'Unknown Subscriber'},
     '102': {'status': 'temporary-failure', 'reason': 'Absent Subscriber'},
     '103': {'status': 'temporary-failure', 'reason': 'Subscriber Busy'},

--- a/tests/app/notifications/test_process_client_response.py
+++ b/tests/app/notifications/test_process_client_response.py
@@ -83,6 +83,19 @@ def test_process_sms_client_response_updates_notification_status_when_called_sec
     assert sample_notification.status == expected_notification_status
 
 
+@pytest.mark.parametrize('code', ['102', None, '000'])
+def test_process_sms_client_response_updates_notification_status_to_pending_with_and_without_failire_code_present(
+    sample_notification,
+    mocker,
+    code
+):
+    sample_notification.status = 'sending'
+
+    process_sms_client_response('2', str(sample_notification.id), 'Firetext', code)
+
+    assert sample_notification.status == 'pending'
+
+
 def test_process_sms_client_response_updates_notification_status_when_code_unknown(
     sample_notification,
     mocker,


### PR DESCRIPTION
We should check error code on failure only, because if we get an
error code on pending code, we should still set the notification
to pending status.