### PR TITLE
enable cell broadcast on prod for vodafone only

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -531,6 +531,9 @@ class Live(Config):
 
     CRONITOR_ENABLED = True
 
+    ENABLED_CBCS = {BroadcastProvider.VODAFONE}
+
+
 
 class CloudFoundryConfig(Config):
     pass


### PR DESCRIPTION
nb: will need cbc aws key to be set in credentials before deploy. will need iam user set up to get those.