### PR TITLE
Don’t return letter contact blocks in service JSON

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -205,7 +205,6 @@ class ServiceSchema(BaseSchema):
     email_branding = field_for(models.Service, 'email_branding')
     organisation = field_for(models.Service, 'organisation')
     override_flag = False
-    letter_contact_block = fields.Method(serialize="get_letter_contact")
     go_live_at = field_for(models.Service, 'go_live_at', format=DATETIME_FORMAT_NO_TIMEZONE)
 
     def get_letter_logo_filename(self, service):
@@ -219,7 +218,6 @@ class ServiceSchema(BaseSchema):
 
     class Meta:
         model = models.Service
-        dump_only = ['letter_contact_block']
         exclude = (
             'updated_at',
             'created_at',


### PR DESCRIPTION
The admin app doesn’t use them: https://github.com/alphagov/notifications-admin/search?q=letter_contact_block&unscoped_q=letter_contact_block

Instead it requests them separately when needed: https://github.com/alphagov/notifications-admin/blob/2f1e8b104b0f8c76e14ba0d0159d0fcaf95a7046/app/models/service.py#L349-L351

Removing this from the response means one fewer database query.

Depends on:
- [x] https://github.com/alphagov/notifications-admin/pull/3490