### PR TITLE
Republish gov.uk/alerts every night to clear down planned tests

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -334,3 +334,11 @@ def auto_expire_broadcast_messages():
             name=TaskNames.PUBLISH_GOVUK_ALERTS,
             queue=QueueNames.GOVUK_ALERTS
         )
+
+
+@notify_celery.task(name='remove-yesterdays-planned-tests-on-govuk-alerts')
+def remove_yesterdays_planned_tests_on_govuk_alerts():
+    notify_celery.send_task(
+        name=TaskNames.PUBLISH_GOVUK_ALERTS,
+        queue=QueueNames.GOVUK_ALERTS
+    )

--- a/app/config.py
+++ b/app/config.py
@@ -332,6 +332,11 @@ class Config(object):
                 'schedule': timedelta(minutes=5),
                 'options': {'queue': QueueNames.PERIODIC}
             },
+            'remove-yesterdays-planned-tests-on-govuk-alerts': {
+                'task': 'remove-yesterdays-planned-tests-on-govuk-alerts',
+                'schedule': crontab(hour=00, minute=00),
+                'options': {'queue': QueueNames.PERIODIC}
+            },
         }
     }
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -19,6 +19,7 @@ from app.celery.scheduled_tasks import (
     check_job_status,
     delete_invitations,
     delete_verify_codes,
+    remove_yesterdays_planned_tests_on_govuk_alerts,
     replay_created_notifications,
     run_scheduled_jobs,
     switch_current_sms_provider_on_slow_delivery,
@@ -700,3 +701,16 @@ def test_auto_expire_broadcast_messages(
         )
     else:
         assert not mock_celery.called
+
+
+def test_remove_yesterdays_planned_tests_on_govuk_alerts(
+    mocker
+):
+    mock_celery = mocker.patch('app.celery.scheduled_tasks.notify_celery.send_task')
+
+    remove_yesterdays_planned_tests_on_govuk_alerts()
+
+    mock_celery.assert_called_once_with(
+        name=TaskNames.PUBLISH_GOVUK_ALERTS,
+        queue=QueueNames.GOVUK_ALERTS
+    )


### PR DESCRIPTION
We have made it so that gov.uk/alerts shows a ‘1 planned test’ banner for the whole of the day when there has been an operator test on that day.

We need to remove the banner when the day is over.

The most straightforward way to do this is to republish the site at the start of every day. The [gov.uk/alerts code will work out if there are or aren’t any planned tests to show that day](https://github.com/alphagov/notifications-govuk-alerts/blob/5a274af6d0c202b7bd5e664967b1e113015b9a31/app/models/alerts.py#L38-L44).