### PR TITLE
Specify sslmode in Cloud Foundry environment variables

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -14,7 +14,12 @@ def extract_cloudfoundry_config():
 
 def set_config_env_vars(vcap_services):
     # Postgres config
-    os.environ['SQLALCHEMY_DATABASE_URI'] = vcap_services['postgres'][0]['credentials']['uri']
+    db_uri = vcap_services['postgres'][0]['credentials']['uri']
+
+    sep = "&" if "?" in db_uri else "?"
+    db_uri += sep + "sslmode=verify-full"
+
+    os.environ['SQLALCHEMY_DATABASE_URI'] = db_uri
 
     vcap_application = json.loads(os.environ['VCAP_APPLICATION'])
     os.environ['NOTIFY_ENVIRONMENT'] = vcap_application['space_name']


### PR DESCRIPTION
What
---

Refer to https://www.postgresql.org/docs/11/libpq-connect.html#LIBPQ-CONNECT-SSLMODE

GOV.UK PaaS gives us the database URI, and we use the default mode of postgres auth which prefers a TLS connection instead of a plain TCP connection

We are now specifying the SSL mode in the URI when establishing our connection to the database, so that:

* We will not connect to the database via a plaintext connection
* We will verify the database connection against a list of trusted CAs

The RDS CA from which the database's certificate is issued is added into
the Cloud Foundry app container via
https://github.com/alphagov/paas-cf/blob/925681f19bbf9d442298fbfa93d18804a7e150eb/manifests/cf-manifest/operations.d/350-diego-cell.yml#L17-L22

---

Pair with @idavidmcdonald 