### PR TITLE
Remove references to stub CBC

### DIFF
--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -1,4 +1,3 @@
-import requests
 from flask import current_app
 from notifications_utils.statsd_decorators import statsd
 
@@ -10,45 +9,43 @@ from app.dao.broadcast_message_dao import dao_get_broadcast_event_by_id
 
 @notify_celery.task(name="send-broadcast-event")
 @statsd(namespace="tasks")
-def send_broadcast_event(broadcast_event_id, provider='stub-1'):
+def send_broadcast_event(broadcast_event_id):
     broadcast_event = dao_get_broadcast_event_by_id(broadcast_event_id)
 
-    if broadcast_event.message_type == BroadcastEventMessageType.ALERT:
-        current_app.logger.info(
-            f'invoking cbc proxy to send '
-            f'broadcast_event {broadcast_event.reference} '
-            f'msgType {broadcast_event.message_type} to {provider}'
+    current_app.logger.info(
+        f'invoking cbc proxy to send '
+        f'broadcast_event {broadcast_event.reference} '
+        f'msgType {broadcast_event.message_type}'
+    )
+
+    areas = [
+        {"description": desc, "polygon": polygon}
+        for desc, polygon in zip(
+            broadcast_event.transmitted_areas["areas"],
+            broadcast_event.transmitted_areas["simple_polygons"],
         )
+    ]
 
-        areas = [
-            {"description": desc, "polygon": polygon}
-            for desc, polygon in zip(
-                broadcast_event.transmitted_areas["areas"],
-                broadcast_event.transmitted_areas["simple_polygons"],
-            )
-        ]
-
+    if broadcast_event.message_type == BroadcastEventMessageType.ALERT:
         cbc_proxy_client.create_and_send_broadcast(
             identifier=str(broadcast_event.id),
             headline="GOV.UK Notify Broadcast",
             description=broadcast_event.transmitted_content['body'],
             areas=areas,
         )
-
-    current_app.logger.info(
-        f'sending broadcast_event {broadcast_event.reference} '
-        f'msgType {broadcast_event.message_type} to {provider}'
-    )
-
-    payload = broadcast_event.serialize()
-
-    resp = requests.post(
-        f'{current_app.config["CBC_PROXY_URL"]}/broadcasts/events/{provider}',
-        json=payload
-    )
-    resp.raise_for_status()
-
-    current_app.logger.info(
-        f'broadcast_event {broadcast_event.reference} '
-        f'msgType {broadcast_event.message_type} sent to {provider}'
-    )
+    elif broadcast_event.message_type == BroadcastEventMessageType.UPDATE:
+        cbc_proxy_client.update_and_send_broadcast(
+            identifier=str(broadcast_event.id),
+            headline="GOV.UK Notify Broadcast",
+            description=broadcast_event.transmitted_content['body'],
+            areas=areas,
+            references=broadcast_event.get_earlier_message_references(),
+        )
+    elif broadcast_event.message_type == BroadcastEventMessageType.CANCEL:
+        cbc_proxy_client.cancel_broadcast(
+            identifier=str(broadcast_event.id),
+            headline="GOV.UK Notify Broadcast",
+            description=broadcast_event.transmitted_content['body'],
+            areas=areas,
+            references=broadcast_event.get_earlier_message_references(),
+        )

--- a/app/config.py
+++ b/app/config.py
@@ -112,9 +112,6 @@ class Config(object):
     # Antivirus
     ANTIVIRUS_ENABLED = True
 
-    # Broadcast Messaging
-    CBC_PROXY_URL = None
-
     ###########################
     # Default config values ###
     ###########################
@@ -402,8 +399,6 @@ class Development(Config):
     API_HOST_NAME = "http://localhost:6011"
     API_RATE_LIMIT_ENABLED = True
 
-    CBC_PROXY_URL = 'http://localhost:8080'
-
 
 class Test(Development):
     NOTIFY_EMAIL_DOMAIN = 'test.notify.com'
@@ -447,8 +442,6 @@ class Test(Development):
     FIRETEXT_INBOUND_SMS_AUTH = ['testkey']
     TEMPLATE_PREVIEW_API_HOST = 'http://localhost:9999'
 
-    CBC_PROXY_URL = 'http://test-cbc-proxy'
-
     MMG_URL = 'https://example.com/mmg'
     FIRETEXT_URL = 'https://example.com/firetext'
 
@@ -465,7 +458,6 @@ class Preview(Config):
     INVALID_PDF_BUCKET_NAME = 'preview-letters-invalid-pdf'
     TRANSIENT_UPLOADED_LETTERS = 'preview-transient-uploaded-letters'
     LETTER_SANITISE_BUCKET_NAME = 'preview-letters-sanitise'
-    CBC_PROXY_URL = 'https://notify-stub-cbc-preview.cloudapps.digital'
     FROM_NUMBER = 'preview'
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = False
@@ -483,7 +475,6 @@ class Staging(Config):
     INVALID_PDF_BUCKET_NAME = 'staging-letters-invalid-pdf'
     TRANSIENT_UPLOADED_LETTERS = 'staging-transient-uploaded-letters'
     LETTER_SANITISE_BUCKET_NAME = 'staging-letters-sanitise'
-    CBC_PROXY_URL = 'https://notify-stub-cbc-staging.cloudapps.digital'
     FROM_NUMBER = 'stage'
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = True
@@ -501,7 +492,6 @@ class Live(Config):
     INVALID_PDF_BUCKET_NAME = 'production-letters-invalid-pdf'
     TRANSIENT_UPLOADED_LETTERS = 'production-transient-uploaded-letters'
     LETTER_SANITISE_BUCKET_NAME = 'production-letters-sanitise'
-    CBC_PROXY_URL = 'https://notify-stub-cbc-production.cloudapps.digital'
     FROM_NUMBER = 'GOVUK'
     PERFORMANCE_PLATFORM_ENABLED = True
     API_RATE_LIMIT_ENABLED = True

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -1,7 +1,5 @@
 from freezegun import freeze_time
 import pytest
-import requests_mock
-from requests import RequestException
 
 from app.models import BROADCAST_TYPE, BroadcastStatusType, BroadcastEventMessageType
 from app.celery.broadcast_message_tasks import send_broadcast_event
@@ -9,7 +7,7 @@ from tests.app.db import create_template, create_broadcast_message, create_broad
 
 
 @freeze_time('2020-08-01 12:00')
-def test_send_broadcast_event_sends_data_correctly(mocker, sample_service):
+def test_create_broadcast_event_sends_data_correctly(mocker, sample_service):
     template = create_template(sample_service, BROADCAST_TYPE)
     broadcast_message = create_broadcast_message(
         template,
@@ -22,9 +20,7 @@ def test_send_broadcast_event_sends_data_correctly(mocker, sample_service):
         'app.cbc_proxy_client.create_and_send_broadcast',
     )
 
-    with requests_mock.Mocker() as request_mock:
-        request_mock.post("http://test-cbc-proxy/broadcasts/events/stub-1", json={'valid': 'true'}, status_code=200)
-        send_broadcast_event(broadcast_event_id=str(event.id))
+    send_broadcast_event(broadcast_event_id=str(event.id))
 
     mock_create_broadcast.assert_called_once_with(
         identifier=str(event.id),
@@ -33,47 +29,57 @@ def test_send_broadcast_event_sends_data_correctly(mocker, sample_service):
         areas=[{
             "description": "london",
             "polygon": [[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]],
-        }]
+        }],
     )
 
