### PR TITLE
Break down how long it takes to send a notification

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -76,6 +76,16 @@ def send_sms_to_provider(notification):
         delta_seconds = (datetime.utcnow() - notification.created_at).total_seconds()
         statsd_client.timing("sms.total-time", delta_seconds)
 
+        if notification.key_type == KEY_TYPE_TEST:
+            statsd_client.timing("sms.test-key.total-time", delta_seconds)
+        else:
+            statsd_client.timing("sms.live-key.total-time", delta_seconds)
+
+        if service.id in current_app.config.get('HIGH_VOLUME_SERVICE'):
+            statsd_client.timing("sms.high-volume.total-time", delta_seconds)
+        else:
+            statsd_client.timing("sms.not-high-volume.total-time", delta_seconds)
+
 
 def send_email_to_provider(notification):
     service = notification.service
@@ -121,6 +131,16 @@ def send_email_to_provider(notification):
 
         delta_seconds = (datetime.utcnow() - notification.created_at).total_seconds()
         statsd_client.timing("email.total-time", delta_seconds)
+
+        if notification.key_type == KEY_TYPE_TEST:
+            statsd_client.timing("email.test-key.total-time", delta_seconds)
+        else:
+            statsd_client.timing("email.live-key.total-time", delta_seconds)
+
+        if service.id in current_app.config.get('HIGH_VOLUME_SERVICE'):
+            statsd_client.timing("email.high-volume.total-time", delta_seconds)
+        else:
+            statsd_client.timing("email.not-high-volume.total-time", delta_seconds)
 
 
 def update_notification_to_sending(notification, provider):


### PR DESCRIPTION
We currently measure the sending time for all. This commit then breaks
it down into
- test keys and non test keys
- high volume services and non high volume services

Breaking it down into test keys and non test keys is important because
we don't care as much about sending test notifications within 10
seconds, only non test keys so we don't want our graphs to reflect poor
performance if it's just test keys affecting this

Breaking it down into high volume and non high volume will allow us to
easily debug issues with slow sending if they are high volume or non
high volume issues