### PR TITLE
Don’t return jobs sent from contact lists (uploads page edition)

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -69,7 +69,6 @@ def dao_get_jobs_by_service_id(
         Job.service_id == service_id,
         Job.original_file_name != current_app.config['TEST_MESSAGE_FILENAME'],
         Job.original_file_name != current_app.config['ONE_OFF_MESSAGE_FILENAME'],
-        Job.contact_list_id == contact_list_id,
     ]
     if limit_days is not None:
         query_filter.append(Job.created_at >= midnight_n_days_ago(limit_days))

--- a/app/dao/uploads_dao.py
+++ b/app/dao/uploads_dao.py
@@ -43,7 +43,8 @@ def dao_get_uploads_by_service_id(service_id, limit_days=None, page=1, page_size
         Job.job_status.notin_([JOB_STATUS_CANCELLED, JOB_STATUS_SCHEDULED]),
         func.coalesce(
             Job.processing_started, Job.created_at
-        ) >= today - func.coalesce(ServiceDataRetention.days_of_retention, 7)
+        ) >= today - func.coalesce(ServiceDataRetention.days_of_retention, 7),
+        Job.contact_list_id.is_(None),
     ]
     if limit_days is not None:
         jobs_query_filter.append(Job.created_at >= midnight_n_days_ago(limit_days))

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -172,6 +172,7 @@ def test_get_jobs_for_service_by_contact_list(sample_template):
     assert dao_get_jobs_by_service_id(
         sample_template.service.id
     ).items == [
+        job_2,
         job_1,
     ]
 

--- a/tests/app/dao/test_uploads_dao.py
+++ b/tests/app/dao/test_uploads_dao.py
@@ -3,7 +3,14 @@ from freezegun import freeze_time
 
 from app.dao.uploads_dao import dao_get_uploads_by_service_id, dao_get_uploaded_letters_by_print_date
 from app.models import LETTER_TYPE, JOB_STATUS_IN_PROGRESS
-from tests.app.db import create_job, create_service, create_service_data_retention, create_template, create_notification
+from tests.app.db import (
+    create_job,
+    create_service,
+    create_service_data_retention,
+    create_service_contact_list,
+    create_template,
+    create_notification,
+)
 
 
 def create_uploaded_letter(letter_template, service, status='created', created_at=None):
@@ -34,6 +41,9 @@ def create_uploaded_template(service):
 @freeze_time("2020-02-02 14:00")  # GMT time
 def test_get_uploads_for_service(sample_template):
     create_service_data_retention(sample_template.service, 'sms', days_of_retention=9)
+    contact_list = create_service_contact_list()
+    # Jobs created from contact lists should be filtered out
+    create_job(sample_template, contact_list_id=contact_list.id)
     job = create_job(sample_template, processing_started=datetime.utcnow())
     letter_template = create_uploaded_template(sample_template.service)
     letter = create_uploaded_letter(letter_template, sample_template.service)

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -743,21 +743,6 @@ def test_get_jobs_with_limit_days(admin_request, sample_template):
     assert len(resp_json['data']) == 2
 
 
-def test_get_jobs_filters_jobs_from_contact_lists(admin_request, sample_template):
-    contact_list = create_service_contact_list()
-
-    create_job(template=sample_template, contact_list_id=contact_list.id)
-    job_without_contact_list = create_job(template=sample_template)
-
-    resp_json = admin_request.get(
-        'job.get_jobs_by_service',
-        service_id=sample_template.service_id,
-    )
-
-    assert len(resp_json['data']) == 1
-    assert resp_json['data'][0]['id'] == str(job_without_contact_list.id)
-
-
 def test_get_jobs_by_contact_list(admin_request, sample_template):
     contact_list = create_service_contact_list()
     create_job(template=sample_template)


### PR DESCRIPTION
Now that we’re grouping jobs sent from contact lists within their parent, they shouldn’t also be listed on the jobs page at the top level.

The jobs page uses the uploads API, not the jobs API, so this commit makes sure that filtering is happening in the proper place (unlike a previous attempt which used the jobs API).