### PR TITLE
Refactor the CBC proxy classes

### DIFF
--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -172,186 +172,77 @@ class CBCProxyCanary(CBCProxyClientBase):
         self._invoke_lambda(self.lambda_name, payload={'identifier': identifier})
 
 
-class CBCProxyEE(CBCProxyClientBase):
+class CBCProxyOne2ManyClient(CBCProxyClientBase):
+    LANGUAGE_ENGLISH = 'en-GB'
+    LANGUAGE_WELSH = 'cy-GB'
+
+    def send_link_test(
+        self,
+        identifier,
+        sequential_number=None,
+    ):
+        """
+        link test - open up a connection to a specific provider, and send them an xml payload with a <msgType> of
+        test.
+        """
+        payload = {
+            'message_type': 'test',
+            'identifier': identifier,
+            'message_format': 'cap'
+        }
+
+        self._invoke_lambda_with_failover(payload=payload)
+
+    def create_and_send_broadcast(
+        self, identifier, headline, description, areas, sent, expires, channel, message_number=None
+    ):
+        payload = {
+            'message_type': 'alert',
+            'identifier': identifier,
+            'message_format': 'cap',
+            'headline': headline,
+            'description': description,
+            'areas': areas,
+            'sent': sent,
+            'expires': expires,
+            'language': self.infer_language_from(description),
+            'channel': channel,
+        }
+        self._invoke_lambda_with_failover(payload=payload)
+
+    def cancel_broadcast(
+        self,
+        identifier, previous_provider_messages,
+        sent, message_number=None
+    ):
+        payload = {
+            'message_type': 'cancel',
+            'identifier': identifier,
+            'message_format': 'cap',
+            "references": [
+                {
+                    "message_id": str(message.id),
+                    "sent": message.created_at.strftime(DATETIME_FORMAT)
+                } for message in previous_provider_messages
+            ],
+            'sent': sent,
+        }
+        self._invoke_lambda_with_failover(payload=payload)
+
+
+class CBCProxyEE(CBCProxyOne2ManyClient):
     lambda_name = 'ee-1-proxy'
     failover_lambda_name = 'ee-2-proxy'
 
-    LANGUAGE_ENGLISH = 'en-GB'
-    LANGUAGE_WELSH = 'cy-GB'
 
-    def send_link_test(
-        self,
-        identifier,
-        sequential_number=None,
-    ):
-        """
-        link test - open up a connection to a specific provider, and send them an xml payload with a <msgType> of
-        test.
-        """
-        payload = {
-            'message_type': 'test',
-            'identifier': identifier,
-            'message_format': 'cap'
-        }
-
-        self._invoke_lambda_with_failover(payload=payload)
-
-    def create_and_send_broadcast(
-        self, identifier, headline, description, areas, sent, expires, channel, message_number=None
-    ):
-        payload = {
-            'message_type': 'alert',
-            'identifier': identifier,
-            'message_format': 'cap',
-            'headline': headline,
-            'description': description,
-            'areas': areas,
-            'sent': sent,
-            'expires': expires,
-            'language': self.infer_language_from(description),
-            'channel': channel,
-        }
-        self._invoke_lambda_with_failover(payload=payload)
-
-    def cancel_broadcast(
-        self,
-        identifier, previous_provider_messages,
-        sent, message_number=None
-    ):
-        payload = {
-            'message_type': 'cancel',
-            'identifier': identifier,
-            'message_format': 'cap',
-            "references": [
-                {
-                    "message_id": str(message.id),
-                    "sent": message.created_at.strftime(DATETIME_FORMAT)
-                } for message in previous_provider_messages
-            ],
-            'sent': sent,
-        }
-        self._invoke_lambda_with_failover(payload=payload)
-
-
-class CBCProxyThree(CBCProxyClientBase):
+class CBCProxyThree(CBCProxyOne2ManyClient):
     lambda_name = 'three-1-proxy'
     failover_lambda_name = 'three-2-proxy'
 
-    LANGUAGE_ENGLISH = 'en-GB'
-    LANGUAGE_WELSH = 'cy-GB'
 
-    def send_link_test(
-        self,
-        identifier,
-        sequential_number=None,
-    ):
-        """
-        link test - open up a connection to a specific provider, and send them an xml payload with a <msgType> of
-        test.
-        """
-        payload = {
-            'message_type': 'test',
-            'identifier': identifier,
-            'message_format': 'cap'
-        }
-
-        self._invoke_lambda_with_failover(payload=payload)
-
-    def create_and_send_broadcast(
-        self, identifier, headline, description, areas, sent, expires, channel, message_number=None
-    ):
-        payload = {
-            'message_type': 'alert',
-            'identifier': identifier,
-            'message_format': 'cap',
-            'headline': headline,
-            'description': description,
-            'areas': areas,
-            'sent': sent,
-            'expires': expires,
-            'language': self.infer_language_from(description),
-            'channel': channel,
-        }
-        self._invoke_lambda_with_failover(payload=payload)
-
-    def cancel_broadcast(
-        self,
-        identifier, previous_provider_messages,
-        sent, message_number=None
-    ):
-        payload = {
-            'message_type': 'cancel',
-            'identifier': identifier,
-            'message_format': 'cap',
-            "references": [
-                {
-                    "message_id": str(message.id),
-                    "sent": message.created_at.strftime(DATETIME_FORMAT)
-                } for message in previous_provider_messages
-            ],
-            'sent': sent,
-        }
-        self._invoke_lambda_with_failover(payload=payload)
-
-class CBCProxyO2(CBCProxyClientBase):
+class CBCProxyO2(CBCProxyOne2ManyClient):
     lambda_name = 'o2-1-proxy'
     failover_lambda_name = 'o2-2-proxy'
-
-    LANGUAGE_ENGLISH = 'en-GB'
-    LANGUAGE_WELSH = 'cy-GB'
-
-    def send_link_test(
-        self,
-        identifier,
-        sequential_number=None,
-    ):
-        """
-        link test - open up a connection to a specific provider, and send them an xml payload with a <msgType> of
-        test.
-        """
-        payload = {
-            'message_type': 'test',
-            'identifier': identifier,
-            'message_format': 'cap'
-        }
-
-        self._invoke_lambda_with_failover(payload=payload)
-
-    def create_and_send_broadcast(
-        self, identifier, headline, description, areas, sent, expires, channel, message_number=None
-    ):
-        payload = {
-            'message_type': 'alert',
-            'identifier': identifier,
-            'message_format': 'cap',
-            'headline': headline,
-            'description': description,
-            'areas': areas,
-            'sent': sent,
-            'expires': expires,
-            'language': self.infer_language_from(description),
-            'channel': channel,
-        }
-        self._invoke_lambda_with_failover(payload=payload)
-
-    def cancel_broadcast(
-        self,
-        identifier, previous_provider_messages,
-        sent, message_number=None
-    ):
-        payload = {
-            'message_type': 'cancel',
-            'identifier': identifier,
-            'message_format': 'cap',
-            "references": [
-                {
-                    "message_id": str(message.id),
-                    "sent": message.created_at.strftime(DATETIME_FORMAT)
-                } for message in previous_provider_messages
-            ],
-            'sent': sent,
-        }
-        self._invoke_lambda_with_failover(payload=payload)
 
 
 class CBCProxyVodafone(CBCProxyClientBase):


### PR DESCRIPTION
By creating a new `CBCProxyOne2ManyClient` class for the three One2Many
clients to inherit from. These three clients are the same apart from the
`lambda_name` and the `failover_lambda_name`.