### PR TITLE
Remove original permissions from broadcast users

### DIFF
--- a/migrations/versions/0361_new_user_bcast_permissions.py
+++ b/migrations/versions/0361_new_user_bcast_permissions.py
@@ -1,0 +1,32 @@
+"""
+
+Revision ID: 0361_new_user_bcast_permissions
+Revises: 0360_remove_sched_notifications
+Create Date: 2021-06-30 11:42:32.780734
+
+"""
+from alembic import op
+
+revision = '0361_new_user_bcast_permissions'
+down_revision = '0360_remove_sched_notifications'
+
+
+def upgrade():
+    """
+    Delete all permissions for broadcast service users and invited pending users, apart from 'view_activity'
+    which they always have.
+    """
+    op.execute(
+        "DELETE FROM permissions WHERE permission != 'view_activity' "
+        "and service_id in (select id from services where organisation_id = '38e4bf69-93b0-445d-acee-53ea53fe02df')"
+    )
+    op.execute(
+        "UPDATE invited_users SET permissions = 'view_activity' WHERE status = 'pending' "
+        "and service_id in (select id from services where organisation_id = '38e4bf69-93b0-445d-acee-53ea53fe02df')"
+    )
+
+
+def downgrade():
+    """
+    This change cannot be downgraded since we no longer have access to the original permissions users had.
+    """


### PR DESCRIPTION
The broadcast user permissions are changing, so to avoid confusion and permissions which exist in the database but don't display on the frontend we are going to remove all existing permissions for users of broadcast services. This also updates the permissions of invited users who are still pending.

The exception to this is the `view_activity` permission, which we [always add for broadcast users](https://github.com/alphagov/notifications-admin/blob/aad017a184d314d9d192f4b9d6485915f83217c1/app/main/forms.py#L1043) even if they have no other permissions.

[Pivotal story](https://www.pivotaltracker.com/story/show/178482657)