### PR TITLE
Bump notifications-utils to 43.5.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,7 +29,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@43.4.0#egg=notifications-utils==43.4.0
+git+https://github.com/alphagov/notifications-utils.git@43.5.0#egg=notifications-utils==43.5.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@43.4.0#egg=notifications-utils==43.4.0
+git+https://github.com/alphagov/notifications-utils.git@43.5.0#egg=notifications-utils==43.5.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0
@@ -42,14 +42,14 @@ alembic==1.4.3
 amqp==1.4.9
 anyjson==0.3.3
 attrs==20.3.0
-awscli==1.18.178
+awscli==1.18.179
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.1.4
 blinker==1.4
 boto==2.49.0
 boto3==1.10.38
-botocore==1.19.18
+botocore==1.19.19
 certifi==2020.11.8
 chardet==3.0.4
 click==7.1.2


### PR DESCRIPTION
This version changes the `.fragment_count` method of the `BaseSMSTemplate` class to take extended GSM characters into account.

[Pivotal story](https://www.pivotaltracker.com/story/show/175457294)