### PR TITLE
Link tests

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -301,3 +301,25 @@ def send_canary_to_cbc_proxy():
     message = f"Sending a canary message to CBC proxy with ID {identifier}"
     current_app.logger.info(message)
     cbc_proxy_client.send_canary(identifier)
+
+
+@notify_celery.task(name='trigger-link-tests')
+def trigger_link_tests():
+    """
+    Currently we only have one hardcoded CBC Proxy, which corresponds to one
+    CBC, and so currently we do not specify the CBC Proxy name
+
+    In future we will have multiple CBC proxies, each proxy corresponding to
+    one MNO's CBC
+
+    This task should invoke other tasks which do the actual link tests, eg:
+    for cbc_name in app.config.ENABLED_CBCS:
+      send_link_test_for_cbc(cbc_name)
+
+    Alternatively this task could be configured to be a Celery group
+    """
+    for _ in range(1):
+        identifier = str(uuid.uuid4())
+        message = f"Sending a link test to CBC proxy with ID {identifier}"
+        current_app.logger.info(message)
+        cbc_proxy_client.send_link_test(identifier)

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -32,6 +32,12 @@ class CBCProxyNoopClient:
     ):
         pass
 
+    def send_link_test(
+        self,
+        identifier,
+    ):
+        pass
+
     def create_and_send_broadcast(
         self,
         identifier, headline, description, areas
@@ -83,11 +89,33 @@ class CBCProxyClient:
         if 'FunctionError' in result:
             raise Exception('Function exited with unhandled exception')
 
+    def send_link_test(
+        self,
+        identifier,
+    ):
+        payload_bytes = bytes(json.dumps({
+            'message_type': 'test',
+            'identifier': identifier,
+        }), encoding='utf8')
+
+        result = self._lambda_client.invoke(
+            FunctionName='bt-ee-1-proxy',
+            InvocationType='RequestResponse',
+            Payload=payload_bytes,
+        )
+
+        if result['StatusCode'] > 299:
+            raise Exception('Could not invoke lambda')
+
+        if 'FunctionError' in result:
+            raise Exception('Function exited with unhandled exception')
+
     def create_and_send_broadcast(
         self,
         identifier, headline, description, areas,
     ):
         payload_bytes = bytes(json.dumps({
+            'message_type': 'alert',
             'identifier': identifier,
             'headline': headline,
             'description': description,

--- a/app/config.py
+++ b/app/config.py
@@ -308,6 +308,11 @@ class Config(object):
             'schedule': timedelta(minutes=5),
             'options': {'queue': QueueNames.PERIODIC}
         },
+        'trigger-link-tests': {
+            'task': 'trigger-link-tests',
+            'schedule': timedelta(minutes=5),
+            'options': {'queue': QueueNames.PERIODIC}
+        },
     }
     CELERY_QUEUES = []
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -575,3 +575,22 @@ def test_send_canary_to_cbc_proxy_invokes_cbc_proxy_client(
         uuid.UUID(identifier)
     except BaseException:
         pytest.fail(f"{identifier} is not a valid uuid")
+
+
+def test_trigger_link_tests_invokes_cbc_proxy_client(
+    mocker,
+):
+    mock_send_link_test = mocker.patch(
+        'app.cbc_proxy_client.send_link_test',
+    )
+
+    scheduled_tasks.trigger_link_tests()
+
+    mock_send_link_test.assert_called
+    # the 0th argument of the call to send_link_test
+    identifier = mock_send_link_test.mock_calls[0][1][0]
+
+    try:
+        uuid.UUID(identifier)
+    except BaseException:
+        pytest.fail(f"{identifier} is not a valid uuid")


### PR DESCRIPTION
What
----

- `cbc_proxy_client` sends `message_type` to the CBC Proxy
- `cbc_proxy_client` can send link test messages using the `test` alert type
- Adds a periodic task to trigger link tests

Further detail in commit messages

Who
----

Mob with @CrystalPea @rjbaker 