### PR TITLE
Use cache to improve performance of CSV processing

### DIFF
--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -51,18 +51,19 @@ class SerialisedTemplate(SerialisedModel):
 
     @classmethod
     @memory_cache
-    def from_id_and_service_id(cls, template_id, service_id):
-        return cls(cls.get_dict(template_id, service_id)['data'])
+    def from_id_and_service_id(cls, template_id, service_id, version=None):
+        return cls(cls.get_dict(template_id, service_id, version)['data'])
 
     @staticmethod
-    @redis_cache.set('service-{service_id}-template-{template_id}-version-None')
-    def get_dict(template_id, service_id):
+    @redis_cache.set('service-{service_id}-template-{template_id}-version-{version}')
+    def get_dict(template_id, service_id, version):
         from app.dao import templates_dao
         from app.schemas import template_schema
 
         fetched_template = templates_dao.dao_get_template_by_id_and_service_id(
             template_id=template_id,
-            service_id=service_id
+            service_id=service_id,
+            version=version,
         )
 
         template_dict = template_schema.dump(fetched_template).data

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -233,7 +233,7 @@ def test_should_cache_template_lookups_in_memory(mocker, client, sample_template
 
     assert mock_get_template.call_count == 1
     assert mock_get_template.call_args_list == [
-        call(service_id=str(sample_template.service_id), template_id=str(sample_template.id))
+        call(service_id=str(sample_template.service_id), template_id=str(sample_template.id), version=None)
     ]
     assert Notification.query.count() == 5
 


### PR DESCRIPTION
When sending jobs from concurrent CSV files we seem to be limited by how fast we can save items to the database. We’ve made saving to the database faster in other places by taking advantage of the service and template cache to open the connection later. 

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/3074
- [x] clear Redis template cache in each environment 