### PR TITLE
Add service versioning to broadcast account type change

### DIFF
--- a/app/dao/broadcast_service_dao.py
+++ b/app/dao/broadcast_service_dao.py
@@ -3,11 +3,19 @@ from datetime import datetime
 from flask import current_app
 
 from app import db
-from app.models import ServiceBroadcastSettings, ServicePermission, Organisation, BROADCAST_TYPE, EMAIL_AUTH_TYPE
-from app.dao.dao_utils import transactional
+from app.dao.dao_utils import transactional, version_class
+from app.models import (
+    Service,
+    ServiceBroadcastSettings,
+    ServicePermission,
+    Organisation,
+    BROADCAST_TYPE,
+    EMAIL_AUTH_TYPE
+)
 
 
 @transactional
+@version_class(Service)
 def set_broadcast_service_type(service, service_mode, broadcast_channel, provider_restriction):
     insert_or_update_service_broadcast_settings(
         service, channel=broadcast_channel, provider_restriction=provider_restriction

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -4059,3 +4059,23 @@ def test_set_as_broadcast_service_errors_if_no_mobile_provider_restriction(
         _data=data,
         _expected_status=400,
     )
+
+
+def test_set_as_broadcast_service_updates_services_history(
+    admin_request, sample_service, broadcast_organisation
+):
+    old_history_records = Service.get_history_model().query.filter_by(id=sample_service.id).all()
+    data = {
+        'broadcast_channel': 'test',
+        'service_mode': 'live',
+        'provider_restriction': None,
+    }
+
+    admin_request.post(
+        'service.set_as_broadcast_service',
+        service_id=sample_service.id,
+        _data=data,
+    )
+
+    new_history_records = Service.get_history_model().query.filter_by(id=sample_service.id).all()
+    assert len(new_history_records) == len(old_history_records) + 1


### PR DESCRIPTION
We are using the `set_broadcast_service_type` route to make changes to
service objects. However, we had forgotten to add the `version_class`
decorator to it which will mean the changing of a service going from
training to live mode will also be recorded in the services_history
table for free. Whilst not essential, this easy change makes things more
consistent for how we update other services.

Have tested locally by making a service a broadcast service and it works
![image](https://user-images.githubusercontent.com/7228605/110005668-a704f200-7d10-11eb-8476-cd10b53edf4b.png)

