### PR TITLE
Remove upload letters permission from the database

### DIFF
--- a/migrations/versions/0332_remove_upload_letters.py
+++ b/migrations/versions/0332_remove_upload_letters.py
@@ -1,0 +1,34 @@
+"""
+
+Revision ID: 0332_remove_upload_letters_permission
+Revises: 0331_add_broadcast_org
+Create Date: 2020-09-23 10:11:01.094412
+
+"""
+from alembic import op
+
+revision = '0332_remove_upload_letters'
+down_revision = '0331_add_broadcast_org'
+
+PERMISSION = 'upload_letters'
+
+
+def upgrade():
+    op.execute(f"""
+        DELETE
+            FROM service_permissions
+        WHERE
+            permission = '{PERMISSION}'
+        ;
+    """)
+    op.execute(f"""
+        DELETE
+            FROM service_permission_types
+        WHERE
+            name = '{PERMISSION}'
+        ;
+    """)
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
The codebase no longer refers to it.

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/3001