### PR TITLE
Serialise content for broadcast templates

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -377,7 +377,6 @@ class TemplateSchemaNoDetail(TemplateSchema):
     class Meta(TemplateSchema.Meta):
         exclude = TemplateSchema.Meta.exclude + (
             'archived',
-            'content',
             'created_at',
             'created_by',
             'created_by_id',
@@ -395,6 +394,11 @@ class TemplateSchemaNoDetail(TemplateSchema):
             'version',
             'broadcast_data',
         )
+
+    @pre_dump
+    def remove_content_for_non_broadcast_templates(self, template):
+        if template.template_type != models.BROADCAST_TYPE:
+            template.content = None
 
 
 class TemplateHistorySchema(BaseSchema):

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -561,22 +561,37 @@ def test_should_get_return_all_fields_by_default(
     {'detailed': False},
     {'detailed': 'False'},
 ))
+@pytest.mark.parametrize('template_type, expected_content', (
+    (EMAIL_TYPE, None),
+    (SMS_TYPE, None),
+    (LETTER_TYPE, None),
+    (BROADCAST_TYPE, 'This is a test'),
+))
 def test_should_not_return_content_and_subject_if_requested(
     admin_request,
-    sample_email_template,
+    sample_service,
     extra_args,
+    template_type,
+    expected_content,
 ):
+    create_template(
+        sample_service,
+        template_type=template_type,
+        content='This is a test',
+    )
     json_response = admin_request.get(
         'template.get_all_templates_for_service',
-        service_id=sample_email_template.service.id,
+        service_id=sample_service.id,
         **extra_args
     )
     assert json_response['data'][0].keys() == {
+        'content',
         'folder',
         'id',
         'name',
         'template_type',
     }
+    assert json_response['data'][0]['content'] == expected_content
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Broadcast services only have broadcast templates. But on the frontend we show the template type under the name of the template. This is redundant. It would be better to preview the content of the template instead.

At the moment we can’t do this because we optimised the template schema response to not include the content of the templates in https://github.com/alphagov/notifications-api/pull/2880

This commit reverses that optimisation, for broadcast templates only. This should be OK, because broadcast services:
- shouldn’t have hundreds of templates
- have templates that are much shorter than the typical email or letter, because of the character restrictions of the broadcast medium