### PR TITLE
Don’t accept cancel or update via broadcast API

### DIFF
--- a/app/broadcast_message/translators.py
+++ b/app/broadcast_message/translators.py
@@ -5,6 +5,7 @@ def cap_xml_to_dict(cap_xml):
     # This function assumes that it’s being passed valid CAP XML
     cap = BeautifulSoup(cap_xml, "xml")
     return {
+        "msgType": cap.alert.msgType.text,
         "reference": cap.alert.identifier.text,
         "category": cap.alert.info.category.text,
         "expires": cap.alert.info.expires.text,

--- a/app/v2/broadcast/broadcast_schemas.py
+++ b/app/v2/broadcast/broadcast_schemas.py
@@ -2,6 +2,7 @@ post_broadcast_schema = {
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
     "required": [
+        "msgType",
         "reference",
         "category",
         "content",
@@ -52,6 +53,18 @@ post_broadcast_schema = {
                 "$ref": "#/definitions/area",
             },
         },
+        "msgType": {
+            "type": "string",
+            "enum": [
+                "Alert",
+                # The following are valid CAP but not supported by our
+                # API at the moment
+                #    "Update",
+                #    "Cancel",
+                #    "Ack",
+                #    "Error",
+            ],
+        }
     },
     "definitions": {
         "area": {

--- a/tests/app/v2/broadcast/sample_cap_xml_documents.py
+++ b/tests/app/v2/broadcast/sample_cap_xml_documents.py
@@ -4,7 +4,7 @@ WAINFLEET = """
         <sender>www.gov.uk/environment-agency</sender>
         <sent>2020-02-16T23:01:13-00:00</sent>
         <status>Actual</status>
-        <msgType>Update</msgType>
+        <msgType>Alert</msgType>
         <source>Flood warning service</source>
         <scope>Public</scope>
         <references>www.gov.uk/environment-agency,4f6d28b10ab7aa447bbd46d85f1e9effE,2020-02-16T19:20:03+00:00</references>
@@ -30,5 +30,171 @@ WAINFLEET = """
                 </geocode>
             </area>
         </info>
+    </alert>
+"""
+
+UPDATE = """
+    <alert xmlns="urn:oasis:names:tc:emergency:cap:1.2">
+      <identifier>PAAQ-4-mg5a94</identifier>
+      <sender>wcatwc@noaa.gov</sender>
+      <sent>2013-01-05T10:58:23-00:00</sent>
+      <status>Actual</status>
+      <msgType>Update</msgType>
+      <source>WCATWC</source>
+      <scope>Public</scope>
+      <code>IPAWSv1.0</code>
+      <references>wcatwc@noaa.gov,PAAQ-1-mg5a94,2013-01-05T09:01:16-00:00 wcatwc@noaa.gov,PAAQ-2-mg5a94,2013-01-05T09:30:16-00:00 wcatwc@noaa.gov,PAAQ-3-mg5a94,2013-01-05T10:17:31-00:00</references>
+      <incidents>mg5a94</incidents>
+      <info>
+        <category>Geo</category>
+        <event>Tsunami Cancellation</event>
+        <responseType>None</responseType>
+        <urgency>Past</urgency>
+        <severity>Unknown</severity>
+        <certainty>Unlikely</certainty>
+        <onset>2013-01-05T10:58:23-00:00</onset>
+        <expires>2013-01-05T10:58:23-00:00</expires>
+        <senderName>NWS West Coast/Alaska Tsunami Warning Center Palmer AK</senderName>
+        <headline>The tsunami Warning is canceled for the coastal areas of British Columbia and Alaska from the north tip of Vancouver Island, British Columbia to Cape Fairweather, Alaska (80 miles SE of Yakutat).</headline>
+        <description>The tsunami Warning is canceled for the coastal areas of British Columbia and Alaska from the north tip of Vancouver Island, British Columbia to Cape Fairweather, Alaska (80 miles SE of Yakutat). - Event details: Preliminary magnitude 7.5 (Mw) earthquake / Lat: 55.300, Lon: -134.900 at 2013-01-05T08:58:20Z Tsunami cancellations indicate the end of the damaging tsunami threat.  A cancellation is issued after an evaluation of sea level data confirms that a destructive tsunami will not impact the alerted region, or after tsunami levels have subsided to non-damaging levels. </description>
+        <instruction>Recommended Actions:   Do not re-occupy hazard zones until local emergency officials indicate it is safe to do so. This will be the last West Coast/Alaska Tsunami Warning Center message issued for this event.  Refer to the internet site ntwc.arh.noaa.gov for more information. </instruction>
+        <web>http://ntwc.arh.noaa.gov/events/PAAQ/2013/01/05/mg5a94/4/WEAK51/WEAK51.txt</web>
+        <parameter>
+          <valueName>EventLocationName</valueName>
+          <value>95 miles NW of Dixon Entrance, Alaska</value>
+        </parameter>
+        <parameter>
+          <valueName>EventPreliminaryMagnitude</valueName>
+          <value>7.5</value>
+        </parameter>
+        <parameter>
+          <valueName>EventPreliminaryMagnitudeType</valueName>
+          <value>Mw</value>
+        </parameter>
+        <parameter>
+          <valueName>EventOriginTime</valueName>
+          <value>2013-01-05T08:58:20-00:00</value>
+        </parameter>
+        <parameter>
+          <valueName>EventDepth</valueName>
+          <value>5 kilometers</value>
+        </parameter>
+        <parameter>
+          <valueName>EventLatLon</valueName>
+          <value>55.300,-134.900 0.000</value>
+        </parameter>
+        <parameter>
+          <valueName>VTEC</valueName>
+          <value>/O.CAN.PAAQ.TS.W.0001.000000T0000Z-000000T0000Z/</value>
+        </parameter>
+        <parameter>
+          <valueName>NWSUGC</valueName>
+          <value>BCZ220-210-922-912-921-911-110-AKZ026&gt;029-023-024-019&gt;022-025-051258-</value>
+        </parameter>
+        <parameter>
+          <valueName>ProductDefinition</valueName>
+          <value>Tsunami cancellations indicate the end of the damaging tsunami threat.  A cancellation is issued after an evaluation of sea level data confirms that a destructive tsunami will not impact the alerted region, or after tsunami levels have subsided to non-damaging levels. </value>
+        </parameter>
+        <parameter>
+          <valueName>WEAK51</valueName>
+          <value>Public Tsunami Warnings, Watches, and Advisories for AK, BC, and US West Coast</value>
+        </parameter>
+        <parameter>
+          <valueName>EAS-ORG</valueName>
+          <value>WXR</value>
+        </parameter>
+        <resource>
+          <resourceDesc>Event Data as a JSON document</resourceDesc>
+          <mimeType>application/json</mimeType>
+          <uri>http://ntwc.arh.noaa.gov/events/PAAQ/2013/01/05/mg5a94/4/WEAK51/PAAQ.json</uri>
+        </resource>
+        <area>
+          <areaDesc>95 miles NW of Dixon Entrance, Alaska</areaDesc>
+          <circle>55.3,-134.9 0.0</circle>
+        </area>
+      </info>
+    </alert>
+"""
+
+CANCEL = """
+    <alert xmlns="urn:oasis:names:tc:emergency:cap:1.2">
+      <identifier>PAAQ-4-mg5a94</identifier>
+      <sender>wcatwc@noaa.gov</sender>
+      <sent>2013-01-05T10:58:23-00:00</sent>
+      <status>Actual</status>
+      <msgType>Cancel</msgType>
+      <source>WCATWC</source>
+      <scope>Public</scope>
+      <code>IPAWSv1.0</code>
+      <references>wcatwc@noaa.gov,PAAQ-1-mg5a94,2013-01-05T09:01:16-00:00 wcatwc@noaa.gov,PAAQ-2-mg5a94,2013-01-05T09:30:16-00:00 wcatwc@noaa.gov,PAAQ-3-mg5a94,2013-01-05T10:17:31-00:00</references>
+      <incidents>mg5a94</incidents>
+      <info>
+        <category>Geo</category>
+        <event>Tsunami Cancellation</event>
+        <responseType>None</responseType>
+        <urgency>Past</urgency>
+        <severity>Unknown</severity>
+        <certainty>Unlikely</certainty>
+        <onset>2013-01-05T10:58:23-00:00</onset>
+        <expires>2013-01-05T10:58:23-00:00</expires>
+        <senderName>NWS West Coast/Alaska Tsunami Warning Center Palmer AK</senderName>
+        <headline>The tsunami Warning is canceled for the coastal areas of British Columbia and Alaska from the north tip of Vancouver Island, British Columbia to Cape Fairweather, Alaska (80 miles SE of Yakutat).</headline>
+        <description>The tsunami Warning is canceled for the coastal areas of British Columbia and Alaska from the north tip of Vancouver Island, British Columbia to Cape Fairweather, Alaska (80 miles SE of Yakutat). - Event details: Preliminary magnitude 7.5 (Mw) earthquake / Lat: 55.300, Lon: -134.900 at 2013-01-05T08:58:20Z Tsunami cancellations indicate the end of the damaging tsunami threat.  A cancellation is issued after an evaluation of sea level data confirms that a destructive tsunami will not impact the alerted region, or after tsunami levels have subsided to non-damaging levels. </description>
+        <instruction>Recommended Actions:   Do not re-occupy hazard zones until local emergency officials indicate it is safe to do so. This will be the last West Coast/Alaska Tsunami Warning Center message issued for this event.  Refer to the internet site ntwc.arh.noaa.gov for more information. </instruction>
+        <web>http://ntwc.arh.noaa.gov/events/PAAQ/2013/01/05/mg5a94/4/WEAK51/WEAK51.txt</web>
+        <parameter>
+          <valueName>EventLocationName</valueName>
+          <value>95 miles NW of Dixon Entrance, Alaska</value>
+        </parameter>
+        <parameter>
+          <valueName>EventPreliminaryMagnitude</valueName>
+          <value>7.5</value>
+        </parameter>
+        <parameter>
+          <valueName>EventPreliminaryMagnitudeType</valueName>
+          <value>Mw</value>
+        </parameter>
+        <parameter>
+          <valueName>EventOriginTime</valueName>
+          <value>2013-01-05T08:58:20-00:00</value>
+        </parameter>
+        <parameter>
+          <valueName>EventDepth</valueName>
+          <value>5 kilometers</value>
+        </parameter>
+        <parameter>
+          <valueName>EventLatLon</valueName>
+          <value>55.300,-134.900 0.000</value>
+        </parameter>
+        <parameter>
+          <valueName>VTEC</valueName>
+          <value>/O.CAN.PAAQ.TS.W.0001.000000T0000Z-000000T0000Z/</value>
+        </parameter>
+        <parameter>
+          <valueName>NWSUGC</valueName>
+          <value>BCZ220-210-922-912-921-911-110-AKZ026&gt;029-023-024-019&gt;022-025-051258-</value>
+        </parameter>
+        <parameter>
+          <valueName>ProductDefinition</valueName>
+          <value>Tsunami cancellations indicate the end of the damaging tsunami threat.  A cancellation is issued after an evaluation of sea level data confirms that a destructive tsunami will not impact the alerted region, or after tsunami levels have subsided to non-damaging levels. </value>
+        </parameter>
+        <parameter>
+          <valueName>WEAK51</valueName>
+          <value>Public Tsunami Warnings, Watches, and Advisories for AK, BC, and US West Coast</value>
+        </parameter>
+        <parameter>
+          <valueName>EAS-ORG</valueName>
+          <value>WXR</value>
+        </parameter>
+        <resource>
+          <resourceDesc>Event Data as a JSON document</resourceDesc>
+          <mimeType>application/json</mimeType>
+          <uri>http://ntwc.arh.noaa.gov/events/PAAQ/2013/01/05/mg5a94/4/WEAK51/PAAQ.json</uri>
+        </resource>
+        <area>
+          <areaDesc>95 miles NW of Dixon Entrance, Alaska</areaDesc>
+          <circle>55.3,-134.9 0.0</circle>
+        </area>
+      </info>
     </alert>
 """


### PR DESCRIPTION
We don’t support these methods at the moment. Instead we were just ignoring the `msgType` field, so issuing one of these commands would cause a new alert to be broadcast 🙃

We might want to support `Cancel` in the future, but for now let’s reject anything that isn’t `Alert` (CAP terminology for the initial broadcast).