### PR TITLE
Add a task to save-api-sms for high volume services.

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -287,13 +287,23 @@ def save_email(self,
 
 @notify_celery.task(bind=True, name="save-api-email", max_retries=5, default_retry_delay=300)
 @statsd(namespace="tasks")
-def save_api_email(self,
-                   encrypted_notification,
-                   ):
+def save_api_email(self, encrypted_notification):
 
+    save_api_email_or_sms(self, encrypted_notification)
+
+
+@notify_celery.task(bind=True, name="save-api-sms", max_retries=5, default_retry_delay=300)
+@statsd(namespace="tasks")
+def save_api_sms(self, encrypted_notification):
+    save_api_email_or_sms(self, encrypted_notification)
+
+
+def save_api_email_or_sms(self, encrypted_notification):
     notification = encryption.decrypt(encrypted_notification)
     service = dao_fetch_service_by_id(notification['service_id'])
-
+    q = QueueNames.SEND_EMAIL if notification['notification_type'] == EMAIL_TYPE else QueueNames.SEND_SMS
+    provider_task = provider_tasks.deliver_email if notification['notification_type'] == EMAIL_TYPE \
+        else provider_tasks.deliver_sms
     try:
 
         persist_notification(
@@ -303,7 +313,7 @@ def save_api_email(self,
             recipient=notification['to'],
             service=service,
             personalisation=notification.get('personalisation'),
-            notification_type=EMAIL_TYPE,
+            notification_type=notification['notification_type'],
             client_reference=notification['client_reference'],
             api_key_id=notification.get('api_key_id'),
             key_type=KEY_TYPE_NORMAL,
@@ -313,14 +323,16 @@ def save_api_email(self,
             document_download_count=notification['document_download_count']
         )
 
-        q = QueueNames.SEND_EMAIL if not service.research_mode else QueueNames.RESEARCH_MODE
-        provider_tasks.deliver_email.apply_async(
+        q = q if not service.research_mode else QueueNames.RESEARCH_MODE
+        provider_task.apply_async(
             [notification['id']],
             queue=q
         )
-        current_app.logger.debug(f"Email {notification['id']} has been persisted and sent to delivery queue.")
+        current_app.logger.debug(
+            f"{notification['notification_type']} {notification['id']} has been persisted and sent to delivery queue."
+        )
     except IntegrityError:
-        current_app.logger.info(f"Email {notification['id']} already exists.")
+        current_app.logger.info(f"{notification['notification_type']} {notification['id']} already exists.")
 
     except SQLAlchemyError:
 

--- a/app/config.py
+++ b/app/config.py
@@ -32,6 +32,7 @@ class QueueNames(object):
     ANTIVIRUS = 'antivirus-tasks'
     SANITISE_LETTERS = 'sanitise-letter-tasks'
     SAVE_API_EMAIL = 'save-api-email-tasks'
+    SAVE_API_SMS = 'save-api-sms-tasks'
 
     @staticmethod
     def all_queues():
@@ -50,7 +51,8 @@ class QueueNames(object):
             QueueNames.CALLBACKS,
             QueueNames.LETTERS,
             QueueNames.SMS_CALLBACKS,
-            QueueNames.SAVE_API_EMAIL
+            QueueNames.SAVE_API_EMAIL,
+            QueueNames.SAVE_API_SMS
         ]
 
 

--- a/scripts/paas_app_wrapper.sh
+++ b/scripts/paas_app_wrapper.sh
@@ -51,7 +51,7 @@ case $NOTIFY_APP_NAME in
     ;;
   delivery-worker-save-api-notifications)
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
-    -Q save-api-email-tasks 2> /dev/null
+    -Q save-api-email-tasks, save-api-sms-tasks 2> /dev/null
     ;;
   delivery-celery-beat)
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery beat --loglevel=INFO

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -33,8 +33,9 @@ from app.celery.tasks import (
     s3,
     send_inbound_sms_to_service,
     process_returned_letters_list,
-    save_api_email,
     get_recipient_csv_and_template_and_sender_id,
+    save_api_email,
+    save_api_sms
 )
 from app.config import QueueNames
 from app.dao import jobs_dao, service_email_reply_to_dao, service_sms_sender_dao
@@ -1791,51 +1792,66 @@ def test_process_returned_letters_populates_returned_letters_table(
 
 
 @freeze_time('2020-03-25 14:30')
-def test_save_api_email(sample_email_template, mocker):
-    mock_send_email_to_provider = mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
-    api_key = create_api_key(service=sample_email_template.service)
+@pytest.mark.parametrize('notification_type', ['sms', 'email'])
+def test_save_api_email_or_sms(mocker, sample_service, notification_type):
+    template = create_template(sample_service) if notification_type == SMS_TYPE \
+        else create_template(sample_service, template_type=EMAIL_TYPE)
+    mock_provider_task = mocker.patch(f'app.celery.provider_tasks.deliver_{notification_type}.apply_async')
+    api_key = create_api_key(service=template.service)
     data = {
         "id": str(uuid.uuid4()),
-        "template_id": str(sample_email_template.id),
-        "template_version": sample_email_template.version,
-        "to": "jane.citizen@example.com",
-        "service_id": str(sample_email_template.service_id),
+        "template_id": str(template.id),
+        "template_version": template.version,
+        "service_id": str(template.service_id),
         "personalisation": None,
-        "notification_type": sample_email_template.template_type,
+        "notification_type": template.template_type,
         "api_key_id": str(api_key.id),
         "key_type": api_key.key_type,
         "client_reference": 'our email',
-        "reply_to_text": "our.email@gov.uk",
+        "reply_to_text": None,
         "document_download_count": 0,
         "status": NOTIFICATION_CREATED,
         "created_at": datetime.utcnow().strftime(DATETIME_FORMAT),
     }
+
+    if notification_type == EMAIL_TYPE:
+        data.update({"to": "jane.citizen@example.com"})
+        expected_queue = QueueNames.SEND_EMAIL
+    else:
+        data.update({"to": "+447700900855"})
+        expected_queue = QueueNames.SEND_SMS
 
     encrypted = encryption.encrypt(
         data
     )
 
     assert len(Notification.query.all()) == 0
-    save_api_email(encrypted)
+    if notification_type == EMAIL_TYPE:
+        save_api_email(encrypted_notification=encrypted)
+    else:
+        save_api_sms(encrypted_notification=encrypted)
     notifications = Notification.query.all()
     assert len(notifications) == 1
     assert str(notifications[0].id) == data['id']
     assert notifications[0].created_at == datetime(2020, 3, 25, 14, 30)
-    mock_send_email_to_provider.assert_called_once_with([data['id']], queue=QueueNames.SEND_EMAIL)
+    assert notifications[0].notification_type == notification_type
+    mock_provider_task.assert_called_once_with([data['id']], queue=expected_queue)
 
 
 @freeze_time('2020-03-25 14:30')
-def test_save_api_email_dont_retry_if_notification_already_exists(sample_email_template, mocker):
-    mock_send_email_to_provider = mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
-    api_key = create_api_key(service=sample_email_template.service)
+@pytest.mark.parametrize('notification_type', ['sms', 'email'])
+def test_save_api_email_dont_retry_if_notification_already_exists(sample_service, mocker, notification_type):
+    template = create_template(sample_service) if notification_type == SMS_TYPE \
+        else create_template(sample_service, template_type=EMAIL_TYPE)
+    mock_provider_task = mocker.patch(f'app.celery.provider_tasks.deliver_{notification_type}.apply_async')
+    api_key = create_api_key(service=template.service)
     data = {
         "id": str(uuid.uuid4()),
-        "template_id": str(sample_email_template.id),
-        "template_version": sample_email_template.version,
-        "to": "jane.citizen@example.com",
-        "service_id": str(sample_email_template.service_id),
+        "template_id": str(template.id),
+        "template_version": template.version,
+        "service_id": str(template.service_id),
         "personalisation": None,
-        "notification_type": sample_email_template.template_type,
+        "notification_type": template.template_type,
         "api_key_id": str(api_key.id),
         "key_type": api_key.key_type,
         "client_reference": 'our email',
@@ -1845,18 +1861,32 @@ def test_save_api_email_dont_retry_if_notification_already_exists(sample_email_t
         "created_at": datetime.utcnow().strftime(DATETIME_FORMAT),
     }
 
+    if notification_type == EMAIL_TYPE:
+        data.update({"to": "jane.citizen@example.com"})
+        expected_queue = QueueNames.SEND_EMAIL
+    else:
+        data.update({"to": "+447700900855"})
+        expected_queue = QueueNames.SEND_SMS
+
     encrypted = encryption.encrypt(
         data
     )
     assert len(Notification.query.all()) == 0
-    save_api_email(encrypted)
+
+    if notification_type == EMAIL_TYPE:
+        save_api_email(encrypted_notification=encrypted)
+    else:
+        save_api_sms(encrypted_notification=encrypted)
     notifications = Notification.query.all()
     assert len(notifications) == 1
     # call the task again with the same notification
-    save_api_email(encrypted)
+    if notification_type == EMAIL_TYPE:
+        save_api_email(encrypted_notification=encrypted)
+    else:
+        save_api_sms(encrypted_notification=encrypted)
     notifications = Notification.query.all()
     assert len(notifications) == 1
     assert str(notifications[0].id) == data['id']
     assert notifications[0].created_at == datetime(2020, 3, 25, 14, 30)
     # should only have sent the notification once.
-    mock_send_email_to_provider.assert_called_once_with([data['id']], queue=QueueNames.SEND_EMAIL)
+    mock_provider_task.assert_called_once_with([data['id']], queue=expected_queue)

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -60,7 +60,7 @@ def test_load_config_if_cloudfoundry_not_available(reload_config):
 def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()
-    assert len(queues) == 15
+    assert len(queues) == 16
     assert set([
         QueueNames.PRIORITY,
         QueueNames.PERIODIC,
@@ -76,5 +76,6 @@ def test_queue_names_all_queues_correct():
         QueueNames.CALLBACKS,
         QueueNames.LETTERS,
         QueueNames.SMS_CALLBACKS,
-        QueueNames.SAVE_API_EMAIL
+        QueueNames.SAVE_API_EMAIL,
+        QueueNames.SAVE_API_SMS
     ]) == set(queues)

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -29,6 +29,7 @@ from tests.app.db import (
     create_service_with_inbound_number,
     create_api_key
 )
+from tests.conftest import set_config_values
 
 
 @pytest.mark.parametrize("reference", [None, "reference_from_client"])
@@ -1029,131 +1030,147 @@ def test_post_email_notification_when_data_is_empty_returns_400(client, sample_s
         assert error_msg == 'email_address is a required property'
 
 
-def test_post_notifications_saves_sms_to_queue(client, notify_db_session, mocker):
-    save_task = mocker.patch("app.celery.tasks.save_api_sms.apply_async")
-    mock_send_task = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
+@pytest.mark.parametrize("notification_type", ("email", "sms"))
+def test_post_notifications_saves_email_or_sms_to_queue(client, notify_db_session, mocker, notification_type):
+    save_task = mocker.patch(f"app.celery.tasks.save_api_{notification_type}.apply_async")
+    mock_send_task = mocker.patch(f'app.celery.provider_tasks.deliver_{notification_type}.apply_async')
 
     service = create_service(
-        service_id=current_app.config['HIGH_VOLUME_SERVICE'][0],
-        service_name=f'high volume service',
-    )
-    template = create_template(service=service, content='((message))')
-    data = {
-        "phone_number": "+447700900855",
-        "template_id": template.id,
-        "personalisation": {"message": "Dear citizen, have a nice day"}
-    }
-
-    response = client.post(
-        path=f'/v2/notifications/sms',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), create_authorization_header(service_id=service.id)]
-    )
-
-    json_resp = response.get_json()
-
-    assert response.status_code == 201
-    assert json_resp['id']
-    assert json_resp['content']['body'] == "Dear citizen, have a nice day"
-    assert json_resp['template']['id'] == str(template.id)
-    save_task.assert_called_once_with([mock.ANY], queue='save-api-sms-tasks')
-    assert not mock_send_task.called
-    assert len(Notification.query.all()) == 0
-
-
-def test_post_notifications_saves_email_to_queue(client, notify_db_session, mocker):
-    save_email_task = mocker.patch("app.celery.tasks.save_api_email.apply_async")
-    mock_send_task = mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
-
-    service = create_service(
-        service_id=current_app.config['HIGH_VOLUME_SERVICE'][1],
         service_name='high volume service',
     )
-    template = create_template(service=service, content='((message))', template_type=EMAIL_TYPE)
-    data = {
-        "email_address": "joe.citizen@example.com",
-        "template_id": template.id,
-        "personalisation": {"message": "Dear citizen, have a nice day"}
-    }
-    response = client.post(
-        path='/v2/notifications/email',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), create_authorization_header(service_id=service.id)]
-    )
+    with set_config_values(current_app, {
+        'HIGH_VOLUME_SERVICE': [str(service.id)],
 
-    json_resp = response.get_json()
+    }):
+        template = create_template(service=service, content='((message))', template_type=notification_type)
+        data = {
+            "template_id": template.id,
+            "personalisation": {"message": "Dear citizen, have a nice day"}
+        }
+        data.update({"email_address": "joe.citizen@example.com"}) if notification_type == EMAIL_TYPE \
+            else data.update({"phone_number": "+447700900855"})
 
