### PR TITLE
Remove whitelist from URLs

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -560,7 +560,6 @@ def get_detailed_services(start_date, end_date, only_active=False, include_from_
     return results
 
 
-@service_blueprint.route('/<uuid:service_id>/whitelist', methods=['GET'])
 @service_blueprint.route('/<uuid:service_id>/guest-list', methods=['GET'])
 def get_guest_list(service_id):
     from app.models import (EMAIL_TYPE, MOBILE_TYPE)
@@ -578,7 +577,6 @@ def get_guest_list(service_id):
     )
 
 
-@service_blueprint.route('/<uuid:service_id>/whitelist', methods=['PUT'])
 @service_blueprint.route('/<uuid:service_id>/guest-list', methods=['PUT'])
 def update_guest_list(service_id):
     # doesn't commit so if there are any errors, we preserve old values in db

--- a/tests/app/service/test_service_guest_list.py
+++ b/tests/app/service/test_service_guest_list.py
@@ -1,4 +1,3 @@
-import pytest
 import uuid
 import json
 
@@ -11,14 +10,10 @@ from app.models import (
 from app.dao.service_guest_list_dao import dao_add_and_commit_guest_list_contacts
 
 
-@pytest.mark.parametrize('url_path', (
-    'service/{}/whitelist',
-    'service/{}/guest-list',
-))
-def test_get_guest_list_returns_data(client, sample_service_guest_list, url_path):
+def test_get_guest_list_returns_data(client, sample_service_guest_list):
     service_id = sample_service_guest_list.service_id
 
-    response = client.get(url_path.format(service_id), headers=[create_authorization_header()])
+    response = client.get(f'service/{service_id}/guest-list', headers=[create_authorization_header()])
     assert response.status_code == 200
     assert json.loads(response.get_data(as_text=True)) == {
         'email_addresses': [sample_service_guest_list.recipient],
@@ -59,18 +54,14 @@ def test_get_guest_list_returns_no_data(client, sample_service):
     assert json.loads(response.get_data(as_text=True)) == {'email_addresses': [], 'phone_numbers': []}
 
 
-@pytest.mark.parametrize('url_path', (
-    'service/{}/whitelist',
-    'service/{}/guest-list',
-))
-def test_update_guest_list_replaces_old_guest_list(client, sample_service_guest_list, url_path):
+def test_update_guest_list_replaces_old_guest_list(client, sample_service_guest_list):
     data = {
         'email_addresses': ['foo@bar.com'],
         'phone_numbers': ['07123456789']
     }
 
     response = client.put(
-        url_path.format(sample_service_guest_list.service_id),
+        f'service/{sample_service_guest_list.service_id}/guest-list',
         data=json.dumps(data),
         headers=[('Content-Type', 'application/json'), create_authorization_header()]
     )


### PR DESCRIPTION
The admin app will soon use the newer, `…/guest-list` URLs, so we can remove the older, deprecated, `…/whitelist` ones.

***

Depends on:

- [x] https://github.com/alphagov/notifications-admin/pull/3536