### PR TITLE
Allow international letters to be cancelled

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -140,7 +140,11 @@ def update_notification_status_by_id(notification_id, status, sent_by=None, deta
         _duplicate_update_warning(notification, status)
         return None
 
-    if notification.international and not country_records_delivery(notification.phone_prefix):
+    if (
+        notification.notification_type == 'sms'
+        and notification.international
+        and not country_records_delivery(notification.phone_prefix)
+    ):
         return None
     if not notification.sent_by and sent_by:
         notification.sent_by = sent_by

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -141,7 +141,7 @@ def update_notification_status_by_id(notification_id, status, sent_by=None, deta
         return None
 
     if (
-        notification.notification_type == 'sms'
+        notification.notification_type == SMS_TYPE
         and notification.international
         and not country_records_delivery(notification.phone_prefix)
     ):

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -122,6 +122,17 @@ def test_should_update_status_by_id_if_pending_virus_check(sample_letter_templat
     assert updated.status == 'cancelled'
 
 
+def test_should_update_status_of_international_letter_to_cancelled(sample_letter_template):
+    notification = create_notification(
+        template=sample_letter_template,
+        international=True,
+        postage='europe',
+    )
+    assert Notification.query.get(notification.id).international is True
+    update_notification_status_by_id(notification.id, 'cancelled')
+    assert Notification.query.get(notification.id).status == 'cancelled'
+
+
 def test_should_update_status_by_id_and_set_sent_by(sample_template):
     notification = create_notification(template=sample_template, status='sending')
 


### PR DESCRIPTION
Our code was assuming that any notifications with `international` set to `True` were text messages. It was then trying to look up delivery information for a notification which wasn’t sent to a phone number, causing an exception.

***

Need to cancel this letter after deploying: https://www.notifications.service.gov.uk/services/d6aa2c68-a2d9-4437-ab19-3ae8eb202553/notification/6420f6d8-0fc8-4574-8e30-7beda9abb86b