### PR TITLE
Improve the query to get today's totals for a service.

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -437,15 +437,13 @@ def dao_fetch_todays_stats_for_service(service_id):
 
 
 def fetch_todays_total_message_count(service_id):
+    start_date = get_london_midnight_in_utc(date.today())
     result = db.session.query(
         func.count(Notification.id).label('count')
     ).filter(
         Notification.service_id == service_id,
         Notification.key_type != KEY_TYPE_TEST,
-        func.date(Notification.created_at) == date.today()
-    ).group_by(
-        Notification.notification_type,
-        Notification.status,
+        Notification.created_at >= start_date
     ).first()
     return 0 if result is None else result.count
 


### PR DESCRIPTION
The query to check daily totals had a group by on notification_type and notification_status, this not only slows the query down but is wrong. The query only looked at the first result, but this query would return as many rows as different notification types and status, meaning the results do not include the correct number. The query is used by process_job task when a CSV is uploaded or send on-off notification or upload a pdf.

This improves the query.