### PR TITLE
✨ Add new API endpoint for retrieving a "blocklist" of protected senders.

### DIFF
--- a/app/dao/service_sms_sender_dao.py
+++ b/app/dao/service_sms_sender_dao.py
@@ -5,6 +5,8 @@ from app.dao.dao_utils import transactional
 from app.exceptions import ArchiveValidationError
 from app.models import ServiceSmsSender
 
+BLACKLISTED_SENDERS = ['GOVUK', 'NHS']
+
 
 def insert_service_sms_sender(service, sms_sender):
     """

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -55,7 +55,8 @@ from app.dao.service_sms_sender_dao import (
     dao_update_service_sms_sender,
     dao_get_service_sms_senders_by_id,
     dao_get_sms_senders_by_service_id,
-    update_existing_sms_sender_with_inbound_number
+    update_existing_sms_sender_with_inbound_number,
+    BLACKLISTED_SENDERS
 )
 from app.dao.services_dao import (
     dao_add_user_to_service,
@@ -786,6 +787,10 @@ def delete_service_letter_contact(service_id, letter_contact_id):
     archived_letter_contact = archive_letter_contact(service_id, letter_contact_id)
 
     return jsonify(data=archived_letter_contact.serialize()), 200
+
+@service_blueprint.route('/<uuid:service_id>/blocklist', methods=['GET'])
+def get_sender_blocklist(service_id):
+    return jsonify({"blocklist":BLACKLISTED_SENDERS})
 
 
 @service_blueprint.route('/<uuid:service_id>/sms-sender', methods=['POST'])


### PR DESCRIPTION
To help avoid abuse of the CAST Notify service, as well as protect our
accounts with backend providers like `firetext`, we want to apply some
restrictions on the Sender IDs that users can apply to our outbound SMS
and emails.

This PR adds a new (admin-only) API endpoint to return a "blocklist" of
protected phrases (such as `GOVUK` or `NHS`) that shouldn't be allowed
to feature in user-submitted SMS senders. This new "blocklist" is
retrieved by our front-end admin app and enforced by a new custom
validator.