### PR TITLE
Fix logging line to include response context

### DIFF
--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import json
 
 from flask import current_app
-from requests import request, RequestException, HTTPError
+from requests import request, HTTPError
 
 from notifications_utils.s3 import s3upload
 
@@ -66,16 +66,14 @@ def make_request(notification_type, provider, data, headers):
             timeout=60
         )
         response.raise_for_status()
-    except RequestException as e:
-        api_error = HTTPError(e)
+    except HTTPError as e:
         current_app.logger.error(
-            "API {} request on {} failed with {}".format(
-                "POST",
+            "API POST request on {} failed with status {}".format(
                 api_call,
-                api_error.response
+                e.response.status_code
             )
         )
-        raise api_error
+        raise e
     finally:
         current_app.logger.info("Mocked provider callback request finished")
     return response.json()


### PR DESCRIPTION
We have been getting log lines of the following:

`API POST request on
https://api.notifications.service.gov.uk/notifications/sms/mmg failed
with None`

It's not clear what error caused the request to fail because the value
of `api_error.response` is always `None`.

There appears to be something wrong with this logging.
`raise_for_status` will raise an `HTTPError`, so then there should be no
reason to then pass that error into another `HTTPError` (which is
causing the response to be lost).

We can instead simply catch the `HTTPError` and log it's status
code.

This might not be perfect, but it's definitely an improvement and should
give us some more context about why these requests occasionally fail.