### PR TITLE
Migrate towards new metrics for Celery tasks

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -110,7 +110,7 @@ def create_app(application):
     email_clients = [aws_ses_stub_client] if application.config['SES_STUB_URL'] else [aws_ses_client]
     notification_provider_clients.init_app(sms_clients=[firetext_client, mmg_client], email_clients=email_clients)
 
-    notify_celery.init_app(application)
+    notify_celery.init_app(application, statsd_client)
     encryption.init_app(application)
     redis_store.init_app(application)
     document_download_client.init_app(application)

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -24,7 +24,7 @@ def make_task(app):
         start = None
 
         def on_success(self, retval, task_id, args, kwargs):
-            elapsed_time = time.time() - self.start
+            elapsed_time = time.monotonic() - self.start
             app.logger.info(
                 "{task_name} took {time}".format(
                     task_name=self.name, time="{0:.4f}".format(elapsed_time)
@@ -39,7 +39,7 @@ def make_task(app):
         def __call__(self, *args, **kwargs):
             # ensure task has flask context to access config, logger, etc
             with app.app_context():
-                self.start = time.time()
+                self.start = time.monotonic()
                 # Remove 'request_id' from the kwargs (so the task doesn't get an unexpected kwarg), then add it to g
                 # so that it gets logged
                 g.request_id = kwargs.pop('request_id', None)

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -8,7 +8,7 @@ pytest-env==0.6.2
 pytest-mock==3.3.1
 pytest-cov==2.10.1
 pytest-xdist==2.1.0
-freezegun==1.0.0
+freezegun==1.1.0
 requests-mock==1.8.0
 # used for creating manifest file locally
 jinja2-cli[yaml]==0.7.0

--- a/tests/app/celery/test_celery.py
+++ b/tests/app/celery/test_celery.py
@@ -1,0 +1,76 @@
+import uuid
+
+import pytest
+from freezegun import freeze_time
+
+from app import notify_celery
+
+
+@pytest.fixture(scope='session')
+def celery_task():
+    @notify_celery.task(name=uuid.uuid4(), base=notify_celery.task_cls)
+    def test_task(delivery_info=None): pass
+    return test_task
+
+
+@pytest.fixture
+def async_task(celery_task):
+    celery_task.push_request(delivery_info={'routing_key': 'test-queue'})
+    yield celery_task
+    celery_task.pop_request()
+
+
+def test_success_should_log_and_call_statsd(mocker, notify_api, async_task):
+    statsd = mocker.patch.object(notify_api.statsd_client, 'timing')
+    logger = mocker.patch.object(notify_api.logger, 'info')
+
+    with freeze_time() as frozen:
+        async_task()
+        frozen.tick(5)
+
+        async_task.on_success(
+            retval=None, task_id=1234, args=[], kwargs={}
+        )
+
+    statsd.assert_called_once_with(f'celery.test-queue.{async_task.name}.success', 5.0)
+    logger.assert_called_once_with(f'Celery task {async_task.name} (queue: test-queue) took 5.0000')
+
+
+def test_success_queue_when_applied_synchronously(mocker, notify_api, celery_task):
+    statsd = mocker.patch.object(notify_api.statsd_client, 'timing')
+    logger = mocker.patch.object(notify_api.logger, 'info')
+
+    with freeze_time() as frozen:
+        celery_task()
+        frozen.tick(5)
+
+        celery_task.on_success(
+            retval=None, task_id=1234, args=[], kwargs={}
+        )
+
+    statsd.assert_called_once_with(f'celery.none.{celery_task.name}.success', 5.0)
+    logger.assert_called_once_with(f'Celery task {celery_task.name} (queue: none) took 5.0000')
+
+
+def test_failure_should_log_and_call_statsd(mocker, notify_api, async_task):
+    statsd = mocker.patch.object(notify_api.statsd_client, 'incr')
+    logger = mocker.patch.object(notify_api.logger, 'exception')
+
+    async_task.on_failure(
+        exc=Exception, task_id=1234, args=[], kwargs={}, einfo=None
+    )
+
+    statsd.assert_called_once_with(f'celery.test-queue.{async_task.name}.failure')
+    logger.assert_called_once_with(f'Celery task {async_task.name} (queue: test-queue) failed')
+
+
+def test_failure_queue_when_applied_synchronously(mocker, notify_api, celery_task):
+    statsd = mocker.patch.object(notify_api.statsd_client, 'incr')
+    logger = mocker.patch.object(notify_api.logger, 'exception')
+
+    celery_task.on_failure(
+        exc=Exception, task_id=1234, args=[], kwargs={}, einfo=None
+    )
+
+    statsd.assert_called_once_with(f'celery.none.{celery_task.name}.failure')
+    logger.assert_called_once_with(f'Celery task {celery_task.name} (queue: none) failed')


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176261229

This adds code to send a new set of StatsD metrics about Celery tasks,
which will replace the existing stats when we have enough data.

The new metrics require less code to implement, are more consistent with
our logging approach, and contain more useful dimensions for filtering.

If the approach here is successful, we can duplicate it in the Antivirus
and Template Preview apps, which have a similar superclass for Celery tasks.

Please see the commit messages for more details.

Note: this will temporarily result in us sending roughly double the number
of datapoints to StatsD. This shouldn't cause a problem, as the data is sent
over UDP. I will do a quick test on Preview to check for any warning signs.