### PR TITLE
Set jobs worker memory to 2GB

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -50,7 +50,7 @@
   },
 
   'notify-delivery-celery-beat': {'memory': '128M'},
-  'notify-delivery-worker-jobs': {},
+  'notify-delivery-worker-jobs': {'memory': '2G'},
   'notify-delivery-worker-research': {},
   'notify-delivery-worker-sender': {'disk_quota': '2G', 'memory': '4G'},
   'notify-delivery-worker-periodic': {},


### PR DESCRIPTION
This is to see if the worker requires slightly more memory than it has access to or to determine if there is a memory  leak somewhere in the code that needs to be further investigated.

This comes at the heels of yesterday's issue that we could not process the CSVs the users uploaded, where the memory graph for this worker showed that it was using almost all of its available memory, so a redeploy fixed the problem.