### PR TITLE
Fix template history created by

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -377,6 +377,7 @@ class TemplateSchemaNoDetail(TemplateSchema):
             'archived',
             'content',
             'created_at',
+            'created_by',
             'created_by_id',
             'hidden',
             'postage',

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -356,9 +356,7 @@ class BaseTemplateSchema(BaseSchema):
 
 class TemplateSchema(BaseTemplateSchema, UUIDsAsStringsMixin):
 
-    created_by_id = field_for(
-        models.Template, 'created_by_id', dump_to='created_by', dump_only=True
-    )
+    created_by = field_for(models.Template, 'created_by', required=True)
     process_type = field_for(models.Template, 'process_type')
     redact_personalisation = fields.Method("redact")
 
@@ -371,9 +369,6 @@ class TemplateSchema(BaseTemplateSchema, UUIDsAsStringsMixin):
             subject = data.get('subject')
             if not subject or subject.strip() == '':
                 raise ValidationError('Invalid template subject', 'subject')
-
-    class Meta(BaseTemplateSchema.Meta):
-        exclude = BaseTemplateSchema.Meta.exclude + ('created_by',)
 
 
 class TemplateSchemaNoDetail(TemplateSchema):

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -340,8 +340,13 @@ def test_must_have_a_subject_on_an_email_or_letter_template(client, sample_user,
 
 
 def test_update_should_update_a_template(client, sample_user):
+
     service = create_service(service_permissions=[LETTER_TYPE])
     template = create_template(service, template_type="letter", postage="second")
+
+    assert template.created_by == service.created_by
+    assert template.created_by != sample_user
+
     data = {
         'content': 'my template has new content, swell!',
         'created_by': str(sample_user.id),
@@ -365,6 +370,14 @@ def test_update_should_update_a_template(client, sample_user):
     assert update_json_resp['data']['name'] == template.name
     assert update_json_resp['data']['template_type'] == template.template_type
     assert update_json_resp['data']['version'] == 2
+
+    assert update_json_resp['data']['created_by'] == str(sample_user.id)
+    assert [
+        template.created_by_id for template in TemplateHistory.query.all()
+    ] == [
+        service.created_by.id,
+        sample_user.id,
+    ]
 
 
 def test_should_be_able_to_archive_template(client, sample_template):


### PR DESCRIPTION
This PR reverts commit 58a9862, which tried to optimise the fetch template query by not doing a separate select from the users table.

However it had the side effect of making Marshmallow ignore `created_by` when loading the JSON in the post request. So the field on the model was never being updated, just copied from the original template.

The quick way of getting things to work again is to revert this optimisation.

There’s probably some Marshmallow magic we could use to avoid the extra query and still have created_by not be ignored.

It does mean we’re introducing an extra query, but I’m not too fussed about that since the caching seems to be working well.

The test I’ve added fails with the existing code that’s on master:

![image](https://user-images.githubusercontent.com/355079/85999694-70017280-ba04-11ea-9d9d-b50222d312d8.png)
