### PR TITLE
Fix exception thrown in service_delivery_callback_task

### DIFF
--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -13,6 +13,7 @@ from app import (
     encryption
 )
 from app.config import QueueNames
+from app.models import Notification
 
 
 @notify_celery.task(bind=True, name="send-delivery-status", max_retries=5, default_retry_delay=300)
@@ -106,11 +107,13 @@ def _send_data_to_service_callback_api(self, data, service_callback_url, token, 
 
 
 def create_delivery_status_callback_data(notification, service_callback_api):
+    # Check notification could be of type NotificationHistory
+    recipient = notification.to if isinstance(notification, Notification) else None
     from app import DATETIME_FORMAT, encryption
     data = {
         "notification_id": str(notification.id),
         "notification_client_reference": notification.client_reference,
-        "notification_to": notification.to,
+        "notification_to": recipient,
         "notification_status": notification.status,
         "notification_created_at": notification.created_at.strftime(DATETIME_FORMAT),
         "notification_updated_at":


### PR DESCRIPTION
The odd time we get a SES callback for a service with a short data retention (1 day), since there isn't a to field in the notification sent to create the status callback an exception is thrown. This PR fixes that by checking if the data type of the object passed in.

Question: what should the "notification_to" property be. I don't like returning None here as that might cause an exception with the service. Perhaps "recipient not available" but what if an invalid email address causes an issue as well.
Or do we not send the update?

The exception this PR removes is: 
```
message: Error processing SES results: <class 'AttributeError'>
traceback: Traceback (most recent call last):
  File "/home/vcap/app/app/celery/process_ses_receipts_tasks.py", line 74, in process_ses_results
    _check_and_queue_callback_task(notification)
  File "/home/vcap/app/app/notifications/notifications_ses_callback.py", line 73, in _check_and_queue_callback_task
    notification_data = create_delivery_status_callback_data(notification, service_callback_api)
  File "/home/vcap/app/app/celery/service_callback_tasks.py", line 113, in create_delivery_status_callback_data
    "notification_to": notification.to,
AttributeError: 'NotificationHistory' object has no attribute 'to'
```