### PR TITLE
Add a type table for broadcast providers

### DIFF
--- a/app/dao/broadcast_service_dao.py
+++ b/app/dao/broadcast_service_dao.py
@@ -64,7 +64,7 @@ def set_broadcast_service_type(service, service_mode, broadcast_channel, provide
     db.session.add(service)
 
 
-def insert_or_update_service_broadcast_settings(service, channel, provider_restriction=None):
+def insert_or_update_service_broadcast_settings(service, channel, provider_restriction="all"):
     if not service.service_broadcast_settings:
         settings = ServiceBroadcastSettings()
         settings.service = service

--- a/app/models.py
+++ b/app/models.py
@@ -560,7 +560,8 @@ class Service(db.Model, Versioned):
 
     def get_available_broadcast_providers(self):
         # There may be future checks here if we add, for example, platform admin level provider killswitches.
-        if self.allowed_broadcast_provider:
+        # NOTE: We are in the middle of changing the value for all allowed_broadcast_provider from `None`to "all"
+        if self.allowed_broadcast_provider and self.allowed_broadcast_provider != ALL_BROADCAST_PROVIDERS:
             return [x for x in current_app.config['ENABLED_CBCS'] if x == self.allowed_broadcast_provider]
         else:
             return current_app.config['ENABLED_CBCS']
@@ -2486,6 +2487,9 @@ class BroadcastProvider:
     O2 = 'o2'
 
     PROVIDERS = [EE, VODAFONE, THREE, O2]
+
+
+ALL_BROADCAST_PROVIDERS = 'all'
 
 
 class BroadcastProviderMessageStatus:

--- a/app/models.py
+++ b/app/models.py
@@ -2553,13 +2553,19 @@ class ServiceBroadcastSettings(db.Model):
     channel = db.Column(
         db.String(255), db.ForeignKey('broadcast_channel_types.name'), nullable=False
     )
-    provider = db.Column(db.String, nullable=True)
+    provider = db.Column(db.String, db.ForeignKey('broadcast_provider_types.name'), nullable=True)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
 
 
 class BroadcastChannelTypes(db.Model):
     __tablename__ = 'broadcast_channel_types'
+
+    name = db.Column(db.String(255), primary_key=True)
+
+
+class BroadcastProviderTypes(db.Model):
+    __tablename__ = 'broadcast_provider_types'
 
     name = db.Column(db.String(255), primary_key=True)
 

--- a/app/service/service_broadcast_settings_schema.py
+++ b/app/service/service_broadcast_settings_schema.py
@@ -6,7 +6,7 @@ service_broadcast_settings_schema = {
     "properties": {
         "broadcast_channel": {"enum": ["test", "severe"]},
         "service_mode": {"enum": ["training", "live"]},
-        "provider_restriction": {"enum": [None, "three", "o2", "vodafone", "ee"]}
+        "provider_restriction": {"enum": [None, "three", "o2", "vodafone", "ee", "all"]}
     },
     "required": ["broadcast_channel", "service_mode", "provider_restriction"]
 }

--- a/migrations/versions/0352_broadcast_provider_types.py
+++ b/migrations/versions/0352_broadcast_provider_types.py
@@ -1,0 +1,32 @@
+"""
+
+Revision ID: 0352_broadcast_provider_types
+Revises: 0351_unique_key_annual_billing
+Create Date: 2021-05-05 15:07:22.146657
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0352_broadcast_provider_types'
+down_revision = '0351_unique_key_annual_billing'
+
+PROVIDER_TYPES = ('ee', 'three', 'vodafone', 'o2', 'all')
+
+
+def upgrade():
+    op.create_table('broadcast_provider_types',
+                    sa.Column('name', sa.String(length=255), nullable=False),
+                    sa.PrimaryKeyConstraint('name'))
+    for provider in PROVIDER_TYPES:
+        op.execute(f"INSERT INTO broadcast_provider_types VALUES ('{provider}')")
+    op.create_foreign_key('service_broadcast_settings_provider_fkey',
+                          'service_broadcast_settings',
+                          'broadcast_provider_types',
+                          ['provider'],
+                          ['name'])
+
+
+def downgrade():
+    op.drop_constraint('service_broadcast_settings_provider_fkey', 'service_broadcast_settings', type_='foreignkey')
+    op.drop_table('broadcast_provider_types')

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -30,7 +30,14 @@ from tests.app.db import (
 from tests.conftest import set_config
 
 
-def test_send_broadcast_event_queues_up_for_active_providers(mocker, notify_api, sample_broadcast_service):
+@pytest.mark.parametrize('available_provider', [None, 'all'])
+def test_send_broadcast_event_queues_up_for_active_providers(
+    mocker,
+    notify_api,
+    sample_broadcast_service,
+    available_provider,
+):
+    sample_broadcast_service.allowed_broadcast_provider = available_provider
     template = create_template(sample_broadcast_service, BROADCAST_TYPE)
     broadcast_message = create_broadcast_message(template, status=BroadcastStatusType.BROADCASTING)
     event = create_broadcast_event(broadcast_message)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -290,6 +290,8 @@ def test_get_service_by_id(admin_request, sample_service):
 
 
 @pytest.mark.parametrize('broadcast_channel,allowed_broadcast_provider', (
+    ('test', 'all'),
+    ('severe', 'all'),
     ('test', None),
     ('severe', None),
     ('test', 'ee'),
@@ -4018,7 +4020,7 @@ def test_set_as_broadcast_service_rejects_if_no_service_mode(
     )
 
 
-@pytest.mark.parametrize('provider', [None, "three", "ee", "vodafone", "o2"])
+@pytest.mark.parametrize('provider', [None, "all", "three", "ee", "vodafone", "o2"])
 def test_set_as_broadcast_service_sets_mobile_provider_restriction(
     admin_request, sample_service, broadcast_organisation, provider
 ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,7 +120,8 @@ def notify_db_session(notify_db, sms_providers):
                             "broadcast_status_type",
                             "invite_status_type",
                             "service_callback_type",
-                            "broadcast_channel_types"]:
+                            "broadcast_channel_types",
+                            "broadcast_provider_types"]:
             notify_db.engine.execute(tbl.delete())
     notify_db.session.commit()
 


### PR DESCRIPTION
This adds a type table for broadcast providers, which is the pattern we
follow with our models (e.g. we have a `broadcast_channel_types` table).

As well as the four providers, the migration populates it with `all`
which is the value that will replace `null` in a later change.

It should be safe to add the foreign key constraint to the
`service_broadcast_settings` in the same migration since the column is
still nullable and we don't have data in that column that is not in the
types table.

Step one of [Pivotal story](https://www.pivotaltracker.com/story/show/177759863)