### PR TITLE
Refactor high volume into serialised service model

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -87,7 +87,7 @@ def send_sms_to_provider(notification):
             statsd_client.timing("sms.test-key.total-time", delta_seconds)
         else:
             statsd_client.timing("sms.live-key.total-time", delta_seconds)
-            if str(service.id) in current_app.config.get('HIGH_VOLUME_SERVICE'):
+            if service.high_volume:
                 statsd_client.timing("sms.live-key.high-volume.total-time", delta_seconds)
             else:
                 statsd_client.timing("sms.live-key.not-high-volume.total-time", delta_seconds)
@@ -142,7 +142,7 @@ def send_email_to_provider(notification):
             statsd_client.timing("email.test-key.total-time", delta_seconds)
         else:
             statsd_client.timing("email.live-key.total-time", delta_seconds)
-            if str(service.id) in current_app.config.get('HIGH_VOLUME_SERVICE'):
+            if service.high_volume:
                 statsd_client.timing("email.live-key.high-volume.total-time", delta_seconds)
             else:
                 statsd_client.timing("email.live-key.not-high-volume.total-time", delta_seconds)

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -3,6 +3,7 @@ from functools import partial
 from threading import RLock
 
 import cachetools
+from flask import current_app
 from notifications_utils.clients.redis import RequestCache
 from notifications_utils.serialised_model import (
     SerialisedModel,
@@ -105,6 +106,10 @@ class SerialisedService(SerialisedModel):
     @cached_property
     def api_keys(self):
         return SerialisedAPIKeyCollection.from_service_id(self.id)
+
+    @property
+    def high_volume(self):
+        return self.id in current_app.config['HIGH_VOLUME_SERVICE']
 
 
 class SerialisedAPIKey(SerialisedModel):

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -211,7 +211,7 @@ def process_sms_or_email_notification(
         template_with_content=template_with_content
     )
 
-    if service.id in current_app.config.get('HIGH_VOLUME_SERVICE') \
+    if service.high_volume \
         and api_user.key_type == KEY_TYPE_NORMAL \
             and notification_type in [EMAIL_TYPE, SMS_TYPE]:
         # Put service with high volumes of notifications onto a queue


### PR DESCRIPTION
Just looks a bit tidier and less repetitive.

I’ve only done this for the serialised service because:
- we’re only checking this in places where we’re already using the serialised service
- if we want to check this elsewhere there’s a good chance that new code should be using the serialised service, since it’ll itself be doing some kind of performance optimisation