### PR TITLE
Broadcast envars

### DIFF
--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -106,10 +106,6 @@ def check_provider_message_should_send(broadcast_event, provider):
 @notify_celery.task(name="send-broadcast-event")
 @statsd(namespace="tasks")
 def send_broadcast_event(broadcast_event_id):
-    if not current_app.config['CBC_PROXY_ENABLED']:
-        current_app.logger.info(f'CBC Proxy disabled, not sending broadcast_event {broadcast_event_id}')
-        return
-
     broadcast_event = dao_get_broadcast_event_by_id(broadcast_event_id)
 
     if (
@@ -149,6 +145,13 @@ def send_broadcast_event(broadcast_event_id):
 @notify_celery.task(bind=True, name="send-broadcast-provider-message", max_retries=None)
 @statsd(namespace="tasks")
 def send_broadcast_provider_message(self, broadcast_event_id, provider):
+    if not current_app.config['CBC_PROXY_ENABLED']:
+        current_app.logger.info(
+            "CBC Proxy disabled, not sending broadcast_provider_message for "
+            f"broadcast_event_id {broadcast_event_id} with provider {provider}"
+        )
+        return
+
     broadcast_event = dao_get_broadcast_event_by_id(broadcast_event_id)
 
     check_provider_message_should_send(broadcast_event, provider)

--- a/app/config.py
+++ b/app/config.py
@@ -365,8 +365,6 @@ class Config(object):
 
     AWS_REGION = 'eu-west-1'
 
-    # CBC Proxy
-    # if the access keys are empty then noop client is used
     CBC_PROXY_AWS_ACCESS_KEY_ID = os.environ.get('CBC_PROXY_AWS_ACCESS_KEY_ID', '')
     CBC_PROXY_AWS_SECRET_ACCESS_KEY = os.environ.get('CBC_PROXY_AWS_SECRET_ACCESS_KEY', '')
 

--- a/app/config.py
+++ b/app/config.py
@@ -365,10 +365,9 @@ class Config(object):
 
     AWS_REGION = 'eu-west-1'
 
+    CBC_PROXY_ENABLED = True
     CBC_PROXY_AWS_ACCESS_KEY_ID = os.environ.get('CBC_PROXY_AWS_ACCESS_KEY_ID', '')
     CBC_PROXY_AWS_SECRET_ACCESS_KEY = os.environ.get('CBC_PROXY_AWS_SECRET_ACCESS_KEY', '')
-
-    CBC_PROXY_ENABLED = bool(CBC_PROXY_AWS_ACCESS_KEY_ID)
 
     ENABLED_CBCS = {BroadcastProvider.EE, BroadcastProvider.THREE, BroadcastProvider.O2, BroadcastProvider.VODAFONE}
 
@@ -419,6 +418,8 @@ class Development(Config):
     API_HOST_NAME = "http://localhost:6011"
     API_RATE_LIMIT_ENABLED = True
     DVLA_EMAIL_ADDRESSES = ['success@simulator.amazonses.com']
+
+    CBC_PROXY_ENABLED = False
 
 
 class Test(Development):

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -65,7 +65,9 @@
   'notify-delivery-worker-retry-tasks': {},
   'notify-delivery-worker-internal': {},
   'notify-delivery-worker-broadcasts': {
+    'additional_env_vars': {
       'CELERYD_PREFETCH_MULTIPLIER': 1,
+    }
   },
   'notify-delivery-worker-receipts': {},
   'notify-delivery-worker-service-callbacks': {'disk_quota': '2G'},

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -67,6 +67,8 @@
   'notify-delivery-worker-broadcasts': {
     'additional_env_vars': {
       'CELERYD_PREFETCH_MULTIPLIER': 1,
+      'CBC_PROXY_AWS_ACCESS_KEY_ID': CBC_PROXY_AWS_ACCESS_KEY_ID,
+      'CBC_PROXY_AWS_SECRET_ACCESS_KEY': CBC_PROXY_AWS_SECRET_ACCESS_KEY,
     }
   },
   'notify-delivery-worker-receipts': {},
@@ -126,11 +128,6 @@ applications:
       NOTIFICATION_QUEUE_PREFIX: '{{ NOTIFICATION_QUEUE_PREFIX }}'
       AWS_ACCESS_KEY_ID: '{{ AWS_ACCESS_KEY_ID }}'
       AWS_SECRET_ACCESS_KEY: '{{ AWS_SECRET_ACCESS_KEY }}'
-
-      {% if CBC_PROXY_AWS_ACCESS_KEY_ID is defined %}
-      CBC_PROXY_AWS_ACCESS_KEY_ID: '{{ CBC_PROXY_AWS_ACCESS_KEY_ID }}'
-      CBC_PROXY_AWS_SECRET_ACCESS_KEY: '{{ CBC_PROXY_AWS_SECRET_ACCESS_KEY }}'
-      {% endif %}
 
       STATSD_HOST: "notify-statsd-exporter-{{ environment }}.apps.internal"
 


### PR DESCRIPTION
Review commit by commit but the main problem this is solving is reducing the number of our API apps that have IAM creds for sending emergency alerts (only the broadcast worker needs them)