### PR TITLE
Start sending letters from Insolvency Service to DVLA again

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -181,6 +181,10 @@ def get_key_and_size_of_letters_to_be_sent_to_print(print_run_deadline, postage)
     letter_pdfs = []
     for letter in letters_awaiting_sending:
         try:
+            if str(letter.service.organisation_id) == 'f33fdfdd-7533-40cb-b5e8-cd78a1f5d21e':
+                letter_service_marking = str(letter.service.id) + ".INSOLVENCY"
+            else:
+                letter_service_marking = str(letter.service.id)
             letter_file_name = get_letter_pdf_filename(
                 reference=letter.reference,
                 crown=letter.service.crown,
@@ -191,7 +195,7 @@ def get_key_and_size_of_letters_to_be_sent_to_print(print_run_deadline, postage)
             letter_pdfs.append({
                 "Key": letter_file_name,
                 "Size": letter_head['ContentLength'],
-                "ServiceId": str(letter.service.id)
+                "ServiceId": letter_service_marking
             })
         except BotoClientError as e:
             current_app.logger.exception(

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -721,16 +721,12 @@ def dao_get_letters_to_be_printed(print_run_deadline, postage):
     """
     Return all letters created before the print run deadline that have not yet been sent
     """
-    notifications = Notification.query.join(
-        Service,
-        Notification.service_id == Service.id
-    ).filter(
+    notifications = Notification.query.filter(
         Notification.created_at < convert_bst_to_utc(print_run_deadline),
         Notification.notification_type == LETTER_TYPE,
         Notification.status == NOTIFICATION_CREATED,
         Notification.key_type == KEY_TYPE_NORMAL,
-        Notification.postage == postage,
-        or_(Service.organisation_id != 'f33fdfdd-7533-40cb-b5e8-cd78a1f5d21e', Service.organisation_id.is_(None)),
+        Notification.postage == postage
     ).order_by(
         Notification.service_id,
         Notification.created_at

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -179,7 +179,7 @@ def _sample_service_full_permissions(notify_db_session):
     service = create_service(
         service_name="sample service full permissions",
         service_permissions=set(SERVICE_PERMISSION_TYPES),
-        check_if_service_exists=True
+        check_if_service_exists=True,
     )
     create_inbound_number('12345', service_id=service.id)
     return service

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -49,7 +49,6 @@ from app.models import (
 from tests.app.db import (
     create_job,
     create_notification,
-    create_organisation,
     create_service,
     create_template,
     create_notification_history
@@ -1696,30 +1695,3 @@ def test_letters_to_be_printed_sort_by_service(notify_db_session):
     results = dao_get_letters_to_be_printed(print_run_deadline=datetime(2020, 12, 1, 17, 30), postage='second')
     assert len(results) == 3
     assert results == [notification_1, notification_2, notification_3]
-
-
-def test_dao_get_letters_to_be_printed_does_not_fetch_insolvency_org_letters(notify_db_session):
-    insolvency_org = create_organisation(organisation_id='f33fdfdd-7533-40cb-b5e8-cd78a1f5d21e', name="Insolvency")
-    other_org = create_organisation(name="Other Org")
-    insolvency_service = create_service(
-        service_name='insolvency_service',
-        organisation=insolvency_org
-    )
-    no_org_service = create_service(
-        service_name='no_org_service'
-    )
-    other_org_service = create_service(
-        service_name='other_org_service',
-        organisation=other_org
-    )
-    first_template = create_template(service=insolvency_service, template_type='letter', postage='second')
-    second_template = create_template(service=no_org_service, template_type='letter', postage='second')
-    third_template = create_template(service=other_org_service, template_type='letter', postage='second')
-    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 9, 30))
-    notification_2 = create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 30))
-    notification_3 = create_notification(template=third_template, created_at=datetime(2020, 12, 1, 8, 30))
-
-    results = dao_get_letters_to_be_printed(print_run_deadline=datetime(2020, 12, 1, 17, 30), postage='second')
-    assert len(results) == 2
-    assert notification_2 in results
-    assert notification_3 in results


### PR DESCRIPTION
Reintroduce the sending of Insolvency letters to DVLA and mark ZIP files with insolvency letters so DVLA knows to process those separately.

Review commit by commit.