### PR TITLE
Add an endpoint for stats about scheduled jobs

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -84,6 +84,18 @@ def dao_get_jobs_by_service_id(
         .paginate(page=page, per_page=page_size)
 
 
+def dao_get_scheduled_job_stats(
+    service_id,
+):
+    return db.session.query(
+        func.count(Job.id),
+        func.min(Job.scheduled_for),
+    ).filter(
+        Job.service_id == service_id,
+        Job.job_status == JOB_STATUS_SCHEDULED,
+    ).one()
+
+
 def dao_get_job_by_id(job_id):
     return Job.query.filter_by(id=job_id).one()
 

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -1,4 +1,5 @@
 import dateutil
+import pytz
 from flask import (
     Blueprint,
     jsonify,
@@ -14,6 +15,7 @@ from app.dao.jobs_dao import (
     dao_get_jobs_by_service_id,
     dao_get_future_scheduled_job_by_id_and_service_id,
     dao_get_notification_outcomes_for_job,
+    dao_get_scheduled_job_stats,
     dao_cancel_letter_job,
     can_letter_job_be_cancelled
 )
@@ -186,6 +188,18 @@ def create_job(service_id):
     job_json['statistics'] = []
 
     return jsonify(data=job_json), 201
+
+
+@job_blueprint.route('/scheduled-job-stats', methods=['GET'])
+def get_scheduled_job_stats(service_id):
+    count, soonest_scheduled_for = dao_get_scheduled_job_stats(service_id)
+    return jsonify(
+        count=count,
+        soonest_scheduled_for=(
+            soonest_scheduled_for.replace(tzinfo=pytz.UTC).isoformat()
+            if soonest_scheduled_for else None
+        ),
+    ), 200
 
 
 def get_paginated_jobs(


### PR DESCRIPTION
At the moment we display the count of scheduled jobs on the dashboard by sending all the scheduled jobs to the admin app and letting it work out the stats.

This is inefficient and, because the get jobs response has a page size of 50, becomes incorrect if a service schedules more than 50 jobs.

This commit adds a separate endpoint which gives the admin app the stats it needs directly and correctly.