### PR TITLE
Cache provider lookups for 10 seconds

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -148,7 +148,7 @@ def update_notification_to_sending(notification, provider):
     dao_update_notification(notification)
 
 
-provider_cache = TTLCache(maxsize=8, ttl=2)
+provider_cache = TTLCache(maxsize=8, ttl=10)
 
 
 @cached(cache=provider_cache)

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -1,7 +1,7 @@
 import random
 from urllib import parse
 from datetime import datetime, timedelta
-
+from cachetools import TTLCache, cached
 from flask import current_app
 from notifications_utils.recipients import (
     validate_and_format_phone_number,
@@ -148,6 +148,10 @@ def update_notification_to_sending(notification, provider):
     dao_update_notification(notification)
 
 
+provider_cache = TTLCache(maxsize=8, ttl=2)
+
+
+@cached(cache=provider_cache)
 def provider_to_use(notification_type, international=False):
     active_providers = [
         p for p in get_provider_details_by_notification_type(notification_type, international) if p.active


### PR DESCRIPTION
For every email or text message we send we have to work out which provider to send it with. Every time we do this we go and load the list of providers from the database.

For emails, the result will always be the same.

For text messages the result is randomly chosen to balance the load between the providers.

For international text messages the result is always the same (we only have one international text message provider).

This pull request adds an in-memory cache with a 2 second time-to-live so that we’re not fetching the providers from the database every time, which should speed things up a bit.

This does mean that, for text messages, the random choice will ‘stick’ for two seconds on each instance, before being re-chosen. I think this is OK because it will even out to the same distribution over time.

I don’t like having to clear the cache in the tests, so would welcome suggestions on a better way of doing this…