### PR TITLE
Force Platform Admins to use WebAuthn

### DIFF
--- a/migrations/versions/0358_require_platform_admin_webauthn.py
+++ b/migrations/versions/0358_require_platform_admin_webauthn.py
@@ -1,0 +1,28 @@
+"""
+
+Revision ID: 4561e334fa59
+Revises: 0357_validate_constraint
+Create Date: 2021-05-25 10:43:33.880337
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '4561e334fa59'
+down_revision = '0357_validate_constraint'
+
+
+def upgrade():
+    op.create_check_constraint(
+        "op_users_webauthn_or_not_platform_admin",
+        "users",
+        "(auth_type = 'webauthn_auth') OR (platform_admin = false)"
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "op_users_webauthn_or_not_platform_admin",
+        "users",
+    )


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178213469

This introduces a DB 'check' constraint to prevent a user being a
platform admin unless they are using WebAuthn as their 2FA method.
On the other hand, a normal user can still use WebAuthn, so:

- A new user can setup their credentials before becoming an admin.

- An existing Platform Admin who is unable to login with WebAuthn
must be demoted before they can use a less secure auth type.

Apart from enforcing these processes, having this check also means
we don't have to worry too much about fixing places in the code
where the auth type may be changed, such as a service invite [1].

[1]: https://github.com/alphagov/notifications-admin/blob/master/app/main/views/manage_users.py#L146