### PR TITLE
Add caching and remove extra call to database

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -196,7 +196,7 @@ def get_html_email_options(service):
             'govuk_banner': True,
             'brand_banner': False,
         }
-    if isinstance(service.email_branding, str):
+    if isinstance(service, SerialisedService):
         branding = dao_get_email_branding_by_id(service.email_branding)
     else:
         branding = service.email_branding

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -3,13 +3,10 @@ from urllib import parse
 from datetime import datetime, timedelta
 from cachetools import TTLCache, cached
 from flask import current_app
-from notifications_utils.recipients import (
-    validate_and_format_phone_number,
-    validate_and_format_email_address
-)
 from notifications_utils.template import HTMLEmailTemplate, PlainTextEmailTemplate, SMSMessageTemplate
 
 from app import notification_provider_clients, statsd_client, create_uuid
+from app.dao.email_branding_dao import dao_get_email_branding_by_id
 from app.dao.notifications_dao import (
     dao_update_notification
 )
@@ -18,7 +15,6 @@ from app.dao.provider_details_dao import (
     dao_reduce_sms_provider_priority
 )
 from app.celery.research_mode_tasks import send_sms_response, send_email_response
-from app.dao.templates_dao import dao_get_template_by_id
 from app.exceptions import NotificationTechnicalFailureException
 from app.models import (
     SMS_TYPE,
@@ -31,10 +27,11 @@ from app.models import (
     NOTIFICATION_SENDING,
     NOTIFICATION_STATUS_TYPES_COMPLETED
 )
+from app.serialised_models import SerialisedTemplate, SerialisedService
 
 
 def send_sms_to_provider(notification):
-    service = notification.service
+    service = SerialisedService.from_id(notification.service_id)
 
     if not service.active:
         technical_failure(notification=notification)
@@ -43,7 +40,9 @@ def send_sms_to_provider(notification):
     if notification.status == 'created':
         provider = provider_to_use(SMS_TYPE, notification.international)
 
-        template_model = dao_get_template_by_id(notification.template_id, notification.template_version)
+        template_model = SerialisedTemplate.from_id_and_service_id(
+            template_id=notification.template_id, service_id=service.id, version=notification.template_version
+        )
 
         template = SMSMessageTemplate(
             template_model.__dict__,
@@ -51,7 +50,8 @@ def send_sms_to_provider(notification):
             prefix=service.name,
             show_prefix=service.prefix_sms,
         )
-
+        created_at = notification.created_at
+        key_type = notification.key_type
         if service.research_mode or notification.key_type == KEY_TYPE_TEST:
             update_notification_to_sending(notification, provider)
             send_sms_response(provider.get_name(), str(notification.id), notification.to)
@@ -59,7 +59,7 @@ def send_sms_to_provider(notification):
         else:
             try:
                 provider.send_sms(
-                    to=validate_and_format_phone_number(notification.to, international=notification.international),
+                    to=notification.normalised_to,
                     content=str(template),
                     reference=str(notification.id),
                     sender=notification.reply_to_text
@@ -73,10 +73,10 @@ def send_sms_to_provider(notification):
                 notification.billable_units = template.fragment_count
                 update_notification_to_sending(notification, provider)
 
-        delta_seconds = (datetime.utcnow() - notification.created_at).total_seconds()
+        delta_seconds = (datetime.utcnow() - created_at).total_seconds()
         statsd_client.timing("sms.total-time", delta_seconds)
 
-        if notification.key_type == KEY_TYPE_TEST:
+        if key_type == KEY_TYPE_TEST:
             statsd_client.timing("sms.test-key.total-time", delta_seconds)
         else:
             statsd_client.timing("sms.live-key.total-time", delta_seconds)
@@ -87,14 +87,17 @@ def send_sms_to_provider(notification):
 
 
 def send_email_to_provider(notification):
-    service = notification.service
+    service = SerialisedService.from_id(notification.service_id)
+
     if not service.active:
         technical_failure(notification=notification)
         return
     if notification.status == 'created':
         provider = provider_to_use(EMAIL_TYPE)
 
-        template_dict = dao_get_template_by_id(notification.template_id, notification.template_version).__dict__
+        template_dict = SerialisedTemplate.from_id_and_service_id(
+            template_id=notification.template_id, service_id=service.id, version=notification.template_version
+        ).__dict__
 
         html_email = HTMLEmailTemplate(
             template_dict,
@@ -106,7 +109,8 @@ def send_email_to_provider(notification):
             template_dict,
             values=notification.personalisation
         )
-
+        created_at = notification.created_at
+        key_type = notification.key_type
         if service.research_mode or notification.key_type == KEY_TYPE_TEST:
             notification.reference = str(create_uuid())
             update_notification_to_sending(notification, provider)
@@ -115,22 +119,19 @@ def send_email_to_provider(notification):
             from_address = '"{}" <{}@{}>'.format(service.name, service.email_from,
                                                  current_app.config['NOTIFY_EMAIL_DOMAIN'])
 
-            email_reply_to = notification.reply_to_text
-
             reference = provider.send_email(
                 from_address,
-                validate_and_format_email_address(notification.to),
+                notification.normalised_to,
                 plain_text_email.subject,
                 body=str(plain_text_email),
                 html_body=str(html_email),
-                reply_to_address=validate_and_format_email_address(email_reply_to) if email_reply_to else None,
+                reply_to_address=notification.reply_to_text
             )
             notification.reference = reference
             update_notification_to_sending(notification, provider)
+        delta_seconds = (datetime.utcnow() - created_at).total_seconds()
 
-        delta_seconds = (datetime.utcnow() - notification.created_at).total_seconds()
-
-        if notification.key_type == KEY_TYPE_TEST:
+        if key_type == KEY_TYPE_TEST:
             statsd_client.timing("email.test-key.total-time", delta_seconds)
         else:
             statsd_client.timing("email.live-key.total-time", delta_seconds)
@@ -190,25 +191,28 @@ def get_logo_url(base_url, logo_file):
 
 
 def get_html_email_options(service):
-
     if service.email_branding is None:
         return {
             'govuk_banner': True,
             'brand_banner': False,
         }
+    if isinstance(service.email_branding, str):
+        branding = dao_get_email_branding_by_id(service.email_branding)
+    else:
+        branding = service.email_branding
 
     logo_url = get_logo_url(
         current_app.config['ADMIN_BASE_URL'],
-        service.email_branding.logo
-    ) if service.email_branding.logo else None
+        branding.logo
+    ) if branding.logo else None
 
     return {
-        'govuk_banner': service.email_branding.brand_type == BRANDING_BOTH,
-        'brand_banner': service.email_branding.brand_type == BRANDING_ORG_BANNER,
-        'brand_colour': service.email_branding.colour,
+        'govuk_banner': branding.brand_type == BRANDING_BOTH,
+        'brand_banner': branding.brand_type == BRANDING_ORG_BANNER,
+        'brand_colour': branding.colour,
         'brand_logo': logo_url,
-        'brand_text': service.email_branding.text,
-        'brand_name': service.email_branding.name,
+        'brand_text': branding.text,
+        'brand_name': branding.name,
     }
 
 

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -75,6 +75,7 @@ class SerialisedTemplate(SerialisedModel):
 class SerialisedService(SerialisedModel):
     ALLOWED_PROPERTIES = {
         'id',
+        'name',
         'active',
         'contact_link',
         'email_from',
@@ -83,6 +84,8 @@ class SerialisedService(SerialisedModel):
         'rate_limit',
         'research_mode',
         'restricted',
+        'prefix_sms',
+        'email_branding'
     }
 
     @classmethod

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -756,9 +756,8 @@ def test_send_email_to_provider_should_user_normalised_to(
     notification = create_notification(template=sample_email_template,
                                        to_field='TEST@example.com',
                                        normalised_to='test@example.com')
-    print("************* start")
+
     send_to_providers.send_email_to_provider(notification)
-    print("End ******************")
     send_mock.assert_called_once_with(ANY,
                                       notification.normalised_to,
                                       ANY,


### PR DESCRIPTION
- Add caching by using the SeriralisedTemplate and SerialisedService objects
- Removed extra call to the database to fetch the notification after the commit by saving the created_at and key_type to a local variable. After the update to the notification to mark it as sending the db.session is committed. Any reference to the the Notification data model after that will require a query to fetch the object again because it is considered "dirty" or out of date.
- Added name, sms_prefix and email branding to SerialisedService.
- Refactor the get_html_options to work with the SerialisedService object.
- Removed the need to validate and format the to field by using `normalised_to`, since when persisting the notification the `normalised_to` field has already had this done.
- Removed the validate and format for reply_to_text for email reply_to, this has been done when the email address has been added via the frontend, no need to validate this address every time a services sends an email.

This PR is to re-apply https://github.com/alphagov/notifications-api/pull/3134, email branding didn't work for the cached data object. This PR fixes that.

NOTE: I think the service and template cache should be cleared after the deploy of this 