### PR TITLE
Optimise query to get notifications to "time out"

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -155,7 +155,7 @@ def timeout_notifications():
                           len(technical_failure_notifications), [str(x.id) for x in technical_failure_notifications])
             raise NotificationTechnicalFailureException(message)
 
-        if len(notifications) == 0:
+        if len(notifications) < 100000:
             return
 
     raise RuntimeError("Some notifications may still be in sending.")


### PR DESCRIPTION
From experimenting in production we found a "!=" caused the engine
to use a sequential scan, whereas explicitly listing all the types
ensured an index scan was used.

We also found that querying for many (over 100K) items leads to
the task stalling - no logs, but no evidence of it running either -
so we also add a limit to the query.

Since the query now only returns a subset of notifications, we need
to ensure the subsequent "update" query operates on the same batch.
Also, as a temporary measure, we have a loop in the task code to
ensure it operates on the total set of notifications to "time out",
which we assume is less than 500K for the time being.

- [ ] Test this works manually in Production before deploying.