### PR TITLE
celery: link test less often

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -312,7 +312,7 @@ class Config(object):
         },
         'trigger-link-tests': {
             'task': 'trigger-link-tests',
-            'schedule': timedelta(minutes=5),
+            'schedule': timedelta(minutes=15),
             'options': {'queue': QueueNames.PERIODIC}
         },
     }


### PR DESCRIPTION
What
----

This is causing the disk of the CBCs to fill up quickly, and their
logrotate seems a bit flakey

Reducing the rate will ensure the disks fill up less often

@yahoopete 