### PR TITLE
Make letter folder name code readable

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -60,12 +60,11 @@ def create_letters_pdf(self, notification_id):
 def get_pdf_for_templated_letter(self, notification_id):
     try:
         notification = get_notification_by_id(notification_id, _raise=True)
-
         letter_filename = get_letter_pdf_filename(
             reference=notification.reference,
             crown=notification.service.crown,
             sending_date=notification.created_at,
-            dont_use_sending_date=notification.key_type == KEY_TYPE_TEST,
+            ignore_folder=notification.key_type == KEY_TYPE_TEST,
             postage=notification.postage
         )
         letter_data = {
@@ -313,7 +312,7 @@ def process_sanitised_letter(self, sanitise_data):
             reference=notification.reference,
             crown=notification.service.crown,
             sending_date=notification.created_at,
-            dont_use_sending_date=True,
+            ignore_folder=True,
             postage=notification.postage
         )
 

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -63,7 +63,7 @@ def get_pdf_for_templated_letter(self, notification_id):
         letter_filename = get_letter_pdf_filename(
             reference=notification.reference,
             crown=notification.service.crown,
-            sending_date=notification.created_at,
+            created_at=notification.created_at,
             ignore_folder=notification.key_type == KEY_TYPE_TEST,
             postage=notification.postage
         )
@@ -182,7 +182,7 @@ def get_key_and_size_of_letters_to_be_sent_to_print(print_run_deadline, postage)
             letter_file_name = get_letter_pdf_filename(
                 reference=letter.reference,
                 crown=letter.service.crown,
-                sending_date=letter.created_at,
+                created_at=letter.created_at,
                 postage=letter.postage
             )
             letter_head = s3.head_s3_object(current_app.config['LETTERS_PDF_BUCKET_NAME'], letter_file_name)
