### PR TITLE
Trigger separate link test for failover lambda

### DIFF
--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -251,6 +251,4 @@ def send_broadcast_provider_message(self, broadcast_event_id, provider):
 @notify_celery.task(name='trigger-link-test')
 def trigger_link_test(provider):
     identifier = str(uuid.uuid4())
-    message = f"Sending a link test to CBC proxy for provider {provider}. Identifier in payload is {identifier}"
-    current_app.logger.info(message)
     cbc_proxy_client.get_proxy(provider).send_link_test(identifier)

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -1,4 +1,3 @@
-import uuid
 from datetime import datetime
 
 from flask import current_app
@@ -250,5 +249,4 @@ def send_broadcast_provider_message(self, broadcast_event_id, provider):
 
 @notify_celery.task(name='trigger-link-test')
 def trigger_link_test(provider):
-    identifier = str(uuid.uuid4())
-    cbc_proxy_client.get_proxy(provider).send_link_test(identifier)
+    cbc_proxy_client.get_proxy(provider).send_link_tests()

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -2,9 +2,8 @@ import uuid
 from datetime import datetime
 
 from flask import current_app
-from sqlalchemy.schema import Sequence
 
-from app import cbc_proxy_client, db, notify_celery, zendesk_client
+from app import cbc_proxy_client, notify_celery, zendesk_client
 from app.clients.cbc_proxy import CBCProxyRetryableException
 from app.config import QueueNames
 from app.dao.broadcast_message_dao import (
@@ -252,11 +251,6 @@ def send_broadcast_provider_message(self, broadcast_event_id, provider):
 @notify_celery.task(name='trigger-link-test')
 def trigger_link_test(provider):
     identifier = str(uuid.uuid4())
-    formatted_seq_number = None
-    if provider == BroadcastProvider.VODAFONE:
-        sequence = Sequence('broadcast_provider_message_number_seq')
-        sequential_number = db.session.connection().execute(sequence)
-        formatted_seq_number = format_sequential_number(sequential_number)
     message = f"Sending a link test to CBC proxy for provider {provider}. Identifier in payload is {identifier}"
     current_app.logger.info(message)
-    cbc_proxy_client.get_proxy(provider).send_link_test(identifier, formatted_seq_number)
+    cbc_proxy_client.get_proxy(provider).send_link_test(identifier)

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -249,4 +249,4 @@ def send_broadcast_provider_message(self, broadcast_event_id, provider):
 
 @notify_celery.task(name='trigger-link-test')
 def trigger_link_test(provider):
-    cbc_proxy_client.get_proxy(provider).send_link_tests()
+    cbc_proxy_client.get_proxy(provider).send_link_test()

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from abc import ABC, abstractmethod
 
 import boto3
@@ -77,11 +78,11 @@ class CBCProxyClientBase(ABC):
     def __init__(self, lambda_client):
         self._lambda_client = lambda_client
 
-    def send_link_test(
-        self,
-        identifier,
-    ):
-        pass
+    def send_link_tests(self):
+        self._send_link_test(self.lambda_name)
+        self._send_link_test(self.failover_lambda_name)
+
+    def _send_link_test(self): pass
 
     def create_and_send_broadcast(
         self, identifier, headline, description, areas, sent, expires, channel, message_number=None
@@ -159,9 +160,9 @@ class CBCProxyOne2ManyClient(CBCProxyClientBase):
     LANGUAGE_ENGLISH = 'en-GB'
     LANGUAGE_WELSH = 'cy-GB'
 
-    def send_link_test(
+    def _send_link_test(
         self,
-        identifier,
+        lambda_name,
     ):
         """
         link test - open up a connection to a specific provider, and send them an xml payload with a <msgType> of
@@ -169,11 +170,11 @@ class CBCProxyOne2ManyClient(CBCProxyClientBase):
         """
         payload = {
             'message_type': 'test',
-            'identifier': identifier,
+            'identifier': str(uuid.uuid4()),
             'message_format': 'cap'
         }
 
-        self._invoke_lambda(lambda_name=self.lambda_name, payload=payload)
+        self._invoke_lambda(lambda_name=lambda_name, payload=payload)
 
     def create_and_send_broadcast(
         self, identifier, headline, description, areas, sent, expires, channel, message_number=None
@@ -234,9 +235,9 @@ class CBCProxyVodafone(CBCProxyClientBase):
     LANGUAGE_ENGLISH = 'English'
     LANGUAGE_WELSH = 'Welsh'
 
-    def send_link_test(
+    def _send_link_test(
         self,
-        identifier,
+        lambda_name,
     ):
         """
         link test - open up a connection to a specific provider, and send them an xml payload with a <msgType> of
@@ -249,12 +250,12 @@ class CBCProxyVodafone(CBCProxyClientBase):
 
         payload = {
             'message_type': 'test',
-            'identifier': identifier,
+            'identifier': str(uuid.uuid4()),
             'message_number': formatted_seq_number,
             'message_format': 'ibag'
         }
 
-        self._invoke_lambda(lambda_name=self.lambda_name, payload=payload)
+        self._invoke_lambda(lambda_name=lambda_name, payload=payload)
 
     def create_and_send_broadcast(
         self, identifier, message_number, headline, description, areas, sent, expires, channel

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -123,7 +123,7 @@ class CBCProxyClientBase(ABC):
         payload_bytes = bytes(json.dumps(payload), encoding='utf8')
         try:
             current_app.logger.info(
-                f"Calling lambda {lambda_name} with payload {payload}"
+                f"Calling lambda {lambda_name} with payload {str(payload)[:1000]}"
             )
 
             result = self._lambda_client.invoke(

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -78,11 +78,14 @@ class CBCProxyClientBase(ABC):
     def __init__(self, lambda_client):
         self._lambda_client = lambda_client
 
-    def send_link_tests(self):
+    def send_link_test(self):
         self._send_link_test(self.lambda_name)
         self._send_link_test(self.failover_lambda_name)
 
-    def _send_link_test(self): pass
+    def _send_link_test(
+        self,
+        lambda_name,
+    ): pass
 
     def create_and_send_broadcast(
         self, identifier, headline, description, areas, sent, expires, channel, message_number=None

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -169,7 +169,7 @@ class CBCProxyOne2ManyClient(CBCProxyClientBase):
             'message_format': 'cap'
         }
 
-        self._invoke_lambda_with_failover(payload=payload)
+        self._invoke_lambda(lambda_name=self.lambda_name, payload=payload)
 
     def create_and_send_broadcast(
         self, identifier, headline, description, areas, sent, expires, channel, message_number=None
@@ -250,7 +250,7 @@ class CBCProxyVodafone(CBCProxyClientBase):
             'message_format': 'ibag'
         }
 
-        self._invoke_lambda_with_failover(payload=payload)
+        self._invoke_lambda(lambda_name=self.lambda_name, payload=payload)
 
     def create_and_send_broadcast(
         self, identifier, message_number, headline, description, areas, sent, expires, channel

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -123,7 +123,7 @@ class CBCProxyClientBase(ABC):
         payload_bytes = bytes(json.dumps(payload), encoding='utf8')
         try:
             current_app.logger.info(
-                f"Calling lambda {lambda_name} for link test with payload {payload}"
+                f"Calling lambda {lambda_name} with payload {payload}"
             )
 
             result = self._lambda_client.invoke(

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -118,6 +118,10 @@ class CBCProxyClientBase(ABC):
     def _invoke_lambda(self, lambda_name, payload):
         payload_bytes = bytes(json.dumps(payload), encoding='utf8')
         try:
+            current_app.logger.info(
+                f"Calling lambda {lambda_name} for link test with payload {payload}"
+            )
+
             result = self._lambda_client.invoke(
                 FunctionName=lambda_name,
                 InvocationType='RequestResponse',

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -566,10 +566,8 @@ def test_trigger_link_tests_invokes_cbc_proxy_client(
         f'app.clients.cbc_proxy.CBCProxy{provider_capitalised}.send_link_test',
     )
 
-    mocker.patch('app.celery.broadcast_message_tasks.uuid.uuid4', return_value=123)
-
     trigger_link_test(provider)
-    assert mock_send_link_test.called_once_with('123')
+    assert mock_send_link_test.called_once()
 
 
 @pytest.mark.parametrize('retry_count, expected_delay', [

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -1,4 +1,3 @@
-import uuid
 from datetime import datetime
 from unittest.mock import ANY, Mock, call
 
@@ -561,29 +560,16 @@ def test_send_broadcast_provider_message_delays_retry_exponentially(
     ['vodafone', 'Vodafone'],
 ])
 def test_trigger_link_tests_invokes_cbc_proxy_client(
-    mocker, provider, provider_capitalised
+    mocker, provider, provider_capitalised, client,
 ):
     mock_send_link_test = mocker.patch(
         f'app.clients.cbc_proxy.CBCProxy{provider_capitalised}.send_link_test',
     )
 
+    mocker.patch('app.celery.broadcast_message_tasks.uuid.uuid4', return_value=123)
+
     trigger_link_test(provider)
-
-    assert mock_send_link_test.called
-    # the 0th argument of the call to send_link_test
-    identifier = mock_send_link_test.mock_calls[0][1][0]
-
-    try:
-        uuid.UUID(identifier)
-    except BaseException:
-        pytest.fail(f"{identifier} is not a valid uuid")
-
-    # testing sequential number:
-    if provider == 'vodafone':
-        assert type(mock_send_link_test.mock_calls[0][1][1]) is str
-        assert len(mock_send_link_test.mock_calls[0][1][1]) == 8
-    else:
-        assert not mock_send_link_test.mock_calls[0][1][1]
+    assert mock_send_link_test.called_once_with('123')
 
 
 @pytest.mark.parametrize('retry_count, expected_delay', [

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -82,9 +82,9 @@ def test_cbc_proxy_lambda_client_has_correct_keys(cbc_proxy_ee):
     assert secret == 'cbc-proxy-aws-secret-access-key'
 
 
-def test_cbc_proxy_send_link_tests(mocker, cbc_proxy_ee):
+def test_cbc_proxy_send_link_test(mocker, cbc_proxy_ee):
     mock_send_link_test = mocker.patch.object(cbc_proxy_ee, '_send_link_test')
-    cbc_proxy_ee.send_link_tests()
+    cbc_proxy_ee.send_link_test()
 
     mock_send_link_test.assert_any_call(cbc_proxy_ee.lambda_name)
     mock_send_link_test.assert_any_call(cbc_proxy_ee.failover_lambda_name)

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, call
 import pytest
 from botocore.exceptions import ClientError as BotoClientError
 
+from app import db
 from app.clients.cbc_proxy import (
     CBCProxyClient,
     CBCProxyEE,
@@ -573,7 +574,6 @@ def test_cbc_proxy_one_2_many_send_link_test_invokes_function(mocker, cbc_proxy_
 
     cbc_proxy.send_link_test(
         identifier=identifier,
-        sequential_number='0000007b',
     )
 
     ld_client_mock.invoke.assert_called_once_with(
@@ -595,6 +595,10 @@ def test_cbc_proxy_one_2_many_send_link_test_invokes_function(mocker, cbc_proxy_
 def test_cbc_proxy_vodafone_send_link_test_invokes_function(mocker, cbc_proxy_vodafone):
     identifier = str(uuid.uuid4())
 
+    db.session.connection().execute(
+        'ALTER SEQUENCE broadcast_provider_message_number_seq RESTART WITH 1'
+    )
+
     ld_client_mock = mocker.patch.object(
         cbc_proxy_vodafone,
         '_lambda_client',
@@ -607,7 +611,6 @@ def test_cbc_proxy_vodafone_send_link_test_invokes_function(mocker, cbc_proxy_vo
 
     cbc_proxy_vodafone.send_link_test(
         identifier=identifier,
-        sequential_number='0000007b',
     )
 
     ld_client_mock.invoke.assert_called_once_with(
@@ -622,5 +625,5 @@ def test_cbc_proxy_vodafone_send_link_test_invokes_function(mocker, cbc_proxy_vo
 
     assert payload['identifier'] == identifier
     assert payload['message_type'] == 'test'
-    assert payload['message_number'] == '0000007b'
+    assert payload['message_number'] == '00000001'
     assert payload['message_format'] == 'ibag'


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178738544

Previously there was a risk that we'd only find out that the failover lambda
was broken at the point when we needed it. This rewrites the link test task
and its supporting code to make it easy to test each lambda independently.

Paired with @rjbaker 