### PR TITLE
Fix cancel broadcast by converting reference date to string

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -31,10 +31,6 @@ from app.clients.sms.firetext import FiretextClient
 from app.clients.sms.mmg import MMGClient
 from app.clients.performance_platform.performance_platform_client import PerformancePlatformClient
 
-DATETIME_FORMAT_NO_TIMEZONE = "%Y-%m-%d %H:%M:%S.%f"
-DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
-DATE_FORMAT = "%Y-%m-%d"
-
 
 class SQLAlchemy(_SQLAlchemy):
     """We need to subclass SQLAlchemy in order to override create_engine options"""

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -8,11 +8,9 @@ from requests import (
     RequestException
 )
 
-from app import (
-    notify_celery,
-    encryption
-)
+from app import encryption, notify_celery
 from app.config import QueueNames
+from app.utils import DATETIME_FORMAT
 
 
 @notify_celery.task(bind=True, name="send-delivery-status", max_retries=5, default_retry_delay=300)
@@ -115,7 +113,6 @@ def _send_data_to_service_callback_api(self, data, service_callback_url, token, 
 
 
 def create_delivery_status_callback_data(notification, service_callback_api):
-    from app import DATETIME_FORMAT, encryption
     data = {
         "notification_id": str(notification.id),
         "notification_client_reference": notification.client_reference,
@@ -133,7 +130,6 @@ def create_delivery_status_callback_data(notification, service_callback_api):
 
 
 def create_complaint_callback_data(complaint, notification, service_callback_api, recipient):
-    from app import DATETIME_FORMAT, encryption
     data = {
         "complaint_id": str(complaint.id),
         "notification_id": str(notification.id),

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -18,7 +18,6 @@ from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from app import (
     create_uuid,
     create_random_identifier,
-    DATETIME_FORMAT,
     encryption,
     notify_celery,
 )
@@ -66,6 +65,7 @@ from app.models import (
 )
 from app.notifications.process_notifications import persist_notification
 from app.service.utils import service_allowed_to_send_to
+from app.utils import DATETIME_FORMAT
 
 
 @notify_celery.task(name="process-job")

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -165,12 +165,16 @@ class CBCProxyEE(CBCProxyClientBase):
         identifier, previous_provider_messages,
         sent, message_number=None
     ):
+        from app import DATETIME_FORMAT
         payload = {
             'message_type': 'cancel',
             'identifier': identifier,
             'message_format': 'cap',
             "references": [
-                {"message_id": str(message.id), "sent": message.created_at} for message in previous_provider_messages
+                {
+                    "message_id": str(message.id),
+                    "sent": message.created_at.strftime(DATETIME_FORMAT)
+                } for message in previous_provider_messages
             ],
             'sent': sent,
         }
@@ -219,6 +223,7 @@ class CBCProxyVodafone(CBCProxyClientBase):
     ):
         # avoid cyclical import
         from app.utils import format_sequential_number
+        from app import DATETIME_FORMAT
 
         payload = {
             'message_type': 'cancel',
@@ -229,7 +234,7 @@ class CBCProxyVodafone(CBCProxyClientBase):
                 {
                     "message_id": str(message.id),
                     "message_number": format_sequential_number(message.message_number),
-                    "sent": message.created_at
+                    "sent": message.created_at.strftime(DATETIME_FORMAT)
                 } for message in previous_provider_messages
             ],
             'sent': sent,

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -4,6 +4,7 @@ import boto3
 from flask import current_app
 
 from app.config import BroadcastProvider
+from app.utils import DATETIME_FORMAT, format_sequential_number
 
 # The variable names in this file have specific meaning in a CAP message
 #
@@ -165,7 +166,6 @@ class CBCProxyEE(CBCProxyClientBase):
         identifier, previous_provider_messages,
         sent, message_number=None
     ):
