### PR TITLE
Don't raise P1 for broadcasts

### DIFF
--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -58,8 +58,8 @@ def check_event_is_authorised_to_be_sent(broadcast_event, provider):
 def check_event_makes_sense_in_sequence(broadcast_event, provider):
     """
     If any previous event hasn't sent yet for that provider, then we shouldn't send the current event. Instead, fail and
-    raise a zendesk ticket - so that a notify team member can assess the state of the previous messages, and if necessary, can
-    replay the `send_broadcast_provider_message` task if the previous message has now been sent.
+    raise a zendesk ticket - so that a notify team member can assess the state of the previous messages, and if
+    necessary, can replay the `send_broadcast_provider_message` task if the previous message has now been sent.
 
     Note: This is called before the new broadcast_provider_message is created.
 

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -58,7 +58,7 @@ def check_event_is_authorised_to_be_sent(broadcast_event, provider):
 def check_event_makes_sense_in_sequence(broadcast_event, provider):
     """
     If any previous event hasn't sent yet for that provider, then we shouldn't send the current event. Instead, fail and
-    raise a P1 - so that a notify team member can assess the state of the previous messages, and if necessary, can
+    raise a zendesk ticket - so that a notify team member can assess the state of the previous messages, and if necessary, can
     replay the `send_broadcast_provider_message` task if the previous message has now been sent.
 
     Note: This is called before the new broadcast_provider_message is created.
@@ -128,7 +128,7 @@ def send_broadcast_event(broadcast_event_id):
         broadcast_event.message_type == BroadcastEventMessageType.ALERT
     ):
         broadcast_message = broadcast_event.broadcast_message
-        # raise a P1 to alert team that broadcast is going out.
+        # raise a zendesk ticket to alert team that broadcast is going out.
         message = '\n'.join([
             'Broadcast Sent',
             '',
@@ -146,7 +146,6 @@ def send_broadcast_event(broadcast_event_id):
             subject="Live broadcast sent",
             message=message,
             ticket_type=zendesk_client.TYPE_INCIDENT,
-            p1=True,
         )
         current_app.logger.error(message)
 

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -99,7 +99,7 @@ def test_send_broadcast_event_does_nothing_if_provider_set_on_service_isnt_enabl
     ({'names': ['England', 'Scotland']}, ['England', 'Scotland']),
     ({}, [])
 ])
-def test_send_broadcast_event_creates_zendesk_p1(
+def test_send_broadcast_event_creates_zendesk(
     area_data,
     expected_message,
     mocker,
@@ -122,7 +122,6 @@ def test_send_broadcast_event_creates_zendesk_p1(
 
     assert mock_create_ticket.call_count == 1
     zendesk_args = mock_create_ticket.call_args[1]
-    assert zendesk_args['p1'] is True
     assert zendesk_args['ticket_type'] == 'incident'
 
     assert str(broadcast_message.id) in zendesk_args['message']
@@ -132,7 +131,7 @@ def test_send_broadcast_event_creates_zendesk_p1(
     assert "Dear Sir/Madam" in zendesk_args['message']
 
 
-def test_send_broadcast_event_doesnt_p1_when_cancelling(mocker, notify_api, sample_broadcast_service):
+def test_send_broadcast_event_doesnt_create_zendesk_when_cancelling(mocker, notify_api, sample_broadcast_service):
     template = create_template(sample_broadcast_service, BROADCAST_TYPE)
     broadcast_message = create_broadcast_message(
         template,


### PR DESCRIPTION
This is happening on the AWS side now as part of
alphagov/notifications-broadcasts-infra#267 - but we still want to keep
the zendesk ticket as it contains useful context _and_ provides
visibility to the team.