### PR TITLE
add content to broadcast_message and make template fields nullable

### DIFF
--- a/migrations/versions/0335_broadcast_msg_content.py
+++ b/migrations/versions/0335_broadcast_msg_content.py
@@ -1,0 +1,27 @@
+"""
+
+Revision ID: 0335_broadcast_msg_content
+Revises: 0334_broadcast_message_number
+Create Date: 2020-12-04 15:06:22.544803
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0335_broadcast_msg_content'
+down_revision = '0334_broadcast_message_number'
+
+
+def upgrade():
+    op.add_column('broadcast_message', sa.Column('content', sa.Text(), nullable=False))
+    op.alter_column('broadcast_message', 'template_id', nullable=True)
+    op.alter_column('broadcast_message', 'template_version', nullable=True)
+
+
+def downgrade():
+    # downgrade fails if there are broadcasts without a template. This is deliberate cos I don't feel comfortable
+    # deleting broadcasts.
+    op.alter_column('broadcast_message', 'template_id', nullable=False)
+    op.alter_column('broadcast_message', 'template_version', nullable=False)
+    op.drop_column('broadcast_message', 'content')


### PR DESCRIPTION
we want to be able to create broadcast messages without templates. To start with, these will come from the API, but in future we may want to let people create via the admin interface without creating a template too.

populate a non-nullable content field with the values supplied via the template (or supplied directly if via api).