### PR TITLE
Tweak sending time metrics to only include live notifications

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -129,7 +129,6 @@ def send_email_to_provider(notification):
             update_notification_to_sending(notification, provider)
 
         delta_seconds = (datetime.utcnow() - notification.created_at).total_seconds()
-        statsd_client.timing("email.total-time", delta_seconds)
 
         if notification.key_type == KEY_TYPE_TEST:
             statsd_client.timing("email.test-key.total-time", delta_seconds)

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -80,11 +80,10 @@ def send_sms_to_provider(notification):
             statsd_client.timing("sms.test-key.total-time", delta_seconds)
         else:
             statsd_client.timing("sms.live-key.total-time", delta_seconds)
-
-        if service.id in current_app.config.get('HIGH_VOLUME_SERVICE'):
-            statsd_client.timing("sms.high-volume.total-time", delta_seconds)
-        else:
-            statsd_client.timing("sms.not-high-volume.total-time", delta_seconds)
+            if service.id in current_app.config.get('HIGH_VOLUME_SERVICE'):
+                statsd_client.timing("sms.live-key.high-volume.total-time", delta_seconds)
+            else:
+                statsd_client.timing("sms.live-key.not-high-volume.total-time", delta_seconds)
 
 
 def send_email_to_provider(notification):
@@ -136,11 +135,10 @@ def send_email_to_provider(notification):
             statsd_client.timing("email.test-key.total-time", delta_seconds)
         else:
             statsd_client.timing("email.live-key.total-time", delta_seconds)
-
-        if service.id in current_app.config.get('HIGH_VOLUME_SERVICE'):
-            statsd_client.timing("email.high-volume.total-time", delta_seconds)
-        else:
-            statsd_client.timing("email.not-high-volume.total-time", delta_seconds)
+            if service.id in current_app.config.get('HIGH_VOLUME_SERVICE'):
+                statsd_client.timing("email.live-key.high-volume.total-time", delta_seconds)
+            else:
+                statsd_client.timing("email.live-key.not-high-volume.total-time", delta_seconds)
 
 
 def update_notification_to_sending(notification, provider):


### PR DESCRIPTION
Review commit by commit

Changes the high volume and not high volume metrics to both only include
non test notifications. This is because when looking at the grafana
metrics, it was impossible to tell what affect the high volume/non high
volume effect was having vs the test/live notification effect.

This leaves us with no break down of high volume/not high volume sending
times for test notifications but I don't think we really need that.

![image](https://user-images.githubusercontent.com/7228605/100626385-af1e5180-331d-11eb-8c7c-f0bebedeced8.png)
