### PR TITLE
Send broadcast

### DIFF
--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -1,0 +1,35 @@
+import requests
+from flask import current_app
+from notifications_utils.statsd_decorators import statsd
+
+from app import notify_celery
+from app.schemas import template_schema
+
+
+from app.dao.broadcast_message_dao import dao_get_broadcast_message_by_id
+
+
+@notify_celery.task(name="send-broadcast-message")
+@statsd(namespace="tasks")
+def send_broadcast_message(broadcast_message_id, provider='stub-1'):
+    broadcast_message = dao_get_broadcast_message_by_id(broadcast_message_id)
+
+    current_app.logger.info(
+        f'sending broadcast_message {broadcast_message_id} '
+        f'status {broadcast_message.status} to {provider}'
+    )
+
+    payload = {
+        "template": template_schema.dump(broadcast_message.template).data,
+        "broadcast_message": broadcast_message.serialize(),
+    }
+    resp = requests.post(
+        f'{current_app.config["CBC_PROXY_URL"]}/broadcasts/{provider}',
+        json=payload
+    )
+    resp.raise_for_status()
+
+    current_app.logger.info(
+        f'broadcast_message {broadcast_message.id} '
+        f'status {broadcast_message.status} sent to {provider}'
+    )

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -3,8 +3,6 @@ from flask import current_app
 from notifications_utils.statsd_decorators import statsd
 
 from app import notify_celery
-from app.schemas import template_schema
-
 
 from app.dao.broadcast_message_dao import dao_get_broadcast_message_by_id
 
@@ -12,6 +10,10 @@ from app.dao.broadcast_message_dao import dao_get_broadcast_message_by_id
 @notify_celery.task(name="send-broadcast-message")
 @statsd(namespace="tasks")
 def send_broadcast_message(broadcast_message_id, provider='stub-1'):
