### PR TITLE
Failover to second lambda on error

### DIFF
--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -109,17 +109,17 @@ class CBCProxyClientBase(ABC):
         pass
 
     def _invoke_lambda_with_failover(self, payload):
-        payload_bytes = bytes(json.dumps(payload), encoding='utf8')
-        result = self._invoke_lambda(self.lambda_name, payload_bytes)
+        result = self._invoke_lambda(self.lambda_name, payload)
 
         if not result:
-            failover_result = self._invoke_lambda(self.failover_lambda_name, payload_bytes)
+            failover_result = self._invoke_lambda(self.failover_lambda_name, payload)
             if not failover_result:
                 raise CBCProxyException(f'Lambda failed for both {self.lambda_name} and {self.failover_lambda_name}')
 
         return result
 
-    def _invoke_lambda(self, lambda_name, payload_bytes):
+    def _invoke_lambda(self, lambda_name, payload):
+        payload_bytes = bytes(json.dumps(payload), encoding='utf8')
         current_app.logger.info(f"Calling lambda {lambda_name}")
         result = self._lambda_client.invoke(
             FunctionName=lambda_name,
@@ -168,7 +168,7 @@ class CBCProxyCanary(CBCProxyClientBase):
         self,
         identifier,
     ):
-        self._invoke_lambda_with_failover(payload={'identifier': identifier})
+        self._invoke_lambda(self.lambda_name, payload={'identifier': identifier})
 
 
 class CBCProxyEE(CBCProxyClientBase):

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -113,7 +113,10 @@ class CBCProxyClientBase(ABC):
         result = self._invoke_lambda(self.lambda_name, payload_bytes)
 
         if 'FunctionError' in result:
-            raise CBCProxyException('Function exited with unhandled exception')
+            if result['Payload']['errorType'] == "CBCNewConnectionError":
+                result = self._invoke_lambda(self.failover_lambda_name, payload_bytes)
+            else:
+                raise CBCProxyException('Function exited with unhandled exception')
 
         return result
 

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -51,7 +51,10 @@ class CBCProxyClient:
 
 
 class CBCProxyClientBase(ABC):
-    lambda_name = None
+    @property
+    @abstractmethod
+    def lambda_name(self):
+        pass
 
     @property
     @abstractmethod
@@ -101,12 +104,6 @@ class CBCProxyClientBase(ABC):
         pass
 
     def _invoke_lambda_with_failover(self, payload):
-        if not self.lambda_name:
-            current_app.logger.warning(
-                '{self.__class__.__name__} tried to send {payload} but cbc proxy aws env vars not set'
-            )
-            return
-
         payload_bytes = bytes(json.dumps(payload), encoding='utf8')
         result = self._invoke_lambda(self.lambda_name, payload_bytes)
 

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -114,6 +114,7 @@ class CBCProxyClientBase(ABC):
 
         if 'FunctionError' in result:
             if result['Payload']['errorType'] == "CBCNewConnectionError":
+                current_app.logger.info(f"Got CBCNewConnectionError for {self.lambda_name}, calling failover lambda")
                 result = self._invoke_lambda(self.failover_lambda_name, payload_bytes)
             else:
                 raise CBCProxyException('Function exited with unhandled exception')
@@ -121,6 +122,7 @@ class CBCProxyClientBase(ABC):
         return result
 
     def _invoke_lambda(self, lambda_name, payload_bytes):
