### PR TITLE
Always keep view activity permissions for broadcast users

### DIFF
--- a/app/dao/broadcast_service_dao.py
+++ b/app/dao/broadcast_service_dao.py
@@ -8,6 +8,7 @@ from app.models import (
     BROADCAST_TYPE,
     EMAIL_AUTH_TYPE,
     INVITE_PENDING,
+    VIEW_ACTIVITY,
     InvitedUser,
     Organisation,
     Permission,
@@ -56,12 +57,15 @@ def set_broadcast_service_type(service, service_mode, broadcast_channel, provide
         service.restricted = True
         service.go_live_at = None
 
-    # Remove all user permissions for the service users and invited users
-    Permission.query.filter_by(service_id=service.id).delete()
+    # Remove all user permissions apart from view_activity for the service users and invited users
+    Permission.query.filter(
+        Permission.service_id == service.id,
+        Permission.permission != VIEW_ACTIVITY
+    ).delete()
     InvitedUser.query.filter_by(
         service_id=service.id,
         status=INVITE_PENDING
-    ).update({'permissions': ''})
+    ).update({'permissions': VIEW_ACTIVITY})
 
     # Add service to organisation
     organisation = Organisation.query.filter_by(

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -4162,9 +4162,11 @@ def test_set_as_broadcast_service_removes_user_permissions(
         }
     )
 
-    # The user permissions for the broadcast service get removed
-    assert len(service_user.get_permissions(service_id=sample_service.id)) == 0
-    # Permissions for users invited to the broadcast service get removed
-    assert sample_invited_user.permissions == ''
+    # The user permissions for the broadcast service (apart from 'view_activity') get removed
+    assert service_user.get_permissions(service_id=sample_service.id) == ['view_activity']
+
+    # Permissions for users invited to the broadcast service (apart from 'view_activity') get removed
+    assert sample_invited_user.permissions == 'view_activity'
+
     # Permissions for other services remain
-    assert len(service_user.get_permissions(service_id=sample_service_full_permissions.id)) == 1
+    assert service_user.get_permissions(service_id=sample_service_full_permissions.id) == ['send_emails']


### PR DESCRIPTION
We made a change to remove all permissions from users and invited users when the broadcast service settings form is submitted (#3284). However, when the form is submitted, notifications-admin always [adds the `view_activity`
permission](https://github.com/alphagov/notifications-admin/blob/256c840b46d4095edbd0af105e5c1a340242575d/app/main/forms.py#L1042) even if no permission boxes are ticked, so we don't want to remove that one permission.