### PR TITLE
Allow old broadcasts to be overridden

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -157,11 +157,14 @@ def create_broadcast_message(service_id):
 def update_broadcast_message(service_id, broadcast_message_id):
     data = request.get_json()
 
+    # TEMPORARY: while we migrate and backfill "areas"
+    force_override = data.pop("force_override", False)
+
     validate(data, update_broadcast_message_schema)
 
     broadcast_message = dao_get_broadcast_message_by_id_and_service_id(broadcast_message_id, service_id)
 
-    if broadcast_message.status not in BroadcastStatusType.PRE_BROADCAST_STATUSES:
+    if not force_override and broadcast_message.status not in BroadcastStatusType.PRE_BROADCAST_STATUSES:
         raise InvalidRequest(
             f'Cannot update broadcast_message {broadcast_message.id} while it has status {broadcast_message.status}',
             status_code=400

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -385,6 +385,10 @@ def test_update_broadcast_message_allows_edit_while_not_yet_live(admin_request, 
     assert response['updated_at'] is not None
 
 
+@pytest.mark.parametrize('force_override', [
+    False,
+    pytest.param(True, marks=pytest.mark.xfail)
+])
 @pytest.mark.parametrize('status', [
     BroadcastStatusType.BROADCASTING,
     BroadcastStatusType.CANCELLED,
@@ -392,14 +396,17 @@ def test_update_broadcast_message_allows_edit_while_not_yet_live(admin_request, 
     BroadcastStatusType.TECHNICAL_FAILURE,
 ])
 def test_update_broadcast_message_doesnt_allow_edits_after_broadcast_goes_live(
-    admin_request, sample_broadcast_service, status
+    admin_request,
+    force_override,
+    sample_broadcast_service,
+    status
 ):
     t = create_template(sample_broadcast_service, BROADCAST_TYPE)
     bm = create_broadcast_message(t, areas=['manchester'], status=status)
 
     response = admin_request.post(
         'broadcast_message.update_broadcast_message',
-        _data={'areas': ['london', 'glasgow']},
+        _data={'areas': ['london', 'glasgow'], 'force_override': force_override},
         service_id=t.service_id,
         broadcast_message_id=bm.id,
         _expected_status=400


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178986763

This is a temporary feature to make it easy to migrate the format
of the "areas" column and backfill extra data for it.

It's not possible to use this feature to update the status of an
old broadcast message, so the risk from this override is minimal.