-    assert response.status_code == 201
-    assert json_resp['id']
-    assert json_resp['content']['body'] == "Dear citizen, have a nice day"
-    assert json_resp['template']['id'] == str(template.id)
-    save_email_task.assert_called_once_with([mock.ANY], queue='save-api-email-tasks')
-    assert not mock_send_task.called
-    assert len(Notification.query.all()) == 0
+        response = client.post(
+            path=f'/v2/notifications/{notification_type}',
+            data=json.dumps(data),
+            headers=[('Content-Type', 'application/json'), create_authorization_header(service_id=service.id)]
+        )
+
+        json_resp = response.get_json()
+
+        assert response.status_code == 201
+        assert json_resp['id']
+        assert json_resp['content']['body'] == "Dear citizen, have a nice day"
+        assert json_resp['template']['id'] == str(template.id)
+        save_task.assert_called_once_with([mock.ANY], queue=f'save-api-{notification_type}-tasks')
+        assert not mock_send_task.called
+        assert len(Notification.query.all()) == 0
 
 
-def test_post_notifications_saves_email_normally_if_save_email_to_queue_fails(client, notify_db_session, mocker):
-    save_email_task = mocker.patch(
-        "app.celery.tasks.save_api_email.apply_async",
+@pytest.mark.parametrize("notification_type", ("email", "sms"))
+def test_post_notifications_saves_email_or_sms_normally_if_saving_to_queue_fails(
+    client, notify_db_session, mocker, notification_type
+):
+    save_task = mocker.patch(
+        f"app.celery.tasks.save_api_{notification_type}.apply_async",
         side_effect=SQSError({'some': 'json'}, 'some opname')
     )
-    mock_send_task = mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
+    mock_send_task = mocker.patch(f'app.celery.provider_tasks.deliver_{notification_type}.apply_async')
 
     service = create_service(
-        service_id=current_app.config['HIGH_VOLUME_SERVICE'][2],
         service_name='high volume service',
     )
-    template = create_template(service=service, content='((message))', template_type=EMAIL_TYPE)
-    data = {
-        "email_address": "joe.citizen@example.com",
-        "template_id": template.id,
-        "personalisation": {"message": "Dear citizen, have a nice day"}
-    }
-    response = client.post(
-        path='/v2/notifications/email',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), create_authorization_header(service_id=service.id)]
-    )
+    with set_config_values(current_app, {
+        'HIGH_VOLUME_SERVICE': [str(service.id)],
 
-    json_resp = response.get_json()
+    }):
+        template = create_template(service=service, content='((message))', template_type=notification_type)
+        data = {
+            "template_id": template.id,
+            "personalisation": {"message": "Dear citizen, have a nice day"}
+        }
+        data.update({"email_address": "joe.citizen@example.com"}) if notification_type == EMAIL_TYPE \
+            else data.update({"phone_number": "+447700900855"})
 
