### PR TITLE
Correct the daily limits cache.

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -161,8 +161,11 @@ def process_row(row, template, job, service, sender_id=None):
 
 def __sending_limits_for_job_exceeded(service, job, job_id):
     try:
-        check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
-        return False
+        total_sent = check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
+        if total_sent + job.notification_count > service.message_limit:
+            raise TooManyRequestsError(service.message_limit)
+        else:
+            return False
     except TooManyRequestsError:
         job.job_status = 'sending limits exceeded'
         job.processing_finished = datetime.utcnow()

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -33,7 +33,6 @@ from app.dao.returned_letters_dao import insert_or_update_returned_letters
 from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_id
 from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
 from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id
-from app.dao.services_dao import fetch_todays_total_message_count
 from app.dao.templates_dao import dao_get_template_by_id
 from app.exceptions import DVLAException, NotificationTechnicalFailureException
 from app.models import (
@@ -55,6 +54,7 @@ from app.models import (
     DailySortedLetter,
 )
 from app.notifications.process_notifications import persist_notification
+from app.notifications.validators import get_service_daily_limit_cache_value
 from app.serialised_models import SerialisedService, SerialisedTemplate
 from app.service.utils import service_allowed_to_send_to
 from app.utils import DATETIME_FORMAT, get_reference_from_personalisation
@@ -159,8 +159,8 @@ def process_row(row, template, job, service, sender_id=None):
 
 
 def __sending_limits_for_job_exceeded(service, job, job_id):
-    total_sent = fetch_todays_total_message_count(service.id)
-
+    total_sent = get_service_daily_limit_cache_value(KEY_TYPE_NORMAL, service)
+    print(total_sent)
     if total_sent + job.notification_count > service.message_limit:
         job.job_status = 'sending limits exceeded'
         job.processing_finished = datetime.utcnow()

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -436,18 +436,6 @@ def dao_fetch_todays_stats_for_service(service_id):
     ).all()
 
 
