### PR TITLE
Add a error log for alert tasks.

### DIFF
--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -150,6 +150,7 @@ def send_broadcast_event(broadcast_event_id):
             ticket_type=zendesk_client.TYPE_INCIDENT,
             p1=True,
         )
+        current_app.logger.error(message)
 
     for provider in broadcast_event.service.get_available_broadcast_providers():
         send_broadcast_provider_message.apply_async(

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -211,14 +211,13 @@ def check_if_letters_still_pending_virus_check():
             https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#Deal-with-letter-pending-virus-scan-for-90-minutes.
             Notifications: {}""".format(len(letters), sorted(letter_ids))
 
-        current_app.logger.warning(msg)
-
         if current_app.config['NOTIFY_ENVIRONMENT'] in ['live', 'production', 'test']:
             zendesk_client.create_ticket(
                 subject="[{}] Letters still pending virus check".format(current_app.config['NOTIFY_ENVIRONMENT']),
                 message=msg,
                 ticket_type=zendesk_client.TYPE_INCIDENT
             )
+            current_app.logger.error(msg)
 
 
 @notify_celery.task(name='check-if-letters-still-in-created')
@@ -227,11 +226,9 @@ def check_if_letters_still_in_created():
 
     if len(letters) > 0:
         msg = "{} letters were created before 17.30 yesterday and still have 'created' status. " \
-            "Follow runbook to resolve: " \
-            "https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook" \
-            "#deal-with-Letters-still-in-created.".format(len(letters))
-
-        current_app.logger.warning(msg)
+              "Follow runbook to resolve: " \
+              "https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook" \
+              "#deal-with-Letters-still-in-created.".format(len(letters))
 
         if current_app.config['NOTIFY_ENVIRONMENT'] in ['live', 'production', 'test']:
             zendesk_client.create_ticket(
@@ -239,6 +236,7 @@ def check_if_letters_still_in_created():
                 message=msg,
                 ticket_type=zendesk_client.TYPE_INCIDENT
             )
+            current_app.logger.error(msg)
 
 
 @notify_celery.task(name='check-for-missing-rows-in-completed-jobs')

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -356,7 +356,7 @@ def test_check_job_status_task_does_not_raise_error(sample_template):
 
 @freeze_time("2019-05-30 14:00:00")
 def test_check_if_letters_still_pending_virus_check(mocker, sample_letter_template):
-    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.warning')
+    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.error')
     mock_create_ticket = mocker.patch('app.celery.nightly_tasks.zendesk_client.create_ticket')
 
     create_notification(template=sample_letter_template,
@@ -393,7 +393,7 @@ def test_check_if_letters_still_pending_virus_check(mocker, sample_letter_templa
 
 @freeze_time("2019-05-30 14:00:00")
 def test_check_if_letters_still_in_created_during_bst(mocker, sample_letter_template):
-    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.warning')
+    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.error')
     mock_create_ticket = mocker.patch('app.celery.nightly_tasks.zendesk_client.create_ticket')
 
     create_notification(template=sample_letter_template, created_at=datetime(2019, 5, 1, 12, 0))
@@ -419,7 +419,7 @@ def test_check_if_letters_still_in_created_during_bst(mocker, sample_letter_temp
 
 @freeze_time("2019-01-30 14:00:00")
 def test_check_if_letters_still_in_created_during_utc(mocker, sample_letter_template):
-    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.warning')
+    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.error')
     mock_create_ticket = mocker.patch('app.celery.scheduled_tasks.zendesk_client.create_ticket')
 
     create_notification(template=sample_letter_template, created_at=datetime(2018, 12, 1, 12, 0))


### PR DESCRIPTION
Many of the team members do not look at emails from zendesk, adding a current_app.logger.error message for things we care about to give developers a better chance of seeing them.
I have purposely not added an erro log for `check_for_services_with_high_failure_rates_or_sending_to_tv_numbers` because it's not something we need to look at immediately.