### PR TITLE
re-enable statsd (and cache statsd DNS lookup)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -309,7 +309,7 @@ class Config(object):
 
     STATSD_HOST = os.getenv('STATSD_HOST')
     STATSD_PORT = 8125
-    STATSD_ENABLED = False
+    STATSD_ENABLED = bool(STATSD_HOST)
 
     SENDING_NOTIFICATIONS_TIMEOUT_PERIOD = 259200  # 3 days
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -26,7 +26,7 @@ notifications-python-client==5.5.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@39.4.4#egg=notifications-utils==39.4.4
+git+https://github.com/alphagov/notifications-utils.git@39.6.0#egg=notifications-utils==39.6.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ notifications-python-client==5.5.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@39.4.4#egg=notifications-utils==39.4.4
+git+https://github.com/alphagov/notifications-utils.git@39.6.0#egg=notifications-utils==39.6.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.7.1
@@ -39,14 +39,15 @@ alembic==1.4.2
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.3.0
-awscli==1.18.75
+awscli==1.18.82
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.4
 blinker==1.4
 boto==2.49.0
 boto3==1.10.38
-botocore==1.16.25
+botocore==1.17.5
+cachetools==4.1.0
 certifi==2020.4.5.2
 chardet==3.0.4
 click==7.1.2
@@ -78,7 +79,7 @@ python-json-logger==0.1.11
 pytz==2020.1
 PyYAML==5.3.1
 redis==3.5.3
-requests==2.23.0
+requests==2.24.0
 rsa==3.4.2
 s3transfer==0.3.3
 six==1.15.0


### PR DESCRIPTION
see https://github.com/alphagov/notifications-utils/pull/752 for implementation details. Cache DNS for 15 seconds. Note: This cache is per eventlet, so concurrent requests will handle their requests separately, but the cache does persist between sequential requests.

re-enable statsd for all environments.