### PR TITLE
Update SerialisedService

### DIFF
--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -75,6 +75,7 @@ class SerialisedTemplate(SerialisedModel):
 class SerialisedService(SerialisedModel):
     ALLOWED_PROPERTIES = {
         'id',
+        'name',
         'active',
         'contact_link',
         'email_from',
@@ -83,6 +84,8 @@ class SerialisedService(SerialisedModel):
         'rate_limit',
         'research_mode',
         'restricted',
+        'prefix_sms',
+        'email_branding'
     }
 
     @classmethod


### PR DESCRIPTION
I need to update the SeriralisedService object before deploying https://github.com/alphagov/notifications-api/pull/3145

If the send_to_provider grabs a SerialisedService that doesn't have these properties the task will fail. If we deploy the change to the SerialisedService first, clear the cache, then deploy https://github.com/alphagov/notifications-api/pull/3145 we can avoid that issue.