### PR TITLE
Log warning for SES send rate throttling rather than exception

### DIFF
--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -43,6 +43,10 @@ class AwsSesClientException(EmailClientException):
     pass
 
 
+class AwsSesClientThrottlingSendRateException(AwsSesClientException):
+    pass
+
+
 class AwsSesClient(EmailClient):
     '''
     Amazon SES email client.
@@ -122,6 +126,11 @@ class AwsSesClient(EmailClient):
                     to_addresses[0],
                     e.response['Error']['Message']
                 ))
+            elif (
+                e.response['Error']['Code'] == 'Throttling'
+                and e.response['Error']['Message'] == 'Maximum sending rate exceeded.'
+            ):
+                raise AwsSesClientThrottlingSendRateException(str(e))
             else:
                 self.statsd_client.incr("clients.ses.error")
                 raise AwsSesClientException(str(e))

--- a/tests/app/clients/test_aws_ses.py
+++ b/tests/app/clients/test_aws_ses.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, ANY
 from notifications_utils.recipients import InvalidEmailError
 
 from app import aws_ses_client
-from app.clients.email.aws_ses import get_aws_responses, AwsSesClientException
+from app.clients.email.aws_ses import get_aws_responses, AwsSesClientException, AwsSesClientThrottlingSendRateException
 
 
 def test_should_return_correct_details_for_delivery():
@@ -114,6 +114,48 @@ def test_send_email_raises_bad_email_as_InvalidEmailError(mocker):
 
     assert 'some error message from amazon' in str(excinfo.value)
     assert 'definitely@invalid_email.com' in str(excinfo.value)
+
+
+def test_send_email_raises_send_rate_throttling_as_AwsSesClientThrottlingSendRateException(mocker):
+    boto_mock = mocker.patch.object(aws_ses_client, '_client', create=True)
+    mocker.patch.object(aws_ses_client, 'statsd_client', create=True)
+    error_response = {
+        'Error': {
+            'Code': 'Throttling',
+            'Message': 'Maximum sending rate exceeded.',
+            'Type': 'Sender'
+        }
+    }
+    boto_mock.send_email.side_effect = botocore.exceptions.ClientError(error_response, 'opname')
+
+    with pytest.raises(AwsSesClientThrottlingSendRateException):
+        aws_ses_client.send_email(
+            source=Mock(),
+            to_addresses='foo@bar.com',
+            subject=Mock(),
+            body=Mock()
+        )
+
+
+def test_send_email_does_not_raise_AwsSesClientThrottlingSendRateException_if_non_send_rate_throttling(mocker):
+    boto_mock = mocker.patch.object(aws_ses_client, '_client', create=True)
+    mocker.patch.object(aws_ses_client, 'statsd_client', create=True)
+    error_response = {
+        'Error': {
+            'Code': 'Throttling',
+            'Message': 'Daily message quota exceeded',
+            'Type': 'Sender'
+        }
+    }
+    boto_mock.send_email.side_effect = botocore.exceptions.ClientError(error_response, 'opname')
+
+    with pytest.raises(AwsSesClientException):
+        aws_ses_client.send_email(
+            source=Mock(),
+            to_addresses='foo@bar.com',
+            subject=Mock(),
+            body=Mock()
+        )
 
 
 def test_send_email_raises_other_errs_as_AwsSesClientException(mocker):


### PR DESCRIPTION
## What this PR does
We have hit throttling limits from SES approximately once a week during
a spike of traffic from GOV.UK. The rate limiting usually only lasts a
couple of minutes but generates enough exceptions to cause a p1 but with
no potential action for the responder.

Therefore we downgrade the warning for this case to a warning and assume
traffic will level back out such that the problem resolves itself.

Note, we will still get exceptions if we go over our daily limit, rather
than our per minute sending limit, which does require immediate action
by someone responding.

If we were to continually go over our per second sending rate for a long
continous period of time, then there is a chance we may not be aware but
given the risk of this happening is low I think it's an acceptable risk
for the moment.


## What this PR doesn't do
In kickoff we spoke about adding exponential backoff as per https://aws.amazon.com/blogs/messaging-and-targeting/how-to-handle-a-throttling-maximum-sending-rate-exceeded-error/

Currently this PR, if an exception is raised for the send rate then we add the item to the retry queue. This means that it will wait 5 minutes before trying to send the email again. This is a form of back off, just not exponential.

If we wanted, we could do the work to make it exponential such that we retry it after say 30 seconds and if that fails, then 60 seconds and then 120 seconds.

The benefit to adding this exponential backoff is that if the sending rate has come down below our limit then we may be able to send the email successfully 30 seconds after the failure, rather than 5 minutes after the failure. This would mean that users would get their emails sooner.

However, I'm not sure the benefits are big enough for us to add this into our code. Last time we had throttling exceptions we had 1200 emails raise errors. If this is out of say 5 million emails in a day then it is 0.02% that would be delayed. These emails are also likely GOV.UK email digests. I don't know if crafting our own exponential backoff functionality is worth this benefit but happy to be talked into it. What do you think?