### PR TITLE
Split up authentication for internal API endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -271,9 +271,15 @@ def register_blueprint(application):
 
 
 def register_v2_blueprints(application):
-    from app.authentication.auth import requires_auth
+    from app.authentication.auth import (
+        requires_auth,
+        requires_govuk_alerts_auth,
+    )
     from app.v2.broadcast.post_broadcast import (
         v2_broadcast_blueprint as post_broadcast,
+    )
+    from app.v2.govuk_alerts.get_broadcasts import (
+        v2_govuk_alerts_blueprint as get_broadcasts,
     )
     from app.v2.inbound_sms.get_inbound_sms import (
         v2_inbound_sms_blueprint as get_inbound_sms,
@@ -314,6 +320,9 @@ def register_v2_blueprints(application):
 
     post_broadcast.before_request(requires_auth)
     application.register_blueprint(post_broadcast)
+
+    get_broadcasts.before_request(requires_govuk_alerts_auth)
+    application.register_blueprint(get_broadcasts)
 
 
 def init_app(app):

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -60,6 +60,10 @@ def requires_no_auth():
     pass
 
 
+def requires_govuk_alerts_auth():
+    requires_internal_auth(current_app.config.get('GOVUK_ALERTS_CLIENT_ID'))
+
+
 def requires_admin_auth():
     requires_internal_auth(current_app.config.get('ADMIN_CLIENT_ID'))
 

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -61,7 +61,7 @@ def requires_no_auth():
 
 
 def requires_admin_auth():
-    requires_internal_auth(current_app.config.get('ADMIN_CLIENT_USER_NAME'))
+    requires_internal_auth(current_app.config.get('ADMIN_CLIENT_ID'))
 
 
 def requires_internal_auth(expected_client_id):

--- a/app/config.py
+++ b/app/config.py
@@ -84,8 +84,15 @@ class Config(object):
     # URL of api app (on AWS this is the internal api endpoint)
     API_HOST_NAME = os.getenv('API_HOST_NAME')
 
-    # secrets that internal apps, such as the admin app or document download, must use to authenticate with the API
+    # LEGACY: replacing with INTERNAL_CLIENT_API_KEYS
     API_INTERNAL_SECRETS = json.loads(os.environ.get('API_INTERNAL_SECRETS', '[]'))
+
+    # secrets that internal apps, such as the admin app or document download, must use to authenticate with the API
+    ADMIN_CLIENT_USER_NAME = 'notify-admin'
+
+    INTERNAL_CLIENT_API_KEYS = {
+        ADMIN_CLIENT_USER_NAME: API_INTERNAL_SECRETS
+    }
 
     # encyption secret/salt
     SECRET_KEY = os.getenv('SECRET_KEY')
@@ -129,7 +136,6 @@ class Config(object):
     ###########################
 
     NOTIFY_ENVIRONMENT = 'development'
-    ADMIN_CLIENT_USER_NAME = 'notify-admin'
     AWS_REGION = 'eu-west-1'
     INVITATION_EXPIRATION_DAYS = 2
     NOTIFY_APP_NAME = 'api'
@@ -399,7 +405,10 @@ class Development(Config):
     TRANSIENT_UPLOADED_LETTERS = 'development-transient-uploaded-letters'
     LETTER_SANITISE_BUCKET_NAME = 'development-letters-sanitise'
 
-    API_INTERNAL_SECRETS = ['dev-notify-secret-key']
+    INTERNAL_CLIENT_API_KEYS = {
+        Config.ADMIN_CLIENT_USER_NAME: ['dev-notify-secret-key']
+    }
+
     SECRET_KEY = 'dev-notify-secret-key'
     DANGEROUS_SALT = 'dev-notify-salt'
 

--- a/app/config.py
+++ b/app/config.py
@@ -89,6 +89,7 @@ class Config(object):
 
     # secrets that internal apps, such as the admin app or document download, must use to authenticate with the API
     ADMIN_CLIENT_ID = 'notify-admin'
+    GOVUK_ALERTS_CLIENT_ID = 'govuk-alerts'
 
     INTERNAL_CLIENT_API_KEYS = {
         ADMIN_CLIENT_ID: API_INTERNAL_SECRETS
@@ -406,7 +407,8 @@ class Development(Config):
     LETTER_SANITISE_BUCKET_NAME = 'development-letters-sanitise'
 
     INTERNAL_CLIENT_API_KEYS = {
-        Config.ADMIN_CLIENT_ID: ['dev-notify-secret-key']
+        Config.ADMIN_CLIENT_ID: ['dev-notify-secret-key'],
+        Config.GOVUK_ALERTS_CLIENT_ID: ['govuk-alerts-secret-key']
     }
 
     SECRET_KEY = 'dev-notify-secret-key'

--- a/app/config.py
+++ b/app/config.py
@@ -88,10 +88,10 @@ class Config(object):
     API_INTERNAL_SECRETS = json.loads(os.environ.get('API_INTERNAL_SECRETS', '[]'))
 
     # secrets that internal apps, such as the admin app or document download, must use to authenticate with the API
-    ADMIN_CLIENT_USER_NAME = 'notify-admin'
+    ADMIN_CLIENT_ID = 'notify-admin'
 
     INTERNAL_CLIENT_API_KEYS = {
-        ADMIN_CLIENT_USER_NAME: API_INTERNAL_SECRETS
+        ADMIN_CLIENT_ID: API_INTERNAL_SECRETS
     }
 
     # encyption secret/salt
@@ -406,7 +406,7 @@ class Development(Config):
     LETTER_SANITISE_BUCKET_NAME = 'development-letters-sanitise'
 
     INTERNAL_CLIENT_API_KEYS = {
-        Config.ADMIN_CLIENT_USER_NAME: ['dev-notify-secret-key']
+        Config.ADMIN_CLIENT_ID: ['dev-notify-secret-key']
     }
 
     SECRET_KEY = 'dev-notify-secret-key'

--- a/app/v2/govuk_alerts/__init__.py
+++ b/app/v2/govuk_alerts/__init__.py
@@ -1,0 +1,11 @@
+from flask import Blueprint
+
+from app.v2.errors import register_errors
+
+v2_govuk_alerts_blueprint = Blueprint(
+    "v2_govuk-alerts_blueprint",
+    __name__,
+    url_prefix='/v2/govuk-alerts',
+)
+
+register_errors(v2_govuk_alerts_blueprint)

--- a/app/v2/govuk_alerts/get_broadcasts.py
+++ b/app/v2/govuk_alerts/get_broadcasts.py
@@ -1,0 +1,8 @@
+from flask import jsonify
+
+from app.v2.govuk_alerts import v2_govuk_alerts_blueprint
+
+
+@v2_govuk_alerts_blueprint.route('')
+def get_broadcasts():
+    return jsonify({})

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,7 +28,7 @@ def create_authorization_header(service_id=None, key_type=KEY_TYPE_NORMAL):
 
     else:
         client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
-        secret = current_app.config['API_INTERNAL_SECRETS'][0]
+        secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
 
     token = create_jwt_token(secret=secret, client_id=client_id)
     return 'Authorization', 'Bearer {}'.format(token)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -27,7 +27,7 @@ def create_authorization_header(service_id=None, key_type=KEY_TYPE_NORMAL):
             secret = api_key.secret
 
     else:
-        client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
+        client_id = current_app.config['ADMIN_CLIENT_ID']
         secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
 
     token = create_jwt_token(secret=secret, client_id=client_id)

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -50,6 +50,22 @@ def admin_jwt_token():
     return create_jwt_token(admin_jwt_secret, admin_jwt_client_id)
 
 
+def test_requires_auth_should_allow_valid_token_for_request_with_path_params_for_public_url(
+    client,
+    service_jwt_token,
+):
+    response = client.get('/notifications', headers={'Authorization': 'Bearer {}'.format(service_jwt_token)})
+    assert response.status_code == 200
+
+
+def test_requires_admin_auth_should_allow_valid_token_for_request_with_path_params(
+    client,
+    admin_jwt_token
+):
+    response = client.get('/service', headers={'Authorization': 'Bearer {}'.format(admin_jwt_token)})
+    assert response.status_code == 200
+
+
 def test_get_auth_token_should_not_allow_request_with_no_token(client):
     request.headers = {}
     with pytest.raises(AuthError) as exc:
@@ -231,22 +247,6 @@ def test_requires_auth_should_not_allow_service_id_with_the_wrong_data_type(
     assert response.status_code == 403
     data = json.loads(response.get_data())
     assert data['message'] == {"token": ['Invalid token: service id is not the right data type']}
-
-
-def test_requires_auth_should_allow_valid_token_for_request_with_path_params_for_public_url(
-    client,
-    service_jwt_token,
-):
-    response = client.get('/notifications', headers={'Authorization': 'Bearer {}'.format(service_jwt_token)})
-    assert response.status_code == 200
-
-
-def test_requires_admin_auth_should_allow_valid_token_for_request_with_path_params(
-    client,
-    admin_jwt_token
-):
-    response = client.get('/service', headers={'Authorization': 'Bearer {}'.format(admin_jwt_token)})
-    assert response.status_code == 200
 
 
 def test_requires_auth_returns_error_when_service_doesnt_exist(

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -295,29 +295,6 @@ def test_should_attach_the_current_api_key_to_current_app(
         assert str(api_user.id) == str(sample_api_key.id)
 
 
-@pytest.mark.parametrize('check_proxy_header,header_value', [
-    (True, 'key_1'),
-    (True, 'wrong_key'),
-    (False, 'key_1'),
-    (False, 'wrong_key'),
-])
-def test_requires_no_auth_proxy_key(notify_api, check_proxy_header, header_value):
-    with set_config_values(notify_api, {
-        'ROUTE_SECRET_KEY_1': 'key_1',
-        'ROUTE_SECRET_KEY_2': '',
-        'CHECK_PROXY_HEADER': check_proxy_header,
-    }):
-
-        with notify_api.test_client() as client:
-            response = client.get(
-                path='/_status',
-                headers=[
-                    ('X-Custom-Forwarder', header_value),
-                ]
-            )
-        assert response.status_code == 200
-
-
 @pytest.mark.parametrize('check_proxy_header,header_value,expected_status', [
     (True, 'key_1', 200),
     (True, 'wrong_key', 403),

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -34,6 +34,34 @@ def create_custom_jwt_token(headers=None, payload=None, key=None):
     return jwt.encode(payload=payload, key=key or str(uuid.uuid4()), headers=headers)
 
 
+@pytest.fixture
+def service_jwt_secret(sample_api_key):
+    return get_unsigned_secrets(sample_api_key.service_id)[0]
+
+
+@pytest.fixture
+def service_jwt_token(sample_api_key, service_jwt_secret):
+    return create_jwt_token(
+        secret=service_jwt_secret,
+        client_id=str(sample_api_key.service_id),
+    )
+
+
+@pytest.fixture
+def admin_jwt_client_id():
+    return current_app.config['ADMIN_CLIENT_USER_NAME']
+
+
+@pytest.fixture
+def admin_jwt_secret(admin_jwt_client_id):
+    return current_app.config['INTERNAL_CLIENT_API_KEYS'][admin_jwt_client_id][0]
+
+
+@pytest.fixture
+def admin_jwt_token(admin_jwt_client_id, admin_jwt_secret):
+    return create_jwt_token(admin_jwt_secret, admin_jwt_client_id)
+
+
 @pytest.mark.parametrize('auth_fn', [requires_auth, requires_admin_auth])
 def test_should_not_allow_request_with_no_token(client, auth_fn):
     request.headers = {}
@@ -93,13 +121,14 @@ def test_requires_auth_should_not_allow_request_with_non_hs256_algorithm(client,
     assert exc.value.short_message == 'Invalid token: algorithm used is not HS256'
 
 
-def test_requires_admin_auth_should_not_allow_request_with_no_iat(client):
-    client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
-    secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
-
+def test_requires_admin_auth_should_not_allow_request_with_no_iat(
+    client,
+    admin_jwt_client_id,
+    admin_jwt_secret,
+):
     token = create_custom_jwt_token(
-        payload={'iss': client_id},
-        key=secret
+        payload={'iss': admin_jwt_client_id},
+        key=admin_jwt_secret
     )
 
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
@@ -108,13 +137,14 @@ def test_requires_admin_auth_should_not_allow_request_with_no_iat(client):
     assert exc.value.short_message == "Unauthorized: API authentication token not found"
 
 
-def test_requires_admin_auth_should_not_allow_request_with_old_iat(client):
-    client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
-    secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
-
+def test_requires_admin_auth_should_not_allow_request_with_old_iat(
+    client,
+    admin_jwt_client_id,
+    admin_jwt_secret,
+):
     token = create_custom_jwt_token(
-        payload={'iss': client_id, 'iat': int(time.time()) - 60},
-        key=secret
+        payload={'iss': admin_jwt_client_id, 'iat': int(time.time()) - 60},
+        key=admin_jwt_secret
     )
 
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
@@ -123,16 +153,18 @@ def test_requires_admin_auth_should_not_allow_request_with_old_iat(client):
     assert exc.value.short_message == "Invalid token: expired, check that your system clock is accurate"
 
 
-def test_requires_auth_should_not_allow_request_with_extra_claims(client, sample_api_key):
-    key = get_unsigned_secrets(sample_api_key.service_id)[0]
-
+def test_requires_auth_should_not_allow_request_with_extra_claims(
+    client,
+    sample_api_key,
+    service_jwt_secret,
+):
     token = create_custom_jwt_token(
         payload={
             'iss': str(sample_api_key.service_id),
             'iat': int(time.time()),
             'aud': 'notifications.service.gov.uk'  # extra claim that we don't support
         },
-        key=key
+        key=service_jwt_secret,
     )
 
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
@@ -155,16 +187,30 @@ def test_requires_auth_should_not_allow_invalid_secret(client, sample_api_key):
 
 
 @pytest.mark.parametrize('scheme', ['bearer', 'Bearer'])
-def test_requires_auth_should_allow_valid_token(client, sample_api_key, scheme):
-    token = __create_token(sample_api_key.service_id)
+def test_requires_auth_should_allow_valid_token(
+    client,
+    sample_api_key,
+    service_jwt_secret,
+    scheme,
+):
+    token = create_jwt_token(
+        client_id=str(sample_api_key.service_id),
+        secret=service_jwt_secret,
+    )
     response = client.get('/notifications', headers={'Authorization': '{} {}'.format(scheme, token)})
     assert response.status_code == 200
 
 
 @pytest.mark.parametrize('service_id', ['not-a-valid-id', 1234])
-def test_requires_auth_should_not_allow_service_id_with_the_wrong_data_type(client, sample_api_key, service_id):
-    token = create_jwt_token(secret=get_unsigned_secrets(sample_api_key.service_id)[0],
-                             client_id=service_id)
+def test_requires_auth_should_not_allow_service_id_with_the_wrong_data_type(
+    client,
+    service_jwt_secret,
+    service_id
+):
+    token = create_jwt_token(
+        client_id=service_id,
+        secret=service_jwt_secret,
+    )
     response = client.get(
         '/notifications',
         headers={'Authorization': "Bearer {}".format(token)}
@@ -174,36 +220,43 @@ def test_requires_auth_should_not_allow_service_id_with_the_wrong_data_type(clie
     assert data['message'] == {"token": ['Invalid token: service id is not the right data type']}
 
 
-def test_requires_auth_should_allow_valid_token_for_request_with_path_params_for_public_url(client, sample_api_key):
-    token = __create_token(sample_api_key.service_id)
-    response = client.get('/notifications', headers={'Authorization': 'Bearer {}'.format(token)})
+def test_requires_auth_should_allow_valid_token_for_request_with_path_params_for_public_url(
+    client,
+    service_jwt_token,
+):
+    response = client.get('/notifications', headers={'Authorization': 'Bearer {}'.format(service_jwt_token)})
     assert response.status_code == 200
 
 
-def test_requires_admin_auth_should_allow_valid_token_for_request_with_path_params(client):
-    client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
-    secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][client_id][0]
-
-    token = create_jwt_token(secret, client_id)
-    response = client.get('/service', headers={'Authorization': 'Bearer {}'.format(token)})
+def test_requires_admin_auth_should_allow_valid_token_for_request_with_path_params(
+    client,
+    admin_jwt_token
+):
+    response = client.get('/service', headers={'Authorization': 'Bearer {}'.format(admin_jwt_token)})
     assert response.status_code == 200
 
 
-def test_requires_admin_auth_should_allow_valid_token_for_request_with_path_params_with_second_secret(client):
-    client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
-    new_secrets = {client_id: ["secret1", "secret2"]}
+def test_requires_admin_auth_should_allow_valid_token_for_request_with_path_params_with_second_secret(
+    client,
+    admin_jwt_client_id,
+):
+    new_secrets = {admin_jwt_client_id: ["secret1", "secret2"]}
 
     with set_config(client.application, 'INTERNAL_CLIENT_API_KEYS', new_secrets):
-        token = create_jwt_token("secret1", client_id)
+        token = create_jwt_token("secret1", admin_jwt_client_id)
         response = client.get('/service', headers={'Authorization': 'Bearer {}'.format(token)})
         assert response.status_code == 200
 
-        token = create_jwt_token("secret2", client_id)
+        token = create_jwt_token("secret2", admin_jwt_client_id)
         response = client.get('/service', headers={'Authorization': 'Bearer {}'.format(token)})
         assert response.status_code == 200
 
 
-def test_requires_auth_should_allow_valid_token_when_service_has_multiple_keys(client, sample_api_key):
+def test_requires_auth_should_allow_valid_token_when_service_has_multiple_keys(
+    client,
+    sample_api_key,
+    service_jwt_token,
+):
     data = {'service': sample_api_key.service,
             'name': 'some key name',
             'created_by': sample_api_key.created_by,
@@ -211,16 +264,16 @@ def test_requires_auth_should_allow_valid_token_when_service_has_multiple_keys(c
             }
     api_key = ApiKey(**data)
     save_model_api_key(api_key)
-    token = __create_token(sample_api_key.service_id)
     response = client.get(
         '/notifications',
-        headers={'Authorization': 'Bearer {}'.format(token)})
+        headers={'Authorization': 'Bearer {}'.format(service_jwt_token)})
     assert response.status_code == 200
 
 
 def test_requires_auth_passes_when_service_has_multiple_keys_some_expired(
-        client,
-        sample_api_key):
+    client,
+    sample_api_key,
+):
     expired_key_data = {'service': sample_api_key.service,
                         'name': 'expired_key',
                         'expiry_date': datetime.utcnow(),
@@ -237,8 +290,9 @@ def test_requires_auth_passes_when_service_has_multiple_keys_some_expired(
     api_key = ApiKey(**another_key)
     save_model_api_key(api_key)
     token = create_jwt_token(
-        secret=get_unsigned_secret(api_key.id),
-        client_id=str(sample_api_key.service_id))
+        client_id=str(sample_api_key.service_id),
+        secret=get_unsigned_secret(api_key.id)
+    )
     response = client.get(
         '/notifications',
         headers={'Authorization': 'Bearer {}'.format(token)})
@@ -246,7 +300,8 @@ def test_requires_auth_passes_when_service_has_multiple_keys_some_expired(
 
 
 def test_requires_auth_returns_token_expired_when_service_uses_expired_key_and_has_multiple_keys(
-    client, sample_api_key
+    client,
+    sample_api_key
 ):
     expired_key = {'service': sample_api_key.service,
                    'name': 'expired_key',
@@ -263,8 +318,9 @@ def test_requires_auth_returns_token_expired_when_service_uses_expired_key_and_h
     api_key = ApiKey(**another_key)
     save_model_api_key(api_key)
     token = create_jwt_token(
-        secret=get_unsigned_secret(expired_api_key.id),
-        client_id=str(sample_api_key.service_id))
+        client_id=str(sample_api_key.service_id),
+        secret=get_unsigned_secret(expired_api_key.id)
+    )
     expire_api_key(service_id=sample_api_key.service_id, api_key_id=expired_api_key.id)
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
     with pytest.raises(AuthError) as exc:
@@ -274,39 +330,41 @@ def test_requires_auth_returns_token_expired_when_service_uses_expired_key_and_h
     assert exc.value.api_key_id == expired_api_key.id
 
 
-def test_requires_admin_auth_returns_error_with_no_secrets(client):
-    client_id = current_app.config.get('ADMIN_CLIENT_USER_NAME')
-    secret = current_app.config.get('INTERNAL_CLIENT_API_KEYS')[client_id][0]
-    token = create_jwt_token(secret, client_id)
-    new_secrets = {client_id: []}
+def test_requires_admin_auth_returns_error_with_no_secrets(
+    client,
+    admin_jwt_client_id,
+    admin_jwt_token,
+):
+    new_secrets = {admin_jwt_client_id: []}
 
     with set_config(client.application, 'INTERNAL_CLIENT_API_KEYS', new_secrets):
         response = client.get(
             '/service',
-            headers={'Authorization': 'Bearer {}'.format(token)})
+            headers={'Authorization': 'Bearer {}'.format(admin_jwt_token)})
 
     assert response.status_code == 401
     error_message = json.loads(response.get_data())
     assert error_message['message'] == {"token": ["Unauthorized: API authentication token not found"]}
 
 
-def test_requires_admin_auth_returns_error_when_secret_is_invalid(client):
-    client_id = current_app.config.get('ADMIN_CLIENT_USER_NAME')
-    secret = current_app.config.get('INTERNAL_CLIENT_API_KEYS')[client_id][0]
-    token = create_jwt_token(secret, client_id)
-    new_secrets = {client_id:  ['something-wrong']}
+def test_requires_admin_auth_returns_error_when_secret_is_invalid(
+    client,
+    admin_jwt_client_id,
+    admin_jwt_token,
+):
+    new_secrets = {admin_jwt_client_id:  ['something-wrong']}
 
     with set_config(client.application, 'INTERNAL_CLIENT_API_KEYS', new_secrets):
         response = client.get(
             '/service',
-            headers={'Authorization': 'Bearer {}'.format(token)})
+            headers={'Authorization': 'Bearer {}'.format(admin_jwt_token)})
 
     assert response.status_code == 401
     error_message = json.loads(response.get_data())
     assert error_message['message'] == {"token": ["Unauthorized: API authentication token not found"]}
 
 
-def test_requires_auth_returns_error_when_service_doesnt_exit(
+def test_requires_auth_returns_error_when_service_doesnt_exist(
     client,
     sample_api_key
 ):
@@ -324,11 +382,13 @@ def test_requires_auth_returns_error_when_service_doesnt_exit(
     assert error_message['message'] == {'token': ['Invalid token: service not found']}
 
 
-def test_requires_auth_returns_error_when_service_inactive(client, sample_api_key):
+def test_requires_auth_returns_error_when_service_inactive(
+    client,
+    sample_api_key,
+    service_jwt_token,
+):
     sample_api_key.service.active = False
-    token = create_jwt_token(secret=str(sample_api_key.id), client_id=str(sample_api_key.service_id))
-
-    response = client.get('/notifications', headers={'Authorization': 'Bearer {}'.format(token)})
+    response = client.get('/notifications', headers={'Authorization': 'Bearer {}'.format(service_jwt_token)})
 
     assert response.status_code == 403
     error_message = json.loads(response.get_data())
@@ -349,22 +409,31 @@ def test_requires_auth_returns_error_when_service_has_no_secrets(
     assert exc.value.service_id == str(sample_service.id)
 
 
-def test_should_attach_the_current_api_key_to_current_app(notify_api, sample_service, sample_api_key):
+def test_should_attach_the_current_api_key_to_current_app(
+    notify_api,
+    sample_service,
+    sample_api_key,
+    service_jwt_token,
+):
     with notify_api.test_request_context(), notify_api.test_client() as client:
-        token = __create_token(sample_api_key.service_id)
         response = client.get(
             '/notifications',
-            headers={'Authorization': 'Bearer {}'.format(token)}
+            headers={'Authorization': 'Bearer {}'.format(service_jwt_token)}
         )
         assert response.status_code == 200
         assert str(api_user.id) == str(sample_api_key.id)
 
 
 def test_requires_auth_return_403_when_token_is_expired(
-    client, sample_api_key
+    client,
+    sample_api_key,
+    service_jwt_secret,
 ):
     with freeze_time('2001-01-01T12:00:00'):
-        token = __create_token(sample_api_key.service_id)
+        token = create_jwt_token(
+            client_id=str(sample_api_key.service_id),
+            secret=service_jwt_secret,
+        )
     with freeze_time('2001-01-01T12:00:40'):
         with pytest.raises(AuthError) as exc:
             request.headers = {'Authorization': 'Bearer {}'.format(token)}
@@ -372,11 +441,6 @@ def test_requires_auth_return_403_when_token_is_expired(
     assert exc.value.short_message == 'Error: Your system clock must be accurate to within 30 seconds'
     assert exc.value.service_id == str(sample_api_key.service_id)
     assert str(exc.value.api_key_id) == str(sample_api_key.id)
-
-
-def __create_token(service_id):
-    return create_jwt_token(secret=get_unsigned_secrets(service_id)[0],
-                            client_id=str(service_id))
 
 
 @pytest.mark.parametrize('check_proxy_header,header_value', [
@@ -408,11 +472,13 @@ def test_requires_no_auth_proxy_key(notify_api, check_proxy_header, header_value
     (False, 'key_1', 200),
     (False, 'wrong_key', 200),
 ])
-def test_requires_admin_auth_proxy_key(notify_api, check_proxy_header, header_value, expected_status):
-    client_id = current_app.config.get('ADMIN_CLIENT_USER_NAME')
-    secret = current_app.config.get('INTERNAL_CLIENT_API_KEYS')[client_id][0]
-    token = create_jwt_token(secret, client_id)
-
+def test_requires_admin_auth_proxy_key(
+    notify_api,
+    check_proxy_header,
+    header_value,
+    expected_status,
+    admin_jwt_token,
+):
     with set_config_values(notify_api, {
         'ROUTE_SECRET_KEY_1': 'key_1',
         'ROUTE_SECRET_KEY_2': '',
@@ -424,13 +490,18 @@ def test_requires_admin_auth_proxy_key(notify_api, check_proxy_header, header_va
                 path='/service',
                 headers=[
                     ('X-Custom-Forwarder', header_value),
-                    ('Authorization', 'Bearer {}'.format(token))
+                    ('Authorization', 'Bearer {}'.format(admin_jwt_token))
                 ]
             )
         assert response.status_code == expected_status
 
 
-def test_requires_auth_should_cache_service_and_api_key_lookups(mocker, client, sample_api_key):
+def test_requires_auth_should_cache_service_and_api_key_lookups(
+    mocker,
+    client,
+    sample_api_key,
+    service_jwt_token
+):
     mock_get_api_keys = mocker.patch(
         'app.serialised_models.get_model_api_keys',
         wraps=get_model_api_keys,
@@ -441,9 +512,8 @@ def test_requires_auth_should_cache_service_and_api_key_lookups(mocker, client, 
     )
 
     for _ in range(5):
-        token = __create_token(sample_api_key.service_id)
         client.get('/notifications', headers={
-            'Authorization': f'Bearer {token}'
+            'Authorization': f'Bearer {service_jwt_token}'
         })
 
     assert mock_get_api_keys.call_args_list == [

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -134,7 +134,7 @@ def test_requires_admin_auth_should_not_allow_request_with_no_iat(
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
     with pytest.raises(AuthError) as exc:
         requires_admin_auth()
-    assert exc.value.short_message == "Unauthorized: API authentication token not found"
+    assert exc.value.short_message == "Invalid token: API key not found"
 
 
 def test_requires_admin_auth_should_not_allow_request_with_old_iat(
@@ -150,7 +150,7 @@ def test_requires_admin_auth_should_not_allow_request_with_old_iat(
     request.headers = {'Authorization': 'Bearer {}'.format(token)}
     with pytest.raises(AuthError) as exc:
         requires_admin_auth()
-    assert exc.value.short_message == "Invalid token: expired, check that your system clock is accurate"
+    assert exc.value.short_message == "Error: Your system clock must be accurate to within 30 seconds"
 
 
 def test_requires_auth_should_not_allow_request_with_extra_claims(
@@ -342,9 +342,9 @@ def test_requires_admin_auth_returns_error_with_no_secrets(
             '/service',
             headers={'Authorization': 'Bearer {}'.format(admin_jwt_token)})
 
-    assert response.status_code == 401
+    assert response.status_code == 403
     error_message = json.loads(response.get_data())
-    assert error_message['message'] == {"token": ["Unauthorized: API authentication token not found"]}
+    assert error_message['message'] == {"token": ["Invalid token: API key not found"]}
 
 
 def test_requires_admin_auth_returns_error_when_secret_is_invalid(
@@ -359,9 +359,9 @@ def test_requires_admin_auth_returns_error_when_secret_is_invalid(
             '/service',
             headers={'Authorization': 'Bearer {}'.format(admin_jwt_token)})
 
-    assert response.status_code == 401
+    assert response.status_code == 403
     error_message = json.loads(response.get_data())
-    assert error_message['message'] == {"token": ["Unauthorized: API authentication token not found"]}
+    assert error_message['message'] == {"token": ["Invalid token: API key not found"]}
 
 
 def test_requires_auth_returns_error_when_service_doesnt_exist(

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -78,6 +78,15 @@ def test_requires_admin_auth_should_allow_valid_token_for_request(client):
     assert response.status_code == 200
 
 
+def test_requires_govuk_alerts_auth_should_allow_valid_token_for_request(client):
+    govuk_alerts_jwt_client_id = current_app.config['GOVUK_ALERTS_CLIENT_ID']
+    govuk_alerts_jwt_secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][govuk_alerts_jwt_client_id][0]
+    govuk_alerts_jwt_token = create_jwt_token(govuk_alerts_jwt_secret, govuk_alerts_jwt_client_id)
+
+    response = client.get('/v2/govuk-alerts', headers={'Authorization': 'Bearer {}'.format(govuk_alerts_jwt_token)})
+    assert response.status_code == 200
+
+
 def test_get_auth_token_should_not_allow_request_with_no_token(client):
     request.headers = {}
     with pytest.raises(AuthError) as exc:

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -61,7 +61,7 @@ def service_jwt_token(sample_api_key, service_jwt_secret):
     )
 
 
-def test_requires_auth_should_allow_valid_token_for_request_with_path_params_for_public_url(
+def test_requires_auth_should_allow_valid_token_for_request(
     client,
     service_jwt_token,
 ):
@@ -69,8 +69,8 @@ def test_requires_auth_should_allow_valid_token_for_request_with_path_params_for
     assert response.status_code == 200
 
 
-def test_requires_admin_auth_should_allow_valid_token_for_request_with_path_params(client):
-    admin_jwt_client_id = current_app.config['ADMIN_CLIENT_USER_NAME']
+def test_requires_admin_auth_should_allow_valid_token_for_request(client):
+    admin_jwt_client_id = current_app.config['ADMIN_CLIENT_ID']
     admin_jwt_secret = current_app.config['INTERNAL_CLIENT_API_KEYS'][admin_jwt_client_id][0]
     admin_jwt_token = create_jwt_token(admin_jwt_secret, admin_jwt_client_id)
 

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -42,10 +42,10 @@ def requires_my_internal_app_auth():
     requires_internal_auth('my-internal-app')
 
 
-def create_custom_jwt_token(headers=None, payload=None, key=None):
+def create_custom_jwt_token(headers=None, payload=None, secret=None):
     # code copied from notifications_python_client.authentication.py::create_jwt_token
     headers = headers or {"typ": 'JWT', "alg": 'HS256'}
-    return jwt.encode(payload=payload, key=key or str(uuid.uuid4()), headers=headers)
+    return jwt.encode(payload=payload, key=secret or str(uuid.uuid4()), headers=headers)
 
 
 @pytest.fixture
@@ -154,7 +154,7 @@ def test_decode_jwt_token_should_not_allow_old_iat(
 ):
     token = create_custom_jwt_token(
         payload={'iss': 'something', 'iat': int(time.time()) - 60},
-        key=sample_api_key.secret,
+        secret=sample_api_key.secret,
     )
 
     with pytest.raises(AuthError) as exc:
@@ -172,7 +172,7 @@ def test_decode_jwt_token_should_not_allow_extra_claims(
             'iat': int(time.time()),
             'aud': 'notifications.service.gov.uk'  # extra claim that we don't support
         },
-        key=sample_api_key.secret,
+        secret=sample_api_key.secret,
     )
 
     with pytest.raises(AuthError) as exc:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179039225

Previously we just had a single array of "API SECRETS" that any app could use to
get access to any internal API. This replaces that approach with something that's
much more similar to service API keys: each app is like a "service", with its own
array of allowed "Internal API keys".

Making this change was hard because:

- Half the tests were written using one pattern (calling functions directly) and
half were written using another pattern (calling an arbitrary endpoint).

- The "requires_auth" function does similar but different checks, which meant a lot
of the tests were duplicated, but others were missing - it was hard to tell.

A lot of the commits are about DRYing up and simplifying the tests (and adding ones
that were missing), so that in the last commit we can just add a single, new test for
a placeholder govuk-alerts API endpoint. I've tried to make the commits small to make
all the test changes easier to understand.