-def fetch_todays_total_message_count(service_id):
-    start_date = get_london_midnight_in_utc(date.today())
-    result = db.session.query(
-        func.count(Notification.id).label('count')
-    ).filter(
-        Notification.service_id == service_id,
-        Notification.key_type != KEY_TYPE_TEST,
-        Notification.created_at >= start_date
-    ).first()
-    return 0 if result is None else result.count
-
-
 def _stats_for_service_query(service_id):
     return db.session.query(
         Notification.notification_type,

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -148,10 +148,8 @@ def persist_notification(
     # if simulated create a Notification model to return but do not persist the Notification to the dB
     if not simulated:
         dao_create_notification(notification)
-        # Only keep track of the daily limit for trial mode services.
-        if service.restricted and key_type != KEY_TYPE_TEST:
-            if redis_store.get(redis.daily_limit_cache_key(service.id)):
-                redis_store.incr(redis.daily_limit_cache_key(service.id))
+        if key_type != KEY_TYPE_TEST and current_app.config['REDIS_ENABLED']:
+            redis_store.incr(redis.daily_limit_cache_key(service.id))
 
         current_app.logger.info(
             "{} {} created at {}".format(notification_type, notification_id, notification_created_at)

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -149,8 +149,15 @@ def persist_notification(
     if not simulated:
         dao_create_notification(notification)
         if key_type != KEY_TYPE_TEST and current_app.config['REDIS_ENABLED']:
-            redis_store.incr(redis.daily_limit_cache_key(service.id))
-
+            cache_key = redis.daily_limit_cache_key(service.id)
+            if redis_store.get(cache_key) is None:
+                # if cache does not exist set the cache to 1 with an expiry of 24 hours,
+                # The cache should be set by the time we create the notification
+                # but in case it is this will make sure the expiry is set to 24 hours,
+                # where if we let the incr method create the cache it will be set a ttl.
+                redis_store.set(cache_key, 1, ex=86400)
+            else:
+                redis_store.incr(cache_key)
         current_app.logger.info(
             "{} {} created at {}".format(notification_type, notification_id, notification_created_at)
         )

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -61,7 +61,7 @@ def check_service_over_daily_message_limit(key_type, service):
     if key_type != KEY_TYPE_TEST and current_app.config['REDIS_ENABLED']:
         cache_key = daily_limit_cache_key(service.id)
         service_stats = redis_store.get(cache_key)
-        if not service_stats:
+        if service_stats is None:
             # first message of the day, set the cache to 0 and the expiry to 24 hours
             service_stats = 0
             redis_store.set(cache_key, service_stats, ex=86400)

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -58,34 +58,22 @@ def check_service_over_api_rate_limit(service, api_key):
 
 
 def check_service_over_daily_message_limit(key_type, service):
-    if key_type != KEY_TYPE_TEST and current_app.config['REDIS_ENABLED']:
-        cache_key = daily_limit_cache_key(service.id)
-        service_stats = redis_store.get(cache_key)
-        if service_stats is None:
-            # first message of the day, set the cache to 0 and the expiry to 24 hours
-            service_stats = 0
-            redis_store.set(cache_key, service_stats, ex=86400)
-        if int(service_stats) >= service.message_limit:
-            current_app.logger.info(
-                "service {} has been rate limited for daily use sent {} limit {}".format(
-                    service.id, int(service_stats), service.message_limit)
-            )
-            raise TooManyRequestsError(service.message_limit)
-
-
-def get_service_daily_limit_cache_value(key_type, service):
-    if key_type != KEY_TYPE_TEST and current_app.config['REDIS_ENABLED']:
-        cache_key = daily_limit_cache_key(service.id)
-        service_stats = redis_store.get(cache_key)
-        if not service_stats:
-            # first message of the day, set the cache to 0 and the expiry to 24 hours
-            service_stats = 0
-            redis_store.set(cache_key, service_stats, ex=86400)
-            return 0
-        else:
-            return int(service_stats)
-    else:
+    if key_type == KEY_TYPE_TEST or not current_app.config['REDIS_ENABLED']:
         return 0
+
+    cache_key = daily_limit_cache_key(service.id)
+    service_stats = redis_store.get(cache_key)
+    if service_stats is None:
+        # first message of the day, set the cache to 0 and the expiry to 24 hours
+        service_stats = 0
+        redis_store.set(cache_key, service_stats, ex=86400)
+        return service_stats
+    if int(service_stats) >= service.message_limit:
+        current_app.logger.info(
+            "service {} has been rate limited for daily use sent {} limit {}".format(
+                service.id, int(service_stats), service.message_limit)
+        )
+        raise TooManyRequestsError(service.message_limit)
 
 
 def check_rate_limiting(service, api_key):

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -160,6 +160,7 @@ def test_should_not_process_sms_job_if_would_exceed_send_limits(
     mocker.patch('app.celery.tasks.s3.get_job_and_metadata_from_s3',
                  return_value=(load_example_csv('multiple_sms'), {'sender_id': None}))
     mocker.patch('app.celery.tasks.process_row')
+    mocker.patch('app.celery.tasks.get_service_daily_limit_cache_value', return_value=8)
 
     process_job(job.id)
 
@@ -181,6 +182,7 @@ def test_should_not_process_sms_job_if_would_exceed_send_limits_inc_today(
     mocker.patch('app.celery.tasks.s3.get_job_and_metadata_from_s3',
                  return_value=(load_example_csv('sms'), {'sender_id': None}))
     mocker.patch('app.celery.tasks.process_row')
+    mocker.patch('app.celery.tasks.get_service_daily_limit_cache_value', return_value=2)
 
     process_job(job.id)
 
@@ -200,6 +202,7 @@ def test_should_not_process_email_job_if_would_exceed_send_limits_inc_today(noti
 
     mocker.patch('app.celery.tasks.s3.get_job_and_metadata_from_s3')
     mocker.patch('app.celery.tasks.process_row')
+    mocker.patch('app.celery.tasks.get_service_daily_limit_cache_value', return_value=2)
 
     process_job(job.id)
 
@@ -232,6 +235,7 @@ def test_should_process_email_job_if_exactly_on_send_limits(notify_db_session,
     mocker.patch('app.celery.tasks.save_email.apply_async')
     mocker.patch('app.encryption.encrypt', return_value="something_encrypted")
     mocker.patch('app.celery.tasks.create_uuid', return_value="uuid")
+    mocker.patch('app.celery.tasks.get_service_daily_limit_cache_value', return_value=0)
 
     process_job(job.id)
 

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -41,7 +41,6 @@ from app.dao.services_dao import (
     dao_suspend_service,
     dao_update_service,
     delete_service_and_all_associated_db_objects,
-    fetch_todays_total_message_count,
     get_live_services_with_organisation,
     get_services_by_partial_name,
 )
@@ -982,31 +981,6 @@ def test_fetch_stats_should_not_gather_notifications_older_than_7_days(
         stats = dao_fetch_stats_for_service(sample_template.service_id, limit_days)
 
     assert len(stats) == rows_returned
-
-
-def test_dao_fetch_todays_total_message_count_returns_count_for_today(notify_db_session):
-    template = create_template(service=create_service())
-    notification = create_notification(template=template)
-    # don't include notifications earlier than today
-    create_notification(template=template, created_at=datetime.utcnow()-timedelta(days=2))
-    assert fetch_todays_total_message_count(notification.service.id) == 1
-
-
-def test_dao_fetch_todays_total_message_count_returns_count_for_all_notification_type_and_selected_service(
-        notify_db_session
-):
-    service = create_service()
-    different_service = create_service(service_name='different service')
-    create_notification(template=create_template(service=service))
-    create_notification(template=create_template(service=service, template_type='email'))
-    create_notification(template=create_template(service=service, template_type='letter'))
-    create_notification(template=create_template(service=different_service))
-    assert fetch_todays_total_message_count(service.id) == 3
-
-
-def test_dao_fetch_todays_total_message_count_returns_0_when_no_messages_for_today(notify_db,
-                                                                                   notify_db_session):
-    assert fetch_todays_total_message_count(uuid.uuid4()) == 0
 
 
 def test_dao_fetch_todays_stats_for_all_services_includes_all_services(notify_db_session):

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -202,6 +202,7 @@ def test_persist_notification_increments_cache_for_trial_service(
     service = create_service(restricted=True)
     template = create_template(service=service)
     api_key = create_api_key(service=service)
+    mocker.patch('app.notifications.process_notifications.redis_store.get', return_value=1)
     mock_incr = mocker.patch('app.notifications.process_notifications.redis_store.incr')
     with set_config(notify_api, 'REDIS_ENABLED', True):
         persist_notification(
@@ -224,6 +225,7 @@ def test_persist_notification_increments_cache_live_service(
     service = create_service(restricted=False)
     template = create_template(service=service)
     api_key = create_api_key(service=service)
+    mocker.patch('app.notifications.process_notifications.redis_store.get', return_value=1)
     mock_incr = mocker.patch('app.notifications.process_notifications.redis_store.incr')
     with set_config(notify_api, 'REDIS_ENABLED', True):
         persist_notification(

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -113,49 +113,6 @@ def test_persist_notification_throws_exception_when_missing_template(sample_api_
     assert NotificationHistory.query.count() == 0
 
 
-def test_cache_is_not_incremented_on_failure_to_persist_notification(notify_api, sample_api_key, mocker):
-    mocked_redis = mocker.patch('app.redis_store.incr')
-    with pytest.raises(SQLAlchemyError):
-        with set_config(notify_api, 'REDIS_ENABLED', True):
-            persist_notification(template_id=None,
-                                 template_version=None,
-                                 recipient='+447111111111',
-                                 service=sample_api_key.service,
-                                 personalisation=None,
-                                 notification_type='sms',
-                                 api_key_id=sample_api_key.id,
-                                 key_type=sample_api_key.key_type)
-    mocked_redis.assert_not_called()
-
-
-def test_persist_notification_does_not_increment_cache_if_test_key(
-        notify_api, sample_template, sample_job, mocker, sample_test_api_key
-):
-    daily_limit_cache = mocker.patch('app.notifications.process_notifications.redis_store.incr')
-
-    assert Notification.query.count() == 0
-    assert NotificationHistory.query.count() == 0
-
-    with set_config(notify_api, 'REDIS_ENABLED', True):
-        persist_notification(
-            template_id=sample_template.id,
-            template_version=sample_template.version,
-            recipient='+447111111111',
-            service=sample_template.service,
-            personalisation={},
-            notification_type='sms',
-            api_key_id=sample_test_api_key.id,
-            key_type=sample_test_api_key.key_type,
-            job_id=sample_job.id,
-            job_row_number=100,
-            reference="ref",
-        )
-
-        assert Notification.query.count() == 1
-
-        assert not daily_limit_cache.called
-
-
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_persist_notification_with_optionals(sample_job, sample_api_key):
     assert Notification.query.count() == 0
@@ -195,11 +152,55 @@ def test_persist_notification_with_optionals(sample_job, sample_api_key):
     assert not persisted_notification.reply_to_text
 
 
-@freeze_time("2016-01-01 11:09:00.061258")
-def test_persist_notification_increments_cache_for_trial_service(
-        notify_api, notify_db_session, mocker
+def test_persist_notification_cache_is_not_incremented_on_failure_to_create_notification(
+        notify_api, sample_api_key, mocker
 ):
-    service = create_service(restricted=True)
+    mocked_redis = mocker.patch('app.redis_store.incr')
+    with pytest.raises(SQLAlchemyError):
+        persist_notification(template_id=None,
+                             template_version=None,
+                             recipient='+447111111111',
+                             service=sample_api_key.service,
+                             personalisation=None,
+                             notification_type='sms',
+                             api_key_id=sample_api_key.id,
+                             key_type=sample_api_key.key_type)
+    mocked_redis.assert_not_called()
+
+
+def test_persist_notification_does_not_increment_cache_if_test_key(
+        notify_api, sample_template, sample_job, mocker, sample_test_api_key
+):
+    daily_limit_cache = mocker.patch('app.notifications.process_notifications.redis_store.incr')
+
+    assert Notification.query.count() == 0
+    assert NotificationHistory.query.count() == 0
+    with set_config(notify_api, 'REDIS_ENABLED', True):
+        persist_notification(
+            template_id=sample_template.id,
+            template_version=sample_template.version,
+            recipient='+447111111111',
+            service=sample_template.service,
+            personalisation={},
+            notification_type='sms',
+            api_key_id=sample_test_api_key.id,
+            key_type=sample_test_api_key.key_type,
+            job_id=sample_job.id,
+            job_row_number=100,
+            reference="ref",
+        )
+
+    assert Notification.query.count() == 1
+
+    assert not daily_limit_cache.called
+
+
+@pytest.mark.parametrize('restricted_service', [True, False])
+@freeze_time("2016-01-01 11:09:00.061258")
+def test_persist_notification_increments_cache_for_trial_or_live_service(
+        notify_api, notify_db_session, mocker, restricted_service
+):
+    service = create_service(restricted=restricted_service)
     template = create_template(service=service)
     api_key = create_api_key(service=service)
     mocker.patch('app.notifications.process_notifications.redis_store.get', return_value=1)
@@ -219,14 +220,16 @@ def test_persist_notification_increments_cache_for_trial_service(
         mock_incr.assert_called_once_with(str(service.id) + "-2016-01-01-count", )
 
 
-def test_persist_notification_increments_cache_live_service(
-    notify_api, notify_db_session, mocker
+@pytest.mark.parametrize('restricted_service', [True, False])
+@freeze_time("2016-01-01 11:09:00.061258")
+def test_persist_notification_sets_daily_limit_cache_if_one_does_not_exists(
+        notify_api, notify_db_session, mocker, restricted_service
 ):
-    service = create_service(restricted=False)
+    service = create_service(restricted=restricted_service)
     template = create_template(service=service)
     api_key = create_api_key(service=service)
-    mocker.patch('app.notifications.process_notifications.redis_store.get', return_value=1)
-    mock_incr = mocker.patch('app.notifications.process_notifications.redis_store.incr')
+    mocker.patch('app.notifications.process_notifications.redis_store.get', return_value=None)
+    mock_set = mocker.patch('app.notifications.process_notifications.redis_store.set')
     with set_config(notify_api, 'REDIS_ENABLED', True):
         persist_notification(
             template_id=template.id,
@@ -239,7 +242,7 @@ def test_persist_notification_increments_cache_live_service(
             key_type=api_key.key_type,
             reference="ref2")
 
-        assert mock_incr.called
+        mock_set.assert_called_once_with(str(service.id) + "-2016-01-01-count", 1, ex=86400)
 
 
 @pytest.mark.parametrize((

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -21,6 +21,7 @@ from app.notifications.process_notifications import (
 from app.serialised_models import SerialisedTemplate
 from app.v2.errors import BadRequestError
 from tests.app.db import create_api_key, create_service, create_template
+from tests.conftest import set_config
 
 
 def test_create_content_for_notification_passes(sample_email_template):
@@ -112,50 +113,47 @@ def test_persist_notification_throws_exception_when_missing_template(sample_api_
     assert NotificationHistory.query.count() == 0
 
 
-def test_cache_is_not_incremented_on_failure_to_persist_notification(sample_api_key, mocker):
-    mocked_redis = mocker.patch('app.redis_store.get')
-    mock_service_template_cache = mocker.patch('app.redis_store.get_all_from_hash')
+def test_cache_is_not_incremented_on_failure_to_persist_notification(notify_api, sample_api_key, mocker):
+    mocked_redis = mocker.patch('app.redis_store.incr')
     with pytest.raises(SQLAlchemyError):
-        persist_notification(template_id=None,
-                             template_version=None,
-                             recipient='+447111111111',
-                             service=sample_api_key.service,
-                             personalisation=None,
-                             notification_type='sms',
-                             api_key_id=sample_api_key.id,
-                             key_type=sample_api_key.key_type)
+        with set_config(notify_api, 'REDIS_ENABLED', True):
+            persist_notification(template_id=None,
+                                 template_version=None,
+                                 recipient='+447111111111',
+                                 service=sample_api_key.service,
+                                 personalisation=None,
+                                 notification_type='sms',
+                                 api_key_id=sample_api_key.id,
+                                 key_type=sample_api_key.key_type)
     mocked_redis.assert_not_called()
-    mock_service_template_cache.assert_not_called()
 
 
 def test_persist_notification_does_not_increment_cache_if_test_key(
-        sample_template, sample_job, mocker, sample_test_api_key
+        notify_api, sample_template, sample_job, mocker, sample_test_api_key
 ):
-    mocker.patch('app.notifications.process_notifications.redis_store.get', return_value="cache")
-    mocker.patch('app.notifications.process_notifications.redis_store.get_all_from_hash', return_value="cache")
     daily_limit_cache = mocker.patch('app.notifications.process_notifications.redis_store.incr')
-    template_usage_cache = mocker.patch('app.notifications.process_notifications.redis_store.increment_hash_value')
 
     assert Notification.query.count() == 0
     assert NotificationHistory.query.count() == 0
-    persist_notification(
-        template_id=sample_template.id,
-        template_version=sample_template.version,
-        recipient='+447111111111',
-        service=sample_template.service,
-        personalisation={},
-        notification_type='sms',
-        api_key_id=sample_test_api_key.id,
-        key_type=sample_test_api_key.key_type,
-        job_id=sample_job.id,
-        job_row_number=100,
-        reference="ref",
-    )
 
-    assert Notification.query.count() == 1
+    with set_config(notify_api, 'REDIS_ENABLED', True):
+        persist_notification(
+            template_id=sample_template.id,
+            template_version=sample_template.version,
+            recipient='+447111111111',
+            service=sample_template.service,
+            personalisation={},
+            notification_type='sms',
+            api_key_id=sample_test_api_key.id,
+            key_type=sample_test_api_key.key_type,
+            job_id=sample_job.id,
+            job_row_number=100,
+            reference="ref",
+        )
 
-    assert not daily_limit_cache.called
-    assert not template_usage_cache.called
+        assert Notification.query.count() == 1
+
+        assert not daily_limit_cache.called
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
@@ -198,77 +196,48 @@ def test_persist_notification_with_optionals(sample_job, sample_api_key):
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
-def test_persist_notification_doesnt_touch_cache_for_old_keys_that_dont_exist(notify_db_session, mocker):
-    service = create_service(restricted=True)
-    template = create_template(service=service)
-    api_key = create_api_key(service=service)
-    mock_incr = mocker.patch('app.notifications.process_notifications.redis_store.incr')
-    mocker.patch('app.notifications.process_notifications.redis_store.get', return_value=None)
-    mocker.patch('app.notifications.process_notifications.redis_store.get_all_from_hash', return_value=None)
-
-    persist_notification(
-        template_id=template.id,
-        template_version=template.version,
-        recipient='+447111111111',
-        service=template.service,
-        personalisation={},
-        notification_type='sms',
-        api_key_id=api_key.id,
-        key_type=api_key.key_type,
-        reference="ref"
-    )
-    mock_incr.assert_not_called()
-
-
-@freeze_time("2016-01-01 11:09:00.061258")
-def test_persist_notification_increments_cache_if_key_exists_and_for_trial_service(
-    notify_db_session, mocker
+def test_persist_notification_increments_cache_for_trial_service(
+        notify_api, notify_db_session, mocker
 ):
     service = create_service(restricted=True)
     template = create_template(service=service)
     api_key = create_api_key(service=service)
     mock_incr = mocker.patch('app.notifications.process_notifications.redis_store.incr')
-    mocker.patch('app.notifications.process_notifications.redis_store.get', return_value=1)
-    mocker.patch('app.notifications.process_notifications.redis_store.get_all_from_hash',
-                 return_value={template.id, 1})
+    with set_config(notify_api, 'REDIS_ENABLED', True):
+        persist_notification(
+            template_id=template.id,
+            template_version=template.version,
+            recipient='+447111111122',
+            service=template.service,
+            personalisation={},
+            notification_type='sms',
+            api_key_id=api_key.id,
+            key_type=api_key.key_type,
+            reference="ref2")
 
-    persist_notification(
-        template_id=template.id,
-        template_version=template.version,
-        recipient='+447111111122',
-        service=template.service,
-        personalisation={},
-        notification_type='sms',
-        api_key_id=api_key.id,
-        key_type=api_key.key_type,
-        reference="ref2")
-
-    mock_incr.assert_called_once_with(str(service.id) + "-2016-01-01-count", )
+        mock_incr.assert_called_once_with(str(service.id) + "-2016-01-01-count", )
 
 
-def test_persist_notification_does_not_increments_cache_live_service(
-    notify_db_session, mocker
+def test_persist_notification_increments_cache_live_service(
+    notify_api, notify_db_session, mocker
 ):
     service = create_service(restricted=False)
     template = create_template(service=service)
     api_key = create_api_key(service=service)
     mock_incr = mocker.patch('app.notifications.process_notifications.redis_store.incr')
-    mocker.patch('app.notifications.process_notifications.redis_store.get', return_value=1)
-    mocker.patch('app.notifications.process_notifications.redis_store.get_all_from_hash',
-                 return_value={template.id, 1})
+    with set_config(notify_api, 'REDIS_ENABLED', True):
+        persist_notification(
+            template_id=template.id,
+            template_version=template.version,
+            recipient='+447111111122',
+            service=template.service,
+            personalisation={},
+            notification_type='sms',
+            api_key_id=api_key.id,
+            key_type=api_key.key_type,
+            reference="ref2")
 
-    persist_notification(
-        template_id=template.id,
-        template_version=template.version,
-        recipient='+447111111122',
-        service=template.service,
-        personalisation={},
-        notification_type='sms',
-        api_key_id=api_key.id,
-        key_type=api_key.key_type,
-        reference="ref2")
-
-    assert not mock_incr.called
+        assert mock_incr.called
 
 
 @pytest.mark.parametrize((

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -65,8 +65,7 @@ def test_check_service_message_limit_in_cache_under_message_limit_passes(
     mock_set = mocker.patch('app.notifications.validators.redis_store.set')
     check_service_over_daily_message_limit(key_type, serialised_service)
     mock_get.assert_called_once_with(f'{serialised_service.id}-{datetime.utcnow().strftime("%Y-%m-%d")}-count')
-    assert mock_get.called
-    assert not mock_set.called
+    mock_set.assert_not_called()
 
 
 def test_check_service_over_daily_message_limit_should_not_interact_with_cache_for_test_key(sample_service, mocker):
@@ -74,7 +73,6 @@ def test_check_service_over_daily_message_limit_should_not_interact_with_cache_f
     mock_get = mocker.patch('app.notifications.validators.redis_store.get', side_effect=[None])
     serialised_service = SerialisedService.from_id(sample_service.id)
     check_service_over_daily_message_limit('test', serialised_service)
-    app.notifications.validators.redis_store.assert_not_called
     mock_get.assert_not_called()
 
 
@@ -105,7 +103,7 @@ def test_check_service_over_daily_message_limit_does_nothing_if_redis_disabled(n
 
 @pytest.mark.parametrize('key_type', ['team', 'normal'])
 def test_check_service_message_limit_over_message_limit_fails(key_type, mocker, notify_db_session):
-    service = create_service(restricted=True, message_limit=4)
+    service = create_service(message_limit=4)
     mocker.patch('app.redis_store.get', return_value=5)
 
     with pytest.raises(TooManyRequestsError) as e:


### PR DESCRIPTION
Last year we had an issue with the daily limit cache and the query that was populating it. As a result we have not been checking the daily limit properly. This PR should correct all that.

The daily limit cache is not being incremented in app.notifications.process_notifications.persist_notification, this method is and should always be the only method used to create a notification.
We increment the daily limit cache is redis is enabled (and it is always enabled for production) and the key type for the notification is team or normal.

We check if the daily limit is exceed in many places:
 - app.celery.tasks.process_job
 -  app.v2.notifications.post_notifications.post_notification
 - app.v2.notifications.post_notifications.post_precompiled_letter_notification
 - app.service.send_notification.send_one_off_notification
 - app.service.send_notification.send_pdf_letter_notification

If the daily limits cache is not found, set the cache to 0 with an expiry of 24 hours. The daily limit cache key is service_id-yyy-mm-dd-count, so each day a new cache is created.

The best thing about this PR is that the app.service_dao.fetch_todays_total_message_count query has been removed. This query did not perform well and had been wrong for ages.

Before we merge this PR we will need to increase the daily limit for some of the services that we expect will exceed their current daily limit. 