+        current_app.logger.info(f"Calling lambda {lambda_name}")
         result = self._lambda_client.invoke(
             FunctionName=lambda_name,
             InvocationType='RequestResponse',
@@ -130,6 +132,7 @@ class CBCProxyClientBase(ABC):
         if result['StatusCode'] > 299:
             raise CBCProxyException('Could not invoke lambda')
 
+        current_app.logger.info(f"Finished calling lambda {lambda_name}")
         return result
 
     def infer_language_from(self, content):

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -58,6 +58,11 @@ class CBCProxyClientBase(ABC):
 
     @property
     @abstractmethod
+    def failover_lambda_name(self):
+        pass
+
+    @property
+    @abstractmethod
     def LANGUAGE_ENGLISH(self):
         pass
 
@@ -136,6 +141,9 @@ class CBCProxyCanary(CBCProxyClientBase):
     canary, a specific lambda that does not open a vpn or connect to a provider but just responds from within AWS.
     """
     lambda_name = 'canary'
+    # we don't need a failover lambda for the canary as it doesn't actually make calls out to a CBC
+    # so we just reuse the normal one in case of a failover scenario
+    failover_lambda_name = 'canary'
 
     LANGUAGE_ENGLISH = None
     LANGUAGE_WELSH = None
@@ -149,6 +157,7 @@ class CBCProxyCanary(CBCProxyClientBase):
 
 class CBCProxyEE(CBCProxyClientBase):
     lambda_name = 'bt-ee-1-proxy'
+    failover_lambda_name = 'bt-ee-2-proxy'
 
     LANGUAGE_ENGLISH = 'en-GB'
     LANGUAGE_WELSH = 'cy-GB'
@@ -208,6 +217,7 @@ class CBCProxyEE(CBCProxyClientBase):
 
 class CBCProxyVodafone(CBCProxyClientBase):
     lambda_name = 'vodafone-1-proxy'
+    failover_lambda_name = 'vodafone-2-proxy'
 
     LANGUAGE_ENGLISH = 'English'
     LANGUAGE_WELSH = 'Welsh'

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -9,6 +9,17 @@ import pytest
 from app.clients.cbc_proxy import CBCProxyClient, CBCProxyException, CBCProxyEE, CBCProxyCanary
 from app.utils import DATETIME_FORMAT
 
+EXAMPLE_AREAS = [{
+    'description': 'london',
+    'polygon': [
+        [51.12, -1.2],
+        [51.12, 1.2],
+        [51.74, 1.2],
+        [51.74, -1.2],
+        [51.12, -1.2],
+    ],
+}]
+
 
 @pytest.fixture(scope='function')
 def cbc_proxy_client(client, mocker):
@@ -75,18 +86,6 @@ def test_cbc_proxy_ee_create_and_send_invokes_function(
     sent = 'a-passed-through-sent-value'
     expires = 'a-passed-through-expires-value'
 
-    # a single area which is a square including london
-    areas = [{
-        'description': 'london',
-        'polygon': [
-            [51.12, -1.2],
-            [51.12, 1.2],
-            [51.74, 1.2],
-            [51.74, -1.2],
-            [51.12, -1.2],
-        ],
-    }]
-
     ld_client_mock = mocker.patch.object(
         cbc_proxy_ee,
         '_lambda_client',
@@ -102,7 +101,7 @@ def test_cbc_proxy_ee_create_and_send_invokes_function(
         message_number='0000007b',
         headline=headline,
         description=description,
-        areas=areas,
+        areas=EXAMPLE_AREAS,
         sent=sent, expires=expires,
     )
 
@@ -122,7 +121,7 @@ def test_cbc_proxy_ee_create_and_send_invokes_function(
     assert payload['message_type'] == 'alert'
     assert payload['headline'] == headline
     assert payload['description'] == description
-    assert payload['areas'] == areas
+    assert payload['areas'] == EXAMPLE_AREAS
     assert payload['sent'] == sent
     assert payload['expires'] == expires
     assert payload['language'] == expected_language
@@ -136,17 +135,6 @@ def test_cbc_proxy_will_failover_to_second_lambda_if_connection_error(
     cbc_proxy_vodafone,
     cbc
 ):
-    # a single area which is a square including london
-    areas = [{
-        'description': 'london',
-        'polygon': [
-            [51.12, -1.2],
-            [51.12, 1.2],
-            [51.74, 1.2],
-            [51.74, -1.2],
-            [51.12, -1.2],
-        ],
-    }]
     cbc_proxy = cbc_proxy_ee if cbc == 'bt-ee' else cbc_proxy_vodafone
 
     ld_client_mock = mocker.patch.object(
@@ -174,7 +162,7 @@ def test_cbc_proxy_will_failover_to_second_lambda_if_connection_error(
         message_number='0000007b',
         headline='my-headline',
         description='test-description',
-        areas=areas,
+        areas=EXAMPLE_AREAS,
         sent='a-passed-through-sent-value',
         expires='a-passed-through-expires-value',
     )
@@ -265,18 +253,6 @@ def test_cbc_proxy_vodafone_create_and_send_invokes_function(
     sent = 'a-passed-through-sent-value'
     expires = 'a-passed-through-expires-value'
 
-    # a single area which is a square including london
-    areas = [{
-        'description': 'london',
-        'polygon': [
-            [51.12, -1.2],
-            [51.12, 1.2],
-            [51.74, 1.2],
-            [51.74, -1.2],
-            [51.12, -1.2],
-        ],
-    }]
-
     ld_client_mock = mocker.patch.object(
         cbc_proxy_vodafone,
         '_lambda_client',
@@ -292,7 +268,7 @@ def test_cbc_proxy_vodafone_create_and_send_invokes_function(
         message_number='0000007b',
         headline=headline,
         description=description,
-        areas=areas,
+        areas=EXAMPLE_AREAS,
         sent=sent, expires=expires,
     )
 
@@ -312,7 +288,7 @@ def test_cbc_proxy_vodafone_create_and_send_invokes_function(
     assert payload['message_type'] == 'alert'
     assert payload['headline'] == headline
     assert payload['description'] == description
-    assert payload['areas'] == areas
+    assert payload['areas'] == EXAMPLE_AREAS
     assert payload['sent'] == sent
     assert payload['expires'] == expires
     assert payload['language'] == expected_language
@@ -385,18 +361,6 @@ def test_cbc_proxy_create_and_send_handles_invoke_error(mocker, cbc_proxy_ee):
     sent = 'a-passed-through-sent-value'
     expires = 'a-passed-through-expires-value'
 
-    # a single area which is a square including london
-    areas = [{
-        'description': 'london',
-        'polygon': [
-            [51.12, -1.2],
-            [51.12, 1.2],
-            [51.74, 1.2],
-            [51.74, -1.2],
-            [51.12, -1.2],
-        ],
-    }]
-
     ld_client_mock = mocker.patch.object(
         cbc_proxy_ee,
         '_lambda_client',
@@ -413,7 +377,7 @@ def test_cbc_proxy_create_and_send_handles_invoke_error(mocker, cbc_proxy_ee):
             message_number='0000007b',
             headline=headline,
             description=description,
-            areas=areas,
+            areas=EXAMPLE_AREAS,
             sent=sent, expires=expires,
         )
 
@@ -433,18 +397,6 @@ def test_cbc_proxy_create_and_send_handles_function_error(mocker, cbc_proxy_ee):
 
     sent = 'a-passed-through-sent-value'
     expires = 'a-passed-through-expires-value'
-
-    # a single area which is a square including london
-    areas = [{
-        'description': 'london',
-        'polygon': [
-            [51.12, -1.2],
-            [51.12, 1.2],
-            [51.74, 1.2],
-            [51.74, -1.2],
-            [51.12, -1.2],
-        ],
-    }]
 
     ld_client_mock = mocker.patch.object(
         cbc_proxy_ee,
@@ -467,7 +419,7 @@ def test_cbc_proxy_create_and_send_handles_function_error(mocker, cbc_proxy_ee):
             message_number='0000007b',
             headline=headline,
             description=description,
-            areas=areas,
+            areas=EXAMPLE_AREAS,
             sent=sent, expires=expires,
         )
 


### PR DESCRIPTION
Introduce failover behaviour such that if any error is raised by the first lambda (that includes both invoke errors and function errors connected to trying to talk to the CBC), then our API will then retry by invoking the second lambda.

Logs error types returned by https://github.com/alphagov/notifications-broadcasts-infra/pull/79

Note, the second lambda doesn't exist yet. It also isn't defined yet whether the second lambda will be pointed at the second CBC or if it will still point at the first CBC (or if it needs to be able to decide on the fly).

Please review this commit by commit.

The annoyance we have is that AWS docs are a bit unclear with what values we get back from an exception in the lambda code. We've made assumptions about the interface in our tests but we will need to do some testing to be 100% sure of these.

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#Lambda.Client.invoke
https://docs.aws.amazon.com/lambda/latest/dg/python-exceptions.html
