### PR TITLE
Bump utils to 39.4.2 to fix whitespace strip bug

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -26,6 +26,6 @@ notifications-python-client==5.5.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@39.4.1#egg=notifications-utils==39.4.1
+git+https://github.com/alphagov/notifications-utils.git@39.4.2#egg=notifications-utils==39.4.2
 
 gds-metrics==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ notifications-python-client==5.5.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@39.4.1#egg=notifications-utils==39.4.1
+git+https://github.com/alphagov/notifications-utils.git@39.4.2#egg=notifications-utils==39.4.2
 
 gds-metrics==0.2.0
 
@@ -37,14 +37,14 @@ alembic==1.4.2
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.3.0
-awscli==1.18.66
+awscli==1.18.69
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.4
 blinker==1.4
 boto==2.49.0
 boto3==1.10.38
-botocore==1.16.16
+botocore==1.16.19
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.2
@@ -60,7 +60,7 @@ importlib-metadata==1.6.0
 Jinja2==2.11.2
 jmespath==0.10.0
 kombu==3.0.37
-Mako==1.1.2
+Mako==1.1.3
 MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5


### PR DESCRIPTION
https://github.com/alphagov/notifications-utils/pull/742

We had been seeing phone numbers making it through in jobs containing
this no-break space which were then causing errors as we could not
process the job as it thought it was an invalid number. This should
solve the problem and strip that special character.