### PR TITLE
Fix incorrect ordering in command wrapper

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -95,8 +95,8 @@ class notify_command:
 
     def __call__(self, func):
         decorators = [
+            functools.wraps(func),  # carry through function name, docstrings, etc.
             click.command(name=self.name),  # turn it into a click.Command
-            functools.wraps(func)  # carry through function name, docstrings, etc.
         ]
 
         # in the test environment the app context is already provided and having


### PR DESCRIPTION
Previously this was causing the wrapper function to become a
command before it started mirroring the original (functools.wraps),
which meant any previous option decorators were "lost".*

We didn't notice the problem in the original PR [1] because the new
command under test has its option decorators *after* the command
decorator, in contrast with all other (now broken) commands.

The original wrapper applied the functools decorator first [2],
so this change just reinstates that ordering.

*This is a hand-wavey explanation as I haven't looked into how
functools.wraps interacts with option decorators.

[1]: https://github.com/alphagov/notifications-api/commit/922fd2f333f62bc7ce1069eae913ed43e9b63652#
[2]: https://github.com/alphagov/notifications-api/commit/922fd2f333f62bc7ce1069eae913ed43e9b63652#diff-c4e75c8613e916687a97191a7a79110dfb47e96ef7df96f7ba25dd94ba64943dL101