### PR TITLE
Remove support for "areas_2" field

### DIFF
--- a/app/broadcast_message/broadcast_message_schema.py
+++ b/app/broadcast_message/broadcast_message_schema.py
@@ -15,7 +15,6 @@ create_broadcast_message_schema = {
         'finishes_at': {'type': 'string', 'format': 'datetime'},
         'areas': {'type': 'object'},
         'areas_2': {'type': 'object'},
-        'simple_polygons': {"type": "array", "items": {"type": "array"}},
         'content': {'type': 'string', 'minLength': 1},
         'reference': {'type': 'string', 'minLength': 1, 'maxLength': 255},
     },
@@ -44,7 +43,6 @@ update_broadcast_message_schema = {
         'finishes_at': {'type': 'string', 'format': 'datetime'},
         'areas': {'type': 'object'},
         'areas_2': {'type': 'object'},
-        'simple_polygons': {"type": "array", "items": {"type": "array"}},
     },
     'required': [],
     'additionalProperties': False

--- a/app/broadcast_message/broadcast_message_schema.py
+++ b/app/broadcast_message/broadcast_message_schema.py
@@ -14,7 +14,6 @@ create_broadcast_message_schema = {
         'starts_at': {'type': 'string', 'format': 'datetime'},
         'finishes_at': {'type': 'string', 'format': 'datetime'},
         'areas': {'type': 'object'},
-        'areas_2': {'type': 'object'},
         'content': {'type': 'string', 'minLength': 1},
         'reference': {'type': 'string', 'minLength': 1, 'maxLength': 255},
     },
@@ -42,7 +41,6 @@ update_broadcast_message_schema = {
         'starts_at': {'type': 'string', 'format': 'datetime'},
         'finishes_at': {'type': 'string', 'format': 'datetime'},
         'areas': {'type': 'object'},
-        'areas_2': {'type': 'object'},
     },
     'required': [],
     'additionalProperties': False

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -138,7 +138,7 @@ def create_broadcast_message(service_id):
         template_id=template_id,
         template_version=template.version if template else None,
         personalisation=personalisation,
-        areas=data.get("areas", data.get("areas_2", {})),  # TEMPORARY: while we repurpose "areas"
+        areas=data.get("areas", {}),
         status=BroadcastStatusType.DRAFT,
         starts_at=_parse_nullable_datetime(data.get('starts_at')),
         finishes_at=_parse_nullable_datetime(data.get('finishes_at')),
@@ -170,8 +170,7 @@ def update_broadcast_message(service_id, broadcast_message_id):
             status_code=400
         )
 
-    # TEMPORARY: while we repurpose "areas"
-    areas = data.get("areas", data.get("areas_2", {}))
+    areas = data.get("areas", {})
 
     if ('ids' in areas and 'simple_polygons' not in areas) or ('ids' not in areas and 'simple_polygons' in areas):
         raise InvalidRequest(

--- a/app/models.py
+++ b/app/models.py
@@ -2353,10 +2353,7 @@ class BroadcastMessage(db.Model):
             'personalisation': self.personalisation if self.template else None,
             'content': self.content,
 
-            # TEMPORARY: switch to this so we can repurpose "areas"
-            'areas_2': areas,
             'areas': areas,
-
             'status': self.status,
 
             'starts_at': get_dt_string_or_none(self.starts_at),

--- a/tests/app/v2/broadcast/test_post_broadcast.py
+++ b/tests/app/v2/broadcast/test_post_broadcast.py
@@ -87,10 +87,6 @@ def test_valid_post_cap_xml_broadcast_returns_201(
     assert response_json['areas']['names'] == [
         'River Steeping in Wainfleet All Saints'
     ]
-    # TEMPORARY: while we repurpose "areas"
-    assert response_json['areas_2']['names'] == [
-        'River Steeping in Wainfleet All Saints'
-    ]
     assert response_json['cancelled_at'] is None
     assert response_json['cancelled_by_id'] is None
     assert response_json['content'].startswith(
@@ -113,11 +109,6 @@ def test_valid_post_cap_xml_broadcast_returns_201(
     assert response_json['areas']['simple_polygons'][0][0] == [53.10562, 0.244127]
     assert response_json['areas']['simple_polygons'][0][-1] == [53.10562, 0.244127]
     assert response_json['areas']['simple_polygons'][0][-1] == [53.10562, 0.244127]
-    assert len(response_json['areas_2']['simple_polygons']) == 1
-    assert len(response_json['areas_2']['simple_polygons'][0]) == 23
-    assert response_json['areas_2']['simple_polygons'][0][0] == [53.10562, 0.244127]
-    assert response_json['areas_2']['simple_polygons'][0][-1] == [53.10562, 0.244127]
-    assert response_json['areas_2']['simple_polygons'][0][-1] == [53.10562, 0.244127]
 
     assert response_json['starts_at'] is None
     assert response_json['status'] == 'pending-approval'


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178986763

Depends on: https://github.com/alphagov/notifications-admin/pull/4006

The Admin app was only using this temporarily and is now using the
"areas" field instead [1], so we can delete this one.

[1]: https://github.com/alphagov/notifications-admin/pull/4006