### PR TITLE
Point API for staging at email and sms stubs for the soak tests.

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -468,6 +468,9 @@ class Staging(Config):
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = True
     REDIS_ENABLED = True
+    SES_STUB_URL = 'https://notify-email-provider-stub-staging.cloudapps.digital/ses'
+    MMG_URL = 'https://notify-sms-provider-stub-staging.cloudapps.digital/mmg'
+    FIRETEXT_URL = 'https://notify-sms-provider-stub-staging.cloudapps.digital/firetext'
 
 
 class Live(Config):


### PR DESCRIPTION
This is done to avoid sending real email and sms and incurring
unnecessary charges while we run the soak tests.