### PR TITLE
Remove user permissions if service becomes a broadcast service

### DIFF
--- a/app/dao/broadcast_service_dao.py
+++ b/app/dao/broadcast_service_dao.py
@@ -7,7 +7,10 @@ from app.dao.dao_utils import autocommit, version_class
 from app.models import (
     BROADCAST_TYPE,
     EMAIL_AUTH_TYPE,
+    INVITE_PENDING,
+    InvitedUser,
     Organisation,
+    Permission,
     Service,
     ServiceBroadcastSettings,
     ServicePermission,
@@ -52,6 +55,13 @@ def set_broadcast_service_type(service, service_mode, broadcast_channel, provide
     else:
         service.restricted = True
         service.go_live_at = None
+
+    # Remove all user permissions for the service users and invited users
+    Permission.query.filter_by(service_id=service.id).delete()
+    InvitedUser.query.filter_by(
+        service_id=service.id,
+        status=INVITE_PENDING
+    ).update({'permissions': ''})
 
     # Add service to organisation
     organisation = Organisation.query.filter_by(

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1115,6 +1115,7 @@ def set_as_broadcast_service(service_id):
     - sets the services `count_as_live` to false
     - adds the service to the broadcast organisation
     - puts the service into training mode or live mode
+    - removes all permissions from current users and invited users
     """
     data = validate(request.get_json(), service_broadcast_settings_schema)
     service = dao_fetch_service_by_id(service_id)


### PR DESCRIPTION
The "normal" service permissions and broadcast service permissions are
going to be different with no overlap. This means that if you were
viewing the team members page, there might be permissions in the
database that are not visible on the frontend if a service has changed
type. For example, someone could have the 'manage_api_keys' permission,
which would not show up on the team members page of a broadcast service.
To avoid people having permissions which aren't visible in admin, we now
remove all permissions from users when their service is converted to a
broadcast service.

Permisions for invited users are also removed.

It's not possible to convert a broadcast service to a normal service, so
we don't need to cover for this scenario.