### PR TITLE
Support granular API auth for internal apps

### DIFF
--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -49,6 +49,13 @@ class AuthError(Exception):
         }
 
 
+class InternalApiKey():
+    def __init__(self, client_id, secret):
+        self.secret = secret
+        self.id = client_id
+        self.expiry_date = None
+
+
 def get_auth_token(req):
     auth_header = req.headers.get('Authorization', None)
     if not auth_header:
@@ -81,23 +88,13 @@ def requires_internal_auth(expected_client_id):
     if client_id != expected_client_id:
         raise AuthError("Unauthorized: not allowed to perform this action", 401)
 
+    api_keys = [
+        InternalApiKey(client_id, secret)
+        for secret in current_app.config.get('INTERNAL_CLIENT_API_KEYS')[client_id]
+    ]
+
+    _decode_jwt_token(auth_token, api_keys)
     g.service_id = client_id
-    secrets = current_app.config.get('INTERNAL_CLIENT_API_KEYS')[client_id]
-
-    for secret in secrets:
-        try:
-            decode_jwt_token(auth_token, secret)
-            return
-        except TokenExpiredError:
-            raise AuthError("Invalid token: expired, check that your system clock is accurate", 403)
-        except TokenDecodeError:
-            # TODO: Change this so it doesn't also catch `TokenIssuerError` or `TokenIssuedAtError` exceptions
-            # (which are children of `TokenDecodeError`) as these should cause an auth error immediately rather
-            # than continue on to check the next admin client secret
-            continue
-
-    # Either there are no admin client secrets or their token didn't match one of them so error
-    raise AuthError("Unauthorized: API authentication token not found", 401)
 
 
 def requires_auth():
@@ -123,15 +120,22 @@ def requires_auth():
     if not service.active:
         raise AuthError("Invalid token: service is archived", 403, service_id=service.id)
 
-    for api_key in service.api_keys:
+    _decode_jwt_token(auth_token, service.api_keys, service.id)
+
+    g.service_id = service_id
+    g.authenticated_service = service
+
+
+def _decode_jwt_token(auth_token, api_keys, service_id=None):
+    for api_key in api_keys:
         try:
             decode_jwt_token(auth_token, api_key.secret)
         except TokenExpiredError:
             err_msg = "Error: Your system clock must be accurate to within 30 seconds"
-            raise AuthError(err_msg, 403, service_id=service.id, api_key_id=api_key.id)
+            raise AuthError(err_msg, 403, service_id=service_id, api_key_id=api_key.id)
         except TokenAlgorithmError:
             err_msg = "Invalid token: algorithm used is not HS256"
-            raise AuthError(err_msg, 403, service_id=service.id, api_key_id=api_key.id)
+            raise AuthError(err_msg, 403, service_id=service_id, api_key_id=api_key.id)
         except TokenDecodeError:
             # we attempted to validate the token but it failed meaning it was not signed using this api key.
             # Let's try the next one
@@ -141,25 +145,24 @@ def requires_auth():
             continue
         except TokenError:
             # General error when trying to decode and validate the token
-            raise AuthError(GENERAL_TOKEN_ERROR_MESSAGE, 403, service_id=service.id, api_key_id=api_key.id)
+            raise AuthError(GENERAL_TOKEN_ERROR_MESSAGE, 403, service_id=service_id, api_key_id=api_key.id)
 
         if api_key.expiry_date:
-            raise AuthError("Invalid token: API key revoked", 403, service_id=service.id, api_key_id=api_key.id)
+            raise AuthError("Invalid token: API key revoked", 403, service_id=service_id, api_key_id=api_key.id)
 
-        g.service_id = service.id
-        g.api_user = api_key
-        g.authenticated_service = service
+        if service_id:
+            g.api_user = api_key
 
-        current_app.logger.info('API authorised for service {} with api key {}, using issuer {} for URL: {}'.format(
-            service.id,
-            api_key.id,
-            request.headers.get('User-Agent'),
-            request.base_url
-        ))
+            current_app.logger.info('API authorised for service {} with api key {}, using issuer {} for URL: {}'.format(
+                service_id,
+                api_key.id,
+                request.headers.get('User-Agent'),
+                request.base_url
+            ))
         return
     else:
         # service has API keys, but none matching the one the user provided
-        raise AuthError("Invalid token: API key not found", 403, service_id=service.id)
+        raise AuthError("Invalid token: API key not found", 403, service_id=service_id)
 
 
 def __get_token_issuer(auth_token):

--- a/app/config.py
+++ b/app/config.py
@@ -84,8 +84,15 @@ class Config(object):
     # URL of api app (on AWS this is the internal api endpoint)
     API_HOST_NAME = os.getenv('API_HOST_NAME')
 
-    # secrets that internal apps, such as the admin app or document download, must use to authenticate with the API
+    # LEGACY: replacing with INTERNAL_CLIENT_API_KEYS
     API_INTERNAL_SECRETS = json.loads(os.environ.get('API_INTERNAL_SECRETS', '[]'))
+
+    # secrets that internal apps, such as the admin app or document download, must use to authenticate with the API
+    ADMIN_CLIENT_USER_NAME = 'notify-admin'
+
+    INTERNAL_CLIENT_API_KEYS = {
+        ADMIN_CLIENT_USER_NAME: API_INTERNAL_SECRETS
+    }
 
     # encyption secret/salt
     SECRET_KEY = os.getenv('SECRET_KEY')
@@ -129,7 +136,6 @@ class Config(object):
     ###########################
 
     NOTIFY_ENVIRONMENT = 'development'
-    ADMIN_CLIENT_USER_NAME = 'notify-admin'
     AWS_REGION = 'eu-west-1'
     INVITATION_EXPIRATION_DAYS = 2
     NOTIFY_APP_NAME = 'api'
@@ -399,7 +405,10 @@ class Development(Config):
     TRANSIENT_UPLOADED_LETTERS = 'development-transient-uploaded-letters'
     LETTER_SANITISE_BUCKET_NAME = 'development-letters-sanitise'
 
-    API_INTERNAL_SECRETS = ['dev-notify-secret-key']
+    INTERNAL_CLIENT_API_KEYS = {
+        Config.ADMIN_CLIENT_USER_NAME: ['dev-notify-secret-key']
+    }
+
     SECRET_KEY = 'dev-notify-secret-key'
     DANGEROUS_SALT = 'dev-notify-salt'
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,7 +28,7 @@ def create_authorization_header(service_id=None, key_type=KEY_TYPE_NORMAL):
 
     else:
         client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
