### PR TITLE
Three proxy

### DIFF
--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -45,6 +45,7 @@ class CBCProxyClient:
         proxy_classes = {
             'canary': CBCProxyCanary,
             BroadcastProvider.EE: CBCProxyEE,
+            BroadcastProvider.THREE: CBCProxyThree,
             BroadcastProvider.VODAFONE: CBCProxyVodafone,
         }
         return proxy_classes[provider](self._lambda_client)
@@ -174,6 +175,66 @@ class CBCProxyCanary(CBCProxyClientBase):
 class CBCProxyEE(CBCProxyClientBase):
     lambda_name = 'bt-ee-1-proxy'
     failover_lambda_name = 'bt-ee-2-proxy'
+
+    LANGUAGE_ENGLISH = 'en-GB'
+    LANGUAGE_WELSH = 'cy-GB'
+
+    def send_link_test(
+        self,
+        identifier,
+        sequential_number=None,
+    ):
+        """
+        link test - open up a connection to a specific provider, and send them an xml payload with a <msgType> of
+        test.
+        """
+        payload = {
+            'message_type': 'test',
+            'identifier': identifier,
+            'message_format': 'cap'
+        }
+
+        self._invoke_lambda_with_failover(payload=payload)
+
+    def create_and_send_broadcast(
+        self, identifier, headline, description, areas, sent, expires, message_number=None
+    ):
+        payload = {
+            'message_type': 'alert',
+            'identifier': identifier,
+            'message_format': 'cap',
+            'headline': headline,
+            'description': description,
+            'areas': areas,
+            'sent': sent,
+            'expires': expires,
+            'language': self.infer_language_from(description),
+        }
+        self._invoke_lambda_with_failover(payload=payload)
+
+    def cancel_broadcast(
+        self,
+        identifier, previous_provider_messages,
+        sent, message_number=None
+    ):
+        payload = {
+            'message_type': 'cancel',
+            'identifier': identifier,
+            'message_format': 'cap',
+            "references": [
+                {
+                    "message_id": str(message.id),
+                    "sent": message.created_at.strftime(DATETIME_FORMAT)
+                } for message in previous_provider_messages
+            ],
+            'sent': sent,
+        }
+        self._invoke_lambda_with_failover(payload=payload)
+
+
+class CBCProxyThree(CBCProxyClientBase):
+    lambda_name = 'three-1-proxy'
+    failover_lambda_name = 'three-2-proxy'
 
     LANGUAGE_ENGLISH = 'en-GB'
     LANGUAGE_WELSH = 'cy-GB'

--- a/app/config.py
+++ b/app/config.py
@@ -378,7 +378,7 @@ class Config(object):
 
     CBC_PROXY_ENABLED = bool(CBC_PROXY_AWS_ACCESS_KEY_ID)
 
-    ENABLED_CBCS = {BroadcastProvider.EE, BroadcastProvider.VODAFONE}
+    ENABLED_CBCS = {BroadcastProvider.EE, BroadcastProvider.THREE, BroadcastProvider.VODAFONE}
 
 
 ######################


### PR DESCRIPTION
Commit one creates the CBC proxy client for Three
Commit two turns it on.

@rjbaker could you confirm whether we are good to release this with it turned on or if we need to hold off on that until later. Note, I'm expecting it will be fine to release it because if Three is not ready then our calls to the lambda will fail and we will log a failure but nothing much else will happen

Decided not to abstract the EE and Three proxies into a `CBCProxyOne2Many` subclass just yet. Will probably be a sensible move in the future but going to hold off until we add O2 or we get Three working as that may provide different information about any differences between the proxies

Note, our tests are made a bit nasty by the fact that we have the `CBCProxyEE` class uses a proxy that is not called `ee-proxy-1` and instead uses `bt-ee-proxy-1`. I would suggest we change the proxy name to `ee-proxy-1` for consistency. Any objections to me doing that?