### PR TITLE
Add splunk service

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -103,6 +103,7 @@ applications:
       - logit-ssl-syslog-drain
       {% if CF_APP == 'notify-api' %}
       - notify-prometheus
+      - notify-splunk
       {% endif %}
 
     env:


### PR DESCRIPTION
This will allow shipping app and router logs to splunk[1]

This is only bound on the API because we're only interested in
paas router logs for the time being

1: https://github.com/alphagov/paas-csls-splunk-broker/blob/main/docs/user-guide.md

Same as alphagov/notifications-admin#3888