### PR TITLE
Fix the filenames for international precompiled letters

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -306,7 +306,23 @@ def process_sanitised_letter(self, sanitise_data):
             billable_units=billable_units,
             recipient_address=letter_details['address']
         )
-        move_sanitised_letter_to_test_or_live_pdf_bucket(filename, is_test_key, notification.created_at)
+
+        # The original filename could be wrong because we didn't know the postage.
+        # Now we know if the letter is international, we can check what the filename should be.
+        upload_file_name = get_letter_pdf_filename(
+            reference=notification.reference,
+            crown=notification.service.crown,
+            sending_date=notification.created_at,
+            dont_use_sending_date=True,
+            postage=notification.postage
+        )
+
+        move_sanitised_letter_to_test_or_live_pdf_bucket(
+            filename,
+            is_test_key,
+            notification.created_at,
+            upload_file_name,
+        )
         # We've moved the sanitised PDF from the sanitise bucket, but still need to delete the original file:
         original_pdf_object.delete()
 

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -148,10 +148,10 @@ def move_uploaded_pdf_to_letters_bucket(source_filename, upload_filename):
     )
 
 
-def move_sanitised_letter_to_test_or_live_pdf_bucket(filename, is_test_letter, created_at):
+def move_sanitised_letter_to_test_or_live_pdf_bucket(filename, is_test_letter, created_at, new_filename):
     target_bucket_config = 'TEST_LETTERS_BUCKET_NAME' if is_test_letter else 'LETTERS_PDF_BUCKET_NAME'
     target_bucket_name = current_app.config[target_bucket_config]
-    target_filename = get_folder_name(created_at, dont_use_sending_date=is_test_letter) + filename
+    target_filename = get_folder_name(created_at, dont_use_sending_date=is_test_letter) + new_filename
 
     _move_s3_object(
         source_bucket=current_app.config['LETTER_SANITISE_BUCKET_NAME'],

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -336,7 +336,8 @@ def test_move_sanitised_letter_to_live_pdf_bucket(notify_api, mocker):
     move_sanitised_letter_to_test_or_live_pdf_bucket(
         filename=filename,
         is_test_letter=False,
-        created_at=datetime.utcnow()
+        created_at=datetime.utcnow(),
+        new_filename=filename
     )
 
     assert not [x for x in source_bucket.objects.all()]
@@ -359,7 +360,8 @@ def test_move_sanitised_letter_to_test_pdf_bucket(notify_api, mocker):
     move_sanitised_letter_to_test_or_live_pdf_bucket(
         filename=filename,
         is_test_letter=True,
-        created_at=datetime.utcnow()
+        created_at=datetime.utcnow(),
+        new_filename=filename
     )
 
     assert not [x for x in source_bucket.objects.all()]


### PR DESCRIPTION
We were determing the filename for precompiled letters before we had
checked if the letters were international. This meant that a letter
could have a filename indicating it was 2nd class, but once we had
sanitised the letter and checked the address we were setting the
notification to international.

This stopped these letters from being picked up to be sent to the DVLA,
since the filename and postage of the letter did not match.

We now regenerate the filename after the letter has been sanitised (and when
we know the postage) and use the updated filename when moving the letter
into the live PDF letters bucket.