### PR TITLE
Add more memory for the sender and letter workers

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -52,7 +52,7 @@
   'notify-delivery-celery-beat': {'memory': '128M'},
   'notify-delivery-worker-jobs': {},
   'notify-delivery-worker-research': {},
-  'notify-delivery-worker-sender': {'disk_quota': '2G', 'memory': '3G'},
+  'notify-delivery-worker-sender': {'disk_quota': '2G', 'memory': '4G'},
   'notify-delivery-worker-periodic': {},
   'notify-delivery-worker-reporting': {
     'additional_env_vars': {
@@ -61,7 +61,7 @@
     }
   },
   'notify-delivery-worker-priority': {},
-  'notify-delivery-worker-letters': {},
+  'notify-delivery-worker-letters': {'memory': '2G'},
   'notify-delivery-worker-retry-tasks': {},
   'notify-delivery-worker-internal': {},
   'notify-delivery-worker-receipts': {},


### PR DESCRIPTION
On monday, we had a build of emails in the email queue that weren't
getting picked up by the sender worker and causing delays.

After further investigation with Andy from the PaaS, we believe the
following happened.

We received a bunch of traffic at 8:30ish which consisted of some
very large emails in terms of their length and complexity. The amount
of memory used by the app instances got very high and a few apps
crashed due to OOM (recorded by 5 cf app event crashes). When new
app instances tried to spin up, they weren't able to as they
potentially also ran out of memory immediately (note, we don't have
app crashes for these recorded in the PaaS, the hypothesis is that the
containers failed on startup and the PaaS does not record these).

![image](https://user-images.githubusercontent.com/7228605/103096078-a528ff00-45fa-11eb-8bec-879e07af524c.png)


This left us in the position of having fewer app instances than we
needed, on top of which they were all using a very large amount of
CPU and may have been limited how quickly an individual app
instance would process tasks. This meant that we were overall
processing fewer tasks then we needed to and our queue of emails
started to build up.

So it appears our sender workers did not have the memory available that
they needed. By looking at a graph for the past 30 days of memory usage
on the sender workers, we see that it on several days breached 90%
memory usage for long periods of time. This in combination of the
hypothesis above of what happened leads us to decide that we want to
give the app instances a bigger memory quota so it has been upped from
3GB to 4GB.

![image](https://user-images.githubusercontent.com/7228605/103096039-87f43080-45fa-11eb-8d56-54244cf905e1.png)


Whilst doing, I also looked at long term memory usage graphs for our
other workers and saw that the letters worker was similarly close to
around 90% of memory used so have taken the opportunity to bump that
too.

![image](https://user-images.githubusercontent.com/7228605/103096050-90e50200-45fa-11eb-9a97-557aa57a9fff.png)