### PR TITLE
Group letter uploads by printing day

### DIFF
--- a/app/dao/uploads_dao.py
+++ b/app/dao/uploads_dao.py
@@ -14,6 +14,8 @@ def _get_printing_day(created_at):
     return func.date_trunc(
         'day',
         func.timezone('Europe/London', func.timezone('UTC', created_at)) + text(
+            # We add 6 hours 30 minutes to the local created_at time so that
+            # any letters created after 5:30pm get shifted into the next day
             "interval '6 hours 30 minutes'"
         )
     )
@@ -21,6 +23,7 @@ def _get_printing_day(created_at):
 
 def _get_printing_datetime(created_at):
     return _get_printing_day(created_at) + text(
+        # Letters are printed from 5:30pm each day
         "interval '17 hours 30 minutes'"
     )
 

--- a/app/dao/uploads_dao.py
+++ b/app/dao/uploads_dao.py
@@ -117,3 +117,23 @@ def dao_get_uploads_by_service_id(service_id, limit_days=None, page=1, page_size
     ).order_by(
         desc("processing_started"), desc("created_at")
     ).paginate(page=page, per_page=page_size)
+
+
+def dao_get_uploaded_letters_by_print_date(service_id, letter_print_date, page=1, page_size=50):
+    return db.session.query(
+        Notification,
+    ).join(
+        Template, Notification.template_id == Template.id
+    ).filter(
+        Notification.service_id == service_id,
+        Notification.notification_type == LETTER_TYPE,
+        Notification.api_key_id.is_(None),
+        Notification.status != NOTIFICATION_CANCELLED,
+        Template.hidden.is_(True),
+        _get_printing_day(Notification.created_at) == letter_print_date.date(),
+    ).order_by(
+        desc(Notification.created_at)
+    ).paginate(
+        page=page,
+        per_page=page_size,
+    )

--- a/app/upload/rest.py
+++ b/app/upload/rest.py
@@ -87,7 +87,7 @@ def get_uploaded_letter_by_service_and_print_day(service_id, letter_print_date):
     try:
         letter_print_datetime = datetime.strptime(letter_print_date, '%Y-%m-%d')
     except ValueError:
