### PR TITLE
Stop searching the to field

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -622,7 +622,6 @@ def dao_get_notifications_by_recipient_or_reference(service_id, search_term, not
     filters = [
         Notification.service_id == service_id,
         or_(
-            Notification.to.ilike("%{}%".format(search_term)),
             Notification.normalised_to.like("%{}%".format(normalised)),
             Notification.client_reference.ilike("%{}%".format(search_term)),
         ),

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1319,13 +1319,12 @@ def test_dao_get_notifications_by_reference(
     assert results[1].id == email.id
     assert results[2].id == sms.id
 
-    # If notification_type isn’t specified then we can’t normalise the phone number
-    # to 4477… but this query will still find the 077… variant in the `to` field,
-    # as well as the email
+    # If notification_type isn’t specified then we can’t normalise the
+    # phone number to 4477… so this query will only find the email sent
+    # to 077@example.com
     results = dao_get_notifications_by_recipient_or_reference(service.id, '077')
-    assert len(results) == 2
+    assert len(results) == 1
     assert results[0].id == email.id
-    assert results[1].id == sms.id
 
     results = dao_get_notifications_by_recipient_or_reference(service.id, '077@')
     assert len(results) == 1


### PR DESCRIPTION
We were doing this temporarily while the `normalised_to` field was not populated for letters. Once we have a week* of data in the `normalised_to` field we can stop looking in the `to` field. This should improve performance because:
- it’s one `WHERE` clause not two
- we had to do `ilike` on the `to` field, because we don’t lowercase its  contents – even if the two where clauses are somehow parallelised it’s is slower than a `like` comparison, which is case-sensitive

I checked on production and no real services have custom data retention for letters.

***

Depends on:
- [x] Tuesday 5 May (7 full days after deploying https://github.com/alphagov/notifications-api/pull/2814)