### PR TITLE
Non-production environments invoke CBC Proxy during broadcast event creation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -23,6 +23,7 @@ from werkzeug.local import LocalProxy
 
 from app.celery.celery import NotifyCelery
 from app.clients import Clients
+from app.clients.cbc_proxy import CBCProxyClient, CBCProxyNoopClient
 from app.clients.document_download import DocumentDownloadClient
 from app.clients.email.aws_ses import AwsSesClient
 from app.clients.email.aws_ses_stub import AwsSesStubClient
@@ -60,6 +61,7 @@ zendesk_client = ZendeskClient()
 statsd_client = StatsdClient()
 redis_store = RedisClient()
 performance_platform_client = PerformancePlatformClient()
+cbc_proxy_client = CBCProxyNoopClient()
 document_download_client = DocumentDownloadClient()
 metrics = GDSMetrics()
 
@@ -111,6 +113,10 @@ def create_app(application):
     redis_store.init_app(application)
     performance_platform_client.init_app(application)
     document_download_client.init_app(application)
+
+    if application.config['CBC_PROXY_AWS_ACCESS_KEY_ID']:
+        cbc_proxy_client = CBCProxyClient()
+    cbc_proxy_client.init_app(application)
 
     register_blueprint(application)
     register_v2_blueprints(application)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -114,6 +114,7 @@ def create_app(application):
     performance_platform_client.init_app(application)
     document_download_client.init_app(application)
 
+    global cbc_proxy_client
     if application.config['CBC_PROXY_AWS_ACCESS_KEY_ID']:
         cbc_proxy_client = CBCProxyClient()
     cbc_proxy_client.init_app(application)

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -2,8 +2,9 @@ import requests
 from flask import current_app
 from notifications_utils.statsd_decorators import statsd
 
-from app import notify_celery
+from app import cbc_proxy_client, notify_celery
 
+from app.models import BroadcastEventMessageType
 from app.dao.broadcast_message_dao import dao_get_broadcast_event_by_id
 
 
@@ -11,6 +12,19 @@ from app.dao.broadcast_message_dao import dao_get_broadcast_event_by_id
 @statsd(namespace="tasks")
 def send_broadcast_event(broadcast_event_id, provider='stub-1'):
     broadcast_event = dao_get_broadcast_event_by_id(broadcast_event_id)
+
+    if broadcast_event.message_type == BroadcastEventMessageType.ALERT:
+        current_app.logger.info(
+            f'invoking cbc proxy to send '
+            f'broadcast_event {broadcast_event.reference} '
+            f'msgType {broadcast_event.message_type} to {provider}'
+        )
+
+        cbc_proxy_client.create_and_send_broadcast(
+            identifier=str(broadcast_event.id),
+            headline="GOV.UK Notify Broadcast",
+            description=broadcast_event.transmitted_content['body'],
+        )
 
     current_app.logger.info(
         f'sending broadcast_event {broadcast_event.reference} '

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -1,0 +1,59 @@
+# Noop = no operation
+class CBCProxyNoopClient:
+
+    def init_app(self, app):
+        pass
+
+    def create_and_send_broadcast(
+        self,
+        identifier, headline, description,
+    ):
+        # identifier=broadcast_message.identifier,
+        # headline="GOV.UK Notify Broadcast",
+        # description=broadcast_message.description,
+        pass
+
+    # We have not implementated updating a broadcast
+    def update_and_send_broadcast(
+        self,
+        identifier, references, headline, description,
+    ):
+        pass
+
+    # We have not implemented cancelling a broadcast
+    def cancel_broadcast(
+        self,
+        identifier, references, headline, description,
+    ):
+        pass
+
+
+class CBCProxyClient:
+
+    def init_app(self, app):
+        self.aws_access_key_id = app.config['CBC_PROXY_AWS_ACCESS_KEY_ID']
+        self.aws_secret_access_key = app.config['CBC_PROXY_AWS_SECRET_ACCESS_KEY']
+        self.aws_region = 'eu-west-2'
+
+    def create_and_send_broadcast(
+        self,
+        identifier, headline, description,
+    ):
+        # identifier=broadcast_message.identifier,
+        # headline="GOV.UK Notify Broadcast",
+        # description=broadcast_message.description,
+        pass
+
+    # We have not implementated updating a broadcast
+    def update_and_send_broadcast(
+        self,
+        identifier, references, headline, description,
+    ):
+        pass
+
+    # We have not implemented cancelling a broadcast
+    def cancel_broadcast(
+        self,
+        identifier, references, headline, description,
+    ):
+        pass

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -46,7 +46,7 @@ class CBCProxyNoopClient:
 class CBCProxyClient:
 
     def init_app(self, app):
-        self._ld_client = boto3.client(
+        self._lambda_client = boto3.client(
             'lambda',
             region_name='eu-west-2',
             aws_access_key_id=app.config['CBC_PROXY_AWS_ACCESS_KEY_ID'],
@@ -63,7 +63,7 @@ class CBCProxyClient:
             'description': description,
         }), encoding='utf8')
 
