### PR TITLE
Report processing stats to 2dp rather than 1dp

### DIFF
--- a/app/performance_dashboard/rest.py
+++ b/app/performance_dashboard/rest.py
@@ -78,7 +78,7 @@ def transform_into_notification_by_type_json(total_notifications):
 def transform_processing_time_results_to_json(processing_time_results):
     j = []
     for x in processing_time_results:
-        j.append({"date": x.date, "percentage_under_10_seconds": round(x.percentage, 1)})
+        j.append({"date": x.date, "percentage_under_10_seconds": x.percentage})
 
     return j
 

--- a/tests/app/performance_dashboard/test_rest.py
+++ b/tests/app/performance_dashboard/test_rest.py
@@ -62,7 +62,7 @@ def test_performance_dashboard(sample_service, admin_request):
 
     create_process_time(bst_date='2021-02-28', messages_total=15, messages_within_10_secs=14)
     create_process_time(bst_date='2021-03-01', messages_total=35, messages_within_10_secs=34)
-    create_process_time(bst_date='2021-03-02', messages_total=15, messages_within_10_secs=14)
+    create_process_time(bst_date='2021-03-02', messages_total=15, messages_within_10_secs=12)
     create_process_time(bst_date='2021-03-03', messages_total=15, messages_within_10_secs=14)
 
     results = admin_request.get(endpoint="performance_dashboard.get_performance_dashboard",
@@ -75,8 +75,8 @@ def test_performance_dashboard(sample_service, admin_request):
     assert results['letter_notifications'] == 2+3+10+15
     assert results['notifications_by_type'] == [{"date": '2021-03-01', "emails": 15, "sms": 20, "letters": 3},
                                                 {"date": '2021-03-02', "emails": 25, "sms": 30, "letters": 10}]
-    assert results['processing_time'] == [{"date": "2021-03-01", "percentage_under_10_seconds": 97.1},
-                                          {"date": "2021-03-02", "percentage_under_10_seconds": 93.3}]
+    assert results['processing_time'] == [{"date": "2021-03-01", "percentage_under_10_seconds": 97.1428571428571},
+                                          {"date": "2021-03-02", "percentage_under_10_seconds": 80.0}]
     assert results["live_service_count"] == 1
     assert results["services_using_notify"][0]["service_name"] == sample_service.name
     assert not results["services_using_notify"][0]["organisation_name"]


### PR DESCRIPTION
We are starting to see lots of 100.0%s in the current table
and we think this looks suspiciously too good so think it is
beneficial to change it to be 2dp such that we get a few more
non 100.0% values.

For the admin app to be able to show things to 2dp, we need to
give at least 2dp of accuracy otherwise we are losing 1dp of
granularity.

See https://github.com/alphagov/notifications-admin/pull/4079 for admin app PR.