### PR TITLE
add broadcast_event table

### DIFF
--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -1,5 +1,5 @@
 from app import db
-from app.models import BroadcastMessage
+from app.models import BroadcastMessage, BroadcastEvent
 from app.dao.dao_utils import transactional
 
 
@@ -28,3 +28,16 @@ def dao_get_broadcast_messages_for_service(service_id):
     return BroadcastMessage.query.filter(
         BroadcastMessage.service_id == service_id
     ).order_by(BroadcastMessage.created_at)
+
+
+def dao_get_earlier_events_for_broadcast_event(broadcast_event_id):
+    """
+    This is used to build up the references list.
+    """
+    this_event = BroadcastEvent.query.get(broadcast_event_id)
+    return BroadcastEvent.query.filter(
+        BroadcastEvent.broadcast_message_id == this_event.id,
+        BroadcastEvent.sent_at < this_event.sent_at
+    ).order_by(
+        BroadcastEvent.sent_at.asc()
+    )

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -30,14 +30,15 @@ def dao_get_broadcast_messages_for_service(service_id):
     ).order_by(BroadcastMessage.created_at)
 
 
-def dao_get_earlier_events_for_broadcast_event(broadcast_event_id):
+def get_earlier_events_for_broadcast_event(broadcast_event_id):
     """
     This is used to build up the references list.
     """
     this_event = BroadcastEvent.query.get(broadcast_event_id)
+
     return BroadcastEvent.query.filter(
-        BroadcastEvent.broadcast_message_id == this_event.id,
+        BroadcastEvent.broadcast_message_id == this_event.broadcast_message_id,
         BroadcastEvent.sent_at < this_event.sent_at
     ).order_by(
         BroadcastEvent.sent_at.asc()
-    )
+    ).all()

--- a/app/models.py
+++ b/app/models.py
@@ -2305,7 +2305,6 @@ class BroadcastEvent(db.Model):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
 
-    # TODO: do we need this? or should we just join via broadcast_message.
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey('services.id'))
     service = db.relationship('Service')
 
@@ -2318,18 +2317,18 @@ class BroadcastEvent(db.Model):
     # msgType. alert, cancel, or update. (other options in the spec are "ack" and "error")
     message_type = db.Column(db.String, nullable=False)
 
-    # reckon: this will be json containing {'headline': '...', 'description': '...', 'title': '...'}. anything that isnt
-    # hardcoded in utils/cbc proxy
+    # this will be json containing anything that isnt hardcoded in utils/cbc proxy. for now just body but may grow to
+    # include, eg, title, headline, instructions.
     transmitted_content = db.Column(
         JSONB(none_as_null=True),
-        nullable=True,
-        default=lambda: {'headline': '', 'description': '', 'title': ''}
+        nullable=True
     )
     # unsubstantiated reckon: even if we're sending a cancel, we'll still need to provide areas
     transmitted_areas = db.Column(JSONB(none_as_null=True), nullable=False, default=list)
     transmitted_sender = db.Column(db.String(), nullable=False)
 
-    # TODO: do we need this?
+    # we may only need this starts_at if this is scheduled for the future. Interested to see how this affects
+    # updates/cancels (ie: can you schedule an update for the future?)
     transmitted_starts_at = db.Column(db.DateTime, nullable=True)
     transmitted_finishes_at = db.Column(db.DateTime, nullable=True)
 

--- a/app/models.py
+++ b/app/models.py
@@ -39,6 +39,7 @@ from app import (
     encryption,
     DATETIME_FORMAT,
     DATETIME_FORMAT_NO_TIMEZONE)
+from app.utils import get_dt_string_or_none
 
 from app.history_meta import Versioned
 
@@ -169,7 +170,7 @@ class User(db.Model):
             'current_session_id': self.current_session_id,
             'failed_login_count': self.failed_login_count,
             'email_access_validated_at': self.email_access_validated_at.strftime(DATETIME_FORMAT),
-            'logged_in_at': self.logged_in_at.strftime(DATETIME_FORMAT) if self.logged_in_at else None,
+            'logged_in_at': get_dt_string_or_none(self.logged_in_at),
             'mobile_number': self.mobile_number,
             'organisations': [x.id for x in self.organisations if x.active],
             'password_changed_at': self.password_changed_at.strftime(DATETIME_FORMAT_NO_TIMEZONE),
@@ -569,7 +570,7 @@ class AnnualBilling(db.Model):
             'service_id': self.service_id,
             'financial_year_start': self.financial_year_start,
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
-            "updated_at": self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None,
+            "updated_at": get_dt_string_or_none(self.updated_at),
             "service": serialize_service() if self.service else None,
         }
 
