### PR TITLE
Update usage endpoint with billing details for orgs and services

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -683,3 +683,20 @@ def fetch_usage_year_for_organisation(organisation_id, year):
         service_with_usage[str(email_usage.service_id)]['emails_sent'] = email_usage.emails_sent
 
     return service_with_usage
+
+
+def fetch_billing_details_for_all_services():
+    billing_details = db.session.query(
+        Service.id.label('service_id'),
+        func.coalesce(Service.purchase_order_number, Organisation.purchase_order_number).label('purchase_order_number'),
+        func.coalesce(Service.billing_contact_names, Organisation.billing_contact_names).label('billing_contact_names'),
+        func.coalesce(
+            Service.billing_contact_email_addresses,
+            Organisation.billing_contact_email_addresses
+        ).label('billing_contact_email_addresses'),
+        func.coalesce(Service.billing_reference, Organisation.billing_reference).label('billing_reference'),
+    ).outerjoin(
+        Service.organisation
+    ).all()
+
+    return billing_details

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -59,7 +59,8 @@ def validate_date_range_is_within_a_financial_year(start_date, end_date):
 
 
 @platform_stats_blueprint.route('usage-for-all-services')
-def get_usage_for_all_services():
+@platform_stats_blueprint.route('data-for-billing-report')
+def get_data_for_billing_report():
     start_date = request.args.get('start_date')
     end_date = request.args.get('end_date')
 

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -77,17 +77,18 @@ def get_data_for_billing_report():
     ]
     combined = {}
     for s in sms_costs:
-        entry = {
-            "organisation_id": str(s.organisation_id) if s.organisation_id else "",
-            "organisation_name": s.organisation_name or "",
-            "service_id": str(s.service_id),
-            "service_name": s.service_name,
-            "sms_cost": float(s.sms_cost),
-            "sms_fragments": s.chargeable_billable_sms,
-            "letter_cost": 0,
-            "letter_breakdown": ""
-        }
-        combined[s.service_id] = entry
+        if float(s.sms_cost) > 0:
+            entry = {
+                "organisation_id": str(s.organisation_id) if s.organisation_id else "",
+                "organisation_name": s.organisation_name or "",
+                "service_id": str(s.service_id),
+                "service_name": s.service_name,
+                "sms_cost": float(s.sms_cost),
+                "sms_fragments": s.chargeable_billable_sms,
+                "letter_cost": 0,
+                "letter_breakdown": ""
+            }
+            combined[s.service_id] = entry
 
     for letter_cost in letter_costs:
         if letter_cost.service_id in combined:

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -600,62 +600,111 @@ def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
 
 
 def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(notify_db_session):
-    org, org_2, service, service_2, service_3, service_sms_only, \
-        org_with_emails, service_with_emails = set_up_usage_data(datetime(2019, 5, 1))
+    setup = set_up_usage_data(datetime(2019, 5, 1))
     results = fetch_sms_billing_for_all_services(datetime(2019, 5, 1), datetime(2019, 5, 31))
 
     assert len(results) == 2
     # organisation_name, organisation_id, service_name, service_id, free_sms_fragment_limit,
     # sms_rate, sms_remainder, sms_billable_units, chargeable_billable_units, sms_cost
-    assert results[0] == (org.name, org.id, service.name, service.id, 10, Decimal('0.11'), 8, 3, 0, Decimal('0'))
-    assert results[1] == (None, None, service_sms_only.name, service_sms_only.id, 10, Decimal('0.11'),
-                          0, 3, 3, Decimal('0.33'))
+    assert results[0] == (
+        setup["org_1"].name,
+        setup["org_1"].id,
+        setup["service_1_sms_and_letter"].name,
+        setup["service_1_sms_and_letter"].id,
+        10, Decimal('0.11'), 8, 3, 0, Decimal('0'))
+    assert results[1] == (
+        None,
+        None,
+        setup["service_with_sms_without_org"].name,
+        setup["service_with_sms_without_org"].id,
+        10, Decimal('0.11'), 0, 3, 3, Decimal('0.33')
+    )
 
 
 def test_fetch_letter_costs_for_all_services(notify_db_session):
-    org, org_2, service, service_2, service_3, service_sms_only, \
-        org_with_emails, service_with_emails = set_up_usage_data(datetime(2019, 6, 1))
+    setup = set_up_usage_data(datetime(2019, 6, 1))
 
     results = fetch_letter_costs_for_all_services(datetime(2019, 6, 1), datetime(2019, 9, 30))
 
     assert len(results) == 3
-    assert results[0] == (org.name, org.id, service.name, service.id, Decimal('3.40'))
-    assert results[1] == (org_2.name, org_2.id, service_2.name, service_2.id, Decimal('14.00'))
-    assert results[2] == (None, None, service_3.name, service_3.id, Decimal('24.45'))
+    assert results[0] == (
+        setup["org_1"].name, setup["org_1"].id,
+        setup["service_1_sms_and_letter"].name, setup["service_1_sms_and_letter"].id,
+        Decimal('3.40')
+    )
+    assert results[1] == (
+        setup["org_for_service_with_letters"].name, setup["org_for_service_with_letters"].id,
+        setup["service_with_letters"].name, setup["service_with_letters"].id,
+        Decimal('14.00')
+    )
+    assert results[2] == (
+        None, None,
+        setup["service_with_letters_without_org"].name, setup["service_with_letters_without_org"].id,
+        Decimal('24.45')
+    )
 
 
 def test_fetch_letter_line_items_for_all_service(notify_db_session):
-    org_1, org_2, service_1, service_2, service_3, service_sms_only, \
-        org_with_emails, service_with_emails = set_up_usage_data(datetime(2019, 6, 1))
+    setup = set_up_usage_data(datetime(2019, 6, 1))
 
     results = fetch_letter_line_items_for_all_services(datetime(2019, 6, 1), datetime(2019, 9, 30))
 
     assert len(results) == 7
