### PR TITLE
Exclude created_by_id from TemplateSchemaNoDetail

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -369,7 +369,7 @@ class TemplateSchemaNoDetail(TemplateSchema):
             'archived',
             'content',
             'created_at',
-            'created_by',
+            'created_by_id',
             'hidden',
             'postage',
             'process_type',


### PR DESCRIPTION
We were already excluding `created_by`, but in a different branch we renamed the property on the schema to `created_by_id`: https://github.com/alphagov/notifications-api/pull/2873/files#diff-691350bfe8029e08252edaad69e871b9R346-R348

We need to rename it in the exclude list to make sure that this assertion still passes:
https://github.com/alphagov/notifications-api/blob/14e7b6b87e4f525d1363a28e2b91882423d513b1/tests/app/template/test_rest.py#L555-L560