### PR TITLE
Put redirect link in reset password email link

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -444,7 +444,10 @@ def send_user_reset_password():
         service=service,
         personalisation={
             'user_name': user_to_send_to.name,
-            'url': _create_reset_password_url(user_to_send_to.email_address)
+            'url': _create_reset_password_url(
+                user_to_send_to.email_address,
+                next_redirect=request.get_json().get('next')
+            )
         },
         notification_type=template.template_type,
         api_key_id=None,
@@ -477,10 +480,13 @@ def get_organisations_and_services_for_user(user_id):
     return jsonify(data)
 
 
-def _create_reset_password_url(email):
+def _create_reset_password_url(email, next_redirect=None):
     data = json.dumps({'email': email, 'created_at': str(datetime.utcnow())})
-    url = '/new-password/'
-    return url_with_token(data, url, current_app.config)
+    static_url_part = '/new-password/'
+    full_url = url_with_token(data, static_url_part, current_app.config)
+    if next_redirect:
+        full_url += '?{}'.format(urlencode({'next': next_redirect}))
+    return full_url
 
 
 def _create_verification_url(user):

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -480,7 +480,7 @@ def get_organisations_and_services_for_user(user_id):
     return jsonify(data)
 
 
-def _create_reset_password_url(email, next_redirect=None):
+def _create_reset_password_url(email, next_redirect):
     data = json.dumps({'email': email, 'created_at': str(datetime.utcnow())})
     static_url_part = '/new-password/'
     full_url = url_with_token(data, static_url_part, current_app.config)
@@ -501,13 +501,13 @@ def _create_confirmation_url(user, email_address):
     return url_with_token(data, url, current_app.config)
 
 
-def _create_2fa_url(user, secret_code, next_redir, email_auth_link_host):
+def _create_2fa_url(user, secret_code, next_redirect, email_auth_link_host):
     data = json.dumps({'user_id': str(user.id), 'secret_code': secret_code})
     url = '/email-auth/'
-    ret = url_with_token(data, url, current_app.config, base_url=email_auth_link_host)
-    if next_redir:
-        ret += '?{}'.format(urlencode({'next': next_redir}))
-    return ret
+    full_url = url_with_token(data, url, current_app.config, base_url=email_auth_link_host)
+    if next_redirect:
+        full_url += '?{}'.format(urlencode({'next': next_redirect}))
+    return full_url
 
 
 def get_orgs_and_services(user):


### PR DESCRIPTION
This is so when users reset their password they are still redirected to pages they were meant to visit.

This change was done specifically so everyone who is meant to see broadcast tour sees it, but it will improve lives of all users who wanted to visit a page on Notify but then had to reset their password in the process

Goes together with: https://github.com/alphagov/notifications-admin/pull/3670

Pivotal ticket: https://www.pivotaltracker.com/story/show/174488590