### PR TITLE
Allow 20 minutes before checking for missing rows

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -209,9 +209,9 @@ def can_letter_job_be_cancelled(job):
 
 
 def find_jobs_with_missing_rows():
-    # Jobs can be a maximum of 50,000 rows. It typically takes 5 minutes to create all those notifications.
-    # Using 10 minutes as a condition seems reasonable.
-    ten_minutes_ago = datetime.utcnow() - timedelta(minutes=10)
+    # Jobs can be a maximum of 100,000 rows. It typically takes 10 minutes to create all those notifications.
+    # Using 20 minutes as a condition seems reasonable.
+    ten_minutes_ago = datetime.utcnow() - timedelta(minutes=20)
     yesterday = datetime.utcnow() - timedelta(days=1)
     jobs_with_rows_missing = db.session.query(
         func.count(Notification.id).label('actual_count'),

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -446,14 +446,14 @@ def test_find_jobs_with_missing_rows(sample_email_template):
     healthy_job = create_job(template=sample_email_template,
                              notification_count=3,
                              job_status=JOB_STATUS_FINISHED,
-                             processing_finished=datetime.utcnow() - timedelta(minutes=11)
+                             processing_finished=datetime.utcnow() - timedelta(minutes=20)
                              )
     for i in range(0, 3):
         create_notification(job=healthy_job, job_row_number=i)
     job_with_missing_rows = create_job(template=sample_email_template,
                                        notification_count=5,
                                        job_status=JOB_STATUS_FINISHED,
-                                       processing_finished=datetime.utcnow() - timedelta(minutes=11)
+                                       processing_finished=datetime.utcnow() - timedelta(minutes=20)
                                        )
     for i in range(0, 4):
         create_notification(job=job_with_missing_rows, job_row_number=i)


### PR DESCRIPTION
Since we’ve doubled the number of rows in a job, jobs can take twice as long to insert all the notifications. We don’t check for missing rows until we’re pretty confident that the original tasks have finished processing. This means we need to double the time we wait to still be as sure.