### PR TITLE
Limit search by recipient to 50 results

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -586,7 +586,14 @@ def dao_update_notifications_by_reference(references, update_dict):
 
 
 @statsd(namespace="dao")
-def dao_get_notifications_by_recipient_or_reference(service_id, search_term, notification_type=None, statuses=None):
+def dao_get_notifications_by_recipient_or_reference(
+    service_id,
+    search_term,
+    notification_type=None,
+    statuses=None,
+    page=1,
+    page_size=None,
+):
 
     if notification_type == SMS_TYPE:
         normalised = try_validate_and_format_phone_number(search_term)
@@ -636,8 +643,7 @@ def dao_get_notifications_by_recipient_or_reference(service_id, search_term, not
     results = db.session.query(Notification)\
         .filter(*filters)\
         .order_by(desc(Notification.created_at))\
-        .limit(current_app.config['PAGE_SIZE'])\
-        .all()
+        .paginate(page=page, per_page=page_size)
     return results
 
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -633,7 +633,11 @@ def dao_get_notifications_by_recipient_or_reference(service_id, search_term, not
     if notification_type:
         filters.append(Notification.notification_type == notification_type)
 
-    results = db.session.query(Notification).filter(*filters).order_by(desc(Notification.created_at)).all()
+    results = db.session.query(Notification)\
+        .filter(*filters)\
+        .order_by(desc(Notification.created_at))\
+        .limit(current_app.config['PAGE_SIZE'])\
+        .all()
     return results
 
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -475,10 +475,19 @@ def search_for_notification_by_to_field(service_id, search_term, statuses, notif
         service_id=service_id,
         search_term=search_term,
         statuses=statuses,
-        notification_type=notification_type
+        notification_type=notification_type,
+        page=1,
+        page_size=current_app.config['PAGE_SIZE'],
     )
     return jsonify(
-        notifications=notification_with_template_schema.dump(results, many=True).data
+        notifications=notification_with_template_schema.dump(results.items, many=True).data,
+        links=pagination_links(
+            results,
+            '.get_all_notifications_for_service',
+            statuses=statuses,
+            notification_type=notification_type,
+            service_id=service_id,
+        ),
     ), 200
 
 

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1057,6 +1057,24 @@ def test_dao_get_notifications_by_recipient(sample_template):
     assert notification1.id == results[0].id
 
 
+def test_dao_get_notifications_by_recipient_is_limited_to_50_results(sample_template):
+
+    for _ in range(100):
+        create_notification(
+            template=sample_template,
+            to_field='+447700900855',
+            normalised_to='447700900855',
+        )
+
+    results = dao_get_notifications_by_recipient_or_reference(
+        sample_template.service_id,
+        '447700900855',
+        notification_type='sms'
+    )
+
+    assert len(results) == 50
+
+
 @pytest.mark.parametrize("search_term",
                          ["JACK", "JACK@gmail.com", "jack@gmail.com"])
 def test_dao_get_notifications_by_recipient_is_not_case_sensitive(sample_email_template, search_term):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2103,6 +2103,24 @@ def test_search_for_notification_by_to_field_return_multiple_matches(client, sam
     assert str(notification4.id) not in notification_ids
 
 
+def test_search_for_notification_by_to_field_returns_next_link_if_more_than_50(
+    client, sample_template
+):
+    for i in range(51):
+        create_notification(sample_template, to_field='+447700900855', normalised_to='447700900855')
+
+    response = client.get(
+        '/service/{}/notifications?to={}&template_type={}'.format(sample_template.service_id, '+447700900855', 'sms'),
+        headers=[create_authorization_header()]
+    )
+    assert response.status_code == 200
+    response_json = json.loads(response.get_data(as_text=True))
+
+    assert len(response_json['notifications']) == 50
+    assert 'prev' not in response_json['links']
+    assert 'page=2' in response_json['links']['next']
+
+
 def test_search_for_notification_by_to_field_for_letter(
     client,
     notify_db,


### PR DESCRIPTION
Things could get ugly if you use a short search string on a service with lots of notifications…