### PR TITLE
Add sms receipts app manifest config

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -40,6 +40,26 @@
     },
   },
 
+  'notify-api-sms-receipts': {
+    'NOTIFY_APP_NAME': 'api',
+    'disk_quota': '2G',
+    'additional_env_vars': {
+      'STATSD_HOST': None
+    },
+    'routes': {
+      'preview': ['api.notify.works/notifications/sms/mmg', 'api.notify.works/notifications/sms/firetext'],
+      'staging': ['api.staging-notify.works/notifications/sms/mmg', 'api.staging-notify.works/notifications/sms/firetext'],
+      'production': ['api.notifications.service.gov.uk/notifications/sms/mmg', 'api.notifications.service.gov.uk/notifications/sms/firetext'],
+    },
+    'health-check-type': 'port',
+    'health-check-invocation-timeout': 3,
+    'instances': {
+      'preview': 1,
+      'staging': 2,
+      'production': 10
+    },
+  },
+
   'notify-api-db-migration': {
     'NOTIFY_APP_NAME': 'api',
     'instances': {


### PR DESCRIPTION
This app will replace the `notify-api-sms-callbacks` app as it is an app
that handles receipts, not callbacks.

After this and the corresponding concourse PR is merged and deployed (at which
point we will have two apps sharing the traffic) we can then put in PRs
to remove the `notify-api-sms-callbacks` app.

There is a chance it could all be done as a single PR (or at least one
for the API and one for the concourse pipelines) but I'm playing it safe
and doing it as a very clear two step process just in case.

See https://github.com/alphagov/notifications-api/pull/2979 for context