### PR TITLE
restore email sign in code expiry functionality

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -190,8 +190,7 @@ def verify_user_code(user_id):
         # only relevant from sms
         increment_failed_login_count(user_to_verify)
         raise InvalidRequest("Code not found", status_code=404)
-    # TODO: Fix email flow so that clicking link doesn't expire emails
-    if datetime.utcnow() > code.expiry_datetime or (code.code_used and data['code_type'] != 'email'):
+    if datetime.utcnow() > code.expiry_datetime or code.code_used:
         # sms and email
         increment_failed_login_count(user_to_verify)
         raise InvalidRequest("Code has expired", status_code=400)

--- a/tests/app/user/test_rest_verify.py
+++ b/tests/app/user/test_rest_verify.py
@@ -453,10 +453,7 @@ def test_user_verify_email_code(admin_request, sample_user, auth_type):
 
 
 @pytest.mark.parametrize('code_type', [
-    pytest.param(
-        EMAIL_TYPE,
-        marks=pytest.mark.xfail(raises=AssertionError, reason='Email code expiry disabled'),
-    ),
+    EMAIL_TYPE,
     SMS_TYPE
 ])
 @freeze_time('2016-01-01T12:00:00')


### PR DESCRIPTION
reverts 789112a31f386c1db2378b2dcee8d16e31224735 (https://github.com/alphagov/notifications-api/pull/2831/)

however, keeps the changes to the tests as they were an improvement