### PR TITLE
Fix broadcast migration

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -189,11 +189,19 @@ def _create_broadcast_event(broadcast_message):
     else:
         transmitted_finishes_at = broadcast_message.finishes_at
 
+    # TODO: Remove this if statement after broadcast message content is guaranteed to always be populated.
+    if broadcast_message.content:
+        content = broadcast_message.content
+    else:
+        content = broadcast_message.template._as_utils_template_with_personalisation(
+            broadcast_message.personalisation
+        ).content_with_placeholders_filled_in
+
     event = BroadcastEvent(
         service=broadcast_message.service,
         broadcast_message=broadcast_message,
         message_type=msg_types[broadcast_message.status],
-        transmitted_content={"body": broadcast_message.content},
+        transmitted_content={"body": content},
         transmitted_areas=broadcast_message.areas,
         # TODO: Probably move this somewhere more standalone too and imply that it shouldn't change. Should it include
         # a service based identifier too? eg "flood-warnings@notifications.service.gov.uk" or similar

--- a/migrations/versions/0335_broadcast_msg_content.py
+++ b/migrations/versions/0335_broadcast_msg_content.py
@@ -14,7 +14,7 @@ down_revision = '0334_broadcast_message_number'
 
 
 def upgrade():
-    op.add_column('broadcast_message', sa.Column('content', sa.Text(), nullable=False))
+    op.add_column('broadcast_message', sa.Column('content', sa.Text(), nullable=True))
     op.alter_column('broadcast_message', 'template_id', nullable=True)
     op.alter_column('broadcast_message', 'template_version', nullable=True)
 


### PR DESCRIPTION
* allow null content in migration because existing rows won't have any content populated yet.
* allow broadcasts to have a template and no content. this ensures code remains backwards compatible during the deploy. this commit should be reverted once all broadcast_message.content fields have been back-filled.