@@ -311,7 +311,7 @@ def process_sanitised_letter(self, sanitise_data):
         upload_file_name = get_letter_pdf_filename(
             reference=notification.reference,
             crown=notification.service.crown,
-            sending_date=notification.created_at,
+            created_at=notification.created_at,
             ignore_folder=True,
             postage=notification.postage
         )

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -432,7 +432,7 @@ def _delete_letters_from_s3(
         if letter.sent_at:
             prefix = get_letter_pdf_filename(reference=letter.reference,
                                              crown=letter.service.crown,
-                                             sending_date=letter.created_at,
+                                             created_at=letter.created_at,
                                              ignore_folder=letter.key_type == KEY_TYPE_TEST,
                                              postage=letter.postage)
             s3_objects = get_s3_bucket_objects(bucket_name=bucket_name, subfolder=prefix)

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -433,7 +433,7 @@ def _delete_letters_from_s3(
             prefix = get_letter_pdf_filename(reference=letter.reference,
                                              crown=letter.service.crown,
                                              sending_date=letter.created_at,
-                                             dont_use_sending_date=letter.key_type == KEY_TYPE_TEST,
+                                             ignore_folder=letter.key_type == KEY_TYPE_TEST,
                                              postage=letter.postage)
             s3_objects = get_s3_bucket_objects(bucket_name=bucket_name, subfolder=prefix)
             for s3_object in s3_objects:

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -34,15 +34,15 @@ def get_folder_name(created_at):
     return '{}/'.format(print_datetime.date())
 
 
-def get_letter_pdf_filename(reference, crown, sending_date, ignore_folder=False, postage=SECOND_CLASS):
+def get_letter_pdf_filename(reference, crown, created_at, ignore_folder=False, postage=SECOND_CLASS):
     upload_file_name = LETTERS_PDF_FILE_LOCATION_STRUCTURE.format(
-        folder='' if ignore_folder else get_folder_name(sending_date),
+        folder='' if ignore_folder else get_folder_name(created_at),
         reference=reference,
         duplex="D",
         letter_class=RESOLVE_POSTAGE_FOR_FILE_NAME[postage],
         colour="C",
         crown="C" if crown else "N",
-        date=sending_date.strftime('%Y%m%d%H%M%S')
+        date=created_at.strftime('%Y%m%d%H%M%S')
     ).upper()
     return upload_file_name
 
@@ -78,7 +78,7 @@ def upload_letter_pdf(notification, pdf_data, precompiled=False):
     upload_file_name = get_letter_pdf_filename(
         reference=notification.reference,
         crown=notification.service.crown,
-        sending_date=notification.created_at,
+        created_at=notification.created_at,
         ignore_folder=precompiled or notification.key_type == KEY_TYPE_TEST,
         postage=notification.postage
     )

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -196,7 +196,7 @@ def send_pdf_letter_notification(service_id, post_data):
         reference=notification.reference,
         crown=notification.service.crown,
         sending_date=notification.created_at,
-        dont_use_sending_date=False,
+        ignore_folder=False,
         postage=notification.postage
     )
 

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -195,7 +195,7 @@ def send_pdf_letter_notification(service_id, post_data):
     upload_filename = get_letter_pdf_filename(
         reference=notification.reference,
         crown=notification.service.crown,
-        sending_date=notification.created_at,
+        created_at=notification.created_at,
         ignore_folder=False,
         postage=notification.postage
     )

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -62,7 +62,10 @@ def test_get_pdf_for_templated_letter_happy_path(mocker, sample_letter_notificat
         letter_branding = create_letter_branding(name=branding_name, filename=logo_filename)
         sample_letter_notification.service.letter_branding = letter_branding
     mock_celery = mocker.patch('app.celery.letters_pdf_tasks.notify_celery.send_task')
-    mocker.patch('app.celery.letters_pdf_tasks.get_letter_pdf_filename', return_value='LETTER.PDF')
+    mock_get_letter_pdf_filename = mocker.patch(
+        'app.celery.letters_pdf_tasks.get_letter_pdf_filename',
+        return_value='LETTER.PDF'
+    )
     get_pdf_for_templated_letter(sample_letter_notification.id)
 
     letter_data = {
@@ -85,6 +88,14 @@ def test_get_pdf_for_templated_letter_happy_path(mocker, sample_letter_notificat
         name=TaskNames.CREATE_PDF_FOR_TEMPLATED_LETTER,
         args=(encrypted_data,),
         queue=QueueNames.SANITISE_LETTERS
+    )
+
+    mock_get_letter_pdf_filename.assert_called_once_with(
+        reference=sample_letter_notification.reference,
+        crown=True,
+        sending_date=sample_letter_notification.created_at,
+        ignore_folder=False,
+        postage='second'
     )
 
 

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -93,13 +93,13 @@ def test_get_pdf_for_templated_letter_happy_path(mocker, sample_letter_notificat
     mock_get_letter_pdf_filename.assert_called_once_with(
         reference=sample_letter_notification.reference,
         crown=True,
-        sending_date=sample_letter_notification.created_at,
+        created_at=sample_letter_notification.created_at,
         ignore_folder=False,
         postage='second'
     )
 
 
-def test_get_pdf_for_templated_letter_non_existent_notification(notify_api, mocker, fake_uuid):
+def test_get_pdf_for_templated_letter_non_existent_notification(notify_db_session, mocker, fake_uuid):
     with pytest.raises(expected_exception=NoResultFound):
         get_pdf_for_templated_letter(fake_uuid)
 

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -312,12 +312,8 @@ def test_move_failed_pdf_scan_failed(notify_api):
                           ])
 def test_get_folder_name_in_british_summer_time(notify_api, timestamp, expected_folder_name):
     timestamp = dateutil.parser.parse(timestamp)
-    folder_name = get_folder_name(created_at=timestamp, ignore_folder=False)
+    folder_name = get_folder_name(created_at=timestamp)
     assert folder_name == expected_folder_name
-
-
-def test_get_folder_name_returns_empty_string_for_test_letter():
-    assert '' == get_folder_name(datetime.utcnow(), ignore_folder=True)
 
 
 @mock_s3

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -140,8 +140,8 @@ def test_get_bucket_name_and_prefix_for_notification_invalid_notification():
 ])
 def test_get_letter_pdf_filename_returns_correct_filename(
         notify_api, mocker, crown_flag, expected_crown_text):
