### PR TITLE
Ensure templates are cached with correct schema

### DIFF
--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -69,7 +69,7 @@ class SerialisedTemplate(SerialisedModel):
     @classmethod
     @memory_cache
     def from_id_and_service_id(cls, template_id, service_id):
-        return cls(cls.get_dict(template_id, service_id))
+        return cls(cls.get_dict(template_id, service_id)['data'])
 
     @staticmethod
     @redis_cache.set('template-{template_id}-version-None')
@@ -83,4 +83,4 @@ class SerialisedTemplate(SerialisedModel):
 
         template_dict = template_schema.dump(fetched_template).data
 
-        return template_dict
+        return {'data': template_dict}

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -276,7 +276,9 @@ def test_should_cache_template_lookups_in_redis(mocker, client, sample_template)
 
     assert len(mock_redis_set.call_args_list) == 1
     assert mock_redis_set.call_args[0][0] == expected_key
-    assert json.loads(mock_redis_set.call_args[0][1]) == template_dict
+    assert json.loads(mock_redis_set.call_args[0][1]) == {
+        'data': template_dict,
+    }
     assert mock_redis_set.call_args[1]['ex'] == 604_800
 
 
@@ -287,7 +289,7 @@ def test_should_return_template_if_found_in_redis(mocker, client, sample_templat
 
     mocker.patch(
         'app.redis_store.get',
-        return_value=json.dumps(template_dict).encode('utf-8')
+        return_value=json.dumps({'data': template_dict}).encode('utf-8')
     )
     mock_get_template = mocker.patch(
         'app.dao.templates_dao.dao_get_template_by_id_and_service_id'


### PR DESCRIPTION
For some reason our V1 get template response wraps the whole template in a dictionary with one key, `'data'`:
https://github.com/alphagov/notifications-api/blob/0d990338893cd0e82e7415e424669f150297be0c/app/template/rest.py#L166

That means when the admin app caches the response it also caches it in this format.

The API needs to do the same, otherwise it will be cacheing data with a schema that the admin app isn’t expecting, and vice-versa.