### PR TITLE
add CBC_PROXY_ENABLED config flag to control if tasks are triggered

### DIFF
--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -12,6 +12,10 @@ from app.dao.broadcast_message_dao import dao_get_broadcast_event_by_id, create_
 @notify_celery.task(name="send-broadcast-event")
 @statsd(namespace="tasks")
 def send_broadcast_event(broadcast_event_id):
+    if not current_app.config['CBC_PROXY_ENABLED']:
+        current_app.logger.info(f'CBC Proxy disabled, not sending broadcast_event {broadcast_event_id}')
+        return
+
     for provider in current_app.config['ENABLED_CBCS']:
         # TODO: Decide whether to send to each provider based on platform admin, service level settings, broadcast
         # level settings, etc.

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -298,13 +298,15 @@ def check_for_services_with_high_failure_rates_or_sending_to_tv_numbers():
 
 @notify_celery.task(name='send-canary-to-cbc-proxy')
 def send_canary_to_cbc_proxy():
-    identifier = str(uuid.uuid4())
-    message = f"Sending a canary message to CBC proxy with ID {identifier}"
-    current_app.logger.info(message)
-    cbc_proxy_client.get_proxy('canary').send_canary(identifier)
+    if current_app.config['CBC_PROXY_ENABLED']:
+        identifier = str(uuid.uuid4())
+        message = f"Sending a canary message to CBC proxy with ID {identifier}"
+        current_app.logger.info(message)
+        cbc_proxy_client.get_proxy('canary').send_canary(identifier)
 
 
 @notify_celery.task(name='trigger-link-tests')
 def trigger_link_tests():
-    for cbc_name in current_app.config['ENABLED_CBCS']:
-        trigger_link_test.apply_async(kwargs={'provider': cbc_name}, queue=QueueNames.NOTIFY)
+    if current_app.config['CBC_PROXY_ENABLED']:
+        for cbc_name in current_app.config['ENABLED_CBCS']:
+            trigger_link_test.apply_async(kwargs={'provider': cbc_name}, queue=QueueNames.NOTIFY)

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -30,7 +30,7 @@ class CBCProxyClient:
     _lambda_client = None
 
     def init_app(self, app):
-        if app.config.get('CBC_PROXY_AWS_ACCESS_KEY_ID'):
+        if app.config.get('CBC_PROXY_ENABLED'):
             self._lambda_client = boto3.client(
                 'lambda',
                 region_name='eu-west-2',

--- a/app/config.py
+++ b/app/config.py
@@ -376,6 +376,8 @@ class Config(object):
     CBC_PROXY_AWS_ACCESS_KEY_ID = os.environ.get('CBC_PROXY_AWS_ACCESS_KEY_ID', '')
     CBC_PROXY_AWS_SECRET_ACCESS_KEY = os.environ.get('CBC_PROXY_AWS_SECRET_ACCESS_KEY', '')
 
+    CBC_PROXY_ENABLED = bool(CBC_PROXY_AWS_ACCESS_KEY_ID)
+
     ENABLED_CBCS = {BroadcastProvider.EE}
 
 
@@ -467,6 +469,8 @@ class Test(Development):
 
     MMG_URL = 'https://example.com/mmg'
     FIRETEXT_URL = 'https://example.com/firetext'
+
+    CBC_PROXY_ENABLED = True
 
 
 class Preview(Config):

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -31,6 +31,18 @@ def test_send_broadcast_event_queues_up_for_active_providers(mocker, notify_api)
     ]
 
 
+def test_send_broadcast_event_does_nothing_if_cbc_proxy_disabled(mocker, notify_api):
+    mock_send_broadcast_provider_message = mocker.patch(
+        'app.celery.broadcast_message_tasks.send_broadcast_provider_message',
+    )
+
+    event_id = uuid.uuid4()
+    with set_config(notify_api, 'ENABLED_CBCS', ['ee', 'vodafone']), set_config(notify_api, 'CBC_PROXY_ENABLED', False):
+        send_broadcast_event(event_id)
+
+    assert mock_send_broadcast_provider_message.apply_async.called is False
+
+
 @freeze_time('2020-08-01 12:00')
 def test_send_broadcast_provider_message_sends_data_correctly(mocker, sample_service):
     template = create_template(sample_service, BROADCAST_TYPE)

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -13,6 +13,7 @@ def cbc_proxy_client(client, mocker):
     current_app = mocker.Mock(config={
         'CBC_PROXY_AWS_ACCESS_KEY_ID': 'cbc-proxy-aws-access-key-id',
         'CBC_PROXY_AWS_SECRET_ACCESS_KEY': 'cbc-proxy-aws-secret-access-key',
+        'CBC_PROXY_ENABLED': True,
     })
     client.init_app(current_app)
     return client


### PR DESCRIPTION
previously we made some incorrect assumptions about set-up on staging and prod - they currently don't have any cbc_proxy aws creds at all.

We shoudn't be attempting canaries or link tests when there's no AWS infrastructure to connect to.

We also shouldn't bother writing a row into the database at all for the broadcast_provider_message since we're not even attempting to send, and we shouldn't get confused between messages that failed and messages we never wanted to send at all.