### PR TITLE
remove broadcast_data from SerialisedTemplate.ALLOWED_PROPERTIES

### DIFF
--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -47,7 +47,6 @@ class SerialisedTemplate(SerialisedModel):
         'subject',
         'template_type',
         'version',
-        'broadcast_data',
     }
 
     @classmethod


### PR DESCRIPTION
ALLOWED_PROPERTIES is a list containing fields that it will attempt to deserialize into the returned object. If a field isn't present on the underlying data source (whether that's a dump from a marshmallow schema, a blob retrieved from redis, or anything else), then SerialisedModel will raise an exception. However, SerialisedModel isn't involved when setting the cache, so with that said the correct flow for adding a column to a cached database model:

PR #1

* add new column to DB
* add new column to model, and to template_schema (because that schema is used to create the dict that goes in to redis). New redis keys start getting populated.

Deploy that through, and then clear redis

PR #2

* add new column to SerialisedTemplate.ALLOWED_PROPERTIES. this means that it'll start reading that value from redis
* now instances of the app will always have the new field in their template objects, whether they came from database directly or from the cache

This commit removes the field from ALLOWED_PROPERTIES. After it's deployed we'll be able to clear redis, observe redis being populated with the new field, and then we'll be able to re-add it to ALLOWED_PROPERTIES, ready to use.