### PR TITLE
Revert "add raw request timings to provider send functions"

### DIFF
--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -62,22 +62,6 @@ class AwsSesClient(EmailClient):
         self.name = 'ses'
         self.statsd_client = statsd_client
 
-        # events are generally undocumented, but some that might be of interest are:
-        # before-call, after-call, after-call-error, request-created, response-received
-        self._client.meta.events.register('request-created.ses.SendEmail', self.ses_request_created_hook)
-        self._client.meta.events.register('response-received.ses.SendEmail', self.ses_response_received_hook)
-
-    def ses_request_created_hook(self, **kwargs):
-        # request created may be called multiple times if the request auto-retries. We want to count all these as the
-        # same request for timing purposes, so only reset the start time if it was cleared completely
-        if self.ses_start_time == 0:
-            self.ses_start_time = monotonic()
-
-    def ses_response_received_hook(self, **kwargs):
-        # response received may be called multiple times if the request auto-retries, however, we want to count the last
-        # time it triggers for timing purposes, so always reset the elapsed time
-        self.ses_elapsed_time = monotonic() - self.ses_start_time
-
     def get_name(self):
         return self.name
 
@@ -88,8 +72,6 @@ class AwsSesClient(EmailClient):
                    body,
                    html_body='',
                    reply_to_address=None):
-        self.ses_elapsed_time = 0
-        self.ses_start_time = 0
         try:
             if isinstance(to_addresses, str):
                 to_addresses = [to_addresses]
@@ -142,8 +124,6 @@ class AwsSesClient(EmailClient):
             elapsed_time = monotonic() - start_time
             current_app.logger.info("AWS SES request finished in {}".format(elapsed_time))
             self.statsd_client.timing("clients.ses.request-time", elapsed_time)
-            if self.ses_elapsed_time != 0:
-                self.statsd_client.timing("clients.ses.raw-request-time", self.ses_elapsed_time)
             self.statsd_client.incr("clients.ses.success")
             return response['MessageId']
 

--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -101,7 +101,6 @@ class FiretextClient(SmsClient):
             "reference": reference
         }
 
-        response = None
         start_time = monotonic()
         try:
             response = request(
@@ -126,6 +125,4 @@ class FiretextClient(SmsClient):
             elapsed_time = monotonic() - start_time
             self.current_app.logger.info("Firetext request for {} finished in {}".format(reference, elapsed_time))
             self.statsd_client.timing("clients.firetext.request-time", elapsed_time)
-            if response and hasattr(response, 'elapsed'):
-                self.statsd_client.timing("clients.firetext.raw-request-time", response.elapsed.total_seconds())
         return response

--- a/app/clients/sms/mmg.py
+++ b/app/clients/sms/mmg.py
@@ -107,7 +107,6 @@ class MMGClient(SmsClient):
             "multi": multi
         }
 
-        response = None
         start_time = monotonic()
         try:
             response = request(
@@ -134,9 +133,6 @@ class MMGClient(SmsClient):
         finally:
             elapsed_time = monotonic() - start_time
             self.statsd_client.timing("clients.mmg.request-time", elapsed_time)
-            if response and hasattr(response, 'elapsed'):
-                self.statsd_client.timing("clients.mmg.raw-request-time", response.elapsed.total_seconds())
-
             self.current_app.logger.info("MMG request for {} finished in {}".format(reference, elapsed_time))
 
         return response


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180016688

This reverts commit f2f2509c9b38d960231e08c863c7591f44206a55.
Raw request stats were added to investigate a hunch about a
performance issue we were seeing [1], but turned out not to
be relevant. We don't use them anymore so we can tidy up.

[1]: https://github.com/alphagov/notifications-api/pull/2858