### PR TITLE
Broadcast crud validation

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -41,16 +41,21 @@ def _update_broadcast_message(broadcast_message, new_status, updating_user):
     if updating_user not in broadcast_message.service.users:
         abort(
             400,
-            f'User {updating_user.id} cannot approve broadcast {broadcast_message.id} from other service'
+            f'User {updating_user.id} cannot approve broadcast_message {broadcast_message.id} from other service'
         )
 
-    # TODO: Restrict status transitions
+    if new_status not in BroadcastStatusType.ALLOWED_STATUS_TRANSITIONS[broadcast_message.status]:
+        abort(
+            400,
+            f'Cannot move broadcast_message {broadcast_message.id} from {broadcast_message.status} to {new_status}'
+        )
+
     if new_status == BroadcastStatusType.BROADCASTING:
         # TODO: Remove this platform admin shortcut when the feature goes live
         if updating_user == broadcast_message.created_by and not updating_user.platform_admin:
             abort(
                 400,
-                f'User {updating_user.id} cannot approve their own broadcast {broadcast_message.id}'
+                f'User {updating_user.id} cannot approve their own broadcast_message {broadcast_message.id}'
             )
         else:
             broadcast_message.approved_at = datetime.utcnow()

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 import iso8601
-from flask import Blueprint, jsonify, request, current_app
+from flask import Blueprint, jsonify, request, current_app, abort
 
 from app.config import QueueNames
 from app.dao.templates_dao import dao_get_template_by_id_and_service_id
@@ -84,6 +84,12 @@ def update_broadcast_message(service_id, broadcast_message_id):
     validate(data, update_broadcast_message_schema)
 
     broadcast_message = dao_get_broadcast_message_by_id_and_service_id(broadcast_message_id, service_id)
+
+    if broadcast_message.status not in BroadcastStatusType.PRE_BROADCAST_STATUSES:
+        abort(
+            400,
+            f'Cannot update broadcast_message {broadcast_message.id} while it has status {broadcast_message.status}'
+        )
 
     if 'personalisation' in data:
         broadcast_message.personalisation = data['personalisation']

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -38,8 +38,13 @@ def _parse_nullable_datetime(dt):
 
 
 def _update_broadcast_message(broadcast_message, new_status, updating_user):
+    if updating_user not in broadcast_message.service.users:
+        abort(
+            400,
+            f'User {updating_user.id} cannot approve broadcast {broadcast_message.id} from other service'
+        )
+
     # TODO: Restrict status transitions
-    # TODO: validate that the user belongs to the same service, isn't the creator, has permissions, etc
     if new_status == BroadcastStatusType.BROADCASTING:
         # TODO: Remove this platform admin shortcut when the feature goes live
         if updating_user == broadcast_message.created_by and not updating_user.platform_admin:

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -41,8 +41,15 @@ def _update_broadcast_message(broadcast_message, new_status, updating_user):
     # TODO: Restrict status transitions
     # TODO: validate that the user belongs to the same service, isn't the creator, has permissions, etc
     if new_status == BroadcastStatusType.BROADCASTING:
-        broadcast_message.approved_at = datetime.utcnow()
-        broadcast_message.approved_by = updating_user
+        # TODO: Remove this platform admin shortcut when the feature goes live
+        if updating_user == broadcast_message.created_by and not updating_user.platform_admin:
+            abort(
+                400,
+                f'User {updating_user.id} cannot approve their own broadcast {broadcast_message.id}'
+            )
+        else:
+            broadcast_message.approved_at = datetime.utcnow()
+            broadcast_message.approved_by = updating_user
 
     if new_status == BroadcastStatusType.CANCELLED:
         broadcast_message.cancelled_at = datetime.utcnow()

--- a/app/models.py
+++ b/app/models.py
@@ -2176,6 +2176,17 @@ class BroadcastStatusType(db.Model):
     PRE_BROADCAST_STATUSES = [DRAFT, PENDING_APPROVAL, REJECTED]
     LIVE_STATUSES = [BROADCASTING, COMPLETED, CANCELLED]
 
+    # these are only the transitions we expect to administer via the API code.
+    ALLOWED_STATUS_TRANSITIONS = {
+        DRAFT: {PENDING_APPROVAL},
+        PENDING_APPROVAL: {REJECTED, DRAFT, BROADCASTING},
+        REJECTED: {DRAFT, PENDING_APPROVAL},
+        BROADCASTING: {COMPLETED, CANCELLED},
+        COMPLETED: {},
+        CANCELLED: {},
+        TECHNICAL_FAILURE: {},
+    }
+
     name = db.Column(db.String, primary_key=True)
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -2178,7 +2178,10 @@ class BroadcastStatusType(db.Model):
 
     # these are only the transitions we expect to administer via the API code.
     ALLOWED_STATUS_TRANSITIONS = {
-        DRAFT: {PENDING_APPROVAL},
+        DRAFT: {
+            PENDING_APPROVAL,
+            BROADCASTING,  # TODO: Remove me once we have pending approval flow put in properly
+        },
         PENDING_APPROVAL: {REJECTED, DRAFT, BROADCASTING},
         REJECTED: {DRAFT, PENDING_APPROVAL},
         BROADCASTING: {COMPLETED, CANCELLED},

--- a/app/models.py
+++ b/app/models.py
@@ -2172,6 +2172,10 @@ class BroadcastStatusType(db.Model):
 
     STATUSES = [DRAFT, PENDING_APPROVAL, REJECTED, BROADCASTING, COMPLETED, CANCELLED, TECHNICAL_FAILURE]
 
+    # a broadcast message can be edited while in one of these states
+    PRE_BROADCAST_STATUSES = [DRAFT, PENDING_APPROVAL, REJECTED]
+    LIVE_STATUSES = [BROADCASTING, COMPLETED, CANCELLED]
+
     name = db.Column(db.String, primary_key=True)
 
 

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -381,10 +381,10 @@ def test_update_broadcast_message_status_rejects_approval_from_user_not_on_that_
 
 @pytest.mark.parametrize('current_status, new_status', [
     (BroadcastStatusType.DRAFT, BroadcastStatusType.DRAFT),
-    (BroadcastStatusType.DRAFT, BroadcastStatusType.BROADCASTING),
     (BroadcastStatusType.BROADCASTING, BroadcastStatusType.PENDING_APPROVAL),
     (BroadcastStatusType.COMPLETED, BroadcastStatusType.BROADCASTING),
     (BroadcastStatusType.CANCELLED, BroadcastStatusType.DRAFT),
+    pytest.param(BroadcastStatusType.DRAFT, BroadcastStatusType.BROADCASTING, marks=pytest.mark.xfail()),
 ])
 def test_update_broadcast_message_status_restricts_status_transitions_to_explicit_list(
     admin_request,

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -66,6 +66,7 @@ from app.models import (
 
 
 def create_user(
+    *,
     mobile_number="+447700900986",
     email="notify@digital.cabinet-office.gov.uk",
     state='active',

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -1011,7 +1011,7 @@ def create_broadcast_message(
         template_id=template.id,
         template_version=template.version,
         personalisation=personalisation,
-        status=BroadcastStatusType.DRAFT,
+        status=status,
         starts_at=starts_at,
         finishes_at=finishes_at,
         created_by_id=created_by.id if created_by else template.created_by_id,


### PR DESCRIPTION
Review commit by commit.

* forbid editing after broadcast message goes live …
* refactor status updating into its own function …
* enforce kwargs when creating user in tests …
* allow platform admins to approve their own messages …
* reject approvals from people outside your service …