-    assert request_mock.call_count == 1
-    assert request_mock.request_history[0].method == 'POST'
-    assert request_mock.request_history[0].headers["Content-type"] == "application/json"
 
-    cbc_json = request_mock.request_history[0].json()
-    assert cbc_json['id'] == str(event.id)
-    assert cbc_json['broadcast_message_id'] == str(broadcast_message.id)
-    assert cbc_json['sent_at'] == '2020-08-01T12:00:00.000000Z'
-    assert cbc_json['transmitted_starts_at'] is None
-    assert cbc_json['transmitted_areas'] == {
-        "areas": ['london'], "simple_polygons": [[[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]]]
-    }
-
-
-def test_send_broadcast_event_sends_references(mocker, sample_service):
+def test_update_broadcast_event_sends_references(mocker, sample_service):
     template = create_template(sample_service, BROADCAST_TYPE, content='content')
     broadcast_message = create_broadcast_message(template, areas=['london'], status=BroadcastStatusType.BROADCASTING)
     alert_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.ALERT)
-    cancel_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.CANCEL)
+    update_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.UPDATE)
 
-    mock_create_broadcast = mocker.patch(
-        'app.cbc_proxy_client.create_and_send_broadcast',
+    mock_update_broadcast = mocker.patch(
+        'app.cbc_proxy_client.update_and_send_broadcast',
     )
 
-    with requests_mock.Mocker() as request_mock:
-        request_mock.post("http://test-cbc-proxy/broadcasts/events/stub-1", json={'valid': 'true'}, status_code=200)
-        send_broadcast_event(broadcast_event_id=str(cancel_event.id))
+    send_broadcast_event(broadcast_event_id=str(update_event.id))
 
-    assert not mock_create_broadcast.called
+    mock_update_broadcast.assert_called_once_with(
+        identifier=str(update_event.id),
+        headline="GOV.UK Notify Broadcast",
+        description='this is an emergency broadcast message',
+        areas=[{
+            "description": "london",
+            "polygon": [[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]],
+        }],
+        references=[alert_event.reference],
+    )
 
-    assert request_mock.call_count == 1
-    assert request_mock.request_history[0].method == 'POST'
-    assert request_mock.request_history[0].headers["Content-type"] == "application/json"
 
-    cbc_json = request_mock.request_history[0].json()
-    assert cbc_json['id'] == str(cancel_event.id)
-    assert cbc_json['message_type'] == cancel_event.message_type
-    assert cbc_json['previous_event_references'] == [alert_event.reference]
+def test_cancel_broadcast_event_sends_references(mocker, sample_service):
+    template = create_template(sample_service, BROADCAST_TYPE, content='content')
+    broadcast_message = create_broadcast_message(template, areas=['london'], status=BroadcastStatusType.BROADCASTING)
+    alert_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.ALERT)
+    update_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.UPDATE)
+    cancel_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.CANCEL)
+
+    mock_cancel_broadcast = mocker.patch(
+        'app.cbc_proxy_client.cancel_broadcast',
+    )
+
+    send_broadcast_event(broadcast_event_id=str(cancel_event.id))
+
+    mock_cancel_broadcast.assert_called_once_with(
+        identifier=str(cancel_event.id),
+        headline="GOV.UK Notify Broadcast",
+        description='this is an emergency broadcast message',
+        areas=[{
+            "description": "london",
+            "polygon": [[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]],
+        }],
+        references=[alert_event.reference, update_event.reference],
+    )
 
 
 def test_send_broadcast_event_errors(mocker, sample_service):
