### PR TITLE
Allow broadcast messages to be created with API key

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2245,13 +2245,20 @@ class BroadcastMessage(db.Model):
     cancelled_at = db.Column(db.DateTime, nullable=True)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
 
-    created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), nullable=False)
+    created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), nullable=True)
     approved_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), nullable=True)
     cancelled_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id'), nullable=True)
 
     created_by = db.relationship('User', foreign_keys=[created_by_id])
     approved_by = db.relationship('User', foreign_keys=[approved_by_id])
     cancelled_by = db.relationship('User', foreign_keys=[cancelled_by_id])
+
+    api_key_id = db.Column(UUID(as_uuid=True), db.ForeignKey('api_keys.id'), nullable=True)
+    api_key = db.relationship('ApiKey')
+
+    reference = db.Column(db.String(255), nullable=True)
+
+    CheckConstraint("created_by_id is not null or api_key_id is not null")
 
     @property
     def personalisation(self):
@@ -2266,6 +2273,7 @@ class BroadcastMessage(db.Model):
     def serialize(self):
         return {
             'id': str(self.id),
+            'reference': self.reference,
 
             'service_id': str(self.service_id),
 

--- a/app/models.py
+++ b/app/models.py
@@ -36,7 +36,12 @@ from app.hashing import (
     check_hash
 )
 from app import db, encryption
-from app.utils import DATETIME_FORMAT, DATETIME_FORMAT_NO_TIMEZONE, get_dt_string_or_none
+from app.utils import (
+    DATETIME_FORMAT,
+    DATETIME_FORMAT_NO_TIMEZONE,
+    get_dt_string_or_none,
+    get_uuid_string_or_none,
+)
 
 from app.history_meta import Versioned
 
@@ -2296,9 +2301,9 @@ class BroadcastMessage(db.Model):
             'cancelled_at': get_dt_string_or_none(self.cancelled_at),
             'updated_at': get_dt_string_or_none(self.updated_at),
 
-            'created_by_id': str(self.created_by_id),
-            'approved_by_id': str(self.approved_by_id),
-            'cancelled_by_id': str(self.cancelled_by_id),
+            'created_by_id': get_uuid_string_or_none(self.created_by_id),
+            'approved_by_id': get_uuid_string_or_none(self.approved_by_id),
+            'cancelled_by_id': get_uuid_string_or_none(self.cancelled_by_id),
         }
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -150,5 +150,9 @@ def get_dt_string_or_none(val):
     return val.strftime(DATETIME_FORMAT) if val else None
 
 
+def get_uuid_string_or_none(val):
+    return str(val)  if val else None
+
+
 def format_sequential_number(sequential_number):
     return format(sequential_number, "x").zfill(8)

--- a/migrations/versions/0337_broadcast_msg_api.py
+++ b/migrations/versions/0337_broadcast_msg_api.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: 0337_broadcast_msg_api
+Revises: 0336_broadcast_msg_content_2
+Create Date: 2020-12-04 15:06:22.544803
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0337_broadcast_msg_api'
+down_revision = '0336_broadcast_msg_content_2'
+
+
+def upgrade():
+    op.alter_column('broadcast_message', 'created_by_id', nullable=True)
+    op.add_column('broadcast_message', sa.Column('api_key_id', postgresql.UUID(), nullable=True))
+    op.create_foreign_key(None, 'broadcast_message', 'api_keys', ['api_key_id'], ['id'])
+    op.add_column('broadcast_message', sa.Column('reference', sa.String(length=255), nullable=True))
+
+
+def downgrade():
+    op.alter_column('broadcast_message', 'created_by_id', nullable=False)
+    op.drop_column('broadcast_message', 'api_key_id')
+    op.add_column('broadcast_message', 'reference')


### PR DESCRIPTION
When we have a public API there will be no human creating the broadcast message. Instead it will be created by an API integration, authenticated by a key (just like for emails or texts).

This updates the database to:
- add a new foreign key from BroadcastMessages to API keys
- make `created_by` nullable when `api_key` is non-null, and vice versa
- add a reference field which the frontend can use instead of template name, for broadcasts without templates

***

This commit also fixes a previous migration to remove use of a model class.

We shouldn’t import models into migrations because if the model changes later down the line then the migration can’t be re-run at a later date (for example to rebuild a database from scratch).
