### PR TITLE
Link to guidance about installing pycurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Contains:
 
 We run python 3.9 both locally and in production.
 
+### pycurl
+
+See https://github.com/alphagov/notifications-manuals/wiki/Getting-started#pycurl
+
 ### AWS credentials
 
 To run the API you will need appropriate AWS credentials. See the [Wiki](https://github.com/alphagov/notifications-manuals/wiki/aws-accounts#how-to-set-up-local-development) for more details.


### PR DESCRIPTION
This seems to be an issue for several people when we install new
versions of the package. Older versions of the package seem to
be equally affected, so the new need for this is likely related
to us using a newer OS / XCode version.