### PR TITLE
Add "government" as a broadcast channel type

### DIFF
--- a/app/service/service_broadcast_settings_schema.py
+++ b/app/service/service_broadcast_settings_schema.py
@@ -4,7 +4,7 @@ service_broadcast_settings_schema = {
     "type": "object",
     "title": "Set a services broadcast settings",
     "properties": {
-        "broadcast_channel": {"enum": ["test", "severe"]},
+        "broadcast_channel": {"enum": ["test", "severe", "government"]},
         "service_mode": {"enum": ["training", "live"]},
         "provider_restriction": {"enum": ["three", "o2", "vodafone", "ee", "all"]}
     },

--- a/migrations/versions/0354_government_channel.py
+++ b/migrations/versions/0354_government_channel.py
@@ -1,0 +1,22 @@
+"""
+
+Revision ID: 0354_government_channel
+Revises: 0353_broadcast_provider_not_null
+Create Date: 2021-05-11 16:17:12.479191
+
+"""
+from alembic import op
+
+revision = '0354_government_channel'
+down_revision = '0353_broadcast_provider_not_null'
+
+
+def upgrade():
+    op.execute("INSERT INTO broadcast_channel_types VALUES ('government')")
+
+
+def downgrade():
+    # This can't be downgraded if there are rows in service_broadcast_settings which
+    # have the channel set to government or if broadcasts have already been sent on the
+    # government channel - it would break foreign key constraints.
+    op.execute("DELETE FROM broadcast_channel_types WHERE name = 'government'")

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -221,7 +221,7 @@ def test_send_broadcast_provider_message_sends_data_correctly(
     ['o2', 'O2'],
     ['vodafone', 'Vodafone'],
 ])
-@pytest.mark.parametrize('channel', ['test', 'severe'])
+@pytest.mark.parametrize('channel', ['test', 'severe', 'government'])
 def test_send_broadcast_provider_message_uses_channel_set_on_broadcast_service(
     notify_db, mocker, sample_broadcast_service, provider, provider_capitalised, channel
 ):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -292,8 +292,10 @@ def test_get_service_by_id(admin_request, sample_service):
 @pytest.mark.parametrize('broadcast_channel,allowed_broadcast_provider', (
     ('test', 'all'),
     ('severe', 'all'),
+    ('government', 'all'),
     ('test', 'ee'),
     ('severe', 'three'),
+    ('government', 'vodafone'),
 ))
 def test_get_service_by_id_for_broadcast_service_returns_broadcast_keys(
     notify_db, admin_request, sample_broadcast_service, broadcast_channel, allowed_broadcast_provider
@@ -3709,7 +3711,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[4]['uploaded_letter_file_name'] == 'filename.pdf'
 
 
-@pytest.mark.parametrize('channel', ["test", "severe"])
+@pytest.mark.parametrize('channel', ["test", "severe", "government"])
 def test_set_as_broadcast_service_sets_broadcast_channel(
     admin_request, sample_service, broadcast_organisation, channel
 ):
@@ -3759,7 +3761,7 @@ def test_set_as_broadcast_service_updates_channel_for_broadcast_service(
     assert records[0].channel == "test"
 
 
-@pytest.mark.parametrize('channel', ["government", "extreme", "exercise", "random", ""])
+@pytest.mark.parametrize('channel', ["extreme", "exercise", "random", ""])
 def test_set_as_broadcast_service_rejects_unknown_channels(
     admin_request, sample_service, broadcast_organisation, channel
 ):


### PR DESCRIPTION
This adds "government" to the broadcast_channel_types table. It also adds it to the service_broadcast_settings_schema so that notifications-admin can pass through a value of "government". We don't have any logic around the value of service.broadcast_channel, so no updates are needed to the tasks etc.

[Pivotal story](https://www.pivotaltracker.com/story/show/178110633)