### PR TITLE
Alert on 2nd class letters still in sending everyday

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -266,11 +266,6 @@ def get_letter_notifications_still_sending_when_they_shouldnt_be():
         func.date(Notification.sent_at) <= expected_sent_date
     )
 
-    if today.isoweekday() in {2, 4}:  # on tue, thu, we only care about first class letters
-        q = q.filter(
-            Notification.postage == 'first'
-        )
-
     return q.count(), expected_sent_date
 
 

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -371,11 +371,12 @@ def test_get_letter_notifications_still_sending_when_they_shouldnt_finds_thursda
 ):
     thursday = datetime(2018, 1, 11, 13, 30)
     yesterday = datetime(2018, 1, 14, 13, 30)
+    create_notification(template=sample_letter_template, status='sending', sent_at=thursday, postage='first')
     create_notification(template=sample_letter_template, status='sending', sent_at=thursday, postage='second')
     create_notification(template=sample_letter_template, status='sending', sent_at=yesterday, postage='second')
 
     count, expected_sent_date = get_letter_notifications_still_sending_when_they_shouldnt_be()
-    assert count == 1
+    assert count == 2
     assert expected_sent_date == date(2018, 1, 11)
 
 
@@ -386,12 +387,11 @@ def test_get_letter_notifications_still_sending_when_they_shouldnt_finds_friday_
     friday = datetime(2018, 1, 12, 13, 30)
     yesterday = datetime(2018, 1, 14, 13, 30)
     create_notification(template=sample_letter_template, status='sending', sent_at=friday, postage='first')
-    create_notification(template=sample_letter_template, status='sending', sent_at=yesterday, postage='first')
-    # doesn't get reported because it's second class, and it's tuesday today
     create_notification(template=sample_letter_template, status='sending', sent_at=friday, postage='second')
+    create_notification(template=sample_letter_template, status='sending', sent_at=yesterday, postage='first')
 
     count, expected_sent_date = get_letter_notifications_still_sending_when_they_shouldnt_be()
-    assert count == 1
+    assert count == 2
     assert expected_sent_date == date(2018, 1, 12)
 
 


### PR DESCRIPTION
In https://github.com/alphagov/notifications-api/pull/2627/commits/8285ef5f89f45287d0bb9e23fd184b0565cb5784
we turned off alerting on 2nd class letters still being in sending on
certain days of the week because we were only sending letters out on
Mon, Wed, Fri.

Now we have swapped back to sending out 2nd class letters on all
workdays so this change can be reverted. Note, I haven't reverted the
commit exactly but more so the behaviour, whilst leaving in some tests
to explicitly test 2nd class letters for the alert in case we change
this again.