### PR TITLE
Add command to migrate custom broadcast areas

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -914,3 +914,26 @@ def populate_annual_billing_with_defaults(year, missing_services_only):
 
     for service in active_services:
         set_default_free_allowance_for_service(service, year)
+
+
+@notify_command(name='tmp-backfill-custom-broadcast-areas')
+def tmp_backfill_custom_broadcast_areas():
+    from app import db
+    from app.models import BroadcastMessage
+
+    custom_broadcasts = BroadcastMessage.query \
+        .filter(BroadcastMessage.api_key_id != None) \
+        .filter(BroadcastMessage.areas.has_key('areas'))  # noqa
+
+    for broadcast in custom_broadcasts:
+        old_areas = broadcast.areas
+
+        new_areas = {
+            'names': old_areas['areas'],
+            'simple_polygons': old_areas['simple_polygons']
+        }
+
+        broadcast.areas = new_areas
+
+        print(f'Migrating {broadcast.id}')
+        db.session.commit()


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178986763

Unlike broadcasts created in the Admin app, these are only expected
to have "names" and "simple_polygons" in their areas column [1].

The migration command in the Admin app [2] isn't suitable for these
broadcasts as it would try to aggregate their areas, etc.

I've put a conditional on "areas" being present (in the areas column)
so this command doesn't pick up any new custom broadcasts.

[1]: https://github.com/alphagov/notifications-api/pull/3312/commits/023a06d5fb4c20e6bf5a1c9e65b473cb376b2b6bo
[2]: https://github.com/alphagov/notifications-admin/pull/4011