### PR TITLE
allow trial mode service users to approve their own broadcasts

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -51,7 +51,11 @@ def _update_broadcast_message(broadcast_message, new_status, updating_user):
 
     if new_status == BroadcastStatusType.BROADCASTING:
         # TODO: Remove this platform admin shortcut when the feature goes live
-        if updating_user == broadcast_message.created_by and not updating_user.platform_admin:
+        if updating_user == broadcast_message.created_by and not (
+            # platform admins and trial mode services can approve their own broadcasts
+            updating_user.platform_admin or
+            broadcast_message.service.restricted
+        ):
             raise InvalidRequest(
                 f'User {updating_user.id} cannot approve their own broadcast_message {broadcast_message.id}',
                 status_code=400

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -357,6 +357,32 @@ def test_update_broadcast_message_status_allows_platform_admin_to_approve_own_me
     mock_task.assert_called_once_with(kwargs={'broadcast_message_id': str(bm.id)}, queue='notify-internal-tasks')
 
 
+def test_update_broadcast_message_status_allows_trial_mode_services_to_approve_own_message(
+    notify_db,
+    admin_request,
+    sample_service,
+    mocker
+):
+    sample_service.restricted = True
+    t = create_template(sample_service, BROADCAST_TYPE)
+    bm = create_broadcast_message(t, status=BroadcastStatusType.PENDING_APPROVAL)
+    mock_task = mocker.patch('app.celery.broadcast_message_tasks.send_broadcast_message.apply_async')
+
+    response = admin_request.post(
+        'broadcast_message.update_broadcast_message_status',
+        _data={'status': BroadcastStatusType.BROADCASTING, 'created_by': str(t.created_by_id)},
+        service_id=t.service_id,
+        broadcast_message_id=bm.id,
+        _expected_status=200
+    )
+
+    assert response['status'] == BroadcastStatusType.BROADCASTING
+    assert response['approved_at'] is not None
+    assert response['created_by_id'] == str(t.created_by_id)
+    assert response['approved_by_id'] == str(t.created_by_id)
+    mock_task.assert_called_once_with(kwargs={'broadcast_message_id': str(bm.id)}, queue='notify-internal-tasks')
+
+
 def test_update_broadcast_message_status_rejects_approval_from_user_not_on_that_service(
     admin_request,
     sample_service,


### PR DESCRIPTION
we won't let trial mode services send real broadcasts, and it's helpful for users to see the flow of messages without having to have a second person with them