### PR TITLE
Revert "Bump utils version for new invalid address character"

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -273,34 +273,48 @@ def register_blueprint(application):
 
 def register_v2_blueprints(application):
     from app.authentication.auth import requires_auth
-    from app.v2.broadcast.post_broadcast import v2_broadcast_blueprint
-    from app.v2.inbound_sms.get_inbound_sms import v2_inbound_sms_blueprint
-    from app.v2.notifications import (  # noqa
-        get_notifications,
-        post_notifications,
-        v2_notification_blueprint,
+    from app.v2.broadcast.post_broadcast import (
+        v2_broadcast_blueprint as post_broadcast,
     )
-    from app.v2.template import (  # noqa
-        get_template,
-        post_template,
-        v2_template_blueprint,
+    from app.v2.inbound_sms.get_inbound_sms import (
+        v2_inbound_sms_blueprint as get_inbound_sms,
     )
-    from app.v2.templates.get_templates import v2_templates_blueprint
+    from app.v2.notifications.get_notifications import (
+        v2_notification_blueprint as get_notifications,
+    )
+    from app.v2.notifications.post_notifications import (
+        v2_notification_blueprint as post_notifications,
+    )
+    from app.v2.template.get_template import (
+        v2_template_blueprint as get_template,
+    )
+    from app.v2.template.post_template import (
+        v2_template_blueprint as post_template,
+    )
+    from app.v2.templates.get_templates import (
+        v2_templates_blueprint as get_templates,
+    )
 
-    v2_notification_blueprint.before_request(requires_auth)
-    application.register_blueprint(v2_notification_blueprint)
+    post_notifications.before_request(requires_auth)
+    application.register_blueprint(post_notifications)
 
-    v2_template_blueprint.before_request(requires_auth)
-    application.register_blueprint(v2_template_blueprint)
+    get_notifications.before_request(requires_auth)
+    application.register_blueprint(get_notifications)
 
-    v2_templates_blueprint.before_request(requires_auth)
-    application.register_blueprint(v2_templates_blueprint)
+    get_templates.before_request(requires_auth)
+    application.register_blueprint(get_templates)
 
-    v2_inbound_sms_blueprint.before_request(requires_auth)
-    application.register_blueprint(v2_inbound_sms_blueprint)
+    get_template.before_request(requires_auth)
+    application.register_blueprint(get_template)
 
-    v2_broadcast_blueprint.before_request(requires_auth)
-    application.register_blueprint(v2_broadcast_blueprint)
+    post_template.before_request(requires_auth)
+    application.register_blueprint(post_template)
+
+    get_inbound_sms.before_request(requires_auth)
+    application.register_blueprint(get_inbound_sms)
+
+    post_broadcast.before_request(requires_auth)
+    application.register_blueprint(post_broadcast)
 
 
 def init_app(app):

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -265,7 +265,7 @@ def validate_address(service, letter_data):
         )
     if address.has_invalid_characters:
         raise ValidationError(
-            message='Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / , < > ~'
+            message='Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / , < >'
         )
     if address.international:
         return address.postage

--- a/app/v2/notifications/get_notifications.py
+++ b/app/v2/notifications/get_notifications.py
@@ -55,7 +55,7 @@ def get_pdf_for_notification(notification_id):
     except Exception:
         raise PDFNotReadyError()
 
-    return send_file(path_or_file=BytesIO(pdf_data), mimetype='application/pdf')
+    return send_file(filename_or_fp=BytesIO(pdf_data), mimetype='application/pdf')
 
 
 @v2_notification_blueprint.route("", methods=['GET'])

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,12 +8,12 @@ Flask-Bcrypt==0.7.1
 flask-marshmallow==0.14.0
 Flask-Migrate==2.7.0
 git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262#egg=Flask-SQLAlchemy==2.3.2.dev20190108
-Flask==2.0.1
+Flask==1.1.2
 click-datetime==0.2
 eventlet==0.30.2 # pyup: ignore # 0.31 breaks Gunicorn
 gunicorn==20.1.0
 iso8601==0.1.14
-itsdangerous==2.0.1
+itsdangerous==1.1.0
 jsonschema==3.2.0
 marshmallow-sqlalchemy==0.23.1 # pyup: <0.24.0 # marshmallow v3 throws errors
 marshmallow==2.21.0 # pyup: <3 # v3 throws errors
@@ -34,7 +34,7 @@ notifications-python-client==6.0.2
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@44.2.2#egg=notifications-utils==44.2.2
+git+https://github.com/alphagov/notifications-utils.git@44.1.0#egg=notifications-utils==44.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,12 +10,12 @@ Flask-Bcrypt==0.7.1
 flask-marshmallow==0.14.0
 Flask-Migrate==2.7.0
 git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262#egg=Flask-SQLAlchemy==2.3.2.dev20190108
-Flask==2.0.1
+Flask==1.1.2
 click-datetime==0.2
 eventlet==0.30.2 # pyup: ignore # 0.31 breaks Gunicorn
 gunicorn==20.1.0
 iso8601==0.1.14
-itsdangerous==2.0.1
+itsdangerous==1.1.0
 jsonschema==3.2.0
 marshmallow-sqlalchemy==0.23.1 # pyup: <0.24.0 # marshmallow v3 throws errors
 marshmallow==2.21.0 # pyup: <3 # v3 throws errors
@@ -36,28 +36,28 @@ notifications-python-client==6.0.2
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@44.2.2#egg=notifications-utils==44.2.2
+git+https://github.com/alphagov/notifications-utils.git@44.1.0#egg=notifications-utils==44.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.10.1
 gds-metrics==0.2.4
 
 ## The following requirements were added by pip freeze:
-alembic==1.6.4
+alembic==1.6.2
 amqp==1.4.9
 anyjson==0.3.3
 attrs==21.2.0
-awscli==1.19.82
+awscli==1.19.69
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.3.0
 blinker==1.4
 boto==2.49.0
-boto3==1.17.82
-botocore==1.20.82
+boto3==1.17.69
+botocore==1.20.69
 certifi==2020.12.5
 chardet==4.0.0
-click==8.0.1
+click==7.1.2
 colorama==0.4.3
 dnspython==1.16.0
 docutils==0.15.2
@@ -66,15 +66,15 @@ geojson==2.5.0
 govuk-bank-holidays==0.8
 greenlet==1.1.0
 idna==2.10
-Jinja2==3.0.1
+Jinja2==2.11.3
 jmespath==0.10.0
 kombu==3.0.37
 Mako==1.1.4
-MarkupSafe==2.0.1
+MarkupSafe==1.1.1
 mistune==0.8.4
 orderedset==2.0.3
 packaging==20.9
-phonenumbers==8.12.23
+phonenumbers==8.12.22
 pyasn1==0.4.8
 pycparser==2.20
 pyparsing==2.4.7
@@ -94,6 +94,6 @@ six==1.16.0
 smartypants==2.0.1
 soupsieve==2.2.1
 statsd==3.3.0
-urllib3==1.26.5
+urllib3==1.26.4
 webencodings==0.5.1
-Werkzeug==2.0.1
+Werkzeug==1.0.1

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,13 +2,13 @@
 flake8==3.8.4
 flake8-bugbear==20.11.1
 isort==5.7.0
-moto==2.0.8
-pytest==6.2.4
+moto==1.3.16
+pytest==6.1.2
 pytest-env==0.6.2
-pytest-mock==3.6.1
-pytest-cov==2.12.0
-pytest-xdist==2.2.1
+pytest-mock==3.3.1
+pytest-cov==2.10.1
+pytest-xdist==2.1.0
 freezegun==1.1.0
-requests-mock==1.9.2
+requests-mock==1.8.0
 # used for creating manifest file locally
 jinja2-cli[yaml]==0.7.0

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -1,10 +1,10 @@
-import unittest.mock as mock
 from collections import namedtuple
 from datetime import datetime, timedelta
 from unittest.mock import call
 
 import pytest
 from freezegun import freeze_time
+from mock import mock
 
 from app.celery import scheduled_tasks
 from app.celery.scheduled_tasks import (

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -1,7 +1,7 @@
-import unittest.mock as mock
 from datetime import date, datetime, time, timedelta
 from uuid import UUID
 
+import mock
 import pytest
 from freezegun import freeze_time
 

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -1,8 +1,8 @@
 import json
-import unittest.mock as mock
 import uuid
 from datetime import datetime
 
+import mock
 import pytest
 from flask import current_app, url_for
 from freezegun import freeze_time

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -222,7 +222,7 @@ def test_post_letter_notification_international_sets_rest_of_world(
             'postcode': 'SW1A 1AA',
             'name': 'Lizzie'
         },
-        'Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / , < > ~',
+        'Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / , < >',
     ),
     (
         [LETTER_TYPE, INTERNATIONAL_LETTERS],

--- a/tests/app/v2/test_errors.py
+++ b/tests/app/v2/test_errors.py
@@ -128,5 +128,7 @@ def test_bad_method(app_for_test):
 
             assert response.status_code == 405
 
-            assert response.get_data(as_text=True) == \
-                   '{"message":"The method is not allowed for the requested URL.","result":"error"}\n'
+            assert response.json == {
+                "result": "error",
+                "message": "The method is not allowed for the requested URL."
+            }


### PR DESCRIPTION
Reverts alphagov/notifications-api#3250

Some sort of potential memory leak

![image](https://user-images.githubusercontent.com/7228605/120304487-bc65ca00-c2c7-11eb-9456-e15a08a737b8.png)

@servingUpAces has said in slack

> If you need to revert  https://github.com/alphagov/notifications-api/pull/3250/files, that is okay. It will only mean that the new validation for letters will not happen for templated letters posted to the API. It will not affect precompiled letters or letters uploaded via UI or CSV files.

Next steps are not as clear but potentially we could wait a week or two and try again with newer versions and hope that someone found the bug and fixed it