### PR TITLE
Put status codes in logs 

### DIFF
--- a/app/celery/process_sms_client_response_tasks.py
+++ b/app/celery/process_sms_client_response_tasks.py
@@ -38,8 +38,8 @@ def process_sms_client_response(self, status, provider_reference, client_name, d
     try:
         notification_status, detailed_status = response_parser(status, detailed_status_code)
         current_app.logger.info(
-            f'{client_name} callback returned '
-            f'status of {notification_status}: {detailed_status} for reference: {provider_reference}'
+            f'{client_name} callback returned status of {notification_status}'
+            f'({status}): {detailed_status}({detailed_status_code}) for reference: {provider_reference}'
         )
     except KeyError:
         _process_for_status(

--- a/tests/app/notifications/test_process_client_response.py
+++ b/tests/app/notifications/test_process_client_response.py
@@ -58,7 +58,7 @@ def test_process_sms_client_response_updates_notification_status(
 
     process_sms_client_response(status, str(sample_notification.id), sms_provider, detailed_status_code)
 
-    message = f"{sms_provider} callback returned status of {expected_notification_status}: {reason} for reference: {sample_notification.id}"  # noqa
+    message = f"{sms_provider} callback returned status of {expected_notification_status}({status}): {reason}({detailed_status_code}) for reference: {sample_notification.id}"  # noqa
     mock_logger.assert_any_call(message)
     assert sample_notification.status == expected_notification_status
 


### PR DESCRIPTION
This is done to see if lack of detailed status is us not recognising a code or provider not having sent the detailed status.
It seems like Firetext is sometimes sending us permanent-failure without detailed status. It could be due to:
- them really not sending any detailed status
- them sending a status code we don't recognise
- them sending 000 code that means 'no errors', which we ignore

To see which one it is, and to debug such issues quicker in the future, this PR adds status and detailed status codes to the logs.