### PR TITLE
Fix app logging

### DIFF
--- a/scripts/paas_app_wrapper.sh
+++ b/scripts/paas_app_wrapper.sh
@@ -22,7 +22,7 @@ case $NOTIFY_APP_NAME in
     ;;
   delivery-worker-sender)
     exec scripts/run_multi_worker_app_paas.sh celery multi start 3 -c 10 -A run_celery.notify_celery --loglevel=INFO \
-    -Q send-sms-tasks,send-email-tasks
+    --logfile=/dev/null --pidfile=/tmp/celery%N.pid -Q send-sms-tasks,send-email-tasks
     ;;
   delivery-worker-periodic)
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=2 \

--- a/scripts/run_multi_worker_app_paas.sh
+++ b/scripts/run_multi_worker_app_paas.sh
@@ -3,7 +3,6 @@
 set -e -o pipefail
 
 TERMINATE_TIMEOUT=9
-MAX_DISK_SPACE_USAGE=75
 readonly LOGS_DIR="/home/vcap/logs"
 
 function check_params {
@@ -125,23 +124,6 @@ function ensure_celery_is_running {
   fi
 }
 
-function check_disk_space {
-    # get something like:
-    #
-    # Filesystem     Use%
-    # overlay         56%
-    # tmpfs            0%
-    #
-    # and only keep '56'
-    SPACE_USAGE=$(df --output="source,pcent" | grep overlay | tr --squeeze-repeats " " | cut -f2 -d" "| cut -f1 -d"%")
-
-    if [[ "${SPACE_USAGE}" -ge "${MAX_DISK_SPACE_USAGE}" ]]; then
-        echo "Terminating ${NOTIFY_APP_NAME}, instance ${INSTANCE_INDEX} because we're running out of disk space"
-        echo "Usage: ${SPACE_USAGE}% - limit ${MAX_DISK_SPACE_USAGE}%"
-        exit
-    fi
-}
-
 function run {
   while true; do
     get_celery_pids
@@ -153,7 +135,6 @@ function run {
     done
     kill -0 ${AWSLOGS_AGENT_PID} 2&>/dev/null || start_aws_logs_agent
     kill -0 ${LOGS_TAIL_PID} 2&>/dev/null || start_logs_tail
-    check_disk_space
     sleep 1
   done
 }


### PR DESCRIPTION
The increased traffic highlighted two issues with our logs:

The first issue was that sender workers, because of the `celery multi`, were keeping duplicate logs: The ones generated from our application and the ones generated from celery itself.

The second issue was around handling the scenario were the instances would run out of disk space. Given the constraints of our runtime environment the simplest solution is to recycle the instances, when their disk usage is over a certain threshold.

For now, I set the threshold to 75%, same as the alert threshold.