### PR TITLE
Pass language through to lambda

### DIFF
--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -1,4 +1,5 @@
 import json
+from abc import ABC, abstractmethod
 
 import boto3
 from flask import current_app
@@ -49,11 +50,18 @@ class CBCProxyClient:
         return proxy_classes[provider](self._lambda_client)
 
 
-class CBCProxyClientBase:
+class CBCProxyClientBase(ABC):
     lambda_name = None
 
-    LANGUAGE_ENGLISH = 'en-GB'
-    LANGUAGE_WELSH = 'cy-GB'
+    @property
+    @abstractmethod
+    def LANGUAGE_ENGLISH(self):
+        pass
+
+    @property
+    @abstractmethod
+    def LANGUAGE_WELSH(self):
+        pass
 
     def __init__(self, lambda_client):
         self._lambda_client = lambda_client
@@ -128,6 +136,9 @@ class CBCProxyCanary(CBCProxyClientBase):
     """
     lambda_name = 'canary'
 
+    LANGUAGE_ENGLISH = None
+    LANGUAGE_WELSH = None
+
     def send_canary(
         self,
         identifier,
@@ -137,6 +148,9 @@ class CBCProxyCanary(CBCProxyClientBase):
 
 class CBCProxyEE(CBCProxyClientBase):
     lambda_name = 'bt-ee-1-proxy'
+
+    LANGUAGE_ENGLISH = 'en-GB'
+    LANGUAGE_WELSH = 'cy-GB'
 
     def send_link_test(
         self,

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -59,10 +59,18 @@ def test_cbc_proxy_lambda_client_has_correct_keys(cbc_proxy_ee):
     assert secret == 'cbc-proxy-aws-secret-access-key'
 
 
-def test_cbc_proxy_ee_create_and_send_invokes_function(mocker, cbc_proxy_ee):
+@pytest.mark.parametrize('description, expected_language', (
+    ('my-description', 'en-GB'),
+    ('mŷ-description', 'cy-GB'),
+))
+def test_cbc_proxy_ee_create_and_send_invokes_function(
+    mocker,
+    cbc_proxy_ee,
+    description,
+    expected_language,
+):
     identifier = 'my-identifier'
     headline = 'my-headline'
-    description = 'my-description'
 
     sent = 'a-passed-through-sent-value'
     expires = 'a-passed-through-expires-value'
@@ -117,6 +125,7 @@ def test_cbc_proxy_ee_create_and_send_invokes_function(mocker, cbc_proxy_ee):
     assert payload['areas'] == areas
     assert payload['sent'] == sent
     assert payload['expires'] == expires
+    assert payload['language'] == expected_language
 
 
 def test_cbc_proxy_ee_cancel_invokes_function(mocker, cbc_proxy_ee):
@@ -175,10 +184,18 @@ def test_cbc_proxy_ee_cancel_invokes_function(mocker, cbc_proxy_ee):
     assert payload['sent'] == sent
 
 
-def test_cbc_proxy_vodafone_create_and_send_invokes_function(mocker, cbc_proxy_vodafone):
+@pytest.mark.parametrize('description, expected_language', (
+    ('my-description', 'English'),
+    ('mŷ-description', 'Welsh'),
+))
+def test_cbc_proxy_vodafone_create_and_send_invokes_function(
+    mocker,
+    cbc_proxy_vodafone,
+    description,
+    expected_language,
+):
     identifier = 'my-identifier'
     headline = 'my-headline'
-    description = 'my-description'
 
     sent = 'a-passed-through-sent-value'
     expires = 'a-passed-through-expires-value'
@@ -233,6 +250,7 @@ def test_cbc_proxy_vodafone_create_and_send_invokes_function(mocker, cbc_proxy_v
     assert payload['areas'] == areas
     assert payload['sent'] == sent
     assert payload['expires'] == expires
+    assert payload['language'] == expected_language
 
 
 def test_cbc_proxy_vodafone_cancel_invokes_function(mocker, cbc_proxy_vodafone):


### PR DESCRIPTION
If we’re sending non-GSM characters, we need to mark the language in the XML as Welsh (`cy-GB` in CAP, `Welsh` in IBAG).

Currently, the CBC proxy checks the content we’re sending, and then uses an approximation based on ASCII to determine whether we’re sending any non-GSM characters, and if so, sets the language appropriately.

Instead, we should can functionality from the notifications-utils repo to determine the language. If any non-GSM characters are used, then the we can set the language to Welsh.

We’ll need to update the proxy to look at this new language flag.

***

https://www.pivotaltracker.com/story/show/176095502