### PR TITLE
Check request size preview

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -381,6 +381,7 @@ class Config(object):
     CBC_PROXY_ENABLED = bool(CBC_PROXY_AWS_ACCESS_KEY_ID)
 
     ENABLED_CBCS = {BroadcastProvider.EE, BroadcastProvider.THREE, BroadcastProvider.O2, BroadcastProvider.VODAFONE}
+    MAX_CONTENT_LENGTH = 5 * 1024 * 1024  # 5MB
 
 
 ######################
@@ -508,6 +509,8 @@ class Staging(Config):
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = True
 
+    MAX_CONTENT_LENGTH = None
+
 
 class Live(Config):
     NOTIFY_EMAIL_DOMAIN = 'notifications.service.gov.uk'
@@ -528,6 +531,8 @@ class Live(Config):
     SES_STUB_URL = None
 
     CRONITOR_ENABLED = True
+
+    MAX_CONTENT_LENGTH = None
 
 
 class CloudFoundryConfig(Config):

--- a/tests/app/test_request_size.py
+++ b/tests/app/test_request_size.py
@@ -1,0 +1,36 @@
+import pytest
+import json
+
+@pytest.mark.parametrize('endpoint, max_content_length, expected_status_code', [
+    ("/_status", 5*1024*1024, 413),
+    ("/provider-details", 5*1024*1024, 413),
+    ("/v2/notifications/email", 5*1024*1024, 413),
+
+    ("/_status", None, 200),
+    ("/provider-details", None, 405),
+    ("/v2/notifications/email", None, 401),
+])
+def test_request_status_when_content_length_is_set(
+    notify_api,
+    sample_email_template_with_placeholders,
+    mocker,
+    endpoint,
+    max_content_length,
+    expected_status_code):
+
+    notify_api.config['MAX_CONTENT_LENGTH'] = max_content_length
+    large_name = "J" * (max_content_length or 1 + 1)
+    data = {
+        'email_address': 'ok@ok.com',
+        'template_id': str(sample_email_template_with_placeholders.id),
+        'personalisation': {
+            'name': large_name
+        }
+    }
+    with notify_api.test_client() as client:
+        response = client.post(
+            path=endpoint,
+            data=json.dumps(data),
+            headers=[('Content-Type', 'application/json')])
+
+        assert response.status_code == expected_status_code


### PR DESCRIPTION
This is to replicate the nginx behaviour now that we're going to retire them.

A couple of questions that I'd like to hear your thoughts about:

- How important it is to have this check?
- Do you see this as a way to protect our instances against big payloads or as a way to control the size of the files our users can upload?

Depending on your answers we can choose between a) keeping the check here and creating a similar one for admin b) replacing this check with a check on cloudfront using something like WAF, or c) a combination of both (i.e. a "hard" limit on the WAF and more adjustable limit in the app).