### PR TITLE
Add support for CSV files

### DIFF
--- a/app/clients/document_download.py
+++ b/app/clients/document_download.py
@@ -1,5 +1,3 @@
-import base64
-
 import requests
 
 from flask import current_app
@@ -26,15 +24,16 @@ class DocumentDownloadClient:
     def get_upload_url(self, service_id):
         return "{}/services/{}/documents".format(self.api_host, service_id)
 
-    def upload_document(self, service_id, file_contents):
+    def upload_document(self, service_id, file_contents, is_csv=None):
         try:
             response = requests.post(
                 self.get_upload_url(service_id),
                 headers={
                     'Authorization': "Bearer {}".format(self.auth_token),
                 },
-                files={
-                    'document': base64.b64decode(file_contents)
+                json={
+                    'document': file_contents,
+                    'is_csv': is_csv or False,
                 }
             )
 

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -325,7 +325,7 @@ def process_document_uploads(personalisation_data, service, simulated=False):
         else:
             try:
                 personalisation_data[key] = document_download_client.upload_document(
-                    service.id, personalisation_data[key]['file']
+                    service.id, personalisation_data[key]['file'], personalisation_data[key].get('is_csv')
                 )
             except DocumentDownloadError as e:
                 raise BadRequestError(message=e.message, status_code=e.status_code)


### PR DESCRIPTION
This addresses the second & third piece in the change proposed to support sending `.csv` files in email notifications here: https://github.com/alphagov/notifications-python-client/issues/164

The first piece for this has already been merged: https://github.com/alphagov/document-download-api/pull/122

