### PR TITLE
Let the admin app create broadcasts without templates

### DIFF
--- a/app/broadcast_message/broadcast_message_schema.py
+++ b/app/broadcast_message/broadcast_message_schema.py
@@ -15,8 +15,13 @@ create_broadcast_message_schema = {
         'finishes_at': {'type': 'string', 'format': 'datetime'},
         'areas': {"type": "array", "items": {"type": "string"}},
         'simple_polygons': {"type": "array", "items": {"type": "array"}},
+        'content': {'type': 'string', 'minLength': 1, 'maxLength': 1395},
     },
-    'required': ['template_id', 'service_id', 'created_by'],
+    'required': ['service_id', 'created_by'],
+    'oneOf': [
+        {'required': ['template_id']},
+        {'required': ['content']},
+    ],
     'additionalProperties': False
 }
 

--- a/app/broadcast_message/broadcast_message_schema.py
+++ b/app/broadcast_message/broadcast_message_schema.py
@@ -16,11 +16,18 @@ create_broadcast_message_schema = {
         'areas': {"type": "array", "items": {"type": "string"}},
         'simple_polygons': {"type": "array", "items": {"type": "array"}},
         'content': {'type': 'string', 'minLength': 1, 'maxLength': 1395},
+        'reference': {'type': 'string', 'minLength': 1, 'maxLength': 255},
     },
     'required': ['service_id', 'created_by'],
-    'oneOf': [
-        {'required': ['template_id']},
-        {'required': ['content']},
+    'allOf': [
+        {'oneOf': [
+            {'required': ['template_id']},
+            {'required': ['content']},
+        ]},
+        {'oneOf': [
+            {'required': ['template_id']},
+            {'required': ['reference']},
+        ]},
     ],
     'additionalProperties': False
 }

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -109,8 +109,9 @@ def create_broadcast_message(service_id):
         content = template._as_utils_template_with_personalisation(
             personalisation
         ).content_with_placeholders_filled_in
+        reference = None
     else:
-        template, content = None, data['content']
+        template, content, reference = None, data['content'], data['reference']
 
     broadcast_message = BroadcastMessage(
         service_id=service.id,
@@ -123,6 +124,7 @@ def create_broadcast_message(service_id):
         finishes_at=_parse_nullable_datetime(data.get('finishes_at')),
         created_by_id=user.id,
         content=content,
+        reference=reference,
     )
 
     dao_save_object(broadcast_message)

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -99,22 +99,30 @@ def create_broadcast_message(service_id):
     validate(data, create_broadcast_message_schema)
     service = dao_fetch_service_by_id(data['service_id'])
     user = get_user_by_id(data['created_by'])
-    template = dao_get_template_by_id_and_service_id(data['template_id'], data['service_id'])
-
     personalisation = data.get('personalisation', {})
+    template_id = data.get('template_id')
+
+    if template_id:
+        template = dao_get_template_by_id_and_service_id(
+            template_id, data['service_id']
+        )
+        content = template._as_utils_template_with_personalisation(
+            personalisation
+        ).content_with_placeholders_filled_in
+    else:
+        template, content = None, data['content']
+
     broadcast_message = BroadcastMessage(
         service_id=service.id,
-        template_id=template.id,
-        template_version=template.version,
+        template_id=template_id,
+        template_version=template.version if template else None,
         personalisation=personalisation,
         areas={"areas": data.get("areas", []), "simple_polygons": data.get("simple_polygons", [])},
         status=BroadcastStatusType.DRAFT,
         starts_at=_parse_nullable_datetime(data.get('starts_at')),
         finishes_at=_parse_nullable_datetime(data.get('finishes_at')),
         created_by_id=user.id,
-        content=template._as_utils_template_with_personalisation(
-            personalisation
-        ).content_with_placeholders_filled_in,
+        content=content,
     )
 
     dao_save_object(broadcast_message)

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -280,6 +280,26 @@ def test_create_broadcast_message_400s_if_reference_not_provided_with_content(
     )
 
 
+def test_create_broadcast_message_400s_if_no_content_or_template(
+    admin_request,
+    sample_broadcast_service,
+):
+    response = admin_request.post(
+        'broadcast_message.create_broadcast_message',
+        _data={
+            'service_id': str(sample_broadcast_service.id),
+            'created_by': str(sample_broadcast_service.created_by_id),
+        },
+        service_id=sample_broadcast_service.id,
+        _expected_status=400
+    )
+    assert len(response['errors']) == 1
+    assert response['errors'][0]['error'] == 'ValidationError'
+    assert response['errors'][0]['message'].endswith(
+        'is not valid under any of the given schemas'
+    )
+
+
 @pytest.mark.parametrize('status', [
     BroadcastStatusType.DRAFT,
     BroadcastStatusType.PENDING_APPROVAL,


### PR DESCRIPTION
This pull request updates the JSON schemas and REST endpoint to allow creation of a broadcast with either:
- a `template_id` or
- `content` and a `reference` 

`reference` is so we have something to show in the admin app in lieu of template name when a template isn’t used.

The JSONSchema errors are a bit gnarly, but I think this is OK because this is the internal API.