### PR TITLE
Improve sender task

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -430,6 +430,7 @@ class Development(Config):
 
 
 class Test(Development):
+    SQLALCHEMY_ECHO = False
     NOTIFY_EMAIL_DOMAIN = 'test.notify.com'
     FROM_NUMBER = 'testing'
     NOTIFY_ENVIRONMENT = 'test'

--- a/app/config.py
+++ b/app/config.py
@@ -430,7 +430,6 @@ class Development(Config):
 
 
 class Test(Development):
-    SQLALCHEMY_ECHO = False
     NOTIFY_EMAIL_DOMAIN = 'test.notify.com'
     FROM_NUMBER = 'testing'
     NOTIFY_ENVIRONMENT = 'test'

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -28,11 +28,11 @@ from app.models import (
     NOTIFICATION_SENDING,
     NOTIFICATION_STATUS_TYPES_COMPLETED
 )
-from app.serialised_models import SerialisedTemplate
+from app.serialised_models import SerialisedTemplate, SerialisedService
 
 
 def send_sms_to_provider(notification):
-    service = notification.service
+    service = SerialisedService.from_id(notification.service_id)
     service_id = service.id
     if not service.active:
         technical_failure(notification=notification)
@@ -42,7 +42,7 @@ def send_sms_to_provider(notification):
         provider = provider_to_use(SMS_TYPE, notification.international)
 
         template_dict = SerialisedTemplate.get_dict(template_id=notification.template_id,
-                                                    service_id=service_id,
+                                                    service_id=service.id,
                                                     version=notification.template_version)['data']
 
         template = SMSMessageTemplate(
@@ -87,7 +87,7 @@ def send_sms_to_provider(notification):
 
 
 def send_email_to_provider(notification):
-    service = notification.service
+    service = SerialisedService.from_id(notification.service_id)
     service_id = service.id
     if not service.active:
         technical_failure(notification=notification)

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -15,7 +15,6 @@ from app.dao.provider_details_dao import (
     dao_reduce_sms_provider_priority
 )
 from app.celery.research_mode_tasks import send_sms_response, send_email_response
-from app.dao.templates_dao import dao_get_template_by_id
 from app.exceptions import NotificationTechnicalFailureException
 from app.models import (
     SMS_TYPE,
@@ -41,9 +40,9 @@ def send_sms_to_provider(notification):
     if notification.status == 'created':
         provider = provider_to_use(SMS_TYPE, notification.international)
 
-        template_dict = SerialisedTemplate.get_dict(template_id=notification.template_id,
-                                                    service_id=service.id,
-                                                    version=notification.template_version)['data']
+        template_dict = SerialisedTemplate.from_id_and_service_id(template_id=notification.template_id,
+                                                                  service_id=service_id,
+                                                                  version=notification.template_version).__dict__
 
         template = SMSMessageTemplate(
             template_dict,
@@ -95,9 +94,9 @@ def send_email_to_provider(notification):
     if notification.status == 'created':
         provider = provider_to_use(EMAIL_TYPE)
 
-        template_dict = SerialisedTemplate.get_dict(template_id=notification.template_id,
-                                                    service_id=service_id,
-                                                    version=notification.template_version)['data']
+        template_dict = SerialisedTemplate.from_id_and_service_id(template_id=notification.template_id,
+                                                                  service_id=service_id,
+                                                                  version=notification.template_version).__dict__
 
         html_email = HTMLEmailTemplate(
             template_dict,

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -28,6 +28,7 @@ from app.models import (
     NOTIFICATION_SENDING,
     NOTIFICATION_STATUS_TYPES_COMPLETED
 )
+from app.serialised_models import SerialisedTemplate
 
 
 def send_sms_to_provider(notification):
@@ -40,10 +41,12 @@ def send_sms_to_provider(notification):
     if notification.status == 'created':
         provider = provider_to_use(SMS_TYPE, notification.international)
 
-        template_model = dao_get_template_by_id(notification.template_id, notification.template_version)
+        template_dict = SerialisedTemplate.get_dict(template_id=notification.template_id,
+                                                    service_id=service_id,
+                                                    version=notification.template_version)['data']
 
         template = SMSMessageTemplate(
-            template_model.__dict__,
+            template_dict,
             values=notification.personalisation,
             prefix=service.name,
             show_prefix=service.prefix_sms,
@@ -92,7 +95,9 @@ def send_email_to_provider(notification):
     if notification.status == 'created':
         provider = provider_to_use(EMAIL_TYPE)
 
-        template_dict = dao_get_template_by_id(notification.template_id, notification.template_version).__dict__
+        template_dict = SerialisedTemplate.get_dict(template_id=notification.template_id,
+                                                    service_id=service_id,
+                                                    version=notification.template_version)['data']
 
         html_email = HTMLEmailTemplate(
             template_dict,

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -75,6 +75,7 @@ class SerialisedTemplate(SerialisedModel):
 class SerialisedService(SerialisedModel):
     ALLOWED_PROPERTIES = {
         'id',
+        'name',
         'active',
         'contact_link',
         'email_from',
@@ -83,6 +84,8 @@ class SerialisedService(SerialisedModel):
         'rate_limit',
         'research_mode',
         'restricted',
+        'prefix_sms',
+        'email_branding'
     }
 
     @classmethod


### PR DESCRIPTION
This PR is to optimise the methods used to send notifications to providers by remove calls to the database. 
It probably easiest to go through it commit by commit.

- Remove validate_and_format for email and phone numbers, using normalised_to instead because that function has already happened when persisting the notificaiton.

- Remove 2 extra select queries after the update and commit. Once a transaction is committed SQLAlchemy will query for the db model if referenced after a commit.
 
- Use the cached template object.
  By adding SerialisedTemplate we can avoid a database call for the template. This is useful when sending many many emails/sms for the same template/version.

- User cache for service in send_to_provider methods. 
  This will remove a call to the db if the service exists in the cache.