### PR TITLE
Remove redundant @statsd timing decorators

### DIFF
--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -2,7 +2,6 @@ import uuid
 from datetime import datetime
 
 from flask import current_app
-from notifications_utils.statsd_decorators import statsd
 from sqlalchemy.schema import Sequence
 
 from app import cbc_proxy_client, db, notify_celery, zendesk_client
@@ -104,7 +103,6 @@ def check_provider_message_should_send(broadcast_event, provider):
 
 
 @notify_celery.task(name="send-broadcast-event")
-@statsd(namespace="tasks")
 def send_broadcast_event(broadcast_event_id):
     if not current_app.config['CBC_PROXY_ENABLED']:
         current_app.logger.info(f'CBC Proxy disabled, not sending broadcast_event {broadcast_event_id}')
@@ -147,7 +145,6 @@ def send_broadcast_event(broadcast_event_id):
 
 # max_retries=None: retry forever
 @notify_celery.task(bind=True, name="send-broadcast-provider-message", max_retries=None)
-@statsd(namespace="tasks")
 def send_broadcast_provider_message(self, broadcast_event_id, provider):
     broadcast_event = dao_get_broadcast_event_by_id(broadcast_event_id)
 

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 
 import pytz
 from flask import current_app
-from notifications_utils.statsd_decorators import statsd
 from sqlalchemy import func
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -43,14 +42,12 @@ from app.utils import get_london_midnight_in_utc
 
 @notify_celery.task(name="remove_sms_email_jobs")
 @cronitor("remove_sms_email_jobs")
-@statsd(namespace="tasks")
 def remove_sms_email_csv_files():
     _remove_csv_files([EMAIL_TYPE, SMS_TYPE])
 
 
 @notify_celery.task(name="remove_letter_jobs")
 @cronitor("remove_letter_jobs")
-@statsd(namespace="tasks")
 def remove_letter_csv_files():
     _remove_csv_files([LETTER_TYPE])
 
@@ -64,7 +61,6 @@ def _remove_csv_files(job_types):
 
 
 @notify_celery.task(name="delete-notifications-older-than-retention")
-@statsd(namespace="tasks")
 def delete_notifications_older_than_retention():
     delete_email_notifications_older_than_retention()
     delete_sms_notifications_older_than_retention()
@@ -73,7 +69,6 @@ def delete_notifications_older_than_retention():
 
 @notify_celery.task(name="delete-sms-notifications")
 @cronitor("delete-sms-notifications")
-@statsd(namespace="tasks")
 def delete_sms_notifications_older_than_retention():
     try:
         start = datetime.utcnow()
@@ -93,7 +88,6 @@ def delete_sms_notifications_older_than_retention():
 
 @notify_celery.task(name="delete-email-notifications")
 @cronitor("delete-email-notifications")
-@statsd(namespace="tasks")
 def delete_email_notifications_older_than_retention():
     try:
         start = datetime.utcnow()
@@ -113,7 +107,6 @@ def delete_email_notifications_older_than_retention():
 
 @notify_celery.task(name="delete-letter-notifications")
 @cronitor("delete-letter-notifications")
-@statsd(namespace="tasks")
 def delete_letter_notifications_older_than_retention():
     try:
         start = datetime.utcnow()
@@ -133,7 +126,6 @@ def delete_letter_notifications_older_than_retention():
 
 @notify_celery.task(name='timeout-sending-notifications')
 @cronitor('timeout-sending-notifications')
-@statsd(namespace="tasks")
 def timeout_notifications():
     technical_failure_notifications, temporary_failure_notifications = \
         dao_timeout_notifications(current_app.config.get('SENDING_NOTIFICATIONS_TIMEOUT_PERIOD'))
@@ -158,7 +150,6 @@ def timeout_notifications():
 
 @notify_celery.task(name="delete-inbound-sms")
 @cronitor("delete-inbound-sms")
-@statsd(namespace="tasks")
 def delete_inbound_sms():
     try:
         start = datetime.utcnow()
@@ -177,7 +168,6 @@ def delete_inbound_sms():
 
 @notify_celery.task(name="raise-alert-if-letter-notifications-still-sending")
 @cronitor("raise-alert-if-letter-notifications-still-sending")
-@statsd(namespace="tasks")
 def raise_alert_if_letter_notifications_still_sending():
     still_sending_count, sent_date = get_letter_notifications_still_sending_when_they_shouldnt_be()
 
