### PR TITLE
Normalise broadcast content before validating length

### DIFF
--- a/app/broadcast_message/broadcast_message_schema.py
+++ b/app/broadcast_message/broadcast_message_schema.py
@@ -15,7 +15,7 @@ create_broadcast_message_schema = {
         'finishes_at': {'type': 'string', 'format': 'datetime'},
         'areas': {"type": "array", "items": {"type": "string"}},
         'simple_polygons': {"type": "array", "items": {"type": "array"}},
-        'content': {'type': 'string', 'minLength': 1, 'maxLength': 1395},
+        'content': {'type': 'string', 'minLength': 1},
         'reference': {'type': 'string', 'minLength': 1, 'maxLength': 255},
     },
     'required': ['service_id', 'created_by'],

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -731,14 +731,24 @@ def test_should_return_404_if_no_templates_for_service_with_id(client, sample_se
     assert json_resp['message'] == 'No result found'
 
 
-def test_create_400_for_over_limit_content(client, notify_api, sample_user, sample_service, fake_uuid):
+@pytest.mark.parametrize('template_type', (
+    SMS_TYPE, BROADCAST_TYPE,
+))
+def test_create_400_for_over_limit_content(
+    client,
+    notify_api,
+    sample_user,
+    fake_uuid,
+    template_type,
+):
+    sample_service = create_service(service_permissions=[template_type])
     content = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(SMS_CHAR_COUNT_LIMIT + 1))
     data = {
         'name': 'too big template',
-        'template_type': SMS_TYPE,
+        'template_type': template_type,
         'content': content,
         'service': str(sample_service.id),
-        'created_by': str(sample_user.id)
+        'created_by': str(sample_service.created_by.id)
     }
     data = json.dumps(data)
     auth_header = create_authorization_header()


### PR DESCRIPTION
This changes the content length validation of the internal API to match the validation of the public broadcast API<sup>1</sup>.

This removes the length check from JSONSchema, which isn’t sophisticated enough to deal with things like normalising newlines or handling different encodings.

The admin app should catch these errors before they’re raised here, but it’s best to be belt and braces.

It also adds a check for creating templates, similar to the existing one we have for SMS.

***

1. https://github.com/alphagov/notifications-api/blob/7ab0403ae7ab9c9a17b3fb6595c8c8d2f8b32cbb/app/v2/broadcast/post_broadcast.py#L53-L63