### PR TITLE
add api-paas-failwhale

### DIFF
--- a/paas-failwhale/README.md
+++ b/paas-failwhale/README.md
@@ -1,0 +1,27 @@
+### What is it?
+
+This is a simple static error page to present to API users in case of a (planned) downtime.
+It is deployed as an individual app and remains dormant until a route is assigned to it.
+It returns a 503 error code and a standard json response for all routes.
+
+
+### How do I use it?
+
+It should already be deployed, but if not (or if you need to make changes to the nginx config) you can deploy it by running
+
+    cf push notify-api-failwhale
+
+To enable it you need to run
+
+    make <environment> enable-failwhale
+
+and to disable it
+
+    make <environment> disable-failwhale
+
+
+Where `<environment>` is any of
+
+- preview
+- staging
+- production

--- a/paas-failwhale/manifest.yml
+++ b/paas-failwhale/manifest.yml
@@ -1,0 +1,8 @@
+---
+
+applications:
+  - name: notify-api-failwhale
+    buildpacks:
+      - nginx_buildpack
+    memory: 256M
+    no-route: true

--- a/paas-failwhale/nginx.conf
+++ b/paas-failwhale/nginx.conf
@@ -1,0 +1,31 @@
+worker_processes 1;
+daemon off;
+
+error_log ./error.log;
+events { worker_connections 8192; }
+
+http {
+  charset utf-8;
+  log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
+  access_log ./access.log cloudfoundry;
+
+  keepalive_timeout 30;
+  server_tokens off;
+
+  server {
+    listen {{port}};
+    server_name localhost;
+
+    location / {
+        set $RESP '{';
+        set $RESP '${RESP} "status_code": 503,';
+        set $RESP '${RESP} "errors": [ {';
+        set $RESP '${RESP} "error": "PlannedMaintenanceError",';
+        set $RESP '${RESP} "message": "We’re performing some essential updates. Notify will be back shortly. Please check https://status.notifications.service.gov.uk/ for more details"';
+        set $RESP '${RESP} } ] }';
+
+        add_header  Content-Type    application/json;
+        return 503 '$RESP';
+    }
+  }
+}


### PR DESCRIPTION
for use when we don't want API to serve any traffic, but paas is still running. It's a simple nginx_buildpack app that is pushed separately, and then two makefile commands that toggle the routes (and also stop/start the nginx app).

For all endpoints/methods it returns a 503, with the response body.

TODO: Some simple load testing - it's one instance with 256mb ram - is this enough to return simple messages to a high load of API users?

```
{
    "status_code": 503,
    "errors": [
        {
            "error": "PlannedMaintenanceError",
            "message": "We’re performing some essential updates. Notify will be back shortly. Please check https://status.notifications.service.gov.uk/ for more details"
        }
    ]
}
```

NB: If you hit `/` it'll still return 404 - as this is defined in the paas-proxy instance on aws.