### PR TITLE
Bump utils to allow double hyphens in email address domain

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -34,7 +34,7 @@ notifications-python-client==6.0.2
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@43.9.1#egg=notifications-utils==43.9.1
+git+https://github.com/alphagov/notifications-utils.git@44.1.0#egg=notifications-utils==44.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ notifications-python-client==6.0.2
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@43.9.1#egg=notifications-utils==43.9.1
+git+https://github.com/alphagov/notifications-utils.git@44.1.0#egg=notifications-utils==44.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.9.0
@@ -47,14 +47,14 @@ alembic==1.5.8
 amqp==1.4.9
 anyjson==0.3.3
 attrs==20.3.0
-awscli==1.19.36
+awscli==1.19.39
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.3.0
 blinker==1.4
 boto==2.49.0
-boto3==1.17.36
-botocore==1.20.36
+boto3==1.17.39
+botocore==1.20.39
 certifi==2020.12.5
 chardet==4.0.0
 click==7.1.2
@@ -66,7 +66,6 @@ geojson==2.5.0
 govuk-bank-holidays==0.8
 greenlet==1.0.0
 idna==2.10
-importlib-metadata==3.7.3
 Jinja2==2.11.3
 jmespath==0.10.0
 kombu==3.0.37
@@ -95,8 +94,6 @@ six==1.15.0
 smartypants==2.0.1
 soupsieve==2.2.1
 statsd==3.3.0
-typing-extensions==3.7.4.3
 urllib3==1.26.4
 webencodings==0.5.1
 Werkzeug==1.0.1
-zipp==3.4.1


### PR DESCRIPTION
It was requested by our user and it is an allowed domain format with Amazon SES, so we started allowing it in our validation.

Utils PR: https://github.com/alphagov/notifications-utils/pull/855 (merged)