### PR TITLE
dont update finishes_at when cancelling broadcast

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -192,12 +192,6 @@ def _create_broadcast_event(broadcast_message):
         BroadcastStatusType.CANCELLED: BroadcastEventMessageType.CANCEL,
     }
 
-    if broadcast_message.status == BroadcastStatusType.CANCELLED:
-        transmitted_finishes_at = broadcast_message.cancelled_at
-    else:
-        transmitted_finishes_at = broadcast_message.finishes_at
-
-
     event = BroadcastEvent(
         service=broadcast_message.service,
         broadcast_message=broadcast_message,
@@ -210,8 +204,7 @@ def _create_broadcast_event(broadcast_message):
 
         # TODO: Should this be set to now? Or the original starts_at?
         transmitted_starts_at=broadcast_message.starts_at,
-        # TODO: When cancelling, do we need to set this to now? Or should we keep it as the original time.
-        transmitted_finishes_at=transmitted_finishes_at,
+        transmitted_finishes_at=broadcast_message.finishes_at,
     )
 
     dao_save_object(event)

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -508,7 +508,7 @@ def test_update_broadcast_message_status_stores_cancelled_by_and_cancelled_at(
     assert cancel_event.service_id == sample_broadcast_service.id
     assert cancel_event.transmitted_areas == bm.areas
     assert cancel_event.message_type == BroadcastEventMessageType.CANCEL
-    assert cancel_event.transmitted_finishes_at == bm.cancelled_at
+    assert cancel_event.transmitted_finishes_at == bm.finishes_at
     assert cancel_event.transmitted_content == {"body": "emergency broadcast"}
 
 


### PR DESCRIPTION
otherwise we run into issues where we dont issue the cancel as we say "oh look the expiry time just passed, so we shouldnt send this message as it's already been removed from the cbc"