### PR TITLE
Adding a commit at the end of each migration file.

### DIFF
--- a/migrations/versions/0321_update_postage_constraint_1.py
+++ b/migrations/versions/0321_update_postage_constraint_1.py
@@ -30,6 +30,7 @@ def upgrade():
     """)
     if environment not in ["live", "production"]:
         op.execute('ALTER TABLE notification_history DROP CONSTRAINT IF EXISTS chk_notification_history_postage_null')
+    op.execute('COMMIT')
 
 
 def downgrade():

--- a/migrations/versions/0322_update_postage_constraint_2.py
+++ b/migrations/versions/0322_update_postage_constraint_2.py
@@ -38,6 +38,7 @@ def upgrade():
         )
         NOT VALID
     """)
+    op.execute('COMMIT')
 
 
 def downgrade():


### PR DESCRIPTION
The assumption that a commit is issued in between migration files was false. This will force the db connection to commit, the alter table commands will complete and the alembic version updated.