### PR TITLE
Make check-if-letters-still-in-created run at 7am

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -288,7 +288,7 @@ class Config(object):
         },
         'check-if-letters-still-in-created': {
             'task': 'check-if-letters-still-in-created',
-            'schedule': crontab(day_of_week='mon-fri', hour=9, minute=0),
+            'schedule': crontab(day_of_week='mon-fri', hour=7, minute=0),
             'options': {'queue': QueueNames.PERIODIC}
         },
         'check-if-letters-still-pending-virus-check': {


### PR DESCRIPTION
If this alert goes off in the morning, it usually means we need to do
something, ideally quite quickly as it indicates a potential problem
with the sending of letters over to DVLA the night before.

Given this goes off at 9am at the moment, but actually some people start
work earlier, if we alert at 7am it means it will likely be looked at
earlier in the day and we can potentially fix any problems with letters
sooner than later.