### PR TITLE
Set the default broadcast channel to test

### DIFF
--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -210,6 +210,7 @@ class CBCProxyEE(CBCProxyClientBase):
             'sent': sent,
             'expires': expires,
             'language': self.infer_language_from(description),
+            'channel': 'test',
         }
         self._invoke_lambda_with_failover(payload=payload)
 
@@ -270,6 +271,7 @@ class CBCProxyThree(CBCProxyClientBase):
             'sent': sent,
             'expires': expires,
             'language': self.infer_language_from(description),
+            'channel': 'test',
         }
         self._invoke_lambda_with_failover(payload=payload)
 
@@ -329,6 +331,7 @@ class CBCProxyO2(CBCProxyClientBase):
             'sent': sent,
             'expires': expires,
             'language': self.infer_language_from(description),
+            'channel': 'test',
         }
         self._invoke_lambda_with_failover(payload=payload)
 
@@ -391,6 +394,7 @@ class CBCProxyVodafone(CBCProxyClientBase):
             'sent': sent,
             'expires': expires,
             'language': self.infer_language_from(description),
+            'channel': 'test',
         }
         self._invoke_lambda_with_failover(payload=payload)
 

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -133,6 +133,7 @@ def test_cbc_proxy_one_2_many_create_and_send_invokes_function(
     assert payload['sent'] == sent
     assert payload['expires'] == expires
     assert payload['language'] == expected_language
+    assert payload['channel'] == 'test'
 
 
 @pytest.mark.parametrize('cbc', ['bt-ee', 'three', 'o2'])
@@ -249,6 +250,7 @@ def test_cbc_proxy_vodafone_create_and_send_invokes_function(
     assert payload['sent'] == sent
     assert payload['expires'] == expires
     assert payload['language'] == expected_language
+    assert payload['channel'] == 'test'
 
 
 def test_cbc_proxy_vodafone_cancel_invokes_function(mocker, cbc_proxy_vodafone):


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176459886

This used to be hardcoded in the CBC proxy but now we will hardcode it
in the cbc_proxy_client.

In a future PR we can start choosing which channel a broadcast will go
to based on the channel configured for that broadcast service.

See https://github.com/alphagov/notifications-broadcasts-infra/pull/102 for related PR that allows the choice of broadcast channel.

This PR will be merged first before the broadcasts-infra PR as that introduces the requirement for the `channel` key. Nothing should break by sending an extra JSON key at the moment that the CBC proxy doesn't know about.