### PR TITLE
Add cancel routes to cbc proxy clients

### DIFF
--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -75,12 +75,8 @@ def send_broadcast_provider_message(broadcast_event_id, provider):
         cbc_proxy_provider_client.cancel_broadcast(
             identifier=str(broadcast_provider_message.id),
             message_number=formatted_message_number,
-            headline="GOV.UK Notify Broadcast",
-            description=broadcast_event.transmitted_content['body'],
-            areas=areas,
             previous_provider_messages=broadcast_event.get_earlier_provider_messages(provider),
             sent=broadcast_event.sent_at_as_cap_datetime_string,
-            expires=broadcast_event.transmitted_finishes_at_as_cap_datetime_string,
         )
 
 

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -217,6 +217,9 @@ class CBCProxyVodafone(CBCProxyClientBase):
     def cancel_broadcast(
         self, identifier, previous_provider_messages, sent, message_number
     ):
+        # avoid cyclical import
+        from app.utils import format_sequential_number
+
         payload = {
             'message_type': 'cancel',
             'identifier': identifier,
@@ -225,7 +228,7 @@ class CBCProxyVodafone(CBCProxyClientBase):
             "references": [
                 {
                     "message_id": str(message.id),
-                    "message_number": message.message_number,
+                    "message_number": format_sequential_number(message.message_number),
                     "sent": message.created_at
                 } for message in previous_provider_messages
             ],

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -62,13 +62,12 @@ class CBCProxyClientBase:
     def send_link_test(
         self,
         identifier,
-        sequential_number,
-        message_format
+        sequential_number
     ):
         pass
 
     def create_and_send_broadcast(
-        self, identifier, message_number, message_format, headline, description, areas, sent, expires,
+        self, identifier, headline, description, areas, sent, expires, message_number=None
     ):
         pass
 
@@ -76,7 +75,7 @@ class CBCProxyClientBase:
     def update_and_send_broadcast(
         self,
         identifier, previous_provider_messages, headline, description, areas,
-        sent, expires, message_number, message_format
+        sent, expires, message_number=None
     ):
         pass
 
@@ -84,7 +83,7 @@ class CBCProxyClientBase:
     def cancel_broadcast(
         self,
         identifier, previous_provider_messages, headline, description, areas,
-        sent, expires, message_number, message_format
+        sent, expires, message_number=None
     ):
         pass
 
@@ -134,7 +133,6 @@ class CBCProxyEE(CBCProxyClientBase):
         identifier,
         sequential_number=None,
     ):
-        pass
         """
         link test - open up a connection to a specific provider, and send them an xml payload with a <msgType> of
         test.
@@ -150,7 +148,6 @@ class CBCProxyEE(CBCProxyClientBase):
     def create_and_send_broadcast(
         self, identifier, headline, description, areas, sent, expires, message_number=None
     ):
-        pass
         payload = {
             'message_type': 'alert',
             'identifier': identifier,
@@ -163,6 +160,22 @@ class CBCProxyEE(CBCProxyClientBase):
         }
         self._invoke_lambda(payload=payload)
 
+    def cancel_broadcast(
+        self,
+        identifier, previous_provider_messages,
+        sent, message_number=None
+    ):
+        payload = {
+            'message_type': 'cancel',
+            'identifier': identifier,
+            'message_format': 'cap',
+            "references": [
+                {"message_id": str(message.id), "sent": message.created_at} for message in previous_provider_messages
+            ],
+            'sent': sent,
+        }
+        self._invoke_lambda(payload=payload)
+
 
 class CBCProxyVodafone(CBCProxyClientBase):
     lambda_name = 'vodafone-1-proxy'
@@ -172,7 +185,6 @@ class CBCProxyVodafone(CBCProxyClientBase):
         identifier,
         sequential_number,
     ):
-        pass
         """
         link test - open up a connection to a specific provider, and send them an xml payload with a <msgType> of
         test.
