### PR TITLE
Don’t return jobs sent from contact lists

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -69,6 +69,7 @@ def dao_get_jobs_by_service_id(
         Job.service_id == service_id,
         Job.original_file_name != current_app.config['TEST_MESSAGE_FILENAME'],
         Job.original_file_name != current_app.config['ONE_OFF_MESSAGE_FILENAME'],
+        Job.contact_list_id == contact_list_id,
     ]
     if limit_days is not None:
         query_filter.append(Job.created_at >= midnight_n_days_ago(limit_days))

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -172,7 +172,6 @@ def test_get_jobs_for_service_by_contact_list(sample_template):
     assert dao_get_jobs_by_service_id(
         sample_template.service.id
     ).items == [
-        job_2,
         job_1,
     ]
 

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -743,6 +743,21 @@ def test_get_jobs_with_limit_days(admin_request, sample_template):
     assert len(resp_json['data']) == 2
 
 
+def test_get_jobs_filters_jobs_from_contact_lists(admin_request, sample_template):
+    contact_list = create_service_contact_list()
+
+    create_job(template=sample_template, contact_list_id=contact_list.id)
+    job_without_contact_list = create_job(template=sample_template)
+
+    resp_json = admin_request.get(
+        'job.get_jobs_by_service',
+        service_id=sample_template.service_id,
+    )
+
+    assert len(resp_json['data']) == 1
+    assert resp_json['data'][0]['id'] == str(job_without_contact_list.id)
+
+
 def test_get_jobs_by_contact_list(admin_request, sample_template):
     contact_list = create_service_contact_list()
     create_job(template=sample_template)


### PR DESCRIPTION
Now that we’re grouping jobs sent from contact lists within their parent, they shouldn’t also be listed on the jobs page at the top level.

***

Depends on:
- [x] https://github.com/alphagov/notifications-admin/pull/3440