### PR TITLE
make sure status is always set by finally block

### DIFF
--- a/app/cronitor.py
+++ b/app/cronitor.py
@@ -38,13 +38,11 @@ def cronitor(task_name):
         @wraps(func)
         def inner_decorator(*args, **kwargs):
             ping_cronitor('run')
+            status = 'fail'
             try:
                 ret = func(*args, **kwargs)
                 status = 'complete'
                 return ret
-            except Exception:
-                status = 'fail'
-                raise
             finally:
                 ping_cronitor(status)
 


### PR DESCRIPTION
confusingly, some errs are not subclasses of Exception (things like sys.exit()). `status` not being set when a BaseException (not an Exception) is thrown was confusing things a bit.

Lets make sure the status is always set so cronitor knows what to ping.