### PR TITLE
Add endpoints to get invited users

### DIFF
--- a/app/invite/rest.py
+++ b/app/invite/rest.py
@@ -60,6 +60,12 @@ def get_invited_users_by_service(service_id):
     return jsonify(data=invited_user_schema.dump(invited_users, many=True).data), 200
 
 
+@invite.route('/<invited_user_id>', methods=['GET'])
+def get_invited_user_by_service(service_id, invited_user_id):
+    invited_user = get_invited_user(service_id, invited_user_id)
+    return jsonify(data=invited_user_schema.dump(invited_user).data), 200
+
+
 @invite.route('/<invited_user_id>', methods=['POST'])
 def update_invited_user(service_id, invited_user_id):
     fetched = get_invited_user(service_id=service_id, invited_user_id=invited_user_id)

--- a/app/organisation/invite_rest.py
+++ b/app/organisation/invite_rest.py
@@ -76,6 +76,12 @@ def get_invited_org_users_by_organisation(organisation_id):
     return jsonify(data=[x.serialize() for x in invited_org_users]), 200
 
 
+@organisation_invite_blueprint.route('/<invited_org_user_id>', methods=['GET'])
+def get_invited_org_user_by_organisation(organisation_id, invited_org_user_id):
+    invited_org_user = get_invited_org_user(organisation_id, invited_org_user_id)
+    return jsonify(data=invited_org_user.serialize()), 200
+
+
 @organisation_invite_blueprint.route('/<invited_org_user_id>', methods=['POST'])
 def update_org_invite_status(organisation_id, invited_org_user_id):
     fetched = get_invited_org_user(organisation_id=organisation_id, invited_org_user_id=invited_org_user_id)

--- a/tests/app/invite/test_invite_rest.py
+++ b/tests/app/invite/test_invite_rest.py
@@ -160,6 +160,29 @@ def test_get_invited_users_by_service_with_no_invites(client, notify_db, notify_
     assert len(json_resp['data']) == 0
 
 
+def test_get_invited_user_by_service(admin_request, sample_invited_user):
+    json_resp = admin_request.get(
+        'invite.get_invited_user_by_service',
+        service_id=sample_invited_user.service.id,
+        invited_user_id=sample_invited_user.id
+    )
+    assert json_resp['data']['email_address'] == sample_invited_user.email_address
+
+
+def test_get_invited_user_by_service_when_user_does_not_belong_to_the_service(
+    admin_request,
+    sample_invited_user,
+    fake_uuid,
+):
+    json_resp = admin_request.get(
+        'invite.get_invited_user_by_service',
+        service_id=fake_uuid,
+        invited_user_id=sample_invited_user.id,
+        _expected_status=404
+    )
+    assert json_resp['result'] == 'error'
+
+
 def test_update_invited_user_set_status_to_cancelled(client, sample_invited_user):
     data = {'status': 'cancelled'}
     url = '/service/{0}/invite/{1}'.format(sample_invited_user.service_id, sample_invited_user.id)

--- a/tests/app/organisation/test_invite_rest.py
+++ b/tests/app/organisation/test_invite_rest.py
@@ -116,6 +116,29 @@ def test_get_invited_users_by_service_with_no_invites(admin_request, sample_orga
     assert len(json_resp['data']) == 0
 
 
+def test_get_invited_user_by_organisation(admin_request, sample_invited_org_user):
+    json_resp = admin_request.get(
+        'organisation_invite.get_invited_org_user_by_organisation',
+        organisation_id=sample_invited_org_user.organisation.id,
+        invited_org_user_id=sample_invited_org_user.id
+    )
+    assert json_resp['data']['email_address'] == sample_invited_org_user.email_address
+
+
+def test_get_invited_user_by_organisation_when_user_does_not_belong_to_the_org(
+    admin_request,
+    sample_invited_org_user,
+    fake_uuid,
+):
+    json_resp = admin_request.get(
+        'organisation_invite.get_invited_org_user_by_organisation',
+        organisation_id=fake_uuid,
+        invited_org_user_id=sample_invited_org_user.id,
+        _expected_status=404
+    )
+    assert json_resp['result'] == 'error'
+
+
 def test_update_org_invited_user_set_status_to_cancelled(admin_request, sample_invited_org_user):
     data = {'status': 'cancelled'}
 


### PR DESCRIPTION
We want to display flash messages in admin when invites have been
cancelled. This message needs to display the user's email address, so
this commit adds endpoints to GET a single invited service user and org
user so that we can look up the email address of a cancelled user.

[Pivotal story](https://www.pivotaltracker.com/story/show/174294749)