### PR TITLE
Get letter data for provided filenames

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -790,7 +790,7 @@ def get_notification_and_service_ids_for_letters_that_failed_to_print(file_name)
 
 def get_letters_data_from_references(notification_references):
     sql = """
-        SELECT id, service_id, reference, job_id, created_at
+        SELECT id, service_id, template_id, reference, job_id, created_at
         FROM notifications
         WHERE reference IN :notification_references
         ORDER BY service_id, job_id"""
@@ -798,7 +798,7 @@ def get_letters_data_from_references(notification_references):
 
     with open('zips_sent_details.csv', 'w') as csvfile:
         csv_writer = csv.writer(csvfile)
-        csv_writer.writerow(['notification_id', 'service_id', 'reference', 'job_id', 'created_at'])
+        csv_writer.writerow(['notification_id', 'service_id', 'template_id', 'reference', 'job_id', 'created_at'])
 
         for row in result:
             csv_writer.writerow(row)

--- a/app/commands.py
+++ b/app/commands.py
@@ -773,7 +773,22 @@ def get_letter_details_from_zips_sent_file(file_paths):
         rows_from_file.extend(json.loads(file_contents))
 
     notification_references = tuple(row[18:34] for row in rows_from_file)
+    get_letters_data_from_references(notification_references)
 
+
+@notify_command(name='get-notification-and-service-ids-for-letters-that-failed-to-print')
+@click.option('-f', '--file_name', required=True,
+              help="""Full path of the file to upload, file should contain letter filenames, one per line""")
+def get_notification_and_service_ids_for_letters_that_failed_to_print(file_name):
+    print("Getting service and notification ids for letter filenames list {}".format(file_name))
+    file = open(file_name)
+    references = tuple([row[7:23] for row in file])
+
+    get_letters_data_from_references(tuple(references))
+    file.close()
+
+
+def get_letters_data_from_references(notification_references):
     sql = """
         SELECT id, service_id, reference, job_id, created_at
         FROM notifications


### PR DESCRIPTION
A command to get letter data based on a list of filenames provided by DVLA.

This is done so that we could try to help narrow down what is causing failed print runs at DVLA