### PR TITLE
Do not include today's totals

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -155,6 +155,9 @@ def fetch_notification_status_for_service_for_today_and_7_previous_days(service_
         FactNotificationStatus.key_type != KEY_TYPE_TEST
     )
     if str(service_id) in (current_app.config['HIGH_VOLUME_SERVICE']):
+        # As a temporary measure we are not including today's totals for high volume service. This will allow the
+        # services to view the dashboard and /notification pages more easily. There is a story to try to resolve the
+        # query performance, https://www.pivotaltracker.com/story/show/178330973
         all_stats_table = stats_for_7_days.subquery()
     else:
         stats_for_today = db.session.query(

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -251,22 +251,8 @@ def test_fetch_notification_status_for_service_for_today_and_7_previous_days(not
     )
 
     assert len(results) == 4
-
-    assert results[0].notification_type == 'email'
-    assert results[0].status == 'delivered'
-    assert results[0].count == 4
-
-    assert results[1].notification_type == 'letter'
-    assert results[1].status == 'delivered'
-    assert results[1].count == 5
-
-    assert results[2].notification_type == 'sms'
-    assert results[2].status == 'created'
-    assert results[2].count == 3
-
-    assert results[3].notification_type == 'sms'
-    assert results[3].status == 'delivered'
-    assert results[3].count == 19
+    assert sorted(results, key=lambda x: (x.notification_type, x.status, x.count)) == \
+           [('email', 'delivered', 4), ('letter', 'delivered', 5), ('sms', 'created', 3), ('sms', 'delivered', 19)]
 
 
 @freeze_time('2018-10-31T18:00:00')
@@ -283,7 +269,7 @@ def test_fetch_notification_status_for_service_for_today_and_7_previous_days_for
     create_ft_notification_status(date(2018, 10, 29), 'sms', service_1, notification_status='created')
     create_ft_notification_status(date(2018, 10, 29), 'email', service_1, count=3)
     create_ft_notification_status(date(2018, 10, 26), 'letter', service_1, count=5)
-
+    # notifications created today will not be included in the resultset
     create_notification(sms_template, created_at=datetime(2018, 10, 31, 11, 0, 0))
     create_notification(sms_template_2, created_at=datetime(2018, 10, 31, 11, 0, 0))
     create_notification(sms_template, created_at=datetime(2018, 10, 31, 12, 0, 0), status='delivered')
@@ -301,22 +287,8 @@ def test_fetch_notification_status_for_service_for_today_and_7_previous_days_for
         )
 
     assert len(results) == 4
-
-    assert results[0].notification_type == 'email'
-    assert results[0].status == 'delivered'
-    assert results[0].count == 3
-
-    assert results[1].notification_type == 'letter'
-    assert results[1].status == 'delivered'
-    assert results[1].count == 5
-
-    assert results[2].notification_type == 'sms'
-    assert results[2].status == 'created'
-    assert results[2].count == 1
-
-    assert results[3].notification_type == 'sms'
-    assert results[3].status == 'delivered'
-    assert results[3].count == 18
+    assert sorted(results, key=lambda x: (x.notification_type, x.status, x.count)) == \
+           [('email', 'delivered', 3), ('letter', 'delivered', 5), ('sms', 'created', 1), ('sms', 'delivered', 18)]
 
 
 @freeze_time('2018-10-31T18:00:00')


### PR DESCRIPTION
This change is a temporary fix to allow users for high volume services to use the admin app.

The trouble is the aggregate query to return the big blue numbers on the dashboard and /notifications/{notification_type} page is taking too long to return.
I have some ideas on how to improve the query, but should take some time to do some more research and test. In the meantime, let's just ignore "todays" total numbers for the high volume services. There are only two services that this will affect.