### PR TITLE
Commit db session before sending http request

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -9,7 +9,7 @@ from notifications_utils.recipients import (
 )
 from notifications_utils.template import HTMLEmailTemplate, PlainTextEmailTemplate, SMSMessageTemplate
 
-from app import notification_provider_clients, statsd_client, create_uuid
+from app import notification_provider_clients, statsd_client, create_uuid, db
 from app.dao.notifications_dao import (
     dao_update_notification
 )
@@ -58,11 +58,16 @@ def send_sms_to_provider(notification):
 
         else:
             try:
+                recipient = notification.to
+                is_international = notification.international
+                notification_id = notification.id
+                reply_to_text = notification.reply_to_text
+                db.session.commit()
                 provider.send_sms(
-                    to=validate_and_format_phone_number(notification.to, international=notification.international),
+                    to=validate_and_format_phone_number(recipient, international=is_international),
                     content=str(template),
-                    reference=str(notification.id),
-                    sender=notification.reply_to_text
+                    reference=str(notification_id),
+                    sender=reply_to_text
                 )
             except Exception as e:
                 notification.billable_units = template.fragment_count


### PR DESCRIPTION
Add a db.session.commit before sending the HTTPS request to the provider to release the db connection for other worker threads.

This should have a positive affect when the workers are really busy and our providers are slow with the responses, which does happen.

NOTE: will want to do this for the send_email_to_provider as well, this is just a draft to get an opinion 