### PR TITLE
Include pending notifications in monthly data by service report

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -17,6 +17,7 @@ from app.models import (
     NOTIFICATION_CREATED,
     NOTIFICATION_DELIVERED,
     NOTIFICATION_FAILED,
+    NOTIFICATION_PENDING,
     NOTIFICATION_SENDING,
     NOTIFICATION_SENT,
     NOTIFICATION_TECHNICAL_FAILURE,
@@ -462,7 +463,7 @@ def fetch_monthly_notification_statuses_per_service(start_date, end_date):
         FactNotificationStatus.notification_type,
         func.sum(case(
             [
-                (FactNotificationStatus.notification_status == NOTIFICATION_SENDING,
+                (FactNotificationStatus.notification_status.in_([NOTIFICATION_SENDING, NOTIFICATION_PENDING]),
                  FactNotificationStatus.notification_count)
             ],
             else_=0)).label('count_sending'),

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -26,6 +26,7 @@ from app.models import (
     NOTIFICATION_CREATED,
     NOTIFICATION_DELIVERED,
     NOTIFICATION_FAILED,
+    NOTIFICATION_PENDING,
     NOTIFICATION_PERMANENT_FAILURE,
     NOTIFICATION_SENDING,
     NOTIFICATION_SENT,
@@ -649,6 +650,8 @@ def test_fetch_monthly_notification_statuses_per_service(notify_db_session):
                                   notification_status=NOTIFICATION_DELIVERED)
     create_ft_notification_status(date(2019, 3, 1), notification_type='email', service=service_one,
                                   notification_status=NOTIFICATION_SENDING, count=4)
+    create_ft_notification_status(date(2019, 3, 1), notification_type='email', service=service_one,
+                                  notification_status=NOTIFICATION_PENDING, count=1)
     create_ft_notification_status(date(2019, 3, 2), notification_type='email', service=service_one,
                                   notification_status=NOTIFICATION_TECHNICAL_FAILURE, count=2)
     create_ft_notification_status(date(2019, 3, 7), notification_type='email', service=service_one,
@@ -670,7 +673,7 @@ def test_fetch_monthly_notification_statuses_per_service(notify_db_session):
     # column order: date, service_id, service_name, notifaction_type, count_sending, count_delivered,
     # count_technical_failure, count_temporary_failure, count_permanent_failure, count_sent
     assert [x for x in results[0]] == [date(2019, 3, 1), service_two.id, 'service two', 'letter', 0, 0, 0, 0, 2, 0]
-    assert [x for x in results[1]] == [date(2019, 3, 1), service_one.id, 'service one', 'email', 4, 0, 3, 0, 0, 0]
+    assert [x for x in results[1]] == [date(2019, 3, 1), service_one.id, 'service one', 'email', 5, 0, 3, 0, 0, 0]
     assert [x for x in results[2]] == [date(2019, 3, 1), service_one.id, 'service one', 'letter', 0, 1, 0, 0, 0, 0]
     assert [x for x in results[3]] == [date(2019, 3, 1), service_one.id, 'service one', 'sms', 0, 0, 0, 0, 0, 1]
     assert [x for x in results[4]] == [date(2019, 4, 1), service_two.id, 'service two', 'letter', 0, 0, 0, 10, 0, 0]


### PR DESCRIPTION
The '/service/monthly-data-by-service' endpoint which is used for the
'Monthly notification statuses for live services' Platform Admin report
did not including `pending` notifications. This updates the DAO function
that the endpoint calls to group `pending` and `sending` notifications together.

[Pivotal story](https://www.pivotaltracker.com/story/show/172474572)