-        result = self._ld_client.invoke(
+        result = self._lambda_client.invoke(
             FunctionName='bt-ee-1-proxy',
             InvocationType='RequestResponse',
             Payload=payload_bytes,

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -52,12 +52,17 @@ class CBCProxyClient:
             'description': description,
         }), encoding='utf8')
 
-        self._ld_client.invoke(
+        result = self._ld_client.invoke(
             FunctionName='bt-ee-1-proxy',
             InvocationType='RequestResponse',
             Payload=payload_bytes,
         )
-        pass
+
+        if result['StatusCode'] > 299:
+            raise Exception('Could not invoke lambda')
+
+        if 'FunctionError' in result:
+            raise Exception('Function exited with unhandled exception')
 
     # We have not implementated updating a broadcast
     def update_and_send_broadcast(

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -1,3 +1,5 @@
+import json
+
 import boto3
 
 # Noop = no operation
@@ -44,9 +46,17 @@ class CBCProxyClient:
         self,
         identifier, headline, description,
     ):
-        # identifier=broadcast_message.identifier,
-        # headline="GOV.UK Notify Broadcast",
-        # description=broadcast_message.description,
+        payload_bytes = bytes(json.dumps({
+            'identifier': identifier,
+            'headline': headline,
+            'description': description,
+        }), encoding='utf8')
+
+        self._ld_client.invoke(
+            FunctionName='bt-ee-1-proxy',
+            InvocationType='RequestResponse',
+            Payload=payload_bytes,
+        )
         pass
 
     # We have not implementated updating a broadcast

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -2,6 +2,19 @@ import json
 
 import boto3
 
+# The variable names in this file have specific meaning in a CAP message
+#
+# identifier is a unique field for each CAP message
+#
+# headline is a field which we are not sure if we will use
+#
+# description is the body of the message
+#
+# references is a whitespace separated list of message identifiers
+# where each identifier is a previous sent message
+# ie a Cancel message would have a unique identifier but have the identifier of
+#    the preceeding Alert message in the references field
+
 
 # Noop = no operation
 class CBCProxyNoopClient:
@@ -13,9 +26,6 @@ class CBCProxyNoopClient:
         self,
         identifier, headline, description,
     ):
-        # identifier=broadcast_message.identifier,
-        # headline="GOV.UK Notify Broadcast",
-        # description=broadcast_message.description,
         pass
 
     # We have not implementated updating a broadcast

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -33,7 +33,7 @@ class CBCProxyNoopClient:
 class CBCProxyClient:
 
     def init_app(self, app):
