### PR TITLE
Fix the endpoint for the monthly status report

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -955,9 +955,24 @@ def get_monthly_notification_data_by_service():
     start_date = request.args.get('start_date')
     end_date = request.args.get('end_date')
 
-    result = fact_notification_status_dao.fetch_monthly_notification_statuses_per_service(start_date, end_date)
+    rows = fact_notification_status_dao.fetch_monthly_notification_statuses_per_service(start_date, end_date)
 
-    return jsonify(result)
+    serialized_results = [
+        [
+            str(row.date_created),
+            str(row.service_id),
+            row.service_name,
+            row.notification_type,
+            row.count_sending,
+            row.count_delivered,
+            row.count_technical_failure,
+            row.count_temporary_failure,
+            row.count_permanent_failure,
+            row.count_sent,
+        ]
+        for row in rows
+    ]
+    return jsonify(serialized_results)
 
 
 def check_request_args(request):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3512,22 +3512,21 @@ def test_cancel_notification_for_service_updates_letter_if_still_time_to_cancel(
     assert response['status'] == 'cancelled'
 
 
-def test_get_monthly_notification_data_by_service(mocker, admin_request):
-    dao_mock = mocker.patch(
-        'app.service.rest.fact_notification_status_dao.fetch_monthly_notification_statuses_per_service',
-        return_value=[])
-
-    start_date = '2019-01-01'
-    end_date = '2019-06-17'
-
+def test_get_monthly_notification_data_by_service(sample_service, admin_request):
+    create_ft_notification_status(date(2019, 4, 17), notification_type='letter', service=sample_service,
+                                  notification_status='delivered')
+    create_ft_notification_status(date(2019, 3, 5), notification_type='email', service=sample_service,
+                                  notification_status='sending', count=4)
     response = admin_request.get(
         'service.get_monthly_notification_data_by_service',
-        start_date=start_date,
-        end_date=end_date
+        start_date='2019-01-01',
+        end_date='2019-06-17'
     )
 
-    dao_mock.assert_called_once_with(start_date, end_date)
-    assert response == []
+    assert response == [
+        ['2019-03-01', str(sample_service.id), 'Sample service', 'email', 4, 0, 0, 0, 0, 0],
+        ['2019-04-01', str(sample_service.id), 'Sample service', 'letter', 0, 1, 0, 0, 0, 0],
+    ]
 
 
 @freeze_time('2019-12-11 13:30')


### PR DESCRIPTION
This wasn't working - the error given when trying to access it was `TypeError: Object of type 'Row' is not JSON serializable` when we tried to serialize a SQLAlchemy Row.

I haven't looked too far into what has changed to stop this from working, but have just changed the endpoint to return a nested list instead.