### PR TITLE
Downgrade exceptions to warnings to reduce emails

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -204,7 +204,7 @@ def check_precompiled_letter_state():
             https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#Deal-with-letter-pending-virus-scan-for-90-minutes.
             Notifications: {}""".format(len(letters), sorted(letter_ids))
 
-        current_app.logger.exception(msg)
+        current_app.logger.warning(msg)
 
         if current_app.config['NOTIFY_ENVIRONMENT'] in ['live', 'production', 'test']:
             zendesk_client.create_ticket(
@@ -225,7 +225,7 @@ def check_templated_letter_state():
         msg = "{} letters were created before 17.30 yesterday and still have 'created' status. " \
               "Notifications: {}".format(len(letters), letter_ids)
 
-        current_app.logger.exception(msg)
+        current_app.logger.warning(msg)
 
         if current_app.config['NOTIFY_ENVIRONMENT'] in ['live', 'production', 'test']:
             zendesk_client.create_ticket(

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -320,7 +320,7 @@ def test_check_job_status_task_does_not_raise_error(sample_template):
 
 @freeze_time("2019-05-30 14:00:00")
 def test_check_precompiled_letter_state(mocker, sample_letter_template):
-    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.exception')
+    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.warning')
     mock_create_ticket = mocker.patch('app.celery.nightly_tasks.zendesk_client.create_ticket')
 
     create_notification(template=sample_letter_template,
@@ -357,7 +357,7 @@ def test_check_precompiled_letter_state(mocker, sample_letter_template):
 
 @freeze_time("2019-05-30 14:00:00")
 def test_check_templated_letter_state_during_bst(mocker, sample_letter_template):
-    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.exception')
+    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.warning')
     mock_create_ticket = mocker.patch('app.celery.nightly_tasks.zendesk_client.create_ticket')
 
     noti_1 = create_notification(template=sample_letter_template, created_at=datetime(2019, 5, 1, 12, 0))
@@ -382,7 +382,7 @@ def test_check_templated_letter_state_during_bst(mocker, sample_letter_template)
 
 @freeze_time("2019-01-30 14:00:00")
 def test_check_templated_letter_state_during_utc(mocker, sample_letter_template):
-    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.exception')
+    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.warning')
     mock_create_ticket = mocker.patch('app.celery.scheduled_tasks.zendesk_client.create_ticket')
 
     noti_1 = create_notification(template=sample_letter_template, created_at=datetime(2018, 12, 1, 12, 0))


### PR DESCRIPTION
We already trigger a zendesk ticket for these two cases, meaning that
whenever we get this situation, we get 3 emails. One for the zendesk
ticket, one from logit raising the fact an exception was raised and one
from cloudwatch raising the fact an exception was raised.

We don't need all these emails, a zendesk ticket is sufficient.
Downgrading to a warning means this event will still be findable in our
logs however.