### PR TITLE
Add workers for sms and email sending

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -53,6 +53,8 @@
   'notify-delivery-worker-jobs': {},
   'notify-delivery-worker-research': {},
   'notify-delivery-worker-sender': {'disk_quota': '2G', 'memory': '3G'},
+  'notify-delivery-worker-email': {'disk_quota': '2G', 'memory': '3G'},
+  'notify-delivery-worker-sms': {'disk_quota': '2G', 'memory': '3G'},
   'notify-delivery-worker-periodic': {},
   'notify-delivery-worker-reporting': {
     'additional_env_vars': {

--- a/scripts/paas_app_wrapper.sh
+++ b/scripts/paas_app_wrapper.sh
@@ -24,6 +24,14 @@ case $NOTIFY_APP_NAME in
     exec scripts/run_multi_worker_app_paas.sh celery multi start 3 -c 10 -A run_celery.notify_celery --loglevel=INFO \
     -Q send-sms-tasks,send-email-tasks
     ;;
+  delivery-worker-sender-sms)
+    exec scripts/run_multi_worker_app_paas.sh celery multi start 3 -c 10 -A run_celery.notify_celery --loglevel=INFO \
+    -Q send-sms-tasks
+    ;;
+  delivery-worker-sender-email)
+    exec scripts/run_multi_worker_app_paas.sh celery multi start 3 -c 10 -A run_celery.notify_celery --loglevel=INFO \
+    -Q send-email-tasks
+    ;;
   delivery-worker-periodic)
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=2 \
     -Q periodic-tasks 2> /dev/null


### PR DESCRIPTION
We want to have different workers for sending out email and sending out
sms. This will enable us to better rate limit ourselves when sending to
our providers. For example, we can make sure we only have capacity in
the email worker to send at our rate of 500rps to SES.

Note, we may in due time need to split the sms sender worker into two
different workers, one for each provider.

A separate PR will come after this to remove the unsplit
`notify-delivery-worker-sender`.

## Deployment order
`cf v3-create-app notify-deliver-worker-sender-sms` run in all envs
`cf v3-create-app notify-deliver-worker-sender-email` run in all envs
This PR
https://github.com/alphagov/notifications-aws/pull/818
https://github.com/alphagov/notifications-paas-autoscaler/pull/105

We can then put up PRs to remove the `notify-deliver-worker-sender` app

## Pros and cons
- Will give us better control about at what rate we can send to our providers however this rate limit won't be perfect and will likely stop us sending at say 800rps to SES but not stop us at sending at 540rps.
- Is this benefit of better rate limiting to each provider even useful? We occasionally go slightly over our rate limit but we don't really overshoot it by masses so does it this actually provide much value?
- If we want to have exactly the same capacity as before we should allow the max that either sms or email sender workers scale to be 35. However, if both of them were to hit full instances at 35 we would have 70 instances which could use double the DB connections as before. We therefore have less control over the number of DB connections if we wish to allow for max sending rates at the same as before.
- Some tweaking to the autoscaling numbers will need to be done

## Main question
Is this a beneficial change that we want to go for?