### PR TITLE
Let users search for letters

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -342,7 +342,6 @@ def save_letter(
 ):
     notification = encryption.decrypt(encrypted_notification)
 
-    # we store the recipient as just the first item of the person's address
     recipient = PostalAddress.from_personalisation(
         Columns(notification['personalisation'])
     ).normalised

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -345,7 +345,7 @@ def save_letter(
     # we store the recipient as just the first item of the person's address
     recipient = PostalAddress.from_personalisation(
         Columns(notification['personalisation'])
-    ).normalised_lines[0]
+    ).normalised
 
     service = dao_fetch_service_by_id(service_id)
     template = dao_get_template_by_id(notification['template'], version=notification['template_version'])

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -26,7 +26,6 @@ from werkzeug.datastructures import MultiDict
 from app import db, create_uuid
 from app.aws.s3 import remove_s3_object, get_s3_bucket_objects
 from app.dao.dao_utils import transactional
-from app.errors import InvalidRequest
 from app.letters.utils import get_letter_pdf_filename
 from app.models import (
     FactNotificationStatus,
@@ -600,11 +599,8 @@ def dao_get_notifications_by_recipient_or_reference(service_id, search_term, not
         except InvalidEmailError:
             normalised = search_term.lower()
 
-    elif notification_type == LETTER_TYPE:
-        raise InvalidRequest("Only email and SMS can use search by recipient", 400)
-
     else:
-        normalised = search_term.lower()
+        normalised = ''.join(search_term.split()).lower()
 
     normalised = escape_special_characters(normalised)
     search_term = escape_special_characters(search_term)
@@ -612,6 +608,7 @@ def dao_get_notifications_by_recipient_or_reference(service_id, search_term, not
     filters = [
         Notification.service_id == service_id,
         or_(
+            Notification.to.ilike("%{}%".format(search_term)),
             Notification.normalised_to.like("%{}%".format(normalised)),
             Notification.client_reference.ilike("%{}%".format(search_term)),
         ),

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -599,8 +599,19 @@ def dao_get_notifications_by_recipient_or_reference(service_id, search_term, not
         except InvalidEmailError:
             normalised = search_term.lower()
 
-    else:
+    elif notification_type in {LETTER_TYPE, None}:
+        # For letters, we store the address without spaces, so we need
+        # to removes spaces from the search term to match. We also do
+        # this when a notification type isn’t provided (this will
+        # happen if a user doesn’t have permission to see the dashboard)
+        # because email addresses and phone numbers will never be stored
+        # with spaces either.
         normalised = ''.join(search_term.split()).lower()
+
+    else:
+        raise TypeError(
+            f'Notification type must be {EMAIL_TYPE}, {SMS_TYPE}, {LETTER_TYPE} or None'
+        )
 
     normalised = escape_special_characters(normalised)
     search_term = escape_special_characters(search_term)

--- a/app/notifications/process_letter_notifications.py
+++ b/app/notifications/process_letter_notifications.py
@@ -1,3 +1,5 @@
+from notifications_utils.postal_address import PostalAddress
+
 from app import create_random_identifier
 from app.models import LETTER_TYPE
 from app.notifications.process_notifications import persist_notification
@@ -9,7 +11,7 @@ def create_letter_notification(letter_data, template, api_key, status, reply_to_
         template_version=template.version,
         template_postage=template.postage,
         # we only accept addresses_with_underscores from the API (from CSV we also accept dashes, spaces etc)
-        recipient=letter_data['personalisation']['address_line_1'],
+        recipient=PostalAddress.from_personalisation(letter_data['personalisation']).normalised,
         service=template.service,
         personalisation=letter_data['personalisation'],
         notification_type=LETTER_TYPE,

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -109,6 +109,7 @@ def persist_notification(
         notification.normalised_to = format_email_address(notification.to)
     elif notification_type == LETTER_TYPE:
         notification.postage = postage or template_postage
+        notification.normalised_to = ''.join(notification.to.split()).lower()
 
     # if simulated create a Notification model to return but do not persist the Notification to the dB
     if not simulated:


### PR DESCRIPTION
Like we have search by email address or phone number, finding an individual letter is a common task. At the moment users are having to click through pages and pages of letters to find the one they’re looking for.

We have to search in the `to` and `normalised_to` fields for now until we’ve been storing the normalised version for a few weeks.

## How we store addresses

At the moment we’re not consistent:

**Precompiled (API and one-off)**
`to` has the whole address
`normalised_to` has nothing

**Templated (API, CSV and one off)**
`to` has the first line of the address
`normalised_to` has nothing

This pull request makes us consistently store the whole address in the `to` field. We think that people might want to search by postcode, not just first line of the address.

This commit also starts to populate the `normalised_to` field with the address lowercased and with all spaces removed, to make it easier to search on.