### PR TITLE
Bump utils to 43.5.9

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,7 +29,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.7#egg=notifications-utils==43.5.7
+git+https://github.com/alphagov/notifications-utils.git@43.5.8#egg=notifications-utils==43.5.8
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -29,7 +29,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.8#egg=notifications-utils==43.5.8
+git+https://github.com/alphagov/notifications-utils.git@43.5.9#egg=notifications-utils==43.5.9
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.7#egg=notifications-utils==43.5.7
+git+https://github.com/alphagov/notifications-utils.git@43.5.8#egg=notifications-utils==43.5.8
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0
@@ -42,16 +42,16 @@ alembic==1.4.3
 amqp==1.4.9
 anyjson==0.3.3
 attrs==20.3.0
-awscli==1.18.197
+awscli==1.18.199
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.2.1
 blinker==1.4
 boto==2.49.0
-boto3==1.16.37
-botocore==1.19.37
+boto3==1.16.39
+botocore==1.19.39
 certifi==2020.12.5
-chardet==3.0.4
+chardet==4.0.0
 click==7.1.2
 colorama==0.4.3
 dnspython==1.16.0
@@ -62,6 +62,7 @@ geojson==2.5.0
 govuk-bank-holidays==0.8
 greenlet==0.4.17
 idna==2.10
+importlib-metadata==3.3.0
 Jinja2==2.11.2
 jmespath==0.10.0
 kombu==3.0.37
@@ -83,12 +84,14 @@ python-json-logger==2.0.1
 pytz==2020.4
 PyYAML==5.3.1
 redis==3.5.3
-requests==2.25.0
+requests==2.25.1
 rsa==4.5
 s3transfer==0.3.3
 six==1.15.0
 smartypants==2.0.1
 statsd==3.3.0
+typing-extensions==3.7.4.3
 urllib3==1.26.2
 webencodings==0.5.1
 Werkzeug==1.0.1
+zipp==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ notifications-python-client==5.7.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.8#egg=notifications-utils==43.5.8
+git+https://github.com/alphagov/notifications-utils.git@43.5.9#egg=notifications-utils==43.5.9
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.8.0

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -345,7 +345,7 @@ def test_check_is_message_too_long_fails(notify_db_session, show_prefix, char_co
 
 
 def test_check_is_message_too_long_passes_for_long_email(sample_service):
-    email_character_count = 2000003
+    email_character_count = 2_000_001
     t = create_template(service=sample_service, content='a' * email_character_count, template_type='email')
     template = templates_dao.dao_get_template_by_id_and_service_id(template_id=t.id,
                                                                    service_id=t.service_id)
@@ -357,7 +357,7 @@ def test_check_is_message_too_long_passes_for_long_email(sample_service):
     expected_message = (
         'Your message is too long. ' +
         'Emails cannot be longer than 2000000 bytes. ' +
-        'Your message is 2000084 bytes.'
+        'Your message is 2000001 bytes.'
     )
     assert e.value.message == expected_message
     assert e.value.fields == []


### PR DESCRIPTION
Fixes bugs with HTML escaping and calculating size of emails.

Changes: https://github.com/alphagov/notifications-utils/compare/43.5.7...43.5.9