### PR TITLE
Add permanent-failure for letters.

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1577,6 +1577,7 @@ class Notification(db.Model):
             },
             'letter': {
                 'technical-failure': 'Technical failure',
+                'permanent-failure': 'Permanent failure',
                 'sending': 'Accepted',
                 'created': 'Accepted',
                 'delivered': 'Received',

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -124,6 +124,7 @@ def test_notification_for_csv_returns_correct_job_row_number(sample_job):
     ('letter', 'created', 'Accepted'),
     ('letter', 'sending', 'Accepted'),
     ('letter', 'technical-failure', 'Technical failure'),
+    ('letter', 'permanent-failure', 'Permanent failure'),
     ('letter', 'delivered', 'Received')
 ])
 def test_notification_for_csv_returns_formatted_status(


### PR DESCRIPTION
It's possible a letter can pass our validation but our print provider can not print the letter. The letter will be marked as permanent failure in this case. Typically happens with precompiled letters.