### PR TITLE
Add new total_letters field to the billing report data

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -114,12 +114,13 @@ def fetch_sms_billing_for_all_services(start_date, end_date):
     return query.all()
 
 
-def fetch_letter_costs_for_all_services(start_date, end_date):
+def fetch_letter_costs_and_totals_for_all_services(start_date, end_date):
     query = db.session.query(
         Organisation.name.label("organisation_name"),
         Organisation.id.label("organisation_id"),
         Service.name.label("service_name"),
         Service.id.label("service_id"),
+        func.sum(FactBilling.notifications_sent).label("total_letters"),
         func.sum(FactBilling.notifications_sent * FactBilling.rate).label("letter_cost")
     ).select_from(
         Service

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -10,7 +10,7 @@ from app.dao.fact_billing_dao import (
     delete_billing_data_for_service_for_day,
     fetch_billing_data_for_day,
     fetch_billing_totals_for_year,
-    fetch_letter_costs_for_all_services,
+    fetch_letter_costs_and_totals_for_all_services,
     fetch_letter_line_items_for_all_services,
     fetch_monthly_billing_for_year,
     fetch_sms_billing_for_all_services,
@@ -628,26 +628,26 @@ def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(noti
     )
 
 
-def test_fetch_letter_costs_for_all_services(notify_db_session):
+def test_fetch_letter_costs_and_totals_for_all_services(notify_db_session):
     fixtures = set_up_usage_data(datetime(2019, 6, 1))
 
-    results = fetch_letter_costs_for_all_services(datetime(2019, 6, 1), datetime(2019, 9, 30))
+    results = fetch_letter_costs_and_totals_for_all_services(datetime(2019, 6, 1), datetime(2019, 9, 30))
 
     assert len(results) == 3
     assert results[0] == (
         fixtures["org_1"].name, fixtures["org_1"].id,
         fixtures["service_1_sms_and_letter"].name, fixtures["service_1_sms_and_letter"].id,
-        Decimal('3.40')
+        8, Decimal('3.40')
     )
     assert results[1] == (
         fixtures["org_for_service_with_letters"].name, fixtures["org_for_service_with_letters"].id,
         fixtures["service_with_letters"].name, fixtures["service_with_letters"].id,
-        Decimal('14.00')
+        22, Decimal('14.00')
     )
     assert results[2] == (
         None, None,
         fixtures["service_with_letters_without_org"].name, fixtures["service_with_letters_without_org"].id,
-        Decimal('24.45')
+        18, Decimal('24.45')
     )
 
 

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -141,6 +141,7 @@ def test_get_data_for_billing_report(notify_db_session, admin_request):
     assert response[0]["service_id"] == str(fixtures["service_1_sms_and_letter"].id)
     assert response[0]["sms_cost"] == 0
     assert response[0]["sms_fragments"] == 0
+    assert response[0]["total_letters"] == 8
     assert response[0]["letter_cost"] == 3.40
     assert response[0]["letter_breakdown"] == "6 second class letters at 45p\n2 first class letters at 35p\n"
     assert response[0]["purchase_order_number"] == "service purchase order number"
@@ -152,6 +153,7 @@ def test_get_data_for_billing_report(notify_db_session, admin_request):
     assert response[1]["service_id"] == str(fixtures["service_with_letters"].id)
     assert response[1]["sms_cost"] == 0
     assert response[1]["sms_fragments"] == 0
+    assert response[1]["total_letters"] == 22
     assert response[1]["letter_cost"] == 14
     assert response[1]["letter_breakdown"] == "20 second class letters at 65p\n2 first class letters at 50p\n"
     assert response[1]["purchase_order_number"] == "org3 purchase order number"
@@ -163,6 +165,7 @@ def test_get_data_for_billing_report(notify_db_session, admin_request):
     assert response[2]["service_id"] == str(fixtures["service_with_sms_without_org"].id)
     assert response[2]["sms_cost"] == 0.33
     assert response[2]["sms_fragments"] == 3
+    assert response[2]["total_letters"] == 0
     assert response[2]["letter_cost"] == 0
     assert response[2]["letter_breakdown"] == ""
     assert response[2]["purchase_order_number"] == "sms purchase order number"
@@ -174,6 +177,7 @@ def test_get_data_for_billing_report(notify_db_session, admin_request):
     assert response[3]["service_id"] == str(fixtures["service_with_letters_without_org"].id)
     assert response[3]["sms_cost"] == 0
     assert response[3]["sms_fragments"] == 0
+    assert response[3]["total_letters"] == 18
     assert response[3]["letter_cost"] == 24.45
     assert response[3]["letter_breakdown"] == (
         "2 second class letters at 35p\n1 first class letters at 50p\n15 international letters at £1.55\n"


### PR DESCRIPTION
This adds total_letters to the data that is returned by the `/platform-stats/data-for-billing-report` endpoint so that we can add total letters as a column in the CSV file that can be downloaded.

[Pivotal story](https://www.pivotaltracker.com/story/show/177558710)