### PR TITLE
Turn off statsd for the API in all environments

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -309,7 +309,7 @@ class Config(object):
 
     STATSD_HOST = os.getenv('STATSD_HOST')
     STATSD_PORT = 8125
-    STATSD_ENABLED = bool(STATSD_HOST)
+    STATSD_ENABLED = False
 
     SENDING_NOTIFICATIONS_TIMEOUT_PERIOD = 259200  # 3 days
 


### PR DESCRIPTION
We have seen bad latency across all apps in the last week. After running
a canary with statsd turned off we have seen these issues dissapear on
that canary instance. We therefore will turn off statsd for all
instances of the API. We will still need to investigate tomorrow what
exactly changed or is causing the issue with statsd as we hadn't made
any changes to it ourself.

Note, this keeps statsd on for all the other apps but this will be a
first step. We will also need to check performance of the other apps
after releasing this.