### PR TITLE
Serialise content in broadcast message response

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2243,6 +2243,12 @@ class BroadcastMessage(db.Model):
     cancelled_by = db.relationship('User', foreign_keys=[cancelled_by_id])
 
     @property
+    def content(self):
+        return self.template._as_utils_template_with_personalisation(
+            self.personalisation
+        ).content_with_placeholders_filled_in
+
+    @property
     def personalisation(self):
         if self._personalisation:
             return encryption.decrypt(self._personalisation)
@@ -2261,6 +2267,7 @@ class BroadcastMessage(db.Model):
             'template_id': str(self.template_id),
             'template_version': self.template_version,
             'template_name': self.template.name,
+            'template_content': self.content,
 
             'personalisation': self.personalisation,
             'areas': self.areas.get("areas", []),

--- a/app/models.py
+++ b/app/models.py
@@ -2267,7 +2267,7 @@ class BroadcastMessage(db.Model):
             'template_id': str(self.template_id),
             'template_version': self.template_version,
             'template_name': self.template.name,
-            'template_content': self.content,
+            'content': self.content,
 
             'personalisation': self.personalisation,
             'areas': self.areas.get("areas", []),

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -24,6 +24,8 @@ def test_get_broadcast_message(admin_request, sample_broadcast_service):
     )
 
     assert response['id'] == str(bm.id)
+    assert response['template_id'] == str(t.id)
+    assert response['template_content'] == t.content
     assert response['template_name'] == t.name
     assert response['status'] == BroadcastStatusType.DRAFT
     assert response['created_at'] is not None

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -10,11 +10,21 @@ from tests.app.db import create_broadcast_message, create_template, create_servi
 
 
 def test_get_broadcast_message(admin_request, sample_broadcast_service):
-    t = create_template(sample_broadcast_service, BROADCAST_TYPE)
-    bm = create_broadcast_message(t, areas={
-        "areas": ['place A', 'region B'],
-        "simple_polygons": [[[50.1, 1.2], [50.12, 1.2], [50.13, 1.2]]]
-    })
+    t = create_template(
+        sample_broadcast_service,
+        BROADCAST_TYPE,
+        content='This is a ((thing))'
+    )
+    bm = create_broadcast_message(
+        t,
+        areas={
+            "areas": ['place A', 'region B'],
+            "simple_polygons": [[[50.1, 1.2], [50.12, 1.2], [50.13, 1.2]]],
+        },
+        personalisation={
+            'thing': 'test',
+        },
+    )
 
     response = admin_request.get(
         'broadcast_message.get_broadcast_message',
@@ -25,13 +35,13 @@ def test_get_broadcast_message(admin_request, sample_broadcast_service):
 
     assert response['id'] == str(bm.id)
     assert response['template_id'] == str(t.id)
-    assert response['template_content'] == t.content
+    assert response['template_content'] == 'This is a test'
     assert response['template_name'] == t.name
     assert response['status'] == BroadcastStatusType.DRAFT
     assert response['created_at'] is not None
     assert response['starts_at'] is None
     assert response['areas'] == ['place A', 'region B']
-    assert response['personalisation'] == {}
+    assert response['personalisation'] == {'thing': 'test'}
 
 
 def test_get_broadcast_message_404s_if_message_doesnt_exist(admin_request, sample_broadcast_service):

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -35,7 +35,7 @@ def test_get_broadcast_message(admin_request, sample_broadcast_service):
 
     assert response['id'] == str(bm.id)
     assert response['template_id'] == str(t.id)
-    assert response['template_content'] == 'This is a test'
+    assert response['content'] == 'This is a test'
     assert response['template_name'] == t.name
     assert response['status'] == BroadcastStatusType.DRAFT
     assert response['created_at'] is not None


### PR DESCRIPTION
This will let us show the content of the broadcast message in places we can’t at the moment.