### PR TITLE
Quieten output for pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,5 +5,5 @@ env =
     MMG_API_KEY=mmg-secret-key
     FIRETEXT_API_KEY=Firetext
     NOTIFICATION_QUEUE_PREFIX=testing
-addopts = -v -p no:warnings
+addopts = -p no:warnings
 xfail_strict = true


### PR DESCRIPTION
This avoids being verbose by default, which is consistent with how
we configure pytest for the admin app [1].

[1]: https://github.com/alphagov/notifications-admin/blob/master/pytest.ini#L16