### PR TITLE
On the crazy weekend we checked for scheduled jobs every minute.

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -194,7 +194,7 @@ class Config(object):
         # app/celery/scheduled_tasks.py
         'run-scheduled-jobs': {
             'task': 'run-scheduled-jobs',
-            'schedule': crontab(),
+            'schedule': crontab(minute='0,15,30,45'),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'delete-verify-codes': {


### PR DESCRIPTION
This changes that scheduled task to run at the top of the hour, 15, 30, and 45 minutes past