### PR TITLE
Revert serialisation changes

### DIFF
--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
 from gds_metrics import Histogram
 
-from app.serialised_models import SerialisedService
+from app.dao.services_dao import dao_fetch_service_by_id_with_api_keys
 
 
 GENERAL_TOKEN_ERROR_MESSAGE = 'Invalid token: make sure your API token matches the example at https://docs.notifications.service.gov.uk/rest-api.html#authorisation-header'  # noqa
@@ -94,7 +94,7 @@ def requires_auth():
 
     try:
         with AUTH_DB_CONNECTION_DURATION_SECONDS.time():
-            service = SerialisedService.from_id(issuer)
+            service = dao_fetch_service_by_id_with_api_keys(issuer)
     except DataError:
         raise AuthError("Invalid token: service id is not the right data type", 403)
     except NoResultFound:
@@ -129,7 +129,7 @@ def requires_auth():
         if api_key.expiry_date:
             raise AuthError("Invalid token: API key revoked", 403, service_id=service.id, api_key_id=api_key.id)
 
-        g.service_id = service.id
+        g.service_id = api_key.service_id
         _request_ctx_stack.top.authenticated_service = service
         _request_ctx_stack.top.api_user = api_key
 

--- a/app/config.py
+++ b/app/config.py
@@ -400,12 +400,7 @@ class Test(Development):
     NOTIFY_ENVIRONMENT = 'test'
     TESTING = True
 