+    # imports of schemas from tasks have to happen within functions to prevent
+    # `AttributeError: 'DummySession' object has no attribute 'query'` errors in unrelated tests
+    from app.schemas import template_schema
+
     broadcast_message = dao_get_broadcast_message_by_id(broadcast_message_id)
 
     current_app.logger.info(

--- a/app/config.py
+++ b/app/config.py
@@ -112,6 +112,9 @@ class Config(object):
     # Antivirus
     ANTIVIRUS_ENABLED = True
 
+    # Broadcast Messaging
+    CBC_PROXY_URL = None
+
     ###########################
     # Default config values ###
     ###########################
@@ -393,6 +396,8 @@ class Development(Config):
     API_HOST_NAME = "http://localhost:6011"
     API_RATE_LIMIT_ENABLED = True
 
+    CBC_PROXY_URL = 'http://localhost:8080'
+
 
 class Test(Development):
     NOTIFY_EMAIL_DOMAIN = 'test.notify.com'
@@ -436,6 +441,8 @@ class Test(Development):
     FIRETEXT_INBOUND_SMS_AUTH = ['testkey']
     TEMPLATE_PREVIEW_API_HOST = 'http://localhost:9999'
 
+    CBC_PROXY_URL = 'http://test-cbc-proxy'
+
     MMG_URL = 'https://example.com/mmg'
     FIRETEXT_URL = 'https://example.com/firetext'
 
@@ -452,6 +459,7 @@ class Preview(Config):
     INVALID_PDF_BUCKET_NAME = 'preview-letters-invalid-pdf'
     TRANSIENT_UPLOADED_LETTERS = 'preview-transient-uploaded-letters'
     LETTER_SANITISE_BUCKET_NAME = 'preview-letters-sanitise'
+    CBC_PROXY_URL = 'https://notify-stub-cbc-sandbox.cloudapps.digital'
     FROM_NUMBER = 'preview'
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = False
@@ -469,6 +477,7 @@ class Staging(Config):
     INVALID_PDF_BUCKET_NAME = 'staging-letters-invalid-pdf'
     TRANSIENT_UPLOADED_LETTERS = 'staging-transient-uploaded-letters'
     LETTER_SANITISE_BUCKET_NAME = 'staging-letters-sanitise'
+    CBC_PROXY_URL = 'https://notify-stub-cbc-sandbox.cloudapps.digital'
     FROM_NUMBER = 'stage'
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = True
@@ -487,6 +496,7 @@ class Live(Config):
     INVALID_PDF_BUCKET_NAME = 'production-letters-invalid-pdf'
     TRANSIENT_UPLOADED_LETTERS = 'production-transient-uploaded-letters'
     LETTER_SANITISE_BUCKET_NAME = 'production-letters-sanitise'
+    CBC_PROXY_URL = 'https://notify-stub-cbc-sandbox.cloudapps.digital'
     FROM_NUMBER = 'GOVUK'
     PERFORMANCE_PLATFORM_ENABLED = True
     API_RATE_LIMIT_ENABLED = True

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -20,6 +20,10 @@ def dao_get_broadcast_message_by_id_and_service_id(broadcast_message_id, service
     ).one()
 
 
+def dao_get_broadcast_message_by_id(broadcast_message_id):
+    return BroadcastMessage.query.get(broadcast_message_id)
+
+
 def dao_get_broadcast_messages_for_service(service_id):
     return BroadcastMessage.query.filter(
         BroadcastMessage.service_id == service_id

--- a/app/models.py
+++ b/app/models.py
@@ -2224,11 +2224,11 @@ class BroadcastMessage(db.Model):
 
     def serialize(self):
         return {
-            'id': self.id,
+            'id': str(self.id),
 
-            'service_id': self.service_id,
+            'service_id': str(self.service_id),
 
-            'template_id': self.template_id,
+            'template_id': str(self.template_id),
             'template_version': self.template_version,
             'template_name': self.template.name,
 
@@ -2245,7 +2245,7 @@ class BroadcastMessage(db.Model):
             'cancelled_at': self.cancelled_at.strftime(DATETIME_FORMAT) if self.cancelled_at else None,
             'updated_at': self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None,
 
-            'created_by_id': self.created_by_id,
-            'approved_by_id': self.approved_by_id,
-            'cancelled_by_id': self.cancelled_by_id,
+            'created_by_id': str(self.created_by_id),
+            'approved_by_id': str(self.approved_by_id),
+            'cancelled_by_id': str(self.cancelled_by_id),
         }

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -1,0 +1,61 @@
+import pytest
+import requests_mock
+from requests import RequestException
+
+from app.dao.templates_dao import dao_update_template
+from app.models import BROADCAST_TYPE, BroadcastStatusType
+from app.celery.broadcast_message_tasks import send_broadcast_message
+from tests.app.db import create_template, create_broadcast_message
+
+
+def test_send_broadcast_message_sends_data_correctly(sample_service):
+    t = create_template(sample_service, BROADCAST_TYPE)
+    bm = create_broadcast_message(t, areas=['london'], status=BroadcastStatusType.BROADCASTING)
+
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post("http://test-cbc-proxy/broadcasts/stub-1", json={'valid': 'true'}, status_code=200)
+        send_broadcast_message(broadcast_message_id=str(bm.id))
+
+    assert request_mock.call_count == 1
+    assert request_mock.request_history[0].method == 'POST'
+    assert request_mock.request_history[0].headers["Content-type"] == "application/json"
+
+    cbc_json = request_mock.request_history[0].json()
+    assert cbc_json['template']['id'] == str(t.id)
+    assert cbc_json['template']['template_type'] == BROADCAST_TYPE
+    assert cbc_json['broadcast_message']['areas'] == ['london']
+
+
+def test_send_broadcast_message_sends_old_version_of_template(sample_service):
+    t = create_template(sample_service, BROADCAST_TYPE, content='first content')
+    bm = create_broadcast_message(t, areas=['london'], status=BroadcastStatusType.BROADCASTING)
+
+    t.content = 'second content'
+    dao_update_template(t)
+    assert t.version == 2
+
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post("http://test-cbc-proxy/broadcasts/stub-1", json={'valid': 'true'}, status_code=200)
+        send_broadcast_message(broadcast_message_id=str(bm.id))
+
+    assert request_mock.call_count == 1
+    assert request_mock.request_history[0].method == 'POST'
+    assert request_mock.request_history[0].headers["Content-type"] == "application/json"
+
+    cbc_json = request_mock.request_history[0].json()
+    assert cbc_json['template']['id'] == str(t.id)
+    assert cbc_json['template']['version'] == 1
+    assert cbc_json['template']['content'] == 'first content'
+
+
+def test_send_broadcast_message_errors(sample_service):
+    t = create_template(sample_service, BROADCAST_TYPE)
+    bm = create_broadcast_message(t, status=BroadcastStatusType.BROADCASTING)
+
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post("http://test-cbc-proxy/broadcasts/stub-1", text='503 bad gateway', status_code=503)
+        # we're not retrying or anything for the moment - but this'll ensure any exception gets logged
+        with pytest.raises(RequestException) as ex:
+            send_broadcast_message(broadcast_message_id=str(bm.id))
+
+    assert ex.value.response.status_code == 503


### PR DESCRIPTION
A new `send_broacast_message` task, triggered when a user hits approve (or send as it currently reads). doesn't trigger on cancellation yet.

the task takes a brodcast_message_id, and makes a post to the cbc-proxy for now, hardcode the url to the notify stub. the stub requires template as the admin/api get it, so use the marshmallow schema to json dump it. Note - this also required us to tweak the BroadcastMessage.serialize function so that it converts uuids in to ids - flask's jsonify function does that for free but requests.post doesn't sadly.

if the request fails (either 4xx or 5xx) just raise an exception and let it bubble up for now - in the future we'll add retry logic