### PR TITLE
Revoke API keys when changing broadcast settings

### DIFF
--- a/app/dao/broadcast_service_dao.py
+++ b/app/dao/broadcast_service_dao.py
@@ -70,7 +70,8 @@ def set_broadcast_service_type(service, service_mode, broadcast_channel, provide
 
     # Revoke any API keys to avoid a regular API key being used to send alerts
     ApiKey.query.filter_by(
-        service_id=service.id
+        service_id=service.id,
+        expiry_date=None,
     ).update({
         ApiKey.expiry_date: datetime.utcnow()
     })

--- a/app/dao/broadcast_service_dao.py
+++ b/app/dao/broadcast_service_dao.py
@@ -9,6 +9,7 @@ from app.models import (
     EMAIL_AUTH_TYPE,
     INVITE_PENDING,
     VIEW_ACTIVITY,
+    ApiKey,
     InvitedUser,
     Organisation,
     Permission,
@@ -66,6 +67,13 @@ def set_broadcast_service_type(service, service_mode, broadcast_channel, provide
         service_id=service.id,
         status=INVITE_PENDING
     ).update({'permissions': VIEW_ACTIVITY})
+
+    # Revoke any API keys to avoid a regular API key being used to send alerts
+    ApiKey.query.filter_by(
+        service_id=service.id
+    ).update({
+        ApiKey.expiry_date: datetime.utcnow()
+    })
 
     # Add service to organisation
     organisation = Organisation.query.filter_by(

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -4172,6 +4172,7 @@ def test_set_as_broadcast_service_removes_user_permissions(
     assert service_user.get_permissions(service_id=sample_service_full_permissions.id) == ['send_emails']
 
 
+@freeze_time('2021-12-21')
 def test_set_as_broadcast_service_revokes_api_keys(
     admin_request,
     broadcast_organisation,
@@ -4179,7 +4180,10 @@ def test_set_as_broadcast_service_revokes_api_keys(
     sample_service_full_permissions,
 ):
     api_key_1 = create_api_key(service=sample_service)
-    api_key_2 = create_api_key(service=sample_service_full_permissions)
+    api_key_2 = create_api_key(service=sample_service)
+    api_key_3 = create_api_key(service=sample_service_full_permissions)
+
+    api_key_2.expiry_date = datetime.utcnow() - timedelta(days=365)
 
     admin_request.post(
         'service.set_as_broadcast_service',
@@ -4190,5 +4194,12 @@ def test_set_as_broadcast_service_revokes_api_keys(
             'provider_restriction': 'all',
         }
     )
-    assert api_key_1.expiry_date < datetime.utcnow()
-    assert api_key_2.expiry_date is None
+
+    # This key should have a new expiry date
+    assert api_key_1.expiry_date.isoformat().startswith('2021-12-21')
+
+    # This key keeps its old expiry date
+    assert api_key_2.expiry_date.isoformat().startswith('2020-12-21')
+
+    # This key is from a different service
+    assert api_key_3.expiry_date is None

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -4170,3 +4170,25 @@ def test_set_as_broadcast_service_removes_user_permissions(
 
     # Permissions for other services remain
     assert service_user.get_permissions(service_id=sample_service_full_permissions.id) == ['send_emails']
+
+
+def test_set_as_broadcast_service_revokes_api_keys(
+    admin_request,
+    broadcast_organisation,
+    sample_service,
+    sample_service_full_permissions,
+):
+    api_key_1 = create_api_key(service=sample_service)
+    api_key_2 = create_api_key(service=sample_service_full_permissions)
+
+    admin_request.post(
+        'service.set_as_broadcast_service',
+        service_id=sample_service.id,
+        _data={
+            'broadcast_channel': 'government',
+            'service_mode': 'live',
+            'provider_restriction': 'all',
+        }
+    )
+    assert api_key_1.expiry_date < datetime.utcnow()
+    assert api_key_2.expiry_date is None


### PR DESCRIPTION
On a regular Notify service anyone with permission can create an API key. If this service then is given permission to send emergency alerts it will have an API key which can create emergency alerts. This feels dangerous.

Secondly, if a service which legitimately has an API key for sending alerts in training mode is changed to live mode you now have an API key which people will think isn’t going to create a real alert but actually will. This feels really dangerous.

Neither of these scenarios are things we should be doing, but having them possible still makes me feel uncomfortable.

This commit revokes all API keys for a service when its broadcast settings change, same way we remove all permissions for its users.