### PR TITLE
Revert werkzeug to the last non-2.0.0 version

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -25,6 +25,10 @@ rfc3987==1.3.8
 cachetools==4.2.1
 beautifulsoup4==4.9.3
 lxml==4.6.3
+
+# When we upgraded to 2.0.1 we noticed significantly higher memory usage on the API
+Werkzeug==1.0.1 # puyp: < 2.0.0
+
 # higher version causes build to fail on PaaS due to lack of Rust
 # see https://github.com/pyca/cryptography/issues/5810
 cryptography<3.4 # pyup: <3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,10 @@ rfc3987==1.3.8
 cachetools==4.2.1
 beautifulsoup4==4.9.3
 lxml==4.6.3
+
+# When we upgraded to 2.0.1 we noticed significantly higher memory usage on the API
+Werkzeug==1.0.1 # puyp: < 2.0.0
+
 # higher version causes build to fail on PaaS due to lack of Rust
 # see https://github.com/pyca/cryptography/issues/5810
 cryptography<3.4 # pyup: <3.4
@@ -47,25 +51,25 @@ alembic==1.6.5
 amqp==1.4.9
 anyjson==0.3.3
 attrs==21.2.0
-awscli==1.19.108
+awscli==1.20.1
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.3.0
 blinker==1.4
 boto==2.49.0
-boto3==1.17.108
-botocore==1.20.108
+boto3==1.18.1
+botocore==1.21.1
 certifi==2021.5.30
-chardet==4.0.0
+charset-normalizer==2.0.3
 click==8.0.1
 colorama==0.4.3
 dnspython==1.16.0
 docutils==0.15.2
 flask-redis==0.4.0
 geojson==2.5.0
-govuk-bank-holidays==0.8
+govuk-bank-holidays==0.9
 greenlet==1.1.0
-idna==2.10
+idna==3.2
 Jinja2==3.0.1
 jmespath==0.10.0
 kombu==3.0.37
@@ -80,15 +84,15 @@ pycparser==2.20
 pyparsing==2.4.7
 PyPDF2==1.26.0
 pyrsistent==0.18.0
-python-dateutil==2.8.1
+python-dateutil==2.8.2
 python-editor==1.0.4
 python-json-logger==2.0.1
 pytz==2021.1
 PyYAML==5.4.1
 redis==3.5.3
-requests==2.25.1
+requests==2.26.0
 rsa==4.7.2
-s3transfer==0.4.2
+s3transfer==0.5.0
 Shapely==1.7.1
 six==1.16.0
 smartypants==2.0.1
@@ -96,4 +100,3 @@ soupsieve==2.2.1
 statsd==3.3.0
 urllib3==1.26.6
 webencodings==0.5.1
-Werkzeug==2.0.1


### PR DESCRIPTION
We observe high memory usage since we bumped it (along with other
things) and because it only appears on the API and not on the workers
the hypothesis is that Werkzeug is responsible for it.