-    assert response.status_code == 201
-    assert json_resp['id']
-    assert json_resp['content']['body'] == "Dear citizen, have a nice day"
-    assert json_resp['template']['id'] == str(template.id)
-    # save email
-    save_email_task.assert_called_once_with([mock.ANY], queue='save-api-email-tasks')
-    mock_send_task.assert_called_once_with([json_resp['id']], queue='send-email-tasks')
-    assert Notification.query.count() == 1
+        response = client.post(
+            path=f'/v2/notifications/{notification_type}',
+            data=json.dumps(data),
+            headers=[('Content-Type', 'application/json'), create_authorization_header(service_id=service.id)]
+        )
+
+        json_resp = response.get_json()
+
+        assert response.status_code == 201
+        assert json_resp['id']
+        assert json_resp['content']['body'] == "Dear citizen, have a nice day"
+        assert json_resp['template']['id'] == str(template.id)
+        save_task.assert_called_once_with([mock.ANY], queue=f'save-api-{notification_type}-tasks')
+        mock_send_task.assert_called_once_with([json_resp['id']], queue=f'send-{notification_type}-tasks')
+        assert Notification.query.count() == 1
 
 
-def test_post_notifications_doesnt_save_email_to_queue_for_test_emails(client, notify_db_session, mocker):
-    save_email_task = mocker.patch("app.celery.tasks.save_api_email.apply_async")
-    mock_send_task = mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
-
+@pytest.mark.parametrize("notification_type", ("email", "sms"))
+def test_post_notifications_doesnt_use_save_queue_for_test_notifications(
+    client, notify_db_session, mocker, notification_type
+):
+    save_task = mocker.patch(f"app.celery.tasks.save_api_{notification_type}.apply_async")
+    mock_send_task = mocker.patch(f'app.celery.provider_tasks.deliver_{notification_type}.apply_async')
     service = create_service(
-        service_id=current_app.config['HIGH_VOLUME_SERVICE'][3],
         service_name='high volume service',
     )
