### PR TITLE
Enforce service suspension for broadcasts

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -176,6 +176,9 @@ def update_broadcast_message_status(service_id, broadcast_message_id):
     validate(data, update_broadcast_message_status_schema)
     broadcast_message = dao_get_broadcast_message_by_id_and_service_id(broadcast_message_id, service_id)
 
+    if not broadcast_message.service.active:
+        raise InvalidRequest("Updating broadcast message is not allowed: service is inactive ", 403)
+
     new_status = data['status']
     updating_user = get_user_by_id(data['created_by'])
 

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -62,6 +62,18 @@ def check_provider_message_should_send(broadcast_event, provider):
             f'to provider {provider}: the service is suspended'
         )
 
+    if broadcast_event.service.restricted:
+        raise BroadcastIntegrityError(
+            f'Cannot send broadcast_event {broadcast_event.id} ' +
+            f'to provider {provider}: the service is not live'
+        )
+
+    if broadcast_event.broadcast_message.stubbed:
+        raise BroadcastIntegrityError(
+            f'Cannot send broadcast_event {broadcast_event.id} ' +
+            f'to provider {provider}: the broadcast message is stubbed'
+        )
+
     current_provider_message = broadcast_event.get_provider_message(provider)
     # if this is the first time a task is being executed, it won't have a provider message yet
     if current_provider_message and current_provider_message.status != BroadcastProviderMessageStatus.SENDING:

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -5,10 +5,7 @@ from flask import current_app
 from sqlalchemy.schema import Sequence
 
 from app import cbc_proxy_client, db, notify_celery, zendesk_client
