### PR TITLE
Update postage constraint (take 2)

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -903,7 +903,7 @@ class TemplateBase(db.Model):
     postage = db.Column(db.String, nullable=True)
     CheckConstraint("""
         CASE WHEN template_type = 'letter' THEN
-            postage is not null and postage in ('first', 'second')
+            postage is not null and postage in ('first', 'second', 'europe', 'rest-of-world')
         ELSE
             postage is null
         END
@@ -1353,10 +1353,13 @@ DVLA_RESPONSE_STATUS_SENT = 'Sent'
 
 FIRST_CLASS = 'first'
 SECOND_CLASS = 'second'
-POSTAGE_TYPES = [FIRST_CLASS, SECOND_CLASS]
+EUROPE = 'europe'
+REST_OF_WORLD = 'rest-of-world'
 RESOLVE_POSTAGE_FOR_FILE_NAME = {
     FIRST_CLASS: 1,
-    SECOND_CLASS: 2
+    SECOND_CLASS: 2,
+    EUROPE: 'E',
+    REST_OF_WORLD: 'N',
 }
 
 
@@ -1433,7 +1436,7 @@ class Notification(db.Model):
     postage = db.Column(db.String, nullable=True)
     CheckConstraint("""
         CASE WHEN notification_type = 'letter' THEN
-            postage is not null and postage in ('first', 'second')
+            postage is not null and postage in ('first', 'second', 'europe', 'rest-of-world')
         ELSE
             postage is null
         END
@@ -1698,13 +1701,6 @@ class NotificationHistory(db.Model, HistoryModel):
     created_by_id = db.Column(UUID(as_uuid=True), nullable=True)
 
     postage = db.Column(db.String, nullable=True)
-    CheckConstraint("""
-        CASE WHEN notification_type = 'letter' THEN
-            postage is not null and postage in ('first', 'second')
-        ELSE
-            postage is null
-        END
-    """)
 
     document_download_count = db.Column(db.Integer, nullable=True)
 

--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -34,8 +34,8 @@ def validate_schema_email_address(instance):
 @format_checker.checks('postage', raises=ValidationError)
 def validate_schema_postage(instance):
     if isinstance(instance, str):
-        if instance not in ["first", "second"]:
-            raise ValidationError("invalid. It must be either first or second.")
+        if instance not in ["first", "second", "europe", "rest-of-world"]:
+            raise ValidationError("invalid. It must be first, second, europe or rest-of-world.")
     return True
 
 

--- a/migrations/versions/0321_update_postage_constraint_1.py
+++ b/migrations/versions/0321_update_postage_constraint_1.py
@@ -1,0 +1,83 @@
+"""
+
+Revision ID: 0321_update_postage_constraint_1
+Revises: 0320_optimise_notifications
+Create Date: 2020-05-12 16:17:21.874281
+
+"""
+import os
+
+from alembic import op
+
+
+revision = '0321_update_postage_constraint_1'
+down_revision = '0320_optimise_notifications'
+environment = os.environ['NOTIFY_ENVIRONMENT']
+
+
+def upgrade():
+    op.drop_constraint('chk_notifications_postage_null', 'notifications')
+    op.execute("""
+        ALTER TABLE notifications ADD CONSTRAINT "chk_notifications_postage_null"
+        CHECK (
+            CASE WHEN notification_type = 'letter' THEN
+                postage is not null and postage in ('first', 'second', 'europe', 'rest-of-world')
+            ELSE
+                postage is null
+            END
+        )
+        NOT VALID
+    """)
+    if environment not in ["live", "production"]:
+        op.execute('ALTER TABLE notification_history DROP CONSTRAINT IF EXISTS chk_notification_history_postage_null')
+
+
+def downgrade():
+    pass
+    # To downgrade this migration and migrations 0322 and 0323 * LOCALLY ONLY * use the following code.
+    # This should not be used in production - it will lock the tables for a long time
+    #
+    # op.drop_constraint('chk_notifications_postage_null', 'notifications')
+    # op.drop_constraint('chk_templates_postage', 'templates')
+    # op.drop_constraint('chk_templates_history_postage', 'templates_history')
+    #
+    # op.execute("""
+    #     ALTER TABLE notifications ADD CONSTRAINT "chk_notifications_postage_null"
+    #     CHECK (
+    #         CASE WHEN notification_type = 'letter' THEN
+    #             postage is not null and postage in ('first', 'second')
+    #         ELSE
+    #             postage is null
+    #         END
+    #     )
+    # """)
+    # op.execute("""
+    #     ALTER TABLE notification_history ADD CONSTRAINT "chk_notification_history_postage_null"
+    #     CHECK (
+    #         CASE WHEN notification_type = 'letter' THEN
+    #             postage is not null and postage in ('first', 'second')
+    #         ELSE
+    #             postage is null
+    #         END
+    #     )
+    # """)
+    # op.execute("""
+    #     ALTER TABLE templates ADD CONSTRAINT "chk_templates_postage"
+    #     CHECK (
+    #         CASE WHEN template_type = 'letter' THEN
+    #             postage is not null and postage in ('first', 'second')
+    #         ELSE
+    #             postage is null
+    #         END
+    #     )
+    # """)
+    # op.execute("""
+    #     ALTER TABLE templates_history ADD CONSTRAINT "chk_templates_history_postage"
+    #     CHECK (
+    #         CASE WHEN template_type = 'letter' THEN
+    #             postage is not null and postage in ('first', 'second')
+    #         ELSE
+    #             postage is null
+    #         END
+    #     )
+    # """)

--- a/migrations/versions/0322_update_postage_constraint_2.py
+++ b/migrations/versions/0322_update_postage_constraint_2.py
@@ -1,0 +1,44 @@
+"""
+
+Revision ID: 0322_update_postage_constraint_2
+Revises: 0321_update_postage_constraint_1
+Create Date: 2020-05-12 16:20:16.548347
+
+"""
+from alembic import op
+
+
+revision = '0322_update_postage_constraint_2'
+down_revision = '0321_update_postage_constraint_1'
+
+
+def upgrade():
+    op.drop_constraint('chk_templates_postage', 'templates')
+    op.drop_constraint('chk_templates_history_postage', 'templates_history')
+
+    op.execute("""
+        ALTER TABLE templates ADD CONSTRAINT "chk_templates_postage"
+        CHECK (
+            CASE WHEN template_type = 'letter' THEN
+                postage is not null and postage in ('first', 'second', 'europe', 'rest-of-world')
+            ELSE
+                postage is null
+            END
+        )
+        NOT VALID
+    """)
+    op.execute("""
+        ALTER TABLE templates_history ADD CONSTRAINT "chk_templates_history_postage"
+        CHECK (
+            CASE WHEN template_type = 'letter' THEN
+                postage is not null and postage in ('first', 'second', 'europe', 'rest-of-world')
+            ELSE
+                postage is null
+            END
+        )
+        NOT VALID
+    """)
+
+
+def downgrade():
+    pass

--- a/migrations/versions/0323_update_postage_constraint_3.py
+++ b/migrations/versions/0323_update_postage_constraint_3.py
@@ -1,0 +1,22 @@
+"""
+
+Revision ID: 0323_update_postage_constraint_3
+Revises: 0322_update_postage_constraint_2
+Create Date: 2020-05-12 16:21:56.210025
+
+"""
+from alembic import op
+
+
+revision = '0323_update_postage_constraint_3'
+down_revision = '0322_update_postage_constraint_2'
+
+
+def upgrade():
+    op.execute('ALTER TABLE notifications VALIDATE CONSTRAINT "chk_notifications_postage_null"')
+    op.execute('ALTER TABLE templates VALIDATE CONSTRAINT "chk_templates_postage"')
+    op.execute('ALTER TABLE templates_history VALIDATE CONSTRAINT "chk_templates_history_postage"')
+
+
+def downgrade():
+    pass

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2343,7 +2343,8 @@ def test_create_pdf_letter(mocker, sample_service_full_permissions, client, fake
         {"postage": "third", "filename": "string", "created_by": "string", "file_id": "string",
          "recipient_address": "Some Address"},
         [
-            {'error': 'ValidationError', 'message': 'postage invalid. It must be either first or second.'}
+            {'error': 'ValidationError',
+             'message': 'postage invalid. It must be first, second, europe or rest-of-world.'}
         ]
     )
 ])

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -636,7 +636,7 @@ def test_post_letter_notification_throws_error_for_invalid_postage(client, notif
 
     assert response.status_code == 400, response.get_data(as_text=True)
     resp_json = json.loads(response.get_data(as_text=True))
-    assert resp_json['errors'][0]['message'] == "postage invalid. It must be either first or second."
+    assert resp_json['errors'][0]['message'] == "postage invalid. It must be first, second, europe or rest-of-world."
 
     assert not Notification.query.first()
 


### PR DESCRIPTION
_This is the same as https://github.com/alphagov/notifications-api/pull/2747, which was reverted except that it does not drop the constraint on `notification_history` in production since that has been done manually._

**Update postage db constraints for international letters**

The `notifications`, `notification_history`, `templates` and `templates_history`
tables all had a check constraint on the postage column which specified
that the postage had to be `first` or `second` if the notification or
template was a letter. We now have two more options for postage -
`europe` and `rest-of-world`.

It's not possible to alter a check constraint, so the constraints have
to be dropped then recreated. We are not recreating the constraint on
the `notification_history` table since values here are always copied
from the `notifications` table.

The constraints get added as `NOT VALID` at first - this stage will lock
the tables, so updating the `notification` table and `templates` and
`templates_history` are done in separate migrations so that we don't lock
all tables at the same time. In a third migration we then run
`VALIDATE CONSTRAINT` for all tables - this will lock a row at a time,
not the whole table.

**Update JSON schema postage validation for new values**