-        from app import DATETIME_FORMAT
         payload = {
             'message_type': 'cancel',
             'identifier': identifier,
@@ -221,9 +221,6 @@ class CBCProxyVodafone(CBCProxyClientBase):
     def cancel_broadcast(
         self, identifier, previous_provider_messages, sent, message_number
     ):
-        # avoid cyclical import
-        from app.utils import format_sequential_number
-        from app import DATETIME_FORMAT
 
         payload = {
             'message_type': 'cancel',

--- a/app/commands.py
+++ b/app/commands.py
@@ -15,7 +15,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 from notifications_utils.statsd_decorators import statsd
 
-from app import db, DATETIME_FORMAT, encryption
+from app import db, encryption
 from app.aws import s3
 from app.celery.tasks import record_daily_sorted_counts, process_row
 from app.celery.nightly_tasks import send_total_sent_notifications_to_performance_platform
@@ -60,7 +60,7 @@ from app.models import (
     LetterBranding,
 )
 from app.performance_platform.processing_time import send_processing_time_for_start_and_end
-from app.utils import get_london_midnight_in_utc, get_midnight_for_day_before
+from app.utils import DATETIME_FORMAT, get_london_midnight_in_utc, get_midnight_for_day_before
 
 
 @click.group(name='command', help='Additional commands')

--- a/app/models.py
+++ b/app/models.py
@@ -35,12 +35,8 @@ from app.hashing import (
     hashpw,
     check_hash
 )
-from app import (
-    db,
-    encryption,
-    DATETIME_FORMAT,
-    DATETIME_FORMAT_NO_TIMEZONE)
-from app.utils import get_dt_string_or_none
+from app import db, encryption
+from app.utils import DATETIME_FORMAT, DATETIME_FORMAT_NO_TIMEZONE, get_dt_string_or_none
 
 from app.history_meta import Versioned
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -23,11 +23,11 @@ from notifications_utils.recipients import (
     validate_and_format_phone_number
 )
 
-from app import ma, DATETIME_FORMAT_NO_TIMEZONE
+from app import ma
 from app import models
 from app.models import ServicePermission
 from app.dao.permissions_dao import permission_dao
-from app.utils import get_template_instance
+from app.utils import DATETIME_FORMAT_NO_TIMEZONE, get_template_instance
 
 
 def _validate_positive_number(value, msg="Not a positive integer"):

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -12,7 +12,6 @@ from notifications_utils.timezones import convert_utc_to_bst
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
-from app import DATE_FORMAT, DATETIME_FORMAT_NO_TIMEZONE
 from app.aws import s3
 from app.config import QueueNames
 from app.dao import fact_notification_status_dao, notifications_dao
@@ -131,7 +130,7 @@ from app.schemas import (
     email_data_request_schema
 )
 from app.user.users_schema import post_set_permissions_schema
-from app.utils import midnight_n_days_ago, pagination_links
+from app.utils import DATE_FORMAT, DATETIME_FORMAT_NO_TIMEZONE, midnight_n_days_ago, pagination_links
 
 service_blueprint = Blueprint('service', __name__)
 

--- a/app/template_statistics/rest.py
+++ b/app/template_statistics/rest.py
@@ -1,11 +1,11 @@
 from flask import Blueprint, jsonify, request
 
-from app import DATETIME_FORMAT
 from app.dao.notifications_dao import dao_get_last_date_template_was_used
 from app.dao.templates_dao import dao_get_template_by_id_and_service_id
 from app.dao.fact_notification_status_dao import fetch_notification_status_for_service_for_today_and_7_previous_days
 
 from app.errors import register_errors, InvalidRequest
+from app.utils import DATETIME_FORMAT
 
 template_statistics = Blueprint('template_statistics',
                                 __name__,

--- a/app/utils.py
+++ b/app/utils.py
@@ -11,8 +11,10 @@ from notifications_utils.template import (
     BroadcastMessageTemplate,
 )
 
-from app import DATETIME_FORMAT
 
+DATETIME_FORMAT_NO_TIMEZONE = "%Y-%m-%d %H:%M:%S.%f"
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+DATE_FORMAT = "%Y-%m-%d"
 local_timezone = pytz.timezone("Europe/London")
 
 

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -14,7 +14,6 @@ from app import (
     notify_celery,
     document_download_client,
     encryption,
-    DATETIME_FORMAT
 )
 from app.celery.letters_pdf_tasks import get_pdf_for_templated_letter, sanitise_letter
 from app.celery.research_mode_tasks import create_fake_letter_response_file
@@ -54,6 +53,7 @@ from app.notifications.validators import (
     validate_template,
     check_is_message_too_long)
 from app.schema_validation import validate
+from app.utils import DATETIME_FORMAT
 from app.v2.errors import BadRequestError
 from app.v2.notifications.create_response import (
     create_post_email_response_from_notification,

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -5,8 +5,9 @@ import pytest
 import requests_mock
 from freezegun import freeze_time
 
-from app import (DATETIME_FORMAT, encryption)
+from app import encryption
 from app.celery.service_callback_tasks import send_delivery_status_to_service, send_complaint_to_service
+from app.utils import DATETIME_FORMAT
 from tests.app.db import (
     create_complaint,
     create_notification,

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -16,10 +16,7 @@ from notifications_utils.template import (
 )
 from notifications_utils.columns import Row
 
-from app import (
-    DATETIME_FORMAT,
-    encryption
-)
+from app import encryption
 from app.celery import provider_tasks
 from app.celery import tasks
 from app.celery.tasks import (
@@ -52,6 +49,7 @@ from app.models import (
     SMS_TYPE,
     ReturnedLetter,
     NOTIFICATION_CREATED)
+from app.utils import DATETIME_FORMAT
 
 from tests.app import load_example_csv
 

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -1,10 +1,12 @@
 import json
 import uuid
 from collections import namedtuple
+from datetime import datetime
 from unittest.mock import Mock
 
 import pytest
 
+from app import DATETIME_FORMAT
 from app.clients.cbc_proxy import CBCProxyClient, CBCProxyException, CBCProxyEE, CBCProxyCanary
 
 
@@ -119,13 +121,15 @@ def test_cbc_proxy_ee_create_and_send_invokes_function(mocker, cbc_proxy_ee):
 
 def test_cbc_proxy_ee_cancel_invokes_function(mocker, cbc_proxy_ee):
     identifier = 'my-identifier'
-    MockProviderMessage = namedtuple('BroadcastProviderMessage', ['id', 'message_number', 'created_at'])
+    MockProviderMessage = namedtuple(
+        'BroadcastProviderMessage', ['id', 'message_number', 'created_at']
+    )
 
     provider_messages = [
-        MockProviderMessage(uuid.uuid4(), '0000007b', '2020-12-10 11:19:44.130585'),
-        MockProviderMessage(uuid.uuid4(), '0000004e', '2020-12-10 12:19:44.130585')
+        MockProviderMessage(uuid.uuid4(), '0000007b', datetime(2020, 12, 16)),
+        MockProviderMessage(uuid.uuid4(), '0000004e', datetime(2020, 12, 17))
     ]
-    sent = '2020-12-10 14:19:44.130585'
+    sent = '2020-12-17 14:19:44.130585'
 
     ld_client_mock = mocker.patch.object(
         cbc_proxy_ee,
@@ -161,11 +165,11 @@ def test_cbc_proxy_ee_cancel_invokes_function(mocker, cbc_proxy_ee):
     assert payload['references'] == [
         {
             "message_id": str(provider_messages[0].id),
-            "sent": provider_messages[0].created_at
+            "sent": provider_messages[0].created_at.strftime(DATETIME_FORMAT)
         },
         {
             "message_id": str(provider_messages[1].id),
-            "sent": provider_messages[1].created_at
+            "sent": provider_messages[1].created_at.strftime(DATETIME_FORMAT)
         },
     ]
     assert payload['sent'] == sent
@@ -233,13 +237,16 @@ def test_cbc_proxy_vodafone_create_and_send_invokes_function(mocker, cbc_proxy_v
 
 def test_cbc_proxy_vodafone_cancel_invokes_function(mocker, cbc_proxy_vodafone):
     identifier = 'my-identifier'
-    MockProviderMessage = namedtuple('BroadcastProviderMessage', ['id', 'message_number', 'created_at'])
+    MockProviderMessage = namedtuple(
+        'BroadcastProviderMessage',
+        ['id', 'message_number', 'created_at']
+    )
 
     provider_messages = [
-        MockProviderMessage(uuid.uuid4(), 78, '2020-12-10 11:19:44.130585'),
-        MockProviderMessage(uuid.uuid4(), 123, '2020-12-10 12:19:44.130585')
+        MockProviderMessage(uuid.uuid4(), 78, datetime(2020, 12, 16)),
+        MockProviderMessage(uuid.uuid4(), 123, datetime(2020, 12, 17))
     ]
-    sent = '2020-12-10 14:19:44.130585'
+    sent = '2020-12-18 14:19:44.130585'
 
     ld_client_mock = mocker.patch.object(
         cbc_proxy_vodafone,
@@ -276,12 +283,12 @@ def test_cbc_proxy_vodafone_cancel_invokes_function(mocker, cbc_proxy_vodafone):
         {
             "message_id": str(provider_messages[0].id),
             "message_number": '0000004e',
-            "sent": provider_messages[0].created_at
+            "sent": provider_messages[0].created_at.strftime(DATETIME_FORMAT)
         },
         {
             "message_id": str(provider_messages[1].id),
             "message_number": '0000007b',
-            "sent": provider_messages[1].created_at
+            "sent": provider_messages[1].created_at.strftime(DATETIME_FORMAT)
         },
     ]
     assert payload['sent'] == sent

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -6,8 +6,8 @@ from unittest.mock import Mock
 
 import pytest
 
-from app import DATETIME_FORMAT
 from app.clients.cbc_proxy import CBCProxyClient, CBCProxyException, CBCProxyEE, CBCProxyCanary
+from app.utils import DATETIME_FORMAT
 
 
 @pytest.fixture(scope='function')

--- a/tests/app/template_statistics/test_rest.py
+++ b/tests/app/template_statistics/test_rest.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import pytest
 from freezegun import freeze_time
 
-from app import DATETIME_FORMAT
+from app.utils import DATETIME_FORMAT
 from tests.app.db import create_ft_notification_status, create_notification
 
 

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -2,7 +2,7 @@ import datetime
 import pytest
 from flask import json, url_for
 
-from app import DATETIME_FORMAT
+from app.utils import DATETIME_FORMAT
 from tests import create_authorization_header
 from tests.app.db import (
     create_notification,

--- a/tests/app/v2/template/test_get_template.py
+++ b/tests/app/v2/template/test_get_template.py
@@ -2,8 +2,8 @@ import pytest
 
 from flask import json
 
-from app import DATETIME_FORMAT
 from app.models import (TEMPLATE_TYPES, EMAIL_TYPE, SMS_TYPE, LETTER_TYPE,)
+from app.utils import DATETIME_FORMAT
 from tests import create_authorization_header
 from tests.app.db import create_template, create_letter_contact
 


### PR DESCRIPTION
Datetime object is not json-serializable, we have to convert it to string for the created_at field of previous broadcast provider messages.

Also move DATETIME_FORMAT from app to app.utils to avoid cyclical import issues

Best to look commit by commit ☺️ 