-        secret = current_app.config['API_INTERNAL_SECRETS'][0]
+        secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
 
     token = create_jwt_token(secret=secret, client_id=client_id)
     return 'Authorization', 'Bearer {}'.format(token)

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -134,7 +134,7 @@ def test_requires_admin_auth_should_not_allow_request_with_no_iat(
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
     with pytest.raises(AuthError) as exc:
         requires_admin_auth()
-    assert exc.value.short_message == "Unauthorized: API authentication token not found"
+    assert exc.value.short_message == "Invalid token: API key not found"
 
 
 def test_requires_admin_auth_should_not_allow_request_with_old_iat(
@@ -150,7 +150,7 @@ def test_requires_admin_auth_should_not_allow_request_with_old_iat(
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
     with pytest.raises(AuthError) as exc:
         requires_admin_auth()
-    assert exc.value.short_message == "Invalid token: expired, check that your system clock is accurate"
+    assert exc.value.short_message == "Error: Your system clock must be accurate to within 30 seconds"
 
 
 def test_requires_auth_should_not_allow_request_with_extra_claims(
@@ -342,9 +342,9 @@ def test_requires_admin_auth_returns_error_with_no_secrets(
             '/service',
             headers={'Authorization': 'Bearer {}'.format(admin_jwt_token)})
 
-    assert response.status_code == 401
+    assert response.status_code == 403
     error_message = json.loads(response.get_data())
-    assert error_message['message'] == {"token": ["Unauthorized: API authentication token not found"]}
+    assert error_message['message'] == {"token": ["Invalid token: API key not found"]}
 
 
 def test_requires_admin_auth_returns_error_when_secret_is_invalid(
@@ -359,9 +359,9 @@ def test_requires_admin_auth_returns_error_when_secret_is_invalid(
             '/service',
             headers={'Authorization': 'Bearer {}'.format(admin_jwt_token)})
 
-    assert response.status_code == 401
+    assert response.status_code == 403
     error_message = json.loads(response.get_data())
-    assert error_message['message'] == {"token": ["Unauthorized: API authentication token not found"]}
+    assert error_message['message'] == {"token": ["Invalid token: API key not found"]}
 
 
 def test_requires_auth_returns_error_when_service_doesnt_exist(

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -116,8 +116,8 @@ def test_auth_should_not_allow_request_with_non_hs256_algorithm(client, sample_a
 
 
 def test_admin_auth_should_not_allow_request_with_no_iat(client):
-    iss = current_app.config['ADMIN_CLIENT_USER_NAME']
-    secret = current_app.config['API_INTERNAL_SECRETS'][0]
+    client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
+    secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
 
     # code copied from notifications_python_client.authentication.py::create_jwt_token
     headers = {
@@ -126,7 +126,7 @@ def test_admin_auth_should_not_allow_request_with_no_iat(client):
     }
 
     claims = {
-        'iss': iss
+        'iss': client_id,
         # 'iat': not provided
     }
 
@@ -135,12 +135,12 @@ def test_admin_auth_should_not_allow_request_with_no_iat(client):
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
     with pytest.raises(AuthError) as exc:
         requires_admin_auth()
-    assert exc.value.short_message == "Unauthorized: admin authentication token not found"
+    assert exc.value.short_message == "Unauthorized: API authentication token not found"
 
 
 def test_admin_auth_should_not_allow_request_with_old_iat(client):
-    iss = current_app.config['ADMIN_CLIENT_USER_NAME']
-    secret = current_app.config['API_INTERNAL_SECRETS'][0]
+    client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
+    secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
 
     # code copied from notifications_python_client.authentication.py::create_jwt_token
     headers = {
@@ -149,7 +149,7 @@ def test_admin_auth_should_not_allow_request_with_old_iat(client):
     }
 
     claims = {
-        'iss': iss,
+        'iss': client_id,
         'iat': int(time.time()) - 60
     }
 
@@ -224,24 +224,24 @@ def test_should_allow_valid_token_for_request_with_path_params_for_public_url(cl
 
 
 def test_should_allow_valid_token_for_request_with_path_params_for_admin_url(client):
-    token = create_jwt_token(
-        current_app.config['API_INTERNAL_SECRETS'][0], current_app.config['ADMIN_CLIENT_USER_NAME']
-    )
+    client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
+    secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
+
+    token = create_jwt_token(secret, client_id)
     response = client.get('/service', headers={'Authorization': 'Bearer {}'.format(token)})
     assert response.status_code == 200
 
 
 def test_should_allow_valid_token_for_request_with_path_params_for_admin_url_with_second_secret(client):
-    with set_config(client.application, 'API_INTERNAL_SECRETS', ["secret1", "secret2"]):
-        token = create_jwt_token(
-            current_app.config['API_INTERNAL_SECRETS'][0], current_app.config['ADMIN_CLIENT_USER_NAME']
-        )
+    client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
+    new_secrets = { client_id: ["secret1", "secret2"] }
+
+    with set_config(client.application, 'INTERNAL_CLIENT_API_KEYS', new_secrets):
+        token = create_jwt_token("secret1", client_id)
         response = client.get('/service', headers={'Authorization': 'Bearer {}'.format(token)})
         assert response.status_code == 200
 
-        token = create_jwt_token(
-            current_app.config['API_INTERNAL_SECRETS'][1], current_app.config['ADMIN_CLIENT_USER_NAME']
-        )
+        token = create_jwt_token("secret2", client_id)
         response = client.get('/service', headers={'Authorization': 'Bearer {}'.format(token)})
         assert response.status_code == 200
 
@@ -317,35 +317,35 @@ def test_authentication_returns_token_expired_when_service_uses_expired_key_and_
 
 
 def test_authentication_returns_error_when_admin_client_has_no_secrets(client):
-    api_secret = current_app.config.get('API_INTERNAL_SECRETS')[0]
-    api_service_id = current_app.config.get('ADMIN_CLIENT_USER_NAME')
-    token = create_jwt_token(
-        secret=api_secret,
-        client_id=api_service_id
-    )
-    with set_config(client.application, 'API_INTERNAL_SECRETS', []):
+    client_id = current_app.config.get('ADMIN_CLIENT_USER_NAME')
+    secret = current_app.config.get('INTERNAL_CLIENT_API_KEYS')[client_id][0]
+    token = create_jwt_token(secret, client_id)
+    new_secrets = { client_id: [] }
+
+    with set_config(client.application, 'INTERNAL_CLIENT_API_KEYS', new_secrets):
         response = client.get(
             '/service',
             headers={'Authorization': 'Bearer {}'.format(token)})
+
     assert response.status_code == 401
     error_message = json.loads(response.get_data())
-    assert error_message['message'] == {"token": ["Unauthorized: admin authentication token not found"]}
+    assert error_message['message'] == {"token": ["Unauthorized: API authentication token not found"]}
 
 
 def test_authentication_returns_error_when_admin_client_secret_is_invalid(client):
-    api_secret = current_app.config.get('API_INTERNAL_SECRETS')[0]
-    token = create_jwt_token(
-        secret=api_secret,
-        client_id=current_app.config.get('ADMIN_CLIENT_USER_NAME')
-    )
-    current_app.config['API_INTERNAL_SECRETS'][0] = 'something-wrong'
-    response = client.get(
-        '/service',
-        headers={'Authorization': 'Bearer {}'.format(token)})
+    client_id = current_app.config.get('ADMIN_CLIENT_USER_NAME')
+    secret = current_app.config.get('INTERNAL_CLIENT_API_KEYS')[client_id][0]
+    token = create_jwt_token(secret, client_id)
+    new_secrets = { client_id:  ['something-wrong'] }
+
+    with set_config(client.application, 'INTERNAL_CLIENT_API_KEYS', new_secrets):
+        response = client.get(
+            '/service',
+            headers={'Authorization': 'Bearer {}'.format(token)})
+
     assert response.status_code == 401
     error_message = json.loads(response.get_data())
-    assert error_message['message'] == {"token": ["Unauthorized: admin authentication token not found"]}
-    current_app.config['API_INTERNAL_SECRETS'][0] = api_secret
+    assert error_message['message'] == {"token": ["Unauthorized: API authentication token not found"]}
 
 
 def test_authentication_returns_error_when_service_doesnt_exit(
@@ -450,9 +450,9 @@ def test_proxy_key_non_auth_endpoint(notify_api, check_proxy_header, header_valu
     (False, 'wrong_key', 200),
 ])
 def test_proxy_key_on_admin_auth_endpoint(notify_api, check_proxy_header, header_value, expected_status):
-    token = create_jwt_token(
-        current_app.config['API_INTERNAL_SECRETS'][0], current_app.config['ADMIN_CLIENT_USER_NAME']
-    )
+    client_id = current_app.config.get('ADMIN_CLIENT_USER_NAME')
+    secret = current_app.config.get('INTERNAL_CLIENT_API_KEYS')[client_id][0]
+    token = create_jwt_token(secret, client_id)
 
     with set_config_values(notify_api, {
         'ROUTE_SECRET_KEY_1': 'key_1',

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -34,6 +34,34 @@ def create_custom_jwt_token(headers = None, payload = None, key = str(uuid.uuid4
     return jwt.encode(payload=payload, key=key, headers=headers)
 
 
+@pytest.fixture
+def service_jwt_secret(sample_api_key):
+    return get_unsigned_secrets(sample_api_key.service_id)[0]
+
+
+@pytest.fixture
+def service_jwt_token(sample_api_key, service_jwt_secret):
+    return create_jwt_token(
+        secret=service_jwt_secret,
+        client_id=str(sample_api_key.service_id),
+    )
+
+
+@pytest.fixture
+def admin_jwt_client_id():
+    return current_app.config['ADMIN_CLIENT_USER_NAME']
+
+
+@pytest.fixture
+def admin_jwt_secret(admin_jwt_client_id):
+    return current_app.config['INTERNAL_CLIENT_API_KEYS'][admin_jwt_client_id][0]
+
+
+@pytest.fixture
+def admin_jwt_token(admin_jwt_client_id, admin_jwt_secret):
+    return create_jwt_token(admin_jwt_secret, admin_jwt_client_id)
+
+
 @pytest.mark.parametrize('auth_fn', [requires_auth, requires_admin_auth])
 def test_should_not_allow_request_with_no_token(client, auth_fn):
     request.headers = {}
@@ -93,13 +121,14 @@ def test_requires_auth_should_not_allow_request_with_non_hs256_algorithm(client,
     assert exc.value.short_message == 'Invalid token: algorithm used is not HS256'
 
 
-def test_requires_admin_auth_should_not_allow_request_with_no_iat(client):
-    client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
-    secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
-
+def test_requires_admin_auth_should_not_allow_request_with_no_iat(
+    client,
+    admin_jwt_client_id,
+    admin_jwt_secret,
+):
     token = create_custom_jwt_token(
-        payload = { 'iss': client_id },
-        key = secret
+        payload = { 'iss': admin_jwt_client_id },
+        key = admin_jwt_secret
     )
 
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
@@ -108,13 +137,14 @@ def test_requires_admin_auth_should_not_allow_request_with_no_iat(client):
     assert exc.value.short_message == "Unauthorized: API authentication token not found"
 
 
-def test_requires_admin_auth_should_not_allow_request_with_old_iat(client):
-    client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
-    secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
-
+def test_requires_admin_auth_should_not_allow_request_with_old_iat(
+    client,
+    admin_jwt_client_id,
+    admin_jwt_secret,
+):
     token = create_custom_jwt_token(
-        payload = { 'iss': client_id, 'iat': int(time.time()) - 60 },
-        key = secret
+        payload = { 'iss': admin_jwt_client_id, 'iat': int(time.time()) - 60 },
+        key = admin_jwt_secret
     )
 
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
@@ -123,16 +153,18 @@ def test_requires_admin_auth_should_not_allow_request_with_old_iat(client):
     assert exc.value.short_message == "Invalid token: expired, check that your system clock is accurate"
 
 
-def test_requires_auth_should_not_allow_request_with_extra_claims(client, sample_api_key):
-    key = get_unsigned_secrets(sample_api_key.service_id)[0]
-
+def test_requires_auth_should_not_allow_request_with_extra_claims(
+    client,
+    sample_api_key,
+    service_jwt_secret,
+):
     token = create_custom_jwt_token(
         payload = {
             'iss': str(sample_api_key.service_id),
             'iat': int(time.time()),
             'aud': 'notifications.service.gov.uk'  # extra claim that we don't support
         },
-        key = key
+        key = service_jwt_secret,
     )
 
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
@@ -155,16 +187,30 @@ def test_requires_auth_should_not_allow_invalid_secret(client, sample_api_key):
 
 
 @pytest.mark.parametrize('scheme', ['bearer', 'Bearer'])
-def test_requires_auth_should_allow_valid_token(client, sample_api_key, scheme):
-    token = __create_token(sample_api_key.service_id)
+def test_requires_auth_should_allow_valid_token(
+    client,
+    sample_api_key,
+    service_jwt_secret,
+    scheme,
+):
+    token = create_jwt_token(
+        client_id=str(sample_api_key.service_id),
+        secret=service_jwt_secret,
+    )
     response = client.get('/notifications', headers={'Authorization': '{} {}'.format(scheme, token)})
     assert response.status_code == 200
 
 
 @pytest.mark.parametrize('service_id', ['not-a-valid-id', 1234])
-def test_requires_auth_should_not_allow_service_id_that_is_not_the_wrong_data_type(client, sample_api_key, service_id):
-    token = create_jwt_token(secret=get_unsigned_secrets(sample_api_key.service_id)[0],
-                             client_id=service_id)
+def test_requires_auth_should_not_allow_service_id_that_is_not_the_wrong_data_type(
+    client,
+    service_jwt_secret,
+    service_id
+):
+    token = create_jwt_token(
+        client_id=service_id,
+        secret=service_jwt_secret,
+    )
     response = client.get(
         '/notifications',
         headers={'Authorization': "Bearer {}".format(token)}
@@ -174,36 +220,43 @@ def test_requires_auth_should_not_allow_service_id_that_is_not_the_wrong_data_ty
     assert data['message'] == {"token": ['Invalid token: service id is not the right data type']}
 
 
-def test_requires_auth_should_allow_valid_token_for_request_with_path_params_for_public_url(client, sample_api_key):
-    token = __create_token(sample_api_key.service_id)
-    response = client.get('/notifications', headers={'Authorization': 'Bearer {}'.format(token)})
+def test_requires_auth_should_allow_valid_token_for_request_with_path_params_for_public_url(
+    client,
+    service_jwt_token,
+):
+    response = client.get('/notifications', headers={'Authorization': 'Bearer {}'.format(service_jwt_token)})
     assert response.status_code == 200
 
 
-def test_requires_admin_auth_should_allow_valid_token_for_request_with_path_params(client):
-    client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
-    secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
-
-    token = create_jwt_token(secret, client_id)
-    response = client.get('/service', headers={'Authorization': 'Bearer {}'.format(token)})
+def test_requires_admin_auth_should_allow_valid_token_for_request_with_path_params(
+    client,
+    admin_jwt_token
+):
+    response = client.get('/service', headers={'Authorization': 'Bearer {}'.format(admin_jwt_token)})
     assert response.status_code == 200
 
 
-def test_requires_admin_auth_should_allow_valid_token_for_request_with_path_params_with_second_secret(client):
-    client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
-    new_secrets = { client_id: ["secret1", "secret2"] }
+def test_requires_admin_auth_should_allow_valid_token_for_request_with_path_params_with_second_secret(
+    client,
+    admin_jwt_client_id,
+):
+    new_secrets = { admin_jwt_client_id: ["secret1", "secret2"] }
 
     with set_config(client.application, 'INTERNAL_CLIENT_API_KEYS', new_secrets):
-        token = create_jwt_token("secret1", client_id)
+        token = create_jwt_token("secret1", admin_jwt_client_id)
         response = client.get('/service', headers={'Authorization': 'Bearer {}'.format(token)})
         assert response.status_code == 200
 
-        token = create_jwt_token("secret2", client_id)
+        token = create_jwt_token("secret2", admin_jwt_client_id)
         response = client.get('/service', headers={'Authorization': 'Bearer {}'.format(token)})
         assert response.status_code == 200
 
 
-def test_requires_auth_should_allow_valid_token_when_service_has_multiple_keys(client, sample_api_key):
+def test_requires_auth_should_allow_valid_token_when_service_has_multiple_keys(
+    client,
+    sample_api_key,
+    service_jwt_token,
+):
     data = {'service': sample_api_key.service,
             'name': 'some key name',
             'created_by': sample_api_key.created_by,
@@ -211,16 +264,16 @@ def test_requires_auth_should_allow_valid_token_when_service_has_multiple_keys(c
             }
     api_key = ApiKey(**data)
     save_model_api_key(api_key)
-    token = __create_token(sample_api_key.service_id)
     response = client.get(
         '/notifications',
-        headers={'Authorization': 'Bearer {}'.format(token)})
+        headers={'Authorization': 'Bearer {}'.format(service_jwt_token)})
     assert response.status_code == 200
 
 
 def test_requires_auth_passes_when_service_has_multiple_keys_some_expired(
-        client,
-        sample_api_key):
+    client,
+    sample_api_key,
+):
     expired_key_data = {'service': sample_api_key.service,
                         'name': 'expired_key',
                         'expiry_date': datetime.utcnow(),
@@ -237,8 +290,9 @@ def test_requires_auth_passes_when_service_has_multiple_keys_some_expired(
     api_key = ApiKey(**another_key)
     save_model_api_key(api_key)
     token = create_jwt_token(
-        secret=get_unsigned_secret(api_key.id),
-        client_id=str(sample_api_key.service_id))
+        client_id=str(sample_api_key.service_id),
+        secret=get_unsigned_secret(api_key.id)
+    )
     response = client.get(
         '/notifications',
         headers={'Authorization': 'Bearer {}'.format(token)})
@@ -246,7 +300,8 @@ def test_requires_auth_passes_when_service_has_multiple_keys_some_expired(
 
 
 def test_requires_auth_returns_token_expired_when_service_uses_expired_key_and_has_multiple_keys(
-    client, sample_api_key
+    client,
+    sample_api_key
 ):
     expired_key = {'service': sample_api_key.service,
                    'name': 'expired_key',
@@ -263,8 +318,9 @@ def test_requires_auth_returns_token_expired_when_service_uses_expired_key_and_h
     api_key = ApiKey(**another_key)
     save_model_api_key(api_key)
     token = create_jwt_token(
-        secret=get_unsigned_secret(expired_api_key.id),
-        client_id=str(sample_api_key.service_id))
+        client_id=str(sample_api_key.service_id),
+        secret=get_unsigned_secret(expired_api_key.id)
+    )
     expire_api_key(service_id=sample_api_key.service_id, api_key_id=expired_api_key.id)
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
     with pytest.raises(AuthError) as exc:
@@ -274,39 +330,41 @@ def test_requires_auth_returns_token_expired_when_service_uses_expired_key_and_h
     assert exc.value.api_key_id == expired_api_key.id
 
 
-def test_requires_admin_auth_returns_error_with_no_secrets(client):
-    client_id = current_app.config.get('ADMIN_CLIENT_USER_NAME')
-    secret = current_app.config.get('INTERNAL_CLIENT_API_KEYS')[client_id][0]
-    token = create_jwt_token(secret, client_id)
-    new_secrets = { client_id: [] }
+def test_requires_admin_auth_returns_error_with_no_secrets(
+    client,
+    admin_jwt_client_id,
+    admin_jwt_token,
+):
+    new_secrets = { admin_jwt_client_id: [] }
 
     with set_config(client.application, 'INTERNAL_CLIENT_API_KEYS', new_secrets):
         response = client.get(
             '/service',
-            headers={'Authorization': 'Bearer {}'.format(token)})
+            headers={'Authorization': 'Bearer {}'.format(admin_jwt_token)})
 
     assert response.status_code == 401
     error_message = json.loads(response.get_data())
     assert error_message['message'] == {"token": ["Unauthorized: API authentication token not found"]}
 
 
-def test_requires_admin_auth_returns_error_when_secret_is_invalid(client):
-    client_id = current_app.config.get('ADMIN_CLIENT_USER_NAME')
-    secret = current_app.config.get('INTERNAL_CLIENT_API_KEYS')[client_id][0]
-    token = create_jwt_token(secret, client_id)
-    new_secrets = { client_id:  ['something-wrong'] }
+def test_requires_admin_auth_returns_error_when_secret_is_invalid(
+    client,
+    admin_jwt_client_id,
+    admin_jwt_token,
+):
+    new_secrets = { admin_jwt_client_id:  ['something-wrong'] }
 
     with set_config(client.application, 'INTERNAL_CLIENT_API_KEYS', new_secrets):
         response = client.get(
             '/service',
-            headers={'Authorization': 'Bearer {}'.format(token)})
+            headers={'Authorization': 'Bearer {}'.format(admin_jwt_token)})
 
     assert response.status_code == 401
     error_message = json.loads(response.get_data())
     assert error_message['message'] == {"token": ["Unauthorized: API authentication token not found"]}
 
 
-def test_requires_auth_returns_error_when_service_doesnt_exit(
+def test_requires_auth_returns_error_when_service_doesnt_exist(
     client,
     sample_api_key
 ):
@@ -324,11 +382,13 @@ def test_requires_auth_returns_error_when_service_doesnt_exit(
     assert error_message['message'] == {'token': ['Invalid token: service not found']}
 
 
-def test_requires_auth_returns_error_when_service_inactive(client, sample_api_key):
+def test_requires_auth_returns_error_when_service_inactive(
+    client,
+    sample_api_key,
+    service_jwt_token,
+):
     sample_api_key.service.active = False
-    token = create_jwt_token(secret=str(sample_api_key.id), client_id=str(sample_api_key.service_id))
-
-    response = client.get('/notifications', headers={'Authorization': 'Bearer {}'.format(token)})
+    response = client.get('/notifications', headers={'Authorization': 'Bearer {}'.format(service_jwt_token)})
 
     assert response.status_code == 403
     error_message = json.loads(response.get_data())
@@ -349,22 +409,31 @@ def test_requires_auth_returns_error_when_service_has_no_secrets(
     assert exc.value.service_id == str(sample_service.id)
 
 
-def test_should_attach_the_current_api_key_to_current_app(notify_api, sample_service, sample_api_key):
+def test_should_attach_the_current_api_key_to_current_app(
+    notify_api,
+    sample_service,
+    sample_api_key,
+    service_jwt_token,
+):
     with notify_api.test_request_context(), notify_api.test_client() as client:
-        token = __create_token(sample_api_key.service_id)
         response = client.get(
             '/notifications',
-            headers={'Authorization': 'Bearer {}'.format(token)}
+            headers={'Authorization': 'Bearer {}'.format(service_jwt_token)}
         )
         assert response.status_code == 200
         assert str(api_user.id) == str(sample_api_key.id)
 
 
 def test_requires_auth_return_403_when_token_is_expired(
-    client, sample_api_key
+    client,
+    sample_api_key,
+    service_jwt_secret,
 ):
     with freeze_time('2001-01-01T12:00:00'):
-        token = __create_token(sample_api_key.service_id)
+        token = create_jwt_token(
+            client_id=str(sample_api_key.service_id),
+            secret=service_jwt_secret,
+        )
     with freeze_time('2001-01-01T12:00:40'):
         with pytest.raises(AuthError) as exc:
             request.headers = {'Authorization': 'Bearer {}'.format(token)}
@@ -372,11 +441,6 @@ def test_requires_auth_return_403_when_token_is_expired(
     assert exc.value.short_message == 'Error: Your system clock must be accurate to within 30 seconds'
     assert exc.value.service_id == str(sample_api_key.service_id)
     assert str(exc.value.api_key_id) == str(sample_api_key.id)
-
-
-def __create_token(service_id):
-    return create_jwt_token(secret=get_unsigned_secrets(service_id)[0],
-                            client_id=str(service_id))
 
 
 @pytest.mark.parametrize('check_proxy_header,header_value', [
@@ -408,11 +472,13 @@ def test_requires_no_auth_proxy_key(notify_api, check_proxy_header, header_value
     (False, 'key_1', 200),
     (False, 'wrong_key', 200),
 ])
-def test_requires_admin_auth_proxy_key(notify_api, check_proxy_header, header_value, expected_status):
-    client_id = current_app.config.get('ADMIN_CLIENT_USER_NAME')
-    secret = current_app.config.get('INTERNAL_CLIENT_API_KEYS')[client_id][0]
-    token = create_jwt_token(secret, client_id)
-
+def test_requires_admin_auth_proxy_key(
+    notify_api,
+    check_proxy_header,
+    header_value,
+    expected_status,
+    admin_jwt_token,
+):
     with set_config_values(notify_api, {
         'ROUTE_SECRET_KEY_1': 'key_1',
         'ROUTE_SECRET_KEY_2': '',
@@ -424,13 +490,18 @@ def test_requires_admin_auth_proxy_key(notify_api, check_proxy_header, header_va
                 path='/service',
                 headers=[
                     ('X-Custom-Forwarder', header_value),
-                    ('Authorization', 'Bearer {}'.format(token))
+                    ('Authorization', 'Bearer {}'.format(admin_jwt_token))
                 ]
             )
         assert response.status_code == expected_status
 
 
-def test_requires_auth_should_cache_service_and_api_key_lookups(mocker, client, sample_api_key):
+def test_requires_auth_should_cache_service_and_api_key_lookups(
+    mocker,
+    client,
+    sample_api_key,
+    service_jwt_token
+):
     mock_get_api_keys = mocker.patch(
         'app.serialised_models.get_model_api_keys',
         wraps=get_model_api_keys,
@@ -441,9 +512,8 @@ def test_requires_auth_should_cache_service_and_api_key_lookups(mocker, client, 
     )
 
     for _ in range(5):
-        token = __create_token(sample_api_key.service_id)
         client.get('/notifications', headers={
-            'Authorization': f'Bearer {token}'
+            'Authorization': f'Bearer {service_jwt_token}'
         })
 
     assert mock_get_api_keys.call_args_list == [

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -70,7 +70,7 @@ def test_should_not_allow_request_with_no_iss(client, auth_fn):
     assert exc.value.short_message == 'Invalid token: iss field not provided'
 
 
-def test_should_not_allow_request_with_no_iat(client, sample_api_key):
+def test_requires_auth_should_not_allow_request_with_no_iat(client, sample_api_key):
     token = create_custom_jwt_token(
         payload = { 'iss': str(sample_api_key.service_id) }
     )
@@ -81,7 +81,7 @@ def test_should_not_allow_request_with_no_iat(client, sample_api_key):
     assert exc.value.short_message == 'Invalid token: API key not found'
 
 
-def test_auth_should_not_allow_request_with_non_hs256_algorithm(client, sample_api_key):
+def test_requires_auth_should_not_allow_request_with_non_hs256_algorithm(client, sample_api_key):
     token = create_custom_jwt_token(
         headers = { "typ": 'JWT', "alg": 'HS512' },
         payload = { 'iss': str(sample_api_key.service_id), 'iat': int(time.time()) }
@@ -93,7 +93,7 @@ def test_auth_should_not_allow_request_with_non_hs256_algorithm(client, sample_a
     assert exc.value.short_message == 'Invalid token: algorithm used is not HS256'
 
 
-def test_admin_auth_should_not_allow_request_with_no_iat(client):
+def test_requires_admin_auth_should_not_allow_request_with_no_iat(client):
     client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
     secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
 
@@ -108,7 +108,7 @@ def test_admin_auth_should_not_allow_request_with_no_iat(client):
     assert exc.value.short_message == "Unauthorized: API authentication token not found"
 
 
-def test_admin_auth_should_not_allow_request_with_old_iat(client):
+def test_requires_admin_auth_should_not_allow_request_with_old_iat(client):
     client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
     secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
 
@@ -123,7 +123,7 @@ def test_admin_auth_should_not_allow_request_with_old_iat(client):
     assert exc.value.short_message == "Invalid token: expired, check that your system clock is accurate"
 
 
-def test_auth_should_not_allow_request_with_extra_claims(client, sample_api_key):
+def test_requires_auth_should_not_allow_request_with_extra_claims(client, sample_api_key):
     key = get_unsigned_secrets(sample_api_key.service_id)[0]
 
     token = create_custom_jwt_token(
@@ -141,7 +141,7 @@ def test_auth_should_not_allow_request_with_extra_claims(client, sample_api_key)
     assert exc.value.short_message == GENERAL_TOKEN_ERROR_MESSAGE
 
 
-def test_should_not_allow_invalid_secret(client, sample_api_key):
+def test_requires_auth_should_not_allow_invalid_secret(client, sample_api_key):
     token = create_jwt_token(
         secret="not-so-secret",
         client_id=str(sample_api_key.service_id))
@@ -155,14 +155,14 @@ def test_should_not_allow_invalid_secret(client, sample_api_key):
 
 
 @pytest.mark.parametrize('scheme', ['bearer', 'Bearer'])
-def test_should_allow_valid_token(client, sample_api_key, scheme):
+def test_requires_auth_should_allow_valid_token(client, sample_api_key, scheme):
     token = __create_token(sample_api_key.service_id)
     response = client.get('/notifications', headers={'Authorization': '{} {}'.format(scheme, token)})
     assert response.status_code == 200
 
 
 @pytest.mark.parametrize('service_id', ['not-a-valid-id', 1234])
-def test_should_not_allow_service_id_that_is_not_the_wrong_data_type(client, sample_api_key, service_id):
+def test_requires_auth_should_not_allow_service_id_that_is_not_the_wrong_data_type(client, sample_api_key, service_id):
     token = create_jwt_token(secret=get_unsigned_secrets(sample_api_key.service_id)[0],
                              client_id=service_id)
     response = client.get(
@@ -174,13 +174,13 @@ def test_should_not_allow_service_id_that_is_not_the_wrong_data_type(client, sam
     assert data['message'] == {"token": ['Invalid token: service id is not the right data type']}
 
 
-def test_should_allow_valid_token_for_request_with_path_params_for_public_url(client, sample_api_key):
+def test_requires_auth_should_allow_valid_token_for_request_with_path_params_for_public_url(client, sample_api_key):
     token = __create_token(sample_api_key.service_id)
     response = client.get('/notifications', headers={'Authorization': 'Bearer {}'.format(token)})
     assert response.status_code == 200
 
 
-def test_should_allow_valid_token_for_request_with_path_params_for_admin_url(client):
+def test_requires_admin_auth_should_allow_valid_token_for_request_with_path_params(client):
     client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
     secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
 
@@ -189,7 +189,7 @@ def test_should_allow_valid_token_for_request_with_path_params_for_admin_url(cli
     assert response.status_code == 200
 
 
-def test_should_allow_valid_token_for_request_with_path_params_for_admin_url_with_second_secret(client):
+def test_requires_admin_auth_should_allow_valid_token_for_request_with_path_params_with_second_secret(client):
     client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
     new_secrets = { client_id: ["secret1", "secret2"] }
 
@@ -203,7 +203,7 @@ def test_should_allow_valid_token_for_request_with_path_params_for_admin_url_wit
         assert response.status_code == 200
 
 
-def test_should_allow_valid_token_when_service_has_multiple_keys(client, sample_api_key):
+def test_requires_auth_should_allow_valid_token_when_service_has_multiple_keys(client, sample_api_key):
     data = {'service': sample_api_key.service,
             'name': 'some key name',
             'created_by': sample_api_key.created_by,
@@ -218,7 +218,7 @@ def test_should_allow_valid_token_when_service_has_multiple_keys(client, sample_
     assert response.status_code == 200
 
 
-def test_authentication_passes_when_service_has_multiple_keys_some_expired(
+def test_requires_auth_passes_when_service_has_multiple_keys_some_expired(
         client,
         sample_api_key):
     expired_key_data = {'service': sample_api_key.service,
@@ -245,8 +245,9 @@ def test_authentication_passes_when_service_has_multiple_keys_some_expired(
     assert response.status_code == 200
 
 
-def test_authentication_returns_token_expired_when_service_uses_expired_key_and_has_multiple_keys(client,
-                                                                                                  sample_api_key):
+def test_requires_auth_returns_token_expired_when_service_uses_expired_key_and_has_multiple_keys(
+    client, sample_api_key
+):
     expired_key = {'service': sample_api_key.service,
                    'name': 'expired_key',
                    'created_by': sample_api_key.created_by,
@@ -273,7 +274,7 @@ def test_authentication_returns_token_expired_when_service_uses_expired_key_and_
     assert exc.value.api_key_id == expired_api_key.id
 
 
-def test_authentication_returns_error_when_admin_client_has_no_secrets(client):
+def test_requires_admin_auth_returns_error_with_no_secrets(client):
     client_id = current_app.config.get('ADMIN_CLIENT_USER_NAME')
     secret = current_app.config.get('INTERNAL_CLIENT_API_KEYS')[client_id][0]
     token = create_jwt_token(secret, client_id)
@@ -289,7 +290,7 @@ def test_authentication_returns_error_when_admin_client_has_no_secrets(client):
     assert error_message['message'] == {"token": ["Unauthorized: API authentication token not found"]}
 
 
-def test_authentication_returns_error_when_admin_client_secret_is_invalid(client):
+def test_requires_admin_auth_returns_error_when_secret_is_invalid(client):
     client_id = current_app.config.get('ADMIN_CLIENT_USER_NAME')
     secret = current_app.config.get('INTERNAL_CLIENT_API_KEYS')[client_id][0]
     token = create_jwt_token(secret, client_id)
@@ -305,7 +306,7 @@ def test_authentication_returns_error_when_admin_client_secret_is_invalid(client
     assert error_message['message'] == {"token": ["Unauthorized: API authentication token not found"]}
 
 
-def test_authentication_returns_error_when_service_doesnt_exit(
+def test_requires_auth_returns_error_when_service_doesnt_exit(
     client,
     sample_api_key
 ):
@@ -323,7 +324,7 @@ def test_authentication_returns_error_when_service_doesnt_exit(
     assert error_message['message'] == {'token': ['Invalid token: service not found']}
 
 
-def test_authentication_returns_error_when_service_inactive(client, sample_api_key):
+def test_requires_auth_returns_error_when_service_inactive(client, sample_api_key):
     sample_api_key.service.active = False
     token = create_jwt_token(secret=str(sample_api_key.id), client_id=str(sample_api_key.service_id))
 
@@ -334,9 +335,9 @@ def test_authentication_returns_error_when_service_inactive(client, sample_api_k
     assert error_message['message'] == {'token': ['Invalid token: service is archived']}
 
 
-def test_authentication_returns_error_when_service_has_no_secrets(client,
-                                                                  sample_service,
-                                                                  fake_uuid):
+def test_requires_auth_returns_error_when_service_has_no_secrets(
+    client, sample_service, fake_uuid
+):
     token = create_jwt_token(
         secret=fake_uuid,
         client_id=str(sample_service.id))
@@ -359,8 +360,9 @@ def test_should_attach_the_current_api_key_to_current_app(notify_api, sample_ser
         assert str(api_user.id) == str(sample_api_key.id)
 
 
-def test_should_return_403_when_token_is_expired(client,
-                                                 sample_api_key):
+def test_requires_auth_return_403_when_token_is_expired(
+    client, sample_api_key
+):
     with freeze_time('2001-01-01T12:00:00'):
         token = __create_token(sample_api_key.service_id)
     with freeze_time('2001-01-01T12:00:40'):
@@ -377,13 +379,13 @@ def __create_token(service_id):
                             client_id=str(service_id))
 
 
-@pytest.mark.parametrize('check_proxy_header,header_value,expected_status', [
-    (True, 'key_1', 200),
-    (True, 'wrong_key', 200),
-    (False, 'key_1', 200),
-    (False, 'wrong_key', 200),
+@pytest.mark.parametrize('check_proxy_header,header_value', [
+    (True, 'key_1'),
+    (True, 'wrong_key'),
+    (False, 'key_1'),
+    (False, 'wrong_key'),
 ])
-def test_proxy_key_non_auth_endpoint(notify_api, check_proxy_header, header_value, expected_status):
+def test_requires_no_auth_proxy_key(notify_api, check_proxy_header, header_value):
     with set_config_values(notify_api, {
         'ROUTE_SECRET_KEY_1': 'key_1',
         'ROUTE_SECRET_KEY_2': '',
@@ -397,7 +399,7 @@ def test_proxy_key_non_auth_endpoint(notify_api, check_proxy_header, header_valu
                     ('X-Custom-Forwarder', header_value),
                 ]
             )
-        assert response.status_code == expected_status
+        assert response.status_code == 200
 
 
 @pytest.mark.parametrize('check_proxy_header,header_value,expected_status', [
@@ -406,7 +408,7 @@ def test_proxy_key_non_auth_endpoint(notify_api, check_proxy_header, header_valu
     (False, 'key_1', 200),
     (False, 'wrong_key', 200),
 ])
-def test_proxy_key_on_admin_auth_endpoint(notify_api, check_proxy_header, header_value, expected_status):
+def test_requires_admin_auth_proxy_key(notify_api, check_proxy_header, header_value, expected_status):
     client_id = current_app.config.get('ADMIN_CLIENT_USER_NAME')
     secret = current_app.config.get('INTERNAL_CLIENT_API_KEYS')[client_id][0]
     token = create_jwt_token(secret, client_id)
@@ -428,8 +430,7 @@ def test_proxy_key_on_admin_auth_endpoint(notify_api, check_proxy_header, header
         assert response.status_code == expected_status
 
 
-def test_should_cache_service_and_api_key_lookups(mocker, client, sample_api_key):
-
+def test_requires_auth_should_cache_service_and_api_key_lookups(mocker, client, sample_api_key):
     mock_get_api_keys = mocker.patch(
         'app.serialised_models.get_model_api_keys',
         wraps=get_model_api_keys,

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -28,6 +28,12 @@ from app.models import KEY_TYPE_NORMAL, ApiKey
 from tests.conftest import set_config, set_config_values
 
 
+def create_custom_jwt_token(headers = None, payload = None, key = str(uuid.uuid4())):
+    # code copied from notifications_python_client.authentication.py::create_jwt_token
+    headers = headers or { "typ": 'JWT', "alg": 'HS256' }
+    return jwt.encode(payload=payload, key=key, headers=headers)
+
+
 @pytest.mark.parametrize('auth_fn', [requires_auth, requires_admin_auth])
 def test_should_not_allow_request_with_no_token(client, auth_fn):
     request.headers = {}
@@ -54,18 +60,9 @@ def test_should_not_allow_request_with_incorrect_token(client, auth_fn):
 
 @pytest.mark.parametrize('auth_fn', [requires_auth, requires_admin_auth])
 def test_should_not_allow_request_with_no_iss(client, auth_fn):
-    # code copied from notifications_python_client.authentication.py::create_jwt_token
-    headers = {
-        "typ": 'JWT',
-        "alg": 'HS256'
-    }
-
-    claims = {
-        # 'iss': not provided
-        'iat': int(time.time())
-    }
-
-    token = jwt.encode(payload=claims, key=str(uuid.uuid4()), headers=headers)
+    token = create_custom_jwt_token(
+        payload = { 'iat': int(time.time()) }
+    )
 
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
     with pytest.raises(AuthError) as exc:
@@ -73,20 +70,10 @@ def test_should_not_allow_request_with_no_iss(client, auth_fn):
     assert exc.value.short_message == 'Invalid token: iss field not provided'
 
 
-def test_auth_should_not_allow_request_with_no_iat(client, sample_api_key):
-    iss = str(sample_api_key.service_id)
-    # code copied from notifications_python_client.authentication.py::create_jwt_token
-    headers = {
-        "typ": 'JWT',
-        "alg": 'HS256'
-    }
-
-    claims = {
-        'iss': iss
-        # 'iat': not provided
-    }
-
-    token = jwt.encode(payload=claims, key=str(uuid.uuid4()), headers=headers)
+def test_should_not_allow_request_with_no_iat(client, sample_api_key):
+    token = create_custom_jwt_token(
+        payload = { 'iss': str(sample_api_key.service_id) }
+    )
 
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
     with pytest.raises(AuthError) as exc:
@@ -95,19 +82,10 @@ def test_auth_should_not_allow_request_with_no_iat(client, sample_api_key):
 
 
 def test_auth_should_not_allow_request_with_non_hs256_algorithm(client, sample_api_key):
-    iss = str(sample_api_key.service_id)
-    # code copied from notifications_python_client.authentication.py::create_jwt_token
-    headers = {
-        "typ": 'JWT',
-        "alg": 'HS512'
-    }
-
-    claims = {
-        'iss': iss,
-        'iat': int(time.time())
-    }
-
-    token = jwt.encode(payload=claims, key=str(uuid.uuid4()), headers=headers)
+    token = create_custom_jwt_token(
+        headers = { "typ": 'JWT', "alg": 'HS512' },
+        payload = { 'iss': str(sample_api_key.service_id), 'iat': int(time.time()) }
+    )
 
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
     with pytest.raises(AuthError) as exc:
@@ -119,18 +97,10 @@ def test_admin_auth_should_not_allow_request_with_no_iat(client):
     client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
     secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
 
-    # code copied from notifications_python_client.authentication.py::create_jwt_token
-    headers = {
-        "typ": 'JWT',
-        "alg": 'HS256'
-    }
-
-    claims = {
-        'iss': client_id,
-        # 'iat': not provided
-    }
-
-    token = jwt.encode(payload=claims, key=secret, headers=headers)
+    token = create_custom_jwt_token(
+        payload = { 'iss': client_id },
+        key = secret
+    )
 
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
     with pytest.raises(AuthError) as exc:
@@ -142,18 +112,10 @@ def test_admin_auth_should_not_allow_request_with_old_iat(client):
     client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
     secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
 
-    # code copied from notifications_python_client.authentication.py::create_jwt_token
-    headers = {
-        "typ": 'JWT',
-        "alg": 'HS256'
-    }
-
-    claims = {
-        'iss': client_id,
-        'iat': int(time.time()) - 60
-    }
-
-    token = jwt.encode(payload=claims, key=secret, headers=headers)
+    token = create_custom_jwt_token(
+        payload = { 'iss': client_id, 'iat': int(time.time()) - 60 },
+        key = secret
+    )
 
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
     with pytest.raises(AuthError) as exc:
@@ -162,21 +124,16 @@ def test_admin_auth_should_not_allow_request_with_old_iat(client):
 
 
 def test_auth_should_not_allow_request_with_extra_claims(client, sample_api_key):
-    iss = str(sample_api_key.service_id)
     key = get_unsigned_secrets(sample_api_key.service_id)[0]
 
-    headers = {
-        "typ": 'JWT',
-        "alg": 'HS256'
-    }
-
-    claims = {
-        'iss': iss,
-        'iat': int(time.time()),
-        'aud': 'notifications.service.gov.uk'  # extra claim that we don't support
-    }
-
-    token = jwt.encode(payload=claims, key=key, headers=headers)
+    token = create_custom_jwt_token(
+        payload = {
+            'iss': str(sample_api_key.service_id),
+            'iat': int(time.time()),
+            'aud': 'notifications.service.gov.uk'  # extra claim that we don't support
+        },
+        key = key
+    )
 
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
     with pytest.raises(AuthError) as exc:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178774818

Previously we just had a single array of API keys / secrets, any of
which could be used to get passed the "requires_admin_auth" check.
While multiple keys are necessary to allow for rotation, we should
avoid giving other apps access this way (too much privilege).

This converts the existing config vars into a new dictionary, keyed
by client_id. We can then use the dictionary to scope auth for new
API consumers like gov.uk/alerts to just the endpoints they need to
access, while maintaining existing access for the Admin app.

Once the new dictionary is available as a JSON environment variable,
we'll be able to remove the old credentials / config. In the next
commits, we'll look at more tests for the new functionality.

TODO:

 - Move tests into own files
 - Remove ADMIN_CLIENT config var
 - Refactor to test internal auth method