### PR TITLE
Increase email size limit to 2MBby pulling in new utils

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -153,7 +153,7 @@ def check_is_message_too_long(template_with_content):
             )
         elif template_with_content.template_type == EMAIL_TYPE:
             message += (
-                f"Emails cannot be longer than 1000000 bytes. "
+                f"Emails cannot be longer than 2000000 bytes. "
                 f"Your message is {template_with_content.content_size_in_bytes} bytes."
             )
         raise BadRequestError(message=message)

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,7 +29,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.6#egg=notifications-utils==43.5.6
+git+https://github.com/alphagov/notifications-utils.git@43.5.7#egg=notifications-utils==43.5.7
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.6#egg=notifications-utils==43.5.6
+git+https://github.com/alphagov/notifications-utils.git@43.5.7#egg=notifications-utils==43.5.7
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0
@@ -42,14 +42,14 @@ alembic==1.4.3
 amqp==1.4.9
 anyjson==0.3.3
 attrs==20.3.0
-awscli==1.18.194
+awscli==1.18.197
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.2.1
 blinker==1.4
 boto==2.49.0
-boto3==1.16.34
-botocore==1.19.34
+boto3==1.16.37
+botocore==1.19.37
 certifi==2020.12.5
 chardet==3.0.4
 click==7.1.2
@@ -62,7 +62,6 @@ geojson==2.5.0
 govuk-bank-holidays==0.8
 greenlet==0.4.17
 idna==2.10
-importlib-metadata==3.1.1
 Jinja2==2.11.2
 jmespath==0.10.0
 kombu==3.0.37
@@ -71,8 +70,8 @@ MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5
 orderedset==2.0.3
-packaging==20.7
-phonenumbers==8.12.14
+packaging==20.8
+phonenumbers==8.12.15
 pyasn1==0.4.8
 pycparser==2.20
 pyparsing==2.4.7
@@ -93,4 +92,3 @@ statsd==3.3.0
 urllib3==1.26.2
 webencodings==0.5.1
 Werkzeug==1.0.1
-zipp==3.4.0

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -345,7 +345,7 @@ def test_check_is_message_too_long_fails(notify_db_session, show_prefix, char_co
 
 
 def test_check_is_message_too_long_passes_for_long_email(sample_service):
-    email_character_count = 1000003
+    email_character_count = 2000003
     t = create_template(service=sample_service, content='a' * email_character_count, template_type='email')
     template = templates_dao.dao_get_template_by_id_and_service_id(template_id=t.id,
                                                                    service_id=t.service_id)
@@ -356,8 +356,8 @@ def test_check_is_message_too_long_passes_for_long_email(sample_service):
     assert e.value.status_code == 400
     expected_message = (
         'Your message is too long. ' +
-        'Emails cannot be longer than 1000000 bytes. ' +
-        'Your message is 1000084 bytes.'
+        'Emails cannot be longer than 2000000 bytes. ' +
+        'Your message is 2000084 bytes.'
     )
     assert e.value.message == expected_message
     assert e.value.fields == []


### PR DESCRIPTION
This is because GOV.UK has hit the email size limit with their
weekly digest email.