### PR TITLE
Add date to personalisation for DVLA email

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -181,10 +181,10 @@ def collate_letter_pdfs_to_be_sent():
 
 def _get_letters_and_sheets_volumes_and_send_to_dvla(print_run_deadline):
     letters_volumes = dao_get_letters_and_sheets_volume_by_postage(print_run_deadline)
-    send_letters_volume_email_to_dvla(letters_volumes)
+    send_letters_volume_email_to_dvla(letters_volumes, print_run_deadline.date())
 
 
-def send_letters_volume_email_to_dvla(letters_volumes):
+def send_letters_volume_email_to_dvla(letters_volumes, date):
     personalisation = {
         'total_volume': 0,
         'first_class_volume': 0,
@@ -193,7 +193,8 @@ def send_letters_volume_email_to_dvla(letters_volumes):
         'total_sheets': 0,
         'first_class_sheets': 0,
         "second_class_sheets": 0,
-        'international_sheets': 0
+        'international_sheets': 0,
+        'date': date.strftime("%d %B %Y")
     }
     for item in letters_volumes:
         personalisation['total_volume'] += item.letters_count

--- a/app/config.py
+++ b/app/config.py
@@ -515,6 +515,7 @@ class Staging(Config):
     FROM_NUMBER = 'stage'
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = True
+    DVLA_EMAIL_ADDRESS = os.getenv('DVLA_EMAIL_ADDRESS')
 
 
 class Live(Config):

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -150,6 +150,8 @@ applications:
       TEMPLATE_PREVIEW_API_HOST: '{{ TEMPLATE_PREVIEW_API_HOST }}'
       TEMPLATE_PREVIEW_API_KEY: '{{ TEMPLATE_PREVIEW_API_KEY }}'
 
+      DVLA_EMAIL_ADDRESS: '{{ DVLA_EMAIL_ADDRESS }}'
+
       {% for key, value in app.get('additional_env_vars', {}).items() %}
       {{key}}: '{{value}}'
       {% endfor %}

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -396,7 +396,7 @@ def test_collate_letter_pdfs_to_be_sent(
 
     mock_send_email_to_dvla.assert_called_once_with([
         (1, 1, 'europe'), (1, 1, 'first'), (1, 1, 'rest-of-world'), (4, 4, 'second')
-    ])
+    ], datetime(2020, 2, 17).date())
 
     assert len(mock_celery.call_args_list) == 6
     assert mock_celery.call_args_list[0] == call(
@@ -476,7 +476,7 @@ def test_send_letters_volume_email_to_dvla(notify_api, notify_db_session, mocker
     ]
     send_mock = mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
 
-    send_letters_volume_email_to_dvla(letters_volumes)
+    send_letters_volume_email_to_dvla(letters_volumes, datetime(2020, 2, 17).date())
 
     email_to_dvla = get_notifications().all()[0]
 
@@ -492,7 +492,8 @@ def test_send_letters_volume_email_to_dvla(notify_api, notify_db_session, mocker
         'total_sheets': 24,
         'first_class_sheets': 7,
         "second_class_sheets": 12,
-        'international_sheets': 5
+        'international_sheets': 5,
+        'date': '17 February 2020'
     }
 
 


### PR DESCRIPTION
Personalisation was missing date attribute. The email still got sent last night, just it didn't have a value for date placeholder.

Also add DVLA_EMAIL_ADDRESS to manifest file, so it gets picked up from Credentials.