### PR TITLE
Pin cryptography to a version < 3.4

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -25,6 +25,8 @@ rfc3987==1.3.8
 cachetools==4.2.0
 beautifulsoup4==4.9.3
 lxml==4.6.2
+# higher version causes build to fail
+cryptography<3.4
 
 notifications-python-client==5.7.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,8 @@ rfc3987==1.3.8
 cachetools==4.2.0
 beautifulsoup4==4.9.3
 lxml==4.6.2
+# higher version causes build to fail
+cryptography<3.4
 
 notifications-python-client==5.7.1
 
@@ -40,18 +42,18 @@ prometheus-client==0.9.0
 gds-metrics==0.2.4
 
 ## The following requirements were added by pip freeze:
-alembic==1.5.2
+alembic==1.5.4
 amqp==1.4.9
 anyjson==0.3.3
 attrs==20.3.0
-awscli==1.18.222
+awscli==1.19.3
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.2.1
 blinker==1.4
 boto==2.49.0
-boto3==1.16.62
-botocore==1.19.62
+boto3==1.17.3
+botocore==1.20.3
 certifi==2020.12.5
 chardet==4.0.0
 click==7.1.2
@@ -64,8 +66,7 @@ geojson==2.5.0
 govuk-bank-holidays==0.8
 greenlet==1.0.0
 idna==2.10
-importlib-metadata==3.4.0
-Jinja2==2.11.2
+Jinja2==2.11.3
 jmespath==0.10.0
 kombu==3.0.37
 Mako==1.1.4
@@ -73,7 +74,7 @@ MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5
 orderedset==2.0.3
-packaging==20.8
+packaging==20.9
 phonenumbers==8.12.17
 pyasn1==0.4.8
 pycparser==2.20
@@ -83,7 +84,7 @@ pyrsistent==0.17.3
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-json-logger==2.0.1
-pytz==2020.5
+pytz==2021.1
 PyYAML==5.3.1
 redis==3.5.3
 requests==2.25.1
@@ -94,8 +95,6 @@ six==1.15.0
 smartypants==2.0.1
 soupsieve==2.1
 statsd==3.3.0
-typing-extensions==3.7.4.3
 urllib3==1.26.3
 webencodings==0.5.1
 Werkzeug==1.0.1
-zipp==3.4.0


### PR DESCRIPTION
One of our dependencies has a dependency on cryptography, which has
recently released version 3.4.

This version introduced a circular import error
(pyca/cryptography#5756) which was fixed in
3.4.1.

However, 3.4.1 has a different error where it fails because it cannot
find a rust compiler.

The suggested
solutions are:

Install a newer version of pip which will install a pre-compiled
cryptography wheel OR
Have rust installed and available on our PATH so that it can be used
to build the package.
Since we can't change the buildpack's pip version and we cannot install
rust ourselves, the only we're left with is to avoid upgrading to 3.4 -
at least until PaaS updates their python buildpacks.