### PR TITLE
Bump Werkzeug to version 2.0.2

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -25,9 +25,7 @@ rfc3987==1.3.8
 cachetools==4.2.1
 beautifulsoup4==4.9.3
 lxml==4.6.3
-
-# When we upgraded to 2.0.1 we noticed significantly higher memory usage on the API
-Werkzeug==1.0.1 # puyp: < 2.0.0
+Werkzeug==2.0.2
 
 # higher version causes build to fail on PaaS due to lack of Rust
 # see https://github.com/pyca/cryptography/issues/5810

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,9 +27,7 @@ rfc3987==1.3.8
 cachetools==4.2.1
 beautifulsoup4==4.9.3
 lxml==4.6.3
-
-# When we upgraded to 2.0.1 we noticed significantly higher memory usage on the API
-Werkzeug==1.0.1 # puyp: < 2.0.0
+Werkzeug==2.0.2
 
 # higher version causes build to fail on PaaS due to lack of Rust
 # see https://github.com/pyca/cryptography/issues/5810


### PR DESCRIPTION
This is the newest version.

Pyup is complaining about vulnerabilities in version 1.0.1, specifically
> Werkzeug version 2.0.2 improves the security of the debugger cookies. "SameSite" attribute is set to "Strict" instead of "None", and the secure flag is added when on HTTPS.

Previously we were using whatever version of Werkzeug that Flask specified. This pins it to get rid of the vulnerability without having to:
- upgrade everything at once
- add another dependency that we tell PyUp to ignore

We’ve done this for the admin app already: https://github.com/alphagov/notifications-admin/pull/4042

I suspect the memory usage issues we saw with version 2.0.1 have been fixed in 2.0.2, per this line in the [changelog](https://werkzeug.palletsprojects.com/en/2.0.x/changes/):
> - Fix memory usage for locals when using Python 3.6 or pre 0.4.17 greenlet versions: https://github.com/pallets/werkzeug/pull/2212