### PR TITLE
Bump utils to 43.5.2

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,7 +29,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.1#egg=notifications-utils==43.5.1
+git+https://github.com/alphagov/notifications-utils.git@43.5.2#egg=notifications-utils==43.5.2
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.1#egg=notifications-utils==43.5.1
+git+https://github.com/alphagov/notifications-utils.git@43.5.2#egg=notifications-utils==43.5.2
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0
@@ -42,14 +42,14 @@ alembic==1.4.3
 amqp==1.4.9
 anyjson==0.3.3
 attrs==20.3.0
-awscli==1.18.180
+awscli==1.18.185
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.1.4
 blinker==1.4
 boto==2.49.0
 boto3==1.10.38
-botocore==1.19.20
+botocore==1.19.25
 certifi==2020.11.8
 chardet==3.0.4
 click==7.1.2
@@ -62,7 +62,7 @@ geojson==2.5.0
 govuk-bank-holidays==0.6
 greenlet==0.4.17
 idna==2.10
-importlib-metadata==2.0.0
+importlib-metadata==3.1.0
 Jinja2==2.11.2
 jmespath==0.10.0
 kombu==3.0.37


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/808

Changes:
- https://github.com/alphagov/notifications-utils/compare/43.5.1...43.5.2