### PR TITLE
Drop postage constraints

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -901,13 +901,6 @@ class TemplateBase(db.Model):
     hidden = db.Column(db.Boolean, nullable=False, default=False)
     subject = db.Column(db.Text)
     postage = db.Column(db.String, nullable=True)
-    CheckConstraint("""
-        CASE WHEN template_type = 'letter' THEN
-            postage is not null and postage in ('first', 'second')
-        ELSE
-            postage is null
-        END
-    """)
 
     @declared_attr
     def service_id(cls):
@@ -1353,10 +1346,14 @@ DVLA_RESPONSE_STATUS_SENT = 'Sent'
 
 FIRST_CLASS = 'first'
 SECOND_CLASS = 'second'
-POSTAGE_TYPES = [FIRST_CLASS, SECOND_CLASS]
+EUROPE = 'europe'
+REST_OF_WORLD = 'rest-of-world'
+POSTAGE_TYPES = [FIRST_CLASS, SECOND_CLASS, EUROPE, REST_OF_WORLD]
 RESOLVE_POSTAGE_FOR_FILE_NAME = {
     FIRST_CLASS: 1,
-    SECOND_CLASS: 2
+    SECOND_CLASS: 2,
+    EUROPE: 'E',
+    REST_OF_WORLD: 'N',
 }
 
 
@@ -1431,13 +1428,6 @@ class Notification(db.Model):
     document_download_count = db.Column(db.Integer, nullable=True)
 
     postage = db.Column(db.String, nullable=True)
