### PR TITLE
Add task to recreate the PDF file for a non-templated letter

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -19,7 +19,10 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from app import db
 from app.aws import s3
-from app.celery.letters_pdf_tasks import get_pdf_for_templated_letter
+from app.celery.letters_pdf_tasks import (
+    get_pdf_for_templated_letter,
+    resanitise_pdf,
+)
 from app.celery.reporting_tasks import (
     create_nightly_notification_status_for_day,
 )
@@ -277,6 +280,14 @@ def insert_inbound_numbers_from_file(file_name):
 def replay_create_pdf_for_templated_letter(notification_id):
     print("Create task to get_pdf_for_templated_letter for notification: {}".format(notification_id))
     get_pdf_for_templated_letter.apply_async([str(notification_id)], queue=QueueNames.CREATE_LETTERS_PDF)
+
+
+@notify_command(name='recreate-pdf-for-precompiled-or-uploaded-letter')
+@click.option('-n', '--notification_id', type=click.UUID, required=True,
+              help="Notification ID of the precompiled or uploaded letter")
+def recreate_pdf_for_precompiled_or_uploaded_letter(notification_id):
+    print(f"Call resanitise_pdf task for notification: {notification_id}")
+    resanitise_pdf.apply_async([str(notification_id)], queue=QueueNames.LETTERS)
 
 
 @notify_command(name='replay-service-callbacks')

--- a/app/commands.py
+++ b/app/commands.py
@@ -271,10 +271,10 @@ def insert_inbound_numbers_from_file(file_name):
     file.close()
 
 
-@notify_command(name='replay-create-pdf-letters')
+@notify_command(name='replay-create-pdf-for-templated-letter')
 @click.option('-n', '--notification_id', type=click.UUID, required=True,
               help="Notification id of the letter that needs the get_pdf_for_templated_letter task replayed")
-def replay_create_pdf_letters(notification_id):
+def replay_create_pdf_for_templated_letter(notification_id):
     print("Create task to get_pdf_for_templated_letter for notification: {}".format(notification_id))
     get_pdf_for_templated_letter.apply_async([str(notification_id)], queue=QueueNames.CREATE_LETTERS_PDF)
 

--- a/app/config.py
+++ b/app/config.py
@@ -77,6 +77,7 @@ class TaskNames(object):
     SANITISE_LETTER = 'sanitise-and-upload-letter'
     CREATE_PDF_FOR_TEMPLATED_LETTER = 'create-pdf-for-templated-letter'
     PUBLISH_GOVUK_ALERTS = 'publish-govuk-alerts'
+    RECREATE_PDF_FOR_PRECOMPILED_LETTER = 'recreate-pdf-for-precompiled-letter'
 
 
 class Config(object):


### PR DESCRIPTION
**Add task to re-sanitise and replace a PDF for precompiled letter**
This adds a task which is designed to be used if we want to recreate the PDF for a precompiled letter (either one that has been created using the API or one that has been uploaded through the website).

The task takes the `notification_id` of the letter and passes template preview the details it needs in order to sanitise the original file and then replace the version in the letters-pdf bucket with the freshly sanitised version.

**Add command to run the new task**
We already had the `replay-create-pdf-for-templated-letter` command. This adds a new command, `recreate-pdf-for-precompiled-or-uploaded-letter` which does the same thing but for non-templated letters.

Part of [Pivotal story](https://www.pivotaltracker.com/story/show/178746435)