### PR TITLE
Fix provider date for inbound SMS

### DIFF
--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -3,7 +3,6 @@ from urllib.parse import unquote
 import iso8601
 from flask import jsonify, Blueprint, current_app, request, abort
 from notifications_utils.recipients import try_validate_and_format_phone_number
-from notifications_utils.timezones import convert_bst_to_utc
 
 from app import statsd_client
 from app.celery import tasks
@@ -114,11 +113,11 @@ def unescape_string(string):
 def format_mmg_datetime(date):
     """
     We expect datetimes in format 2017-05-21+11%3A56%3A11 - ie, spaces replaced with pluses, and URI encoded
-    (the same as UTC)
+    and in UTC
     """
     orig_date = format_mmg_message(date)
     parsed_datetime = iso8601.parse_date(orig_date).replace(tzinfo=None)
-    return convert_bst_to_utc(parsed_datetime)
+    return parsed_datetime
 
 
 def create_inbound_sms_object(service, content, from_number, provider_ref, date_received, provider_name):

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -210,7 +210,7 @@ def test_unescape_string(raw, expected):
 
 @pytest.mark.parametrize('provider_date, expected_output', [
     ('2017-01-21+11%3A56%3A11', datetime(2017, 1, 21, 11, 56, 11)),
-    ('2017-05-21+11%3A56%3A11', datetime(2017, 5, 21, 10, 56, 11))
+    ('2017-05-21+11%3A56%3A11', datetime(2017, 5, 21, 11, 56, 11))
 ])
 def test_format_mmg_datetime(provider_date, expected_output):
     assert format_mmg_datetime(provider_date) == expected_output


### PR DESCRIPTION
When we get an inbound message from MMG, the function format_mmg_date time was converting the date to UTC, however, the provider date is already in UTC format.