### PR TITLE
Enable EE Cell Broadcasts in production environment

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -539,8 +539,6 @@ class Live(Config):
 
     CRONITOR_ENABLED = True
 
-    ENABLED_CBCS = {BroadcastProvider.THREE, BroadcastProvider.O2, BroadcastProvider.VODAFONE}
-
 
 class CloudFoundryConfig(Config):
     pass


### PR DESCRIPTION
Removes the configuration override for Live, so the base configuration is used, enabling cell broadcasting for all MNOs in the production environment.
