### PR TITLE
Stop raising error in scheduled task

### DIFF
--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -10,23 +10,6 @@ from app.authentication.auth import AuthError
 from app.errors import InvalidRequest
 
 
-class JobIncompleteError(Exception):
-    def __init__(self, message):
-        self.message = message
-        self.status_code = 500
-
-    def to_dict_v2(self):
-        return {
-            'status_code': self.status_code,
-            "errors": [
-                {
-                    "error": 'JobIncompleteError',
-                    "message": self.message
-                }
-            ]
-        }
-
-
 class TooManyRequestsError(InvalidRequest):
     status_code = 429
     message_template = 'Exceeded send limits ({}) for today'
@@ -90,10 +73,6 @@ def register_errors(blueprint):
     def validation_error(error):
         current_app.logger.info(error)
         return jsonify(json.loads(error.message)), 400
-
-    @blueprint.errorhandler(JobIncompleteError)
-    def job_incomplete_error(error):
-        return jsonify(error.to_dict_v2()), 500
 
     @blueprint.errorhandler(NoResultFound)
     @blueprint.errorhandler(DataError)

--- a/tests/app/v2/test_errors.py
+++ b/tests/app/v2/test_errors.py
@@ -8,7 +8,7 @@ def app_for_test():
     import flask
     from flask import Blueprint
     from app.authentication.auth import AuthError
-    from app.v2.errors import BadRequestError, TooManyRequestsError, JobIncompleteError
+    from app.v2.errors import BadRequestError, TooManyRequestsError
     from app import init_app
 
     app = flask.Flask(__name__)
@@ -41,10 +41,6 @@ def app_for_test():
     @blue.route("raise_data_error", methods=["GET"])
     def raising_data_error():
         raise DataError("There was a db problem", "params", "orig")
-
-    @blue.route("raise_job_incomplete_error", methods=["GET"])
-    def raising_job_incomplete_error():
-        raise JobIncompleteError("Raising job incomplete error")
 
     @blue.route("raise_exception", methods=["GET"])
     def raising_exception():
@@ -112,16 +108,6 @@ def test_data_errors(app_for_test):
             error = response.json
             assert error == {"status_code": 404,
                              "errors": [{"error": "DataError", "message": "No result found"}]}
-
-
-def test_job_incomplete_errors(app_for_test):
-    with app_for_test.test_request_context():
-        with app_for_test.test_client() as client:
-            response = client.get(url_for('v2_under_test.raising_job_incomplete_error'))
-            assert response.status_code == 500
-            error = response.json
-            assert error == {"status_code": 500,
-                             "errors": [{"error": "JobIncompleteError", "message": "Raising job incomplete error"}]}
 
 
 def test_internal_server_error_handler(app_for_test):


### PR DESCRIPTION
We have a scheduled task to check that all the jobs have completed, this will catch if an app is shut down and the job is complete yet, we only wait 10 seconds before forcing the app to shut down.

The task was raising a JobIncompleteError, yet it is not an error the task is performing correctly and calling the appropriate task to restart the job.
Also used apply_sync to create the task instead of send_task.