### PR TITLE
make create_letters_pdf always use right queue

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -188,7 +188,7 @@ def replay_created_notifications():
 
         current_app.logger.info(msg)
         for letter in letters:
-            create_letters_pdf.apply_async([str(letter.id)], queue=QueueNames.LETTERS)
+            create_letters_pdf.apply_async([str(letter.id)], queue=QueueNames.CREATE_LETTERS_PDF)
 
 
 @notify_celery.task(name='check-precompiled-letter-state')

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -309,8 +309,8 @@ def test_replay_created_notifications_create_letters_pdf_tasks_for_letters_not_r
 
     replay_created_notifications()
 
-    calls = [call([str(notification_1.id)], queue=QueueNames.LETTERS),
-             call([str(notification_2.id)], queue=QueueNames.LETTERS),
+    calls = [call([str(notification_1.id)], queue=QueueNames.CREATE_LETTERS_PDF),
+             call([str(notification_2.id)], queue=QueueNames.CREATE_LETTERS_PDF),
              ]
     mock_task.assert_has_calls(calls, any_order=True)
 


### PR DESCRIPTION
create-letters-pdf-tasks is for contacting template preview (synchronous web requests).
letters-tasks is for doing other things around letters (including putting things on template preview queue)