### PR TITLE
Increase warning threshold for SMS failures

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -563,7 +563,7 @@ def dao_find_services_sending_to_tv_numbers(start_date, end_date, threshold=500)
     ).all()
 
 
-def dao_find_services_with_high_failure_rates(start_date, end_date, threshold=100):
+def dao_find_services_with_high_failure_rates(start_date, end_date, threshold=1000):
     subquery = db.session.query(
         func.count(Notification.id).label('total_count'),
         Notification.service_id.label('service_id')


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177908219

Second attempt [1]. This increases the threshold so:

- It's a more substantial amount of money lost (£16).

- It's 10% of the minimum free allowance for a service.

- It's greater than the threshold we have for TV numbers (500).

Having a higher threshold for this alert will help prevent wasted
effort investigating more negligible failures, and reduces the
ambiguity of whether we should take action: we should.

[1]: https://github.com/alphagov/notifications-api/pull/3221