### PR TITLE
Bump utils to 43.5.6

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,7 +29,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.4#egg=notifications-utils==43.5.4
+git+https://github.com/alphagov/notifications-utils.git@43.5.6#egg=notifications-utils==43.5.6
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.4#egg=notifications-utils==43.5.4
+git+https://github.com/alphagov/notifications-utils.git@43.5.6#egg=notifications-utils==43.5.6
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0
@@ -42,14 +42,14 @@ alembic==1.4.3
 amqp==1.4.9
 anyjson==0.3.3
 attrs==20.3.0
-awscli==1.18.190
+awscli==1.18.194
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.2.1
 blinker==1.4
 boto==2.49.0
-boto3==1.16.30
-botocore==1.19.30
+boto3==1.16.34
+botocore==1.19.34
 certifi==2020.12.5
 chardet==3.0.4
 click==7.1.2


### PR DESCRIPTION
Changes: https://github.com/alphagov/notifications-utils/compare/43.5.4...43.5.6