-    HIGH_VOLUME_SERVICE = [
-        '941b6f9a-50d7-4742-8d50-f365ca74bf27',
-        '63f95b86-2d19-4497-b8b2-ccf25457df4e',
-        '7e5950cb-9954-41f5-8376-962b8c8555cf',
-        '10d1b9c9-0072-4fa9-ae1c-595e333841da',
-    ]
+    HIGH_VOLUME_SERVICE = ['941b6f9a-50d7-4742-8d50-f365ca74bf27']
 
     CSV_UPLOAD_BUCKET_NAME = 'test-notifications-csv-upload'
     CONTACT_LIST_BUCKET_NAME = 'test-contact-list'

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -120,6 +120,7 @@ def persist_notification(
         template_version=template_version,
         to=recipient,
         service_id=service.id,
+        service=service,
         personalisation=personalisation,
         notification_type=notification_type,
         api_key_id=api_key_id,

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -90,7 +90,7 @@ def service_can_send_to_recipient(send_to, key_type, service, allow_whitelisted_
 
 
 def service_has_permission(notify_type, permissions):
-    return notify_type in permissions
+    return notify_type in [p.permission for p in permissions]
 
 
 def check_service_has_permission(notify_type, permissions):
@@ -131,7 +131,7 @@ def check_if_service_can_send_to_number(service, number):
     if (
         # if number is international and not a crown dependency
         international_phone_info.international and not international_phone_info.crown_dependency
-    ) and INTERNATIONAL_SMS_TYPE not in service.permissions:
+    ) and INTERNATIONAL_SMS_TYPE not in [p.permission for p in service.permissions]:
         raise BadRequestError(message="Cannot send to international mobile numbers")
     else:
         return international_phone_info

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -249,7 +249,6 @@ class ServiceSchema(BaseSchema):
             'inbound_number',
             'inbound_sms',
             'letter_logo_filename',
-            'rate_limit',
             'returned_letters',
             'users',
             'version',

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -205,7 +205,7 @@ class ProviderDetailsHistorySchema(BaseSchema):
         strict = True
 
 
-class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
+class ServiceSchema(BaseSchema):
 
     created_by = field_for(models.Service, 'created_by', required=True)
     organisation_type = field_for(models.Service, 'organisation_type')

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -9,6 +9,7 @@ from werkzeug.utils import cached_property
 
 from app import db, redis_store
 
+from app.dao import templates_dao
 from app.dao.api_key_dao import get_model_api_keys
 from app.dao.services_dao import dao_fetch_service_by_id
 
@@ -100,7 +101,6 @@ class SerialisedTemplate(SerialisedModel):
     @staticmethod
     @redis_cache.set('template-{template_id}-version-None')
     def get_dict(template_id, service_id):
-        from app.dao import templates_dao
         from app.schemas import template_schema
 
         fetched_template = templates_dao.dao_get_template_by_id_and_service_id(

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -5,13 +5,9 @@ from threading import RLock
 
 import cachetools
 from notifications_utils.clients.redis import RequestCache
-from werkzeug.utils import cached_property
 
-from app import db, redis_store
-
+from app import redis_store
 from app.dao import templates_dao
-from app.dao.api_key_dao import get_model_api_keys
-from app.dao.services_dao import dao_fetch_service_by_id
 
 caches = defaultdict(partial(cachetools.TTLCache, maxsize=1024, ttl=2))
 locks = defaultdict(RLock)
@@ -57,29 +53,6 @@ class SerialisedModel(ABC):
         return super().__dir__() + list(sorted(self.ALLOWED_PROPERTIES))
 
 
-class SerialisedModelCollection(ABC):
-
-    """
-    A SerialisedModelCollection takes a list of dictionaries, typically
-    created by serialising database objects. When iterated over it
-    returns a SerialisedModel instance for each of the items in the list.
-    """
-
-    @property
-    @abstractmethod
-    def model(self):
-        pass
-
-    def __init__(self, items):
-        self.items = items
-
-    def __bool__(self):
-        return bool(self.items)
-
-    def __getitem__(self, index):
-        return self.model(self.items[index])
-
-
 class SerialisedTemplate(SerialisedModel):
     ALLOWED_PROPERTIES = {
         'archived',
@@ -109,60 +82,5 @@ class SerialisedTemplate(SerialisedModel):
         )
 
         template_dict = template_schema.dump(fetched_template).data
-        db.session.commit()
 
         return {'data': template_dict}
-
-
-class SerialisedService(SerialisedModel):
-    ALLOWED_PROPERTIES = {
-        'id',
-        'active',
-        'contact_link',
-        'email_from',
-        'permissions',
-        'research_mode',
-        'restricted',
-    }
-
-    @classmethod
-    @memory_cache
-    def from_id(cls, service_id):
-        return cls(cls.get_dict(service_id)['data'])
-
-    @staticmethod
-    @redis_cache.set('service-{service_id}')
-    def get_dict(service_id):
-        from app.schemas import service_schema
-
-        service_dict = service_schema.dump(dao_fetch_service_by_id(service_id)).data
-        db.session.commit()
-
-        return {'data': service_dict}
-
-    @cached_property
-    def api_keys(self):
-        return SerialisedAPIKeyCollection.from_service_id(self.id)
-
-
-class SerialisedAPIKey(SerialisedModel):
-    ALLOWED_PROPERTIES = {
-        'id',
-        'secret',
-        'expiry_date',
-        'key_type',
-    }
-
-
-class SerialisedAPIKeyCollection(SerialisedModelCollection):
-    model = SerialisedAPIKey
-
-    @classmethod
-    @memory_cache
-    def from_service_id(cls, service_id):
-        keys = [
-            {k: getattr(key, k) for k in SerialisedAPIKey.ALLOWED_PROPERTIES}
-            for key in get_model_api_keys(service_id)
-        ]
-        db.session.commit()
-        return cls(keys)

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -137,9 +137,7 @@ def get_reply_to_text(notification_type, sender_id, service, template):
 def send_pdf_letter_notification(service_id, post_data):
     service = dao_fetch_service_by_id(service_id)
 
-    check_service_has_permission(LETTER_TYPE, [
-        p.permission for p in service.permissions
-    ])
+    check_service_has_permission(LETTER_TYPE, service.permissions)
     check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
     validate_created_by(service, post_data['created_by'])
     validate_and_format_recipient(

--- a/app/service/utils.py
+++ b/app/service/utils.py
@@ -7,8 +7,6 @@ from app.models import (
     MOBILE_TYPE, EMAIL_TYPE,
     KEY_TYPE_TEST, KEY_TYPE_TEAM, KEY_TYPE_NORMAL)
 
-from app.dao.services_dao import dao_fetch_service_by_id
-
 
 def get_recipients_from_request(request_json, key, type):
     return [(type, recipient) for recipient in request_json.get(key)]
@@ -34,10 +32,6 @@ def service_allowed_to_send_to(recipient, service, key_type, allow_whitelisted_r
 
     if key_type == KEY_TYPE_NORMAL and not service.restricted:
         return True
-
-    # Revert back to the ORM model here so we can get some things which
-    # aren’t in the serialised model
-    service = dao_fetch_service_by_id(service.id)
 
     team_members = itertools.chain.from_iterable(
         [user.mobile_number, user.email_address] for user in service.users

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -69,9 +69,7 @@ def validate_parent_folder(template_json):
 def create_template(service_id):
     fetched_service = dao_fetch_service_by_id(service_id=service_id)
     # permissions needs to be placed here otherwise marshmallow will interfere with versioning
-    permissions = [
-        p.permission for p in fetched_service.permissions
-    ]
+    permissions = fetched_service.permissions
     template_json = validate(request.get_json(), post_create_template_schema)
     folder = validate_parent_folder(template_json=template_json)
     new_template = Template.from_json(template_json, folder)
@@ -104,12 +102,7 @@ def create_template(service_id):
 def update_template(service_id, template_id):
     fetched_template = dao_get_template_by_id_and_service_id(template_id=template_id, service_id=service_id)
 
-    if not service_has_permission(
-        fetched_template.template_type,
-        [
-            p.permission for p in fetched_template.service.permissions
-        ]
-    ):
+    if not service_has_permission(fetched_template.template_type, fetched_template.service.permissions):
         message = "Updating {} templates is not allowed".format(
             get_public_notify_type_text(fetched_template.template_type))
         errors = {'template_type': [message]}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -20,7 +20,6 @@ marshmallow==2.21.0 # pyup: <3 # v3 throws errors
 psycopg2-binary==2.8.5
 PyJWT==1.7.1
 SQLAlchemy==1.3.17
-cachetools==4.1.0
 
 notifications-python-client==5.5.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ marshmallow==2.21.0 # pyup: <3 # v3 throws errors
 psycopg2-binary==2.8.5
 PyJWT==1.7.1
 SQLAlchemy==1.3.17
-cachetools==4.1.0
 
 notifications-python-client==5.5.1
 
@@ -40,14 +39,15 @@ alembic==1.4.2
 amqp==1.4.9
 anyjson==0.3.3
 attrs==19.3.0
-awscli==1.18.85
+awscli==1.18.84
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.4
 blinker==1.4
 boto==2.49.0
 boto3==1.10.38
-botocore==1.17.8
+botocore==1.17.7
+cachetools==4.1.0
 certifi==2020.6.20
 chardet==3.0.4
 click==7.1.2

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -8,18 +8,9 @@ import pytest
 from flask import json, current_app, request
 from freezegun import freeze_time
 from notifications_python_client.authentication import create_jwt_token
-from unittest.mock import call
 
 from app import api_user
-from app.dao.api_key_dao import (
-    get_unsigned_secrets,
-    save_model_api_key,
-    get_unsigned_secret,
-    expire_api_key,
-    get_model_api_keys,
-)
-from app.dao.services_dao import dao_fetch_service_by_id
-
+from app.dao.api_key_dao import get_unsigned_secrets, save_model_api_key, get_unsigned_secret, expire_api_key
 from app.models import ApiKey, KEY_TYPE_NORMAL
 from app.authentication.auth import AuthError, requires_admin_auth, requires_auth, GENERAL_TOKEN_ERROR_MESSAGE
 
@@ -309,7 +300,7 @@ def test_authentication_returns_token_expired_when_service_uses_expired_key_and_
     with pytest.raises(AuthError) as exc:
         requires_auth()
     assert exc.value.short_message == 'Invalid token: API key revoked'
-    assert exc.value.service_id == str(expired_api_key.service_id)
+    assert exc.value.service_id == expired_api_key.service_id
     assert exc.value.api_key_id == expired_api_key.id
 
 
@@ -385,7 +376,7 @@ def test_authentication_returns_error_when_service_has_no_secrets(client,
     with pytest.raises(AuthError) as exc:
         requires_auth()
     assert exc.value.short_message == 'Invalid token: service has no API keys'
-    assert exc.value.service_id == str(sample_service.id)
+    assert exc.value.service_id == sample_service.id
 
 
 def test_should_attach_the_current_api_key_to_current_app(notify_api, sample_service, sample_api_key):
@@ -396,7 +387,7 @@ def test_should_attach_the_current_api_key_to_current_app(notify_api, sample_ser
             headers={'Authorization': 'Bearer {}'.format(token)}
         )
         assert response.status_code == 200
-        assert str(api_user.id) == str(sample_api_key.id)
+        assert api_user == sample_api_key
 
 
 def test_should_return_403_when_token_is_expired(client,
@@ -408,8 +399,8 @@ def test_should_return_403_when_token_is_expired(client,
             request.headers = {'Authorization': 'Bearer {}'.format(token)}
             requires_auth()
     assert exc.value.short_message == 'Error: Your system clock must be accurate to within 30 seconds'
-    assert exc.value.service_id == str(sample_api_key.service_id)
-    assert str(exc.value.api_key_id) == str(sample_api_key.id)
+    assert exc.value.service_id == sample_api_key.service_id
+    assert exc.value.api_key_id == sample_api_key.id
 
 
 def __create_token(service_id):
@@ -466,28 +457,3 @@ def test_proxy_key_on_admin_auth_endpoint(notify_api, check_proxy_header, header
                 ]
             )
         assert response.status_code == expected_status
-
-
-def test_should_cache_service_and_api_key_lookups(mocker, client, sample_api_key):
-
-    mock_get_api_keys = mocker.patch(
-        'app.serialised_models.get_model_api_keys',
-        wraps=get_model_api_keys,
-    )
-    mock_get_service = mocker.patch(
-        'app.serialised_models.dao_fetch_service_by_id',
-        wraps=dao_fetch_service_by_id,
-    )
-
-    for i in range(5):
-        token = __create_token(sample_api_key.service_id)
-        client.get('/notifications', headers={
-            'Authorization': f'Bearer {token}'
-        })
-
-    assert mock_get_api_keys.call_args_list == [
-        call(str(sample_api_key.service_id))
-    ]
-    assert mock_get_service.call_args_list == [
-        call(str(sample_api_key.service_id))
-    ]

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -23,7 +23,7 @@ from app.notifications.validators import (
     validate_and_format_recipient,
     validate_template,
 )
-from app.serialised_models import SerialisedService, SerialisedTemplate
+from app.serialised_models import SerialisedTemplate
 from app.utils import get_template_instance
 
 from app.v2.errors import (
@@ -439,9 +439,8 @@ def test_rejects_api_calls_with_international_numbers_if_service_does_not_allow_
         notify_db_session,
 ):
     service = create_service(service_permissions=[SMS_TYPE])
-    service_model = SerialisedService.from_id(service.id)
     with pytest.raises(BadRequestError) as e:
-        validate_and_format_recipient('20-12-1234-1234', key_type, service_model, SMS_TYPE)
+        validate_and_format_recipient('20-12-1234-1234', key_type, service, SMS_TYPE)
     assert e.value.status_code == 400
     assert e.value.message == 'Cannot send to international mobile numbers'
     assert e.value.fields == []
@@ -450,8 +449,7 @@ def test_rejects_api_calls_with_international_numbers_if_service_does_not_allow_
 @pytest.mark.parametrize('key_type', ['test', 'normal'])
 def test_allows_api_calls_with_international_numbers_if_service_does_allow_int_sms(
         key_type, sample_service_full_permissions):
-    service_model = SerialisedService.from_id(sample_service_full_permissions.id)
-    result = validate_and_format_recipient('20-12-1234-1234', key_type, service_model, SMS_TYPE)
+    result = validate_and_format_recipient('20-12-1234-1234', key_type, sample_service_full_permissions, SMS_TYPE)
     assert result == '201212341234'
 
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -233,8 +233,34 @@ def test_get_service_by_id(admin_request, sample_service):
     assert json_resp['data']['id'] == str(sample_service.id)
     assert not json_resp['data']['research_mode']
     assert json_resp['data']['email_branding'] is None
-    assert 'branding' not in json_resp['data']
     assert json_resp['data']['prefix_sms'] is True
+    assert json_resp['data'].keys() == {
+        'active',
+        'consent_to_research',
+        'contact_link',
+        'count_as_live',
+        'created_by',
+        'email_branding',
+        'email_from',
+        'go_live_at',
+        'go_live_user',
+        'id',
+        'inbound_api',
+        'letter_branding',
+        'message_limit',
+        'name',
+        'organisation',
+        'organisation_type',
+        'permissions',
+        'prefix_sms',
+        'rate_limit',
+        'research_mode',
+        'restricted',
+        'service_callback_api',
+        'volume_email',
+        'volume_letter',
+        'volume_sms',
+    }
 
 
 @pytest.mark.parametrize('detailed', [True, False])


### PR DESCRIPTION
We need to ensure that `rate_limit` is in the serialised service before we start using it to power the `POST` notifications endpoint.