### PR TITLE
set preload_app=True in gunicorn config

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -12,6 +12,7 @@ errorlog = "/home/vcap/logs/gunicorn_error.log"
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
 gunicorn.SERVER_SOFTWARE = 'None'
+preload_app = True
 
 
 def on_starting(server):


### PR DESCRIPTION
preload_app is a flag that makes the gunicorn master process load the app code, and then copy that code to each worker. This is opposed to the default, where each worker initialises the app itself. We hope that by enabling this flag, we'll solve issues we've seen where instances sometimes return 502s when they start up. Our gut feel is that this happens because the workers are listening on the socket before they've finished loading the config etc. If the master thread loads the config, there shouldn't be this issue.

Advantages of preload_app: "save some RAM resources as well as speed up server boot times" [1]

Disadvantages of preload_app. Can no longer live-reload gunicorn workers to get new code. We don't do this anyway.

[1] https://docs.gunicorn.org/en/stable/settings.html#preload-app


#### Testing

I've locally tested this. And you can too! Just run `PORT=6011 gunicorn -c gunicorn_config.py application --error-logfile - --access-logfile -` to run gunicorn. You'll be able to see it only prints `Logging configured` once, before it prints "Starting gunicorn 20.0.4". If you run that command on master it'll print `Logging configured` four times (from each worker thread), after "Booting worker with pid: #####".

Start up times appear to be about the same (~3 seconds) using my very unscientific testing.