### PR TITLE
Set cbc proxy message_format to "cap"

### DIFF
--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -142,7 +142,7 @@ class CBCProxyEE(CBCProxyClientBase):
         payload = {
             'message_type': 'test',
             'identifier': identifier,
-            'message_format': 'cbc'
+            'message_format': 'cap'
         }
 
         self._invoke_lambda(payload=payload)
@@ -154,7 +154,7 @@ class CBCProxyEE(CBCProxyClientBase):
         payload = {
             'message_type': 'alert',
             'identifier': identifier,
-            'message_format': 'cbc',
+            'message_format': 'cap',
             'headline': headline,
             'description': description,
             'areas': areas,

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -107,7 +107,7 @@ def test_cbc_proxy_ee_create_and_send_invokes_function(mocker, cbc_proxy_ee):
 
     assert payload['identifier'] == identifier
     assert 'message_number' not in payload
-    assert payload['message_format'] == 'cbc'
+    assert payload['message_format'] == 'cap'
     assert payload['message_type'] == 'alert'
     assert payload['headline'] == headline
     assert payload['description'] == description
@@ -338,7 +338,7 @@ def test_cbc_proxy_ee_send_link_test_invokes_function(mocker, cbc_proxy_ee):
     assert payload['identifier'] == identifier
     assert payload['message_type'] == 'test'
     assert 'message_number' not in payload
-    assert payload['message_format'] == 'cbc'
+    assert payload['message_format'] == 'cap'
 
 
 def test_cbc_proxy_vodafone_send_link_test_invokes_function(mocker, cbc_proxy_vodafone):


### PR DESCRIPTION
A minor fix to set the `message_format` parameter sent to the CBC Proxy to be one of `cap` or `ibag`.