### PR TITLE
Serialise process_type for template history

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -410,6 +410,7 @@ class TemplateHistorySchema(BaseSchema):
 
     reply_to = fields.Method("get_reply_to", allow_none=True)
     reply_to_text = fields.Method("get_reply_to_text", allow_none=True)
+    process_type = field_for(models.Template, 'process_type')
 
     created_by = fields.Nested(UserSchema, only=['id', 'name', 'email_address'], dump_only=True)
     created_at = field_for(models.Template, 'created_at', format=DATETIME_FORMAT_NO_TIMEZONE)

--- a/tests/app/template/test_rest_history.py
+++ b/tests/app/template/test_rest_history.py
@@ -24,6 +24,7 @@ def test_template_history_version(notify_api, sample_user, sample_template):
             assert json_resp['data']['id'] == str(sample_template.id)
             assert json_resp['data']['content'] == sample_template.content
             assert json_resp['data']['version'] == 1
+            assert json_resp['data']['process_type'] == 'normal'
             assert json_resp['data']['created_by']['name'] == sample_user.name
             assert datetime.strptime(json_resp['data']['created_at'], '%Y-%m-%d %H:%M:%S.%f').date() == date.today()
 
@@ -31,6 +32,7 @@ def test_template_history_version(notify_api, sample_user, sample_template):
 def test_previous_template_history_version(notify_api, sample_template):
     old_content = sample_template.content
     sample_template.content = "New content"
+    sample_template.process_type = "priority"
     dao_update_template(sample_template)
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
@@ -49,6 +51,7 @@ def test_previous_template_history_version(notify_api, sample_template):
             assert json_resp['data']['id'] == str(sample_template.id)
             assert json_resp['data']['version'] == 1
             assert json_resp['data']['content'] == old_content
+            assert json_resp['data']['process_type'] == 'normal'
 
 
 def test_404_missing_template_version(notify_api, sample_template):


### PR DESCRIPTION
We already serialise it in the templates response. We should make sure the field is also present in the history response, if we want to use cached template versions when processing notifications.