### PR TITLE
[DO NOT MERGE] Reenable argument checking for Celery tasks

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -22,7 +22,6 @@ def make_task(app):
     class NotifyTask(Task):
         abstract = True
         start = None
-        typing = False
 
         def on_success(self, retval, task_id, args, kwargs):
             elapsed_time = time.monotonic() - self.start
@@ -68,8 +67,6 @@ def make_task(app):
             # ensure task has flask context to access config, logger, etc
             with app.app_context():
                 self.start = time.monotonic()
-                # TEMPORARY: remove old piggyback values from kwargs
-                kwargs.pop('request_id', None)
                 # Add 'request_id' to 'g' so that it gets logged. Note
                 # that each header is a direct attribute of the task
                 # context (aka "request").

--- a/tests/app/celery/test_celery.py
+++ b/tests/app/celery/test_celery.py
@@ -22,6 +22,15 @@ def async_task(celery_task):
     celery_task.pop_request()
 
 
+@pytest.fixture
+def request_id_task(celery_task):
+    # Note that each header is a direct attribute of the
+    # task context (aka "request").
+    celery_task.push_request(notify_request_id='1234')
+    yield celery_task
+    celery_task.pop_request()
+
+
 def test_success_should_log_and_call_statsd(mocker, notify_api, async_task):
     statsd = mocker.patch.object(notify_api.statsd_client, 'timing')
     logger = mocker.patch.object(notify_api.logger, 'info')
@@ -78,32 +87,67 @@ def test_failure_queue_when_applied_synchronously(mocker, notify_api, celery_tas
     logger.assert_called_once_with(f'Celery task {celery_task.name} (queue: none) failed')
 
 
-def test_call_exports_request_id_from_kwargs(mocker, celery_task):
+def test_call_exports_request_id_from_headers(mocker, request_id_task):
     g = mocker.patch('app.celery.celery.g')
-    # this would fail if the kwarg was passed through unexpectedly
-    celery_task(request_id='1234')
+    request_id_task()
     assert g.request_id == '1234'
 
 
-def test_send_task_injects_global_request_id_into_kwargs(mocker, notify_api):
+def test_call_copes_if_request_id_not_in_headers(mocker, celery_task):
+    g = mocker.patch('app.celery.celery.g')
+    celery_task()
+    assert g.request_id == None
+
+
+def test_send_task_injects_global_request_id_into_headers(mocker, notify_api):
     super_apply = mocker.patch('celery.Celery.send_task')
     g.request_id = '1234'
     notify_celery.send_task('some-task')
-    super_apply.assert_called_with('some-task', None, {'request_id': '1234'})
+
+    super_apply.assert_called_with(
+        'some-task',  # name
+        None,  # args
+        None,   # kwargs
+        headers={'notify_request_id': '1234'}  # other kwargs
+    )
 
 
-def test_send_task_injects_request_id_with_other_kwargs(mocker, notify_api):
+def test_send_task_injects_request_id_with_existing_headers(mocker, notify_api):
     super_apply = mocker.patch('celery.Celery.send_task')
     g.request_id = '1234'
-    notify_celery.send_task('some-task', kwargs={'something': 'else'})
-    super_apply.assert_called_with('some-task', None, {'request_id': '1234', 'something': 'else'})
+
+    notify_celery.send_task(
+        'some-task',
+        None,  # args
+        None,  # kwargs
+        headers={'something': 'else'}  # other kwargs
+    )
+
+    super_apply.assert_called_with(
+        'some-task',  # name
+        None,  # args
+        None,  # kwargs
+        headers={'notify_request_id': '1234', 'something': 'else'}  # other kwargs
+    )
 
 
-def test_send_task_injects_request_id_with_positional_args(mocker, notify_api):
+def test_send_task_injects_request_id_with_none_headers(mocker, notify_api):
     super_apply = mocker.patch('celery.Celery.send_task')
     g.request_id = '1234'
-    notify_celery.send_task('some-task', ['args'], {'kw': 'args'})
-    super_apply.assert_called_with('some-task', ['args'], {'request_id': '1234', 'kw': 'args'})
+
+    notify_celery.send_task(
+        'some-task',
+        None,  # args
+        None,  # kwargs
+        headers=None,  # other kwargs (task retry set headers to "None")
+    )
+
+    super_apply.assert_called_with(
+        'some-task',  # name
+        None,  # args
+        None,  # kwargs
+        headers={'notify_request_id': '1234'}  # other kwargs
+    )
 
 
 def test_send_task_injects_id_into_kwargs_from_request(mocker, notify_api):
@@ -114,4 +158,9 @@ def test_send_task_injects_id_into_kwargs_from_request(mocker, notify_api):
     with notify_api.test_request_context(headers=request_headers):
         notify_celery.send_task('some-task')
 
-    super_apply.assert_called_with('some-task', None, {'request_id': '1234'})
+    super_apply.assert_called_with(
+        'some-task',  # name
+        None,  # args
+        None,   # kwargs
+        headers={'notify_request_id': '1234'}  # other kwargs
+    )


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180213914

Relates to: [1].

This is safe now that [2] has been deployed for all apps, and enough
time has elapsed for in-flight tasks created using the old approach
to clear through the system.

- [x] Checked that tasks created using the new approach retry successfully ✅.

[1]: https://github.com/alphagov/notifications-api/pull/3355/commits/3ecbdbb2609a9edcca5be1892053d8379bb6b580
[2]: https://github.com/alphagov/notifications-api/pull/3364