### PR TITLE
Reduce the use of db connections

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -127,7 +127,6 @@ def persist_notification(
     # if simulated create a Notification model to return but do not persist the Notification to the dB
     if not simulated:
         dao_create_notification(notification)
-        print("****** COMMIT *******")
         # Only keep track of the daily limit for trial mode services.
         if service_in_trial_mode and key_type != KEY_TYPE_TEST:
             if redis_store.get(redis.daily_limit_cache_key(service_id)):
@@ -168,8 +167,8 @@ def send_notification_to_queue_detached(
         "{} {} sent to the {} queue for delivery".format(notification_type,
                                                          notification_id,
                                                          queue))
-    
-    
+
+
 def send_notification_to_queue(notification, research_mode, queue=None):
     send_notification_to_queue_detached(
         notification.key_type, notification.notification_type, notification.id, research_mode, queue

--- a/app/v2/notifications/create_response.py
+++ b/app/v2/notifications/create_response.py
@@ -1,57 +1,10 @@
 
 
-def create_post_sms_response_from_notification(notification, content, from_number, url_root, scheduled_for):
-    noti = __create_notification_response(notification, url_root, scheduled_for)
-    noti['content'] = {
-        'from_number': from_number,
-        'body': content
-    }
-    return noti
-
-
-def create_post_email_response_from_notification(notification, content, subject, email_from, url_root, scheduled_for):
-    noti = __create_notification_response(notification, url_root, scheduled_for)
-    noti['content'] = {
-        "from_email": email_from,
-        "body": content,
-        "subject": subject
-    }
-    return noti
-
-
-def create_post_letter_response_from_notification(notification, content, subject, url_root, scheduled_for):
-    noti = __create_notification_response(notification, url_root, scheduled_for)
-    noti['content'] = {
-        "body": content,
-        "subject": subject
-    }
-    return noti
-
-
-def __create_notification_response(notification, url_root, scheduled_for):
-    return {
-        "id": notification.id,
-        "reference": notification.client_reference,
-        "uri": "{}v2/notifications/{}".format(url_root, str(notification.id)),
-        'template': {
-            "id": notification.template_id,
-            "version": notification.template_version,
-            "uri": "{}services/{}/templates/{}".format(
-                url_root,
-                str(notification.service_id),
-                str(notification.template_id)
-            )
-        },
-        "scheduled_for": scheduled_for if scheduled_for else None
-    }
-
-
-# test detaching notification
-def create_post_sms_response_from_notification_detached(
-    notification_id, client_reference, template_id, template_version, service_id, 
+def create_post_sms_response_from_notification(
+    notification_id, client_reference, template_id, template_version, service_id,
     content, from_number, url_root, scheduled_for
 ):
-    resp = __create_notification_response_detached(
+    resp = __create_notification_response(
         notification_id, client_reference, template_id, template_version, service_id, url_root, scheduled_for
     )
     resp['content'] = {
@@ -61,10 +14,19 @@ def create_post_sms_response_from_notification_detached(
     return resp
 
 
-def create_post_email_response_from_notification_detached(
-    notification_id, client_reference, template_id, template_version, service_id, content, subject, email_from, 
-    url_root, scheduled_for):
-    resp = __create_notification_response_detached(
+def create_post_email_response_from_notification(
+    notification_id,
+    client_reference,
+    template_id,
+    template_version,
+    service_id,
+    content,
+    subject,
+    email_from,
+    url_root,
+    scheduled_for
+):
+    resp = __create_notification_response(
         notification_id, client_reference, template_id, template_version, service_id, url_root, scheduled_for
     )
     resp['content'] = {
@@ -75,11 +37,11 @@ def create_post_email_response_from_notification_detached(
     return resp
 
 
-def create_post_letter_response_from_notification_detached(
+def create_post_letter_response_from_notification(
     notification_id, client_reference, template_id, template_version, service_id,
     content, subject, url_root, scheduled_for
 ):
-    resp = __create_notification_response_detached(
+    resp = __create_notification_response(
         notification_id, client_reference, template_id, template_version, service_id, url_root, scheduled_for
     )
     resp['content'] = {
@@ -89,7 +51,7 @@ def create_post_letter_response_from_notification_detached(
     return resp
 
 
-def __create_notification_response_detached(
+def __create_notification_response(
     notification_id, client_reference, template_id, template_version, service_id, url_root, scheduled_for
 ):
     return {

--- a/app/v2/notifications/create_response.py
+++ b/app/v2/notifications/create_response.py
@@ -44,3 +44,66 @@ def __create_notification_response(notification, url_root, scheduled_for):
         },
         "scheduled_for": scheduled_for if scheduled_for else None
     }
+
+
+# test detaching notification
+def create_post_sms_response_from_notification_detached(
+    notification_id, client_reference, template_id, template_version, service_id, 
+    content, from_number, url_root, scheduled_for
+):
+    resp = __create_notification_response_detached(
+        notification_id, client_reference, template_id, template_version, service_id, url_root, scheduled_for
+    )
+    resp['content'] = {
+        'from_number': from_number,
+        'body': content
+    }
+    return resp
+
+
+def create_post_email_response_from_notification_detached(
+    notification_id, client_reference, template_id, template_version, service_id, content, subject, email_from, 
+    url_root, scheduled_for):
+    resp = __create_notification_response_detached(
+        notification_id, client_reference, template_id, template_version, service_id, url_root, scheduled_for
+    )
+    resp['content'] = {
+        "from_email": email_from,
+        "body": content,
+        "subject": subject
+    }
+    return resp
+
+
+def create_post_letter_response_from_notification_detached(
+    notification_id, client_reference, template_id, template_version, service_id,
+    content, subject, url_root, scheduled_for
+):
+    resp = __create_notification_response_detached(
+        notification_id, client_reference, template_id, template_version, service_id, url_root, scheduled_for
+    )
+    resp['content'] = {
+        "body": content,
+        "subject": subject
+    }
+    return resp
+
+
+def __create_notification_response_detached(
+    notification_id, client_reference, template_id, template_version, service_id, url_root, scheduled_for
+):
+    return {
+        "id": notification_id,
+        "reference": client_reference,
+        "uri": "{}v2/notifications/{}".format(url_root, str(notification_id)),
+        'template': {
+            "id": template_id,
+            "version": template_version,
+            "uri": "{}services/{}/templates/{}".format(
+                url_root,
+                str(service_id),
+                str(template_id)
+            )
+        },
+        "scheduled_for": scheduled_for if scheduled_for else None
+    }

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -44,15 +44,14 @@ def test_post_sms_notification_returns_201(client, sample_template_with_placehol
     if reference:
         data.update({"reference": reference})
     auth_header = create_authorization_header(service_id=sample_template_with_placeholders.service_id)
-    print("********* Start")
+
     response = client.post(
         path='/v2/notifications/sms',
         data=json.dumps(data),
         headers=[('Content-Type', 'application/json'), auth_header])
-    print("********* End")
+
     assert response.status_code == 201
     resp_json = json.loads(response.get_data(as_text=True))
-    print(resp_json)
     assert validate(resp_json, post_sms_response) == resp_json
     notifications = Notification.query.all()
     assert len(notifications) == 1

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -33,7 +33,7 @@ from tests.app.db import (
 )
 
 
-@pytest.mark.parametrize("reference", [None, "reference_from_client"])
+@pytest.mark.parametrize("reference", ["reference_from_client"])
 def test_post_sms_notification_returns_201(client, sample_template_with_placeholders, mocker, reference):
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
     data = {
@@ -44,13 +44,15 @@ def test_post_sms_notification_returns_201(client, sample_template_with_placehol
     if reference:
         data.update({"reference": reference})
     auth_header = create_authorization_header(service_id=sample_template_with_placeholders.service_id)
-
+    print("********* Start")
     response = client.post(
         path='/v2/notifications/sms',
         data=json.dumps(data),
         headers=[('Content-Type', 'application/json'), auth_header])
+    print("********* End")
     assert response.status_code == 201
     resp_json = json.loads(response.get_data(as_text=True))
+    print(resp_json)
     assert validate(resp_json, post_sms_response) == resp_json
     notifications = Notification.query.all()
     assert len(notifications) == 1

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -426,7 +426,7 @@ def test_returns_a_429_limit_exceeded_if_rate_limit_exceeded(
 ):
     sample = create_template(service=sample_service, template_type=notification_type)
     persist_mock = mocker.patch('app.v2.notifications.post_notifications.persist_notification')
-    deliver_mock = mocker.patch('app.v2.notifications.post_notifications.send_notification_to_queue')
+    deliver_mock = mocker.patch('app.v2.notifications.post_notifications.send_notification_to_queue_detached')
     mocker.patch(
         'app.v2.notifications.post_notifications.check_rate_limiting',
         side_effect=RateLimitError("LIMIT", "INTERVAL", "TYPE"))

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -33,7 +33,7 @@ from tests.app.db import (
 )
 
 
-@pytest.mark.parametrize("reference", ["reference_from_client"])
+@pytest.mark.parametrize("reference", [None, "reference_from_client"])
 def test_post_sms_notification_returns_201(client, sample_template_with_placeholders, mocker, reference):
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
     data = {


### PR DESCRIPTION
In the effort to reduce the number of queries to the database this PR removes the need to fetch the notification and service after the commit when persisting the notification, this releases the db connection back to the connection pool.

If you look at the queries made during the POST /notification/email or sms you should see no new queries made after the insert into notifications transaction.

The letter flow will need some more work in order to remove the need for the db after the notification insert. This PR prioritises the email and sms flow first.