### PR TITLE
retry sending broadcasts

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -56,7 +56,7 @@ def _update_broadcast_message(broadcast_message, new_status, updating_user):
                 f'User {updating_user.id} cannot approve their own broadcast_message {broadcast_message.id}',
                 status_code=400
             )
-        elif not broadcast_message.areas:
+        elif len(broadcast_message.areas['simple_polygons']) == 0:
             raise InvalidRequest(
                 f'broadcast_message {broadcast_message.id} has no selected areas and so cannot be broadcasted.',
                 status_code=400

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -70,7 +70,11 @@ def send_broadcast_event(broadcast_event_id):
 def send_broadcast_provider_message(self, broadcast_event_id, provider):
     broadcast_event = dao_get_broadcast_event_by_id(broadcast_event_id)
 
-    broadcast_provider_message = create_broadcast_provider_message(broadcast_event, provider)
+    # the broadcast_provider_message will already exist if we retried previously
+    broadcast_provider_message = broadcast_event.get_provider_message(provider)
+    if broadcast_provider_message is None:
+        broadcast_provider_message = create_broadcast_provider_message(broadcast_event, provider)
+
     formatted_message_number = None
     if provider == BroadcastProvider.VODAFONE:
         formatted_message_number = format_sequential_number(broadcast_provider_message.message_number)

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -1,15 +1,52 @@
 import uuid
+from datetime import datetime
 
 from flask import current_app
 from notifications_utils.statsd_decorators import statsd
 from sqlalchemy.schema import Sequence
+from celery.exceptions import MaxRetriesExceededError
 
 from app import cbc_proxy_client, db, notify_celery
+from app.clients.cbc_proxy import CBCProxyFatalException, CBCProxyRetryableException
 from app.config import QueueNames
 from app.models import BroadcastEventMessageType, BroadcastProvider
 from app.dao.broadcast_message_dao import dao_get_broadcast_event_by_id, create_broadcast_provider_message
 
 from app.utils import format_sequential_number
+
+
+def get_retry_delay(retry_count):
+    """
+    Given a count of retries so far, return a delay for the next one.
+    `retry_count` should be 0 the first time a task fails.
+    """
+    # TODO: replace with celery's built in exponential backoff
+
+    # 2 to the power of x. 1, 2, 4, 8, 16, 32, ...
+    delay = 2**retry_count
+    # never wait longer than 5 minutes
+    return min(delay, 300)
+
+
+def check_provider_message_should_retry(broadcast_provider_message):
+    this_event = broadcast_provider_message.broadcast_event
+
+    if this_event.transmitted_finishes_at < datetime.utcnow():
+        print(this_event.transmitted_finishes_at, datetime.utcnow(),)
+        raise MaxRetriesExceededError(
+            f'Given up sending broadcast_event {this_event.id} ' +
+            f'to provider {broadcast_provider_message.provider}: ' +
+            f'The expiry time of {this_event.transmitted_finishes_at} has already passed'
+        )
+
+    newest_event = max(this_event.broadcast_message.events, key=lambda x: x.sent_at)
+
+    if this_event != newest_event:
+        raise MaxRetriesExceededError(
+            f'Given up sending broadcast_event {this_event.id} ' +
+            f'to provider {broadcast_provider_message.provider}: ' +
+            f'This event has been superceeded by {newest_event.message_type} broadcast_event {newest_event.id}'
+        )
 
 
 @notify_celery.task(name="send-broadcast-event")
@@ -27,9 +64,10 @@ def send_broadcast_event(broadcast_event_id):
         )
 
 
-@notify_celery.task(name="send-broadcast-provider-message")
+# max_retries=None: retry forever
+@notify_celery.task(bind=True, name="send-broadcast-provider-message", max_retries=None)
 @statsd(namespace="tasks")
-def send_broadcast_provider_message(broadcast_event_id, provider):
+def send_broadcast_provider_message(self, broadcast_event_id, provider):
     broadcast_event = dao_get_broadcast_event_by_id(broadcast_event_id)
 
     broadcast_provider_message = create_broadcast_provider_message(broadcast_event, provider)
