### PR TITLE
Make sure people without international sms permission can send to crown dependencies

### DIFF
--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -15,7 +15,7 @@ from app.errors import (
     InvalidRequest
 )
 from app.models import (
-    EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, SMS_TYPE,
+    EMAIL_TYPE, SMS_TYPE,
     KEY_TYPE_TEAM, PRIORITY,
     LETTER_TYPE)
 from app.notifications.process_notifications import (
@@ -24,9 +24,10 @@ from app.notifications.process_notifications import (
     simulated_recipient
 )
 from app.notifications.validators import (
+    check_if_service_can_send_to_number,
     check_rate_limiting,
     service_has_permission,
-    validate_template
+    validate_template,
 )
 from app.schemas import (
     email_notification_schema,
@@ -38,7 +39,6 @@ from app.service.utils import service_allowed_to_send_to
 from app.utils import pagination_links, get_public_notify_type_text
 
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
-from notifications_utils.recipients import get_international_phone_info
 
 notifications = Blueprint('notifications', __name__)
 
@@ -115,7 +115,7 @@ def send_notification(notification_type):
         )
 
     if notification_type == SMS_TYPE:
-        _service_can_send_internationally(authenticated_service, notification_form['to'])
+        check_if_service_can_send_to_number(authenticated_service, notification_form['to'])
     # Do not persist or send notification to the queue if it is a simulated recipient
     simulated = simulated_recipient(notification_form['to'], notification_type)
     notification_model = persist_notification(template_id=template.id,
@@ -158,17 +158,6 @@ def get_notification_return_data(notification_id, notification, template):
         output['subject'] = template.subject
 
     return output
-
-
-def _service_can_send_internationally(service, number):
-    international_phone_info = get_international_phone_info(number)
-
-    if (international_phone_info.international and international_phone_info.country_prefix != '44') and \
-            INTERNATIONAL_SMS_TYPE not in [p.permission for p in service.permissions]:
-        raise InvalidRequest(
-            {'to': ["Cannot send to international mobile numbers"]},
-            status_code=400
-        )
 
 
 def _service_allowed_to_send_to(notification, service):

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -163,7 +163,7 @@ def get_notification_return_data(notification_id, notification, template):
 def _service_can_send_internationally(service, number):
     international_phone_info = get_international_phone_info(number)
 
-    if international_phone_info.international and \
+    if (international_phone_info.international and international_phone_info.country_prefix != '44') and \
             INTERNATIONAL_SMS_TYPE not in [p.permission for p in service.permissions]:
         raise InvalidRequest(
             {'to': ["Cannot send to international mobile numbers"]},

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -26,7 +26,7 @@ notifications-python-client==5.5.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@39.6.0#egg=notifications-utils==39.6.0
+git+https://github.com/alphagov/notifications-utils.git@39.7.0#egg=notifications-utils==39.7.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ notifications-python-client==5.5.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@39.6.0#egg=notifications-utils==39.6.0
+git+https://github.com/alphagov/notifications-utils.git@39.7.0#egg=notifications-utils==39.7.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.7.1
@@ -39,14 +39,14 @@ alembic==1.4.2
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.3.0
-awscli==1.18.82
+awscli==1.18.83
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.4
 blinker==1.4
 boto==2.49.0
 boto3==1.10.38
-botocore==1.17.5
+botocore==1.17.6
 cachetools==4.1.0
 certifi==2020.4.5.2
 chardet==3.0.4

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -356,7 +356,7 @@ def test_simulated_recipient(notify_api, to_address, notification_type, expected
 @pytest.mark.parametrize('recipient, expected_international, expected_prefix, expected_units', [
     ('7900900123', False, '44', 1),  # UK
     ('+447900900123', False, '44', 1),  # UK
-    ('07700900222', False, '44', 1),  # UK
+    ('07700900222', True, '44', 1),  # UK (Jersey)
     ('73122345678', True, '7', 1),  # Russia
     ('360623400400', True, '36', 3)]  # Hungary
 )


### PR DESCRIPTION
In this PR we make sure that people without international sms permission can send to crown dependencies after we start treating those numbers as international here: https://github.com/alphagov/notifications-utils/pull/749

A Jersey (tv) number, and my (standard UK) number, both sent to successfully, from a service without international sms permission, and with correct flags resulting in correct providers used:

<img width="488" alt="Screenshot 2020-06-16 at 18 00 48" src="https://user-images.githubusercontent.com/20957548/84804973-6dae1a00-affb-11ea-9588-1ee35c74b0ff.png">


TODO: Import this version utils once they are merged: https://github.com/alphagov/notifications-utils/pull/749
Tests will fail without it.