### PR TITLE
Fix sending one-off international text messages

### DIFF
--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -103,6 +103,29 @@ def test_send_one_off_notification_calls_persist_correctly_for_sms(
     )
 
 
+def test_send_one_off_notification_calls_persist_correctly_for_international_sms(
+    persist_mock,
+    celery_mock,
+    notify_db_session
+):
+    service = create_service(service_permissions=['sms', 'international_sms'])
+    template = create_template(
+        service=service,
+        template_type=SMS_TYPE,
+    )
+
+    post_data = {
+        'template_id': str(template.id),
+        'to': '+1 555 0100',
+        'personalisation': {'name': 'foo'},
+        'created_by': str(service.created_by_id)
+    }
+
+    send_one_off_notification(service.id, post_data)
+
+    assert persist_mock.call_args[1]['recipient'] == '+1 555 0100'
+
+
 def test_send_one_off_notification_calls_persist_correctly_for_email(
     persist_mock,
     celery_mock,


### PR DESCRIPTION
This was broken because sometimes `service.permissions` is a list of strings (when we’ve caching the service object) and sometimes it’s a list of permission objects (when we’re dealing with ORM objects).

Because the validator code is shared, the least-messy way to fix it is to make sure it can handle both types.

It can’t just take a list of permissions as argument, because it uses other fields on the service.

It would be messy to rewrite the endpoint to use a serialised service because the tests all expect to be dealing with database objects, so it would be a faff to change what they’re mocking.