### PR TITLE
add POST get user by email endpoint

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -417,6 +417,19 @@ def set_permissions(user_id, service_id):
     return jsonify({}), 204
 
 
+@user_blueprint.route('/email', methods=['POST'])
+def fetch_user_by_email():
+
+    email, errors = email_data_request_schema.load(request.get_json())
+    if errors:
+        raise InvalidRequest(message=errors, status_code=400)
+
+    fetched_user = get_user_by_email(email['email'])
+    result = fetched_user.serialize()
+    return jsonify(data=result)
+
+
+# TODO: Deprecate this GET endpoint
 @user_blueprint.route('/email', methods=['GET'])
 def get_by_email():
     email = request.args.get('email')


### PR DESCRIPTION
the existing endpoint is a GET, and so leaves email addresses in log files.

we've got an existing POST find_users_by_partial_email, but not one that matches on a whole email address.