### PR TITLE
add notify-api-sms-callbacks app

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -19,6 +19,27 @@
       'production': 25
     },
   },
+
+  'notify-api-sms-callbacks': {
+    'NOTIFY_APP_NAME': 'api',
+    'disk_quota': '2G',
+    'additional_env_vars': {
+      'STATSD_HOST': None
+    },
+    'routes': {
+      'preview': ['api.notify.works/notifications/sms/mmg', 'api.notify.works/notifications/sms/firetext'],
+      'staging': ['api.staging-notify.works/notifications/sms/mmg', 'api.staging-notify.works/notifications/sms/firetext'],
+      'production': ['api.notifications.service.gov.uk/notifications/sms/mmg', 'api.notifications.service.gov.uk/notifications/sms/firetext'],
+    },
+    'health-check-type': 'port',
+    'health-check-invocation-timeout': 3,
+    'instances': {
+      'preview': 1,
+      'staging': 2,
+      'production': 10
+    },
+  },
+
   'notify-api-db-migration': {
     'NOTIFY_APP_NAME': 'api',
     'instances': {


### PR DESCRIPTION
we might need to deal with a potential large volume of SMS delivery receipts. These receipts are POSTed to oru public api to two URLs. The actual endpoint just parses the response body and puts a task on an SQS queue - no database connections are required or anything like that.

Split up this traffic from other traffic, so that any increase in volume of callbacks won't affect the scaling/load/etc of the main api apps. We've hard coded instance counts to 10 on prod for now until we get an idea of load.

This is deployed on preview already if you want to test that it works properly.