### PR TITLE
[work in progress] Cache API keys and service is active checks

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -66,7 +66,17 @@ metrics = GDSMetrics()
 clients = Clients()
 
 api_user = LocalProxy(lambda: _request_ctx_stack.top.api_user)
-authenticated_service = LocalProxy(lambda: _request_ctx_stack.top.authenticated_service)
+
+
+def lazy_authenticated_service():
+    svc = _request_ctx_stack.top.authenticated_service
+    if callable(svc):
+        return svc()
+    return svc
+
+
+authenticated_service = LocalProxy(lazy_authenticated_service)
+authenticated_service_id = LocalProxy(lambda: _request_ctx_stack.top.authenticated_service_id)
 
 CONCURRENT_REQUESTS = Gauge(
     'concurrent_web_request_count',

--- a/app/cache/__init__.py
+++ b/app/cache/__init__.py
@@ -1,0 +1,8 @@
+from app.cache.api_keys_for_service_cache import ApiKeysForServiceCache
+from app.cache.permissions_for_service_cache import PermissionsForServiceCache
+from app.cache.service_is_active_cache import ServiceIsActiveCache
+
+
+api_keys_for_service_cache = ApiKeysForServiceCache()
+permissions_for_service_cache = PermissionsForServiceCache()
+service_is_active_cache = ServiceIsActiveCache()

--- a/app/cache/api_keys_for_service_cache.py
+++ b/app/cache/api_keys_for_service_cache.py
@@ -1,0 +1,19 @@
+from cachetools import TTLCache
+from collections import namedtuple
+
+
+ApiKey = namedtuple('ApiKey', ['id', 'secret', 'expiry_date'])
+
+
+class ApiKeysForServiceCache(object):
+    def __init__(self):
+        self.cache = TTLCache(maxsize=1024, ttl=10)
+
+    def get(self, service_id):
+        try:
+            return self.cache[service_id]
+        except KeyError:
+            return None
+
+    def put(self, s, ks):
+        self.cache[s] = [ApiKey(k.id, k.secret, k.expiry_date) for k in ks]

--- a/app/cache/permissions_for_service_cache.py
+++ b/app/cache/permissions_for_service_cache.py
@@ -1,0 +1,19 @@
+from cachetools import TTLCache
+from collections import namedtuple
+
+
+Permission = namedtuple('Permission', ['permission'])
+
+
+class PermissionsForServiceCache(object):
+    def __init__(self):
+        self.cache = TTLCache(maxsize=1024, ttl=2)
+
+    def get(self, service_id):
+        try:
+            return self.cache[service_id]
+        except KeyError:
+            return None
+
+    def put(self, s, ps):
+        self.cache[s] = [Permission(p.permission) for p in ps]

--- a/app/cache/permissions_for_service_cache.py
+++ b/app/cache/permissions_for_service_cache.py
@@ -11,7 +11,7 @@ Permission = namedtuple('Permission', ['permission'])
 class PermissionsForServiceCache(object):
     def __init__(self):
         self.lock = RLock()
-        self.cache = TTLCache(ttl=2, maxsize=1024)
+        self.cache = TTLCache(ttl=30, maxsize=1024)
         self.permissions_for_service = {}
 
     @cachedmethod(operator.attrgetter('cache'), lock=RLock)

--- a/app/cache/service_is_active_cache.py
+++ b/app/cache/service_is_active_cache.py
@@ -1,0 +1,15 @@
+from cachetools import TTLCache
+
+
+class ServiceIsActiveCache(object):
+    def __init__(self):
+        self.cache = TTLCache(maxsize=1024, ttl=30)
+
+    def get(self, service_id):
+        try:
+            return self.cache[service_id]
+        except KeyError:
+            return None
+
+    def put(self, s, active):
+        self.cache[s] = active

--- a/app/cache/service_is_active_cache.py
+++ b/app/cache/service_is_active_cache.py
@@ -7,7 +7,7 @@ from cachetools import cachedmethod, TTLCache
 class ServiceIsActiveCache(object):
     def __init__(self):
         self.lock = RLock()
-        self.cache = TTLCache(ttl=2, maxsize=1024)
+        self.cache = TTLCache(ttl=30, maxsize=1024)
         self.active_services = {}
 
     def get(self, service_id):

--- a/app/json_models.py
+++ b/app/json_models.py
@@ -3,7 +3,6 @@ class JSONModel():
     ALLOWED_PROPERTIES = set()
 
     def __init__(self, _dict):
-        self._dict = _dict
         for property in self.ALLOWED_PROPERTIES:
             setattr(self, property, _dict[property])
 
@@ -14,10 +13,12 @@ class JSONModel():
 class TemplateJSONModel(JSONModel):
     ALLOWED_PROPERTIES = {
         'archived',
+        'content',
         'id',
         'postage',
         'process_type',
         'reply_to_text',
+        'subject',
         'template_type',
         'version',
     }

--- a/app/json_models.py
+++ b/app/json_models.py
@@ -3,43 +3,12 @@ class JSONModel():
     ALLOWED_PROPERTIES = set()
 
     def __init__(self, _dict):
-        # in the case of a bad request _dict may be `None`
-        self._dict = _dict or {}
-
-    def __bool__(self):
-        return self._dict != {}
-
-    def __hash__(self):
-        return hash(self.id)
+        self._dict = _dict
+        for property in self.ALLOWED_PROPERTIES:
+            setattr(self, property, _dict[property])
 
     def __dir__(self):
         return super().__dir__() + list(sorted(self.ALLOWED_PROPERTIES))
-
-    def __eq__(self, other):
-        return self.id == other.id
-
-    def __getattribute__(self, attr):
-
-        try:
-            return super().__getattribute__(attr)
-        except AttributeError as e:
-            # Re-raise any `AttributeError`s that are not directly on
-            # this object because they indicate an underlying exception
-            # that we don’t want to swallow
-            if str(e) != "'{}' object has no attribute '{}'".format(
-                self.__class__.__name__, attr
-            ):
-                raise e
-
-        if attr in super().__getattribute__('ALLOWED_PROPERTIES'):
-            return super().__getattribute__('_dict')[attr]
-
-        raise AttributeError((
-            "'{}' object has no attribute '{}' and '{}' is not a field "
-            "in the underlying JSON"
-        ).format(
-            self.__class__.__name__, attr, attr
-        ))
 
 
 class TemplateJSONModel(JSONModel):

--- a/app/json_models.py
+++ b/app/json_models.py
@@ -1,0 +1,54 @@
+class JSONModel():
+
+    ALLOWED_PROPERTIES = set()
+
+    def __init__(self, _dict):
+        # in the case of a bad request _dict may be `None`
+        self._dict = _dict or {}
+
+    def __bool__(self):
+        return self._dict != {}
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __dir__(self):
+        return super().__dir__() + list(sorted(self.ALLOWED_PROPERTIES))
+
+    def __eq__(self, other):
+        return self.id == other.id
+
+    def __getattribute__(self, attr):
+
+        try:
+            return super().__getattribute__(attr)
+        except AttributeError as e:
+            # Re-raise any `AttributeError`s that are not directly on
+            # this object because they indicate an underlying exception
+            # that we don’t want to swallow
+            if str(e) != "'{}' object has no attribute '{}'".format(
+                self.__class__.__name__, attr
+            ):
+                raise e
+
+        if attr in super().__getattribute__('ALLOWED_PROPERTIES'):
+            return super().__getattribute__('_dict')[attr]
+
+        raise AttributeError((
+            "'{}' object has no attribute '{}' and '{}' is not a field "
+            "in the underlying JSON"
+        ).format(
+            self.__class__.__name__, attr, attr
+        ))
+
+
+class TemplateJSONModel(JSONModel):
+    ALLOWED_PROPERTIES = {
+        'archived',
+        'id',
+        'postage',
+        'process_type',
+        'reply_to_text',
+        'template_type',
+        'version',
+    }

--- a/app/notifications/process_letter_notifications.py
+++ b/app/notifications/process_letter_notifications.py
@@ -5,14 +5,22 @@ from app.models import LETTER_TYPE
 from app.notifications.process_notifications import persist_notification
 
 
-def create_letter_notification(letter_data, template, api_key, status, reply_to_text=None, billable_units=None):
+def create_letter_notification(
+    letter_data,
+    template,
+    service,
+    api_key,
+    status,
+    reply_to_text=None,
+    billable_units=None,
+):
     notification = persist_notification(
         template_id=template.id,
-        template_version=template.version,
-        template_postage=template.postage,
+        template_version=template._template['version'],
+        template_postage=template._template['postage'],
         # we only accept addresses_with_underscores from the API (from CSV we also accept dashes, spaces etc)
         recipient=PostalAddress.from_personalisation(letter_data['personalisation']).normalised,
-        service=template.service,
+        service=service,
         personalisation=letter_data['personalisation'],
         notification_type=LETTER_TYPE,
         api_key_id=api_key.id,

--- a/app/notifications/process_letter_notifications.py
+++ b/app/notifications/process_letter_notifications.py
@@ -16,8 +16,8 @@ def create_letter_notification(
 ):
     notification = persist_notification(
         template_id=template.id,
-        template_version=template._template['version'],
-        template_postage=template._template['postage'],
+        template_version=template.version,
+        template_postage=template.postage,
         # we only accept addresses_with_underscores from the API (from CSV we also accept dashes, spaces etc)
         recipient=PostalAddress.from_personalisation(letter_data['personalisation']).normalised,
         service=service,

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -50,12 +50,29 @@ REDIS_GET_AND_INCR_DAILY_LIMIT_DURATION_SECONDS = Histogram(
 
 def create_content_for_notification(template, personalisation):
     if template.template_type == EMAIL_TYPE:
-        template_object = PlainTextEmailTemplate(template._dict, personalisation)
+        template_object = PlainTextEmailTemplate(
+            {
+                'content': template.content,
+                'subject': template.subject,
+                'template_type': template.template_type,
+            },
+            personalisation,
+        )
     if template.template_type == SMS_TYPE:
-        template_object = SMSMessageTemplate(template._dict, personalisation)
+        template_object = SMSMessageTemplate(
+            {
+                'content': template.content,
+                'template_type': template.template_type,
+            },
+            personalisation,
+        )
     if template.template_type == LETTER_TYPE:
         template_object = LetterPrintTemplate(
-            template._dict,
+            {
+                'content': template.content,
+                'subject': template.subject,
+                'template_type': template.template_type,
+            },
             personalisation,
             contact_block=template.reply_to_text,
         )

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -9,6 +9,11 @@ from notifications_utils.recipients import (
     validate_and_format_phone_number,
     format_email_address
 )
+from notifications_utils.template import (
+    PlainTextEmailTemplate,
+    SMSMessageTemplate,
+    LetterPrintTemplate,
+)
 from notifications_utils.timezones import convert_bst_to_utc
 
 from app import redis_store
@@ -43,8 +48,18 @@ REDIS_GET_AND_INCR_DAILY_LIMIT_DURATION_SECONDS = Histogram(
 )
 
 
-def create_content_for_notification(template, personalisation):
-    template_object = template._as_utils_template_with_personalisation(personalisation)
+def create_content_for_notification(template_dict, personalisation):
+    if template_dict['template_type'] == EMAIL_TYPE:
+        template_object = PlainTextEmailTemplate(template_dict, personalisation)
+    if template_dict['template_type'] == SMS_TYPE:
+        template_object = SMSMessageTemplate(template_dict, personalisation)
+    if template_dict['template_type'] == LETTER_TYPE:
+        template_object = LetterPrintTemplate(
+            template_dict,
+            personalisation,
+            contact_block=template_dict['reply_to_text'],
+        )
+
     check_placeholders(template_object)
 
     return template_object

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -48,16 +48,16 @@ REDIS_GET_AND_INCR_DAILY_LIMIT_DURATION_SECONDS = Histogram(
 )
 
 
-def create_content_for_notification(template_dict, personalisation):
-    if template_dict['template_type'] == EMAIL_TYPE:
-        template_object = PlainTextEmailTemplate(template_dict, personalisation)
-    if template_dict['template_type'] == SMS_TYPE:
-        template_object = SMSMessageTemplate(template_dict, personalisation)
-    if template_dict['template_type'] == LETTER_TYPE:
+def create_content_for_notification(template, personalisation):
+    if template.template_type == EMAIL_TYPE:
+        template_object = PlainTextEmailTemplate(template._dict, personalisation)
+    if template.template_type == SMS_TYPE:
+        template_object = SMSMessageTemplate(template._dict, personalisation)
+    if template.template_type == LETTER_TYPE:
         template_object = LetterPrintTemplate(
-            template_dict,
+            template._dict,
             personalisation,
-            contact_block=template_dict['reply_to_text'],
+            contact_block=template.reply_to_text,
         )
 
     check_placeholders(template_object)

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -100,13 +100,12 @@ def send_notification(notification_type):
 
     check_rate_limiting(authenticated_service, api_user)
 
-    template_with_content = validate_template(
+    template, template_with_content = validate_template(
         template_id=notification_form['template'],
         personalisation=notification_form.get('personalisation', {}),
         service=authenticated_service,
         notification_type=notification_type
     )
-    template_dict = template_with_content._template
 
     _service_allowed_to_send_to(notification_form, authenticated_service)
     if not service_has_permission(notification_type, authenticated_service.permissions):
@@ -119,9 +118,9 @@ def send_notification(notification_type):
         _service_can_send_internationally(authenticated_service, notification_form['to'])
     # Do not persist or send notification to the queue if it is a simulated recipient
     simulated = simulated_recipient(notification_form['to'], notification_type)
-    notification_model = persist_notification(template_id=template_dict['id'],
-                                              template_version=template_dict['version'],
-                                              template_postage=template_dict['postage'],
+    notification_model = persist_notification(template_id=template.id,
+                                              template_version=template.version,
+                                              template_postage=template.postage,
                                               recipient=request.get_json()['to'],
                                               service=authenticated_service,
                                               personalisation=notification_form.get('personalisation', None),
@@ -129,16 +128,16 @@ def send_notification(notification_type):
                                               api_key_id=api_user.id,
                                               key_type=api_user.key_type,
                                               simulated=simulated,
-                                              reply_to_text=template_dict['reply_to_text']
+                                              reply_to_text=template.reply_to_text
                                               )
     if not simulated:
-        queue_name = QueueNames.PRIORITY if template_dict['process_type'] == PRIORITY else None
+        queue_name = QueueNames.PRIORITY if template.process_type == PRIORITY else None
         send_notification_to_queue(notification=notification_model,
                                    research_mode=authenticated_service.research_mode,
                                    queue=queue_name)
     else:
         current_app.logger.debug("POST simulated notification for id: {}".format(notification_model.id))
-    notification_form.update({"template_version": template_dict['version']})
+    notification_form.update({"template_version": template.version})
 
     return jsonify(
         data=get_notification_return_data(

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -43,6 +43,7 @@ from app.notifications.process_letter_notifications import (
     create_letter_notification
 )
 from app.notifications.process_notifications import (
+    create_content_for_notification,
     persist_notification,
     persist_scheduled_notification,
     send_notification_to_queue,
@@ -83,6 +84,7 @@ POST_NOTIFICATION_JSON_PARSE_DURATION_SECONDS = Histogram(
 
 @v2_notification_blueprint.route('/{}'.format(LETTER_TYPE), methods=['POST'])
 def post_precompiled_letter_notification():
+    from app.schemas import template_schema
     request_json = get_valid_json()
     if 'content' not in (request_json or {}):
         return post_notification(LETTER_TYPE)
@@ -95,6 +97,9 @@ def post_precompiled_letter_notification():
     check_rate_limiting(authenticated_service, api_user)
 
     template = get_precompiled_letter_template(authenticated_service.id)
+    template = create_content_for_notification(
+        template_schema.dump(template).data, {}
+    )
 
     # For precompiled letters the to field will be set to Provided as PDF until the validation passes,
     # then the address of the letter will be set as the to field
@@ -102,13 +107,12 @@ def post_precompiled_letter_notification():
         'address_line_1': 'Provided as PDF'
     }
 
-    reply_to = get_reply_to_text(LETTER_TYPE, form, template)
-
     notification = process_letter_notification(
         letter_data=form,
         api_key=api_user,
         template=template,
-        reply_to_text=reply_to,
+        service=authenticated_service,
+        reply_to_text=template._template['reply_to_text'],
         precompiled=True
     )
 
@@ -143,20 +147,21 @@ def post_notification(notification_type):
 
     check_rate_limiting(authenticated_service, api_user)
 
-    template, template_with_content = validate_template(
+    template_with_content = validate_template(
         form['template_id'],
         form.get('personalisation', {}),
         authenticated_service,
         notification_type,
     )
 
-    reply_to = get_reply_to_text(notification_type, form, template)
+    reply_to = get_reply_to_text(notification_type, form, template_with_content)
 
     if notification_type == LETTER_TYPE:
         notification = process_letter_notification(
             letter_data=form,
             api_key=api_user,
-            template=template,
+            template=template_with_content,
+            service=authenticated_service,
             reply_to_text=reply_to
         )
     else:
@@ -164,11 +169,12 @@ def post_notification(notification_type):
             form=form,
             notification_type=notification_type,
             api_key=api_user,
-            template=template,
+            template=template_with_content,
             service=authenticated_service,
             reply_to_text=reply_to
         )
 
+        # Think this is redundant
         template_with_content.values = notification.personalisation
 
     if notification_type == SMS_TYPE:
@@ -245,7 +251,7 @@ def process_sms_or_email_notification(*, form, notification_type, api_key, templ
     notification = persist_notification(
         notification_id=notification_id,
         template_id=template.id,
-        template_version=template.version,
+        template_version=template._template['version'],
         recipient=form_send_to,
         service=service,
         personalisation=personalisation,
@@ -263,7 +269,7 @@ def process_sms_or_email_notification(*, form, notification_type, api_key, templ
         persist_scheduled_notification(notification.id, form["scheduled_for"])
     else:
         if not simulated:
-            queue_name = QueueNames.PRIORITY if template.process_type == PRIORITY else None
+            queue_name = QueueNames.PRIORITY if template._template['process_type'] == PRIORITY else None
             send_notification_to_queue(
                 notification=notification,
                 research_mode=service.research_mode,
@@ -290,7 +296,7 @@ def save_email_to_queue(
     data = {
         "id": notification_id,
         "template_id": str(template.id),
-        "template_version": template.version,
+        "template_version": template._template['version'],
         "to": form['email_address'],
         "service_id": str(service_id),
         "personalisation": personalisation,
@@ -341,7 +347,7 @@ def process_document_uploads(personalisation_data, service, simulated=False):
     return personalisation_data, len(file_keys)
 
 
-def process_letter_notification(*, letter_data, api_key, template, reply_to_text, precompiled=False):
+def process_letter_notification(*, letter_data, api_key, template, service, reply_to_text, precompiled=False):
     if api_key.key_type == KEY_TYPE_TEAM:
         raise BadRequestError(message='Cannot send letters with a team api key', status_code=403)
 
@@ -352,6 +358,7 @@ def process_letter_notification(*, letter_data, api_key, template, reply_to_text
         return process_precompiled_letter_notifications(letter_data=letter_data,
                                                         api_key=api_key,
                                                         template=template,
+                                                        service=service,
                                                         reply_to_text=reply_to_text)
 
     address = PostalAddress.from_personalisation(
@@ -386,6 +393,7 @@ def process_letter_notification(*, letter_data, api_key, template, reply_to_text
 
     notification = create_letter_notification(letter_data=letter_data,
                                               template=template,
+                                              service=service,
                                               api_key=api_key,
                                               status=status,
                                               reply_to_text=reply_to_text)
@@ -407,7 +415,7 @@ def process_letter_notification(*, letter_data, api_key, template, reply_to_text
     return notification
 
 
-def process_precompiled_letter_notifications(*, letter_data, api_key, template, reply_to_text):
+def process_precompiled_letter_notifications(*, letter_data, api_key, template, service, reply_to_text):
     try:
         status = NOTIFICATION_PENDING_VIRUS_CHECK
         letter_content = base64.b64decode(letter_data['content'])
@@ -416,6 +424,7 @@ def process_precompiled_letter_notifications(*, letter_data, api_key, template, 
 
     notification = create_letter_notification(letter_data=letter_data,
                                               template=template,
+                                              service=service,
                                               api_key=api_key,
                                               status=status,
                                               reply_to_text=reply_to_text)
@@ -447,7 +456,7 @@ def get_reply_to_text(notification_type, form, template):
         service_email_reply_to_id = form.get("email_reply_to_id", None)
         reply_to = check_service_email_reply_to_id(
             str(authenticated_service.id), service_email_reply_to_id, notification_type
-        ) or template.get_reply_to_text()
+        ) or template._template['reply_to_text']
 
     elif notification_type == SMS_TYPE:
         service_sms_sender_id = form.get("sms_sender_id", None)
@@ -457,9 +466,9 @@ def get_reply_to_text(notification_type, form, template):
         if sms_sender_id:
             reply_to = try_validate_and_format_phone_number(sms_sender_id)
         else:
-            reply_to = template.get_reply_to_text()
+            reply_to = template._template['reply_to_text']
 
     elif notification_type == LETTER_TYPE:
-        reply_to = template.get_reply_to_text()
+        reply_to = template._template['reply_to_text']
 
     return reply_to

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,6 +1,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
+cachetools==4.1.0
 cffi==1.14.0
 celery[sqs]==3.1.26.post2 # pyup: <4
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
+cachetools==4.1.0
 cffi==1.14.0
 celery[sqs]==3.1.26.post2 # pyup: <4
 docopt==0.6.2
@@ -39,14 +40,14 @@ alembic==1.4.2
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.3.0
-awscli==1.18.75
+awscli==1.18.79
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.4
 blinker==1.4
 boto==2.49.0
 boto3==1.10.38
-botocore==1.16.25
+botocore==1.17.2
 certifi==2020.4.5.2
 chardet==3.0.4
 click==7.1.2

--- a/tests/app/notifications/test_process_letter_notifications.py
+++ b/tests/app/notifications/test_process_letter_notifications.py
@@ -2,6 +2,8 @@ from app.models import LETTER_TYPE
 from app.models import Notification
 from app.models import NOTIFICATION_CREATED
 from app.notifications.process_letter_notifications import create_letter_notification
+from app.notifications.process_notifications import create_content_for_notification
+from app.notifications.validators import get_template_dict
 
 
 def test_create_letter_notification_creates_notification(sample_letter_template, sample_api_key):
@@ -13,7 +15,17 @@ def test_create_letter_notification_creates_notification(sample_letter_template,
         }
     }
 
-    notification = create_letter_notification(data, sample_letter_template, sample_api_key, NOTIFICATION_CREATED)
+    template = create_content_for_notification(get_template_dict(
+        sample_letter_template.id, sample_letter_template.service_id
+    ), {})
+
+    notification = create_letter_notification(
+        data,
+        template,
+        sample_letter_template.service,
+        sample_api_key,
+        NOTIFICATION_CREATED,
+    )
 
     assert notification == Notification.query.one()
     assert notification.job is None
@@ -38,7 +50,17 @@ def test_create_letter_notification_sets_reference(sample_letter_template, sampl
         'reference': 'foo'
     }
 
-    notification = create_letter_notification(data, sample_letter_template, sample_api_key, NOTIFICATION_CREATED)
+    template = create_content_for_notification(get_template_dict(
+        sample_letter_template.id, sample_letter_template.service_id
+    ), {})
+
+    notification = create_letter_notification(
+        data,
+        template,
+        sample_letter_template.service,
+        sample_api_key,
+        NOTIFICATION_CREATED,
+    )
 
     assert notification.client_reference == 'foo'
 
@@ -52,7 +74,17 @@ def test_create_letter_notification_sets_billable_units(sample_letter_template, 
         },
     }
 
-    notification = create_letter_notification(data, sample_letter_template, sample_api_key, NOTIFICATION_CREATED,
-                                              billable_units=3)
+    template = create_content_for_notification(get_template_dict(
+        sample_letter_template.id, sample_letter_template.service_id
+    ), {})
+
+    notification = create_letter_notification(
+        data,
+        template,
+        sample_letter_template.service,
+        sample_api_key,
+        NOTIFICATION_CREATED,
+        billable_units=3,
+    )
 
     assert notification.billable_units == 3

--- a/tests/app/notifications/test_process_letter_notifications.py
+++ b/tests/app/notifications/test_process_letter_notifications.py
@@ -2,8 +2,8 @@ from app.models import LETTER_TYPE
 from app.models import Notification
 from app.models import NOTIFICATION_CREATED
 from app.notifications.process_letter_notifications import create_letter_notification
-from app.notifications.process_notifications import create_content_for_notification
 from app.notifications.validators import get_template_dict
+from app.json_models import TemplateJSONModel
 
 
 def test_create_letter_notification_creates_notification(sample_letter_template, sample_api_key):
@@ -15,9 +15,9 @@ def test_create_letter_notification_creates_notification(sample_letter_template,
         }
     }
 
-    template = create_content_for_notification(get_template_dict(
+    template = TemplateJSONModel(get_template_dict(
         sample_letter_template.id, sample_letter_template.service_id
-    ), {})
+    ))
 
     notification = create_letter_notification(
         data,
@@ -50,9 +50,9 @@ def test_create_letter_notification_sets_reference(sample_letter_template, sampl
         'reference': 'foo'
     }
 
-    template = create_content_for_notification(get_template_dict(
+    template = TemplateJSONModel(get_template_dict(
         sample_letter_template.id, sample_letter_template.service_id
-    ), {})
+    ))
 
     notification = create_letter_notification(
         data,
@@ -74,9 +74,9 @@ def test_create_letter_notification_sets_billable_units(sample_letter_template, 
         },
     }
 
-    template = create_content_for_notification(get_template_dict(
+    template = TemplateJSONModel(get_template_dict(
         sample_letter_template.id, sample_letter_template.service_id
-    ), {})
+    ))
 
     notification = create_letter_notification(
         data,

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -21,6 +21,7 @@ from app.notifications.process_notifications import (
     send_notification_to_queue,
     simulated_recipient
 )
+from app.notifications.validators import get_template_dict
 from notifications_utils.recipients import validate_and_format_phone_number, validate_and_format_email_address
 from app.v2.errors import BadRequestError
 from tests.app.db import create_service, create_template
@@ -28,26 +29,30 @@ from tests.app.db import create_service, create_template
 
 def test_create_content_for_notification_passes(sample_email_template):
     template = Template.query.get(sample_email_template.id)
-    content = create_content_for_notification(template, None)
+    template_dict = get_template_dict(template.id, template.service_id)
+    content = create_content_for_notification(template_dict, None)
     assert str(content) == template.content + '\n'
 
 
 def test_create_content_for_notification_with_placeholders_passes(sample_template_with_placeholders):
     template = Template.query.get(sample_template_with_placeholders.id)
-    content = create_content_for_notification(template, {'name': 'Bobby'})
+    template_dict = get_template_dict(template.id, template.service_id)
+    content = create_content_for_notification(template_dict, {'name': 'Bobby'})
     assert content.content == template.content
     assert 'Bobby' in str(content)
 
 
 def test_create_content_for_notification_fails_with_missing_personalisation(sample_template_with_placeholders):
     template = Template.query.get(sample_template_with_placeholders.id)
+    template_dict = get_template_dict(template.id, template.service_id)
     with pytest.raises(BadRequestError):
-        create_content_for_notification(template, None)
+        create_content_for_notification(template_dict, None)
 
 
 def test_create_content_for_notification_allows_additional_personalisation(sample_template_with_placeholders):
     template = Template.query.get(sample_template_with_placeholders.id)
-    create_content_for_notification(template, {'name': 'Bobby', 'Additional placeholder': 'Data'})
+    template_dict = get_template_dict(template.id, template.service_id)
+    create_content_for_notification(template_dict, {'name': 'Bobby', 'Additional placeholder': 'Data'})
 
 
 @freeze_time("2016-01-01 11:09:00.061258")

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -29,7 +29,7 @@ from tests.app.db import create_service, create_template
 def test_create_content_for_notification_passes(sample_email_template):
     template = get_template_model(sample_email_template.id, sample_email_template.service_id)
     content = create_content_for_notification(template, None)
-    assert str(content) == template._dict['content'] + '\n'
+    assert str(content) == template.content + '\n'
 
 
 def test_create_content_for_notification_with_placeholders_passes(sample_template_with_placeholders):
@@ -37,7 +37,7 @@ def test_create_content_for_notification_with_placeholders_passes(sample_templat
         sample_template_with_placeholders.id, sample_template_with_placeholders.service_id
     )
     content = create_content_for_notification(template, {'name': 'Bobby'})
-    assert content.content == template._dict['content']
+    assert content.content == template.content
     assert 'Bobby' in str(content)
 
 


### PR DESCRIPTION
***This is a work in progress**

Before each request for v2 notifications we make a database round trip to check whether the API key is present/valid/correct

We only care if API keys are eventually consistent, ie if someone deletes an API key and it is used for 5 more seconds after is deleted, this is not a big deal.

We can use a new dependency (cachetools) to cache these calls to the database, effectively trading memory for database roundtrips. We will cache the "service JOIN api_keys" database call that is performed for every request (only for v2 notifications)

This commit introduces a TTL cache which will cache these calls for 2s. I expect this to marginally improve performance in cases when a service is posting many notifications for a sustained period of time

I'm not entirely sure how effective this will be in an using eventlets, but it is worth testing IMO

I chose this dao because it is the first dao usage in the notifications codepath