### PR TITLE
Fix comparison of uuid to string

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -80,7 +80,7 @@ def send_sms_to_provider(notification):
             statsd_client.timing("sms.test-key.total-time", delta_seconds)
         else:
             statsd_client.timing("sms.live-key.total-time", delta_seconds)
-            if service.id in current_app.config.get('HIGH_VOLUME_SERVICE'):
+            if str(service.id) in current_app.config.get('HIGH_VOLUME_SERVICE'):
                 statsd_client.timing("sms.live-key.high-volume.total-time", delta_seconds)
             else:
                 statsd_client.timing("sms.live-key.not-high-volume.total-time", delta_seconds)
@@ -134,7 +134,7 @@ def send_email_to_provider(notification):
             statsd_client.timing("email.test-key.total-time", delta_seconds)
         else:
             statsd_client.timing("email.live-key.total-time", delta_seconds)
-            if service.id in current_app.config.get('HIGH_VOLUME_SERVICE'):
+            if str(service.id) in current_app.config.get('HIGH_VOLUME_SERVICE'):
                 statsd_client.timing("email.live-key.high-volume.total-time", delta_seconds)
             else:
                 statsd_client.timing("email.live-key.not-high-volume.total-time", delta_seconds)


### PR DESCRIPTION
`service.id` is a uuid so will not be matched to anything in
`current_app.config.get('HIGH_VOLUME_SERVICE')` because that is a list
of strings.

This is why we are never falling into the first if statement and having
any metrics for high volume services on our dashboards at the moment.

Note, I had taken the existing line from the `post_notification`
endpoint, but that is using a serialised service which already has the
UUID converted to a string.