### PR TITLE
Broadcast DB models

### DIFF
--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -78,7 +78,8 @@ def dao_update_template_reply_to(template_id, reply_to):
                                   "version": template.version,
                                   "archived": template.archived,
                                   "process_type": template.process_type,
-                                  "service_letter_contact_id": template.service_letter_contact_id
+                                  "service_letter_contact_id": template.service_letter_contact_id,
+                                  "broadcast_data": template.broadcast_data,
                               })
     db.session.add(history)
     return template

--- a/app/models.py
+++ b/app/models.py
@@ -991,7 +991,7 @@ class TemplateBase(db.Model):
         template.values = values
         return template
 
-    def serialize(self):
+    def serialize_for_v2(self):
         serialized = {
             "id": str(self.id),
             "type": self.template_type,
@@ -1009,7 +1009,6 @@ class TemplateBase(db.Model):
                 for key in self._as_utils_template().placeholders
             },
             "postage": self.postage,
-            "broadcast_data": self.broadcast_data
         }
 
         return serialized

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -365,7 +365,7 @@ class TemplateSchema(BaseTemplateSchema, UUIDsAsStringsMixin):
 
     @validates_schema
     def validate_type(self, data):
-        if data.get('template_type') in [models.EMAIL_TYPE, models.LETTER_TYPE]:
+        if data.get('template_type') in {models.EMAIL_TYPE, models.LETTER_TYPE}:
             subject = data.get('subject')
             if not subject or subject.strip() == '':
                 raise ValidationError('Invalid template subject', 'subject')
@@ -391,6 +391,7 @@ class TemplateSchemaNoDetail(TemplateSchema):
             'template_redacted',
             'updated_at',
             'version',
+            'broadcast_data',
         )
 
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -260,6 +260,7 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
             'users',
             'version',
             'whitelist',
+            'broadcast_messages',
         )
         strict = True
 
@@ -326,6 +327,7 @@ class DetailedServiceSchema(BaseSchema):
             'users',
             'version',
             'whitelist',
+            'broadcast_messages',
         )
 
 
@@ -350,7 +352,7 @@ class BaseTemplateSchema(BaseSchema):
 
     class Meta:
         model = models.Template
-        exclude = ("service_id", "jobs", "service_letter_contact_id")
+        exclude = ("service_id", "jobs", "service_letter_contact_id", "broadcast_messages")
         strict = True
 
 

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -47,6 +47,7 @@ class SerialisedTemplate(SerialisedModel):
         'subject',
         'template_type',
         'version',
+        'broadcast_data',
     }
 
     @classmethod

--- a/app/service/statistics.py
+++ b/app/service/statistics.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from notifications_utils.timezones import convert_utc_to_bst
 
-from app.models import NOTIFICATION_STATUS_TYPES, TEMPLATE_TYPES
+from app.models import NOTIFICATION_STATUS_TYPES, NOTIFICATION_TYPES
 from app.dao.date_util import get_months_for_financial_year
 
 
@@ -37,7 +37,7 @@ def format_admin_stats(statistics):
 
 def create_stats_dict():
     stats_dict = {}
-    for template in TEMPLATE_TYPES:
+    for template in NOTIFICATION_TYPES:
         stats_dict[template] = {}
 
         for status in ('total', 'test-key'):
@@ -79,7 +79,7 @@ def create_zeroed_stats_dicts():
     return {
         template_type: {
             status: 0 for status in ('requested', 'delivered', 'failed')
-        } for template_type in TEMPLATE_TYPES
+        } for template_type in NOTIFICATION_TYPES
     }
 
 
@@ -100,7 +100,7 @@ def create_empty_monthly_notification_status_stats_dict(year):
     return {
         convert_utc_to_bst(start).strftime('%Y-%m'): {
             template_type: defaultdict(int)
-            for template_type in TEMPLATE_TYPES
+            for template_type in NOTIFICATION_TYPES
         }
         for start in utc_month_starts
     }

--- a/app/utils.py
+++ b/app/utils.py
@@ -4,7 +4,12 @@ import pytz
 from flask import url_for
 from sqlalchemy import func
 from notifications_utils.timezones import convert_utc_to_bst
-from notifications_utils.template import SMSMessageTemplate, HTMLEmailTemplate, LetterPrintTemplate
+from notifications_utils.template import (
+    SMSMessageTemplate,
+    HTMLEmailTemplate,
+    LetterPrintTemplate,
+    BroadcastMessageTemplate,
+)
 
 
 local_timezone = pytz.timezone("Europe/London")
@@ -30,9 +35,12 @@ def url_with_token(data, url, config, base_url=None):
 
 
 def get_template_instance(template, values):
