### PR TITLE
clients: cbc_proxy actions accepts areas param

### DIFF
--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -20,10 +20,19 @@ def send_broadcast_event(broadcast_event_id, provider='stub-1'):
             f'msgType {broadcast_event.message_type} to {provider}'
         )
 
+        areas = [
+            {"description": desc, "polygon": polygon}
+            for desc, polygon in zip(
+                broadcast_event.transmitted_areas["areas"],
+                broadcast_event.transmitted_areas["simple_polygons"],
+            )
+        ]
+
         cbc_proxy_client.create_and_send_broadcast(
             identifier=str(broadcast_event.id),
             headline="GOV.UK Notify Broadcast",
             description=broadcast_event.transmitted_content['body'],
+            areas=areas,
         )
 
     current_app.logger.info(

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -9,6 +9,10 @@ import boto3
 # headline is a field which we are not sure if we will use
 #
 # description is the body of the message
+
+# areas is a list of dicts, with the following items
+# * description is a string which populates the areaDesc field
+# * polygon is a list of lat/long pairs
 #
 # references is a whitespace separated list of message identifiers
 # where each identifier is a previous sent message
@@ -24,21 +28,21 @@ class CBCProxyNoopClient:
 
     def create_and_send_broadcast(
         self,
-        identifier, headline, description,
+        identifier, headline, description, areas
     ):
         pass
 
     # We have not implementated updating a broadcast
     def update_and_send_broadcast(
         self,
-        identifier, references, headline, description,
+        identifier, references, headline, description, areas
     ):
         pass
 
     # We have not implemented cancelling a broadcast
     def cancel_broadcast(
         self,
-        identifier, references, headline, description,
+        identifier, references, headline, description, areas
     ):
         pass
 
@@ -55,12 +59,13 @@ class CBCProxyClient:
 
     def create_and_send_broadcast(
         self,
-        identifier, headline, description,
+        identifier, headline, description, areas,
     ):
         payload_bytes = bytes(json.dumps({
             'identifier': identifier,
             'headline': headline,
             'description': description,
+            'areas': areas,
         }), encoding='utf8')
 
         result = self._lambda_client.invoke(
@@ -78,13 +83,13 @@ class CBCProxyClient:
     # We have not implementated updating a broadcast
     def update_and_send_broadcast(
         self,
-        identifier, references, headline, description,
+        identifier, references, headline, description, areas,
     ):
         pass
 
     # We have not implemented cancelling a broadcast
     def cancel_broadcast(
         self,
-        identifier, references, headline, description,
+        identifier, references, headline, description, areas,
     ):
         pass

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -30,6 +30,10 @@ def test_send_broadcast_event_sends_data_correctly(mocker, sample_service):
         identifier=str(event.id),
         headline="GOV.UK Notify Broadcast",
         description='this is an emergency broadcast message',
+        areas=[{
+            "description": "london",
+            "polygon": [[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]],
+        }]
     )
 
     assert request_mock.call_count == 1
@@ -93,4 +97,12 @@ def test_send_broadcast_event_errors(mocker, sample_service):
         identifier=str(event.id),
         headline="GOV.UK Notify Broadcast",
         description='this is an emergency broadcast message',
+        areas=[{
+            'description': 'london',
+            'polygon': [
+                [50.12, 1.2],
+                [50.13, 1.2],
+                [50.14, 1.21],
+            ],
+        }],
     )

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -33,6 +33,18 @@ def test_cbc_proxy_create_and_send_invokes_function(mocker, cbc_proxy):
     headline = 'my-headline'
     description = 'my-description'
 
+    # a single area which is a square including london
+    areas = [{
+        'description': 'london',
+        'polygon': [
+            [51.12, -1.2],
+            [51.12, 1.2],
+            [51.74, 1.2],
+            [51.74, -1.2],
+            [51.12, -1.2],
+        ],
+    }]
+
     ld_client_mock = mocker.patch.object(
         cbc_proxy,
         '_lambda_client',
@@ -47,6 +59,7 @@ def test_cbc_proxy_create_and_send_invokes_function(mocker, cbc_proxy):
         identifier=identifier,
         headline=headline,
         description=description,
+        areas=areas,
     )
 
     ld_client_mock.invoke.assert_called_once_with(
@@ -62,12 +75,25 @@ def test_cbc_proxy_create_and_send_invokes_function(mocker, cbc_proxy):
     assert payload['identifier'] == identifier
     assert payload['headline'] == headline
     assert payload['description'] == description
+    assert payload['areas'] == areas
 
 
 def test_cbc_proxy_create_and_send_handles_invoke_error(mocker, cbc_proxy):
     identifier = 'my-identifier'
     headline = 'my-headline'
     description = 'my-description'
+
+    # a single area which is a square including london
+    areas = [{
+        'description': 'london',
+        'polygon': [
+            [51.12, -1.2],
+            [51.12, 1.2],
+            [51.74, 1.2],
+            [51.74, -1.2],
+            [51.12, -1.2],
+        ],
+    }]
 
     ld_client_mock = mocker.patch.object(
         cbc_proxy,
@@ -84,6 +110,7 @@ def test_cbc_proxy_create_and_send_handles_invoke_error(mocker, cbc_proxy):
             identifier=identifier,
             headline=headline,
             description=description,
+            areas=areas,
         )
 
     assert e.match('Could not invoke lambda')
@@ -99,6 +126,18 @@ def test_cbc_proxy_create_and_send_handles_function_error(mocker, cbc_proxy):
     identifier = 'my-identifier'
     headline = 'my-headline'
     description = 'my-description'
+
+    # a single area which is a square including london
+    areas = [{
+        'description': 'london',
+        'polygon': [
+            [51.12, -1.2],
+            [51.12, 1.2],
+            [51.74, 1.2],
+            [51.74, -1.2],
+            [51.12, -1.2],
+        ],
+    }]
 
     ld_client_mock = mocker.patch.object(
         cbc_proxy,
@@ -116,6 +155,7 @@ def test_cbc_proxy_create_and_send_handles_function_error(mocker, cbc_proxy):
             identifier=identifier,
             headline=headline,
             description=description,
+            areas=areas,
         )
 
         assert e.match('Function exited with unhandled exception')


### PR DESCRIPTION
What
----

Related to https://github.com/alphagov/notifications-broadcasts-infra/pull/23

Currently when we send an alert, the area is hardcoded to a large area around London

This PR passes through the area names and transmitted areas from the `BroadcastEvent` to the CBC Proxy function, so that when we choose an area, it is reflected in the generated CAP XML