### PR TITLE
Remove the use of schedule_for in post_notifications

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -78,6 +78,7 @@ def create_app(application):
     from app.config import configs
 
     notify_environment = os.environ['NOTIFY_ENVIRONMENT']
+    print(notify_environment)
 
     application.config.from_object(configs[notify_environment])
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -677,12 +677,6 @@ def dao_get_notifications_by_references(references):
     ).all()
 
 
-@statsd(namespace="dao")
-def dao_created_scheduled_notification(scheduled_notification):
-    db.session.add(scheduled_notification)
-    db.session.commit()
-
-
 def dao_get_total_notifications_sent_per_day_for_performance_platform(start_date, end_date):
     """
     SELECT

--- a/app/models.py
+++ b/app/models.py
@@ -27,7 +27,7 @@ from notifications_utils.template import (
     SMSMessageTemplate,
     LetterPrintTemplate,
 )
-from notifications_utils.timezones import convert_bst_to_utc, convert_utc_to_bst
+from notifications_utils.timezones import convert_utc_to_bst
 
 from app.hashing import (
     hashpw,
@@ -1412,8 +1412,6 @@ class Notification(db.Model):
     client_reference = db.Column(db.String, index=True, nullable=True)
     _personalisation = db.Column(db.String, nullable=True)
 
-    scheduled_notification = db.relationship('ScheduledNotification', uselist=False)
-
     client_reference = db.Column(db.String, index=True, nullable=True)
 
     international = db.Column(db.Boolean, nullable=False, default=False)
@@ -1622,13 +1620,7 @@ class Notification(db.Model):
             "created_by_name": self.get_created_by_name(),
             "sent_at": self.sent_at.strftime(DATETIME_FORMAT) if self.sent_at else None,
             "completed_at": self.completed_at(),
-            "scheduled_for": (
-                convert_bst_to_utc(
-                    self.scheduled_notification.scheduled_for
-                ).strftime(DATETIME_FORMAT)
-                if self.scheduled_notification
-                else None
-            ),
+            "scheduled_for": None,
             "postage": self.postage
         }
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -14,7 +14,6 @@ from notifications_utils.template import (
     SMSMessageTemplate,
     LetterPrintTemplate,
 )
-from notifications_utils.timezones import convert_bst_to_utc
 
 from app import redis_store
 from app.celery import provider_tasks
@@ -28,12 +27,10 @@ from app.models import (
     LETTER_TYPE,
     NOTIFICATION_CREATED,
     Notification,
-    ScheduledNotification
 )
 from app.dao.notifications_dao import (
     dao_create_notification,
     dao_delete_notifications_by_id,
-    dao_created_scheduled_notification
 )
 
 from app.v2.errors import BadRequestError
@@ -217,10 +214,3 @@ def simulated_recipient(to_address, notification_type):
         return to_address in formatted_simulated_numbers
     else:
         return to_address in current_app.config['SIMULATED_EMAIL_ADDRESSES']
-
-
-def persist_scheduled_notification(notification_id, scheduled_for):
-    scheduled_datetime = convert_bst_to_utc(datetime.strptime(scheduled_for, "%Y-%m-%d %H:%M"))
-    scheduled_notification = ScheduledNotification(notification_id=notification_id,
-                                                   scheduled_for=scheduled_datetime)
-    dao_created_scheduled_notification(scheduled_notification)

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -12,7 +12,7 @@ from app.dao import services_dao
 from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id
 from app.models import (
     INTERNATIONAL_SMS_TYPE, SMS_TYPE, EMAIL_TYPE, LETTER_TYPE,
-    KEY_TYPE_TEST, KEY_TYPE_TEAM, SCHEDULE_NOTIFICATIONS
+    KEY_TYPE_TEST, KEY_TYPE_TEAM
 )
 from app.service.utils import service_allowed_to_send_to
 from app.v2.errors import TooManyRequestsError, BadRequestError, RateLimitError
@@ -106,12 +106,6 @@ def check_if_service_can_send_files_by_email(service_contact_link, service_id):
             message=f"Send files by email has not been set up - add contact details for your service at "
                     f"{current_app.config['ADMIN_BASE_URL']}/services/{service_id}/service-settings/send-files-by-email"
         )
-
-
-def check_service_can_schedule_notification(permissions, scheduled_for):
-    if scheduled_for:
-        if not service_has_permission(SCHEDULE_NOTIFICATIONS, permissions):
-            raise BadRequestError(message="Cannot schedule notifications (this feature is invite-only)")
 
 
 def validate_and_format_recipient(send_to, key_type, service, notification_type, allow_whitelisted_recipients=True):

--- a/app/v2/notifications/create_response.py
+++ b/app/v2/notifications/create_response.py
@@ -2,10 +2,10 @@
 
 def create_post_sms_response_from_notification(
     notification_id, client_reference, template_id, template_version, service_id,
-    content, from_number, url_root, scheduled_for
+    content, from_number, url_root
 ):
     resp = __create_notification_response(
-        notification_id, client_reference, template_id, template_version, service_id, url_root, scheduled_for
+        notification_id, client_reference, template_id, template_version, service_id, url_root
     )
     resp['content'] = {
         'from_number': from_number,
@@ -24,10 +24,9 @@ def create_post_email_response_from_notification(
     subject,
     email_from,
     url_root,
-    scheduled_for
 ):
     resp = __create_notification_response(
-        notification_id, client_reference, template_id, template_version, service_id, url_root, scheduled_for
+        notification_id, client_reference, template_id, template_version, service_id, url_root
     )
     resp['content'] = {
         "from_email": email_from,
@@ -39,10 +38,10 @@ def create_post_email_response_from_notification(
 
 def create_post_letter_response_from_notification(
     notification_id, client_reference, template_id, template_version, service_id,
-    content, subject, url_root, scheduled_for
+    content, subject, url_root
 ):
     resp = __create_notification_response(
-        notification_id, client_reference, template_id, template_version, service_id, url_root, scheduled_for
+        notification_id, client_reference, template_id, template_version, service_id, url_root
     )
     resp['content'] = {
         "body": content,
@@ -52,7 +51,7 @@ def create_post_letter_response_from_notification(
 
 
 def __create_notification_response(
-    notification_id, client_reference, template_id, template_version, service_id, url_root, scheduled_for
+    notification_id, client_reference, template_id, template_version, service_id, url_root
 ):
     return {
         "id": notification_id,
@@ -67,5 +66,5 @@ def __create_notification_response(
                 str(template_id)
             )
         },
-        "scheduled_for": scheduled_for if scheduled_for else None
+        "scheduled_for": None
     }

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -10,7 +10,6 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from app.dao.notifications_dao import (
     dao_create_notification,
-    dao_created_scheduled_notification,
     dao_delete_notifications_by_id,
     dao_get_last_notification_added_for_job_id,
     dao_get_notifications_by_recipient_or_reference,
@@ -36,7 +35,6 @@ from app.models import (
     Job,
     Notification,
     NotificationHistory,
-    ScheduledNotification,
     NOTIFICATION_STATUS_TYPES,
     NOTIFICATION_STATUS_TYPES_FAILED,
     NOTIFICATION_TEMPORARY_FAILURE,
@@ -449,7 +447,6 @@ def test_save_notification_with_no_job(sample_template, mmg_provider):
 
 def test_get_notification_with_personalisation_by_id(sample_template):
     notification = create_notification(template=sample_template,
-                                       scheduled_for='2017-05-05 14:15',
                                        status='created')
     notification_from_db = get_notification_with_personalisation(
         sample_template.service.id,
@@ -457,7 +454,6 @@ def test_get_notification_with_personalisation_by_id(sample_template):
         key_type=None
     )
     assert notification == notification_from_db
-    assert notification_from_db.scheduled_notification.scheduled_for == datetime(2017, 5, 5, 14, 15)
 
 
 def test_get_notification_by_id_when_notification_exists(sample_notification):
@@ -1390,18 +1386,6 @@ def test_dao_get_notifications_by_reference(
     results = dao_get_notifications_by_recipient_or_reference(service.id, '77', notification_type='letter')
     assert len(results.items) == 1
     assert results.items[0].id == letter.id
-
-
-def test_dao_created_scheduled_notification(sample_notification):
-
-    scheduled_notification = ScheduledNotification(notification_id=sample_notification.id,
-                                                   scheduled_for=datetime.strptime("2017-01-05 14:15",
-                                                                                   "%Y-%m-%d %H:%M"))
-    dao_created_scheduled_notification(scheduled_notification)
-    saved_notification = ScheduledNotification.query.all()
-    assert len(saved_notification) == 1
-    assert saved_notification[0].notification_id == sample_notification.id
-    assert saved_notification[0].scheduled_for == datetime(2017, 1, 5, 14, 15)
 
 
 def test_dao_get_notifications_by_to_field_filters_status(sample_template):

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -10,7 +10,6 @@ from app.dao.invited_user_dao import save_invited_user
 from app.dao.jobs_dao import dao_create_job
 from app.dao.notifications_dao import (
     dao_create_notification,
-    dao_created_scheduled_notification
 )
 from app.dao.organisation_dao import dao_create_organisation, dao_add_service_to_organisation
 from app.dao.permissions_dao import permission_dao
@@ -39,7 +38,6 @@ from app.models import (
     ServiceInboundApi,
     ServiceCallbackApi,
     ServiceLetterContact,
-    ScheduledNotification,
     ServicePermission,
     ServiceSmsSender,
     ServiceWhitelist,
@@ -294,14 +292,6 @@ def create_notification(
     }
     notification = Notification(**data)
     dao_create_notification(notification)
-    if scheduled_for:
-        scheduled_notification = ScheduledNotification(id=uuid.uuid4(),
-                                                       notification_id=notification.id,
-                                                       scheduled_for=datetime.strptime(scheduled_for,
-                                                                                       "%Y-%m-%d %H:%M"))
-        if status != 'created':
-            scheduled_notification.pending = False
-        dao_created_scheduled_notification(scheduled_notification)
 
     return notification
 

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -10,13 +10,11 @@ from collections import namedtuple
 from app.models import (
     Notification,
     NotificationHistory,
-    ScheduledNotification,
     LETTER_TYPE
 )
 from app.notifications.process_notifications import (
     create_content_for_notification,
     persist_notification,
-    persist_scheduled_notification,
     send_notification_to_queue,
     simulated_recipient
 )
@@ -420,14 +418,6 @@ def test_persist_notification_with_international_info_does_not_store_for_email(
     assert persisted_notification.international is False
     assert persisted_notification.phone_prefix is None
     assert persisted_notification.rate_multiplier is None
-
-
-def test_persist_scheduled_notification(sample_notification):
-    persist_scheduled_notification(sample_notification.id, '2017-05-12 14:15')
-    scheduled_notification = ScheduledNotification.query.all()
-    assert len(scheduled_notification) == 1
-    assert scheduled_notification[0].notification_id == sample_notification.id
-    assert scheduled_notification[0].scheduled_for == datetime.datetime(2017, 5, 12, 13, 15)
 
 
 @pytest.mark.parametrize('recipient, expected_recipient_normalised', [

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -70,7 +70,7 @@ def test_get_notification_by_id_returns_200(
         "subject": None,
         'sent_at': sample_notification.sent_at,
         'completed_at': sample_notification.completed_at(),
-        'scheduled_for': '2017-05-12T14:15:00.000000Z',
+        'scheduled_for': None,
         'postage': None,
     }
 
@@ -164,26 +164,6 @@ def test_get_notification_by_id_returns_created_by_name_if_notification_created_
 
     json_response = response.get_json()
     assert json_response['created_by_name'] == 'Test User'
-
-
-def test_get_notifications_returns_scheduled_for(client, sample_template):
-    sample_notification_with_reference = create_notification(template=sample_template,
-                                                             client_reference='some-client-reference',
-                                                             scheduled_for='2017-05-23 17:15')
-
-    auth_header = create_authorization_header(service_id=sample_notification_with_reference.service_id)
-    response = client.get(
-        path='/v2/notifications?reference={}'.format(sample_notification_with_reference.client_reference),
-        headers=[('Content-Type', 'application/json'), auth_header])
-
-    assert response.status_code == 200
-    assert response.headers['Content-type'] == 'application/json'
-
-    json_response = json.loads(response.get_data(as_text=True))
-    assert len(json_response['notifications']) == 1
-
-    assert json_response['notifications'][0]['id'] == str(sample_notification_with_reference.id)
-    assert json_response['notifications'][0]['scheduled_for'] == "2017-05-23T16:15:00.000000Z"
 
 
 def test_get_notification_by_reference_nonexistent_reference_returns_no_notifications(client, sample_service):

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -3,16 +3,13 @@ from unittest import mock
 from unittest.mock import call
 
 import pytest
-from freezegun import freeze_time
 from boto.exception import SQSError
 
 from app.dao import templates_dao
 from app.dao.service_sms_sender_dao import dao_update_service_sms_sender
 from app.models import (
-    ScheduledNotification,
     EMAIL_TYPE,
     NOTIFICATION_CREATED,
-    SCHEDULE_NOTIFICATIONS,
     SMS_TYPE,
     INTERNATIONAL_SMS_TYPE
 )
@@ -710,56 +707,6 @@ def test_post_sms_should_persist_supplied_sms_number(client, sample_template_wit
     assert '+(44) 77009-00855' == notifications[0].to
     assert resp_json['id'] == str(notification_id)
     assert mocked.called
-
-
-@pytest.mark.parametrize("notification_type, key_send_to, send_to",
-                         [("sms", "phone_number", "07700 900 855"),
-                          ("email", "email_address", "sample@email.com")])
-@freeze_time("2017-05-14 14:00:00")
-def test_post_notification_with_scheduled_for(
-        client, notify_db_session, notification_type, key_send_to, send_to
-):
-    service = create_service(service_name=str(uuid.uuid4()),
-                             service_permissions=[EMAIL_TYPE, SMS_TYPE, SCHEDULE_NOTIFICATIONS])
-    template = create_template(service=service, template_type=notification_type)
-    data = {
-        key_send_to: send_to,
-        'template_id': str(template.id) if notification_type == EMAIL_TYPE else str(template.id),
-        'scheduled_for': '2017-05-14 14:15'
-    }
-    auth_header = create_authorization_header(service_id=service.id)
-
-    response = client.post('/v2/notifications/{}'.format(notification_type),
-                           data=json.dumps(data),
-                           headers=[('Content-Type', 'application/json'), auth_header])
-    assert response.status_code == 201
-    resp_json = json.loads(response.get_data(as_text=True))
-    scheduled_notification = ScheduledNotification.query.filter_by(notification_id=resp_json["id"]).all()
-    assert len(scheduled_notification) == 1
-    assert resp_json["id"] == str(scheduled_notification[0].notification_id)
-    assert resp_json["scheduled_for"] == '2017-05-14 14:15'
-
-
-@pytest.mark.parametrize("notification_type, key_send_to, send_to",
-                         [("sms", "phone_number", "07700 900 855"),
-                          ("email", "email_address", "sample@email.com")])
-@freeze_time("2017-05-14 14:00:00")
-def test_post_notification_raises_bad_request_if_service_not_invited_to_schedule(
-        client, sample_template, sample_email_template, notification_type, key_send_to, send_to):
-    data = {
-        key_send_to: send_to,
-        'template_id': str(sample_email_template.id) if notification_type == EMAIL_TYPE else str(sample_template.id),
-        'scheduled_for': '2017-05-14 14:15'
-    }
-    auth_header = create_authorization_header(service_id=sample_template.service_id)
-
-    response = client.post('/v2/notifications/{}'.format(notification_type),
-                           data=json.dumps(data),
-                           headers=[('Content-Type', 'application/json'), auth_header])
-    assert response.status_code == 400
-    error_json = json.loads(response.get_data(as_text=True))
-    assert error_json['errors'] == [
-        {"error": "BadRequestError", "message": 'Cannot schedule notifications (this feature is invite-only)'}]
 
 
 def test_post_notification_raises_bad_request_if_not_valid_notification_type(client, sample_service):


### PR DESCRIPTION
Years ago we started to implement a way to schedule a notification. We hit a problem but we never came up with a good solution and the feature never made it back to the top of the priority list.

This PR removes the code for scheduled_for. There will be another PR to drop the scheduled_notifications table and remove the schedule_notifications service permission

Unfortunately, I don't think we can remove the `scheduled_for` attribute from the notification.serialized method because out clients might fail if something is missing. For now I have left it in but defaulted the value to None.