### PR TITLE
Remove api-sms-callbacks app

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -20,26 +20,6 @@
     },
   },
 
-  'notify-api-sms-callbacks': {
-    'NOTIFY_APP_NAME': 'api',
-    'disk_quota': '2G',
-    'additional_env_vars': {
-      'STATSD_HOST': None
-    },
-    'routes': {
-      'preview': ['api.notify.works/notifications/sms/mmg', 'api.notify.works/notifications/sms/firetext'],
-      'staging': ['api.staging-notify.works/notifications/sms/mmg', 'api.staging-notify.works/notifications/sms/firetext'],
-      'production': ['api.notifications.service.gov.uk/notifications/sms/mmg', 'api.notifications.service.gov.uk/notifications/sms/firetext'],
-    },
-    'health-check-type': 'port',
-    'health-check-invocation-timeout': 3,
-    'instances': {
-      'preview': 1,
-      'staging': 2,
-      'production': 10
-    },
-  },
-
   'notify-api-sms-receipts': {
     'NOTIFY_APP_NAME': 'api',
     'disk_quota': '2G',


### PR DESCRIPTION
We no longer need this as it has been replaced by the api-sms-receipts
app which is the new app with the correct name but no functionality
change.