### PR TITLE
Warn about SMS failures when it's cost effective

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -274,7 +274,7 @@ def check_for_services_with_high_failure_rates_or_sending_to_tv_numbers():
             )
             message += "service: {} failure rate: {},\n".format(service_dashboard, service.permanent_failure_rate)
     elif services_sending_to_tv_numbers:
-        message += "{} service(s) have sent over 500 sms messages to tv numbers in last 24 hours:\n".format(
+        message += "{} service(s) have sent high volumes of sms messages to tv numbers in last 24 hours:\n".format(
             len(services_sending_to_tv_numbers)
         )
         for service in services_sending_to_tv_numbers:

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -542,7 +542,7 @@ def dao_fetch_active_users_for_service(service_id):
     return query.all()
 
 
-def dao_find_services_sending_to_tv_numbers(start_date, end_date, threshold=500):
+def dao_find_services_sending_to_tv_numbers(start_date, end_date, threshold=62_500):
     return db.session.query(
         Notification.service_id.label('service_id'),
         func.count(Notification.id).label('notification_count')
@@ -563,7 +563,7 @@ def dao_find_services_sending_to_tv_numbers(start_date, end_date, threshold=500)
     ).all()
 
 
-def dao_find_services_with_high_failure_rates(start_date, end_date, threshold=100):
+def dao_find_services_with_high_failure_rates(start_date, end_date, threshold=62_500):
     subquery = db.session.query(
         func.count(Notification.id).label('total_count'),
         Notification.service_id.label('service_id')

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -564,9 +564,9 @@ MockServicesWithHighFailureRate = namedtuple(
     ],
     [
         [],
-        [MockServicesSendingToTVNumbers("123", 300)],
-        "1 service(s) have sent over 500 sms messages to tv numbers in last 24 hours:\n"
-        "service: {}/services/{} count of sms to tv numbers: 300,\n".format(
+        [MockServicesSendingToTVNumbers("123", 63_000)],
+        "1 service(s) have sent high volumes of sms messages to tv numbers in last 24 hours:\n"
+        "service: {}/services/{} count of sms to tv numbers: 63000,\n".format(
             Config.ADMIN_BASE_URL, "123"
         )
     ]


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177908219

Previously we warned when as little as 100 SMS messages failed, which
equates to £1.60 in cost. This increases the absolute threshold so that
we avoid taking action when the cost in developer time is greater than
the money wasted. If it takes us an hour to solve the ticket, then that 
equates to roughly £100 in people costs.

In future, we should also consider simplifying this check to be about
permanent failures in general.