### PR TITLE
Cache serialised template in Redis and in memory

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -13,6 +13,7 @@ from marshmallow import (
     post_dump
 )
 from marshmallow_sqlalchemy import field_for
+from uuid import UUID
 
 from notifications_utils.recipients import (
     validate_email_address,
@@ -56,6 +57,14 @@ def _validate_datetime_not_in_future(dte, msg="Date cannot be in the future"):
 def _validate_datetime_not_in_past(dte, msg="Date cannot be in the past"):
     if dte < datetime.utcnow():
         raise ValidationError(msg)
+
+
+class UUIDsAsStringsMixin:
+    @post_dump()
+    def __post_dump(self, data):
+        for key, value in data.items():
+            if isinstance(value, UUID):
+                data[key] = str(value)
 
 
 class BaseSchema(ma.ModelSchema):
@@ -341,7 +350,7 @@ class BaseTemplateSchema(BaseSchema):
         strict = True
 
 
-class TemplateSchema(BaseTemplateSchema):
+class TemplateSchema(BaseTemplateSchema, UUIDsAsStringsMixin):
 
     created_by_id = field_for(
         models.Template, 'created_by_id', dump_to='created_by', dump_only=True

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -4,11 +4,14 @@ from functools import partial
 from threading import RLock
 
 import cachetools
+from notifications_utils.clients.redis import RequestCache
 
+from app import redis_store
 from app.dao import templates_dao
 
 caches = defaultdict(partial(cachetools.TTLCache, maxsize=1024, ttl=2))
 locks = defaultdict(RLock)
+redis_cache = RequestCache(redis_store)
 
 
 def memory_cache(func):
@@ -69,6 +72,7 @@ class SerialisedTemplate(SerialisedModel):
         return cls(cls.get_dict(template_id, service_id))
 
     @staticmethod
+    @redis_cache.set('template-{template_id}-version-None')
     def get_dict(template_id, service_id):
         from app.schemas import template_schema
 

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -233,6 +233,7 @@ def test_should_cache_template_lookups_in_memory(mocker, client, sample_template
             headers=[('Content-Type', 'application/json'), auth_header]
         )
 
+    assert mock_get_template.call_count == 1
     assert mock_get_template.call_args_list == [
         call(service_id=sample_template.service_id, template_id=str(sample_template.id))
     ]


### PR DESCRIPTION
This pull request caches just the serialised template object or dictionary in memory and Redis respectively.

It should improve performance for high volume services by releasing the DB connection more quickly.