-    assert results[0] == (org_1.name, org_1.id, service_1.name, service_1.id, Decimal('0.45'), 'second', 6)
-    assert results[1] == (org_1.name, org_1.id, service_1.name, service_1.id, Decimal("0.35"), 'first', 2)
-    assert results[2] == (org_2.name, org_2.id, service_2.name, service_2.id, Decimal("0.65"), 'second', 20)
-    assert results[3] == (org_2.name, org_2.id, service_2.name, service_2.id, Decimal("0.50"), 'first', 2)
-    assert results[4] == (None, None, service_3.name, service_3.id, Decimal("0.35"), 'second', 2)
-    assert results[5] == (None, None, service_3.name, service_3.id, Decimal("0.50"), 'first', 1)
-    assert results[6] == (None, None, service_3.name, service_3.id, Decimal("1.55"), 'international', 15)
+    assert results[0] == (
+        setup["org_1"].name, setup["org_1"].id,
+        setup["service_1_sms_and_letter"].name, setup["service_1_sms_and_letter"].id,
+        Decimal('0.45'), 'second', 6
+    )
+    assert results[1] == (
+        setup["org_1"].name, setup["org_1"].id,
+        setup["service_1_sms_and_letter"].name, setup["service_1_sms_and_letter"].id,
+        Decimal("0.35"), 'first', 2
+    )
+    assert results[2] == (
+        setup["org_for_service_with_letters"].name, setup["org_for_service_with_letters"].id,
+        setup["service_with_letters"].name, setup["service_with_letters"].id,
+        Decimal("0.65"), 'second', 20
+    )
+    assert results[3] == (
+        setup["org_for_service_with_letters"].name, setup["org_for_service_with_letters"].id,
+        setup["service_with_letters"].name, setup["service_with_letters"].id,
+        Decimal("0.50"), 'first', 2
+    )
+    assert results[4] == (
+        None, None,
+        setup["service_with_letters_without_org"].name, setup["service_with_letters_without_org"].id,
+        Decimal("0.35"), 'second', 2
+    )
+    assert results[5] == (
+        None, None,
+        setup["service_with_letters_without_org"].name, setup["service_with_letters_without_org"].id,
+        Decimal("0.50"), 'first', 1
+    )
+    assert results[6] == (
+        None, None,
+        setup["service_with_letters_without_org"].name, setup["service_with_letters_without_org"].id,
+        Decimal("1.55"), 'international', 15
+    )
 
 
 @freeze_time('2019-06-01 13:30')
 def test_fetch_usage_year_for_organisation(notify_db_session):
-    org, org_2, service, service_2, service_3, service_sms_only, \
-        org_with_emails, service_with_emails = set_up_usage_data(datetime(2019, 5, 1))
+    setup = set_up_usage_data(datetime(2019, 5, 1))
     service_with_emails_for_org = create_service(service_name='Service with emails for org')
-    dao_add_service_to_organisation(service=service_with_emails_for_org, organisation_id=org.id)
+    dao_add_service_to_organisation(
+        service=service_with_emails_for_org,
+        organisation_id=setup["org_1"].id
+    )
     template = create_template(service=service_with_emails_for_org, template_type='email')
     create_ft_billing(bst_date=datetime(2019, 5, 1),
                       template=template,
                       notifications_sent=1100)
-    results = fetch_usage_year_for_organisation(org.id, 2019)
+    results = fetch_usage_year_for_organisation(setup["org_1"].id, 2019)
 
     assert len(results) == 2
-    first_row = results[str(service.id)]
-    assert first_row['service_id'] == service.id
-    assert first_row['service_name'] == service.name
+    first_row = results[str(setup["service_1_sms_and_letter"].id)]
+    assert first_row['service_id'] == setup["service_1_sms_and_letter"].id
+    assert first_row['service_name'] == setup["service_1_sms_and_letter"].name
     assert first_row['free_sms_limit'] == 10
     assert first_row['sms_remainder'] == 10
     assert first_row['chargeable_billable_sms'] == 0

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -600,111 +600,118 @@ def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
 
 
 def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(notify_db_session):
-    setup = set_up_usage_data(datetime(2019, 5, 1))
+    fixtures = set_up_usage_data(datetime(2019, 5, 1))
     results = fetch_sms_billing_for_all_services(datetime(2019, 5, 1), datetime(2019, 5, 31))
 
-    assert len(results) == 2
+    assert len(results) == 3
     # organisation_name, organisation_id, service_name, service_id, free_sms_fragment_limit,
     # sms_rate, sms_remainder, sms_billable_units, chargeable_billable_units, sms_cost
     assert results[0] == (
-        setup["org_1"].name,
-        setup["org_1"].id,
-        setup["service_1_sms_and_letter"].name,
-        setup["service_1_sms_and_letter"].id,
+        fixtures["org_1"].name,
+        fixtures["org_1"].id,
+        fixtures["service_1_sms_and_letter"].name,
+        fixtures["service_1_sms_and_letter"].id,
         10, Decimal('0.11'), 8, 3, 0, Decimal('0'))
     assert results[1] == (
         None,
         None,
-        setup["service_with_sms_without_org"].name,
-        setup["service_with_sms_without_org"].id,
+        fixtures["service_with_sms_without_org"].name,
+        fixtures["service_with_sms_without_org"].id,
         10, Decimal('0.11'), 0, 3, 3, Decimal('0.33')
+    )
+    assert results[2] == (
+        None,
+        None,
+        fixtures["service_with_sms_within_allowance"].name,
+        fixtures["service_with_sms_within_allowance"].id,
+        10, Decimal('0.11'), 10, 2, 0, Decimal('0.00')
     )
 
 
 def test_fetch_letter_costs_for_all_services(notify_db_session):
