### PR TITLE
Cache service callback API in memory 

### DIFF
--- a/app/celery/process_sms_client_response_tasks.py
+++ b/app/celery/process_sms_client_response_tasks.py
@@ -15,6 +15,7 @@ from app.dao import notifications_dao
 from app.dao.service_callback_api_dao import get_service_delivery_status_callback_api_for_service
 from app.dao.templates_dao import dao_get_template_by_id
 from app.models import NOTIFICATION_PENDING
+from app.serialised_models import SerialisedServiceCallbackApi
 
 sms_response_mapper = {
     'MMG': get_mmg_responses,
@@ -91,7 +92,7 @@ def _process_for_status(notification_status, client_name, provider_reference, de
         notifications_dao.dao_update_notification(notification)
 
     if notification_status != NOTIFICATION_PENDING:
-        service_callback_api = get_service_delivery_status_callback_api_for_service(service_id=notification.service_id)
+        service_callback_api = SerialisedServiceCallbackApi.from_service_id(service_id)
         # queue callback task only if the service_callback_api exists
         if service_callback_api:
             encrypted_notification = create_delivery_status_callback_data(notification, service_callback_api)

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -67,7 +67,7 @@ def remove_emails_from_complaint(complaint_dict):
 
 def _check_and_queue_callback_task(notification):
     # queue callback task only if the service_callback_api exists
-    service_callback_api = get_service_delivery_status_callback_api_for_service(service_id=notification.service_id)
+    service_callback_api = SerialisedServiceCallbackApi.from_service_id(service_id)
     if service_callback_api:
         notification_data = create_delivery_status_callback_data(notification, service_callback_api)
         send_delivery_status_to_service.apply_async([str(notification.id), notification_data],

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -125,3 +125,25 @@ class SerialisedAPIKeyCollection(SerialisedModelCollection):
         ]
         db.session.commit()
         return cls(keys)
+
+
+class SerialisedServiceCallbackApi(SerialisedModel):
+
+    @classmethod
+    @memory_cache
+    def from_service_id(cls, service_id):
+        service_callback_api_dict = cls.get_dict(service_id)
+        if service_callback_api_dict:
+            return cls(cls.get_dict(service_id))
+        return None
+
+    @staticmethod
+    # Don’t cache this because we probably don’t wanna put people’s
+    # bearer tokens in Redis
+    def get_dict(service_id):
+        service_callback_api = get_service_delivery_status_callback_api_for_service(
+            service_id
+        )
+        if service_callback_api:
+            return service_callback_api.serialize()
+        return None


### PR DESCRIPTION
This would mean the callback task for emails wouldn’t need to open a database connection at all.