### PR TITLE
[needs work] Use opentelemetry project to instrument v2 post notifications using Jaeger

### DIFF
--- a/app/status/healthcheck.py
+++ b/app/status/healthcheck.py
@@ -7,12 +7,14 @@ from flask import (
 from app import db, version
 from app.dao.services_dao import dao_count_live_services
 from app.dao.organisation_dao import dao_count_organisations_with_live_services
+from app.tracing import trace_request
 
 status = Blueprint('status', __name__)
 
 
 @status.route('/', methods=['GET'])
 @status.route('/_status', methods=['GET', 'POST'])
+@trace_request
 def show_status():
     if request.args.get('simple', None):
         return jsonify(status="ok"), 200

--- a/app/tracing/__init__.py
+++ b/app/tracing/__init__.py
@@ -1,0 +1,35 @@
+from functools import wraps
+
+from flask import _request_ctx_stack, request
+
+from opentelemetry import trace
+from opentelemetry.ext import jaeger
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
+
+
+trace.set_tracer_provider(TracerProvider())
+
+jaeger_exporter = jaeger.JaegerSpanExporter(
+    service_name="notify-api",
+    agent_host_name="localhost",
+    agent_port=6831,
+)
+span_processor = BatchExportSpanProcessor(jaeger_exporter)
+trace.get_tracer_provider().add_span_processor(span_processor)
+
+
+def trace_request(f):
+    @wraps(f)
+    def inner(*args, **kwargs):
+        tracer = trace.get_tracer(__name__)
+        _request_ctx_stack.top.tracer = tracer
+
+        with tracer.start_as_current_span(str(request.url_rule)):
+            return f(*args, **kwargs)
+
+    return inner
+
+
+def span(name):
+    return _request_ctx_stack.top.tracer.start_as_current_span(name)

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -31,3 +31,8 @@ git+https://github.com/alphagov/notifications-utils.git@39.4.4#egg=notifications
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.7.1
 gds-metrics==0.2.0
+
+# tracing
+opentelemetry-api==0.9b0
+opentelemetry-ext-jaeger==0.9b0
+opentelemetry-sdk==0.9b0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,23 +34,30 @@ git+https://github.com/alphagov/notifications-utils.git@39.4.4#egg=notifications
 prometheus-client==0.7.1
 gds-metrics==0.2.0
 
+# tracing
+opentelemetry-api==0.9b0
+opentelemetry-ext-jaeger==0.9b0
+opentelemetry-sdk==0.9b0
+
 ## The following requirements were added by pip freeze:
+aiocontextvars==0.2.2
 alembic==1.4.2
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.3.0
-awscli==1.18.75
+awscli==1.18.79
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.4
 blinker==1.4
 boto==2.49.0
 boto3==1.10.38
-botocore==1.16.25
+botocore==1.17.2
 certifi==2020.4.5.2
 chardet==3.0.4
 click==7.1.2
 colorama==0.4.3
+contextvars==2.4
 dnspython==1.16.0
 docutils==0.15.2
 flask-redis==0.4.0
@@ -58,6 +65,7 @@ future==0.18.2
 govuk-bank-holidays==0.6
 greenlet==0.4.16
 idna==2.9
+immutables==0.14
 importlib-metadata==1.6.1
 Jinja2==2.11.2
 jmespath==0.10.0
@@ -84,6 +92,7 @@ s3transfer==0.3.3
 six==1.15.0
 smartypants==2.0.1
 statsd==3.3.0
+thrift==0.13.0
 urllib3==1.25.9
 webencodings==0.5.1
 Werkzeug==1.0.1


### PR DESCRIPTION
What
----

[OpenTelemetry](https://opentelemetry.io/) is a cross-platform set of APIs and SDKs and extensions for adding telemetry to applications.

The OpenTelemetry python libraries seem to work okay with `eventlet`.

This PR isn't production ready yet but could be useful in its current state for looking for performance improvements.

It adds a new package `app.tracing` which has a decorator `trace_request` and a convenience function `span`. Using `span` when not in a traced request is a runtime error.

Example usage
----

If you wanted to instrument:

```
@app.route('/do-two-things')
def do_two_things():
  do_thing_1()
  do_thing_2()
  return "done"
```

You would do:

```
@app.route('/do-two-things')
@trace_request
def do_two_things():
  with span('do-thing-1'):
    do_thing_1()
  with span('do-thing-2'):
    do_thing_2()

  return "done"
```

Which would generate a trace which looks like:

```
|========== total-request ==========|
 |== do-thing-1 ==|
                  |== do-thing-2 ==|
```

Instrumentation
----

When running the Jaeger all-in-one image locally, and running the tests, the API now generates traces for v2/notifications POSTs like:

![image](https://user-images.githubusercontent.com/1482692/84632127-60533b80-aee6-11ea-8db2-d844ef07dd37.png)

Next steps
----

I want to think about this a bit more, and get comments/thoughts/feedback - you have done some tracing work already, as I may have duplicated what you've already done.

This also needs:

- Tests
- Tuning - such that we don't trace 100% of requests
- Proper configuration
- Rethinking how the current tracer is grabbed, the request context isn't good long term because it will prevent us from instrumenting daos low level