### PR TITLE
Bump lxml for security vulnerability

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -24,7 +24,7 @@ strict-rfc3339==0.7
 rfc3987==1.3.8
 cachetools==4.2.1
 beautifulsoup4==4.9.3
-lxml==4.6.2
+lxml==4.6.3
 # higher version causes build to fail on PaaS due to lack of Rust
 # see https://github.com/pyca/cryptography/issues/5810
 cryptography<3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ strict-rfc3339==0.7
 rfc3987==1.3.8
 cachetools==4.2.1
 beautifulsoup4==4.9.3
-lxml==4.6.2
+lxml==4.6.3
 # higher version causes build to fail on PaaS due to lack of Rust
 # see https://github.com/pyca/cryptography/issues/5810
 cryptography<3.4
@@ -43,18 +43,18 @@ prometheus-client==0.9.0
 gds-metrics==0.2.4
 
 ## The following requirements were added by pip freeze:
-alembic==1.5.6
+alembic==1.5.8
 amqp==1.4.9
 anyjson==0.3.3
 attrs==20.3.0
-awscli==1.19.22
+awscli==1.19.35
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.3.0
 blinker==1.4
 boto==2.49.0
-boto3==1.17.22
-botocore==1.20.22
+boto3==1.17.35
+botocore==1.20.35
 certifi==2020.12.5
 chardet==4.0.0
 click==7.1.2
@@ -66,7 +66,6 @@ geojson==2.5.0
 govuk-bank-holidays==0.8
 greenlet==1.0.0
 idna==2.10
-importlib-metadata==3.7.2
 Jinja2==2.11.3
 jmespath==0.10.0
 kombu==3.0.37
@@ -75,7 +74,7 @@ MarkupSafe==1.1.1
 mistune==0.8.4
 orderedset==2.0.3
 packaging==20.9
-phonenumbers==8.12.19
+phonenumbers==8.12.20
 pyasn1==0.4.8
 pycparser==2.20
 pyparsing==2.4.7
@@ -89,14 +88,12 @@ PyYAML==5.4.1
 redis==3.5.3
 requests==2.25.1
 rsa==4.7.2
-s3transfer==0.3.4
+s3transfer==0.3.6
 Shapely==1.7.1
 six==1.15.0
 smartypants==2.0.1
-soupsieve==2.2
+soupsieve==2.2.1
 statsd==3.3.0
-typing-extensions==3.7.4.3
-urllib3==1.26.3
+urllib3==1.26.4
 webencodings==0.5.1
 Werkzeug==1.0.1
-zipp==3.4.1


### PR DESCRIPTION
This bumps lxml to version 4.6.3 because version 4.6.2 had a vulnerability (https://lxml.de/4.6/changes-4.6.3.html).