### PR TITLE
return contact list created_at in UTC, not BST

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2218,7 +2218,6 @@ class ServiceContactList(db.Model):
         ).first())
 
     def serialize(self):
-        created_at_in_bst = convert_utc_to_bst(self.created_at)
         contact_list = {
             "id": str(self.id),
             "original_file_name": self.original_file_name,
@@ -2228,7 +2227,7 @@ class ServiceContactList(db.Model):
             "template_type": self.template_type,
             "service_id": str(self.service_id),
             "created_by": self.created_by.name,
-            "created_at": created_at_in_bst.strftime("%Y-%m-%d %H:%M:%S"),
+            "created_at": self.created_at.strftime(DATETIME_FORMAT),
         }
         return contact_list
 

--- a/tests/app/service/test_service_contact_list_rest.py
+++ b/tests/app/service/test_service_contact_list_rest.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime, timedelta
 
 import pytest
+from freezegun import freeze_time
 
 from app.models import ServiceContactList
 from tests.app.db import (
@@ -59,6 +60,7 @@ def test_create_service_contact_list_cannot_save_type_letter(sample_service, adm
     assert response['errors'][0]['message'] == "template_type letter is not one of [email, sms]"
 
 
+@freeze_time('2020-06-06 12:00')
 def test_get_contact_list(admin_request, notify_db_session):
     contact_list = create_service_contact_list()
 
@@ -70,6 +72,7 @@ def test_get_contact_list(admin_request, notify_db_session):
     assert len(response) == 1
     assert response[0] == contact_list.serialize()
     assert response[0]['recent_job_count'] == 0
+    assert response[0]['created_at'] == '2020-06-06T12:00:00.000000Z'
 
 
 @pytest.mark.parametrize('days_of_email_retention, expected_job_count', (


### PR DESCRIPTION
make sure timestamps returned from the api are always consistent.

The only place in models where we're serializing a BST timestamp is on the Notification.serialize_for_csv method now, which at least is a bit different as this is user-facing (it also returns a formatted human-readable notification_status for example).

see also

- [ ] https://github.com/alphagov/notifications-admin/pull/4022