### PR TITLE
add content to old broadcast messages with no content

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -189,19 +189,12 @@ def _create_broadcast_event(broadcast_message):
     else:
         transmitted_finishes_at = broadcast_message.finishes_at
 
-    # TODO: Remove this if statement after broadcast message content is guaranteed to always be populated.
-    if broadcast_message.content:
-        content = broadcast_message.content
-    else:
-        content = broadcast_message.template._as_utils_template_with_personalisation(
-            broadcast_message.personalisation
-        ).content_with_placeholders_filled_in
 
     event = BroadcastEvent(
         service=broadcast_message.service,
         broadcast_message=broadcast_message,
         message_type=msg_types[broadcast_message.status],
-        transmitted_content={"body": content},
+        transmitted_content={"body": broadcast_message.content},
         transmitted_areas=broadcast_message.areas,
         # TODO: Probably move this somewhere more standalone too and imply that it shouldn't change. Should it include
         # a service based identifier too? eg "flood-warnings@notifications.service.gov.uk" or similar

--- a/migrations/versions/0336_broadcast_msg_content_2.py
+++ b/migrations/versions/0336_broadcast_msg_content_2.py
@@ -1,0 +1,35 @@
+"""
+
+Revision ID: 0336_broadcast_msg_content_2
+Revises: 0335_broadcast_msg_content
+Create Date: 2020-12-04 15:06:22.544803
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm.session import Session
+
+from app.models import BroadcastMessage
+
+revision = '0336_broadcast_msg_content_2'
+down_revision = '0335_broadcast_msg_content'
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+
+    broadcast_messages = session.query(BroadcastMessage).filter(BroadcastMessage.content == None)
+
+    for broadcast_message in broadcast_messages:
+        broadcast_message.content = broadcast_message.template._as_utils_template_with_personalisation(
+            broadcast_message.personalisation
+        ).content_with_placeholders_filled_in
+
+    session.commit()
+
+    op.alter_column('broadcast_message', 'content', nullable=False)
+
+
+def downgrade():
+    op.alter_column('broadcast_message', 'content', nullable=True)

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -477,43 +477,6 @@ def test_update_broadcast_message_status_creates_event_with_correct_content_if_b
     assert alert_event.transmitted_content == {"body": "tailor made emergency broadcast content"}
 
 
-# TODO: Remove this unit test after broadcast message content is guaranteed to always be populated.
-def test_update_broadcast_message_status_creates_event_with_correct_content_if_broadcast_has_no_content_field(
-    admin_request,
-    sample_broadcast_service,
-    mocker
-):
-    t = create_template(sample_broadcast_service, BROADCAST_TYPE, content='emergency broadcast')
-    bm = create_broadcast_message(
-        t,
-        status=BroadcastStatusType.PENDING_APPROVAL,
-        areas={"areas": ["london"], "simple_polygons": [[[51.30, 0.7], [51.28, 0.8], [51.25, -0.7]]]}
-    )
-    # simulate having no content because the broadcast message was created before migration 0335 came in
-    bm.content = None
-
-    approver = create_user(email='approver@gov.uk')
-    sample_broadcast_service.users.append(approver)
-    mock_task = mocker.patch('app.celery.broadcast_message_tasks.send_broadcast_event.apply_async')
-
-    response = admin_request.post(
-        'broadcast_message.update_broadcast_message_status',
-        _data={'status': BroadcastStatusType.BROADCASTING, 'created_by': str(approver.id)},
-        service_id=t.service_id,
-        broadcast_message_id=bm.id,
-        _expected_status=200
-    )
-
-    assert response['status'] == BroadcastStatusType.BROADCASTING
-
-    assert len(bm.events) == 1
-    alert_event = bm.events[0]
-
-    mock_task.assert_called_once_with(kwargs={'broadcast_event_id': str(alert_event.id)}, queue='notify-internal-tasks')
-
-    assert alert_event.transmitted_content == {"body": "emergency broadcast"}
-
-
 def test_update_broadcast_message_status_rejects_approval_from_creator(
     admin_request,
     sample_broadcast_service,


### PR DESCRIPTION
new broadcast messages will have content filled whether they have a template or not, but old ones won't so populate.

Stole the session constructor from 0044_jos_to_notification_hist.py