### PR TITLE
fix environment var checking

### DIFF
--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -112,7 +112,10 @@ def send_broadcast_event(broadcast_event_id):
 
     broadcast_event = dao_get_broadcast_event_by_id(broadcast_event_id)
 
-    if current_app.config['NOTIFY_ENVIRONMENT'] == 'live':
+    if (
+        current_app.config['NOTIFY_ENVIRONMENT'] == 'live' and
+        broadcast_event.message_type == BroadcastEventMessageType.ALERT
+    ):
         broadcast_message = broadcast_event.broadcast_message
         # raise a P1 to alert team that broadcast is going out.
         message = '\n'.join([

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -112,7 +112,7 @@ def send_broadcast_event(broadcast_event_id):
 
     broadcast_event = dao_get_broadcast_event_by_id(broadcast_event_id)
 
-    if current_app.config['NOTIFY_ENVIRONMENT'] == 'production':
+    if current_app.config['NOTIFY_ENVIRONMENT'] == 'live':
         broadcast_message = broadcast_event.broadcast_message
         # raise a P1 to alert team that broadcast is going out.
         message = '\n'.join([

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -137,6 +137,25 @@ def test_send_broadcast_event_creates_zendesk_p1(mocker, notify_api, sample_broa
     assert "Dear Sir/Madam" in zendesk_args['message']
 
 
+def test_send_broadcast_event_doesnt_p1_when_cancelling(mocker, notify_api, sample_broadcast_service):
+    template = create_template(sample_broadcast_service, BROADCAST_TYPE)
+    broadcast_message = create_broadcast_message(
+        template,
+        status=BroadcastStatusType.BROADCASTING,
+        areas={'areas': ['wd20-S13002775', 'wd20-S13002773'], 'simple_polygons': []},
+    )
+    create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.ALERT)
+    cancel_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.CANCEL)
+    mock_create_ticket = mocker.patch("app.celery.broadcast_message_tasks.zendesk_client.create_ticket")
+
+    mocker.patch('app.celery.broadcast_message_tasks.send_broadcast_provider_message')
+
+    with set_config(notify_api, 'NOTIFY_ENVIRONMENT', 'live'):
+        send_broadcast_event(cancel_event.id)
+
+    assert mock_create_ticket.called is False
+
+
 def test_send_broadcast_event_doesnt_create_zendesk_on_staging(mocker, notify_api, sample_broadcast_service):
     template = create_template(sample_broadcast_service, BROADCAST_TYPE)
     broadcast_message = create_broadcast_message(template, status=BroadcastStatusType.BROADCASTING)

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -122,7 +122,7 @@ def test_send_broadcast_event_creates_zendesk_p1(mocker, notify_api, sample_broa
 
     mocker.patch('app.celery.broadcast_message_tasks.send_broadcast_provider_message')
 
-    with set_config(notify_api, 'NOTIFY_ENVIRONMENT', 'production'):
+    with set_config(notify_api, 'NOTIFY_ENVIRONMENT', 'live'):
         send_broadcast_event(event.id)
 
     assert mock_create_ticket.call_count == 1


### PR DESCRIPTION
# look for 'live', not 'production

config['NOTIFY_ENVIRONMENT'] is hardcoded to `'live'` in the Live config class. The values as seen on the environment which we send real messages from:

```
>>> json.loads(os.environ['VCAP_APPLICATION'])['space_name']  # what cloudfoundry sets
'production'
>>> os.environ['NOTIFY_ENVIRONMENT']  # we set this from cloudfoundry
'production'
>>> current_app.config['NOTIFY_ENVIRONMENT']  # hardcoded in the Live config
'live'
>>> current_app.config['NOTIFICATION_QUEUE_PREFIX']  # pulled from env var of same name
'live'
>>> current_app.config['ENV']  # this is an unrelated flask variable
'production'
```

# only send zendesk P1 for alerts

we don't need to be re-notified when someone clicks cancel