@@ -83,15 +89,13 @@ def test_send_broadcast_event_errors(mocker, sample_service):
 
     mock_create_broadcast = mocker.patch(
         'app.cbc_proxy_client.create_and_send_broadcast',
+        side_effect=Exception('oh no'),
     )
 
-    with requests_mock.Mocker() as request_mock:
-        request_mock.post("http://test-cbc-proxy/broadcasts/events/stub-1", text='503 bad gateway', status_code=503)
-        # we're not retrying or anything for the moment - but this'll ensure any exception gets logged
-        with pytest.raises(RequestException) as ex:
-            send_broadcast_event(broadcast_event_id=str(event.id))
+    with pytest.raises(Exception) as ex:
+        send_broadcast_event(broadcast_event_id=str(event.id))
 
-    assert ex.value.response.status_code == 503
+    assert ex.match('oh no')
 
     mock_create_broadcast.assert_called_once_with(
         identifier=str(event.id),


### PR DESCRIPTION
⚠️ Needs a rebase once https://github.com/alphagov/notifications-api/pull/3011 is merged

What
----

Removes references to the CBC stub

Wires up the update and cancel methods of the `cbc_proxy` client

Why
----

We are testing with live CBCs, we don't need to use a stub and the two codepaths will diverge and make things unnecessarily complicated and non-obvious