### PR TITLE
Allow jobs to be grouped by contact list 

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -65,6 +65,7 @@ def dao_get_jobs_by_service_id(
     page=1,
     page_size=50,
     statuses=None,
+    contact_list_id=None,
 ):
     query_filter = [
         Job.service_id == service_id,
@@ -77,6 +78,8 @@ def dao_get_jobs_by_service_id(
         query_filter.append(
             Job.job_status.in_(statuses)
         )
+    if contact_list_id is not None:
+        query_filter.append(Job.contact_list_id == contact_list_id)
     return Job.query \
         .filter(*query_filter) \
         .order_by(Job.processing_started.desc(), Job.created_at.desc()) \

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -58,7 +58,14 @@ def dao_get_job_by_service_id_and_job_id(service_id, job_id):
     return Job.query.filter_by(service_id=service_id, id=job_id).one()
 
 
-def dao_get_jobs_by_service_id(service_id, limit_days=None, page=1, page_size=50, statuses=None):
+def dao_get_jobs_by_service_id(
+    service_id,
+    *,
+    limit_days=None,
+    page=1,
+    page_size=50,
+    statuses=None,
+):
     query_filter = [
         Job.service_id == service_id,
         Job.original_file_name != current_app.config['TEST_MESSAGE_FILENAME'],

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -128,10 +128,12 @@ def get_jobs_by_service(service_id):
     else:
         limit_days = None
 
-    statuses = [x.strip() for x in request.args.get('statuses', '').split(',')]
-
-    page = int(request.args.get('page', 1))
-    return jsonify(**get_paginated_jobs(service_id, limit_days, statuses, page))
+    return jsonify(**get_paginated_jobs(
+        service_id,
+        limit_days=limit_days,
+        statuses=[x.strip() for x in request.args.get('statuses', '').split(',')],
+        page=int(request.args.get('page', 1)),
+    ))
 
 
 @job_blueprint.route('', methods=['POST'])
@@ -185,7 +187,13 @@ def create_job(service_id):
     return jsonify(data=job_json), 201
 
 
-def get_paginated_jobs(service_id, limit_days, statuses, page):
+def get_paginated_jobs(
+    service_id,
+    *,
+    limit_days,
+    statuses,
+    page,
+):
     pagination = dao_get_jobs_by_service_id(
         service_id,
         limit_days=limit_days,

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -133,6 +133,7 @@ def get_jobs_by_service(service_id):
         limit_days=limit_days,
         statuses=[x.strip() for x in request.args.get('statuses', '').split(',')],
         page=int(request.args.get('page', 1)),
+        contact_list_id=request.args.get('contact_list_id'),
     ))
 
 
@@ -193,13 +194,15 @@ def get_paginated_jobs(
     limit_days,
     statuses,
     page,
+    contact_list_id,
 ):
     pagination = dao_get_jobs_by_service_id(
         service_id,
         limit_days=limit_days,
         page=page,
         page_size=current_app.config['PAGE_SIZE'],
-        statuses=statuses
+        statuses=statuses,
+        contact_list_id=contact_list_id,
     )
     data = job_schema.dump(pagination.items, many=True).data
     for job_data in data:

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -380,8 +380,12 @@ class JobSchema(BaseSchema):
     service_name = fields.Nested(
         ServiceSchema, attribute="service", dump_to="service_name", only=["name"], dump_only=True)
 
+    template_name = fields.Method('get_template_name', dump_only=True)
     template_type = fields.Method('get_template_type', dump_only=True)
     contact_list_id = field_for(models.Job, 'contact_list_id')
+
+    def get_template_name(self, job):
+        return job.template.name
 
     def get_template_type(self, job):
         return job.template.template_type

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -25,7 +25,7 @@ from app.models import (
     EMAIL_TYPE, SMS_TYPE, LETTER_TYPE,
     JOB_STATUS_FINISHED
 )
-from tests.app.db import create_job, create_service, create_template, create_notification
+from tests.app.db import create_job, create_service, create_template, create_notification, create_service_contact_list
 
 
 def test_should_have_decorated_notifications_dao_functions():
@@ -166,6 +166,26 @@ def test_get_jobs_for_service_in_processed_at_then_created_at_order(notify_db, n
 
     for index in range(0, len(created_jobs)):
         assert jobs[index].id == created_jobs[index].id
+
+
+def test_get_jobs_for_service_by_contact_list(sample_template):
+    contact_list = create_service_contact_list()
+    job_1 = create_job(sample_template)
+    job_2 = create_job(sample_template, contact_list_id=contact_list.id)
+
+    assert dao_get_jobs_by_service_id(
+        sample_template.service.id
+    ).items == [
+        job_2,
+        job_1,
+    ]
+
+    assert dao_get_jobs_by_service_id(
+        sample_template.service.id,
+        contact_list_id=contact_list.id,
+    ).items == [
+        job_2,
+    ]
 
 
 def test_update_job(sample_job):

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -740,6 +740,20 @@ def test_get_jobs_with_limit_days(admin_request, sample_template):
     assert len(resp_json['data']) == 2
 
 
+def test_get_jobs_by_contact_list(admin_request, sample_template):
+    contact_list = create_service_contact_list()
+    create_job(template=sample_template)
+    create_job(template=sample_template, contact_list_id=contact_list.id)
+
+    resp_json = admin_request.get(
+        'job.get_jobs_by_service',
+        service_id=sample_template.service_id,
+        contact_list_id=contact_list.id,
+    )
+
+    assert len(resp_json['data']) == 1
+
+
 def test_get_jobs_should_return_statistics(admin_request, sample_template):
     now = datetime.utcnow()
     earlier = datetime.utcnow() - timedelta(days=1)

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -718,6 +718,7 @@ def test_get_jobs(admin_request, sample_template):
         'service_name': {'name': sample_template.service.name},
         'statistics': [],
         'template': str(sample_template.id),
+        'template_name': sample_template.name,
         'template_type': 'sms',
         'template_version': 1,
         'updated_at': None,


### PR DESCRIPTION
At the moment jobs created from contact lists are ‘copied’. They appear as duplicates on the jobs page, but have count of sending/failed/delivered rather than just an overall count.

The only thing tying them back to the original contact list is the filename (even though  we store a relationship in the database).

It feels a bit richer to be able to see, for a given contact list, what messages (that is to say jobs) have been sent to that group of people. This pul request implements the extra arguments and fields the API needs to accept and return in order to display the jobs for a given contact list on that contact list’s page.