@@ -54,41 +92,52 @@ def send_broadcast_provider_message(broadcast_event_id, provider):
 
     cbc_proxy_provider_client = cbc_proxy_client.get_proxy(provider)
 
-    if broadcast_event.message_type == BroadcastEventMessageType.ALERT:
-        cbc_proxy_provider_client.create_and_send_broadcast(
-            identifier=str(broadcast_provider_message.id),
-            message_number=formatted_message_number,
-            headline="GOV.UK Notify Broadcast",
-            description=broadcast_event.transmitted_content['body'],
-            areas=areas,
-            sent=broadcast_event.sent_at_as_cap_datetime_string,
-            expires=broadcast_event.transmitted_finishes_at_as_cap_datetime_string,
-            channel=channel
-        )
-    elif broadcast_event.message_type == BroadcastEventMessageType.UPDATE:
-        cbc_proxy_provider_client.update_and_send_broadcast(
-            identifier=str(broadcast_provider_message.id),
-            message_number=formatted_message_number,
-            headline="GOV.UK Notify Broadcast",
-            description=broadcast_event.transmitted_content['body'],
-            areas=areas,
-            previous_provider_messages=broadcast_event.get_earlier_provider_messages(provider),
-            sent=broadcast_event.sent_at_as_cap_datetime_string,
-            expires=broadcast_event.transmitted_finishes_at_as_cap_datetime_string,
-            # We think an alert update should always go out on the same channel that created the alert
-            # We recognise there is a small risk with this code here that if the services channel was
-            # changed between an alert being sent out and then updated, then something might go wrong
-            # but we are relying on service channels changing almost never, and not mid incident
-            # We may consider in the future, changing this such that we store the channel a broadcast was
-            # sent on on the broadcast message itself and pick the value from there instead of the service
-            channel=channel
-        )
-    elif broadcast_event.message_type == BroadcastEventMessageType.CANCEL:
-        cbc_proxy_provider_client.cancel_broadcast(
-            identifier=str(broadcast_provider_message.id),
-            message_number=formatted_message_number,
-            previous_provider_messages=broadcast_event.get_earlier_provider_messages(provider),
-            sent=broadcast_event.sent_at_as_cap_datetime_string,
+    try:
+        if broadcast_event.message_type == BroadcastEventMessageType.ALERT:
+            cbc_proxy_provider_client.create_and_send_broadcast(
+                identifier=str(broadcast_provider_message.id),
+                message_number=formatted_message_number,
+                headline="GOV.UK Notify Broadcast",
+                description=broadcast_event.transmitted_content['body'],
+                areas=areas,
+                sent=broadcast_event.sent_at_as_cap_datetime_string,
+                expires=broadcast_event.transmitted_finishes_at_as_cap_datetime_string,
+                channel=channel
+            )
+        elif broadcast_event.message_type == BroadcastEventMessageType.UPDATE:
+            cbc_proxy_provider_client.update_and_send_broadcast(
+                identifier=str(broadcast_provider_message.id),
+                message_number=formatted_message_number,
+                headline="GOV.UK Notify Broadcast",
+                description=broadcast_event.transmitted_content['body'],
+                areas=areas,
+                previous_provider_messages=broadcast_event.get_earlier_provider_messages(provider),
+                sent=broadcast_event.sent_at_as_cap_datetime_string,
+                expires=broadcast_event.transmitted_finishes_at_as_cap_datetime_string,
+                # We think an alert update should always go out on the same channel that created the alert
+                # We recognise there is a small risk with this code here that if the services channel was
+                # changed between an alert being sent out and then updated, then something might go wrong
+                # but we are relying on service channels changing almost never, and not mid incident
+                # We may consider in the future, changing this such that we store the channel a broadcast was
+                # sent on on the broadcast message itself and pick the value from there instead of the service
+                channel=channel
+            )
+        elif broadcast_event.message_type == BroadcastEventMessageType.CANCEL:
+            cbc_proxy_provider_client.cancel_broadcast(
+                identifier=str(broadcast_provider_message.id),
+                message_number=formatted_message_number,
+                previous_provider_messages=broadcast_event.get_earlier_provider_messages(provider),
+                sent=broadcast_event.sent_at_as_cap_datetime_string,
+            )
+    except CBCProxyRetryableException as exc:
+        # this will raise MaxRetriesExceededError if we no longer want to retry
+        # (because the message has expired)
+        check_provider_message_should_retry(broadcast_provider_message)
+
+        self.retry(
+            exc=exc,
+            countdown=get_retry_delay(self.request.retries),
+            queue=QueueNames.BROADCASTS,
         )
 
 

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -25,7 +25,11 @@ from app.utils import DATETIME_FORMAT, format_sequential_number
 #    the preceeding Alert message in the previous_provider_messages field
 
 
-class CBCProxyException(Exception):
+class CBCProxyFatalException(Exception):
+    pass
+
+
+class CBCProxyRetryableException(Exception):
     pass
 
 
@@ -115,7 +119,9 @@ class CBCProxyClientBase(ABC):
         if not result:
             failover_result = self._invoke_lambda(self.failover_lambda_name, payload)
             if not failover_result:
-                raise CBCProxyException(f'Lambda failed for both {self.lambda_name} and {self.failover_lambda_name}')
+                raise CBCProxyRetryableException(
+                    f'Lambda failed for both {self.lambda_name} and {self.failover_lambda_name}'
+                )
 
         return result
 

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -64,5 +64,5 @@ def create_broadcast_provider_message(broadcast_event, provider):
 
 
 @transactional
-def update_broadcast_provider_message_status(broadcast_provider_message, status):
+def update_broadcast_provider_message_status(broadcast_provider_message, *, status):
     broadcast_provider_message.status = status

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -61,3 +61,8 @@ def create_broadcast_provider_message(broadcast_event, provider):
         db.session.add(provider_message_number)
         db.session.commit()
     return provider_message
+
+
+@transactional
+def update_broadcast_provider_message_status(broadcast_provider_message, status):
+    broadcast_provider_message.status = status

--- a/app/models.py
+++ b/app/models.py
@@ -2412,7 +2412,7 @@ class BroadcastEvent(db.Model):
 
     def get_earlier_provider_messages(self, provider):
         """
-        Get the previous message for a provider. These are differentper provider, as the identifiers are different.
+        Get the previous message for a provider. These are different per provider, as the identifiers are different.
         Return the full provider_message object rather than just an identifier, since the different providers expect
         reference to contain different things - let the cbc_proxy work out what information is relevant.
         """

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -254,6 +254,48 @@ def test_send_broadcast_provider_message_defaults_to_test_channel_if_no_service_
     )
 
 
