### PR TITLE
Bug fix: update normalised_to, not just `to` after letter sanitise

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -479,6 +479,7 @@ def update_letter_pdf_status(reference, status, billable_units, recipient_addres
         update_dict.update({'postage': postage, 'international': True})
     if recipient_address:
         update_dict['to'] = recipient_address
+        update_dict['normalised_to'] = ''.join(recipient_address.split()).lower()
     return dao_update_notifications_by_reference(
         references=[reference],
         update_dict=update_dict)[0]

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -843,6 +843,7 @@ def test_process_sanitised_letter_with_valid_letter(
     assert sample_letter_notification.status == expected_status
     assert sample_letter_notification.billable_units == 1
     assert sample_letter_notification.to == 'A. User\nThe house on the corner'
+    assert sample_letter_notification.normalised_to == 'a.userthehouseonthecorner'
 
     assert not [x for x in scan_bucket.objects.all()]
     assert not [x for x in template_preview_bucket.objects.all()]


### PR DESCRIPTION
When a precompiled letter is sent to us, we set the `to` field as
'Provided as PDF' in
https://github.com/alphagov/notifications-api/blob/1c1023a877d7c7da6ab4524a9fd21f930b7fbe1f/app/v2/notifications/post_notifications.py#L100-L104

This then also sets `normalised_to` as `providedaspdf`.

However, when template preview sanitises the letter, pulls out the
address and gives it to the API, we were only setting `to` to be
the new address and had forgotten to also amend `normalised_to` to
be the normalised version. This meant that for all these letters
we accidentally left `normalised_to` as `providedaspdf`. The impact
of this was that we can not then search for these letters in the
admin user interface as they rely on the `normalised_to` field
containing the recipient address.

This commit fixes that bug by also setting the `normalised_to`
field.