### PR TITLE
Change letter zip file names for Insolvency Service letters

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -143,15 +143,17 @@ def collate_letter_pdfs_to_be_sent():
             filenames = [letter['Key'] for letter in letters]
 
             service_id = letters[0]['ServiceId']
+            organisation_id = letters[0]['OrganisationId']
 
             hash = urlsafe_b64encode(sha512(''.join(filenames).encode()).digest())[:20].decode()
             # eg NOTIFY.2018-12-31.001.Wjrui5nAvObjPd-3GEL-.ZIP
-            dvla_filename = 'NOTIFY.{date}.{postage}.{num:03}.{hash}.{service_id}.ZIP'.format(
+            dvla_filename = 'NOTIFY.{date}.{postage}.{num:03}.{hash}.{service_id}.{organisation_id}.ZIP'.format(
                 date=print_run_deadline.strftime("%Y-%m-%d"),
                 postage=RESOLVE_POSTAGE_FOR_FILE_NAME[postage],
                 num=i + 1,
                 hash=hash,
-                service_id=service_id
+                service_id=service_id,
+                organisation_id=organisation_id
             )
 
             current_app.logger.info(
@@ -236,7 +238,8 @@ def get_key_and_size_of_letters_to_be_sent_to_print(print_run_deadline, postage)
             yield {
                 "Key": letter_pdf.key,
                 "Size": letter_pdf.size,
-                "ServiceId": str(letter.service_id)
+                "ServiceId": str(letter.service_id),
+                "OrganisationId": str(letter.service.organisation_id)
             }
         except (BotoClientError, LetterPDFNotFound) as e:
             current_app.logger.exception(

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -750,9 +750,7 @@ def dao_get_letters_to_be_printed(print_run_deadline, postage, query_limit=10000
     https://docs.sqlalchemy.org/en/13/orm/query.html?highlight=yield_per#sqlalchemy.orm.query.Query.yield_per
     https://www.mail-archive.com/sqlalchemy@googlegroups.com/msg12443.html
     """
-    notifications = Notification.query.join(
-        Notification.service
-    ).filter(
+    notifications = Notification.query.filter(
         Notification.created_at < convert_bst_to_utc(print_run_deadline),
         Notification.notification_type == LETTER_TYPE,
         Notification.status == NOTIFICATION_CREATED,


### PR DESCRIPTION
DVLA would like to be able to identify letters sent by the Insolvency Service, so we are changing the zipfile name. They need all zipfile names to have the same structure, so we can't just add a marker to files sent by that service - we have to change all filenames.

The new format is like this: `{NOTIFY}.{DATE}.{SEQUENCE_ID}.{UNIQUE_ID}.{SERVICE_ID}.{ORG_NAME}.{EXTENSION}`

[Pivotal story](https://www.pivotaltracker.com/story/show/177644984)

_**Note**_
This change means that we now call `letter.service.organisation_id` (where `letter` is a `Notification`) for each letter, so we are now loading the service relationship. However, the alternative would be to make [this query](https://github.com/alphagov/notifications-api/blob/0161adca063ee58d2ee38b394a646e6afb8ebade/app/dao/notifications_dao.py#L738) return the organisation_id for the service. This would mean the code needs a bit of a rewrite elsewhere (since [this change](https://github.com/alphagov/notifications-api/pull/3172/commits/b43a367d5f3dc56cea89353ee807f0e0436625f3) required `dao_get_letters_to_be_printed` to return a Notification). We also have to be careful with modifiying `dao_get_letters_to_be_printed`, particularly when joins are involved (see [this commit](https://github.com/alphagov/notifications-api/commit/3bc3ed88b300d5648379b8380ff2f719d1abda30)).