### PR TITLE
Give sms providers equal shares of traffic

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -143,8 +143,8 @@ class Config(object):
 
     # these should always add up to 100%
     SMS_PROVIDER_RESTING_POINTS = {
-        'mmg': 60,
-        'firetext': 40
+        'mmg': 50,
+        'firetext': 50
     }
 
     NOTIFY_SERVICE_ID = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'


### PR DESCRIPTION
This is done on a temporary basis for billing-related reasons.