+def test_send_broadcast_provider_message_works_if_we_retried_previously(mocker, sample_service):
+    template = create_template(sample_service, BROADCAST_TYPE)
+    broadcast_message = create_broadcast_message(
+        template,
+        areas={'areas': [], 'simple_polygons': [],},
+        status=BroadcastStatusType.BROADCASTING
+    )
+    event = create_broadcast_event(broadcast_message)
+
+    # an existing provider message already exists, and previously failed
+    existing_provider_message = create_broadcast_provider_message(
+        broadcast_event=event,
+        provider='ee',
+        status=BroadcastProviderMessageStatus.TECHNICAL_FAILURE
+    )
+
+    mock_create_broadcast = mocker.patch(
+        f'app.clients.cbc_proxy.CBCProxyEE.create_and_send_broadcast',
+    )
+
+    send_broadcast_provider_message(provider='ee', broadcast_event_id=str(event.id))
+
+    # make sure we haven't completed a duplicate event - we shouldn't record the failure
+    assert len(event.provider_messages) == 1
+
+    broadcast_provider_message = event.get_provider_message('ee')
+    # TODO: Should be ACK, and should have an updated_at
+    assert broadcast_provider_message.status == BroadcastProviderMessageStatus.TECHNICAL_FAILURE
+    assert broadcast_provider_message.updated_at is None
+
+    mock_create_broadcast.assert_called_once_with(
+        identifier=str(broadcast_provider_message.id),
+        message_number=mocker.ANY,
+        headline='GOV.UK Notify Broadcast',
+        description='this is an emergency broadcast message',
+        areas=[],
+        sent=event.sent_at_as_cap_datetime_string,
+        expires=event.transmitted_finishes_at_as_cap_datetime_string,
+        channel='test',
+    )
+
+
 @freeze_time('2020-08-01 12:00')
 @pytest.mark.parametrize('provider,provider_capitalised', [
     ['ee', 'EE'],

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, call
 import pytest
 
 from app.clients.cbc_proxy import (
-    CBCProxyClient, CBCProxyException, CBCProxyEE, CBCProxyCanary, CBCProxyVodafone, CBCProxyThree, CBCProxyO2
+    CBCProxyClient, CBCProxyRetryableException, CBCProxyEE, CBCProxyCanary, CBCProxyVodafone, CBCProxyThree, CBCProxyO2
 )
 from app.utils import DATETIME_FORMAT
 
@@ -433,7 +433,7 @@ def test_cbc_proxy_create_and_send_tries_failover_lambda_on_invoke_error_and_rai
         'StatusCode': 400,
     }
 
-    with pytest.raises(CBCProxyException) as e:
+    with pytest.raises(CBCProxyRetryableException) as e:
         cbc_proxy.create_and_send_broadcast(
             identifier='my-identifier',
             message_number='0000007b',
@@ -482,7 +482,7 @@ def test_cbc_proxy_create_and_send_tries_failover_lambda_on_function_error_and_r
         }
     }
 
