### PR TITLE
Temporarily remove the new queue

### DIFF
--- a/scripts/paas_app_wrapper.sh
+++ b/scripts/paas_app_wrapper.sh
@@ -51,7 +51,7 @@ case $NOTIFY_APP_NAME in
     ;;
   delivery-worker-save-api-notifications)
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=11 \
-    -Q save-api-email-tasks, save-api-sms-tasks 2> /dev/null
+    -Q save-api-email-tasks 2> /dev/null
     ;;
   delivery-celery-beat)
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery beat --loglevel=INFO


### PR DESCRIPTION
Rather than revert an entire PR, I am going to remove the new save-api-sms-task queue until I update terraform for the new queue.