### PR TITLE
Do not let us delete letters that have not reached a final state

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -419,6 +419,7 @@ def _move_notifications_to_notification_history(notification_type, service_id, d
 def _delete_letters_from_s3(
         notification_type, service_id, date_to_delete_from, query_limit
 ):
+    bucket_name = current_app.config['LETTERS_PDF_BUCKET_NAME']
     letters_to_delete_from_s3 = db.session.query(
         Notification
     ).filter(
@@ -427,7 +428,6 @@ def _delete_letters_from_s3(
         Notification.service_id == service_id
     ).limit(query_limit).all()
     for letter in letters_to_delete_from_s3:
-        bucket_name = current_app.config['LETTERS_PDF_BUCKET_NAME']
         # although letters without a `sent_at` timestamp do have PDFs, they do not exist in the
         # production-letters-pdf bucket as they never made it that far so we do not try and delete
         # them from it

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -428,7 +428,9 @@ def _delete_letters_from_s3(
     ).limit(query_limit).all()
     for letter in letters_to_delete_from_s3:
         bucket_name = current_app.config['LETTERS_PDF_BUCKET_NAME']
-        # I don't think we need this anymore, we should update the query to get letters sent 7 days ago
+        # although letters without a `sent_at` timestamp do have PDFs, they do not exist in the
+        # production-letters-pdf bucket as they never made it that far so we do not try and delete
+        # them from it
         if letter.sent_at:
             prefix = get_letter_pdf_filename(reference=letter.reference,
                                              crown=letter.service.crown,

--- a/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
@@ -212,13 +212,17 @@ def test_delete_notifications_delete_notification_type_for_default_time_if_no_da
     assert Notification.query.filter_by(notification_type='email').count() == 1
 
 
-def test_delete_notifications_does_try_to_delete_from_s3_when_letter_has_not_been_sent(sample_service, mocker):
+def test_delete_notifications_doesnt_try_to_delete_from_s3_when_letter_has_not_sent(sample_service, mocker):
     mock_get_s3 = mocker.patch("app.dao.notifications_dao.get_s3_bucket_objects")
     letter_template = create_template(service=sample_service, template_type='letter')
 
-    create_notification(template=letter_template, status='sending',
-                        reference='LETTER_REF')
-    delete_notifications_older_than_retention_by_type('email', qry_limit=1)
+    create_notification(
+        template=letter_template,
+        status='created',
+        reference='LETTER_REF',
+        created_at=datetime.utcnow() - timedelta(days=14)
+    )
+    delete_notifications_older_than_retention_by_type('letter', qry_limit=1)
     mock_get_s3.assert_not_called()
 
 

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -256,7 +256,7 @@ def create_notification(
     if to_field is None:
         to_field = '+447700900855' if template.template_type == SMS_TYPE else 'test@example.com'
 
-    if status != 'created':
+    if status not in ('created', 'validation-failed', 'virus-scan-failed', 'pending-virus-check'):
         sent_at = sent_at or datetime.utcnow()
         updated_at = updated_at or datetime.utcnow()
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176141920

Definitely review commit by commit

Definitely up for conversation about which is the lesser of two evils here in terms of losing letters and sticking strictly to our data retention policy. I wrote the pivotal ticket so that's only my opinion, would like to hear opposing.

Note, as per the ticket, this will stop us deleting letters that have not moved into a final state. We already have alerts for each of the non final statuses

`raise_alert_if_letter_notifications_still_sending` to alert us about notifications still in sending when they shouldn't be
`check_precompiled_letter_state` to alert us about notifications still in `pending-virus-scan` when they shouldn't' be
`check_templated_letter_state` to alert us about notifications still in `created` when they shouldn't be