### PR TITLE
Optimise dao_get_letters_to_be_printed query

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -182,15 +182,15 @@ def get_key_and_size_of_letters_to_be_sent_to_print(print_run_deadline, postage)
         try:
             letter_file_name = get_letter_pdf_filename(
                 reference=letter.reference,
-                crown=letter.service.crown,
+                crown=letter.crown,
                 created_at=letter.created_at,
-                postage=letter.postage
+                postage=postage
             )
             letter_head = s3.head_s3_object(current_app.config['LETTERS_PDF_BUCKET_NAME'], letter_file_name)
             yield {
                 "Key": letter_file_name,
                 "Size": letter_head['ContentLength'],
-                "ServiceId": str(letter.service.id)
+                "ServiceId": str(letter.service_id)
             }
         except BotoClientError as e:
             current_app.logger.exception(

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -721,7 +721,15 @@ def dao_get_letters_to_be_printed(print_run_deadline, postage):
     """
     Return all letters created before the print run deadline that have not yet been sent
     """
-    notifications = Notification.query.filter(
+    notifications = db.session.query(
+        Notification.id,
+        Notification.created_at,
+        Notification.reference,
+        Notification.service_id,
+        Service.crown,
+    ).join(
+        Notification.service
+    ).filter(
         Notification.created_at < convert_bst_to_utc(print_run_deadline),
         Notification.notification_type == LETTER_TYPE,
         Notification.status == NOTIFICATION_CREATED,

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1688,10 +1688,20 @@ def test_letters_to_be_printed_sort_by_service(notify_db_session):
     second_service = create_service(service_name='second service', service_id='642bf33b-54b5-45f2-8c13-942a46616704')
     first_template = create_template(service=first_service, template_type='letter', postage='second')
     second_template = create_template(service=second_service, template_type='letter', postage='second')
-    notification_1 = create_notification(template=first_template, created_at=datetime(2020, 12, 1, 9, 30))
-    notification_2 = create_notification(template=first_template, created_at=datetime(2020, 12, 1, 12, 30))
-    notification_3 = create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 30))
+    letters_ordered_by_service_then_time = [
+        create_notification(template=first_template, created_at=datetime(2020, 12, 1, 9, 30)),
+        create_notification(template=first_template, created_at=datetime(2020, 12, 1, 12, 30)),
+        create_notification(template=first_template, created_at=datetime(2020, 12, 1, 13, 30)),
+        create_notification(template=first_template, created_at=datetime(2020, 12, 1, 14, 30)),
+        create_notification(template=first_template, created_at=datetime(2020, 12, 1, 15, 30)),
+        create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 30)),
+        create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 31)),
+        create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 32)),
+        create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 33)),
+        create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 34))
+    ]
 
-    results = list(dao_get_letters_to_be_printed(print_run_deadline=datetime(2020, 12, 1, 17, 30), postage='second'))
-    assert len(results) == 3
-    assert [x.id for x in results] == [notification_1.id, notification_2.id, notification_3.id]
+    results = list(
+        dao_get_letters_to_be_printed(print_run_deadline=datetime(2020, 12, 1, 17, 30), postage='second', query_limit=4)
+    )
+    assert [x.id for x in results] == [x.id for x in letters_ordered_by_service_then_time]

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1694,4 +1694,4 @@ def test_letters_to_be_printed_sort_by_service(notify_db_session):
 
     results = list(dao_get_letters_to_be_printed(print_run_deadline=datetime(2020, 12, 1, 17, 30), postage='second'))
     assert len(results) == 3
-    assert results == [notification_1, notification_2, notification_3]
+    assert [x.id for x in results] == [notification_1.id, notification_2.id, notification_3.id]


### PR DESCRIPTION
Two main concepts here - for info on each one, check the commit messages for more info

#### return just the columns we need for collating letters

Rather than using `Notification.query` to return an ORM Notification object, we can just return the specific columns we need. We can join on service to fetch the crown status, there's much less data sent over the wire, less memory used on the app, and it's also useful for...

#### use yield_per instead of limit

Sqlalchemy supports not pre-fetching all results, but instead yielding every X (I set this to 10k, ignore the branch name). This is risky to use with more ORM features like referring to relationships (which is part of the motive for the first commit), but means that we don't fetch all data and build up lots of ORM objects in memory - only 10k each time, then we'll go get the files from s3 and start to send them before going back to the database for more.