@@ -224,7 +214,6 @@ def get_letter_notifications_still_sending_when_they_shouldnt_be():
 
 @notify_celery.task(name='raise-alert-if-no-letter-ack-file')
 @cronitor('raise-alert-if-no-letter-ack-file')
-@statsd(namespace="tasks")
 def letter_raise_alert_if_no_ack_file_for_zip():
     # get a list of zip files since yesterday
     zip_file_set = set()
@@ -276,7 +265,6 @@ def letter_raise_alert_if_no_ack_file_for_zip():
 
 @notify_celery.task(name='save-daily-notification-processing-time')
 @cronitor("save-daily-notification-processing-time")
-@statsd(namespace="tasks")
 def save_daily_notification_processing_time(bst_date=None):
     # bst_date is a string in the format of "YYYY-MM-DD"
     if bst_date is None:

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 import iso8601
 from celery.exceptions import Retry
 from flask import current_app, json
-from notifications_utils.statsd_decorators import statsd
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import notify_celery, statsd_client
@@ -20,7 +19,6 @@ from app.notifications.notifications_ses_callback import (
 
 
 @notify_celery.task(bind=True, name="process-ses-result", max_retries=5, default_retry_delay=300)
-@statsd(namespace="tasks")
 def process_ses_results(self, response):
     try:
         ses_message = json.loads(response['Message'])

--- a/app/celery/process_sms_client_response_tasks.py
+++ b/app/celery/process_sms_client_response_tasks.py
@@ -2,7 +2,6 @@ import uuid
 from datetime import datetime
 
 from flask import current_app
-from notifications_utils.statsd_decorators import statsd
 from notifications_utils.template import SMSMessageTemplate
 
 from app import notify_celery, statsd_client
@@ -28,7 +27,6 @@ sms_response_mapper = {
 
 
 @notify_celery.task(bind=True, name="process-sms-client-response", max_retries=5, default_retry_delay=300)
-@statsd(namespace="tasks")
 def process_sms_client_response(self, status, provider_reference, client_name, detailed_status_code=None):
     # validate reference
     try:

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -1,5 +1,4 @@
 from flask import current_app
-from notifications_utils.statsd_decorators import statsd
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import notify_celery
@@ -15,7 +14,6 @@ from app.models import NOTIFICATION_TECHNICAL_FAILURE
 
 
 @notify_celery.task(bind=True, name="deliver_sms", max_retries=48, default_retry_delay=300)
-@statsd(namespace="tasks")
 def deliver_sms(self, notification_id):
     try:
         current_app.logger.info("Start sending SMS for notification id: {}".format(notification_id))
@@ -46,7 +44,6 @@ def deliver_sms(self, notification_id):
 
 
 @notify_celery.task(bind=True, name="deliver_email", max_retries=48, default_retry_delay=300)
-@statsd(namespace="tasks")
 def deliver_email(self, notification_id):
     try:
         current_app.logger.info("Start sending email for notification id: {}".format(notification_id))

--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 
 from flask import current_app
-from notifications_utils.statsd_decorators import statsd
 from notifications_utils.timezones import convert_utc_to_bst
 
 from app import notify_celery
@@ -20,7 +19,6 @@ from app.models import EMAIL_TYPE, LETTER_TYPE, SMS_TYPE
 
 @notify_celery.task(name="create-nightly-billing")
 @cronitor("create-nightly-billing")
-@statsd(namespace="tasks")
 def create_nightly_billing(day_start=None):
     current_app.logger.info("create-nightly-billing task: started")
     # day_start is a datetime.date() object. e.g.
@@ -43,7 +41,6 @@ def create_nightly_billing(day_start=None):
 
 
 @notify_celery.task(name="create-nightly-billing-for-day")
-@statsd(namespace="tasks")
 def create_nightly_billing_for_day(process_day):
     process_day = datetime.strptime(process_day, "%Y-%m-%d").date()
     current_app.logger.info(
@@ -69,7 +66,6 @@ def create_nightly_billing_for_day(process_day):
 
 @notify_celery.task(name="create-nightly-notification-status")
 @cronitor("create-nightly-notification-status")
-@statsd(namespace="tasks")
 def create_nightly_notification_status():
     current_app.logger.info("create-nightly-notification-status task: started")
     yesterday = convert_utc_to_bst(datetime.utcnow()).date() - timedelta(days=1)
@@ -100,7 +96,6 @@ def create_nightly_notification_status():
 
 
 @notify_celery.task(name="create-nightly-notification-status-for-day")
-@statsd(namespace="tasks")
 def create_nightly_notification_status_for_day(process_day, notification_type):
     process_day = datetime.strptime(process_day, "%Y-%m-%d").date()
     current_app.logger.info(

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 
 from flask import current_app
-from notifications_utils.statsd_decorators import statsd
 from sqlalchemy import between
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -55,7 +54,6 @@ from app.notifications.process_notifications import send_notification_to_queue
 
 
 @notify_celery.task(name="run-scheduled-jobs")
-@statsd(namespace="tasks")
 def run_scheduled_jobs():
     try:
         for job in dao_set_scheduled_jobs_to_pending():
@@ -67,7 +65,6 @@ def run_scheduled_jobs():
 
 
 @notify_celery.task(name="delete-verify-codes")
-@statsd(namespace="tasks")
 def delete_verify_codes():
     try:
         start = datetime.utcnow()
@@ -81,7 +78,6 @@ def delete_verify_codes():
 
 
 @notify_celery.task(name="delete-invitations")
-@statsd(namespace="tasks")
 def delete_invitations():
     try:
         start = datetime.utcnow()
@@ -96,7 +92,6 @@ def delete_invitations():
 
 
 @notify_celery.task(name='switch-current-sms-provider-on-slow-delivery')
-@statsd(namespace="tasks")
 def switch_current_sms_provider_on_slow_delivery():
     """
     Reduce provider's priority if at least 30% of notifications took more than four minutes to be delivered
@@ -119,13 +114,11 @@ def switch_current_sms_provider_on_slow_delivery():
 
 
 @notify_celery.task(name='tend-providers-back-to-middle')
-@statsd(namespace='tasks')
 def tend_providers_back_to_middle():
     dao_adjust_provider_priority_back_to_resting_points()
 
 
 @notify_celery.task(name='check-job-status')
-@statsd(namespace="tasks")
 def check_job_status():
     """
     every x minutes do this check
@@ -175,7 +168,6 @@ def check_job_status():
 
 
 @notify_celery.task(name='replay-created-notifications')
-@statsd(namespace="tasks")
 def replay_created_notifications():
     # if the notification has not be send after 1 hour, then try to resend.
     resend_created_notifications_older_than = (60 * 60)
@@ -209,7 +201,6 @@ def replay_created_notifications():
 
 
 @notify_celery.task(name='check-if-letters-still-pending-virus-check')
-@statsd(namespace="tasks")
 def check_if_letters_still_pending_virus_check():
     letters = dao_precompiled_letters_still_pending_virus_check()
 
@@ -231,7 +222,6 @@ def check_if_letters_still_pending_virus_check():
 
 
 @notify_celery.task(name='check-if-letters-still-in-created')
-@statsd(namespace="tasks")
 def check_if_letters_still_in_created():
     letters = dao_old_letters_with_created_status()
 
@@ -268,7 +258,6 @@ def check_for_missing_rows_in_completed_jobs():
 
 
 @notify_celery.task(name='check-for-services-with-high-failure-rates-or-sending-to-tv-numbers')
-@statsd(namespace="tasks")
 def check_for_services_with_high_failure_rates_or_sending_to_tv_numbers():
     start_date = (datetime.utcnow() - timedelta(days=1))
     end_date = datetime.utcnow()

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -1,7 +1,6 @@
 import json
 
 from flask import current_app
-from notifications_utils.statsd_decorators import statsd
 from requests import HTTPError, RequestException, request
 
 from app import encryption, notify_celery
@@ -10,7 +9,6 @@ from app.utils import DATETIME_FORMAT
 
 
 @notify_celery.task(bind=True, name="send-delivery-status", max_retries=5, default_retry_delay=300)
-@statsd(namespace="tasks")
 def send_delivery_status_to_service(
     self, notification_id, encrypted_status_update
 ):
@@ -39,7 +37,6 @@ def send_delivery_status_to_service(
 
 
 @notify_celery.task(bind=True, name="send-complaint", max_retries=5, default_retry_delay=300)
-@statsd(namespace="tasks")
 def send_complaint_to_service(self, complaint_data):
     complaint = encryption.decrypt(complaint_data)
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176261229

These are superseded by timing task execution generically in the
NotifyTask superclass [1]. Note that we need to wait until we've
gathered enough data under the new metrics before removing these.

[1]: https://github.com/alphagov/notifications-api/pull/3201#pullrequestreview-633549376