### PR TITLE
Send daily email with volumes of letters and sheets to DVLA

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -14,12 +14,12 @@ from app import encryption, notify_celery
 from app.aws import s3
 from app.config import QueueNames, TaskNames
 from app.dao.notifications_dao import (
+    dao_get_letters_to_be_printed,
+    dao_get_notification_by_reference,
+    dao_update_notification,
+    dao_update_notifications_by_reference,
     get_notification_by_id,
     update_notification_status_by_id,
-    dao_update_notification,
-    dao_get_notification_by_reference,
-    dao_update_notifications_by_reference,
-    dao_get_letters_to_be_printed,
 )
 from app.letters.utils import get_letter_pdf_filename
 from app.errors import VirusScanError

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -14,6 +14,7 @@ from app import encryption, notify_celery
 from app.aws import s3
 from app.config import QueueNames, TaskNames
 from app.dao.notifications_dao import (
+    dao_get_letters_and_sheets_volume_by_postage,
     dao_get_letters_to_be_printed,
     dao_get_notification_by_reference,
     dao_update_notification,
@@ -21,6 +22,7 @@ from app.dao.notifications_dao import (
     get_notification_by_id,
     update_notification_status_by_id,
 )
+from app.dao.templates_dao import dao_get_template_by_id
 from app.letters.utils import get_letter_pdf_filename
 from app.errors import VirusScanError
 from app.exceptions import NotificationTechnicalFailureException
@@ -36,6 +38,8 @@ from app.letters.utils import (
 )
 from app.models import (
     INTERNATIONAL_LETTERS,
+    INTERNATIONAL_POSTAGE_TYPES,
+    KEY_TYPE_NORMAL,
     KEY_TYPE_TEST,
     NOTIFICATION_CREATED,
     NOTIFICATION_DELIVERED,
@@ -45,7 +49,9 @@ from app.models import (
     NOTIFICATION_VIRUS_SCAN_FAILED,
     POSTAGE_TYPES,
     RESOLVE_POSTAGE_FOR_FILE_NAME,
-    INTERNATIONAL_POSTAGE_TYPES)
+    Service,
+)
+
 from app.cronitor import cronitor
 
 
@@ -131,12 +137,15 @@ def collate_letter_pdfs_to_be_sent():
     print_run_deadline = print_run_date.replace(
         hour=17, minute=30, second=0, microsecond=0
     )
+    _get_letters_and_sheets_volumes_and_send_to_dvla(print_run_deadline)
+
     for postage in POSTAGE_TYPES:
         current_app.logger.info(f"starting collate-letter-pdfs-to-be-sent processing for postage class {postage}")
         letters_to_print = get_key_and_size_of_letters_to_be_sent_to_print(print_run_deadline, postage)
 
         for i, letters in enumerate(group_letters(letters_to_print)):
             filenames = [letter['Key'] for letter in letters]
+
             service_id = letters[0]['ServiceId']
 
             hash = urlsafe_b64encode(sha512(''.join(filenames).encode()).digest())[:20].decode()
@@ -168,6 +177,58 @@ def collate_letter_pdfs_to_be_sent():
         current_app.logger.info(f"finished collate-letter-pdfs-to-be-sent processing for postage class {postage}")
 
     current_app.logger.info("finished collate-letter-pdfs-to-be-sent")
+
+
+def _get_letters_and_sheets_volumes_and_send_to_dvla(print_run_deadline):
+    letters_volumes = dao_get_letters_and_sheets_volume_by_postage(print_run_deadline)
+    send_letters_volume_email_to_dvla(letters_volumes)
+
+
+def send_letters_volume_email_to_dvla(letters_volumes):
+    personalisation = {
+        'total_volume': 0,
+        'first_class_volume': 0,
+        'second_class_volume': 0,
+        'international_volume': 0,
+        'total_sheets': 0,
+        'first_class_sheets': 0,
+        "second_class_sheets": 0,
+        'international_sheets': 0
+    }
+    for item in letters_volumes:
+        personalisation['total_volume'] += item.letters_count
+        personalisation['total_sheets'] += item.sheets_count
+        if f"{item.postage}_class_volume" in personalisation:
+            personalisation[f"{item.postage}_class_volume"] = item.letters_count
+            personalisation[f"{item.postage}_class_sheets"] = item.sheets_count
+        else:
+            personalisation["international_volume"] += item.letters_count
+            personalisation["international_sheets"] += item.sheets_count
+
+    template = dao_get_template_by_id(current_app.config['LETTERS_VOLUME_EMAIL_TEMPLATE_ID'])
+    recipient = current_app.config['DVLA_EMAIL_ADDRESS']
+    reply_to = template.service.get_default_reply_to_email_address()
+    service = Service.query.get(current_app.config['NOTIFY_SERVICE_ID'])
+
+    # avoid circular imports:
+    from app.notifications.process_notifications import (
+        persist_notification,
+        send_notification_to_queue
+    )
+
+    saved_notification = persist_notification(
+        template_id=template.id,
+        template_version=template.version,
+        recipient=recipient,
+        service=service,
+        personalisation=personalisation,
+        notification_type=template.template_type,
+        api_key_id=None,
+        key_type=KEY_TYPE_NORMAL,
+        reply_to_text=reply_to
+    )
+
+    send_notification_to_queue(saved_notification, False, queue=QueueNames.NOTIFY)
 
 
 def get_key_and_size_of_letters_to_be_sent_to_print(print_run_deadline, postage):

--- a/app/config.py
+++ b/app/config.py
@@ -180,7 +180,8 @@ class Config(object):
     MOU_SIGNED_ON_BEHALF_ON_BEHALF_RECEIPT_TEMPLATE_ID = '522b6657-5ca5-4368-a294-6b527703bd0b'
     NOTIFY_INTERNATIONAL_SMS_SENDER = '07984404008'
     LETTERS_VOLUME_EMAIL_TEMPLATE_ID = '11fad854-fd38-4a7c-bd17-805fb13dfc12'
-    DVLA_EMAIL_ADDRESS = os.getenv('DVLA_EMAIL_ADDRESS')
+    # we only need real email in Live environment (production)
+    DVLA_EMAIL_ADDRESS = 'success@simulator.amazonses.com'
 
     BROKER_URL = 'sqs://'
     BROKER_TRANSPORT_OPTIONS = {
@@ -480,7 +481,6 @@ class Test(Development):
     FIRETEXT_URL = 'https://example.com/firetext'
 
     CBC_PROXY_ENABLED = True
-    DVLA_EMAIL_ADDRESS = 'some_email@example.com'
 
 
 class Preview(Config):
@@ -538,6 +538,7 @@ class Live(Config):
     CRONITOR_ENABLED = True
 
     ENABLED_CBCS = {BroadcastProvider.THREE, BroadcastProvider.O2, BroadcastProvider.VODAFONE}
+    DVLA_EMAIL_ADDRESS = os.getenv('DVLA_EMAIL_ADDRESS')
 
 
 class CloudFoundryConfig(Config):

--- a/app/config.py
+++ b/app/config.py
@@ -179,6 +179,8 @@ class Config(object):
     MOU_SIGNED_ON_BEHALF_SIGNER_RECEIPT_TEMPLATE_ID = 'c20206d5-bf03-4002-9a90-37d5032d9e84'
     MOU_SIGNED_ON_BEHALF_ON_BEHALF_RECEIPT_TEMPLATE_ID = '522b6657-5ca5-4368-a294-6b527703bd0b'
     NOTIFY_INTERNATIONAL_SMS_SENDER = '07984404008'
+    LETTERS_VOLUME_EMAIL_TEMPLATE_ID = '11fad854-fd38-4a7c-bd17-805fb13dfc12'
+    DVLA_EMAIL_ADDRESS = os.getenv('DVLA_EMAIL_ADDRESS')
 
     BROKER_URL = 'sqs://'
     BROKER_TRANSPORT_OPTIONS = {
@@ -478,6 +480,7 @@ class Test(Development):
     FIRETEXT_URL = 'https://example.com/firetext'
 
     CBC_PROXY_ENABLED = True
+    DVLA_EMAIL_ADDRESS = 'some_email@example.com'
 
 
 class Preview(Config):

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -772,6 +772,22 @@ def dao_get_letters_to_be_printed(print_run_deadline, postage, query_limit=10000
     return notifications
 
 
+def dao_get_letters_and_sheets_volume_by_postage(print_run_deadline):
+    notifications = db.session.query(
+        func.count(Notification.id).label('letters_count'),
+        func.sum(Notification.billable_units).label('sheets_count'),
+        Notification.postage
+    ).filter(
+        Notification.created_at < convert_bst_to_utc(print_run_deadline),
+        Notification.notification_type == LETTER_TYPE,
+        Notification.status == NOTIFICATION_CREATED,
+        Notification.key_type == KEY_TYPE_NORMAL,
+    ).group_by(
+        Notification.postage
+    ).all()
+    return notifications
+
+
 def dao_old_letters_with_created_status():
     yesterday_bst = convert_utc_to_bst(datetime.utcnow()) - timedelta(days=1)
     last_processing_deadline = yesterday_bst.replace(hour=17, minute=30, second=0, microsecond=0)

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -784,6 +784,8 @@ def dao_get_letters_and_sheets_volume_by_postage(print_run_deadline):
         Notification.key_type == KEY_TYPE_NORMAL,
     ).group_by(
         Notification.postage
+    ).order_by(
+        Notification.postage
     ).all()
     return notifications
 

--- a/migrations/versions/0347_add_dvla_volumes_template.py
+++ b/migrations/versions/0347_add_dvla_volumes_template.py
@@ -1,0 +1,81 @@
+"""
+
+Revision ID: 0347_add_dvla_volumes_template
+Revises: 0346_notify_number_sms_sender
+Create Date: 2021-02-15 15:36:34.654275
+
+"""
+from datetime import datetime
+
+from alembic import op
+from flask import current_app
+
+revision = '0347_add_dvla_volumes_template'
+down_revision = '0346_notify_number_sms_sender'
+
+email_template_id = "11fad854-fd38-4a7c-bd17-805fb13dfc12"
+
+
+def upgrade():
+    template_insert = """
+        INSERT INTO templates (id, name, template_type, created_at, content, archived, service_id, subject,
+        created_by_id, version, process_type, hidden)
+        VALUES ('{}', '{}', '{}', '{}', '{}', False, '{}', '{}', '{}', 1, '{}', false)
+    """
+    template_history_insert = """
+        INSERT INTO templates_history (id, name, template_type, created_at, content, archived, service_id, subject,
+        created_by_id, version, process_type, hidden)
+        VALUES ('{}', '{}', '{}', '{}', '{}', False, '{}', '{}', '{}', 1, '{}', false)
+    """
+
+    email_template_content = '\n'.join([
+        "((total_volume)) letters (((total_sheets)) sheets) sent via Notify are coming in today''s batch. These include: ",
+        "",
+        "((first_class_volume)) first class letters (((first_class_sheets)) sheets).",
+        "((second_class_volume)) second class letters (((second_class_sheets)) sheets).",
+        "((international_volume)) international letters (((international_sheets)) sheets).",
+        "",
+        "Thanks",
+        "",
+        "GOV.​UK Notify team",
+        "https://www.gov.uk/notify"
+    ])
+
+    email_template_name = "Notify daily letter volumes"
+    email_template_subject = "Notify letter volume for ((date)): ((total_volume)) letters, ((total_sheets)) sheets"
+
+    op.execute(
+        template_history_insert.format(
+            email_template_id,
+            email_template_name,
+            'email',
+            datetime.utcnow(),
+            email_template_content,
+            current_app.config['NOTIFY_SERVICE_ID'],
+            email_template_subject,
+            current_app.config['NOTIFY_USER_ID'],
+            'normal'
+        )
+    )
+
+    op.execute(
+        template_insert.format(
+            email_template_id,
+            email_template_name,
+            'email',
+            datetime.utcnow(),
+            email_template_content,
+            current_app.config['NOTIFY_SERVICE_ID'],
+            email_template_subject,
+            current_app.config['NOTIFY_USER_ID'],
+            'normal'
+        )
+    )
+
+
+def downgrade():
+    op.execute("DELETE FROM notifications WHERE template_id = '{}'".format(email_template_id))
+    op.execute("DELETE FROM notification_history WHERE template_id = '{}'".format(email_template_id))
+    op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(email_template_id))
+    op.execute("DELETE FROM templates_history WHERE id = '{}'".format(email_template_id))
+    op.execute("DELETE FROM templates WHERE id = '{}'".format(email_template_id))

--- a/migrations/versions/0347_add_dvla_volumes_template.py
+++ b/migrations/versions/0347_add_dvla_volumes_template.py
@@ -5,6 +5,7 @@ Revises: 0346_notify_number_sms_sender
 Create Date: 2021-02-15 15:36:34.654275
 
 """
+import os
 from datetime import datetime
 
 from alembic import op
@@ -14,6 +15,7 @@ revision = '0347_add_dvla_volumes_template'
 down_revision = '0346_notify_number_sms_sender'
 
 email_template_id = "11fad854-fd38-4a7c-bd17-805fb13dfc12"
+environment = os.environ['NOTIFY_ENVIRONMENT']
 
 
 def upgrade():
@@ -74,8 +76,9 @@ def upgrade():
 
 
 def downgrade():
-    op.execute("DELETE FROM notifications WHERE template_id = '{}'".format(email_template_id))
-    op.execute("DELETE FROM notification_history WHERE template_id = '{}'".format(email_template_id))
-    op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(email_template_id))
-    op.execute("DELETE FROM templates_history WHERE id = '{}'".format(email_template_id))
-    op.execute("DELETE FROM templates WHERE id = '{}'".format(email_template_id))
+    if environment not in ["live", "production"]:
+        op.execute("DELETE FROM notifications WHERE template_id = '{}'".format(email_template_id))
+        op.execute("DELETE FROM notification_history WHERE template_id = '{}'".format(email_template_id))
+        op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(email_template_id))
+        op.execute("DELETE FROM templates_history WHERE id = '{}'".format(email_template_id))
+        op.execute("DELETE FROM templates WHERE id = '{}'".format(email_template_id))

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -819,6 +819,34 @@ def create_custom_template(service, user, template_config_name, template_type, c
     return template
 
 
+@pytest.fixture(scope='function')
+def letter_volumes_email_template(notify_db,
+                                  notify_db_session):
+    service, user = notify_service(notify_db, notify_db_session)
+
+    email_template_content = '\n'.join([
+        "((total_volume)) letters (((total_sheets)) sheets) sent via Notify are coming in today''s batch. These include: ",  # noqa
+        "",
+        "((first_class_volume)) first class letters (((first_class_sheets)) sheets).",
+        "((second_class_volume)) second class letters (((second_class_sheets)) sheets).",
+        "((international_volume)) international letters (((international_sheets)) sheets).",
+        "",
+        "Thanks",
+        "",
+        "GOV.​UK Notify team",
+        "https://www.gov.uk/notify"
+    ])
+
+    return create_custom_template(
+        service=service,
+        user=user,
+        template_config_name='LETTERS_VOLUME_EMAIL_TEMPLATE_ID',
+        content=email_template_content,
+        subject="Notify letter volume for ((date)): ((total_volume)) letters, ((total_sheets)) sheets",
+        template_type='email'
+    )
+
+
 def notify_service(notify_db, notify_db_session):
     user = create_user()
     service = Service.query.get(current_app.config['NOTIFY_SERVICE_ID'])

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1713,18 +1713,16 @@ def test_dao_get_letters_and_sheets_volume_by_postage(notify_db_session):
     second_service = create_service(service_name='second service', service_id='642bf33b-54b5-45f2-8c13-942a46616704')
     first_template = create_template(service=first_service, template_type='letter', postage='second')
     second_template = create_template(service=second_service, template_type='letter', postage='second')
-    letters = [
-        create_notification(template=first_template, created_at=datetime(2020, 12, 1, 9, 30), postage='first'),
-        create_notification(template=first_template, created_at=datetime(2020, 12, 1, 12, 30), postage='europe'),
-        create_notification(template=first_template, created_at=datetime(2020, 12, 1, 13, 30), postage='rest-of-world'),
-        create_notification(template=first_template, created_at=datetime(2020, 12, 1, 14, 30), billable_units=3),
-        create_notification(template=first_template, created_at=datetime(2020, 12, 1, 15, 30)),
-        create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 30), postage='first'),
-        create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 31), postage='first'),
-        create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 32)),
-        create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 33)),
-        create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 34))
-    ]
+    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 9, 30), postage='first'),
+    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 12, 30), postage='europe'),
+    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 13, 30), postage='rest-of-world'),
+    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 14, 30), billable_units=3),
+    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 15, 30)),
+    create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 30), postage='first'),
+    create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 31), postage='first'),
+    create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 32)),
+    create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 33)),
+    create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 34))
 
     results = dao_get_letters_and_sheets_volume_by_postage(print_run_deadline=datetime(2020, 12, 1, 17, 30))
 


### PR DESCRIPTION
Send daily email with volumes of letters and sheets to DVLA around 6pm so they know how many letters to expect for printing.

To do this we need to:
- create an email template by migration - done here
- add DVLA email to our credentials - done: https://github.com/alphagov/notifications-credentials/pull/199
- gather volumes of letters and sheets - done here
- create a notification and put it on the queue - done here