### PR TITLE
Set international postage and international flag for international letters

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -354,7 +354,7 @@ def save_letter(
         saved_notification = persist_notification(
             template_id=notification['template'],
             template_version=notification['template_version'],
-            template_postage=template.postage,
+            postage=template.postage,
             recipient=recipient,
             service=service,
             personalisation=notification['personalisation'],

--- a/app/notifications/process_letter_notifications.py
+++ b/app/notifications/process_letter_notifications.py
@@ -14,6 +14,7 @@ def create_letter_notification(
     reply_to_text=None,
     billable_units=None,
     updated_at=None,
+    postage=None
 ):
     notification = persist_notification(
         template_id=template.id,
@@ -33,7 +34,9 @@ def create_letter_notification(
         status=status,
         reply_to_text=reply_to_text,
         billable_units=billable_units,
-        postage=letter_data.get('postage'),
+        # letter_data.get('postage') is only set for precompiled letters
+        # letters from a template will pass in 'europe' or 'rest-of-world' if None then use postage from template
+        postage=postage or letter_data.get('postage'),
         updated_at=updated_at
     )
     return notification

--- a/app/notifications/process_letter_notifications.py
+++ b/app/notifications/process_letter_notifications.py
@@ -19,7 +19,6 @@ def create_letter_notification(
     notification = persist_notification(
         template_id=template.id,
         template_version=template.version,
-        template_postage=template.postage,
         # we only accept addresses_with_underscores from the API (from CSV we also accept dashes, spaces etc)
         recipient=PostalAddress.from_personalisation(letter_data['personalisation']).normalised,
         service=service,
@@ -34,9 +33,9 @@ def create_letter_notification(
         status=status,
         reply_to_text=reply_to_text,
         billable_units=billable_units,
-        # letter_data.get('postage') is only set for precompiled letters
+        # letter_data.get('postage') is only set for precompiled letters (if international it is set after sanitise)
         # letters from a template will pass in 'europe' or 'rest-of-world' if None then use postage from template
-        postage=postage or letter_data.get('postage'),
+        postage=postage or letter_data.get('postage') or template.postage,
         updated_at=updated_at
     )
     return notification

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -107,7 +107,6 @@ def persist_notification(
     reply_to_text=None,
     billable_units=None,
     postage=None,
-    template_postage=None,
     document_download_count=None,
     updated_at=None
 ):
@@ -147,8 +146,8 @@ def persist_notification(
     elif notification_type == EMAIL_TYPE:
         notification.normalised_to = format_email_address(notification.to)
     elif notification_type == LETTER_TYPE:
-        notification.postage = postage or template_postage
-        notification.international = True if postage in INTERNATIONAL_POSTAGE_TYPES else False
+        notification.postage = postage
+        notification.international = postage in INTERNATIONAL_POSTAGE_TYPES
         notification.normalised_to = ''.join(notification.to.split()).lower()
 
     # if simulated create a Notification model to return but do not persist the Notification to the dB

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -27,7 +27,7 @@ from app.models import (
     LETTER_TYPE,
     NOTIFICATION_CREATED,
     Notification,
-)
+    INTERNATIONAL_POSTAGE_TYPES)
 from app.dao.notifications_dao import (
     dao_create_notification,
     dao_delete_notifications_by_id,
@@ -148,6 +148,7 @@ def persist_notification(
         notification.normalised_to = format_email_address(notification.to)
     elif notification_type == LETTER_TYPE:
         notification.postage = postage or template_postage
+        notification.international = True if postage in INTERNATIONAL_POSTAGE_TYPES else False
         notification.normalised_to = ''.join(notification.to.split()).lower()
 
     # if simulated create a Notification model to return but do not persist the Notification to the dB

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -120,7 +120,7 @@ def send_notification(notification_type):
     simulated = simulated_recipient(notification_form['to'], notification_type)
     notification_model = persist_notification(template_id=template.id,
                                               template_version=template.version,
-                                              template_postage=template.postage,
+                                              postage=template.postage,
                                               recipient=request.get_json()['to'],
                                               service=authenticated_service,
                                               personalisation=notification_form.get('personalisation', None),

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -80,6 +80,8 @@ def send_one_off_notification(service_id, post_data):
         # Validate address and set postage to europe|rest-of-world if international letter,
         # otherwise persist_notification with use template postage
         postage = validate_address(service, personalisation)
+        if not postage:
+            postage = template.postage
     validate_created_by(service, post_data['created_by'])
 
     sender_id = post_data.get('sender_id', None)
@@ -92,7 +94,6 @@ def send_one_off_notification(service_id, post_data):
     notification = persist_notification(
         template_id=template.id,
         template_version=template.version,
-        template_postage=template.postage,
         recipient=post_data['to'],
         service=service,
         personalisation=personalisation,
@@ -178,7 +179,6 @@ def send_pdf_letter_notification(service_id, post_data):
         notification_id=post_data['file_id'],
         template_id=template.id,
         template_version=template.version,
-        template_postage=template.postage,
         recipient=urllib.parse.unquote(post_data['recipient_address']),
         service=service,
         personalisation=personalisation,
@@ -189,7 +189,7 @@ def send_pdf_letter_notification(service_id, post_data):
         client_reference=post_data['filename'],
         created_by_id=post_data['created_by'],
         billable_units=billable_units,
-        postage=post_data['postage'],
+        postage=post_data['postage'] or template.postage,
     )
 
     upload_filename = get_letter_pdf_filename(

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -339,7 +339,7 @@ def process_letter_notification(
                                                         template=template,
                                                         reply_to_text=reply_to_text)
 
-    validate_address(service, letter_data)
+    postage = validate_address(service, letter_data)
 
     test_key = api_key.key_type == KEY_TYPE_TEST
 
@@ -362,7 +362,8 @@ def process_letter_notification(
                                               api_key=api_key,
                                               status=status,
                                               reply_to_text=reply_to_text,
-                                              updated_at=updated_at
+                                              updated_at=updated_at,
+                                              postage=postage
                                               )
 
     get_pdf_for_templated_letter.apply_async(
@@ -413,6 +414,10 @@ def validate_address(service, letter_data):
         raise ValidationError(
             message='Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,'
         )
+    if address.postage == 'united-kingdom':
+        return None  # use postage from template
+    else:
+        return address.postage
 
 
 def process_precompiled_letter_notifications(*, letter_data, api_key, service, template, reply_to_text):

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -541,3 +541,23 @@ def test_persist_notification_with_billable_units_stores_correct_info(
     persisted_notification = Notification.query.all()[0]
 
     assert persisted_notification.billable_units == 3
+
+
+@pytest.mark.parametrize('postage', ['europe', 'rest-of-world'])
+def test_persist_notification_for_international_letter(sample_letter_template, postage):
+    notification = persist_notification(
+        template_id=sample_letter_template.id,
+        template_version=sample_letter_template.version,
+        recipient="123 Main Street",
+        service=sample_letter_template.service,
+        personalisation=None,
+        notification_type=sample_letter_template.template_type,
+        api_key_id=None,
+        key_type="normal",
+        billable_units=3,
+        postage=postage,
+        template_postage='second'
+    )
+    persisted_notification = Notification.query.get(notification.id)
+    assert persisted_notification.postage == postage
+    assert persisted_notification.international

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -489,8 +489,7 @@ def test_persist_email_notification_stores_normalised_email(
     [
         ("second", "first", "second"),
         ("first", "first", "first"),
-        ("first", "second", "first"),
-        (None, "second", "second")
+        ("first", "second", "first")
     ]
 )
 def test_persist_letter_notification_finds_correct_postage(
@@ -506,7 +505,6 @@ def test_persist_letter_notification_finds_correct_postage(
     persist_notification(
         template_id=template.id,
         template_version=template.version,
-        template_postage=template.postage,
         recipient="Jane Doe, 10 Downing Street, London",
         service=sample_service_full_permissions,
         personalisation=None,
@@ -536,7 +534,6 @@ def test_persist_notification_with_billable_units_stores_correct_info(
         api_key_id=None,
         key_type="normal",
         billable_units=3,
-        template_postage=template.postage
     )
     persisted_notification = Notification.query.all()[0]
 
@@ -556,7 +553,6 @@ def test_persist_notification_for_international_letter(sample_letter_template, p
         key_type="normal",
         billable_units=3,
         postage=postage,
-        template_postage='second'
     )
     persisted_notification = Notification.query.get(notification.id)
     assert persisted_notification.postage == postage

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -100,6 +100,7 @@ def test_send_one_off_notification_calls_persist_correctly_for_sms(
         created_by_id=str(service.created_by_id),
         reply_to_text='testing',
         reference=None,
+        postage=None
     )
 
 
@@ -161,6 +162,7 @@ def test_send_one_off_notification_calls_persist_correctly_for_email(
         created_by_id=str(service.created_by_id),
         reply_to_text=None,
         reference=None,
+        postage=None
     )
 
 
@@ -188,8 +190,8 @@ def test_send_one_off_notification_calls_persist_correctly_for_letter(
         'to': 'First Last',
         'personalisation': {
             'name': 'foo',
-            'address line 1': 'First Last',
-            'address line 2': '1 Example Street',
+            'address_line_1': 'First Last',
+            'address_line_2': '1 Example Street',
             'postcode': 'SW1A 1AA',
         },
         'created_by': str(service.created_by_id)
@@ -210,6 +212,7 @@ def test_send_one_off_notification_calls_persist_correctly_for_letter(
         created_by_id=str(service.created_by_id),
         reply_to_text=None,
         reference='this-is-random-in-real-life',
+        postage=None
     )
 
 
@@ -362,6 +365,12 @@ def test_send_one_off_letter_notification_should_use_template_reply_to_text(samp
     data = {
         'to': 'user@example.com',
         'template_id': str(sample_letter_template.id),
+        'personalisation': {
+            'name': 'foo',
+            'address_line_1': 'First Last',
+            'address_line_2': '1 Example Street',
+            'address_line_3': 'SW1A 1AA',
+        },
         'created_by': str(sample_letter_template.service.created_by_id)
     }
 
@@ -383,6 +392,12 @@ def test_send_one_off_letter_should_not_make_pdf_in_research_mode(sample_letter_
     data = {
         'to': 'A. Name',
         'template_id': str(sample_letter_template.id),
+        'personalisation': {
+            'name': 'foo',
+            'address_line_1': 'First Last',
+            'address_line_2': '1 Example Street',
+            'address_line_3': 'SW1A 1AA',
+        },
         'created_by': str(sample_letter_template.service.created_by_id)
     }
 

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -90,7 +90,6 @@ def test_send_one_off_notification_calls_persist_correctly_for_sms(
     persist_mock.assert_called_once_with(
         template_id=template.id,
         template_version=template.version,
-        template_postage=None,
         recipient=post_data['to'],
         service=template.service,
         personalisation={'name': 'foo'},
@@ -152,7 +151,6 @@ def test_send_one_off_notification_calls_persist_correctly_for_email(
     persist_mock.assert_called_once_with(
         template_id=template.id,
         template_version=template.version,
-        template_postage=None,
         recipient=post_data['to'],
         service=template.service,
         personalisation={'name': 'foo'},
@@ -202,7 +200,6 @@ def test_send_one_off_notification_calls_persist_correctly_for_letter(
     persist_mock.assert_called_once_with(
         template_id=template.id,
         template_version=template.version,
-        template_postage='first',
         recipient=post_data['to'],
         service=template.service,
         personalisation=post_data['personalisation'],
@@ -212,7 +209,7 @@ def test_send_one_off_notification_calls_persist_correctly_for_letter(
         created_by_id=str(service.created_by_id),
         reply_to_text=None,
         reference='this-is-random-in-real-life',
-        postage=None
+        postage='first'
     )
 
 

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -175,29 +175,30 @@ def test_post_letter_notification_stores_country(
         'Germany'
     )
     assert notification.postage == 'europe'
+    assert notification.international
 
 
 def test_post_letter_notification_international_sets_rest_of_world(
-        client, notify_db_session, mocker
-    ):
-        service = create_service(service_permissions=[LETTER_TYPE, INTERNATIONAL_LETTERS])
-        template = create_template(service, template_type="letter")
-        mocker.patch('app.celery.tasks.letters_pdf_tasks.get_pdf_for_templated_letter.apply_async')
-        data = {
-            'template_id': str(template.id),
-            'personalisation': {
-                'address_line_1': 'Prince Harry',
-                'address_line_2': 'Toronto',
-                'address_line_5': 'Canada',
-            }
+    client, notify_db_session, mocker
+):
+    service = create_service(service_permissions=[LETTER_TYPE, INTERNATIONAL_LETTERS])
+    template = create_template(service, template_type="letter")
+    mocker.patch('app.celery.tasks.letters_pdf_tasks.get_pdf_for_templated_letter.apply_async')
+    data = {
+        'template_id': str(template.id),
+        'personalisation': {
+            'address_line_1': 'Prince Harry',
+            'address_line_2': 'Toronto',
+            'address_line_5': 'Canada',
         }
+    }
 
-        resp_json = letter_request(client, data, service_id=service.id)
+    resp_json = letter_request(client, data, service_id=service.id)
 
-        assert validate(resp_json, post_letter_response) == resp_json
-        notification = Notification.query.one()
+    assert validate(resp_json, post_letter_response) == resp_json
+    notification = Notification.query.one()
 
-        assert notification.postage == 'rest-of-world'
+    assert notification.postage == 'rest-of-world'
 
 
 @pytest.mark.parametrize('permissions, personalisation, expected_error', (

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -174,6 +174,30 @@ def test_post_letter_notification_stores_country(
         'Kronprinzenpalais\n'
         'Germany'
     )
+    assert notification.postage == 'europe'
+
+
+def test_post_letter_notification_international_sets_rest_of_world(
+        client, notify_db_session, mocker
+    ):
+        service = create_service(service_permissions=[LETTER_TYPE, INTERNATIONAL_LETTERS])
+        template = create_template(service, template_type="letter")
+        mocker.patch('app.celery.tasks.letters_pdf_tasks.get_pdf_for_templated_letter.apply_async')
+        data = {
+            'template_id': str(template.id),
+            'personalisation': {
+                'address_line_1': 'Prince Harry',
+                'address_line_2': 'Toronto',
+                'address_line_5': 'Canada',
+            }
+        }
+
+        resp_json = letter_request(client, data, service_id=service.id)
+
+        assert validate(resp_json, post_letter_response) == resp_json
+        notification = Notification.query.one()
+
+        assert notification.postage == 'rest-of-world'
 
 
 @pytest.mark.parametrize('permissions, personalisation, expected_error', (


### PR DESCRIPTION
Make sure to set the postage and international flag correctly for all letters. 

There are many ways to send a letter with Notify:

1. send one-off templated letter
2. upload CSV for a templated letter
3. send template letter via the API
4. send PDF letter via the API
5. upload PDF via the UI

Possible postage types are first | second | europe | rest-of-world.