-from app.clients.cbc_proxy import (
-    CBCProxyFatalException,
-    CBCProxyRetryableException,
-)
+from app.clients.cbc_proxy import CBCProxyRetryableException
 from app.config import QueueNames
 from app.dao.broadcast_message_dao import (
     create_broadcast_provider_message,
@@ -21,6 +18,10 @@ from app.models import (
     BroadcastProviderMessageStatus,
 )
 from app.utils import format_sequential_number
+
+
+class BroadcastIntegrityError(Exception):
+    pass
 
 
 def get_retry_delay(retry_count):
@@ -58,16 +59,14 @@ def check_provider_message_should_send(broadcast_event, provider):
     current_provider_message = broadcast_event.get_provider_message(provider)
     # if this is the first time a task is being executed, it won't have a provider message yet
     if current_provider_message and current_provider_message.status != BroadcastProviderMessageStatus.SENDING:
-        raise CBCProxyFatalException(
+        raise BroadcastIntegrityError(
             f'Cannot send broadcast_event {broadcast_event.id} ' +
             f'to provider {provider}: ' +
             f'It is in status {current_provider_message.status}'
         )
 
     if broadcast_event.transmitted_finishes_at < datetime.utcnow():
-        # TODO: This should be a different kind of exception to distinguish "We should know something went wrong, but
-        # no immediate action" from "We need to fix this immediately"
-        raise CBCProxyFatalException(
+        raise BroadcastIntegrityError(
             f'Cannot send broadcast_event {broadcast_event.id} ' +
             f'to provider {provider}: ' +
             f'The expiry time of {broadcast_event.transmitted_finishes_at} has already passed'
@@ -83,7 +82,7 @@ def check_provider_message_should_send(broadcast_event, provider):
 
             # the previous message hasn't even got round to running `send_broadcast_provider_message` yet.
             if not prev_provider_message:
-                raise CBCProxyFatalException(
+                raise BroadcastIntegrityError(
                     f'Cannot send {broadcast_event.id}. Previous event {prev_event.id} ' +
                     f'(type {prev_event.message_type}) has no provider_message for provider {provider} yet.\n' +
                     'You must ensure that the other event sends succesfully, then manually kick off this event ' +
@@ -93,7 +92,7 @@ def check_provider_message_should_send(broadcast_event, provider):
             # if there's a previous message that has started but not finished sending (whether it fatally errored or is
             # currently retrying)
             if prev_provider_message.status != BroadcastProviderMessageStatus.ACK:
-                raise CBCProxyFatalException(
+                raise BroadcastIntegrityError(
                     f'Cannot send {broadcast_event.id}. Previous event {prev_event.id} ' +
                     f'(type {prev_event.message_type}) has not finished sending to provider {provider} yet.\n' +
                     f'It is currently in status "{prev_provider_message.status}".\n' +

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -56,6 +56,12 @@ def check_provider_message_should_send(broadcast_event, provider):
     4. If you need to re-send this task off again, you'll need to run the following command on paas:
        `send_broadcast_provider_message.apply_async(args=(broadcast_event_id, provider), queue=QueueNames.BROADCASTS)`
     """
+    if not broadcast_event.service.active:
+        raise BroadcastIntegrityError(
+            f'Cannot send broadcast_event {broadcast_event.id} ' +
+            f'to provider {provider}: the service is suspended'
+        )
+
     current_provider_message = broadcast_event.get_provider_message(provider)
     # if this is the first time a task is being executed, it won't have a provider message yet
     if current_provider_message and current_provider_message.status != BroadcastProviderMessageStatus.SENDING:

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -26,10 +26,6 @@ from app.utils import DATETIME_FORMAT, format_sequential_number
 #    the preceeding Alert message in the previous_provider_messages field
 
 
-class CBCProxyFatalException(Exception):
-    pass
-
-
 class CBCProxyRetryableException(Exception):
     pass
 

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -604,6 +604,22 @@ def test_update_broadcast_message_status_updates_details_but_does_not_queue_task
     assert len(mock_task.mock_calls) == 0
 
 
+def test_update_broadcast_message_status_aborts_if_service_is_suspended(
+    admin_request,
+    sample_broadcast_service,
+):
+    bm = create_broadcast_message(service=sample_broadcast_service, content='test')
+    sample_broadcast_service.active = False
+
+    admin_request.post(
+        'broadcast_message.update_broadcast_message_status',
+        _data={'status': BroadcastStatusType.BROADCASTING, 'created_by': str(uuid.uuid4())},
+        service_id=sample_broadcast_service.id,
+        broadcast_message_id=bm.id,
+        _expected_status=403
+    )
+
+
 def test_update_broadcast_message_status_creates_event_with_correct_content_if_broadcast_has_no_template(
     admin_request,
     sample_broadcast_service,

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -748,6 +748,31 @@ def test_check_provider_message_should_send_raises_if_service_is_suspended(
     assert 'service is suspended' in str(exc.value)
 
 
+def test_check_provider_message_should_send_raises_if_service_is_not_live(
+    sample_broadcast_service,
+):
+    sample_broadcast_service.restricted = True
+    broadcast_message = create_broadcast_message(service=sample_broadcast_service, content='test')
+    current_event = create_broadcast_event(broadcast_message, message_type='alert')
+
+    with pytest.raises(BroadcastIntegrityError) as exc:
+        check_provider_message_should_send(current_event, 'ee')
+
+    assert 'service is not live' in str(exc.value)
+
+
+def test_check_provider_message_should_send_raises_if_message_is_stubbed(
+    sample_template,
+):
+    broadcast_message = create_broadcast_message(sample_template, stubbed=True)
+    current_event = create_broadcast_event(broadcast_message, message_type='alert')
+
+    with pytest.raises(BroadcastIntegrityError) as exc:
+        check_provider_message_should_send(current_event, 'ee')
+
+    assert 'message is stubbed' in str(exc.value)
+
+
 def test_send_broadcast_provider_message_does_nothing_if_cbc_proxy_disabled(mocker, notify_api, sample_template):
     mock_proxy_client_getter = mocker.patch(
         'app.celery.broadcast_message_tasks.cbc_proxy_client',

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -735,6 +735,19 @@ def test_check_provider_message_should_send_raises_if_current_event_already_has_
     check_provider_message_should_send(current_event, 'ee')
 
 
+def test_check_provider_message_should_send_raises_if_service_is_suspended(
+    sample_broadcast_service,
+):
+    sample_broadcast_service.active = False
+    broadcast_message = create_broadcast_message(service=sample_broadcast_service, content='test')
+    current_event = create_broadcast_event(broadcast_message, message_type='alert')
+
+    with pytest.raises(BroadcastIntegrityError) as exc:
+        check_provider_message_should_send(current_event, 'ee')
+
+    assert 'service is suspended' in str(exc.value)
+
+
 def test_send_broadcast_provider_message_does_nothing_if_cbc_proxy_disabled(mocker, notify_api, sample_template):
     mock_proxy_client_getter = mocker.patch(
         'app.celery.broadcast_message_tasks.cbc_proxy_client',


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177758598

Note that this should be unnecessary, since:

- The API routes for broadcasts already have this protection [1][2].

- The Admin app prevents any action against a suspended service [3].

However, just like for jobs, we feel it's important to have a secondary layer
of checks for such a high impact action.

Please see the commit messages for more details.

[1]: https://github.com/alphagov/notifications-api/blob/3d71815956eb930a1683d47e60d8c4a53974fd32/app/__init__.py#L312
[2]: https://github.com/alphagov/notifications-api/blob/3d71815956eb930a1683d47e60d8c4a53974fd32/app/authentication/auth.py#L112
[3]: https://github.com/alphagov/notifications-admin/pull/3854/commits/63c597d540be7457ac5a489a3dcc99539e5c2ce6#diff-09dc9a05865349d00b85e381975b49e622d72d82a8fb17cbaeaba4594de0582aR408