-        abort(404)
+        abort(400)
     pagination = dao_get_uploaded_letters_by_print_date(
         service_id,
         letter_print_date=letter_print_datetime,

--- a/app/upload/rest.py
+++ b/app/upload/rest.py
@@ -61,7 +61,7 @@ def get_paginated_uploads(service_id, limit_days, page):
             upload_dict['statistics'] = [{'status': statistic.status, 'count': statistic.count} for statistic in
                                          statistics]
         else:
-            upload_dict['statistics'] = [{'status': upload.status, 'count': 1}]
+            upload_dict['statistics'] = []
         data.append(upload_dict)
 
     return {

--- a/tests/app/dao/test_uploads_dao.py
+++ b/tests/app/dao/test_uploads_dao.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from freezegun import freeze_time
 
-from app.dao.uploads_dao import dao_get_uploads_by_service_id
+from app.dao.uploads_dao import dao_get_uploads_by_service_id, dao_get_uploaded_letters_by_print_date
 from app.models import LETTER_TYPE, JOB_STATUS_IN_PROGRESS
 from tests.app.db import create_job, create_service, create_service_data_retention, create_template, create_notification
 
@@ -302,3 +302,56 @@ def test_get_uploads_is_paginated(sample_template):
 def test_get_uploads_returns_empty_list(sample_service):
     items = dao_get_uploads_by_service_id(sample_service.id).items
     assert items == []
+
+
+@freeze_time('2020-02-02 14:00')
+def test_get_uploaded_letters_by_print_date(sample_template):
+    letter_template = create_uploaded_template(sample_template.service)
+
+    # Letters for the previous day’s run
+    for i in range(3):
+        create_uploaded_letter(
+            letter_template, sample_template.service, status='delivered',
+            created_at=datetime.utcnow().replace(day=1, hour=17, minute=29, second=59)
+        )
+
+    # Letters from yesterday that rolled into today’s run
+    for i in range(30):
+        create_uploaded_letter(
+            letter_template, sample_template.service, status='delivered',
+            created_at=datetime.utcnow().replace(day=1, hour=17, minute=30, second=0)
+        )
+
+    # Letters that just made today’s run
+    for i in range(30):
+        create_uploaded_letter(
+            letter_template, sample_template.service, status='delivered',
+            created_at=datetime.utcnow().replace(hour=17, minute=29, second=59)
+        )
+
+    # Letters that just missed today’s run
+    for i in range(3):
+        create_uploaded_letter(
+            letter_template, sample_template.service, status='delivered',
+            created_at=datetime.utcnow().replace(hour=17, minute=30, second=0)
+        )
+
+    result = dao_get_uploaded_letters_by_print_date(
+        sample_template.service_id,
+        datetime.utcnow(),
+    )
+    assert result.total == 60
+    assert len(result.items) == 50
+    assert result.has_next is True
+    assert result.has_prev is False
+
+    result = dao_get_uploaded_letters_by_print_date(
+        sample_template.service_id,
+        datetime.utcnow(),
+        page=10,
+        page_size=2,
+    )
+    assert result.total == 60
+    assert len(result.items) == 2
+    assert result.has_next is True
+    assert result.has_prev is True

--- a/tests/app/upload/test_rest.py
+++ b/tests/app/upload/test_rest.py
@@ -32,16 +32,17 @@ def create_precompiled_template(service):
     )
 
 
+@freeze_time('2020-02-02 14:00')
 def test_get_uploads(admin_request, sample_template):
     letter_template = create_precompiled_template(sample_template.service)
 
-    upload_1 = create_uploaded_letter(letter_template, sample_template.service, status='delivered',
-                                      created_at=datetime.utcnow() - timedelta(minutes=4))
+    create_uploaded_letter(letter_template, sample_template.service, status='delivered',
+                           created_at=datetime.utcnow() - timedelta(minutes=4))
     upload_2 = create_job(template=sample_template,
                           processing_started=datetime.utcnow() - timedelta(minutes=3),
                           job_status=JOB_STATUS_FINISHED)
-    upload_3 = create_uploaded_letter(letter_template, sample_template.service, status='delivered',
-                                      created_at=datetime.utcnow() - timedelta(minutes=2))
+    create_uploaded_letter(letter_template, sample_template.service, status='delivered',
+                           created_at=datetime.utcnow() - timedelta(minutes=2))
     upload_4 = create_job(template=sample_template,
                           processing_started=datetime.utcnow() - timedelta(minutes=1),
                           job_status=JOB_STATUS_FINISHED)
@@ -52,7 +53,7 @@ def test_get_uploads(admin_request, sample_template):
 
     resp_json = admin_request.get('upload.get_uploads_by_service', service_id=service_id)
     data = resp_json['data']
-    assert len(data) == 5
+    assert len(data) == 4
     assert data[0] == {'id': str(upload_5.id),
                        'original_file_name': 'some.csv',
                        'recipient': None,
@@ -61,23 +62,15 @@ def test_get_uploads(admin_request, sample_template):
                        'created_at': upload_5.created_at.strftime("%Y-%m-%d %H:%M:%S"),
                        'statistics': [],
                        'upload_type': 'job'}
-    assert data[1] == {'id': str(upload_4.id),
-                       'original_file_name': 'some.csv',
+    assert data[1] == {'id': None,
+                       'original_file_name': 'Uploaded letters',
                        'recipient': None,
-                       'notification_count': 1,
-                       'template_type': 'sms',
-                       'created_at': upload_4.created_at.strftime(
+                       'notification_count': 2,
+                       'template_type': 'letter',
+                       'created_at': upload_4.created_at.replace(hour=17, minute=30).strftime(
                            "%Y-%m-%d %H:%M:%S"),
                        'statistics': [],
-                       'upload_type': 'job'}
-    assert data[2] == {'id': str(upload_3.id),
-                       'original_file_name': "file-name",
-                       'recipient': '742 Evergreen Terrace',
-                       'notification_count': 1,
-                       'template_type': None,
-                       'created_at': upload_3.created_at.strftime("%Y-%m-%d %H:%M:%S"),
-                       'statistics': [{'count': 1, 'status': 'delivered'}],
-                       'upload_type': 'letter'}
+                       'upload_type': 'letter_day'}
     assert data[3] == {'id': str(upload_2.id),
                        'original_file_name': "some.csv",
                        'recipient': None,
@@ -87,14 +80,6 @@ def test_get_uploads(admin_request, sample_template):
                            "%Y-%m-%d %H:%M:%S"),
                        'statistics': [],
                        'upload_type': 'job'}
-    assert data[4] == {'id': str(upload_1.id),
-                       'original_file_name': "file-name",
-                       'recipient': '742 Evergreen Terrace',
-                       'notification_count': 1,
-                       'template_type': None,
-                       'created_at': upload_1.created_at.strftime("%Y-%m-%d %H:%M:%S"),
-                       'statistics': [{'count': 1, 'status': 'delivered'}],
-                       'upload_type': 'letter'}
 
 
 def test_get_uploads_should_return_statistics(admin_request, sample_template):
@@ -110,8 +95,8 @@ def test_get_uploads_should_return_statistics(admin_request, sample_template):
         create_notification(template=sample_template, job=job_3, status='sending')
 
     letter_template = create_precompiled_template(sample_template.service)
-    letter_1 = create_uploaded_letter(letter_template, sample_template.service, status='delivered',
-                                      created_at=datetime.utcnow() - timedelta(days=3))
+    create_uploaded_letter(letter_template, sample_template.service, status='delivered',
+                           created_at=datetime.utcnow() - timedelta(days=3))
 
     resp_json = admin_request.get('upload.get_uploads_by_service', service_id=sample_template.service_id)['data']
     assert len(resp_json) == 4
@@ -121,8 +106,8 @@ def test_get_uploads_should_return_statistics(admin_request, sample_template):
     assert resp_json[1]['statistics'] == [{'status': 'sending', 'count': 4}]
     assert resp_json[2]['id'] == str(job_2.id)
     assert resp_json[2]['statistics'] == [{'status': 'created', 'count': 3}]
-    assert resp_json[3]['id'] == str(letter_1.id)
-    assert resp_json[3]['statistics'] == [{'status': 'delivered', 'count': 1}]
+    assert resp_json[3]['id'] is None
+    assert resp_json[3]['statistics'] == []
 
 
 def test_get_uploads_should_paginate(admin_request, sample_template):

--- a/tests/app/upload/test_rest.py
+++ b/tests/app/upload/test_rest.py
@@ -245,5 +245,5 @@ def test_get_uploaded_letters_by_print_date_404s_for_bad_date(
         'upload.get_uploaded_letter_by_service_and_print_day',
         service_id=sample_service.id,
         letter_print_date='foo',
-        _expected_status=404,
+        _expected_status=400,
     )


### PR DESCRIPTION
Some teams have started uploading quite a lot of letters (in the hundreds per week). They’re also uploading CSVs of emails. This means the uploads page ends up quite jumbled.

This is because:
- there’s just a lot of items to scan through
- conceptually it’s a bit odd to have batches of things displayed alongside individual things on the same page

So instead this pull request starts grouping together uploaded letters into pseudo-jobs. It does this by the date on which we ‘start’ printing them, or in other words the time at which they can no longer be cancelled.

This feels like a natural grouping, and it matches what we know about people’s mental models of ‘batches’ and ‘runs’ when talking about printing.

The code for this is a bit gnarly because:
- timezones
- the print cutoff doesn’t align with the end of a day
- we have to do this in SQL because it wouldn’t be efficient to query thousands of letters and then do the timezone calculations on them in Python

This pull request also adds an endpoint to get uploaded letters for a day because we won’t be showing uploaded letters individually on the uploads page any more we need a way of listing them.

***

## Raw query

To check performance run this (replacing `service_id` with a real service ID):

```sql
SELECT
    NULL AS id,
    'Uploaded letters' AS original_file_name,
    anon_1.notification_count AS notification_count,
    NULL AS template_type,
    NULL AS days_of_retention,
    anon_1.printing_at AS created_at,
    NULL AS scheduled_for,
    anon_1.printing_at AS processing_started,
    NULL AS status,
    'letter_day' AS upload_type,
    NULL AS recipient 
FROM
    (
        SELECT
            count(*) AS notification_count,
            timezone('UTC', timezone('Europe/London', date_trunc('day', timezone('Europe/London', timezone('UTC', notifications.created_at)) + interval '6 hours 30 minutes') + interval '17 hours 30 minutes')) AS printing_at 
        FROM
            notifications 
            JOIN
                templates 
                ON notifications.template_id = templates.id 
            LEFT OUTER JOIN
                service_data_retention 
                ON templates.service_id = service_data_retention.service_id 
                AND CAST(templates.template_type AS VARCHAR) = CAST(service_data_retention.notification_type AS VARCHAR) 
        WHERE
            notifications.service_id = '0759cacc-3031-4f83-9576-be4cb9be0804' 
            AND notifications.notification_type = 'letter' 
            AND notifications.api_key_id IS NULL 
            AND notifications.notification_status != 'cancelled' 
            AND templates.hidden = true 
            AND notifications.created_at >= to_date('2020-05-11', 'YYYY-MM-DD') - coalesce(service_data_retention.days_of_retention, 7) 
        GROUP BY
            printing_at
    )
    AS anon_1 
GROUP BY
    anon_1.notification_count,
    anon_1.printing_at
```

***

## Query performance

For the service that’s sending the most uploaded letters:

```
 id | original_file_name | notification_count | template_type | days_of_retention |     created_at      | scheduled_for | processing_started  | status | upload_type | recipient
----+--------------------+--------------------+---------------+-------------------+---------------------+---------------+---------------------+--------+-------------+-----------
    | Uploaded letters   |                 84 |               |                   | 2020-05-04 16:30:00 |               | 2020-05-04 16:30:00 |        | letter_day  |
    | Uploaded letters   |                133 |               |                   | 2020-05-06 16:30:00 |               | 2020-05-06 16:30:00 |        | letter_day  |
    | Uploaded letters   |                146 |               |                   | 2020-05-05 16:30:00 |               | 2020-05-05 16:30:00 |        | letter_day  |
    | Uploaded letters   |                151 |               |                   | 2020-05-07 16:30:00 |               | 2020-05-07 16:30:00 |        | letter_day  |
    | Uploaded letters   |                153 |               |                   | 2020-05-11 16:30:00 |               | 2020-05-11 16:30:00 |        | letter_day  |
(5 rows)

Time: 49.115 ms
```

For the service with the most notifications (GOV.UK Email):
```
 id | original_file_name | notification_count | template_type | days_of_retention | created_at | scheduled_for | processing_started | status | upload_type | recipient
----+--------------------+--------------------+---------------+-------------------+------------+---------------+--------------------+--------+-------------+-----------
(0 rows)

Time: 27.266 ms
```

For the service with a lot of templated letters (35,000 in the last week):
```
 id | original_file_name | notification_count | template_type | days_of_retention | created_at | scheduled_for | processing_started | status | upload_type | recipient
----+--------------------+--------------------+---------------+-------------------+------------+---------------+--------------------+--------+-------------+-----------
(0 rows)

Time: 66.620 ms
```

***


Depends on:
- [x] https://github.com/alphagov/notifications-admin/pull/3437 (so that the admin app knows how to display these new types of job)