### PR TITLE
Show separate error for when user tries to cancel letter

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -38,7 +38,7 @@ notifications-python-client==6.0.2
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@44.4.3#egg=notifications-utils==44.4.3
+git+https://github.com/alphagov/notifications-utils.git@44.5.1#egg=notifications-utils==44.5.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ notifications-python-client==6.0.2
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@44.4.3#egg=notifications-utils==44.4.3
+git+https://github.com/alphagov/notifications-utils.git@44.5.1#egg=notifications-utils==44.5.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.10.1
@@ -51,14 +51,14 @@ alembic==1.6.5
 amqp==1.4.9
 anyjson==0.3.3
 attrs==21.2.0
-awscli==1.20.1
+awscli==1.20.8
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.3.0
 blinker==1.4
 boto==2.49.0
-boto3==1.18.1
-botocore==1.21.1
+boto3==1.18.8
+botocore==1.21.8
 certifi==2021.5.30
 charset-normalizer==2.0.3
 click==8.0.1
@@ -78,7 +78,7 @@ MarkupSafe==2.0.1
 mistune==0.8.4
 orderedset==2.0.3
 packaging==21.0
-phonenumbers==8.12.27
+phonenumbers==8.12.28
 pyasn1==0.4.8
 pycparser==2.20
 pyparsing==2.4.7
@@ -86,7 +86,7 @@ PyPDF2==1.26.0
 pyrsistent==0.18.0
 python-dateutil==2.8.2
 python-editor==1.0.4
-python-json-logger==2.0.1
+python-json-logger==2.0.2
 pytz==2021.1
 PyYAML==5.4.1
 redis==3.5.3

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3445,6 +3445,7 @@ def test_cancel_notification_for_service_raises_invalid_request_when_letter_is_i
     notification_status,
 ):
     sample_letter_notification.status = notification_status
+    sample_letter_notification.created_at = datetime.now()
 
     response = admin_request.post(
         'service.cancel_notification_for_service',
@@ -3452,7 +3453,13 @@ def test_cancel_notification_for_service_raises_invalid_request_when_letter_is_i
         notification_id=sample_letter_notification.id,
         _expected_status=400
     )
-    assert response['message'] == 'It’s too late to cancel this letter. Printing started today at 5.30pm'
+    if notification_status == 'cancelled':
+        assert response['message'] == 'This letter has already been cancelled.'
+    else:
+        assert response['message'] == (
+            f"We could not cancel this letter. "
+            f"Letter status: {notification_status}, created_at: 2018-07-07 12:00:00"
+        )
     assert response['result'] == 'error'
 
 


### PR DESCRIPTION
Show separate error for when user tries to cancel letter that is already cancelled. 

This is to show a better error messages to our users, and also so we have more detailed log messages for related errors.

Relies on: https://github.com/alphagov/notifications-utils/pull/886

Needed for: https://github.com/alphagov/notifications-admin/pull/3984