### PR TITLE
CBC Proxy does not need area descriptions

### DIFF
--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -19,11 +19,8 @@ def send_broadcast_event(broadcast_event_id):
     )
 
     areas = [
-        {"description": desc, "polygon": polygon}
-        for desc, polygon in zip(
-            broadcast_event.transmitted_areas["areas"],
-            broadcast_event.transmitted_areas["simple_polygons"],
-        )
+        {"polygon": polygon}
+        for polygon in broadcast_event.transmitted_areas["simple_polygons"]
     ]
 
     if broadcast_event.message_type == BroadcastEventMessageType.ALERT:

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -72,7 +72,6 @@ def test_update_broadcast_event_sends_references(mocker, sample_service):
         headline="GOV.UK Notify Broadcast",
         description='this is an emergency broadcast message',
         areas=[{
-            "description": "london",
             "polygon": [[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]],
         }],
         references=[alert_event.reference],
@@ -108,7 +107,6 @@ def test_cancel_broadcast_event_sends_references(mocker, sample_service):
         headline="GOV.UK Notify Broadcast",
         description='this is an emergency broadcast message',
         areas=[{
-            "description": "london",
             "polygon": [[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]],
         }],
         references=[alert_event.reference, update_event.reference],
@@ -146,7 +144,6 @@ def test_send_broadcast_event_errors(mocker, sample_service):
         headline="GOV.UK Notify Broadcast",
         description='this is an emergency broadcast message',
         areas=[{
-            'description': 'london',
             'polygon': [
                 [50.12, 1.2],
                 [50.13, 1.2],

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -11,7 +11,13 @@ def test_create_broadcast_event_sends_data_correctly(mocker, sample_service):
     template = create_template(sample_service, BROADCAST_TYPE)
     broadcast_message = create_broadcast_message(
         template,
-        areas={"areas": ['london'], "simple_polygons": [[[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]]]},
+        areas={
+            'areas': ['london', 'glasgow'],
+            'simple_polygons': [
+                [[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]],
+                [[-4.53, 55.72], [-3.88, 55.72], [-3.88, 55.96], [-4.53, 55.96]],
+            ],
+        },
         status=BroadcastStatusType.BROADCASTING
     )
     event = create_broadcast_event(broadcast_message)
@@ -24,18 +30,34 @@ def test_create_broadcast_event_sends_data_correctly(mocker, sample_service):
 
     mock_create_broadcast.assert_called_once_with(
         identifier=str(event.id),
-        headline="GOV.UK Notify Broadcast",
+        headline='GOV.UK Notify Broadcast',
         description='this is an emergency broadcast message',
         areas=[{
-            "description": "london",
-            "polygon": [[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]],
+            'polygon': [
+                [50.12, 1.2], [50.13, 1.2], [50.14, 1.21],
+            ],
+        }, {
+            'polygon': [
+                [-4.53, 55.72], [-3.88, 55.72], [-3.88, 55.96], [-4.53, 55.96],
+            ],
         }],
     )
 
 
 def test_update_broadcast_event_sends_references(mocker, sample_service):
     template = create_template(sample_service, BROADCAST_TYPE, content='content')
-    broadcast_message = create_broadcast_message(template, areas=['london'], status=BroadcastStatusType.BROADCASTING)
+
+    broadcast_message = create_broadcast_message(
+        template,
+        areas={
+            'areas': ['london'],
+            'simple_polygons': [
+                [[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]],
+            ],
+        },
+        status=BroadcastStatusType.BROADCASTING
+    )
+
     alert_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.ALERT)
     update_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.UPDATE)
 
@@ -59,7 +81,18 @@ def test_update_broadcast_event_sends_references(mocker, sample_service):
 
 def test_cancel_broadcast_event_sends_references(mocker, sample_service):
     template = create_template(sample_service, BROADCAST_TYPE, content='content')
-    broadcast_message = create_broadcast_message(template, areas=['london'], status=BroadcastStatusType.BROADCASTING)
+
+    broadcast_message = create_broadcast_message(
+        template,
+        areas={
+            'areas': ['london'],
+            'simple_polygons': [
+                [[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]],
+            ],
+        },
+        status=BroadcastStatusType.BROADCASTING
+    )
+
     alert_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.ALERT)
     update_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.UPDATE)
     cancel_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.CANCEL)
@@ -84,7 +117,18 @@ def test_cancel_broadcast_event_sends_references(mocker, sample_service):
 
 def test_send_broadcast_event_errors(mocker, sample_service):
     template = create_template(sample_service, BROADCAST_TYPE)
-    broadcast_message = create_broadcast_message(template, status=BroadcastStatusType.BROADCASTING)
+
+    broadcast_message = create_broadcast_message(
+        template,
+        areas={
+            'areas': ['london'],
+            'simple_polygons': [
+                [[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]],
+            ],
+        },
+        status=BroadcastStatusType.BROADCASTING
+    )
+
     event = create_broadcast_event(broadcast_message)
 
     mock_create_broadcast = mocker.patch(

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -1042,9 +1042,7 @@ def create_broadcast_event(
         sent_at=sent_at or datetime.utcnow(),
         message_type=message_type,
         transmitted_content=transmitted_content or {'body': 'this is an emergency broadcast message'},
-        transmitted_areas=transmitted_areas or {
-            'areas': ['london'], 'simple_polygons': [[[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]]]
-        },
+        transmitted_areas=transmitted_areas or broadcast_message.areas,
         transmitted_sender=transmitted_sender or 'www.notifications.service.gov.uk',
         transmitted_starts_at=transmitted_starts_at,
         transmitted_finishes_at=transmitted_finishes_at or datetime.utcnow(),


### PR DESCRIPTION
What
----

* More explicit areas within tests
* Do not pass "description" to CBC Proxy, as it is not needed

_more context in individual commit messages_

@idavidmcdonald @rjbaker 
