### PR TITLE
Fix 'flask db upgrade' not working on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ NOTIFY_CREDENTIALS ?= ~/.notify-credentials
 bootstrap: generate-version-file ## Set up everything to run the app
 	pip3 install -r requirements_for_test.txt
 	createdb notification_api || true
-	. environment.sh && flask db upgrade
+	(. environment.sh && flask db upgrade) || flask db upgrade
 
 .PHONY: run-flask
 run-flask: ## Run flask


### PR DESCRIPTION
Related to: https://github.com/alphagov/notifications-aws/pull/905

Previously this would fail because the Docker image we use for CI
builds doesn't have an 'environment.sh' file; it uses preset env
vars instead. This makes the command to load the file optional,
for which the error should be self evident if it's missing locally.