### PR TITLE
Reduce max concurrent 2 factor codes

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -146,7 +146,7 @@ class Config(object):
     API_PAGE_SIZE = 250
     TEST_MESSAGE_FILENAME = 'Test message'
     ONE_OFF_MESSAGE_FILENAME = 'Report'
-    MAX_VERIFY_CODE_COUNT = 10
+    MAX_VERIFY_CODE_COUNT = 5
 
     # be careful increasing this size without being sure that we won't see slowness in pysftp
     MAX_LETTER_PDF_ZIP_FILESIZE = 40 * 1024 * 1024  # 40mb


### PR DESCRIPTION
I was doing some analysis and saw that in the last 24 hours the most codes that anyone had was in a 15 minute window was 3:

![image](https://user-images.githubusercontent.com/355079/112338570-cf03c780-8cb6-11eb-87fd-e21bda372a2f.png)

So I think we can safely reduce this to 5 to get a bit more security with enough headroom to not have any negative impact to the user.