### PR TITLE
Re run failed reporting tasks

### DIFF
--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -1,10 +1,12 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 
+import iso8601
 from flask import current_app
 from notifications_utils.statsd_decorators import statsd
 from notifications_utils.timezones import convert_utc_to_bst
 
-from app import notify_celery
+from app.utils import get_london_midnight_in_utc
+from app import notify_celery, redis_store
 from app.config import QueueNames
 from app.cronitor import cronitor
 from app.dao.fact_billing_dao import (
@@ -19,10 +21,43 @@ from app.models import (
 )
 
 
+# this is how long we store the task run timestamp in redis before expiring it. it gives us time to work out what
+# happened after a long weekend, but we shouldn't really care about tasks older than that.
+FOUR_DAYS_IN_SECONDS = int(timedelta(days=4).total_seconds())
+
+
+def _get_nightly_task_redis_key(task_name, task_kwargs):
+    """
+    Redis key that identifies a run of a given daily task. EG:
+    task_last_run_timestamp_create-nightly-billing-for-day_process_day_2020-04-04
+    """
+    redis_key = f'task_last_run_timestamp_{task_name}'
+    # make sure we sort the kwargs so the string is always consistent
+    for key, value in sorted(task_kwargs.items()):
+        if isinstance(value, date):
+            value = value.strftime("%Y-%m-%d")
+        redis_key += f'_{key}_{value}'
+    return redis_key
+
+
+def _task_has_run_today(task_name, task_kwargs):
+    if not current_app.config['REDIS_ENABLED']:
+        return True
+
+    redis_key = _get_nightly_task_redis_key(task_name, task_kwargs)
+
+    day_start = get_london_midnight_in_utc(datetime.utcnow())
+
+    # if its not in redis set to datetime.min so we assume it has never been run and re-trigger it
+    val_from_redis = redis_store.get(redis_key)
+    last_ran_timestamp = iso8601.parse_date(val_from_redis).replace(tzinfo=None) if val_from_redis else datetime.min
+    return last_ran_timestamp > day_start
+
+
 @notify_celery.task(name="create-nightly-billing")
 @cronitor("create-nightly-billing")
 @statsd(namespace="tasks")
-def create_nightly_billing(day_start=None):
+def create_nightly_billing(day_start=None, only_run_missing_days=False):
     current_app.logger.info("create-nightly-billing task: started")
     # day_start is a datetime.date() object. e.g.
     # up to 4 days of data counting back from day_start is consolidated
@@ -36,15 +71,23 @@ def create_nightly_billing(day_start=None):
         process_day = (day_start - timedelta(days=i)).isoformat()
         kwargs = {'process_day': process_day}
 
+        if only_run_missing_days:
+            child_task_name = create_nightly_billing_for_day.name
+            if _task_has_run_today(child_task_name, kwargs):
+                # skip this task
+                continue
+            else:
+                current_app.logger.warning(f'task not completed retriggering task {child_task_name} with args {kwargs}')
+
         create_nightly_billing_for_day.apply_async(kwargs=kwargs, queue=QueueNames.REPORTING)
         current_app.logger.info(
             f"create-nightly-billing task: create-nightly-billing-for-day task created for {process_day}"
         )
 
 
-@notify_celery.task(name="create-nightly-billing-for-day")
+@notify_celery.task(bind=True, name="create-nightly-billing-for-day")
 @statsd(namespace="tasks")
-def create_nightly_billing_for_day(process_day):
+def create_nightly_billing_for_day(self, process_day):
     process_day = datetime.strptime(process_day, "%Y-%m-%d").date()
     current_app.logger.info(
         f'create-nightly-billing-for-day task for {process_day}: started'
@@ -66,11 +109,15 @@ def create_nightly_billing_for_day(process_day):
         f"task complete. {len(transit_data)} rows updated"
     )
 
+    if current_app.config['REDIS_ENABLED']:
+        redis_key = _get_nightly_task_redis_key(self.name, task_kwargs={'process_day': process_day})
+        redis_store.set(redis_key, datetime.utcnow().isoformat(), ex=FOUR_DAYS_IN_SECONDS)
+
 
 @notify_celery.task(name="create-nightly-notification-status")
 @cronitor("create-nightly-notification-status")
 @statsd(namespace="tasks")
-def create_nightly_notification_status():
+def create_nightly_notification_status(only_run_missing_days=False):
     current_app.logger.info("create-nightly-notification-status task: started")
     yesterday = convert_utc_to_bst(datetime.utcnow()).date() - timedelta(days=1)
 
@@ -87,18 +134,27 @@ def create_nightly_notification_status():
         process_day = yesterday - timedelta(days=i)
         tasks_to_run.append({'process_day': process_day.isoformat(), 'notification_type': LETTER_TYPE})
 
-    child_task_name = create_nightly_billing_for_day.name
+    child_task_name = create_nightly_notification_status_for_day.name
     for kwargs in tasks_to_run:
+        if only_run_missing_days:
+            if _task_has_run_today(child_task_name, kwargs):
+                # skip this task
+                continue
+            else:
+                current_app.logger.warning(
+                    f'task not completed since midnight: {child_task_name} task with args {kwargs}'
+                )
+
         create_nightly_notification_status_for_day.apply_async(kwargs=kwargs, queue=QueueNames.REPORTING)
         current_app.logger.info(
             f"create-nightly-notification-status task: {child_task_name} task created "
-            f"for type letter for {process_day}"
+            f"for type {kwargs['notification_type']} for {kwargs['process_day']}"
         )
 
 
-@notify_celery.task(name="create-nightly-notification-status-for-day")
+@notify_celery.task(bind=True, name="create-nightly-notification-status-for-day")
 @statsd(namespace="tasks")
-def create_nightly_notification_status_for_day(process_day, notification_type):
+def create_nightly_notification_status_for_day(self, process_day, notification_type):
     process_day = datetime.strptime(process_day, "%Y-%m-%d").date()
     current_app.logger.info(
         f'create-nightly-notification-status-for-day task for {process_day} type {notification_type}: started'
@@ -118,3 +174,16 @@ def create_nightly_notification_status_for_day(process_day, notification_type):
         f'create-nightly-notification-status-for-day task for {process_day} type {notification_type}: '
         f'task complete - {len(transit_data)} rows updated'
     )
+
+    if current_app.config['REDIS_ENABLED']:
+        redis_key = _get_nightly_task_redis_key(
+            self.name,
+            task_kwargs={'notification_type': notification_type, 'process_day': process_day}
+        )
+        redis_store.set(redis_key, datetime.utcnow().isoformat(), ex=FOUR_DAYS_IN_SECONDS)
+
+
+@notify_celery.task(name='rerun-failed-nightly-tasks')
+def rerun_failed_nightly_tasks():
+    create_nightly_billing(only_run_missing_days=True)
+    create_nightly_notification_status(only_run_missing_days=True)

--- a/app/config.py
+++ b/app/config.py
@@ -91,8 +91,6 @@ class Config(object):
     # URL of redis instance
     REDIS_URL = os.getenv('REDIS_URL')
     REDIS_ENABLED = os.getenv('REDIS_ENABLED') == '1'
-    EXPIRE_CACHE_TEN_MINUTES = 600
-    EXPIRE_CACHE_EIGHT_DAYS = 8 * 24 * 60 * 60
 
     # Performance platform
     PERFORMANCE_PLATFORM_ENABLED = False
@@ -228,12 +226,7 @@ class Config(object):
             'schedule': crontab(minute='0, 15, 30, 45'),
             'options': {'queue': QueueNames.PERIODIC}
         },
