### PR TITLE
Bump utils to 43.8.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -31,7 +31,7 @@ notifications-python-client==5.7.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@43.8.0#egg=notifications-utils==43.8.0
+git+https://github.com/alphagov/notifications-utils.git@43.8.1#egg=notifications-utils==43.8.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ notifications-python-client==5.7.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@43.8.0#egg=notifications-utils==43.8.0
+git+https://github.com/alphagov/notifications-utils.git@43.8.1#egg=notifications-utils==43.8.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.9.0
@@ -44,14 +44,14 @@ alembic==1.5.2
 amqp==1.4.9
 anyjson==0.3.3
 attrs==20.3.0
-awscli==1.18.219
+awscli==1.18.222
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.2.1
 blinker==1.4
 boto==2.49.0
-boto3==1.16.59
-botocore==1.19.59
+boto3==1.16.62
+botocore==1.19.62
 certifi==2020.12.5
 chardet==4.0.0
 click==7.1.2
@@ -74,7 +74,7 @@ mistune==0.8.4
 monotonic==1.5
 orderedset==2.0.3
 packaging==20.8
-phonenumbers==8.12.16
+phonenumbers==8.12.17
 pyasn1==0.4.8
 pycparser==2.20
 pyparsing==2.4.7
@@ -95,7 +95,7 @@ smartypants==2.0.1
 soupsieve==2.1
 statsd==3.3.0
 typing-extensions==3.7.4.3
-urllib3==1.26.2
+urllib3==1.26.3
 webencodings==0.5.1
 Werkzeug==1.0.1
 zipp==3.4.0

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -362,7 +362,8 @@ def test_simulated_recipient(notify_api, to_address, notification_type, expected
 @pytest.mark.parametrize('recipient, expected_international, expected_prefix, expected_units', [
     ('7900900123', False, '44', 1),  # UK
     ('+447900900123', False, '44', 1),  # UK
-    ('07700900222', True, '44', 1),  # UK (Jersey)
+    ('07700910222', True, '44', 1),  # UK (Jersey)
+    ('07700900222', False, '44', 1),  # TV number
     ('73122345678', True, '7', 1),  # Russia
     ('360623400400', True, '36', 3)]  # Hungary
 )


### PR DESCRIPTION
This brings in the change to stop TV numbers from being treated as international numbers.