### PR TITLE
Bump utils to 48.0.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -36,7 +36,7 @@ notifications-python-client==6.0.2
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@47.1.0#egg=notifications-utils==47.1.0
+git+https://github.com/alphagov/notifications-utils.git@48.0.0#egg=notifications-utils==48.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ notifications-python-client==6.0.2
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@47.1.0#egg=notifications-utils==47.1.0
+git+https://github.com/alphagov/notifications-utils.git@48.0.0#egg=notifications-utils==48.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.10.1


### PR DESCRIPTION
Brings in fixes for non breaking space support in templates

See https://github.com/alphagov/notifications-utils/pull/908 for context