### PR TITLE
Fix bug with missing template version param

### DIFF
--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -243,8 +243,7 @@ def preview_letter_template_by_notification_id(service_id, notification_id, file
     page = request.args.get('page')
 
     notification = get_notification_by_id(notification_id)
-
-    template = dao_get_template_by_id(notification.template_id)
+    template = dao_get_template_by_id(notification.template_id, notification.template_version)
     metadata = {}
 
     if template.is_precompiled_letter:


### PR DESCRIPTION
We were asking for the latest version of a letter template rather than
the version that the notification was sent with. This mean that if you
previewed a letter and had made edits to the template since it was sent
you would be shown an incorrect preview.

## Link to bug in the wild
https://www.notifications.service.gov.uk/services/4493cb7d-b8c7-4fae-bc68-fc4619c71841/notification/ea1cc66e-8ea8-4456-a4fe-f4687ee29d7f
Was sent with template version 7 but we are trying to display it with the most recent template


## Before locally for notification sent using template version 2
![image](https://user-images.githubusercontent.com/7228605/90391601-520bd200-e085-11ea-979d-eceedcb70905.png)


## After locally for notification sent using template version 2
![image](https://user-images.githubusercontent.com/7228605/90391652-6223b180-e085-11ea-9d25-314c3ab6ec0c.png)