-    sending_date = datetime(2017, 12, 4, 17, 29)
-    filename = get_letter_pdf_filename(reference='foo', crown=crown_flag, sending_date=sending_date)
+    created_at = datetime(2017, 12, 4, 17, 29)
+    filename = get_letter_pdf_filename(reference='foo', crown=crown_flag, created_at=created_at)
 
     assert filename == '2017-12-04/NOTIFY.FOO.D.2.C.{}.20171204172900.PDF'.format(expected_crown_text)
 
@@ -152,24 +152,24 @@ def test_get_letter_pdf_filename_returns_correct_filename(
 ])
 def test_get_letter_pdf_filename_returns_correct_postage_for_filename(
         notify_api, postage, expected_postage):
-    sending_date = datetime(2017, 12, 4, 17, 29)
-    filename = get_letter_pdf_filename(reference='foo', crown=True, sending_date=sending_date, postage=postage)
+    created_at = datetime(2017, 12, 4, 17, 29)
+    filename = get_letter_pdf_filename(reference='foo', crown=True, created_at=created_at, postage=postage)
 
     assert filename == '2017-12-04/NOTIFY.FOO.D.{}.C.C.20171204172900.PDF'.format(expected_postage)
 
 
 def test_get_letter_pdf_filename_returns_correct_filename_for_test_letters(
         notify_api, mocker):
-    sending_date = datetime(2017, 12, 4, 17, 29)
+    created_at = datetime(2017, 12, 4, 17, 29)
     filename = get_letter_pdf_filename(reference='foo', crown='C',
-                                       sending_date=sending_date, ignore_folder=True)
+                                       created_at=created_at, ignore_folder=True)
 
     assert filename == 'NOTIFY.FOO.D.2.C.C.20171204172900.PDF'
 
 
 def test_get_letter_pdf_filename_returns_tomorrows_filename(notify_api, mocker):
-    sending_date = datetime(2017, 12, 4, 17, 31)
-    filename = get_letter_pdf_filename(reference='foo', crown=True, sending_date=sending_date)
+    created_at = datetime(2017, 12, 4, 17, 31)
+    filename = get_letter_pdf_filename(reference='foo', crown=True, created_at=created_at)
 
     assert filename == '2017-12-05/NOTIFY.FOO.D.2.C.C.20171204173100.PDF'
 
@@ -216,7 +216,7 @@ def test_upload_letter_pdf_to_correct_bucket(
     filename = get_letter_pdf_filename(
         reference=sample_letter_notification.reference,
         crown=sample_letter_notification.service.crown,
-        sending_date=sample_letter_notification.created_at,
+        created_at=sample_letter_notification.created_at,
         ignore_folder=is_precompiled_letter
     )
 
@@ -243,7 +243,7 @@ def test_upload_letter_pdf_uses_postage_from_notification(
     filename = get_letter_pdf_filename(
         reference=letter_notification.reference,
         crown=letter_notification.service.crown,
-        sending_date=letter_notification.created_at,
+        created_at=letter_notification.created_at,
         ignore_folder=False,
         postage=letter_notification.postage
     )


### PR DESCRIPTION
Had a little bit of a headache trying to read the get_folder_name function the other day.

Key things here are:

* Moving decision around whether a folder exists outside of `get_folder_name`
* renaming `sending_date` to `created_at`, because that's what it's always set to, even if the letter was sent many days later due to technical issues with us or with dvla