@@ -600,7 +601,7 @@ class InboundNumber(db.Model):
             "service": serialize_service() if self.service else None,
             "active": self.active,
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
-            "updated_at": self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None,
+            "updated_at": get_dt_string_or_none(self.updated_at),
         }
 
 
@@ -631,7 +632,7 @@ class ServiceSmsSender(db.Model):
             "archived": self.archived,
             "inbound_number_id": str(self.inbound_number_id) if self.inbound_number_id else None,
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
-            "updated_at": self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None,
+            "updated_at": get_dt_string_or_none(self.updated_at),
         }
 
 
@@ -723,7 +724,7 @@ class ServiceInboundApi(db.Model, Versioned):
             "url": self.url,
             "updated_by_id": str(self.updated_by_id),
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
-            "updated_at": self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None
+            "updated_at": get_dt_string_or_none(self.updated_at),
         }
 
 
@@ -762,7 +763,7 @@ class ServiceCallbackApi(db.Model, Versioned):
             "url": self.url,
             "updated_by_id": str(self.updated_by_id),
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
-            "updated_at": self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None
+            "updated_at": get_dt_string_or_none(self.updated_at),
         }
 
 
@@ -996,7 +997,7 @@ class TemplateBase(db.Model):
             "id": str(self.id),
             "type": self.template_type,
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
-            "updated_at": self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None,
+            "updated_at": get_dt_string_or_none(self.updated_at),
             "created_by": self.created_by.email_address,
             "version": self.version,
             "body": self.content,
@@ -1628,7 +1629,7 @@ class Notification(db.Model):
             "subject": self.subject,
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
             "created_by_name": self.get_created_by_name(),
-            "sent_at": self.sent_at.strftime(DATETIME_FORMAT) if self.sent_at else None,
+            "sent_at": get_dt_string_or_none(self.sent_at),
             "completed_at": self.completed_at(),
             "scheduled_for": None,
             "postage": self.postage
@@ -1955,7 +1956,7 @@ class ServiceEmailReplyTo(db.Model):
             'is_default': self.is_default,
             'archived': self.archived,
             'created_at': self.created_at.strftime(DATETIME_FORMAT),
-            'updated_at': self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None
+            'updated_at': get_dt_string_or_none(self.updated_at),
         }
 
 
@@ -1981,7 +1982,7 @@ class ServiceLetterContact(db.Model):
             'is_default': self.is_default,
             'archived': self.archived,
             'created_at': self.created_at.strftime(DATETIME_FORMAT),
-            'updated_at': self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None
+            'updated_at': get_dt_string_or_none(self.updated_at),
         }
 
 
@@ -2058,7 +2059,7 @@ class Complaint(db.Model):
             'service_name': self.service.name,
             'ses_feedback_id': str(self.ses_feedback_id),
             'complaint_type': self.complaint_type,
-            'complaint_date': self.complaint_date.strftime(DATETIME_FORMAT) if self.complaint_date else None,
+            'complaint_date': get_dt_string_or_none(self.complaint_date),
             'created_at': self.created_at.strftime(DATETIME_FORMAT),
         }
 
@@ -2092,7 +2093,7 @@ class ServiceDataRetention(db.Model):
             "notification_type": self.notification_type,
             "days_of_retention": self.days_of_retention,
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
-            "updated_at": self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None,
+            "updated_at": get_dt_string_or_none(self.updated_at),
         }
 
 
@@ -2266,13 +2267,13 @@ class BroadcastMessage(db.Model):
 
             'status': self.status,
 
-            'starts_at': self.starts_at.strftime(DATETIME_FORMAT) if self.starts_at else None,
-            'finishes_at': self.finishes_at.strftime(DATETIME_FORMAT) if self.finishes_at else None,
+            'starts_at': get_dt_string_or_none(self.starts_at),
+            'finishes_at': get_dt_string_or_none(self.finishes_at),
 
-            'created_at': self.created_at.strftime(DATETIME_FORMAT) if self.created_at else None,
-            'approved_at': self.approved_at.strftime(DATETIME_FORMAT) if self.approved_at else None,
-            'cancelled_at': self.cancelled_at.strftime(DATETIME_FORMAT) if self.cancelled_at else None,
-            'updated_at': self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None,
+            'created_at': get_dt_string_or_none(self.created_at),
+            'approved_at': get_dt_string_or_none(self.approved_at),
+            'cancelled_at': get_dt_string_or_none(self.cancelled_at),
+            'updated_at': get_dt_string_or_none(self.updated_at),
 
             'created_by_id': str(self.created_by_id),
             'approved_by_id': str(self.approved_by_id),
