### PR TITLE
client: cbc_proxy passes through sent/expires

### DIFF
--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -29,6 +29,8 @@ def send_broadcast_event(broadcast_event_id):
             headline="GOV.UK Notify Broadcast",
             description=broadcast_event.transmitted_content['body'],
             areas=areas,
+            sent=broadcast_event.sent_at_as_cap_datetime_string,
+            expires=broadcast_event.transmitted_finishes_at_as_cap_datetime_string,
         )
     elif broadcast_event.message_type == BroadcastEventMessageType.UPDATE:
         cbc_proxy_client.update_and_send_broadcast(
@@ -37,6 +39,8 @@ def send_broadcast_event(broadcast_event_id):
             description=broadcast_event.transmitted_content['body'],
             areas=areas,
             references=broadcast_event.get_earlier_message_references(),
+            sent=broadcast_event.sent_at_as_cap_datetime_string,
+            expires=broadcast_event.transmitted_finishes_at_as_cap_datetime_string,
         )
     elif broadcast_event.message_type == BroadcastEventMessageType.CANCEL:
         cbc_proxy_client.cancel_broadcast(
@@ -45,4 +49,6 @@ def send_broadcast_event(broadcast_event_id):
             description=broadcast_event.transmitted_content['body'],
             areas=areas,
             references=broadcast_event.get_earlier_message_references(),
+            sent=broadcast_event.sent_at_as_cap_datetime_string,
+            expires=broadcast_event.transmitted_finishes_at_as_cap_datetime_string,
         )

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -40,21 +40,24 @@ class CBCProxyNoopClient:
 
     def create_and_send_broadcast(
         self,
-        identifier, headline, description, areas
+        identifier, headline, description, areas,
+        sent, expires,
     ):
         pass
 
     # We have not implementated updating a broadcast
     def update_and_send_broadcast(
         self,
-        identifier, references, headline, description, areas
+        identifier, references, headline, description, areas,
+        sent, expires,
     ):
         pass
 
     # We have not implemented cancelling a broadcast
     def cancel_broadcast(
         self,
-        identifier, references, headline, description, areas
+        identifier, references, headline, description, areas,
+        sent, expires,
     ):
         pass
 
@@ -113,6 +116,7 @@ class CBCProxyClient:
     def create_and_send_broadcast(
         self,
         identifier, headline, description, areas,
+        sent, expires,
     ):
         payload_bytes = bytes(json.dumps({
             'message_type': 'alert',
@@ -120,6 +124,7 @@ class CBCProxyClient:
             'headline': headline,
             'description': description,
             'areas': areas,
+            'sent': sent, 'expires': expires,
         }), encoding='utf8')
 
         result = self._lambda_client.invoke(
@@ -138,6 +143,7 @@ class CBCProxyClient:
     def update_and_send_broadcast(
         self,
         identifier, references, headline, description, areas,
+        sent, expires,
     ):
         pass
 
@@ -145,5 +151,6 @@ class CBCProxyClient:
     def cancel_broadcast(
         self,
         identifier, references, headline, description, areas,
+        sent, expires,
     ):
         pass

--- a/app/models.py
+++ b/app/models.py
@@ -2353,6 +2353,10 @@ class BroadcastEvent(db.Model):
     def sent_at_as_cap_datetime_string(self):
         return self.formatted_datetime_for('sent_at')
 
+    @property
+    def transmitted_finishes_at_as_cap_datetime_string(self):
+        return self.formatted_datetime_for('transmitted_finishes_at')
+
     def formatted_datetime_for(self, property_name):
         return self.convert_naive_utc_datetime_to_cap_standard_string(
             getattr(self, property_name)

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -41,6 +41,8 @@ def test_create_broadcast_event_sends_data_correctly(mocker, sample_service):
                 [-4.53, 55.72], [-3.88, 55.72], [-3.88, 55.96], [-4.53, 55.96],
             ],
         }],
+        sent=event.sent_at_as_cap_datetime_string,
+        expires=event.transmitted_finishes_at_as_cap_datetime_string,
     )
 
 
@@ -75,6 +77,8 @@ def test_update_broadcast_event_sends_references(mocker, sample_service):
             "polygon": [[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]],
         }],
         references=[alert_event.reference],
+        sent=update_event.sent_at_as_cap_datetime_string,
+        expires=update_event.transmitted_finishes_at_as_cap_datetime_string,
     )
 
 
@@ -110,6 +114,8 @@ def test_cancel_broadcast_event_sends_references(mocker, sample_service):
             "polygon": [[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]],
         }],
         references=[alert_event.reference, update_event.reference],
+        sent=cancel_event.sent_at_as_cap_datetime_string,
+        expires=cancel_event.transmitted_finishes_at_as_cap_datetime_string,
     )
 
 
@@ -150,4 +156,6 @@ def test_send_broadcast_event_errors(mocker, sample_service):
                 [50.14, 1.21],
             ],
         }],
+        sent=event.sent_at_as_cap_datetime_string,
+        expires=event.transmitted_finishes_at_as_cap_datetime_string,
     )

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -34,6 +34,9 @@ def test_cbc_proxy_create_and_send_invokes_function(mocker, cbc_proxy):
     headline = 'my-headline'
     description = 'my-description'
 
+    sent = 'a-passed-through-sent-value'
+    expires = 'a-passed-through-expires-value'
+
     # a single area which is a square including london
     areas = [{
         'description': 'london',
@@ -61,6 +64,7 @@ def test_cbc_proxy_create_and_send_invokes_function(mocker, cbc_proxy):
         headline=headline,
         description=description,
         areas=areas,
+        sent=sent, expires=expires,
     )
 
     ld_client_mock.invoke.assert_called_once_with(
@@ -78,12 +82,17 @@ def test_cbc_proxy_create_and_send_invokes_function(mocker, cbc_proxy):
     assert payload['headline'] == headline
     assert payload['description'] == description
     assert payload['areas'] == areas
+    assert payload['sent'] == sent
+    assert payload['expires'] == expires
 
 
 def test_cbc_proxy_create_and_send_handles_invoke_error(mocker, cbc_proxy):
     identifier = 'my-identifier'
     headline = 'my-headline'
     description = 'my-description'
+
+    sent = 'a-passed-through-sent-value'
+    expires = 'a-passed-through-expires-value'
 
     # a single area which is a square including london
     areas = [{
@@ -113,6 +122,7 @@ def test_cbc_proxy_create_and_send_handles_invoke_error(mocker, cbc_proxy):
             headline=headline,
             description=description,
             areas=areas,
+            sent=sent, expires=expires,
         )
 
     assert e.match('Could not invoke lambda')
@@ -128,6 +138,9 @@ def test_cbc_proxy_create_and_send_handles_function_error(mocker, cbc_proxy):
     identifier = 'my-identifier'
     headline = 'my-headline'
     description = 'my-description'
+
+    sent = 'a-passed-through-sent-value'
+    expires = 'a-passed-through-expires-value'
 
     # a single area which is a square including london
     areas = [{
@@ -158,6 +171,7 @@ def test_cbc_proxy_create_and_send_handles_function_error(mocker, cbc_proxy):
             headline=headline,
             description=description,
             areas=areas,
+            sent=sent, expires=expires,
         )
 
         assert e.match('Function exited with unhandled exception')


### PR DESCRIPTION
What
----

A `BroadcastEvent` knows when an event was sent and should expire using the fields

* `sent` == `sent_at`
* `expires` == `transmitted_finishes_at`

We pass through these values directly to the CBC Proxy, because `BroadcastEvent` knows how they should be formatted