-    from app.models import SMS_TYPE, EMAIL_TYPE, LETTER_TYPE
+    from app.models import SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, BROADCAST_TYPE
     return {
-        SMS_TYPE: SMSMessageTemplate, EMAIL_TYPE: HTMLEmailTemplate, LETTER_TYPE: LetterPrintTemplate
+        SMS_TYPE: SMSMessageTemplate,
+        EMAIL_TYPE: HTMLEmailTemplate,
+        LETTER_TYPE: LetterPrintTemplate,
+        BROADCAST_TYPE: BroadcastMessageTemplate,
     }[template['template_type']](template, values)
 
 
@@ -70,14 +78,16 @@ def get_london_month_from_utc_column(column):
 
 
 def get_public_notify_type_text(notify_type, plural=False):
-    from app.models import (SMS_TYPE, UPLOAD_DOCUMENT, PRECOMPILED_LETTER)
+    from app.models import (SMS_TYPE, BROADCAST_TYPE, UPLOAD_DOCUMENT, PRECOMPILED_LETTER)
     notify_type_text = notify_type
     if notify_type == SMS_TYPE:
         notify_type_text = 'text message'
-    if notify_type == UPLOAD_DOCUMENT:
+    elif notify_type == UPLOAD_DOCUMENT:
         notify_type_text = 'document'
-    if notify_type == PRECOMPILED_LETTER:
+    elif notify_type == PRECOMPILED_LETTER:
         notify_type_text = 'precompiled letter'
+    elif notify_type == BROADCAST_TYPE:
+        notify_type_text = 'broadcast message'
 
     return '{}{}'.format(notify_type_text, 's' if plural else '')
 

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -2,7 +2,7 @@ from app.models import (
     NOTIFICATION_STATUS_TYPES,
     NOTIFICATION_STATUS_LETTER_ACCEPTED,
     NOTIFICATION_STATUS_LETTER_RECEIVED,
-    TEMPLATE_TYPES
+    NOTIFICATION_TYPES,
 )
 from app.schema_validation.definitions import (uuid, personalisation)
 
