### PR TITLE
Allow service to be archived if service with the same name has already been archived

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -53,7 +53,13 @@ from app.models import (
     LETTER_TYPE,
     UPLOAD_LETTERS,
 )
-from app.utils import email_address_is_nhs, escape_special_characters, get_london_midnight_in_utc, midnight_n_days_ago
+from app.utils import (
+    email_address_is_nhs,
+    escape_special_characters,
+    get_archived_db_column_value,
+    get_london_midnight_in_utc,
+    midnight_n_days_ago,
+)
 
 DEFAULT_SERVICE_PERMISSIONS = [
     SMS_TYPE,
@@ -260,8 +266,8 @@ def dao_archive_service(service_id):
     ).filter(Service.id == service_id).one()
 
     service.active = False
-    service.name = '_archived_' + service.name
-    service.email_from = '_archived_' + service.email_from
+    service.name = get_archived_db_column_value(service.name)
+    service.email_from = get_archived_db_column_value(service.email_from)
 
     for template in service.templates:
         if not template.archived:

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -11,7 +11,7 @@ from app.dao.service_user_dao import dao_get_service_users_by_user_id
 from app.dao.dao_utils import transactional
 from app.errors import InvalidRequest
 from app.models import (EMAIL_AUTH_TYPE, User, VerifyCode)
-from app.utils import escape_special_characters
+from app.utils import escape_special_characters, get_archived_db_column_value
 
 
 def _remove_values_for_keys_if_present(dict, keys):
@@ -161,7 +161,7 @@ def dao_archive_user(user):
     user.organisations = []
 
     user.auth_type = EMAIL_AUTH_TYPE
-    user.email_address = get_archived_email_address(user.email_address)
+    user.email_address = get_archived_db_column_value(user.email_address)
     user.mobile_number = None
     user.password = str(uuid.uuid4())
     # Changing the current_session_id signs the user out
@@ -185,8 +185,3 @@ def user_can_be_archived(user):
             return False
 
     return True
-
-
-def get_archived_email_address(email_address):
-    date = datetime.utcnow().strftime("%Y-%m-%d")
-    return '_archived_{}_{}'.format(date, email_address)

--- a/app/utils.py
+++ b/app/utils.py
@@ -126,3 +126,8 @@ def get_notification_table_to_use(service, notification_type, process_day, has_d
         days_of_retention += 1
 
     return Notification if days_ago <= timedelta(days=days_of_retention) else NotificationHistory
+
+
+def get_archived_db_column_value(column):
+    date = datetime.utcnow().strftime("%Y-%m-%d")
+    return f'_archived_{date}_{column}'

--- a/tests/app/service/test_archived_service.py
+++ b/tests/app/service/test_archived_service.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 
 from app import db
 from app.models import Service
-from app.dao.services_dao import dao_archive_service
+from app.dao.services_dao import dao_archive_service, dao_fetch_service_by_id
 from app.dao.api_key_dao import expire_api_key
 from app.dao.templates_dao import dao_update_template
 
@@ -50,9 +50,15 @@ def archived_service(client, notify_db, sample_service):
     return sample_service
 
 
-def test_deactivating_service_changes_name_and_email(archived_service):
-    assert archived_service.name == '_archived_Sample service'
-    assert archived_service.email_from == '_archived_sample.service'
+@freeze_time('2018-07-07 12:00:00')
+def test_deactivating_service_changes_name_and_email(client, sample_service):
+    auth_header = create_authorization_header()
+    client.post('/service/{}/archive'.format(sample_service.id), headers=[auth_header])
+
+    archived_service = dao_fetch_service_by_id(sample_service.id)
+
+    assert archived_service.name == '_archived_2018-07-07_Sample service'
+    assert archived_service.email_from == '_archived_2018-07-07_sample.service'
 
 
 def test_deactivating_service_revokes_api_keys(archived_service):


### PR DESCRIPTION
We were prefixing the service `name` and `email_reply_to` with `_archived_` when a service was archived. Since there are unique constraints on both these columns, this meant that archiving a service with the same name twice would cause an error.

This change copies what we do when archiving a user by prefixing these values with `_archived_{date}` instead. We would still see an error if a service with the same name gets archived more than once on the same day, but the chance of this happening is very low.

https://www.pivotaltracker.com/story/show/172955194