-    CheckConstraint("""
-        CASE WHEN notification_type = 'letter' THEN
-            postage is not null and postage in ('first', 'second')
-        ELSE
-            postage is null
-        END
-    """)
 
     __table_args__ = (
         db.ForeignKeyConstraint(
@@ -1698,13 +1688,6 @@ class NotificationHistory(db.Model, HistoryModel):
     created_by_id = db.Column(UUID(as_uuid=True), nullable=True)
 
     postage = db.Column(db.String, nullable=True)
-    CheckConstraint("""
-        CASE WHEN notification_type = 'letter' THEN
-            postage is not null and postage in ('first', 'second')
-        ELSE
-            postage is null
-        END
-    """)
 
     document_download_count = db.Column(db.Integer, nullable=True)
 

--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -34,8 +34,8 @@ def validate_schema_email_address(instance):
 @format_checker.checks('postage', raises=ValidationError)
 def validate_schema_postage(instance):
     if isinstance(instance, str):
-        if instance not in ["first", "second"]:
-            raise ValidationError("invalid. It must be either first or second.")
+        if instance not in ["first", "second", "europe", "rest-of-world"]:
+            raise ValidationError("invalid. It must be first, second, europe or rest-of-world.")
     return True
 
 

--- a/migrations/versions/0321_drop_postage_constraints.py
+++ b/migrations/versions/0321_drop_postage_constraints.py
@@ -1,0 +1,69 @@
+"""
+
+Revision ID: 0321_drop_postage_constraints
+Revises: 0320_optimise_notifications
+Create Date: 2020-06-08 11:48:53.315768
+
+"""
+import os
+
+from alembic import op
+
+
+revision = '0321_drop_postage_constraints'
+down_revision = '0320_optimise_notifications'
+environment = os.environ['NOTIFY_ENVIRONMENT']
+
+
+def upgrade():
+    if environment not in ["live", "production"]:
+        op.execute('ALTER TABLE notifications DROP CONSTRAINT IF EXISTS chk_notifications_postage_null')
+        op.execute('ALTER TABLE notification_history DROP CONSTRAINT IF EXISTS chk_notification_history_postage_null')
+
+    op.execute('ALTER TABLE templates DROP CONSTRAINT IF EXISTS chk_templates_postage')
+    op.execute('ALTER TABLE templates_history DROP CONSTRAINT IF EXISTS chk_templates_history_postage')
+
+
+def downgrade():
+    # The downgrade command must not be run in production - it will lock the tables for a long time
+    if environment not in ["live", "production"]:
+        op.execute("""
+            ALTER TABLE notifications ADD CONSTRAINT "chk_notifications_postage_null"
+            CHECK (
+                CASE WHEN notification_type = 'letter' THEN
+                    postage is not null and postage in ('first', 'second')
+                ELSE
+                    postage is null
+                END
+            )
+        """)
+        op.execute("""
+            ALTER TABLE notification_history ADD CONSTRAINT "chk_notification_history_postage_null"
+            CHECK (
+                CASE WHEN notification_type = 'letter' THEN
+                    postage is not null and postage in ('first', 'second')
+                ELSE
+                    postage is null
+                END
+            )
+        """)
+        op.execute("""
+            ALTER TABLE templates ADD CONSTRAINT "chk_templates_postage"
+            CHECK (
+                CASE WHEN template_type = 'letter' THEN
+                    postage is not null and postage in ('first', 'second')
+                ELSE
+                    postage is null
+                END
+            )
+        """)
+        op.execute("""
+            ALTER TABLE templates_history ADD CONSTRAINT "chk_templates_history_postage"
+            CHECK (
+                CASE WHEN template_type = 'letter' THEN
+                    postage is not null and postage in ('first', 'second')
+                ELSE
+                    postage is null
+                END
+            )
+        """)

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from freezegun import freeze_time
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.exc import NoResultFound
 import pytest
 
@@ -485,37 +484,3 @@ def test_get_template_versions_is_empty_for_hidden_templates(sample_service):
     )
     versions = dao_get_template_versions(service_id=sample_template.service_id, template_id=sample_template.id)
     assert len(versions) == 0
-
-
-@pytest.mark.parametrize("template_type,postage", [('letter', 'third'), ('sms', 'second')])
-def test_template_postage_constraint_on_create(sample_service, sample_user, template_type, postage):
-    data = {
-        'name': 'Sample Template',
-        'template_type': template_type,
-        'content': "Template content",
-        'service': sample_service,
-        'created_by': sample_user,
-        'postage': postage
-    }
-    template = Template(**data)
-    with pytest.raises(expected_exception=SQLAlchemyError):
-        dao_create_template(template)
-
-
-def test_template_postage_constraint_on_update(sample_service, sample_user):
-    data = {
-        'name': 'Sample Template',
-        'template_type': "letter",
-        'content': "Template content",
-        'service': sample_service,
-        'created_by': sample_user,
-        'postage': 'second'
-    }
-    template = Template(**data)
-    dao_create_template(template)
-    created = dao_get_all_templates_for_service(sample_service.id)[0]
-    assert created.name == 'Sample Template'
-
-    created.postage = 'third'
-    with pytest.raises(expected_exception=SQLAlchemyError):
-        dao_update_template(created)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2340,7 +2340,8 @@ def test_create_pdf_letter(mocker, sample_service_full_permissions, client, fake
         {"postage": "third", "filename": "string", "created_by": "string", "file_id": "string",
          "recipient_address": "Some Address"},
         [
-            {'error': 'ValidationError', 'message': 'postage invalid. It must be either first or second.'}
+            {'error': 'ValidationError',
+             'message': 'postage invalid. It must be first, second, europe or rest-of-world.'}
         ]
     )
 ])

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -794,7 +794,8 @@ def test_create_a_template_with_foreign_service_reply_to(admin_request, sample_u
         {"name": "my template", "template_type": "sms", "content": "hi", "postage": "third",
          "service": "1af43c02-b5a8-4923-ad7f-5279b75ff2d0", "created_by": "30587644-9083-44d8-a114-98887f07f1e3"},
         [
-            {"error": "ValidationError", "message": "postage invalid. It must be either first or second."},
+            {"error": "ValidationError",
+             "message": "postage invalid. It must be first, second, europe or rest-of-world."},
         ]
     ),
 ])

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -637,7 +637,7 @@ def test_post_letter_notification_throws_error_for_invalid_postage(client, notif
 
     assert response.status_code == 400, response.get_data(as_text=True)
     resp_json = json.loads(response.get_data(as_text=True))
-    assert resp_json['errors'][0]['message'] == "postage invalid. It must be either first or second."
+    assert resp_json['errors'][0]['message'] == "postage invalid. It must be first, second, europe or rest-of-world."
 
     assert not Notification.query.first()
 


### PR DESCRIPTION
We've decided to drop the postage constraints, so this adds a migration to do that (the constraint on notifications and notification_history has already been dropped in production and preview).

Also removes a few tests that are no longer needed and updates the JSON schemas for the new postage values we want to allow.