@@ -189,7 +201,6 @@ class CBCProxyVodafone(CBCProxyClientBase):
     def create_and_send_broadcast(
         self, identifier, message_number, headline, description, areas, sent, expires,
     ):
-        pass
         payload = {
             'message_type': 'alert',
             'identifier': identifier,
@@ -200,5 +211,24 @@ class CBCProxyVodafone(CBCProxyClientBase):
             'areas': areas,
             'sent': sent,
             'expires': expires,
+        }
+        self._invoke_lambda(payload=payload)
+
+    def cancel_broadcast(
+        self, identifier, previous_provider_messages, sent, message_number
+    ):
+        payload = {
+            'message_type': 'cancel',
+            'identifier': identifier,
+            'message_number': message_number,
+            'message_format': 'ibag',
+            "references": [
+                {
+                    "message_id": str(message.id),
+                    "message_number": message.message_number,
+                    "sent": message.created_at
+                } for message in previous_provider_messages
+            ],
+            'sent': sent,
         }
         self._invoke_lambda(payload=payload)

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -244,17 +244,11 @@ def test_send_broadcast_provider_message_sends_cancel_with_references(
     mock_cancel_broadcast.assert_called_once_with(
         identifier=str(broadcast_provider_message.id),
         message_number=mocker.ANY,
-        headline="GOV.UK Notify Broadcast",
-        description='this is an emergency broadcast message',
-        areas=[{
-            "polygon": [[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]],
-        }],
         previous_provider_messages=[
             alert_event.get_provider_message(provider),
             update_event.get_provider_message(provider)
         ],
         sent=cancel_event.sent_at_as_cap_datetime_string,
-        expires=cancel_event.transmitted_finishes_at_as_cap_datetime_string,
     )
 
 

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from collections import namedtuple
 from unittest.mock import Mock
 
 import pytest
@@ -116,6 +117,60 @@ def test_cbc_proxy_ee_create_and_send_invokes_function(mocker, cbc_proxy_ee):
     assert payload['expires'] == expires
 
 
+def test_cbc_proxy_ee_cancel_invokes_function(mocker, cbc_proxy_ee):
+    identifier = 'my-identifier'
+    MockProviderMessage = namedtuple('BroadcastProviderMessage', ['id', 'message_number', 'created_at'])
+
+    provider_messages = [
+        MockProviderMessage(uuid.uuid4(), '0000007b', '2020-12-10 11:19:44.130585'),
+        MockProviderMessage(uuid.uuid4(), '0000004e', '2020-12-10 12:19:44.130585')
+    ]
+    sent = '2020-12-10 14:19:44.130585'
+
+    ld_client_mock = mocker.patch.object(
+        cbc_proxy_ee,
+        '_lambda_client',
+        create=True,
+    )
+
+    ld_client_mock.invoke.return_value = {
+        'StatusCode': 200,
+    }
+
+    cbc_proxy_ee.cancel_broadcast(
+        identifier=identifier,
+        message_number='00000050',
+        previous_provider_messages=provider_messages,
+        sent=sent
+    )
+
+    ld_client_mock.invoke.assert_called_once_with(
+        FunctionName='bt-ee-1-proxy',
+        InvocationType='RequestResponse',
+        Payload=mocker.ANY,
+    )
+
+    kwargs = ld_client_mock.invoke.mock_calls[0][-1]
+    payload_bytes = kwargs['Payload']
+    payload = json.loads(payload_bytes)
+
+    assert payload['identifier'] == identifier
+    assert 'message_number' not in payload
+    assert payload['message_format'] == 'cap'
+    assert payload['message_type'] == 'cancel'
+    assert payload['references'] == [
+        {
+            "message_id": str(provider_messages[0].id),
+            "sent": provider_messages[0].created_at
+        },
+        {
+            "message_id": str(provider_messages[1].id),
+            "sent": provider_messages[1].created_at
+        },
+    ]
+    assert payload['sent'] == sent
+
+
 def test_cbc_proxy_vodafone_create_and_send_invokes_function(mocker, cbc_proxy_vodafone):
     identifier = 'my-identifier'
     headline = 'my-headline'
@@ -174,6 +229,62 @@ def test_cbc_proxy_vodafone_create_and_send_invokes_function(mocker, cbc_proxy_v
     assert payload['areas'] == areas
     assert payload['sent'] == sent
     assert payload['expires'] == expires
+
+
+def test_cbc_proxy_vodafone_cancel_invokes_function(mocker, cbc_proxy_vodafone):
+    identifier = 'my-identifier'
+    MockProviderMessage = namedtuple('BroadcastProviderMessage', ['id', 'message_number', 'created_at'])
+
+    provider_messages = [
+        MockProviderMessage(uuid.uuid4(), '0000007b', '2020-12-10 11:19:44.130585'),
+        MockProviderMessage(uuid.uuid4(), '0000004e', '2020-12-10 12:19:44.130585')
+    ]
+    sent = '2020-12-10 14:19:44.130585'
+
+    ld_client_mock = mocker.patch.object(
+        cbc_proxy_vodafone,
+        '_lambda_client',
+        create=True,
+    )
+
+    ld_client_mock.invoke.return_value = {
+        'StatusCode': 200,
+    }
+
+    cbc_proxy_vodafone.cancel_broadcast(
+        identifier=identifier,
+        message_number='00000050',
+        previous_provider_messages=provider_messages,
+        sent=sent
+    )
+
+    ld_client_mock.invoke.assert_called_once_with(
+        FunctionName='vodafone-1-proxy',
+        InvocationType='RequestResponse',
+        Payload=mocker.ANY,
+    )
+
+    kwargs = ld_client_mock.invoke.mock_calls[0][-1]
+    payload_bytes = kwargs['Payload']
+    payload = json.loads(payload_bytes)
+
+    assert payload['identifier'] == identifier
+    assert payload['message_number'] == '00000050'
+    assert payload['message_format'] == 'ibag'
+    assert payload['message_type'] == 'cancel'
+    assert payload['references'] == [
+        {
+            "message_id": str(provider_messages[0].id),
+            "message_number": provider_messages[0].message_number,
+            "sent": provider_messages[0].created_at
+        },
+        {
+            "message_id": str(provider_messages[1].id),
+            "message_number": provider_messages[1].message_number,
+            "sent": provider_messages[1].created_at
+        },
+    ]
+    assert payload['sent'] == sent
 
 
 def test_cbc_proxy_create_and_send_handles_invoke_error(mocker, cbc_proxy_ee):

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -236,8 +236,8 @@ def test_cbc_proxy_vodafone_cancel_invokes_function(mocker, cbc_proxy_vodafone):
     MockProviderMessage = namedtuple('BroadcastProviderMessage', ['id', 'message_number', 'created_at'])
 
     provider_messages = [
-        MockProviderMessage(uuid.uuid4(), '0000007b', '2020-12-10 11:19:44.130585'),
-        MockProviderMessage(uuid.uuid4(), '0000004e', '2020-12-10 12:19:44.130585')
+        MockProviderMessage(uuid.uuid4(), 78, '2020-12-10 11:19:44.130585'),
+        MockProviderMessage(uuid.uuid4(), 123, '2020-12-10 12:19:44.130585')
     ]
     sent = '2020-12-10 14:19:44.130585'
 
@@ -275,12 +275,12 @@ def test_cbc_proxy_vodafone_cancel_invokes_function(mocker, cbc_proxy_vodafone):
     assert payload['references'] == [
         {
             "message_id": str(provider_messages[0].id),
-            "message_number": provider_messages[0].message_number,
+            "message_number": '0000004e',
             "sent": provider_messages[0].created_at
         },
         {
             "message_id": str(provider_messages[1].id),
-            "message_number": provider_messages[1].message_number,
+            "message_number": '0000007b',
             "sent": provider_messages[1].created_at
         },
     ]


### PR DESCRIPTION
This is so we could send cancel messages to the lambda.