### PR TITLE
Fix error message when invitation has expired

### DIFF
--- a/app/accept_invite/rest.py
+++ b/app/accept_invite/rest.py
@@ -35,8 +35,8 @@ def validate_invitation_token(invitation_type, token):
                                       max_age_seconds)
     except SignatureExpired:
         errors = {'invitation':
-                  ['Your invitation to GOV.UK Notify has expired. '
-                   'Please ask the person that invited you to send you another one']}
+                  'Your invitation to GOV.UK Notify has expired. '
+                  'Please ask the person that invited you to send you another one'}
         raise InvalidRequest(errors, status_code=400)
     except BadData:
         errors = {'invitation': 'Something’s wrong with this link. Make sure you’ve copied the whole thing.'}

--- a/tests/app/accept_invite/test_accept_invite_rest.py
+++ b/tests/app/accept_invite/test_accept_invite_rest.py
@@ -19,9 +19,9 @@ def test_validate_invitation_token_for_expired_token_returns_400(client, invitat
     assert response.status_code == 400
     json_resp = json.loads(response.get_data(as_text=True))
     assert json_resp['result'] == 'error'
-    assert json_resp['message'] == {'invitation': [
-        'Your invitation to GOV.UK Notify has expired. '
-        'Please ask the person that invited you to send you another one']}
+    assert json_resp['message'] == {
+        'invitation': 'Your invitation to GOV.UK Notify has expired. '
+                      'Please ask the person that invited you to send you another one'}
 
 
 @pytest.mark.parametrize('invitation_type', ['service', 'organisation'])

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -57,11 +57,6 @@ def test_load_config_if_cloudfoundry_not_available(reload_config):
     assert config.Config.ADMIN_BASE_URL == 'env'
 
 
-def test_cloudfoundry_config_has_different_defaults():
-    # these should always be set on Sandbox
-    assert config.Sandbox.REDIS_ENABLED is False
-
-
 def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()


### PR DESCRIPTION
The error message for when an invitation to Notify had expired was displaying in admin with square brackets round it because admin is not expecting the message to be a list (https://github.com/alphagov/notifications-admin/blob/a85134ee227a89fbe13ee470a7b74b69e01ad7e2/app/models/user.py#L500)

Before:
![Screenshot 2020-05-14 at 14 48 14](https://user-images.githubusercontent.com/12881990/90047606-15795880-dcca-11ea-96a9-5b235ab4e0d2.png)
