### PR TITLE
Use utils template to format broadcast content

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -185,13 +185,16 @@ def _create_broadcast_event(broadcast_message):
     else:
         transmitted_finishes_at = broadcast_message.finishes_at
 
-    # TODO: This doesn't support placeholders yet. We shouldn't use BroadcastMessageTemplate when we add placeholders
-    # as that just outputs XML, we need the raw text.
+    template = broadcast_message.template._as_utils_template_with_personalisation(
+        # Broadcast events don’t support personalisation yet
+        values={}
+    )
+
     event = BroadcastEvent(
         service=broadcast_message.service,
         broadcast_message=broadcast_message,
         message_type=msg_types[broadcast_message.status],
-        transmitted_content={"body": broadcast_message.template.content},
+        transmitted_content={"body": str(template)},
         transmitted_areas=broadcast_message.areas,
         # TODO: Probably move this somewhere more standalone too and imply that it shouldn't change. Should it include
         # a service based identifier too? eg "flood-warnings@notifications.service.gov.uk" or similar

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,7 +29,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@42.2.1#egg=notifications-utils==42.2.1
+git+https://github.com/alphagov/notifications-utils.git@43.0.0#egg=notifications-utils==43.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@42.2.1#egg=notifications-utils==42.2.1
+git+https://github.com/alphagov/notifications-utils.git@43.0.0#egg=notifications-utils==43.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0
@@ -42,14 +42,14 @@ alembic==1.4.3
 amqp==1.4.9
 anyjson==0.3.3
 attrs==20.2.0
-awscli==1.18.148
+awscli==1.18.164
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.1.4
 blinker==1.4
 boto==2.49.0
 boto3==1.10.38
-botocore==1.18.7
+botocore==1.19.4
 certifi==2020.6.20
 chardet==3.0.4
 click==7.1.2
@@ -66,7 +66,6 @@ importlib-metadata==2.0.0
 Jinja2==2.11.2
 jmespath==0.10.0
 kombu==3.0.37
-lxml==4.5.1
 Mako==1.1.3
 MarkupSafe==1.1.1
 mistune==0.8.4
@@ -89,7 +88,7 @@ s3transfer==0.3.3
 six==1.15.0
 smartypants==2.0.1
 statsd==3.3.0
-urllib3==1.25.10
+urllib3==1.25.11
 webencodings==0.5.1
 Werkzeug==1.0.1
-zipp==3.2.0
+zipp==3.4.0


### PR DESCRIPTION
This PR uses the `BroadcastMessageTemplate` to format the content of the message at the time of creating the event. This means that any downstream code (eg Celery tasks) can assume the content is already formatted correctly.

Also, these downstream tasks don’t  know which template the broadcast was created from, so if we support personalisation in the future this is the most sensible place to bring together the template and the personalisation.

***

I had to re-create some of the deleted code from utils for stuff like formatting the timestamp to the CAP standard.

***

Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/801