### PR TITLE
Bump utils to 42.2.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,7 +29,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@42.0.0#egg=notifications-utils==42.0.0
+git+https://github.com/alphagov/notifications-utils.git@42.2.0#egg=notifications-utils==42.2.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@42.0.0#egg=notifications-utils==42.0.0
+git+https://github.com/alphagov/notifications-utils.git@42.2.0#egg=notifications-utils==42.2.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0
@@ -42,14 +42,14 @@ alembic==1.4.3
 amqp==1.4.9
 anyjson==0.3.3
 attrs==20.2.0
-awscli==1.18.137
+awscli==1.18.146
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.1.4
 blinker==1.4
 boto==2.49.0
 boto3==1.10.38
-botocore==1.17.60
+botocore==1.18.5
 certifi==2020.6.20
 chardet==3.0.4
 click==7.1.2
@@ -60,9 +60,9 @@ flask-redis==0.4.0
 future==0.18.2
 geojson==2.5.0
 govuk-bank-holidays==0.6
-greenlet==0.4.16
+greenlet==0.4.17
 idna==2.10
-importlib-metadata==1.7.0
+importlib-metadata==2.0.0
 Jinja2==2.11.2
 jmespath==0.10.0
 kombu==3.0.37
@@ -92,4 +92,4 @@ statsd==3.3.0
 urllib3==1.25.10
 webencodings==0.5.1
 Werkzeug==1.0.1
-zipp==3.1.0
+zipp==3.2.0


### PR DESCRIPTION
Increases CSV row limit from 50,000 to 100,000

Changes: https://github.com/alphagov/notifications-utils/compare/42.0.0...42.2.0