### PR TITLE
Add property to contact lists to say if they’ve ever been used

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2136,13 +2136,19 @@ class ServiceContactList(db.Model):
             )
         ).count()
 
+    def get_has_jobs(self):
+        return bool(Job.query.filter(
+            Job.contact_list_id == self.id,
+        ).first())
+
     def serialize(self):
         created_at_in_bst = convert_utc_to_bst(self.created_at)
         contact_list = {
             "id": str(self.id),
             "original_file_name": self.original_file_name,
             "row_count": self.row_count,
-            "job_count": self.get_job_count(),
+            "recent_job_count": self.get_job_count(),
+            "has_jobs": self.get_has_jobs(),
             "template_type": self.template_type,
             "service_id": str(self.service_id),
             "created_by": self.created_by.name,

--- a/app/models.py
+++ b/app/models.py
@@ -2122,7 +2122,8 @@ class ServiceContactList(db.Model):
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
     archived = db.Column(db.Boolean, nullable=False, default=False)
 
-    def get_job_count(self):
+    @property
+    def job_count(self):
         today = datetime.datetime.utcnow().date()
         return Job.query.filter(
             Job.contact_list_id == self.id,
@@ -2136,7 +2137,8 @@ class ServiceContactList(db.Model):
             )
         ).count()
 
-    def get_has_jobs(self):
+    @property
+    def has_jobs(self):
         return bool(Job.query.filter(
             Job.contact_list_id == self.id,
         ).first())
@@ -2147,8 +2149,8 @@ class ServiceContactList(db.Model):
             "id": str(self.id),
             "original_file_name": self.original_file_name,
             "row_count": self.row_count,
-            "recent_job_count": self.get_job_count(),
-            "has_jobs": self.get_has_jobs(),
+            "recent_job_count": self.job_count,
+            "has_jobs": self.has_jobs,
             "template_type": self.template_type,
             "service_id": str(self.service_id),
             "created_by": self.created_by.name,

--- a/tests/app/service/test_service_contact_list_rest.py
+++ b/tests/app/service/test_service_contact_list_rest.py
@@ -69,7 +69,7 @@ def test_get_contact_list(admin_request, notify_db_session):
 
     assert len(response) == 1
     assert response[0] == contact_list.serialize()
-    assert response[0]['job_count'] == 0
+    assert response[0]['recent_job_count'] == 0
 
 
 @pytest.mark.parametrize('days_of_email_retention, expected_job_count', (
@@ -107,10 +107,12 @@ def test_get_contact_list_counts_jobs(
     assert len(response) == 2
 
     assert response[0]['id'] == str(contact_list_2.id)
-    assert response[0]['job_count'] == expected_job_count
+    assert response[0]['recent_job_count'] == expected_job_count
+    assert response[0]['has_jobs'] is True
 
     assert response[1]['id'] == str(contact_list_1.id)
-    assert response[1]['job_count'] == 0
+    assert response[1]['recent_job_count'] == 0
+    assert response[1]['has_jobs'] is False
 
 
 def test_get_contact_list_returns_for_service(admin_request, notify_db_session):


### PR DESCRIPTION
At the moment we return a count of recent jobs for contact lists, where recent is defined as being within the service’s data retention period.

This lets us write nice bits of UI copy like ‘used 3 times in the last 7 days’. But it’s hard to write the copy for when the count is 0, because this could be for one of two reasons:
- the contact list has never been used
- the contact list has been used, but not within the data retention period for that channel

At the moment we can’t know which of those reasons is the case, so we can’t write nice clear content like ‘never been used’.

This commit adds a property to contact lists which says whether they’ve ever been used.

It also renames the existing, as-yet-unused property to make clear that it’s only counting within the data retention (so can still be 0 even if `has_jobs` is `True`).