### PR TITLE
Remove ability for platform admins to approve own broadcast

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -49,12 +49,8 @@ def _update_broadcast_message(broadcast_message, new_status, updating_user):
         )
 
     if new_status == BroadcastStatusType.BROADCASTING:
-        # TODO: Remove this platform admin shortcut when the feature goes live
-        if updating_user == broadcast_message.created_by and not (
-            # platform admins and trial mode services can approve their own broadcasts
-            updating_user.platform_admin or
-            broadcast_message.service.restricted
-        ):
+        # trial mode services can approve their own broadcasts
+        if updating_user == broadcast_message.created_by and not broadcast_message.service.restricted:
             raise InvalidRequest(
                 f'User {updating_user.id} cannot approve their own broadcast_message {broadcast_message.id}',
                 status_code=400

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -49,7 +49,7 @@ def _update_broadcast_message(broadcast_message, new_status, updating_user):
         )
 
     if new_status == BroadcastStatusType.BROADCASTING:
-        # trial mode services can approve their own broadcasts
+        # training mode services can approve their own broadcasts
         if updating_user == broadcast_message.created_by and not broadcast_message.service.restricted:
             raise InvalidRequest(
                 f'User {updating_user.id} cannot approve their own broadcast_message {broadcast_message.id}',


### PR DESCRIPTION
This has been added in for speed of development but now we are getting
close to integrating with production systems, we will be turning off
these helpful hacks to reduce the risk of someone sending a real
broadcast to citizens.

Note, platforms are still able to approve broadcasts when their service
is in training mode.