@@ -83,7 +83,7 @@ get_notifications_request = {
         "template_type": {
             "type": "array",
             "items": {
-                "enum": TEMPLATE_TYPES
+                "enum": NOTIFICATION_TYPES
             }
         },
         "include_jobs": {"enum": ["true", "True"]},

--- a/app/v2/template/get_template.py
+++ b/app/v2/template/get_template.py
@@ -18,4 +18,4 @@ def get_template_by_id(template_id, version=None):
 
     template = templates_dao.dao_get_template_by_id_and_service_id(
         template_id, authenticated_service.id, data.get('version'))
-    return jsonify(template.serialize()), 200
+    return jsonify(template.serialize_for_v2()), 200

--- a/app/v2/templates/get_templates.py
+++ b/app/v2/templates/get_templates.py
@@ -14,5 +14,5 @@ def get_templates():
     templates = templates_dao.dao_get_all_templates_for_service(authenticated_service.id, data.get('type'))
 
     return jsonify(
-        templates=[template.serialize() for template in templates]
+        templates=[template.serialize_for_v2() for template in templates]
     ), 200

--- a/migrations/versions/0323_broadcast_message.py
+++ b/migrations/versions/0323_broadcast_message.py
@@ -85,6 +85,11 @@ def upgrade():
 
 
 def downgrade():
+    op.execute("DELETE FROM template_folder_map WHERE template_id IN (SELECT id FROM templates WHERE template_type = 'broadcast')")
+    op.execute("DELETE FROM template_redacted WHERE template_id IN (SELECT id FROM templates WHERE template_type = 'broadcast')")
+    op.execute("DELETE FROM templates WHERE template_type = 'broadcast'")
+    op.execute("DELETE FROM templates_history WHERE template_type = 'broadcast'")
+
     op.execute(f'ALTER TYPE {name} RENAME TO {tmp_name}')
     old_type.create(op.get_bind())
 

--- a/migrations/versions/0323_broadcast_message.py
+++ b/migrations/versions/0323_broadcast_message.py
@@ -1,0 +1,98 @@
+"""
+
+Revision ID: 0323_broadcast_message
+Revises: 0322_broadcast_service_perm
+Create Date: 2020-07-02 11:59:38.734650
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import column, func
+from sqlalchemy.dialects import postgresql
+
+from app.models import BroadcastMessage
+
+revision = '0323_broadcast_message'
+down_revision = '0322_broadcast_service_perm'
+
+
+name = 'template_type'
+tmp_name = 'tmp_' + name
+
+old_options = ('sms', 'email', 'letter')
+new_options = old_options + ('broadcast',)
+
+new_type = sa.Enum(*new_options, name=name)
+old_type = sa.Enum(*old_options, name=name)
+
+
+STATUSES = [
+    'draft',
+    'pending-approval',
+    'rejected',
+    'broadcasting',
+    'completed',
+    'cancelled',
+    'technical-failure',
+]
+
+
+def upgrade():
+    op.execute(f'ALTER TYPE {name} RENAME TO {tmp_name}')
+    new_type.create(op.get_bind())
+
+    for table in ['templates', 'templates_history', 'service_contact_list']:
+        op.execute(f'ALTER TABLE {table} ALTER COLUMN template_type TYPE {name} USING template_type::text::{name}')
+
+    op.execute(f'DROP TYPE {tmp_name}')
+
+    broadcast_status_type = op.create_table(
+        'broadcast_status_type',
+        sa.Column('name', sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint('name')
+    )
+    op.bulk_insert(broadcast_status_type, [{'name': state} for state in STATUSES])
+
+    op.create_table(
+        'broadcast_message',
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('service_id', postgresql.UUID(as_uuid=True)),
+        sa.Column('template_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('template_version', sa.Integer(), nullable=False),
+        sa.Column('_personalisation', sa.String()),
+        sa.Column('areas', postgresql.JSONB(none_as_null=True, astext_type=sa.Text())),
+        sa.Column('status', sa.String()),
+        sa.Column('starts_at', sa.DateTime()),
+        sa.Column('finishes_at', sa.DateTime()),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('approved_at', sa.DateTime()),
+        sa.Column('cancelled_at', sa.DateTime()),
+        sa.Column('updated_at', sa.DateTime()),
+        sa.Column('created_by_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('approved_by_id', postgresql.UUID(as_uuid=True)),
+        sa.Column('cancelled_by_id', postgresql.UUID(as_uuid=True)),
+
+        sa.ForeignKeyConstraint(['approved_by_id'], ['users.id'], ),
+        sa.ForeignKeyConstraint(['cancelled_by_id'], ['users.id'], ),
+        sa.ForeignKeyConstraint(['created_by_id'], ['users.id'], ),
+        sa.ForeignKeyConstraint(['service_id'], ['services.id'], ),
+        sa.ForeignKeyConstraint(['template_id', 'template_version'], ['templates_history.id', 'templates_history.version'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+    op.add_column('templates', sa.Column('broadcast_data', postgresql.JSONB(none_as_null=True, astext_type=sa.Text())))
+    op.add_column('templates_history', sa.Column('broadcast_data', postgresql.JSONB(none_as_null=True, astext_type=sa.Text())))
+
+
+def downgrade():
+    op.execute(f'ALTER TYPE {name} RENAME TO {tmp_name}')
+    old_type.create(op.get_bind())
+
+    for table in ['templates', 'templates_history', 'service_contact_list']:
+        op.execute(f'ALTER TABLE {table} ALTER COLUMN template_type TYPE {name} USING template_type::text::{name}')
+    op.execute(f'DROP TYPE {tmp_name}')
+
+    op.drop_column('templates_history', 'broadcast_data')
+    op.drop_column('templates', 'broadcast_data')
+    op.drop_table('broadcast_message')
+    op.drop_table('broadcast_status_type')

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -212,6 +212,7 @@ def test_should_raise_error_if_service_does_not_exist_on_create(client, sample_u
 
 
 @pytest.mark.parametrize('permissions, template_type, subject, expected_error', [
+    ([EMAIL_TYPE, SMS_TYPE, LETTER_TYPE], BROADCAST_TYPE, None, {'template_type': ['Creating broadcast message templates is not allowed']}),  # noqa
     ([EMAIL_TYPE], SMS_TYPE, None, {'template_type': ['Creating text message templates is not allowed']}),
     ([SMS_TYPE], EMAIL_TYPE, 'subject', {'template_type': ['Creating email templates is not allowed']}),
     ([SMS_TYPE], LETTER_TYPE, 'subject', {'template_type': ['Creating letter templates is not allowed']}),

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -14,6 +14,7 @@ from notifications_utils import SMS_CHAR_COUNT_LIMIT
 
 
 from app.models import (
+    BROADCAST_TYPE,
     EMAIL_TYPE,
     LETTER_TYPE,
     SMS_TYPE,
@@ -31,6 +32,7 @@ from tests.conftest import set_config_values
 
 
 @pytest.mark.parametrize('template_type, subject', [
+    (BROADCAST_TYPE, None),
     (SMS_TYPE, None),
     (EMAIL_TYPE, 'subject'),
     (LETTER_TYPE, 'subject'),
@@ -529,6 +531,7 @@ def test_should_get_return_all_fields_by_default(
     )
     assert json_response['data'][0].keys() == {
         'archived',
+        'broadcast_data',
         'content',
         'created_at',
         'created_by',

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -214,17 +214,17 @@ def test_notification_serializes_created_by_name_with_created_by_id(client, samp
 
 
 def test_sms_notification_serializes_without_subject(client, sample_template):
-    res = sample_template.serialize()
+    res = sample_template.serialize_for_v2()
     assert res['subject'] is None
 
 
 def test_email_notification_serializes_with_subject(client, sample_email_template):
-    res = sample_email_template.serialize()
+    res = sample_email_template.serialize_for_v2()
     assert res['subject'] == 'Email Subject'
 
 
 def test_letter_notification_serializes_with_subject(client, sample_letter_template):
-    res = sample_letter_template.serialize()
+    res = sample_letter_template.serialize_for_v2()
     assert res['subject'] == 'Template subject'
 
 

--- a/tests/app/v2/template/test_get_template.py
+++ b/tests/app/v2/template/test_get_template.py
@@ -3,7 +3,7 @@ import pytest
 from flask import json
 
 from app import DATETIME_FORMAT
-from app.models import TEMPLATE_TYPES, EMAIL_TYPE, SMS_TYPE, LETTER_TYPE
+from app.models import (TEMPLATE_TYPES, EMAIL_TYPE, SMS_TYPE, LETTER_TYPE,)
 from tests import create_authorization_header
 from tests.app.db import create_template, create_letter_contact
 
@@ -44,6 +44,7 @@ def test_get_template_by_id_returns_200(
         'name': expected_name,
         'personalisation': {},
         'postage': postage,
+        'broadcast_data': None,
     }
 
     assert json_response == expected_response

--- a/tests/app/v2/template/test_get_template.py
+++ b/tests/app/v2/template/test_get_template.py
@@ -44,7 +44,6 @@ def test_get_template_by_id_returns_200(
         'name': expected_name,
         'personalisation': {},
         'postage': postage,
-        'broadcast_data': None,
     }
 
     assert json_response == expected_response

--- a/tests/app/v2/template/test_post_template.py
+++ b/tests/app/v2/template/test_post_template.py
@@ -2,7 +2,7 @@ import pytest
 
 from flask import json
 
-from app.models import EMAIL_TYPE, LETTER_TYPE, SMS_TYPE, TEMPLATE_TYPES
+from app.models import EMAIL_TYPE, LETTER_TYPE, TEMPLATE_TYPES
 from tests import create_authorization_header
 from tests.app.db import create_template
 

--- a/tests/app/v2/template/test_post_template.py
+++ b/tests/app/v2/template/test_post_template.py
@@ -97,7 +97,7 @@ def test_valid_post_template_returns_200(
 
     assert resp_json['id'] == str(template.id)
 
-    if tmp_type != SMS_TYPE:
+    if tmp_type in {EMAIL_TYPE, LETTER_TYPE}:
         assert expected_subject in resp_json['subject']
 
     if tmp_type == EMAIL_TYPE:

--- a/tests/app/v2/templates/test_get_templates.py
+++ b/tests/app/v2/templates/test_get_templates.py
@@ -112,7 +112,7 @@ def test_get_all_templates_for_invalid_type_returns_400(client, sample_service):
         'status_code': 400,
         'errors': [
             {
-                'message': 'type coconut is not one of [sms, email, letter]',
+                'message': 'type coconut is not one of [sms, email, letter, broadcast]',
                 'error': 'ValidationError'
             }
         ]

--- a/tests/app/v2/templates/test_templates_schemas.py
+++ b/tests/app/v2/templates/test_templates_schemas.py
@@ -242,7 +242,7 @@ def test_get_all_template_request_schema_against_invalid_args_is_invalid(templat
 
     assert errors['status_code'] == 400
     assert len(errors['errors']) == 1
-    assert errors['errors'][0]['message'] == 'type unknown is not one of [sms, email, letter]'
+    assert errors['errors'][0]['message'] == 'type unknown is not one of [sms, email, letter, broadcast]'
 
 
 @pytest.mark.parametrize("response", valid_json_get_all_response)


### PR DESCRIPTION
### Template changes

#### add `broadcast` to template_type

this is the trickiest bit of this PR, if only because lots of places refer to template_type all over the place. I think I've caught everywhere, but not sure. This also involved resurrecting enum migration code from https://github.com/alphagov/notifications-api/blob/master/migrations/versions/0060_add_letter_template_type.py

#### add `broadcast_data` to template

this'll contain everything that we need to save on templates for a broadcast message. We don't know what that is yet, so it's just a jsonb field

### New model

BroadcastMessage model. A broadcast has a bunch of states - see the commit message for the proposed state diagram. I've tried to add as many timestamps/user ids in to the model, I wanted to avoid using an `updated_at` to refer to different things based on the state.