### PR TITLE
Bump utils to 43.5.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,7 +29,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.0#egg=notifications-utils==43.5.0
+git+https://github.com/alphagov/notifications-utils.git@43.5.1#egg=notifications-utils==43.5.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.0#egg=notifications-utils==43.5.0
+git+https://github.com/alphagov/notifications-utils.git@43.5.1#egg=notifications-utils==43.5.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0
@@ -42,14 +42,14 @@ alembic==1.4.3
 amqp==1.4.9
 anyjson==0.3.3
 attrs==20.3.0
-awscli==1.18.179
+awscli==1.18.180
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.1.4
 blinker==1.4
 boto==2.49.0
 boto3==1.10.38
-botocore==1.19.19
+botocore==1.19.20
 certifi==2020.11.8
 chardet==3.0.4
 click==7.1.2


### PR DESCRIPTION
Brings in https://github.com/alphagov/notifications-utils/pull/807
which removes a hack we had in our email template
to deal with this bug:

https://www.pivotaltracker.com/story/show/161183433

This behaviour is no longer happening so this
removes the hack.

See
https://www.pivotaltracker.com/story/show/161183433/comments/219297211
for evidence of the change in behaviour.