### PR TITLE
Add new broadcast related permissions

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1870,6 +1870,10 @@ SEND_LETTERS = 'send_letters'
 MANAGE_API_KEYS = 'manage_api_keys'
 PLATFORM_ADMIN = 'platform_admin'
 VIEW_ACTIVITY = 'view_activity'
+CREATE_BROADCASTS = 'create_broadcasts'
+APPROVE_BROADCASTS = 'approve_broadcasts'
+CANCEL_BROADCASTS = 'cancel_broadcasts'
+REJECT_BROADCASTS = 'reject_broadcasts'
 
 # List of permissions
 PERMISSION_LIST = [
@@ -1881,7 +1885,12 @@ PERMISSION_LIST = [
     SEND_LETTERS,
     MANAGE_API_KEYS,
     PLATFORM_ADMIN,
-    VIEW_ACTIVITY]
+    VIEW_ACTIVITY,
+    CREATE_BROADCASTS,
+    APPROVE_BROADCASTS,
+    CANCEL_BROADCASTS,
+    REJECT_BROADCASTS,
+]
 
 
 class Permission(db.Model):

--- a/migrations/versions/0359_more_permissions.py
+++ b/migrations/versions/0359_more_permissions.py
@@ -1,0 +1,50 @@
+"""
+
+Revision ID: 0359_more_permissions
+Revises: 0358_operator_channel
+Create Date: 2021-06-15 17:47:16.871071
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0359_more_permissions'
+down_revision = '0358_operator_channel'
+
+enum_name = 'permission_types'
+tmp_name = 'tmp_' + enum_name
+
+old_options = (
+    'manage_users',
+    'manage_templates',
+    'manage_settings',
+    'send_texts',
+    'send_emails',
+    'send_letters',
+    'manage_api_keys',
+    'platform_admin',
+    'view_activity',
+)
+old_type = sa.Enum(*old_options, name=enum_name)
+
+
+def upgrade():
+    # ALTER TYPE must be run outside of a transaction block (see link below for details)
+    # https://alembic.sqlalchemy.org/en/latest/api/runtime.html#alembic.runtime.migration.MigrationContext.autocommit_block
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE permission_types ADD VALUE 'create_broadcasts'")
+        op.execute("ALTER TYPE permission_types ADD VALUE 'approve_broadcasts'")
+        op.execute("ALTER TYPE permission_types ADD VALUE 'cancel_broadcasts'")
+        op.execute("ALTER TYPE permission_types ADD VALUE 'reject_broadcasts'")
+
+
+def downgrade():
+    op.execute(
+        "DELETE FROM permissions WHERE permission in "
+        "('create_broadcasts', 'approve_broadcasts', 'cancel_broadcasts', 'reject_broadcasts')"
+    )
+
+    op.execute(f'ALTER TYPE {enum_name} RENAME TO {tmp_name}')
+    old_type.create(op.get_bind())
+    op.execute(f'ALTER TABLE permissions ALTER COLUMN permission TYPE {enum_name} USING permission::text::{enum_name}')
+    op.execute(f'DROP TYPE {tmp_name}')


### PR DESCRIPTION
We want to have new permissions which will be used specifically for broadcasts:
- `create_broadcasts`
- `approve_broadcasts`
- `reject_broadcasts`
- `cancel_broadcasts`

Cancel and reject will always go together, but having separate database permissions makes things easier to change in the future.

The permission column of the permissions table is an enum. We can add values in the alembic upgrade script, but removing individual values from an enum is not supported by Postgres. To remove values, we have to recreate the enum with the old values.

[Pivotal story](https://www.pivotaltracker.com/story/show/178482657)