### PR TITLE
Use the new Zendesk form for all tickets

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -257,11 +257,14 @@ def letter_raise_alert_if_no_ack_file_for_zip():
 
     if len(zip_file_set - ack_file_set) > 0:
         if current_app.config['NOTIFY_ENVIRONMENT'] in ['live', 'production', 'test']:
-            zendesk_client.create_ticket(
+            ticket = NotifySupportTicket(
                 subject="Letter acknowledge error",
                 message=message,
-                ticket_type=zendesk_client.TYPE_INCIDENT
+                ticket_type=NotifySupportTicket.TYPE_INCIDENT,
+                technical_ticket=True,
+                ticket_categories=['notify_letters']
             )
+            zendesk_client.send_ticket_to_zendesk(ticket)
         current_app.logger.error(message)
 
     if len(ack_file_set - zip_file_set) > 0:

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -239,11 +239,14 @@ def check_if_letters_still_in_created():
               "#deal-with-Letters-still-in-created.".format(len(letters))
 
         if current_app.config['NOTIFY_ENVIRONMENT'] in ['live', 'production', 'test']:
-            zendesk_client.create_ticket(
-                subject="[{}] Letters still in 'created' status".format(current_app.config['NOTIFY_ENVIRONMENT']),
+            ticket = NotifySupportTicket(
+                subject=f"[{current_app.config['NOTIFY_ENVIRONMENT']}] Letters still in 'created' status",
                 message=msg,
-                ticket_type=zendesk_client.TYPE_INCIDENT
+                ticket_type=NotifySupportTicket.TYPE_INCIDENT,
+                technical_ticket=True,
+                ticket_categories=['notify_letters']
             )
+            zendesk_client.send_ticket_to_zendesk(ticket)
             current_app.logger.error(msg)
 
 

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -1,6 +1,9 @@
 from datetime import datetime, timedelta
 
 from flask import current_app
+from notifications_utils.clients.zendesk.zendesk_client import (
+    NotifySupportTicket,
+)
 from sqlalchemy import between
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -214,11 +217,14 @@ def check_if_letters_still_pending_virus_check():
             Notifications: {}""".format(len(letters), sorted(letter_ids))
 
         if current_app.config['NOTIFY_ENVIRONMENT'] in ['live', 'production', 'test']:
-            zendesk_client.create_ticket(
-                subject="[{}] Letters still pending virus check".format(current_app.config['NOTIFY_ENVIRONMENT']),
+            ticket = NotifySupportTicket(
+                subject=f"[{current_app.config['NOTIFY_ENVIRONMENT']}] Letters still pending virus check",
                 message=msg,
-                ticket_type=zendesk_client.TYPE_INCIDENT
+                ticket_type=NotifySupportTicket.TYPE_INCIDENT,
+                technical_ticket=True,
+                ticket_categories=['notify_letters']
             )
+            zendesk_client.send_ticket_to_zendesk(ticket)
             current_app.logger.error(msg)
 
 

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -301,13 +301,13 @@ def check_for_services_with_high_failure_rates_or_sending_to_tv_numbers():
         if current_app.config['NOTIFY_ENVIRONMENT'] in ['live', 'production', 'test']:
             message += ("\nYou can find instructions for this ticket in our manual:\n"
                         "https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#Deal-with-services-with-high-failure-rates-or-sending-sms-to-tv-numbers")  # noqa
-            zendesk_client.create_ticket(
-                subject="[{}] High failure rates for sms spotted for services".format(
-                    current_app.config['NOTIFY_ENVIRONMENT']
-                ),
+            ticket = NotifySupportTicket(
+                subject=f"[{current_app.config['NOTIFY_ENVIRONMENT']}] High failure rates for sms spotted for services",
                 message=message,
-                ticket_type=zendesk_client.TYPE_INCIDENT
+                ticket_type=NotifySupportTicket.TYPE_INCIDENT,
+                technical_ticket=True
             )
+            zendesk_client.send_ticket_to_zendesk(ticket)
 
 
 @notify_celery.task(name='trigger-link-tests')

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -38,7 +38,7 @@ notifications-python-client==6.0.2
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@46.0.0#egg=notifications-utils==46.0.0
+git+https://github.com/alphagov/notifications-utils.git@46.1.0#egg=notifications-utils==46.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ notifications-python-client==6.0.2
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@46.0.0#egg=notifications-utils==46.0.0
+git+https://github.com/alphagov/notifications-utils.git@46.1.0#egg=notifications-utils==46.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.10.1
@@ -51,41 +51,40 @@ alembic==1.6.5
 amqp==1.4.9
 anyjson==0.3.3
 attrs==21.2.0
-awscli==1.20.8
+awscli==1.20.46
 bcrypt==3.2.0
 billiard==3.3.0.23
 bleach==3.3.0
 blinker==1.4
 boto==2.49.0
-boto3==1.18.8
-botocore==1.21.8
+boto3==1.18.46
+botocore==1.21.46
 certifi==2021.5.30
-charset-normalizer==2.0.3
+charset-normalizer==2.0.6
 click==8.0.1
 colorama==0.4.3
 dnspython==1.16.0
 docutils==0.15.2
 flask-redis==0.4.0
 geojson==2.5.0
-govuk-bank-holidays==0.9
-greenlet==1.1.0
+govuk-bank-holidays==0.10
+greenlet==1.1.1
 idna==3.2
 Jinja2==3.0.1
 jmespath==0.10.0
 kombu==3.0.37
-Mako==1.1.4
+Mako==1.1.5
 MarkupSafe==2.0.1
 mistune==0.8.4
 orderedset==2.0.3
 packaging==21.0
-phonenumbers==8.12.28
+phonenumbers==8.12.31
 pyasn1==0.4.8
 pycparser==2.20
 pyparsing==2.4.7
 PyPDF2==1.26.0
 pyrsistent==0.18.0
 python-dateutil==2.8.2
-python-editor==1.0.4
 python-json-logger==2.0.2
 pytz==2021.1
 PyYAML==5.4.1
@@ -98,5 +97,5 @@ six==1.16.0
 smartypants==2.0.1
 soupsieve==2.2.1
 statsd==3.3.0
-urllib3==1.26.6
+urllib3==1.26.7
 webencodings==0.5.1


### PR DESCRIPTION
We introduced a new way of creating Zendesk tickets here https://github.com/alphagov/notifications-utils/pull/899 and tried it out first just on the request to go live tickets (https://github.com/alphagov/notifications-admin/pull/4024).

It worked! So now we want to use the new way of creating tickets everywhere.

[Pivotal story](https://www.pivotaltracker.com/story/show/179005041)