### PR TITLE
Fix test that fails after 5:30pm

### DIFF
--- a/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
@@ -236,6 +236,7 @@ def test_delete_notifications_deletes_letters_not_sent_and_in_final_state_from_t
     mock_get_s3.assert_not_called()
 
 
+@freeze_time('2020-12-24 04:30')
 @pytest.mark.parametrize('notification_status', ['delivered', 'returned-letter', 'technical-failure'])
 def test_delete_notifications_deletes_letters_sent_and_in_final_state_from_table_and_s3(
     sample_service, mocker, notification_status


### PR DESCRIPTION
Was failing when ran after 5:30pm as this would cause the letters to be
in a different subfolder (for one day later). Solved by freezetiming it

Example build that failed: https://cd.gds-reliability.engineering/builds/1876957