### PR TITLE
Temporarily do not send letters from Insolvency Service to DVLA

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -721,12 +721,16 @@ def dao_get_letters_to_be_printed(print_run_deadline, postage):
     """
     Return all letters created before the print run deadline that have not yet been sent
     """
-    notifications = Notification.query.filter(
+    notifications = Notification.query.join(
+        Service,
+        Notification.service_id == Service.id
+    ).filter(
         Notification.created_at < convert_bst_to_utc(print_run_deadline),
         Notification.notification_type == LETTER_TYPE,
         Notification.status == NOTIFICATION_CREATED,
         Notification.key_type == KEY_TYPE_NORMAL,
         Notification.postage == postage,
+        or_(Service.organisation_id != 'f33fdfdd-7533-40cb-b5e8-cd78a1f5d21e', Service.organisation_id.is_(None)),
     ).order_by(
         Notification.service_id,
         Notification.created_at

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -49,6 +49,7 @@ from app.models import (
 from tests.app.db import (
     create_job,
     create_notification,
+    create_organisation,
     create_service,
     create_template,
     create_notification_history
@@ -1695,3 +1696,30 @@ def test_letters_to_be_printed_sort_by_service(notify_db_session):
     results = dao_get_letters_to_be_printed(print_run_deadline=datetime(2020, 12, 1, 17, 30), postage='second')
     assert len(results) == 3
     assert results == [notification_1, notification_2, notification_3]
+
+
+def test_dao_get_letters_to_be_printed_does_not_fetch_insolvency_org_letters(notify_db_session):
+    insolvency_org = create_organisation(organisation_id='f33fdfdd-7533-40cb-b5e8-cd78a1f5d21e', name="Insolvency")
+    other_org = create_organisation(name="Other Org")
+    insolvency_service = create_service(
+        service_name='insolvency_service',
+        organisation=insolvency_org
+    )
+    no_org_service = create_service(
+        service_name='no_org_service'
+    )
+    other_org_service = create_service(
+        service_name='other_org_service',
+        organisation=other_org
+    )
+    first_template = create_template(service=insolvency_service, template_type='letter', postage='second')
+    second_template = create_template(service=no_org_service, template_type='letter', postage='second')
+    third_template = create_template(service=other_org_service, template_type='letter', postage='second')
+    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 9, 30))
+    notification_2 = create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 30))
+    notification_3 = create_notification(template=third_template, created_at=datetime(2020, 12, 1, 8, 30))
+
+    results = dao_get_letters_to_be_printed(print_run_deadline=datetime(2020, 12, 1, 17, 30), postage='second')
+    assert len(results) == 2
+    assert notification_2 in results
+    assert notification_3 in results

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -128,6 +128,7 @@ def create_service(
             created_by=user if user else create_user(email='{}@digital.cabinet-office.gov.uk'.format(uuid.uuid4())),
             prefix_sms=prefix_sms,
             organisation_type=organisation_type,
+            organisation=organisation,
             go_live_user=go_live_user,
             go_live_at=go_live_at,
             crown=crown
@@ -636,8 +637,9 @@ def create_domain(domain, organisation_id):
     return domain
 
 
-def create_organisation(name='test_org_1', active=True, organisation_type=None, domains=None):
+def create_organisation(name='test_org_1', active=True, organisation_type=None, domains=None, organisation_id=None):
     data = {
+        'id': organisation_id,
         'name': name,
         'active': active,
         'organisation_type': organisation_type,


### PR DESCRIPTION
This is a temporary measure over the weekend so that DVLA can catch up with all other letters.

We should revert this on Monday 19.10.2020