### PR TITLE
Add task to send canary to cbc proxy

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -1,3 +1,5 @@
+import uuid
+
 from datetime import (
     datetime,
     timedelta
@@ -8,7 +10,7 @@ from notifications_utils.statsd_decorators import statsd
 from sqlalchemy import and_
 from sqlalchemy.exc import SQLAlchemyError
 
-from app import notify_celery, zendesk_client
+from app import cbc_proxy_client, notify_celery, zendesk_client
 from app.celery.tasks import (
     process_job,
     get_recipient_csv_and_template_and_sender_id,
@@ -291,3 +293,9 @@ def check_for_services_with_high_failure_rates_or_sending_to_tv_numbers():
                 message=message,
                 ticket_type=zendesk_client.TYPE_INCIDENT
             )
+
+
+@notify_celery.task(name='send-canary-to-cbc-proxy')
+def send_canary_to_cbc_proxy():
+    identifier = str(uuid.uuid4())
+    cbc_proxy_client.send_canary(identifier)

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -298,4 +298,6 @@ def check_for_services_with_high_failure_rates_or_sending_to_tv_numbers():
 @notify_celery.task(name='send-canary-to-cbc-proxy')
 def send_canary_to_cbc_proxy():
     identifier = str(uuid.uuid4())
+    message = f"Sending a canary message to CBC proxy with ID {identifier}"
+    current_app.logger.info(message)
     cbc_proxy_client.send_canary(identifier)

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -26,6 +26,12 @@ class CBCProxyNoopClient:
     def init_app(self, app):
         pass
 
+    def send_canary(
+        self,
+        identifier,
+    ):
+        pass
+
     def create_and_send_broadcast(
         self,
         identifier, headline, description, areas
@@ -56,6 +62,26 @@ class CBCProxyClient:
             aws_access_key_id=app.config['CBC_PROXY_AWS_ACCESS_KEY_ID'],
             aws_secret_access_key=app.config['CBC_PROXY_AWS_SECRET_ACCESS_KEY'],
         )
+
+    def send_canary(
+        self,
+        identifier,
+    ):
+        payload_bytes = bytes(json.dumps({
+            'identifier': identifier,
+        }), encoding='utf8')
+
+        result = self._lambda_client.invoke(
+            FunctionName='canary',
+            InvocationType='RequestResponse',
+            Payload=payload_bytes,
+        )
+
+        if result['StatusCode'] > 299:
+            raise Exception('Could not invoke lambda')
+
+        if 'FunctionError' in result:
+            raise Exception('Function exited with unhandled exception')
 
     def create_and_send_broadcast(
         self,

--- a/app/config.py
+++ b/app/config.py
@@ -303,6 +303,11 @@ class Config(object):
             'schedule': crontab(hour=23, minute=00),
             'options': {'queue': QueueNames.PERIODIC}
         },
+        'send-canary-to-cbc-proxy': {
+            'task': 'send-canary-to-cbc-proxy',
+            'schedule': timedelta(minutes=5),
+            'options': {'queue': QueueNames.PERIODIC}
+        },
     }
     CELERY_QUEUES = []
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime, timedelta
 from unittest.mock import call
 
@@ -555,3 +556,22 @@ def test_check_for_services_with_high_failure_rates_or_sending_to_tv_numbers(
         subject="[test] High failure rates for sms spotted for services",
         ticket_type='incident'
     )
+
+
+def test_send_canary_to_cbc_proxy_invokes_cbc_proxy_client(
+    mocker,
+):
+    mock_send_canary = mocker.patch(
+        'app.cbc_proxy_client.send_canary',
+    )
+
+    scheduled_tasks.send_canary_to_cbc_proxy()
+
+    mock_send_canary.assert_called
+    # the 0th argument of the call to send_canary
+    identifier = mock_send_canary.mock_calls[0][1][0]
+
+    try:
+        uuid.UUID(identifier)
+    except BaseException:
+        pytest.fail(f"{identifier} is not a valid uuid")

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 
 import pytest
 
@@ -162,6 +163,91 @@ def test_cbc_proxy_create_and_send_handles_function_error(mocker, cbc_proxy):
 
     ld_client_mock.invoke.assert_called_once_with(
         FunctionName='bt-ee-1-proxy',
+        InvocationType='RequestResponse',
+        Payload=mocker.ANY,
+    )
+
+
+def test_cbc_proxy_send_canary_invokes_function(mocker, cbc_proxy):
+    identifier = str(uuid.uuid4())
+
+    ld_client_mock = mocker.patch.object(
+        cbc_proxy,
+        '_lambda_client',
+        create=True,
+    )
+
+    ld_client_mock.invoke.return_value = {
+        'StatusCode': 200,
+    }
+
+    cbc_proxy.send_canary(
+        identifier=identifier,
+    )
+
+    ld_client_mock.invoke.assert_called_once_with(
+        FunctionName='canary',
+        InvocationType='RequestResponse',
+        Payload=mocker.ANY,
+    )
+
+    kwargs = ld_client_mock.invoke.mock_calls[0][-1]
+    payload_bytes = kwargs['Payload']
+    payload = json.loads(payload_bytes)
+
+    assert payload['identifier'] == identifier
+
+
+def test_cbc_proxy_send_canary_handles_invoke_error(mocker, cbc_proxy):
+    identifier = str(uuid.uuid4())
+
+    ld_client_mock = mocker.patch.object(
+        cbc_proxy,
+        '_lambda_client',
+        create=True,
+    )
+
+    ld_client_mock.invoke.return_value = {
+        'StatusCode': 400,
+    }
+
+    with pytest.raises(Exception) as e:
+        cbc_proxy.send_canary(
+            identifier=identifier,
+        )
+
+        assert e.match('Function exited with unhandled exception')
+
+    ld_client_mock.invoke.assert_called_once_with(
+        FunctionName='canary',
+        InvocationType='RequestResponse',
+        Payload=mocker.ANY,
+    )
+
+
+def test_cbc_proxy_send_canary_handles_function_error(mocker, cbc_proxy):
+    identifier = str(uuid.uuid4())
+
+    ld_client_mock = mocker.patch.object(
+        cbc_proxy,
+        '_lambda_client',
+        create=True,
+    )
+
+    ld_client_mock.invoke.return_value = {
+        'StatusCode': 200,
+        'FunctionError': 'something',
+    }
+
+    with pytest.raises(Exception) as e:
+        cbc_proxy.send_canary(
+            identifier=identifier,
+        )
+
+        assert e.match('Could not invoke lambda')
+
+    ld_client_mock.invoke.assert_called_once_with(
+        FunctionName='canary',
         InvocationType='RequestResponse',
         Payload=mocker.ANY,
     )


### PR DESCRIPTION
The CBC Proxy is essentially a lambda function which we invoke with
various arguments.

A way in which this can fail is that the notifications-api app invoking
the function may not be able, any longer, to invoke the function.

This could be caused by, for example:
* an egress restriction preventing access to eu-west-2.lambda.amazonaws.com
* a network partition preventing access to eu-west-2.lambda.amazonaws.com
* the app's credentials have been rotated or revoked

If we invoke a simple "canary" lambda function for which the app should
have access to invoke, and check it for failures, we will know quickly
if something is likely to be broken.

This is especially important for cell broadcasts compared to email/SMS
because we always have a baseline of traffic for email/SMS, and so any
failure is observed almost immediately. This is not true for CB where we
may expect to only see one CB message every week/month/quarter/year, as
opposed to every minute or second for email/SMS.