### PR TITLE
Change the sort order for the organisation usage page

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -607,6 +607,7 @@ def fetch_sms_billing_for_organisation(organisation_id, start_date, end_date):
         sms_billable_units.label('sms_billable_units'),
         chargeable_sms.label("chargeable_billable_sms"),
         sms_cost.label('sms_cost'),
+        Service.active.label("active")
     ).select_from(
         Service
     ).outerjoin(
@@ -658,7 +659,8 @@ def fetch_usage_year_for_organisation(organisation_id, year):
             'chargeable_billable_sms': 0,
             'sms_cost': 0.0,
             'letter_cost': 0.0,
-            'emails_sent': 0
+            'emails_sent': 0,
+            'active': service.active
         }
     sms_usages = fetch_sms_billing_for_organisation(organisation_id, year_start_date, year_end_date)
     letter_usages = fetch_letter_costs_for_organisation(organisation_id, year_start_date, year_end_date)
@@ -673,7 +675,8 @@ def fetch_usage_year_for_organisation(organisation_id, year):
             'chargeable_billable_sms': usage.chargeable_billable_sms,
             'sms_cost': float(usage.sms_cost),
             'letter_cost': 0.0,
-            'emails_sent': 0
+            'emails_sent': 0,
+            'active': usage.active
         }
     for letter_usage in letter_usages:
         service_with_usage[str(letter_usage.service_id)]['letter_cost'] = float(letter_usage.letter_cost)

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -135,7 +135,7 @@ def get_organisation_services_usage(organisation_id):
         return jsonify(result='error', message='No valid year provided'), 400
     services = fetch_usage_year_for_organisation(organisation_id, year)
     list_services = services.values()
-    sorted_services = sorted(list_services, key=lambda s: s['service_name'].lower())
+    sorted_services = sorted(list_services, key=lambda s: (-s['active'], s['service_name'].lower()))
     return jsonify(services=sorted_services)
 
 


### PR DESCRIPTION
Ensure the archived services are at the bottom of the list. The organisation trial mode page already sorts the archived services to the bottom.