### PR TITLE
Add make help commands for commonly used tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,17 +22,17 @@ NOTIFY_CREDENTIALS ?= ~/.notify-credentials
 ## DEVELOPMENT
 
 .PHONY: bootstrap
-bootstrap: generate-version-file
+bootstrap: generate-version-file ## Set up everything to run the app
 	pip3 install -r requirements_for_test.txt
 	createdb notification_api || true
 	. environment.sh && flask db upgrade
 
 .PHONY: run-flask
-run-flask:
+run-flask: ## Run flask
 	. environment.sh && flask run -p 6011
 
 .PHONY: run-celery
-run-celery:
+run-celery: ## Run celery
 	. environment.sh && celery \
 		-A run_celery.notify_celery worker \
 		--pidfile="/tmp/celery.pid" \
@@ -40,7 +40,7 @@ run-celery:
 		--concurrency=4
 
 .PHONY: run-celery-beat
-run-celery-beat:
+run-celery-beat: ## Run celery beat
 	. environment.sh && celery \
 		-A run_celery.notify_celery beat \
 		--loglevel=INFO
@@ -167,7 +167,7 @@ check-if-migrations-to-run:
 	@echo $(shell python3 scripts/check_if_new_migration.py)
 
 .PHONY: cf-deploy-failwhale
-cf-deploy-failwhale:  #
+cf-deploy-failwhale:
 	$(if ${CF_SPACE},,$(error Must target space, eg `make preview cf-deploy-failwhale`))
 	cd ./paas-failwhale; cf push notify-api-failwhale -f manifest.yml
 


### PR DESCRIPTION
if you run `make help` or just `make` then you get a nice list of the
tasks that you can run (or at least, the ones with help text added to
them.

We were missing these for some of the key commands that a developer
would want to know about.

By adding help text to them, they will now show up in `make` or `make
help` and saves a developer needing to go either look in the README or
go look in the Makefile to figure out what commands are available.

Note, there is no particular convention around which commands have help
comments. I don't think we need to figure out this but at the least, the
ones which developers may want to run locally I think should show up.