-        # app/celery/nightly_tasks.py
-        'timeout-sending-notifications': {
-            'task': 'timeout-sending-notifications',
-            'schedule': crontab(hour=0, minute=5),
-            'options': {'queue': QueueNames.PERIODIC}
-        },
+        # app/celery/reporting_tasks.py
         'create-nightly-billing': {
             'task': 'create-nightly-billing',
             'schedule': crontab(hour=0, minute=15),
@@ -243,6 +236,17 @@ class Config(object):
             'task': 'create-nightly-notification-status',
             'schedule': crontab(hour=0, minute=30),  # after 'timeout-sending-notifications'
             'options': {'queue': QueueNames.REPORTING}
+        },
+        'rerun-failed-nightly-tasks': {
+            'task': 'rerun-failed-nightly-tasks',
+            'schedule': crontab(hour=6, minute=0),
+            'options': {'queue': QueueNames.REPORTING}
+        },
+        # app/celery/nightly_tasks.py
+        'timeout-sending-notifications': {
+            'task': 'timeout-sending-notifications',
+            'schedule': crontab(hour=0, minute=5),
+            'options': {'queue': QueueNames.PERIODIC}
         },
         'delete-notifications-older-than-retention': {
             'task': 'delete-notifications-older-than-retention',


### PR DESCRIPTION
We've had issues with long running tasks dying for a variety of reasons, and us having to manually kick things off again.

when a task runs, we store a key in redis. The key looks like `task_last_run_timestamp_{task_name}_{kwargs}` where kwargs are `key_value` separeated by underscores. The value is the timestamp of when the task completed.

Then, every morning at 6am BST we can run a task that checks the timestamps of all the individual day tasks. If that timestamp is older than midnight, the task didn't run this morning, so kick it off again. To kick it off again it just runs the parent tasks with a new flag "only_run_missing_days", to keep code duplication down.

The reason that each task and param gets an individual key is so that each one can be given an expiry date. If it was a hash set inside redis, then we wouldn't have a nice automated way of expiring individual keys without doing the work ourselves.

I've set the expiry date to four days, so that we can check on things after the weekend if everything goes really wrong.
