### PR TITLE
Fix update organisations

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -89,6 +89,9 @@ def dao_update_organisation(organisation_id, **kwargs):
     if 'organisation_type' in kwargs:
         _update_organisation_services(organisation, 'organisation_type', only_where_none=False)
 
+    if 'crown' in kwargs:
+        _update_organisation_services(organisation, 'crown', only_where_none=False)
+
     if 'email_branding_id' in kwargs:
         _update_organisation_services(organisation, 'email_branding')
 

--- a/tests/app/dao/test_organisation_dao.py
+++ b/tests/app/dao/test_organisation_dao.py
@@ -213,6 +213,20 @@ def test_update_organisation_does_not_override_service_branding(
     assert sample_service.letter_branding == custom_letter_branding
 
 
+def test_update_organisation_updates_services_with_new_crown_type(
+    sample_service,
+    sample_organisation
+):
+    sample_organisation.services.append(sample_service)
+    db.session.commit()
+
+    assert Service.query.get(sample_service.id).crown
+
+    dao_update_organisation(sample_organisation.id, crown=False)
+
+    assert not Service.query.get(sample_service.id).crown
+
+
 def test_add_service_to_organisation(sample_service, sample_organisation):
     assert sample_organisation.services == []
 


### PR DESCRIPTION
When the organisation updates the crown attribute it should update all the services associated with that organisation too.