-    template = create_template(service=service, content='((message))', template_type=EMAIL_TYPE)
-    data = {
-        "email_address": "joe.citizen@example.com",
-        "template_id": template.id,
-        "personalisation": {"message": "Dear citizen, have a nice day"}
-    }
-    response = client.post(
-        path='/v2/notifications/email',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'),
-                 create_authorization_header(service_id=service.id, key_type='test')]
-    )
+    with set_config_values(current_app, {
+        'HIGH_VOLUME_SERVICE': [str(service.id)],
 
-    json_resp = response.get_json()
+    }):
+        template = create_template(service=service, content='((message))', template_type=notification_type)
+        data = {
+            "template_id": template.id,
+            "personalisation": {"message": "Dear citizen, have a nice day"}
+        }
+        data.update({"email_address": "joe.citizen@example.com"}) if notification_type == EMAIL_TYPE \
+            else data.update({"phone_number": "+447700900855"})
+        response = client.post(
+            path=f'/v2/notifications/{notification_type}',
+            data=json.dumps(data),
+            headers=[('Content-Type', 'application/json'),
+                     create_authorization_header(service_id=service.id, key_type='test')]
+        )
 
-    assert response.status_code == 201
-    assert json_resp['id']
-    assert json_resp['content']['body'] == "Dear citizen, have a nice day"
-    assert json_resp['template']['id'] == str(template.id)
-    assert mock_send_task.called
-    assert not save_email_task.called
-    assert len(Notification.query.all()) == 1
+        json_resp = response.get_json()
+
+        assert response.status_code == 201
+        assert json_resp['id']
+        assert json_resp['content']['body'] == "Dear citizen, have a nice day"
+        assert json_resp['template']['id'] == str(template.id)
+        assert mock_send_task.called
+        assert not save_task.called
+        assert len(Notification.query.all()) == 1
+
+
+def test_post_notification_does_not_use_save_queue_for_letters(client, sample_letter_template, mocker):
+    mock_save = mocker.patch("app.v2.notifications.post_notifications.save_email_or_sms_to_queue")
+    mock_create_pdf_task = mocker.patch('app.celery.tasks.letters_pdf_tasks.get_pdf_for_templated_letter.apply_async')
+
+    with set_config_values(current_app, {
+        'HIGH_VOLUME_SERVICE': [str(sample_letter_template.service_id)],
+
+    }):
+        data = {
+            'template_id': str(sample_letter_template.id),
+            'personalisation': {
+                'address_line_1': 'Her Royal Highness Queen Elizabeth II',
+                'address_line_2': 'Buckingham Palace',
+                'address_line_3': 'London',
+                'postcode': 'SW1 1AA',
+            }
+        }
+        response = client.post(
+            path='/v2/notifications/letter',
+            data=json.dumps(data),
+            headers=[('Content-Type', 'application/json'),
+                     create_authorization_header(service_id=sample_letter_template.service_id)]
+        )
+        assert response.status_code == 201
+        json_resp = response.get_json()
+        assert not mock_save.called
+        mock_create_pdf_task.assert_called_once_with([str(json_resp['id'])], queue='create-letters-pdf-tasks')


### PR DESCRIPTION
When we initially added a new task to persist the notifications for a high volume service we wanted to implement it as quickly as possible, so ignored SMS.
This will allow a high volume service to send SMS, the SMS will be sent to a queue to then persist and send the SMS, similar to emails.

At this point I haven't added a new application to consume the new save-api-sms-tasks. But we can add a separate application or be happy with how the app scales for both email and sms.

How to test:
Add a local service to the HIGH_VOLUME_SERVICE in app.config.Development or your source environment.sh, it's an array. Then post a sms and email from the python client using that service, need to use a live or team key. You should see the save-api-email-task or save-api-sms-task being called from the celery app. 