### PR TITLE
Turn off email stub on staging

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -468,7 +468,7 @@ class Staging(Config):
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = True
     REDIS_ENABLED = True
-    SES_STUB_URL = 'https://notify-email-provider-stub-staging.cloudapps.digital/ses'
+    # SES_STUB_URL = 'https://notify-email-provider-stub-staging.cloudapps.digital/ses'
     MMG_URL = 'https://notify-sms-provider-stub-staging.cloudapps.digital/mmg'
     FIRETEXT_URL = 'https://notify-sms-provider-stub-staging.cloudapps.digital/firetext'
 


### PR DESCRIPTION
To check if it was our congestion point for the soak test.
(Email stub is a bit slower to respond than Amazon SES, and the difference could lead to us having to many connections to db open as we wait for response from the stub)

I'm only commenting it out as we are continuing soak testing and may turn it back on, and we can delete it fully when we are getting rid of the variables for sms provider stub.