### PR TITLE
Update the dao_fetch_todays_stats_for_service query.

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -431,10 +431,8 @@ def dao_fetch_stats_for_service(service_id, limit_days):
 def dao_fetch_todays_stats_for_service(service_id):
     today = date.today()
     start_date = get_london_midnight_in_utc(today)
-    end_date = get_london_midnight_in_utc(today + timedelta(days=1))
     return _stats_for_service_query(service_id).filter(
-        Notification.created_at >= start_date,
-        Notification.created_at < end_date
+        Notification.created_at >= start_date
     ).all()
 
 

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -429,8 +429,12 @@ def dao_fetch_stats_for_service(service_id, limit_days):
 
 
 def dao_fetch_todays_stats_for_service(service_id):
+    today = date.today()
+    start_date = get_london_midnight_in_utc(today)
+    end_date = get_london_midnight_in_utc(today + timedelta(days=1))
     return _stats_for_service_query(service_id).filter(
-        func.date(Notification.created_at) == date.today()
+        Notification.created_at >= start_date,
+        Notification.created_at < end_date
     ).all()
 
 


### PR DESCRIPTION
We have an index on Notifications(service_id, created_at), by updating the query to use between created_at rather than date(created_at) this query will use the index. See the commit message for details about the query plan. 

This query is still rather slow but is improved by this update.

https://www.pivotaltracker.com/story/show/178263480

We can try to revert https://github.com/alphagov/notifications-admin/pull/3895 once this is deployed. 

