### PR TITLE
Improve log message searchability for duplicate receipts

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -834,7 +834,7 @@ def _duplicate_update_warning(notification, status):
     current_app.logger.info(
         (
             'Duplicate callback received. Notification id {id} received a status update to {new_status}'
-            '{time_diff} after being set to {old_status}. {type} sent by {sent_by}'
+            ' from {old_status} for {type} sent by {sent_by}. This happened {time_diff} after being first set.'
         ).format(
             id=notification.id,
             old_status=notification.status,


### PR DESCRIPTION
There were two problems with the existing message.

1. There was no space between the new status and the time taken
   which made reading and searching harder
2. They key bits of information (before and after status) were
   separated by the time taken (which will always be unique) meaning
   you couldn't do an easy search for a message that is say in delivered
   being attempted to be set to temporary-failure.

Example logs at the moment in Logit which are a bit hard to search through:
![image](https://user-images.githubusercontent.com/7228605/141480239-d0a44a63-6aff-4ebb-aa35-e4640f71b7d9.png)
