### PR TITLE
Fix bug in check_service_over_daily_limit

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -74,6 +74,7 @@ def check_service_over_daily_message_limit(key_type, service):
                 service.id, int(service_stats), service.message_limit)
         )
         raise TooManyRequestsError(service.message_limit)
+    return service_stats
 
 
 def check_rate_limiting(service, api_key):


### PR DESCRIPTION
I forgot to return service_stats if the cache exists. And fixed the tests to check service_stats value.