### PR TITLE
Upgrade runtime to Python 3.9

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.x
+python-3.9.x


### PR DESCRIPTION
Tests pass in a clean Python 3.9 environment locally without any dependency changes.

