### PR TITLE
Lookup PDFs by prefix in S3 (not whole filename)

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -69,22 +69,6 @@ def remove_contact_list_from_s3(service_id, contact_list_id):
     return remove_s3_object(*get_contact_list_location(service_id, contact_list_id))
 
 
-def get_s3_bucket_objects(bucket_name, subfolder=''):
-    boto_client = client('s3', current_app.config['AWS_REGION'])
-    paginator = boto_client.get_paginator('list_objects_v2')
-    page_iterator = paginator.paginate(
-        Bucket=bucket_name,
-        Prefix=subfolder
-    )
-
-    all_objects_in_bucket = []
-    for page in page_iterator:
-        if page.get('Contents'):
-            all_objects_in_bucket.extend(page['Contents'])
-
-    return all_objects_in_bucket
-
-
 def remove_s3_object(bucket_name, object_key):
     obj = get_s3_object(bucket_name, object_key)
     return obj.delete()

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -28,7 +28,7 @@ from app.exceptions import NotificationTechnicalFailureException
 from app.letters.utils import (
     LetterPDFNotFound,
     ScanErrorType,
-    find_letter_pdf_filename,
+    find_letter_pdf_in_s3,
     generate_letter_pdf_filename,
     get_billable_units_for_letter_page_count,
     get_file_names_from_error_bucket,
@@ -237,11 +237,10 @@ def get_key_and_size_of_letters_to_be_sent_to_print(print_run_deadline, postage)
     letters_awaiting_sending = dao_get_letters_to_be_printed(print_run_deadline, postage)
     for letter in letters_awaiting_sending:
         try:
-            letter_file_name = find_letter_pdf_filename(letter)
-            letter_head = s3.head_s3_object(current_app.config['LETTERS_PDF_BUCKET_NAME'], letter_file_name)
+            letter_pdf = find_letter_pdf_in_s3(letter)
             yield {
-                "Key": letter_file_name,
-                "Size": letter_head['ContentLength'],
+                "Key": letter_pdf.key,
+                "Size": letter_pdf.size,
                 "ServiceId": str(letter.service_id)
             }
         except (BotoClientError, LetterPDFNotFound) as e:

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -26,6 +26,7 @@ from app.dao.templates_dao import dao_get_template_by_id
 from app.errors import VirusScanError
 from app.exceptions import NotificationTechnicalFailureException
 from app.letters.utils import (
+    LetterPDFNotFound,
     ScanErrorType,
     find_letter_pdf_filename,
     generate_letter_pdf_filename,
@@ -243,7 +244,7 @@ def get_key_and_size_of_letters_to_be_sent_to_print(print_run_deadline, postage)
                 "Size": letter_head['ContentLength'],
                 "ServiceId": str(letter.service_id)
             }
-        except BotoClientError as e:
+        except (BotoClientError, LetterPDFNotFound) as e:
             current_app.logger.exception(
                 f"Error getting letter from bucket for notification: {letter.id} with reference: {letter.reference}", e)
 

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -37,6 +37,10 @@ def get_folder_name(created_at):
     return '{}/'.format(print_datetime.date())
 
 
+class LetterPDFNotFound(Exception):
+    pass
+
+
 def find_letter_pdf_filename(notification):
     """
     Retrieve the filename of a letter from s3 by searching for it based on a prefix.
@@ -47,7 +51,10 @@ def find_letter_pdf_filename(notification):
 
     s3 = boto3.resource('s3')
     bucket = s3.Bucket(bucket_name)
-    item = next(x for x in bucket.objects.filter(Prefix=prefix))
+    try:
+        item = next(x for x in bucket.objects.filter(Prefix=prefix))
+    except StopIteration:
+        raise LetterPDFNotFound(f'File not found in bucket {bucket_name} with prefix {prefix}', )
     return item.key
 
 

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -41,12 +41,7 @@ class LetterPDFNotFound(Exception):
     pass
 
 
-def find_letter_pdf_filename(notification):
-    """
-    Retrieve the filename of a letter from s3 by searching for it based on a prefix.
-
-    Use this when retrieving existing pdfs, so that we can be more resilient if the naming convention changes.
-    """
+def find_letter_pdf_in_s3(notification):
     bucket_name, prefix = get_bucket_name_and_prefix_for_notification(notification)
 
     s3 = boto3.resource('s3')
@@ -55,16 +50,10 @@ def find_letter_pdf_filename(notification):
         item = next(x for x in bucket.objects.filter(Prefix=prefix))
     except StopIteration:
         raise LetterPDFNotFound(f'File not found in bucket {bucket_name} with prefix {prefix}', )
-    return item.key
+    return item
 
 
 def generate_letter_pdf_filename(reference, crown, created_at, ignore_folder=False, postage=SECOND_CLASS):
-    """
-    Generate a filename for putting a letter into s3 or sending to dvla.
-
-    We should only use this function when uploading data. If you need to get a letter or its metadata from s3
-    then use `find_letter_pdf_filename` instead.
-    """
     upload_file_name = LETTERS_PDF_FILE_LOCATION_STRUCTURE.format(
         folder='' if ignore_folder else get_folder_name(created_at),
         reference=reference,

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -186,16 +186,7 @@ def get_file_names_from_error_bucket():
 
 
 def get_letter_pdf_and_metadata(notification):
-    bucket_name, prefix = get_bucket_name_and_prefix_for_notification(notification)
-
-    s3 = boto3.resource('s3')
-    bucket = s3.Bucket(bucket_name)
-    item = next(x for x in bucket.objects.filter(Prefix=prefix))
-
-    obj = s3.Object(
-        bucket_name=bucket_name,
-        key=item.key
-    ).get()
+    obj = find_letter_pdf_in_s3(notification).get()
     return obj["Body"].read(), obj["Metadata"]
 
 

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -17,8 +17,8 @@ from app.dao.templates_dao import (
 )
 from app.dao.users_dao import get_user_by_id
 from app.letters.utils import (
+    generate_letter_pdf_filename,
     get_billable_units_for_letter_page_count,
-    get_letter_pdf_filename,
     get_page_count,
     move_uploaded_pdf_to_letters_bucket,
 )
@@ -197,7 +197,7 @@ def send_pdf_letter_notification(service_id, post_data):
         postage=post_data['postage'] or template.postage,
     )
 
-    upload_filename = get_letter_pdf_filename(
+    upload_filename = generate_letter_pdf_filename(
         reference=notification.reference,
         crown=notification.service.crown,
         created_at=notification.created_at,

--- a/tests/app/aws/test_s3.py
+++ b/tests/app/aws/test_s3.py
@@ -1,15 +1,10 @@
 from datetime import datetime, timedelta
-from unittest.mock import call
 
 import pytest
 import pytz
 from freezegun import freeze_time
 
-from app.aws.s3 import (
-    get_list_of_files_by_suffix,
-    get_s3_bucket_objects,
-    get_s3_file,
-)
+from app.aws.s3 import get_list_of_files_by_suffix, get_s3_file
 from tests.app.conftest import datetime_in_past
 
 
@@ -29,39 +24,6 @@ def test_get_s3_file_makes_correct_call(notify_api, mocker):
         'foo-bucket',
         'bar-file.txt'
     )
-
-
-def test_get_s3_bucket_objects_make_correct_pagination_call(notify_api, mocker):
-    paginator_mock = mocker.patch('app.aws.s3.client')
-
-    get_s3_bucket_objects('foo-bucket', subfolder='bar')
-
-    paginator_mock.assert_has_calls([
-        call().get_paginator().paginate(Bucket='foo-bucket', Prefix='bar')
-    ])
-
-
-def test_get_s3_bucket_objects_builds_objects_list_from_paginator(notify_api, mocker):
-    AFTER_SEVEN_DAYS = datetime_in_past(days=8)
-    paginator_mock = mocker.patch('app.aws.s3.client')
-    multiple_pages_s3_object = [
-        {
-            "Contents": [
-                single_s3_object_stub('bar/foo.txt', AFTER_SEVEN_DAYS),
-            ]
-        },
-        {
-            "Contents": [
-                single_s3_object_stub('bar/foo1.txt', AFTER_SEVEN_DAYS),
-            ]
-        }
-    ]
-    paginator_mock.return_value.get_paginator.return_value.paginate.return_value = multiple_pages_s3_object
-
-    bucket_objects = get_s3_bucket_objects('foo-bucket', subfolder='bar')
-
-    assert len(bucket_objects) == 2
-    assert set(bucket_objects[0].keys()) == set(['ETag', 'Key', 'LastModified'])
 
 
 @freeze_time("2018-01-11 00:00:00")

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -10,7 +10,7 @@ from moto import mock_s3
 from app.letters.utils import (
     LetterPDFNotFound,
     ScanErrorType,
-    find_letter_pdf_filename,
+    find_letter_pdf_in_s3,
     generate_letter_pdf_filename,
     get_bucket_name_and_prefix_for_notification,
     get_folder_name,
@@ -49,7 +49,7 @@ def _sample_precompiled_letter_notification_using_test_key(sample_precompiled_le
 
 
 @mock_s3
-def test_find_letter_pdf_filename_returns_filename(sample_notification):
+def test_find_letter_pdf_in_s3_returns_object(sample_notification):
     bucket_name = current_app.config['LETTERS_PDF_BUCKET_NAME']
     s3 = boto3.client('s3', region_name='eu-west-1')
     s3.create_bucket(
@@ -60,11 +60,11 @@ def test_find_letter_pdf_filename_returns_filename(sample_notification):
     _, prefix = get_bucket_name_and_prefix_for_notification(sample_notification)
     s3.put_object(Bucket=bucket_name, Key=f'{prefix}-and-then-some', Body=b'f')
 
-    assert find_letter_pdf_filename(sample_notification) == f'{prefix}-and-then-some'
+    assert find_letter_pdf_in_s3(sample_notification).key == f'{prefix}-and-then-some'
 
 
 @mock_s3
-def test_find_letter_pdf_filename_raises_if_not_found(sample_notification):
+def test_find_letter_pdf_in_s3_raises_if_not_found(sample_notification):
     bucket_name = current_app.config['LETTERS_PDF_BUCKET_NAME']
     s3 = boto3.client('s3', region_name='eu-west-1')
     s3.create_bucket(
@@ -73,7 +73,7 @@ def test_find_letter_pdf_filename_raises_if_not_found(sample_notification):
     )
 
     with pytest.raises(LetterPDFNotFound):
-        find_letter_pdf_filename(sample_notification)
+        find_letter_pdf_in_s3(sample_notification)
 
 
 @pytest.mark.parametrize('created_at,folder', [


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176823265

Please see the commit messages for more details.

A couple of extra notes:

- This duplicates an existing precedent for getting files in S3 by prefix [1].
Unfortunately it would be quite hard to DRY up the new code, so I'm going to
leave it as-is unless someone feels strongly.

- While this makes it a moot point whether we remove the crown / non-crown part
of the filename, I still intent to pursue this in follow-up work, just so that we
have one less thing to remember the meaning of.

- This makes additional use of S3, so warrants a bit of performance testing just
to make sure there's no unexpected impact from the change. I'll do that before
merging the PR.

[1]: https://github.com/alphagov/notifications-api/blob/6db9a7a2f2b7d9ebb24cae7f8a976f6eb42b3a88/app/letters/utils.py#L169