### PR TITLE
Fix circular import

### DIFF
--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -9,7 +9,6 @@ from werkzeug.utils import cached_property
 
 from app import db, redis_store
 
-from app.dao import templates_dao
 from app.dao.api_key_dao import get_model_api_keys
 from app.dao.services_dao import dao_fetch_service_by_id
 
@@ -101,6 +100,7 @@ class SerialisedTemplate(SerialisedModel):
     @staticmethod
     @redis_cache.set('template-{template_id}-version-None')
     def get_dict(template_id, service_id):
+        from app.dao import templates_dao
         from app.schemas import template_schema
 
         fetched_template = templates_dao.dao_get_template_by_id_and_service_id(


### PR DESCRIPTION
# Problem

We changed `app/auth.py` to import from `app/serialised_models.py` here: https://github.com/alphagov/notifications-api/pull/2887/files#diff-77cbb1e03185c7319f0311371c438b0cR11

So:

- `app/auth.py` imports from `app/serialised_models.py`
- `app/serialised_models.py` imports from `app/dao/templates_dao.py`
- `app/dao/templates_dao.py` imports from `app/dao/users_dao.py`
- `app/dao/users_dao.py` imports from `app/errors.py`
- `app/errors.py` imports from `app/auth.py`
- …and the circle is complete 💥

For some reason this caused the Celery workers to crash on startup, but not the app. Which I guess is why the integration tests didn’t catch this?

# How to review 

Check that the app and Celery workers start up OK when running locally.