### PR TITLE
Bump notifications-utils version

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,7 +29,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@43.0.0#egg=notifications-utils==43.0.0
+git+https://github.com/alphagov/notifications-utils.git@43.4.0#egg=notifications-utils==43.4.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@43.0.0#egg=notifications-utils==43.0.0
+git+https://github.com/alphagov/notifications-utils.git@43.4.0#egg=notifications-utils==43.4.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0


### PR DESCRIPTION
Bump notifications-utils version to get the service_id showing up in the logs for API requests.