@@ -2353,6 +2354,6 @@ class BroadcastEvent(db.Model):
             'transmitted_areas': self.transmitted_areas,
             'transmitted_sender': self.transmitted_sender,
 
-            'transmitted_starts_at': self.updated_at.strftime(DATETIME_FORMAT) if self.transmitted_starts_at else None,
-            'transmitted_finishes_at': self.updated_at.strftime(DATETIME_FORMAT) if self.transmitted_finishes_at else None,
+            'transmitted_starts_at': get_dt_string_or_none(self.transmitted_starts_at),
+            'transmitted_finishes_at': get_dt_string_or_none(self.transmitted_finishes_at),
         }

--- a/app/utils.py
+++ b/app/utils.py
@@ -11,6 +11,7 @@ from notifications_utils.template import (
     BroadcastMessageTemplate,
 )
 
+from app import DATETIME_FORMAT
 
 local_timezone = pytz.timezone("Europe/London")
 
@@ -141,3 +142,7 @@ def get_notification_table_to_use(service, notification_type, process_day, has_d
 def get_archived_db_column_value(column):
     date = datetime.utcnow().strftime("%Y-%m-%d")
     return f'_archived_{date}_{column}'
+
+
+def get_dt_string_or_none(val):
+    return val.strftime(DATETIME_FORMAT) if val else None

--- a/migrations/versions/0326_broadcast_event.py
+++ b/migrations/versions/0326_broadcast_event.py
@@ -1,0 +1,43 @@
+"""
+
+Revision ID: 0326_broadcast_event
+Revises: 0325_int_letter_rates_fix
+Create Date: 2020-07-24 12:40:35.809523
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0326_broadcast_event'
+down_revision = '0325_int_letter_rates_fix'
+
+
+def upgrade():
+    op.create_table('broadcast_event',
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('service_id', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('broadcast_message_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('sent_at', sa.DateTime(), nullable=False),
+        sa.Column('message_type', sa.String(), nullable=False),
+        sa.Column('transmitted_content', postgresql.JSONB(none_as_null=True, astext_type=sa.Text()), nullable=True),
+        sa.Column('transmitted_areas', postgresql.JSONB(none_as_null=True, astext_type=sa.Text()), nullable=False),
+        sa.Column('transmitted_sender', sa.String(), nullable=False),
+        sa.Column('transmitted_starts_at', sa.DateTime(), nullable=True),
+        sa.Column('transmitted_finishes_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['broadcast_message_id'], ['broadcast_message.id'], ),
+        sa.ForeignKeyConstraint(['service_id'], ['services.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+    # this shouldn't be nullable. it defaults to `[]` in python.
+    op.alter_column('broadcast_message', 'areas', existing_type=postgresql.JSONB(astext_type=sa.Text()), nullable=False)
+    # this can't be nullable. it defaults to 'draft' in python.
+    op.alter_column('broadcast_message', 'status', existing_type=sa.VARCHAR(), nullable=False)
+    op.create_foreign_key(None, 'broadcast_message', 'broadcast_status_type', ['status'], ['name'])
+
+
+def downgrade():
+    op.drop_constraint('broadcast_message_status_fkey', 'broadcast_message', type_='foreignkey')
+    op.alter_column('broadcast_message', 'status', existing_type=sa.VARCHAR(), nullable=True)
+    op.alter_column('broadcast_message', 'areas', existing_type=postgresql.JSONB(astext_type=sa.Text()), nullable=True)
+    op.drop_table('broadcast_event')

--- a/tests/app/dao/test_broadcast_message_dao.py
+++ b/tests/app/dao/test_broadcast_message_dao.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from app.models import BROADCAST_TYPE
+from app.models import BroadcastEventMessageType
+from app.dao.broadcast_message_dao import get_earlier_events_for_broadcast_event
+
+from tests.app.db import create_broadcast_message, create_template, create_broadcast_event
+
+
+def test_get_earlier_events_for_broadcast_event(sample_service):
+    t = create_template(sample_service, BROADCAST_TYPE)
+    bm = create_broadcast_message(t)
+
+    events = [
+        create_broadcast_event(
+            bm,
+            sent_at=datetime(2020, 1, 1, 12, 0, 0),
+            message_type=BroadcastEventMessageType.ALERT,
+            transmitted_content={'body': 'Initial content'}
+        ),
+        create_broadcast_event(
+            bm,
+            sent_at=datetime(2020, 1, 1, 13, 0, 0),
+            message_type=BroadcastEventMessageType.UPDATE,
+            transmitted_content={'body': 'Updated content'}
+        ),
+        create_broadcast_event(
+            bm,
+            sent_at=datetime(2020, 1, 1, 14, 0, 0),
+            message_type=BroadcastEventMessageType.UPDATE,
+            transmitted_content={'body': 'Updated content'},
+            transmitted_areas=['wales']
+        ),
+        create_broadcast_event(
+            bm,
+            sent_at=datetime(2020, 1, 1, 15, 0, 0),
+            message_type=BroadcastEventMessageType.CANCEL,
+            transmitted_finishes_at=datetime(2020, 1, 1, 15, 0, 0),
+        )
+    ]
+
+    # only fetches earlier events, and they're in time order
+    earlier_events = get_earlier_events_for_broadcast_event(events[2].id)
+    assert earlier_events == [events[0], events[1]]

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -62,6 +62,7 @@ from app.models import (
     ServiceContactList,
     BroadcastMessage,
     BroadcastStatusType,
+    BroadcastEvent
 )
 
 
@@ -1021,3 +1022,29 @@ def create_broadcast_message(
     db.session.add(broadcast_message)
     db.session.commit()
     return broadcast_message
+
+
+def create_broadcast_event(
+    broadcast_message,
+    sent_at=None,
+    message_type='alert',
+    transmitted_content=None,
+    transmitted_areas=None,
+    transmitted_sender=None,
+    transmitted_starts_at=None,
+    transmitted_finishes_at=None,
+):
+    b_e = BroadcastEvent(
+        service=broadcast_message.service,
+        broadcast_message=broadcast_message,
+        sent_at=sent_at or datetime.utcnow(),
+        message_type=message_type,
+        transmitted_content=transmitted_content or {'body': 'this is an emergency broadcast message'},
+        transmitted_areas=transmitted_areas or ['london'],
+        transmitted_sender=transmitted_sender or 'www.notifications.service.gov.uk',
+        transmitted_starts_at=transmitted_starts_at,
+        transmitted_finishes_at=transmitted_finishes_at,
+    )
+    db.session.add(b_e)
+    db.session.commit()
+    return b_e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,7 @@ def notify_db_session(notify_db, sms_providers):
                             "organisation_types",
                             "service_permission_types",
                             "auth_type",
+                            "broadcast_status_type",
                             "invite_status_type",
                             "service_callback_type"]:
             notify_db.engine.execute(tbl.delete())


### PR DESCRIPTION
It's clear that we need a way to track updates to a broadcast message. It's also clear that we'll need some kind of audit log that captures exactly what was sent out in a message.

This commit adds a new database table, `broadcast_event`, which maps 1:1 with CAP XML sent to the CBCs. We'll create one of these just before sending out.

The main driver for this was that cancel and update messages need to contain a list of references of all previous messages that they're amending. This is of format `{sender},{identifier},{sent_timestamp}`, and the identifier itself needs to be unique for each message.


--------

I've left lots of questions/thoughts in the comments


```python
# user creates draft
broadcast_message = BroadcastMessage(
    service_id=template.service_id,
    template_id=template.id,
    template_version=template.version,
    personalisation={},
    status=BroadcastStatusType.DRAFT,
    starts_at=None,
    finishes_at=None,
    created_by_id=None,
    areas=None,
)

# broadcast_message gets approved, we create a BroadcastEvent
original_alert_msg = BroadcastEvent(
    broadcast_message=broadcast_message_id
    msgType=alert
    transmitted_sender='covid-19@notify.gov.uk'
    transmitted_content = {'description': 'this is data from a template'},
    transmitted_areas=['england']
    transmitted_finishes_at=datetime(2020, 07, 23, 0, 0)
    transmitted_anything_else_derived_from_template_or_service=...?
    created_by_id = the_person_that_issued_the_thing?

    # not mvp
    status = 'draft', 'active'  # does this confuse things? do we need to think about clearing this up if people abandon updates etc?
)

# user updates content.
update_msg = BroadcastEvent(
    broadcast_message=broadcast_message_id  # same id
    msgType=update
    transmitted_content = {'description': 'this is data i wrote by hand'},
    transmitted_areas = ['england']  # unchanged, but we still copy it down
    transmitted_finishes_at = datetime(2020, 07, 23, 12, 0)
)

cancel_msg = BroadcastEvent(
    broadcast_message=broadcast_message_id  # same id
    msgType=cancel
    transmitted_content = None,
    transmitted_areas = ['england'],  # hunch: i think we'll always need this so provider knows which masts to send the message to.
    transmitted_finishes_at = None,
)
```