### PR TITLE
The reporting app populates the stats table each evening.

### DIFF
--- a/scripts/paas_app_wrapper.sh
+++ b/scripts/paas_app_wrapper.sh
@@ -29,7 +29,7 @@ case $NOTIFY_APP_NAME in
     -Q periodic-tasks 2> /dev/null
     ;;
   delivery-worker-reporting)
-    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
+    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=2 \
     -Q reporting-tasks 2> /dev/null
     ;;
   delivery-worker-priority)


### PR DESCRIPTION
The `create-nightly-notification-status` task, kicks off 4 tasks for email for 4 days plus 4 tasks for sms plus 10 tasks for letters for a total of 18 tasks. Since there are 2 delivery-worker-reporting apps with 11 worker threads all 18tasks are running in parallel. This put unnecessary pressure on the app, recently we had the app crash with a `out of memory` error. If we reduce the number of worker threads this will all the tasks to be run 4 at a time.