### PR TITLE
Run 'test-requirements' as part of 'make test'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ generate-version-file: ## Generates the app version file
 	@echo -e "__git_commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"" > ${APP_VERSION_FILE}
 
 .PHONY: test
-test: generate-version-file ## Run tests
+test: test-requirements ## Run tests
 	./scripts/run_tests.sh
 
 .PHONY: freeze-requirements


### PR DESCRIPTION
This is consistent with our other apps [1]. Although it won't get
picked up by CI just yet [2], we can still benefit from it locally.

[1]: https://github.com/alphagov/document-download-api/blob/master/Makefile#L25
[2]: https://github.com/alphagov/notifications-manuals/issues/9