-    setup = set_up_usage_data(datetime(2019, 6, 1))
+    fixtures = set_up_usage_data(datetime(2019, 6, 1))
 
     results = fetch_letter_costs_for_all_services(datetime(2019, 6, 1), datetime(2019, 9, 30))
 
     assert len(results) == 3
     assert results[0] == (
-        setup["org_1"].name, setup["org_1"].id,
-        setup["service_1_sms_and_letter"].name, setup["service_1_sms_and_letter"].id,
+        fixtures["org_1"].name, fixtures["org_1"].id,
+        fixtures["service_1_sms_and_letter"].name, fixtures["service_1_sms_and_letter"].id,
         Decimal('3.40')
     )
     assert results[1] == (
-        setup["org_for_service_with_letters"].name, setup["org_for_service_with_letters"].id,
-        setup["service_with_letters"].name, setup["service_with_letters"].id,
+        fixtures["org_for_service_with_letters"].name, fixtures["org_for_service_with_letters"].id,
+        fixtures["service_with_letters"].name, fixtures["service_with_letters"].id,
         Decimal('14.00')
     )
     assert results[2] == (
         None, None,
-        setup["service_with_letters_without_org"].name, setup["service_with_letters_without_org"].id,
+        fixtures["service_with_letters_without_org"].name, fixtures["service_with_letters_without_org"].id,
         Decimal('24.45')
     )
 
 
 def test_fetch_letter_line_items_for_all_service(notify_db_session):
-    setup = set_up_usage_data(datetime(2019, 6, 1))
+    fixtures = set_up_usage_data(datetime(2019, 6, 1))
 
     results = fetch_letter_line_items_for_all_services(datetime(2019, 6, 1), datetime(2019, 9, 30))
 
     assert len(results) == 7
     assert results[0] == (
-        setup["org_1"].name, setup["org_1"].id,
-        setup["service_1_sms_and_letter"].name, setup["service_1_sms_and_letter"].id,
+        fixtures["org_1"].name, fixtures["org_1"].id,
+        fixtures["service_1_sms_and_letter"].name, fixtures["service_1_sms_and_letter"].id,
         Decimal('0.45'), 'second', 6
     )
     assert results[1] == (
-        setup["org_1"].name, setup["org_1"].id,
-        setup["service_1_sms_and_letter"].name, setup["service_1_sms_and_letter"].id,
+        fixtures["org_1"].name, fixtures["org_1"].id,
+        fixtures["service_1_sms_and_letter"].name, fixtures["service_1_sms_and_letter"].id,
         Decimal("0.35"), 'first', 2
     )
     assert results[2] == (
-        setup["org_for_service_with_letters"].name, setup["org_for_service_with_letters"].id,
-        setup["service_with_letters"].name, setup["service_with_letters"].id,
+        fixtures["org_for_service_with_letters"].name, fixtures["org_for_service_with_letters"].id,
+        fixtures["service_with_letters"].name, fixtures["service_with_letters"].id,
         Decimal("0.65"), 'second', 20
     )
     assert results[3] == (
-        setup["org_for_service_with_letters"].name, setup["org_for_service_with_letters"].id,
-        setup["service_with_letters"].name, setup["service_with_letters"].id,
+        fixtures["org_for_service_with_letters"].name, fixtures["org_for_service_with_letters"].id,
+        fixtures["service_with_letters"].name, fixtures["service_with_letters"].id,
         Decimal("0.50"), 'first', 2
     )
     assert results[4] == (
         None, None,
-        setup["service_with_letters_without_org"].name, setup["service_with_letters_without_org"].id,
+        fixtures["service_with_letters_without_org"].name, fixtures["service_with_letters_without_org"].id,
         Decimal("0.35"), 'second', 2
     )
     assert results[5] == (
         None, None,
-        setup["service_with_letters_without_org"].name, setup["service_with_letters_without_org"].id,
+        fixtures["service_with_letters_without_org"].name, fixtures["service_with_letters_without_org"].id,
         Decimal("0.50"), 'first', 1
     )
     assert results[6] == (
         None, None,
-        setup["service_with_letters_without_org"].name, setup["service_with_letters_without_org"].id,
+        fixtures["service_with_letters_without_org"].name, fixtures["service_with_letters_without_org"].id,
         Decimal("1.55"), 'international', 15
     )
 
 
 @freeze_time('2019-06-01 13:30')
 def test_fetch_usage_year_for_organisation(notify_db_session):
-    setup = set_up_usage_data(datetime(2019, 5, 1))
+    fixtures = set_up_usage_data(datetime(2019, 5, 1))
     service_with_emails_for_org = create_service(service_name='Service with emails for org')
     dao_add_service_to_organisation(
         service=service_with_emails_for_org,
-        organisation_id=setup["org_1"].id
+        organisation_id=fixtures["org_1"].id
     )
     template = create_template(service=service_with_emails_for_org, template_type='email')
     create_ft_billing(bst_date=datetime(2019, 5, 1),
                       template=template,
                       notifications_sent=1100)
-    results = fetch_usage_year_for_organisation(setup["org_1"].id, 2019)
+    results = fetch_usage_year_for_organisation(fixtures["org_1"].id, 2019)
 
     assert len(results) == 2
-    first_row = results[str(setup["service_1_sms_and_letter"].id)]
-    assert first_row['service_id'] == setup["service_1_sms_and_letter"].id
-    assert first_row['service_name'] == setup["service_1_sms_and_letter"].name
+    first_row = results[str(fixtures["service_1_sms_and_letter"].id)]
+    assert first_row['service_id'] == fixtures["service_1_sms_and_letter"].id
+    assert first_row['service_name'] == fixtures["service_1_sms_and_letter"].name
     assert first_row['free_sms_limit'] == 10
     assert first_row['sms_remainder'] == 10
     assert first_row['chargeable_billable_sms'] == 0

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -126,7 +126,11 @@ def create_service(
         go_live_user=None,
         go_live_at=None,
         crown=True,
-        organisation=None
+        organisation=None,
+        purchase_order_number=None,
+        billing_contact_names=None,
+        billing_contact_email_addresses=None,
+        billing_reference=None,
 ):
     if check_if_service_exists:
         service = Service.query.filter_by(name=service_name).first()
