### PR TITLE
Rename bt-ee-proxy to ee-proxy

### DIFF
--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -174,8 +174,8 @@ class CBCProxyCanary(CBCProxyClientBase):
 
 
 class CBCProxyEE(CBCProxyClientBase):
-    lambda_name = 'bt-ee-1-proxy'
-    failover_lambda_name = 'bt-ee-2-proxy'
+    lambda_name = 'ee-1-proxy'
+    failover_lambda_name = 'ee-2-proxy'
 
     LANGUAGE_ENGLISH = 'en-GB'
     LANGUAGE_WELSH = 'cy-GB'

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -78,7 +78,7 @@ def test_cbc_proxy_lambda_client_has_correct_keys(cbc_proxy_ee):
     ('my-description', 'en-GB'),
     ('mŷ-description', 'cy-GB'),
 ))
-@pytest.mark.parametrize('cbc', ['bt-ee', 'three', 'o2'])
+@pytest.mark.parametrize('cbc', ['ee', 'three', 'o2'])
 def test_cbc_proxy_one_2_many_create_and_send_invokes_function(
     mocker,
     cbc_proxy_client,
@@ -86,7 +86,7 @@ def test_cbc_proxy_one_2_many_create_and_send_invokes_function(
     cbc,
     expected_language,
 ):
-    cbc_proxy = cbc_proxy_client.get_proxy('ee') if cbc == 'bt-ee' else cbc_proxy_client.get_proxy(cbc)
+    cbc_proxy = cbc_proxy_client.get_proxy(cbc)
 
     identifier = 'my-identifier'
     headline = 'my-headline'
@@ -135,9 +135,9 @@ def test_cbc_proxy_one_2_many_create_and_send_invokes_function(
     assert payload['language'] == expected_language
 
 
-@pytest.mark.parametrize('cbc', ['bt-ee', 'three', 'o2'])
+@pytest.mark.parametrize('cbc', ['ee', 'three', 'o2'])
 def test_cbc_proxy_one_2_many_cancel_invokes_function(mocker, cbc_proxy_client, cbc):
-    cbc_proxy = cbc_proxy_client.get_proxy('ee') if cbc == 'bt-ee' else cbc_proxy_client.get_proxy(cbc)
+    cbc_proxy = cbc_proxy_client.get_proxy(cbc)
 
     identifier = 'my-identifier'
     MockProviderMessage = namedtuple(
@@ -310,13 +310,13 @@ def test_cbc_proxy_vodafone_cancel_invokes_function(mocker, cbc_proxy_vodafone):
     assert payload['sent'] == sent
 
 
-@pytest.mark.parametrize('cbc', ['bt-ee', 'vodafone', 'three', 'o2'])
+@pytest.mark.parametrize('cbc', ['ee', 'vodafone', 'three', 'o2'])
 def test_cbc_proxy_will_failover_to_second_lambda_if_function_error(
     mocker,
     cbc_proxy_client,
     cbc
 ):
-    cbc_proxy = cbc_proxy_client.get_proxy('ee') if cbc == 'bt-ee' else cbc_proxy_client.get_proxy(cbc)
+    cbc_proxy = cbc_proxy_client.get_proxy(cbc)
 
     ld_client_mock = mocker.patch.object(
         cbc_proxy,
@@ -362,13 +362,13 @@ def test_cbc_proxy_will_failover_to_second_lambda_if_function_error(
     ]
 
 
-@pytest.mark.parametrize('cbc', ['bt-ee', 'vodafone', 'three', 'o2'])
+@pytest.mark.parametrize('cbc', ['ee', 'vodafone', 'three', 'o2'])
 def test_cbc_proxy_will_failover_to_second_lambda_if_invoke_error(
     mocker,
     cbc_proxy_client,
     cbc
 ):
-    cbc_proxy = cbc_proxy_client.get_proxy('ee') if cbc == 'bt-ee' else cbc_proxy_client.get_proxy(cbc)
+    cbc_proxy = cbc_proxy_client.get_proxy(cbc)
 
     ld_client_mock = mocker.patch.object(
         cbc_proxy,
@@ -409,11 +409,11 @@ def test_cbc_proxy_will_failover_to_second_lambda_if_invoke_error(
     ]
 
 
-@pytest.mark.parametrize('cbc', ['bt-ee', 'vodafone', 'three', 'o2'])
+@pytest.mark.parametrize('cbc', ['ee', 'vodafone', 'three', 'o2'])
 def test_cbc_proxy_create_and_send_tries_failover_lambda_on_invoke_error_and_raises_if_both_invoke_error(
     mocker, cbc_proxy_client, cbc
 ):
-    cbc_proxy = cbc_proxy_client.get_proxy('ee') if cbc == 'bt-ee' else cbc_proxy_client.get_proxy(cbc)
+    cbc_proxy = cbc_proxy_client.get_proxy(cbc)
 
     ld_client_mock = mocker.patch.object(
         cbc_proxy,
@@ -452,11 +452,11 @@ def test_cbc_proxy_create_and_send_tries_failover_lambda_on_invoke_error_and_rai
     ]
 
 
-@pytest.mark.parametrize('cbc', ['bt-ee', 'vodafone', 'three', 'o2'])
+@pytest.mark.parametrize('cbc', ['ee', 'vodafone', 'three', 'o2'])
 def test_cbc_proxy_create_and_send_tries_failover_lambda_on_function_error_and_raises_if_both_function_error(
     mocker, cbc_proxy_client, cbc
 ):
-    cbc_proxy = cbc_proxy_client.get_proxy('ee') if cbc == 'bt-ee' else cbc_proxy_client.get_proxy(cbc)
+    cbc_proxy = cbc_proxy_client.get_proxy(cbc)
 
     ld_client_mock = mocker.patch.object(
         cbc_proxy,
@@ -532,9 +532,9 @@ def test_cbc_proxy_send_canary_invokes_function(mocker, cbc_proxy_client):
     assert payload['identifier'] == identifier
 
 
-@pytest.mark.parametrize('cbc', ['bt-ee', 'three', 'o2'])
+@pytest.mark.parametrize('cbc', ['ee', 'three', 'o2'])
 def test_cbc_proxy_one_2_many_send_link_test_invokes_function(mocker, cbc_proxy_client, cbc):
-    cbc_proxy = cbc_proxy_client.get_proxy('ee') if cbc == 'bt-ee' else cbc_proxy_client.get_proxy(cbc)
+    cbc_proxy = cbc_proxy_client.get_proxy(cbc)
 
     identifier = str(uuid.uuid4())
 


### PR DESCRIPTION
We want to rename the `bt-ee-1-proxy` lambda function to `ee-1-proxy`.
This change will need to be deployed at the same time that we change
the name of the lambda function in the Terraform.

https://www.pivotaltracker.com/story/show/176551400