### PR TITLE
Don’t update `email_access_validated_at` on password reset

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -123,12 +123,10 @@ def reset_failed_login_count(user):
         db.session.commit()
 
 
-def update_user_password(user, password, validated_email_access=False):
+def update_user_password(user, password):
     # reset failed login count - they've just reset their password so should be fine
     user.password = password
     user.password_changed_at = datetime.utcnow()
-    if validated_email_access:
-        user.email_access_validated_at = datetime.utcnow()
     db.session.add(user)
     db.session.commit()
 

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -533,11 +533,10 @@ def update_password(user_id):
     user = get_user_by_id(user_id=user_id)
     req_json = request.get_json()
     password = req_json.get('_password')
-    validated_email_access = req_json.pop('validated_email_access', False)
     update_dct, errors = user_update_password_schema_load_json.load(req_json)
     if errors:
         raise InvalidRequest(errors, status_code=400)
-    update_user_password(user, password, validated_email_access=validated_email_access)
+    update_user_password(user, password)
     return jsonify(data=user.serialize()), 200
 
 

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -159,19 +159,13 @@ def test_update_user_attribute(client, sample_user, user_attribute, user_value):
 
 
 @freeze_time('2020-01-24T12:00:00')
-@pytest.mark.parametrize('from_email', [True, False])
-def test_update_user_password(notify_api, notify_db, notify_db_session, sample_user, from_email):
+def test_update_user_password(notify_api, notify_db, notify_db_session, sample_user):
     sample_user.password_changed_at = datetime.utcnow() - timedelta(days=1)
-    sample_user.email_access_validated_at = datetime.utcnow() - timedelta(days=1)
     password = 'newpassword'
     assert not sample_user.check_password(password)
-    update_user_password(sample_user, password, validated_email_access=from_email)
+    update_user_password(sample_user, password)
     assert sample_user.check_password(password)
     assert sample_user.password_changed_at == datetime.utcnow()
-    if from_email:
-        assert sample_user.email_access_validated_at == datetime.utcnow()
-    else:
-        assert sample_user.email_access_validated_at == datetime.utcnow() - timedelta(days=1)
 
 
 def test_count_user_verify_codes(sample_user):

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -791,30 +791,18 @@ def test_send_user_confirm_new_email_returns_400_when_email_missing(client, samp
     mocked.assert_not_called()
 
 
-@pytest.mark.parametrize('data,email_access_validated_at', [
-    ({'_password': '1234567890'}, datetime(2020, 2, 13, 12, 0)),
-    ({
-        '_password': '1234567890',
-        'validated_email_access': True,
-    }, datetime(2020, 2, 14, 12, 0)),
-    ({
-        '_password': '1234567890',
-        'validated_email_access': False,
-    }, datetime(2020, 2, 13, 12, 0))
-])
 @freeze_time('2020-02-14T12:00:00')
-def test_update_user_password_saves_correctly(client, sample_service, data, email_access_validated_at):
+def test_update_user_password_saves_correctly(client, sample_service):
     sample_user = sample_service.users[0]
-    sample_user.email_access_validated_at = datetime(2020, 2, 13, 12, 0)
     new_password = '1234567890'
     auth_header = create_admin_authorization_header()
     headers = [('Content-Type', 'application/json'), auth_header]
+    data = {'_password': '1234567890'}
     resp = client.post(
         url_for('user.update_password', user_id=sample_user.id),
         data=json.dumps(data),
         headers=headers)
     assert resp.status_code == 200
-    assert sample_user.email_access_validated_at == email_access_validated_at
 
     json_resp = json.loads(resp.get_data(as_text=True))
     assert json_resp['data']['password_changed_at'] is not None


### PR DESCRIPTION
As of https://github.com/alphagov/notifications-admin/pull/4000 the admin app is doing this, so we don’t need to do it here as well.