### PR TITLE
don't expire email sign in codes on use

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -190,7 +190,8 @@ def verify_user_code(user_id):
         # only relevant from sms
         increment_failed_login_count(user_to_verify)
         raise InvalidRequest("Code not found", status_code=404)
-    if datetime.utcnow() > code.expiry_datetime or code.code_used:
+    # TODO: Fix email flow so that clicking link doesn't expire emails
+    if datetime.utcnow() > code.expiry_datetime or (code.code_used and data['code_type'] != 'email'):
         # sms and email
         increment_failed_login_count(user_to_verify)
         raise InvalidRequest("Code has expired", status_code=400)

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ env =
     FIRETEXT_API_KEY=Firetext
     NOTIFICATION_QUEUE_PREFIX=testing
 addopts = -v -p no:warnings
+xfail_strict = true


### PR DESCRIPTION
we're seeing issues with email clients sniffing links, and causing them to expire before the user gets a chance to click on them. Temporarily disable the expiry while we work on a more permanent solution.

NB: The link will still expire after twenty four hours.