@@ -142,7 +146,11 @@ def create_service(
             organisation=organisation,
             go_live_user=go_live_user,
             go_live_at=go_live_at,
-            crown=crown
+            crown=crown,
+            purchase_order_number=purchase_order_number,
+            billing_contact_names=billing_contact_names,
+            billing_contact_email_addresses=billing_contact_email_addresses,
+            billing_reference=billing_reference,
         )
         dao_create_service(
             service,
@@ -653,12 +661,26 @@ def create_domain(domain, organisation_id):
     return domain
 
 
-def create_organisation(name='test_org_1', active=True, organisation_type=None, domains=None, organisation_id=None):
+def create_organisation(
+    name='test_org_1',
+    active=True,
+    organisation_type=None,
+    domains=None,
+    organisation_id=None,
+    purchase_order_number=None,
+    billing_contact_names=None,
+    billing_contact_email_addresses=None,
+    billing_reference=None,
+):
     data = {
         'id': organisation_id,
         'name': name,
         'active': active,
         'organisation_type': organisation_type,
+        'purchase_order_number': purchase_order_number,
+        'billing_contact_names': billing_contact_names,
+        'billing_contact_email_addresses': billing_contact_email_addresses,
+        'billing_reference': billing_reference,
     }
     organisation = Organisation(**data)
     dao_create_organisation(organisation)
@@ -927,27 +949,53 @@ def set_up_usage_data(start_date):
     one_week_later = start_date + timedelta(days=7)
     one_month_later = start_date + timedelta(days=31)
 
-    service = create_service(service_name='a - with sms and letter')
+    service = create_service(
+        service_name='a - with sms and letter',
+        purchase_order_number="service purchase order number",
+        billing_contact_names="service billing contact names",
+        billing_contact_email_addresses="service@billing.contact email@addresses.gov.uk",
+        billing_reference="service billing reference"
+    )
     letter_template_1 = create_template(service=service, template_type='letter')
     sms_template_1 = create_template(service=service, template_type='sms')
     create_annual_billing(service_id=service.id, free_sms_fragment_limit=10, financial_year_start=year)
-    org = create_organisation(name="Org for {}".format(service.name))
+    org = create_organisation(
+        name="Org for {}".format(service.name),
+        purchase_order_number="org1 purchase order number",
+        billing_contact_names="org1 billing contact names",
+        billing_contact_email_addresses="org1@billing.contact email@addresses.gov.uk",
+        billing_reference="org1 billing reference"
+    )
     dao_add_service_to_organisation(service=service, organisation_id=org.id)
 
     service_2 = create_service(service_name='b - emails')
     email_template = create_template(service=service_2, template_type='email')
-    org_2 = create_organisation(name='Org for {}'.format(service_2.name))
+    org_2 = create_organisation(
+        name='Org for {}'.format(service_2.name),
+    )
     dao_add_service_to_organisation(service=service_2, organisation_id=org_2.id)
 
     service_3 = create_service(service_name='c - letters only')
     letter_template_3 = create_template(service=service_3, template_type='letter')
-    org_3 = create_organisation(name="Org for {}".format(service_3.name))
+    org_3 = create_organisation(
+        name="Org for {}".format(service_3.name),
+        purchase_order_number="org3 purchase order number",
+        billing_contact_names="org3 billing contact names",
+        billing_contact_email_addresses="org3@billing.contact email@addresses.gov.uk",
+        billing_reference="org3 billing reference"
+    )
     dao_add_service_to_organisation(service=service_3, organisation_id=org_3.id)
 
     service_4 = create_service(service_name='d - service without org')
     letter_template_4 = create_template(service=service_4, template_type='letter')
 
-    service_sms_only = create_service(service_name='b - chargeable sms')
+    service_sms_only = create_service(
+        service_name='b - chargeable sms',
+        purchase_order_number="sms purchase order number",
+        billing_contact_names="sms billing contact names",
+        billing_contact_email_addresses="sms@billing.contact email@addresses.gov.uk",
+        billing_reference="sms billing reference"
+    )
     sms_template = create_template(service=service_sms_only, template_type='sms')
     create_annual_billing(service_id=service_sms_only.id, free_sms_fragment_limit=10, financial_year_start=year)
 

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -949,55 +949,62 @@ def set_up_usage_data(start_date):
     one_week_later = start_date + timedelta(days=7)
     one_month_later = start_date + timedelta(days=31)
 
-    service = create_service(
+    service_1_sms_and_letter = create_service(
         service_name='a - with sms and letter',
         purchase_order_number="service purchase order number",
         billing_contact_names="service billing contact names",
         billing_contact_email_addresses="service@billing.contact email@addresses.gov.uk",
         billing_reference="service billing reference"
     )
-    letter_template_1 = create_template(service=service, template_type='letter')
-    sms_template_1 = create_template(service=service, template_type='sms')
-    create_annual_billing(service_id=service.id, free_sms_fragment_limit=10, financial_year_start=year)
-    org = create_organisation(
-        name="Org for {}".format(service.name),
+    letter_template_1 = create_template(service=service_1_sms_and_letter, template_type='letter')
+    sms_template_1 = create_template(service=service_1_sms_and_letter, template_type='sms')
+    create_annual_billing(
+        service_id=service_1_sms_and_letter.id, free_sms_fragment_limit=10, financial_year_start=year
+    )
+    org_1 = create_organisation(
+        name="Org for {}".format(service_1_sms_and_letter.name),
         purchase_order_number="org1 purchase order number",
         billing_contact_names="org1 billing contact names",
         billing_contact_email_addresses="org1@billing.contact email@addresses.gov.uk",
         billing_reference="org1 billing reference"
     )
-    dao_add_service_to_organisation(service=service, organisation_id=org.id)
-
-    service_2 = create_service(service_name='b - emails')
-    email_template = create_template(service=service_2, template_type='email')
-    org_2 = create_organisation(
-        name='Org for {}'.format(service_2.name),
+    dao_add_service_to_organisation(
+        service=service_1_sms_and_letter,
+        organisation_id=org_1.id
     )
-    dao_add_service_to_organisation(service=service_2, organisation_id=org_2.id)
 
-    service_3 = create_service(service_name='c - letters only')
-    letter_template_3 = create_template(service=service_3, template_type='letter')
-    org_3 = create_organisation(
-        name="Org for {}".format(service_3.name),
+    service_with_emails = create_service(service_name='b - emails')
+    email_template = create_template(service=service_with_emails, template_type='email')
+    org_2 = create_organisation(
+        name='Org for {}'.format(service_with_emails.name),
+    )
+    dao_add_service_to_organisation(service=service_with_emails, organisation_id=org_2.id)
+
+    service_with_letters = create_service(service_name='c - letters only')
+    letter_template_3 = create_template(service=service_with_letters, template_type='letter')
+    org_for_service_with_letters = create_organisation(
+        name="Org for {}".format(service_with_letters.name),
         purchase_order_number="org3 purchase order number",
         billing_contact_names="org3 billing contact names",
         billing_contact_email_addresses="org3@billing.contact email@addresses.gov.uk",
         billing_reference="org3 billing reference"
     )
-    dao_add_service_to_organisation(service=service_3, organisation_id=org_3.id)
+    dao_add_service_to_organisation(service=service_with_letters, organisation_id=org_for_service_with_letters.id)
 
-    service_4 = create_service(service_name='d - service without org')
-    letter_template_4 = create_template(service=service_4, template_type='letter')
+    service_with_letters_without_org = create_service(service_name='d - service without org')
+    letter_template_4 = create_template(service=service_with_letters_without_org, template_type='letter')
 
-    service_sms_only = create_service(
+    service_with_sms_without_org = create_service(
         service_name='b - chargeable sms',
         purchase_order_number="sms purchase order number",
         billing_contact_names="sms billing contact names",
         billing_contact_email_addresses="sms@billing.contact email@addresses.gov.uk",
         billing_reference="sms billing reference"
     )
-    sms_template = create_template(service=service_sms_only, template_type='sms')
-    create_annual_billing(service_id=service_sms_only.id, free_sms_fragment_limit=10, financial_year_start=year)
+    sms_template = create_template(service=service_with_sms_without_org, template_type='sms')
+    create_annual_billing(
+        service_id=service_with_sms_without_org.id, free_sms_fragment_limit=10, financial_year_start=year
+    )
 
     create_ft_billing(bst_date=one_week_earlier, template=sms_template_1, billable_unit=2, rate=0.11)
     create_ft_billing(bst_date=start_date, template=sms_template_1, billable_unit=2, rate=0.11)
@@ -1031,7 +1038,16 @@ def set_up_usage_data(start_date):
 
     create_ft_billing(bst_date=start_date, template=email_template, notifications_sent=10)
 
-    return org, org_3, service, service_3, service_4, service_sms_only, org_2, service_2
+    return {
+        "org_1": org_1,
+        "service_1_sms_and_letter": service_1_sms_and_letter,
+        "org_2": org_2,
+        "service_with_emails": service_with_emails,
+        "org_for_service_with_letters": org_for_service_with_letters,
+        "service_with_letters": service_with_letters,
+        "service_with_letters_without_org": service_with_letters_without_org,
+        "service_with_sms_without_org": service_with_sms_without_org
+    }
 
 
 def create_returned_letter(service=None, reported_at=None, notification_id=None):

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -949,6 +949,7 @@ def set_up_usage_data(start_date):
     one_week_later = start_date + timedelta(days=7)
     one_month_later = start_date + timedelta(days=31)
 
+    # service with sms and letters:
     service_1_sms_and_letter = create_service(
         service_name='a - with sms and letter',
         purchase_order_number="service purchase order number",
@@ -973,6 +974,7 @@ def set_up_usage_data(start_date):
         organisation_id=org_1.id
     )
 
+    # service with emails only:
     service_with_emails = create_service(service_name='b - emails')
     email_template = create_template(service=service_with_emails, template_type='email')
     org_2 = create_organisation(
@@ -980,6 +982,7 @@ def set_up_usage_data(start_date):
     )
     dao_add_service_to_organisation(service=service_with_emails, organisation_id=org_2.id)
 
+    # service with letters:
     service_with_letters = create_service(service_name='c - letters only')
     letter_template_3 = create_template(service=service_with_letters, template_type='letter')
     org_for_service_with_letters = create_organisation(
@@ -991,9 +994,11 @@ def set_up_usage_data(start_date):
     )
     dao_add_service_to_organisation(service=service_with_letters, organisation_id=org_for_service_with_letters.id)
 
+    # service with letters, without an organisation:
     service_with_letters_without_org = create_service(service_name='d - service without org')
     letter_template_4 = create_template(service=service_with_letters_without_org, template_type='letter')
 
+    # service with chargeable SMS, without an organisation
     service_with_sms_without_org = create_service(
         service_name='b - chargeable sms',
         purchase_order_number="sms purchase order number",
@@ -1006,6 +1011,17 @@ def set_up_usage_data(start_date):
         service_id=service_with_sms_without_org.id, free_sms_fragment_limit=10, financial_year_start=year
     )
 
+    # service with SMS within free allowance
+    service_with_sms_within_allowance = create_service(
+        service_name='e - sms within allowance'
+    )
+    sms_template_2 = create_template(service=service_with_sms_within_allowance, template_type='sms')
+    create_annual_billing(
+        service_id=service_with_sms_within_allowance.id, free_sms_fragment_limit=10, financial_year_start=year
+    )
+    create_ft_billing(bst_date=one_week_later, template=sms_template_2, billable_unit=2, rate=0.11)
+
+    # all other ft billing isntances:
     create_ft_billing(bst_date=one_week_earlier, template=sms_template_1, billable_unit=2, rate=0.11)
     create_ft_billing(bst_date=start_date, template=sms_template_1, billable_unit=2, rate=0.11)
     create_ft_billing(bst_date=two_days_later, template=sms_template_1, billable_unit=1, rate=0.11)

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -974,6 +974,17 @@ def set_up_usage_data(start_date):
         organisation_id=org_1.id
     )
 
+    create_ft_billing(bst_date=one_week_earlier, template=sms_template_1, billable_unit=2, rate=0.11)
+    create_ft_billing(bst_date=start_date, template=sms_template_1, billable_unit=2, rate=0.11)
+    create_ft_billing(bst_date=two_days_later, template=sms_template_1, billable_unit=1, rate=0.11)
+
+    create_ft_billing(bst_date=one_week_later, template=letter_template_1,
+                      notifications_sent=2, billable_unit=1, rate=.35, postage='first')
+    create_ft_billing(bst_date=one_month_later, template=letter_template_1,
+                      notifications_sent=4, billable_unit=2, rate=.45, postage='second')
+    create_ft_billing(bst_date=one_week_later, template=letter_template_1,
+                      notifications_sent=2, billable_unit=2, rate=.45, postage='second')
+
     # service with emails only:
     service_with_emails = create_service(service_name='b - emails')
     email_template = create_template(service=service_with_emails, template_type='email')
@@ -981,6 +992,8 @@ def set_up_usage_data(start_date):
         name='Org for {}'.format(service_with_emails.name),
     )
     dao_add_service_to_organisation(service=service_with_emails, organisation_id=org_2.id)
+
+    create_ft_billing(bst_date=start_date, template=email_template, notifications_sent=10)
 
     # service with letters:
     service_with_letters = create_service(service_name='c - letters only')
@@ -994,9 +1007,25 @@ def set_up_usage_data(start_date):
     )
     dao_add_service_to_organisation(service=service_with_letters, organisation_id=org_for_service_with_letters.id)
 
+    create_ft_billing(bst_date=start_date, template=letter_template_3,
+                      notifications_sent=2, billable_unit=3, rate=.50, postage='first')
+    create_ft_billing(bst_date=one_week_later, template=letter_template_3,
+                      notifications_sent=8, billable_unit=5, rate=.65, postage='second')
+    create_ft_billing(bst_date=one_month_later, template=letter_template_3,
+                      notifications_sent=12, billable_unit=5, rate=.65, postage='second')
+
     # service with letters, without an organisation:
     service_with_letters_without_org = create_service(service_name='d - service without org')
     letter_template_4 = create_template(service=service_with_letters_without_org, template_type='letter')
+
+    create_ft_billing(bst_date=two_days_later, template=letter_template_4,
+                      notifications_sent=7, billable_unit=4, rate=1.55, postage='rest-of-world')
+    create_ft_billing(bst_date=two_days_later, template=letter_template_4,
+                      notifications_sent=8, billable_unit=4, rate=1.55, postage='europe')
+    create_ft_billing(bst_date=two_days_later, template=letter_template_4,
+                      notifications_sent=2, billable_unit=1, rate=.35, postage='second')
+    create_ft_billing(bst_date=two_days_later, template=letter_template_4,
+                      notifications_sent=1, billable_unit=1, rate=.50, postage='first')
 
     # service with chargeable SMS, without an organisation
     service_with_sms_without_org = create_service(
@@ -1010,6 +1039,9 @@ def set_up_usage_data(start_date):
     create_annual_billing(
         service_id=service_with_sms_without_org.id, free_sms_fragment_limit=10, financial_year_start=year
     )
+    create_ft_billing(bst_date=one_week_earlier, template=sms_template, rate=0.11, billable_unit=12)
+    create_ft_billing(bst_date=two_days_later, template=sms_template, rate=0.11)
+    create_ft_billing(bst_date=one_week_later, template=sms_template, billable_unit=2, rate=0.11)
 
     # service with SMS within free allowance
     service_with_sms_within_allowance = create_service(
@@ -1021,39 +1053,7 @@ def set_up_usage_data(start_date):
     )
     create_ft_billing(bst_date=one_week_later, template=sms_template_2, billable_unit=2, rate=0.11)
 
-    # all other ft billing isntances:
-    create_ft_billing(bst_date=one_week_earlier, template=sms_template_1, billable_unit=2, rate=0.11)
-    create_ft_billing(bst_date=start_date, template=sms_template_1, billable_unit=2, rate=0.11)
-    create_ft_billing(bst_date=two_days_later, template=sms_template_1, billable_unit=1, rate=0.11)
-    create_ft_billing(bst_date=one_week_later, template=letter_template_1,
-                      notifications_sent=2, billable_unit=1, rate=.35, postage='first')
-    create_ft_billing(bst_date=one_month_later, template=letter_template_1,
-                      notifications_sent=4, billable_unit=2, rate=.45, postage='second')
-    create_ft_billing(bst_date=one_week_later, template=letter_template_1,
-                      notifications_sent=2, billable_unit=2, rate=.45, postage='second')
-
-    create_ft_billing(bst_date=one_week_earlier, template=sms_template, rate=0.11, billable_unit=12)
-    create_ft_billing(bst_date=two_days_later, template=sms_template, rate=0.11)
-    create_ft_billing(bst_date=one_week_later, template=sms_template, billable_unit=2, rate=0.11)
-
-    create_ft_billing(bst_date=start_date, template=letter_template_3,
-                      notifications_sent=2, billable_unit=3, rate=.50, postage='first')
-    create_ft_billing(bst_date=one_week_later, template=letter_template_3,
-                      notifications_sent=8, billable_unit=5, rate=.65, postage='second')
-    create_ft_billing(bst_date=one_month_later, template=letter_template_3,
-                      notifications_sent=12, billable_unit=5, rate=.65, postage='second')
-
-    create_ft_billing(bst_date=two_days_later, template=letter_template_4,
-                      notifications_sent=7, billable_unit=4, rate=1.55, postage='rest-of-world')
-    create_ft_billing(bst_date=two_days_later, template=letter_template_4,
-                      notifications_sent=8, billable_unit=4, rate=1.55, postage='europe')
-    create_ft_billing(bst_date=two_days_later, template=letter_template_4,
-                      notifications_sent=2, billable_unit=1, rate=.35, postage='second')
-    create_ft_billing(bst_date=two_days_later, template=letter_template_4,
-                      notifications_sent=1, billable_unit=1, rate=.50, postage='first')
-
-    create_ft_billing(bst_date=start_date, template=email_template, notifications_sent=10)
-
+    # dictionary with services and orgs to return
     return {
         "org_1": org_1,
         "service_1_sms_and_letter": service_1_sms_and_letter,
@@ -1062,7 +1062,8 @@ def set_up_usage_data(start_date):
         "org_for_service_with_letters": org_for_service_with_letters,
         "service_with_letters": service_with_letters,
         "service_with_letters_without_org": service_with_letters_without_org,
-        "service_with_sms_without_org": service_with_sms_without_org
+        "service_with_sms_without_org": service_with_sms_without_org,
+        "service_with_sms_within_allowance": service_with_sms_within_allowance,
     }
 
 

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -134,7 +134,8 @@ def test_get_data_for_billing_report(notify_db_session, admin_request):
         end_date='2019-06-30'
     )
 
-    # we set up 5 services, but only 4 returned. service_with_emails was skipped as it had no bills to pay
+    # we set up 6 services, but only 4 returned. service_with_emails was skipped as it had no bills to pay,
+    # and likewise the service with SMS within allowance was skipped. too.
     assert len(response) == 4
     assert response[0]["organisation_id"] == str(setup["org_1"].id)
     assert response[0]["service_id"] == str(setup["service_1_sms_and_letter"].id)

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -127,7 +127,7 @@ def test_validate_date_is_within_a_financial_year_when_input_is_not_a_date(start
 
 
 def test_get_data_for_billing_report(notify_db_session, admin_request):
-    setup = set_up_usage_data(datetime(2019, 5, 1))
+    fixtures = set_up_usage_data(datetime(2019, 5, 1))
     response = admin_request.get(
         "platform_stats.get_data_for_billing_report",
         start_date='2019-05-01',
@@ -137,8 +137,8 @@ def test_get_data_for_billing_report(notify_db_session, admin_request):
     # we set up 6 services, but only 4 returned. service_with_emails was skipped as it had no bills to pay,
     # and likewise the service with SMS within allowance was skipped. too.
     assert len(response) == 4
-    assert response[0]["organisation_id"] == str(setup["org_1"].id)
-    assert response[0]["service_id"] == str(setup["service_1_sms_and_letter"].id)
+    assert response[0]["organisation_id"] == str(fixtures["org_1"].id)
+    assert response[0]["service_id"] == str(fixtures["service_1_sms_and_letter"].id)
     assert response[0]["sms_cost"] == 0
     assert response[0]["sms_fragments"] == 0
     assert response[0]["letter_cost"] == 3.40
@@ -148,8 +148,8 @@ def test_get_data_for_billing_report(notify_db_session, admin_request):
     assert response[0]["contact_email_addresses"] == "service@billing.contact email@addresses.gov.uk"
     assert response[0]["billing_reference"] == "service billing reference"
 
-    assert response[1]["organisation_id"] == str(setup["org_for_service_with_letters"].id)
-    assert response[1]["service_id"] == str(setup["service_with_letters"].id)
+    assert response[1]["organisation_id"] == str(fixtures["org_for_service_with_letters"].id)
+    assert response[1]["service_id"] == str(fixtures["service_with_letters"].id)
     assert response[1]["sms_cost"] == 0
     assert response[1]["sms_fragments"] == 0
     assert response[1]["letter_cost"] == 14
@@ -160,7 +160,7 @@ def test_get_data_for_billing_report(notify_db_session, admin_request):
     assert response[1]["billing_reference"] == "org3 billing reference"
 
     assert response[2]["organisation_id"] == ""
-    assert response[2]["service_id"] == str(setup["service_with_sms_without_org"].id)
+    assert response[2]["service_id"] == str(fixtures["service_with_sms_without_org"].id)
     assert response[2]["sms_cost"] == 0.33
     assert response[2]["sms_fragments"] == 3
     assert response[2]["letter_cost"] == 0
@@ -171,7 +171,7 @@ def test_get_data_for_billing_report(notify_db_session, admin_request):
     assert response[2]["billing_reference"] == "sms billing reference"
 
     assert response[3]["organisation_id"] == ""
-    assert response[3]["service_id"] == str(setup["service_with_letters_without_org"].id)
+    assert response[3]["service_id"] == str(fixtures["service_with_letters_without_org"].id)
     assert response[3]["sms_cost"] == 0
     assert response[3]["sms_fragments"] == 0
     assert response[3]["letter_cost"] == 24.45

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -127,14 +127,13 @@ def test_validate_date_is_within_a_financial_year_when_input_is_not_a_date(start
 
 
 def test_get_usage_for_all_services(notify_db_session, admin_request):
-    org, org_3, service, service_3, service_without_org, service_sms_only, \
-        org_with_emails, service_with_emails = set_up_usage_data(datetime(2019, 5, 1))
+    setup = set_up_usage_data(datetime(2019, 5, 1))
     response = admin_request.get("platform_stats.get_usage_for_all_services",
                                  start_date='2019-05-01',
                                  end_date='2019-06-30')
     assert len(response) == 4
-    assert response[0]["organisation_id"] == str(org.id)
-    assert response[0]["service_id"] == str(service.id)
+    assert response[0]["organisation_id"] == str(setup["org_1"].id)
+    assert response[0]["service_id"] == str(setup["service_1_sms_and_letter"].id)
     assert response[0]["sms_cost"] == 0
     assert response[0]["sms_fragments"] == 0
     assert response[0]["letter_cost"] == 3.40
@@ -144,8 +143,8 @@ def test_get_usage_for_all_services(notify_db_session, admin_request):
     assert response[0]["contact_email_addresses"] == "service@billing.contact email@addresses.gov.uk"
     assert response[0]["billing_reference"] == "service billing reference"
 
-    assert response[1]["organisation_id"] == str(org_3.id)
-    assert response[1]["service_id"] == str(service_3.id)
+    assert response[1]["organisation_id"] == str(setup["org_for_service_with_letters"].id)
+    assert response[1]["service_id"] == str(setup["service_with_letters"].id)
     assert response[1]["sms_cost"] == 0
     assert response[1]["sms_fragments"] == 0
     assert response[1]["letter_cost"] == 14
@@ -156,7 +155,7 @@ def test_get_usage_for_all_services(notify_db_session, admin_request):
     assert response[1]["billing_reference"] == "org3 billing reference"
 
     assert response[2]["organisation_id"] == ""
-    assert response[2]["service_id"] == str(service_sms_only.id)
+    assert response[2]["service_id"] == str(setup["service_with_sms_without_org"].id)
     assert response[2]["sms_cost"] == 0.33
     assert response[2]["sms_fragments"] == 3
     assert response[2]["letter_cost"] == 0
@@ -167,10 +166,11 @@ def test_get_usage_for_all_services(notify_db_session, admin_request):
     assert response[2]["billing_reference"] == "sms billing reference"
 
     assert response[3]["organisation_id"] == ""
-    assert response[3]["service_id"] == str(service_without_org.id)
+    assert response[3]["service_id"] == str(setup["service_with_letters_without_org"].id)
     assert response[3]["sms_cost"] == 0
     assert response[3]["sms_fragments"] == 0
     assert response[3]["letter_cost"] == 24.45
     assert response[3]["letter_breakdown"] == (
         "2 second class letters at 35p\n1 first class letters at 50p\n15 international letters at £1.55\n"
     )
+    assert response[3]["purchase_order_number"] is None

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -126,11 +126,15 @@ def test_validate_date_is_within_a_financial_year_when_input_is_not_a_date(start
     assert e.value.status_code == 400
 
 
-def test_get_usage_for_all_services(notify_db_session, admin_request):
+def test_get_data_for_billing_report(notify_db_session, admin_request):
     setup = set_up_usage_data(datetime(2019, 5, 1))
-    response = admin_request.get("platform_stats.get_usage_for_all_services",
-                                 start_date='2019-05-01',
-                                 end_date='2019-06-30')
+    response = admin_request.get(
+        "platform_stats.get_data_for_billing_report",
+        start_date='2019-05-01',
+        end_date='2019-06-30'
+    )
+
+    # we set up 5 services, but only 4 returned. service_with_emails was skipped as it had no bills to pay
     assert len(response) == 4
     assert response[0]["organisation_id"] == str(setup["org_1"].id)
     assert response[0]["service_id"] == str(setup["service_1_sms_and_letter"].id)

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -127,7 +127,7 @@ def test_validate_date_is_within_a_financial_year_when_input_is_not_a_date(start
 
 
 def test_get_usage_for_all_services(notify_db_session, admin_request):
-    org, org_2, service, service_2, service_3, service_sms_only, \
+    org, org_3, service, service_3, service_without_org, service_sms_only, \
         org_with_emails, service_with_emails = set_up_usage_data(datetime(2019, 5, 1))
     response = admin_request.get("platform_stats.get_usage_for_all_services",
                                  start_date='2019-05-01',
@@ -139,13 +139,21 @@ def test_get_usage_for_all_services(notify_db_session, admin_request):
     assert response[0]["sms_fragments"] == 0
     assert response[0]["letter_cost"] == 3.40
     assert response[0]["letter_breakdown"] == "6 second class letters at 45p\n2 first class letters at 35p\n"
+    assert response[0]["purchase_order_number"] == "service purchase order number"
+    assert response[0]["contact_names"] == "service billing contact names"
+    assert response[0]["contact_email_addresses"] == "service@billing.contact email@addresses.gov.uk"
+    assert response[0]["billing_reference"] == "service billing reference"
 
-    assert response[1]["organisation_id"] == str(org_2.id)
-    assert response[1]["service_id"] == str(service_2.id)
+    assert response[1]["organisation_id"] == str(org_3.id)
+    assert response[1]["service_id"] == str(service_3.id)
     assert response[1]["sms_cost"] == 0
     assert response[1]["sms_fragments"] == 0
     assert response[1]["letter_cost"] == 14
     assert response[1]["letter_breakdown"] == "20 second class letters at 65p\n2 first class letters at 50p\n"
+    assert response[1]["purchase_order_number"] == "org3 purchase order number"
+    assert response[1]["contact_names"] == "org3 billing contact names"
+    assert response[1]["contact_email_addresses"] == "org3@billing.contact email@addresses.gov.uk"
+    assert response[1]["billing_reference"] == "org3 billing reference"
 
     assert response[2]["organisation_id"] == ""
     assert response[2]["service_id"] == str(service_sms_only.id)
@@ -153,9 +161,13 @@ def test_get_usage_for_all_services(notify_db_session, admin_request):
     assert response[2]["sms_fragments"] == 3
     assert response[2]["letter_cost"] == 0
     assert response[2]["letter_breakdown"] == ""
+    assert response[2]["purchase_order_number"] == "sms purchase order number"
+    assert response[2]["contact_names"] == "sms billing contact names"
+    assert response[2]["contact_email_addresses"] == "sms@billing.contact email@addresses.gov.uk"
+    assert response[2]["billing_reference"] == "sms billing reference"
 
     assert response[3]["organisation_id"] == ""
-    assert response[3]["service_id"] == str(service_3.id)
+    assert response[3]["service_id"] == str(service_without_org.id)
     assert response[3]["sms_cost"] == 0
     assert response[3]["sms_fragments"] == 0
     assert response[3]["letter_cost"] == 24.45


### PR DESCRIPTION
So that when we build the billing report, we get the new details:
- purchase order number
- billing contact names
- billing contact email addresses
- billing reference

Also only return services with bills to pay.

Pivotal ticket: https://www.pivotaltracker.com/story/show/176521236

From the ticket:
> In order to determine where to fetch these values from, first check if there is a ‘purchase order number’ present for the service. If there is then set these fields using the values stored against the service.

> If there is no purchase order number on the service, then check if there is a purchase order number on the parent organisation. If there is then set these fields using the values stored against the organisation.

> If neither is present leave those fields empty in the report.

How to review:
review the whole PR together.

Next steps:
Use this additional data to update the billing report we create in admin app.