### PR TITLE
Ignore Parse error in receive notifications endpoint

### DIFF
--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from urllib.parse import unquote
 
 import iso8601
@@ -115,9 +116,12 @@ def format_mmg_datetime(date):
     We expect datetimes in format 2017-05-21+11%3A56%3A11 - ie, spaces replaced with pluses, and URI encoded
     and in UTC
     """
-    orig_date = format_mmg_message(date)
-    parsed_datetime = iso8601.parse_date(orig_date).replace(tzinfo=None)
-    return parsed_datetime
+    try:
+        orig_date = format_mmg_message(date)
+        parsed_datetime = iso8601.parse_date(orig_date).replace(tzinfo=None)
+        return parsed_datetime
+    except iso8601.ParseError:
+        return datetime.utcnow()
 
 
 def create_inbound_sms_object(service, content, from_number, provider_ref, date_received, provider_name):

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -4,6 +4,7 @@ from unittest.mock import call
 
 import pytest
 from flask import json
+from freezegun import freeze_time
 
 from app.notifications.receive_notifications import (
     format_mmg_message,
@@ -214,6 +215,11 @@ def test_unescape_string(raw, expected):
 ])
 def test_format_mmg_datetime(provider_date, expected_output):
     assert format_mmg_datetime(provider_date) == expected_output
+
+
+@freeze_time('2020-05-14 14:30:00')
+def test_format_mmg_datetime_returns_now_if_cannot_parse_date():
+    assert format_mmg_datetime('13-05-2020 08%3A37%3A43') == datetime.utcnow()
 
 
 def test_create_inbound_mmg_sms_object(sample_service_full_permissions):


### PR DESCRIPTION
This morning we raise a ParseError for a bad date format for the DateReceived attribute on the /notifications/receive/mmg request.

This PR tries to parse the date, if that throws an error return now as the DateReceived. This will at least allow the message to be persisted. Typically the DateReceived, provider_date, and the created_at date in the inbound_sms table are within a second of each other.