### PR TITLE
Set free allow to default if row is missing when calling GET

### DIFF
--- a/app/dao/annual_billing_dao.py
+++ b/app/dao/annual_billing_dao.py
@@ -102,7 +102,7 @@ def set_default_free_allowance_for_service(service, year_start=None):
                                 f"{default_free_sms_fragment_limits['other'][year_start]}")
         free_allowance = default_free_sms_fragment_limits['other'][year_start]
 
-    dao_create_or_update_annual_billing_for_year(
+    return dao_create_or_update_annual_billing_for_year(
         service.id,
         free_allowance,
         year_start


### PR DESCRIPTION
Simplify the get_free_sms_fragment limit for the case when the row is missing, by setting the free allowance to the default.