### PR TITLE
Turn on SMS and email stubs on staging

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -490,6 +490,9 @@ class Staging(Config):
     FROM_NUMBER = 'stage'
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = True
+    SES_STUB_URL = 'https://notify-email-provider-stub-staging.cloudapps.digital/ses'
+    MMG_URL = 'https://notify-sms-provider-stub-staging.cloudapps.digital/mmg'
+    FIRETEXT_URL = 'https://notify-sms-provider-stub-staging.cloudapps.digital/firetext'
 
 
 class Live(Config):


### PR DESCRIPTION
This is done because we will be load testing on staging.