-    with pytest.raises(CBCProxyException) as e:
+    with pytest.raises(CBCProxyRetryableException) as e:
         cbc_proxy.create_and_send_broadcast(
             identifier='my-identifier',
             message_number='0000007b',

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -1049,7 +1049,7 @@ def create_broadcast_message(
         starts_at=starts_at,
         finishes_at=finishes_at,
         created_by_id=created_by.id if created_by else service.created_by_id,
-        areas=areas or {},
+        areas=areas or {'areas': [], 'simple_polygons': []},
         content=content,
         stubbed=stubbed
     )
@@ -1077,7 +1077,7 @@ def create_broadcast_event(
         transmitted_areas=transmitted_areas or broadcast_message.areas,
         transmitted_sender=transmitted_sender or 'www.notifications.service.gov.uk',
         transmitted_starts_at=transmitted_starts_at,
-        transmitted_finishes_at=transmitted_finishes_at or datetime.utcnow(),
+        transmitted_finishes_at=transmitted_finishes_at or datetime.utcnow() + timedelta(hours=24),
     )
     db.session.add(b_e)
     db.session.commit()
@@ -1105,4 +1105,4 @@ def create_broadcast_provider_message(
             broadcast_provider_message_id=broadcast_provider_message_id)
         db.session.add(provider_message_number)
         db.session.commit()
-    return provider_message, provider_message_number
+    return provider_message


### PR DESCRIPTION
Retry tasks if they fail to send a broadcast event. Note that each task tries the regular proxy and the failover proxy for that provider. This runs a bit differently than our other retries:

Retry with exponential backoff. Our other tasks retry with a fixed delay of 5 minutes between tries. If we can't send a broadcast, we want to try immediately. So instead, implement an exponential backoff (1, 2, 4, 8, ... seconds delay). We can't delay for longer than 310 seconds due to visibility timeout settings in SQS, so cap the delay at that amount.

Normally we give up retrying after a set amount of retries (often 4 hours). As broadcast content is much more important than normal notifications, we don't ever want to give up on sending them to phones...

...UNLESS WE DO!

Sometimes we do want to give up sending a broadcast though! Broadcasts have an expiry time, when they stop showing up on peoples devices, so if that has passed then we don't need to send the broadcast out.

Broadcast events can also be superceded by updates or cancels. Check that the event is the most recent event for that broadcast message, if not, give up, as we don't want to accidentally send out two conflicting events for the same message.