### PR TITLE
Remove the emergency alerts canary

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -1,4 +1,3 @@
-import uuid
 from datetime import datetime, timedelta
 
 from flask import current_app
@@ -6,7 +5,7 @@ from notifications_utils.statsd_decorators import statsd
 from sqlalchemy import between
 from sqlalchemy.exc import SQLAlchemyError
 
-from app import cbc_proxy_client, notify_celery, zendesk_client
+from app import notify_celery, zendesk_client
 from app.celery.broadcast_message_tasks import trigger_link_test
 from app.celery.letters_pdf_tasks import get_pdf_for_templated_letter
 from app.celery.tasks import (
@@ -314,15 +313,6 @@ def check_for_services_with_high_failure_rates_or_sending_to_tv_numbers():
                 message=message,
                 ticket_type=zendesk_client.TYPE_INCIDENT
             )
-
-
-@notify_celery.task(name='send-canary-to-cbc-proxy')
-def send_canary_to_cbc_proxy():
-    if current_app.config['CBC_PROXY_ENABLED']:
-        identifier = str(uuid.uuid4())
-        message = f"Sending a canary message to CBC proxy with ID {identifier}"
-        current_app.logger.info(message)
-        cbc_proxy_client.get_proxy('canary').send_canary(identifier)
 
 
 @notify_celery.task(name='trigger-link-tests')

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -48,7 +48,6 @@ class CBCProxyClient:
 
     def get_proxy(self, provider):
         proxy_classes = {
-            'canary': CBCProxyCanary,
             BroadcastProvider.EE: CBCProxyEE,
             BroadcastProvider.THREE: CBCProxyThree,
             BroadcastProvider.O2: CBCProxyO2,
@@ -80,12 +79,6 @@ class CBCProxyClientBase(ABC):
 
     def __init__(self, lambda_client):
         self._lambda_client = lambda_client
-
-    def send_canary(
-        self,
-        identifier,
-    ):
-        pass
 
     def send_link_test(
         self,
@@ -160,26 +153,6 @@ class CBCProxyClientBase(ABC):
         if non_gsm_characters(content):
             return self.LANGUAGE_WELSH
         return self.LANGUAGE_ENGLISH
-
-
-class CBCProxyCanary(CBCProxyClientBase):
-    """
-    The canary is a lambda which tests notify's connectivity to the Cell Broadcast AWS infrastructure. It calls the
-    canary, a specific lambda that does not open a vpn or connect to a provider but just responds from within AWS.
-    """
-    lambda_name = 'canary'
-    # we don't need a failover lambda for the canary as it doesn't actually make calls out to a CBC
-    # so we just reuse the normal one in case of a failover scenario
-    failover_lambda_name = 'canary'
-
-    LANGUAGE_ENGLISH = None
-    LANGUAGE_WELSH = None
-
-    def send_canary(
-        self,
-        identifier,
-    ):
-        self._invoke_lambda(self.lambda_name, payload={'identifier': identifier})
 
 
 class CBCProxyOne2ManyClient(CBCProxyClientBase):

--- a/app/config.py
+++ b/app/config.py
@@ -317,11 +317,6 @@ class Config(object):
             'schedule': crontab(hour=23, minute=00),
             'options': {'queue': QueueNames.PERIODIC}
         },
-        'send-canary-to-cbc-proxy': {
-            'task': 'send-canary-to-cbc-proxy',
-            'schedule': timedelta(minutes=5),
-            'options': {'queue': QueueNames.PERIODIC}
-        },
         'trigger-link-tests': {
             'task': 'trigger-link-tests',
             'schedule': timedelta(minutes=15),

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -1,4 +1,3 @@
-import uuid
 from collections import namedtuple
 from datetime import datetime, timedelta
 from unittest.mock import call
@@ -598,39 +597,6 @@ def test_check_for_services_with_high_failure_rates_or_sending_to_tv_numbers(
         subject="[test] High failure rates for sms spotted for services",
         ticket_type='incident'
     )
-
-
-def test_send_canary_to_cbc_proxy_invokes_cbc_proxy_client(
-    mocker,
-    notify_api
-):
-    mock_send_canary = mocker.patch(
-        'app.clients.cbc_proxy.CBCProxyCanary.send_canary',
-    )
-
-    scheduled_tasks.send_canary_to_cbc_proxy()
-
-    assert mock_send_canary.called is True
-    # the 0th argument of the call to send_canary
-    identifier = mock_send_canary.mock_calls[0][1][0]
-
-    try:
-        uuid.UUID(identifier)
-    except BaseException:
-        pytest.fail(f"{identifier} is not a valid uuid")
-
-
-def test_send_canary_to_cbc_proxy_does_nothing_if_cbc_proxy_disabled(
-    mocker, notify_api
-):
-    mock_send_canary = mocker.patch(
-        'app.clients.cbc_proxy.CBCProxyCanary.send_canary',
-    )
-
-    with set_config(notify_api, 'CBC_PROXY_ENABLED', False):
-        scheduled_tasks.send_canary_to_cbc_proxy()
-
-    assert mock_send_canary.called is False
 
 
 def test_trigger_link_tests_calls_for_all_providers(


### PR DESCRIPTION
See https://github.com/alphagov/notifications-broadcasts-infra/pull/197
for why we no longer need this and we get to delete some code!