### PR TITLE
Add gds-pre-commit file to repo

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,246 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-09-07T15:19:39Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "Makefile": [
+      {
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 77,
+        "type": "Basic Auth Credentials"
+      },
+      {
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 94,
+        "type": "Secret Keyword"
+      }
+    ],
+    "README.md": [
+      {
+        "hashed_secret": "2b6ec9c0b166743e652d3e60822140b8ee909b7a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "dd755c3a48b6a5065d19b806fdcee15abee5338b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 37,
+        "type": "Secret Keyword"
+      }
+    ],
+    "manifest.yml.j2": [
+      {
+        "hashed_secret": "6f803b24314c39062efe38d0c1da8c472f47eab3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 122,
+        "type": "Secret Keyword"
+      }
+    ],
+    "pytest.ini": [
+      {
+        "hashed_secret": "e501a39b67f82817f7ec580a36f6932e5377e59c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "c0dd73cb8396ad2ebf39530a4e44504bc9628d87",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Secret Keyword"
+      }
+    ],
+    "tests/app/authentication/test_authentication.py": [
+      {
+        "hashed_secret": "23332b8380ee6a1c573083631c41d8d5130e8d2a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 187,
+        "type": "Secret Keyword"
+      }
+    ],
+    "tests/app/aws/test_s3.py": [
+      {
+        "hashed_secret": "67a74306b06d0c01624fe0d0249a570f4d093747",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "tests/app/clients/test_document_download.py": [
+      {
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Secret Keyword"
+      }
+    ],
+    "tests/app/conftest.py": [
+      {
+        "hashed_secret": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 561,
+        "type": "Secret Keyword"
+      }
+    ],
+    "tests/app/dao/test_users_dao.py": [
+      {
+        "hashed_secret": "f2c57870308dc87f432e5912d4de6f8e322721ba",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 159,
+        "type": "Secret Keyword"
+      }
+    ],
+    "tests/app/db.py": [
+      {
+        "hashed_secret": "2020f1df1bb8bbe6d7f3e6b2d136cd2a38ad7fed",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 836,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0362114f115be22057673eda269208449bec65ff",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 837,
+        "type": "Base64 High Entropy String"
+      }
+    ],
+    "tests/app/letters/test_returned_letters.py": [
+      {
+        "hashed_secret": "d782ccb6785b5e3cef91a149f946a38cea88fb81",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "52f1e518a8f64e70f1f443eebe7cdd2e8cdaf83f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "tests/app/notifications/test_receive_notification.py": [
+      {
+        "hashed_secret": "913a73b565c8e2c8ed94497580f619397709b8b6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 38,
+        "type": "Secret Keyword"
+      }
+    ],
+    "tests/app/public_contracts/schemas/v0/email_notification.json": [
+      {
+        "hashed_secret": "3e2d2a4dc7ae395c670309f278338e5d12d01d4a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 76,
+        "type": "Secret Keyword"
+      }
+    ],
+    "tests/app/public_contracts/schemas/v0/sms_notification.json": [
+      {
+        "hashed_secret": "3e2d2a4dc7ae395c670309f278338e5d12d01d4a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 76,
+        "type": "Secret Keyword"
+      }
+    ],
+    "tests/app/template/test_rest.py": [
+      {
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1642,
+        "type": "Secret Keyword"
+      }
+    ],
+    "tests/app/user/test_rest.py": [
+      {
+        "hashed_secret": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 829,
+        "type": "Secret Keyword"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
https://github.com/alphagov/gds-pre-commit

This should help us avoid accidently checking in any real secrets. It
has detected secrets in other repos at GDS so worth us trialling.

As part of this, it is suggested that we check in the
`.secrets.baseline` file as this will mean that the state of which
strings are safe is stored in the repo and won't be flagged as non safe
by any other team mates checking.

Interested to hear if you think this is worth adding?

![image](https://user-images.githubusercontent.com/7228605/87175094-0a4c9a80-c2d0-11ea-96a1-8c70ccfbf9f2.png)
