### PR TITLE
restart reporting worker after each task

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -174,6 +174,8 @@ class Config(object):
     CELERY_TIMEZONE = 'Europe/London'
     CELERY_ACCEPT_CONTENT = ['json']
     CELERY_TASK_SERIALIZER = 'json'
+    # on reporting worker, restart workers after each task is executed to help prevent memory leaks
+    CELERYD_MAX_TASKS_PER_CHILD = os.getenv('CELERYD_MAX_TASKS_PER_CHILD')
     CELERY_IMPORTS = (
         'app.celery.tasks',
         'app.celery.scheduled_tasks',

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -30,7 +30,7 @@
   'notify-delivery-worker-research': {},
   'notify-delivery-worker-sender': {'disk_quota': '2G', 'memory': '3G'},
   'notify-delivery-worker-periodic': {},
-  'notify-delivery-worker-reporting': {},
+  'notify-delivery-worker-reporting': {'additional_env_vars': {'CELERYD_MAX_TASKS_PER_CHILD': 1}},
   'notify-delivery-worker-priority': {},
   'notify-delivery-worker-letters': {},
   'notify-delivery-worker-retry-tasks': {},
@@ -112,3 +112,7 @@ applications:
 
       TEMPLATE_PREVIEW_API_HOST: '{{ TEMPLATE_PREVIEW_API_HOST }}'
       TEMPLATE_PREVIEW_API_KEY: '{{ TEMPLATE_PREVIEW_API_KEY }}'
+
+      {% for key, value in app.get('additional_env_vars', {}).items() %}
+      {{key}}: '{{value}}'
+      {% endfor %}


### PR DESCRIPTION
The reporting worker tasks fetch large amounts of data from the db, do some processing then store back in the database. As the reporting worker only processes the create nightly billing/stats table tasks, which aren't high performance or high volume, we're fine with the performance hit from restarting the worker between every task (which based on limited local testing takes about a second or so).

This causes some real funky shit with the app_context (used for accessing current_app.logger). To access flask's global state we use the standard way of importing `from flask import current_app`. However, processes after the first one don't have the current_app available on shut down (they're fine during the actual task running), and are unable to call `with current_app.app_context()` to create it. They _are_ able to call `with app.app_context()` to create it, where `app` is the initial app that we pass in to `NotifyCelery.init_app`.

NotifyCelery.init_app is only called once, in the master process - I think the application state is then stored and passed to the celery workers. But then it looks like the teardown might clear it, but it never gets set up again for the new workers? Unsure.

To fix this, store a copy of the initial flask app on the NotifyCelery object and then use that from within the shutdown signal logging function.

Nothing's ever easy ¯\\\_(ツ)\_/¯