### PR TITLE
Bump utils to 46.0.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -38,7 +38,7 @@ notifications-python-client==6.0.2
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@44.5.1#egg=notifications-utils==44.5.1
+git+https://github.com/alphagov/notifications-utils.git@46.0.0#egg=notifications-utils==46.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ notifications-python-client==6.0.2
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@44.5.1#egg=notifications-utils==44.5.1
+git+https://github.com/alphagov/notifications-utils.git@46.0.0#egg=notifications-utils==46.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.10.1

--- a/tests/app/v2/broadcast/test_post_broadcast.py
+++ b/tests/app/v2/broadcast/test_post_broadcast.py
@@ -104,7 +104,7 @@ def test_valid_post_cap_xml_broadcast_returns_201(
     assert response_json['service_id'] == str(sample_broadcast_service.id)
 
     assert len(response_json['areas']['simple_polygons']) == 1
-    assert len(response_json['areas']['simple_polygons'][0]) == 23
+    assert len(response_json['areas']['simple_polygons'][0]) == 22
     assert response_json['areas']['simple_polygons'][0][0] == [53.10562, 0.244127]
     assert response_json['areas']['simple_polygons'][0][-1] == [53.10562, 0.244127]
     assert response_json['areas']['names'] == ['River Steeping in Wainfleet All Saints']


### PR DESCRIPTION
This brings in some new polygon simplication code [1] so we need to
tweak any tests that rely on the exact number of polygons after this
operation.

[1]: https://github.com/alphagov/notifications-utils/pull/890