-        self._lambda_client = boto3.client(
+        self._ld_client = boto3.client(
             'lambda',
             region_name='eu-west-2',
             aws_access_key_id=app.config['CBC_PROXY_AWS_ACCESS_KEY_ID'],

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -1,3 +1,5 @@
+import boto3
+
 # Noop = no operation
 class CBCProxyNoopClient:
 
@@ -31,9 +33,12 @@ class CBCProxyNoopClient:
 class CBCProxyClient:
 
     def init_app(self, app):
-        self.aws_access_key_id = app.config['CBC_PROXY_AWS_ACCESS_KEY_ID']
-        self.aws_secret_access_key = app.config['CBC_PROXY_AWS_SECRET_ACCESS_KEY']
-        self.aws_region = 'eu-west-2'
+        self._lambda_client = boto3.client(
+            'lambda',
+            region_name='eu-west-2',
+            aws_access_key_id=app.config['CBC_PROXY_AWS_ACCESS_KEY_ID'],
+            aws_secret_access_key=app.config['CBC_PROXY_AWS_SECRET_ACCESS_KEY'],
+        )
 
     def create_and_send_broadcast(
         self,

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -2,6 +2,7 @@ import json
 
 import boto3
 
+
 # Noop = no operation
 class CBCProxyNoopClient:
 

--- a/app/config.py
+++ b/app/config.py
@@ -353,6 +353,11 @@ class Config(object):
 
     AWS_REGION = 'eu-west-1'
 
+    # CBC Proxy
+    # if the access keys are empty then noop client is used
+    CBC_PROXY_AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', '')
+    CBC_PROXY_AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', '')
+
 
 ######################
 # Config overrides ###

--- a/app/config.py
+++ b/app/config.py
@@ -355,8 +355,8 @@ class Config(object):
 
     # CBC Proxy
     # if the access keys are empty then noop client is used
-    CBC_PROXY_AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', '')
-    CBC_PROXY_AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', '')
+    CBC_PROXY_AWS_ACCESS_KEY_ID = os.environ.get('CBC_PROXY_AWS_ACCESS_KEY_ID', '')
+    CBC_PROXY_AWS_SECRET_ACCESS_KEY = os.environ.get('CBC_PROXY_AWS_SECRET_ACCESS_KEY', '')
 
 
 ######################

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -125,6 +125,11 @@ applications:
       AWS_ACCESS_KEY_ID: '{{ AWS_ACCESS_KEY_ID }}'
       AWS_SECRET_ACCESS_KEY: '{{ AWS_SECRET_ACCESS_KEY }}'
 
+      {% if CBC_PROXY_AWS_ACCESS_KEY_ID is defined %}
+      CBC_PROXY_AWS_ACCESS_KEY_ID: '{{ CBC_PROXY_AWS_ACCESS_KEY_ID }}'
+      CBC_PROXY_AWS_SECRET_ACCESS_KEY: '{{ CBC_PROXY_AWS_SECRET_ACCESS_KEY }}'
+      {% endif %}
+
       STATSD_HOST: "notify-statsd-exporter-{{ environment }}.apps.internal"
 
       ZENDESK_API_KEY: '{{ ZENDESK_API_KEY }}'

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -18,7 +18,6 @@ def cbc_proxy(client, mocker):
 
 def test_cbc_proxy_ld_client_has_correct_region(cbc_proxy):
     assert cbc_proxy._ld_client._client_config.region_name == 'eu-west-2'
-    pass
 
 
 def test_cbc_proxy_ld_client_has_correct_keys(cbc_proxy):

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -16,13 +16,13 @@ def cbc_proxy(client, mocker):
     return client
 
 
-def test_cbc_proxy_ld_client_has_correct_region(cbc_proxy):
-    assert cbc_proxy._ld_client._client_config.region_name == 'eu-west-2'
+def test_cbc_proxy_lambda_client_has_correct_region(cbc_proxy):
+    assert cbc_proxy._lambda_client._client_config.region_name == 'eu-west-2'
 
 
-def test_cbc_proxy_ld_client_has_correct_keys(cbc_proxy):
-    key = cbc_proxy._ld_client._request_signer._credentials.access_key
-    secret = cbc_proxy._ld_client._request_signer._credentials.secret_key
+def test_cbc_proxy_lambda_client_has_correct_keys(cbc_proxy):
+    key = cbc_proxy._lambda_client._request_signer._credentials.access_key
+    secret = cbc_proxy._lambda_client._request_signer._credentials.secret_key
 
     assert key == 'cbc-proxy-aws-access-key-id'
     assert secret == 'cbc-proxy-aws-secret-access-key'
@@ -35,7 +35,7 @@ def test_cbc_proxy_create_and_send_invokes_function(mocker, cbc_proxy):
 
     ld_client_mock = mocker.patch.object(
         cbc_proxy,
-        '_ld_client',
+        '_lambda_client',
         create=True,
     )
 
@@ -71,7 +71,7 @@ def test_cbc_proxy_create_and_send_handles_invoke_error(mocker, cbc_proxy):
 
     ld_client_mock = mocker.patch.object(
         cbc_proxy,
-        '_ld_client',
+        '_lambda_client',
         create=True,
     )
 
@@ -102,7 +102,7 @@ def test_cbc_proxy_create_and_send_handles_function_error(mocker, cbc_proxy):
 
     ld_client_mock = mocker.patch.object(
         cbc_proxy,
-        '_ld_client',
+        '_lambda_client',
         create=True,
     )
 

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from app.clients.cbc_proxy import CBCProxyClient
@@ -25,3 +27,35 @@ def test_cbc_proxy_ld_client_has_correct_keys(cbc_proxy):
 
     assert key == 'cbc-proxy-aws-access-key-id'
     assert secret == 'cbc-proxy-aws-secret-access-key'
+
+
+def test_cbc_proxy_create_and_send_invokes_function(mocker, cbc_proxy):
+    identifier = 'my-identifier'
+    headline = 'my-headline'
+    description = 'my-description'
+
+    ld_client_mock = mocker.patch.object(
+        cbc_proxy,
+        '_ld_client',
+        create=True,
+    )
+
+    cbc_proxy.create_and_send_broadcast(
+        identifier=identifier,
+        headline=headline,
+        description=description,
+    )
+
+    ld_client_mock.invoke.assert_called_once_with(
+        FunctionName='bt-ee-1-proxy',
+        InvocationType='RequestResponse',
+        Payload=mocker.ANY,
+    )
+
+    kwargs = ld_client_mock.invoke.mock_calls[0][-1]
+    payload_bytes = kwargs['Payload']
+    payload = json.loads(payload_bytes)
+
+    assert payload['identifier'] == identifier
+    assert payload['headline'] == headline
+    assert payload['description'] == description

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -1,0 +1,27 @@
+import pytest
+
+from app.clients.cbc_proxy import CBCProxyClient
+
+
+@pytest.fixture(scope='function')
+def cbc_proxy(client, mocker):
+    client = CBCProxyClient()
+    current_app = mocker.Mock(config={
+        'CBC_PROXY_AWS_ACCESS_KEY_ID': 'cbc-proxy-aws-access-key-id',
+        'CBC_PROXY_AWS_SECRET_ACCESS_KEY': 'cbc-proxy-aws-secret-access-key',
+    })
+    client.init_app(current_app)
+    return client
+
+
+def test_cbc_proxy_lambda_client_has_correct_region(cbc_proxy):
+    assert cbc_proxy._lambda_client._client_config.region_name == 'eu-west-2'
+    pass
+
+
+def test_cbc_proxy_lambda_client_has_correct_keys(cbc_proxy):
+    key = cbc_proxy._lambda_client._request_signer._credentials.access_key
+    secret = cbc_proxy._lambda_client._request_signer._credentials.secret_key
+
+    assert key == 'cbc-proxy-aws-access-key-id'
+    assert secret == 'cbc-proxy-aws-secret-access-key'

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -14,14 +14,14 @@ def cbc_proxy(client, mocker):
     return client
 
 
-def test_cbc_proxy_lambda_client_has_correct_region(cbc_proxy):
-    assert cbc_proxy._lambda_client._client_config.region_name == 'eu-west-2'
+def test_cbc_proxy_ld_client_has_correct_region(cbc_proxy):
+    assert cbc_proxy._ld_client._client_config.region_name == 'eu-west-2'
     pass
 
 
-def test_cbc_proxy_lambda_client_has_correct_keys(cbc_proxy):
-    key = cbc_proxy._lambda_client._request_signer._credentials.access_key
-    secret = cbc_proxy._lambda_client._request_signer._credentials.secret_key
+def test_cbc_proxy_ld_client_has_correct_keys(cbc_proxy):
+    key = cbc_proxy._ld_client._request_signer._credentials.access_key
+    secret = cbc_proxy._ld_client._request_signer._credentials.secret_key
 
     assert key == 'cbc-proxy-aws-access-key-id'
     assert secret == 'cbc-proxy-aws-secret-access-key'

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -29,6 +29,7 @@ def test_cbc_proxy_ld_client_has_correct_keys(cbc_proxy):
     assert secret == 'cbc-proxy-aws-secret-access-key'
 
 
+
 def test_cbc_proxy_create_and_send_invokes_function(mocker, cbc_proxy):
     identifier = 'my-identifier'
     headline = 'my-headline'
@@ -39,6 +40,10 @@ def test_cbc_proxy_create_and_send_invokes_function(mocker, cbc_proxy):
         '_ld_client',
         create=True,
     )
+
+    ld_client_mock.invoke.return_value = {
+        'StatusCode': 200,
+    }
 
     cbc_proxy.create_and_send_broadcast(
         identifier=identifier,


### PR DESCRIPTION
What
----

When a broadcast is approved, and a new Broadcast Event is despatched with status`ALERT` we want to invoke the CBC Proxy which will generate a CAP XML message and send it to the CBC

Checklist
----

* [x] Plumbing up client to app
* [x] Celery task invokes CBC Proxy client when necessary
* [x] CBC Proxy client invokes AWS lambda function

Pair
----

@klssmith @CrystalPea 