### PR TITLE
Fix flakey Cronitor test using caplog fixture

### DIFF
--- a/tests/app/test_cronitor.py
+++ b/tests/app/test_cronitor.py
@@ -1,4 +1,3 @@
-import logging
 from urllib import parse
 
 import pytest
@@ -75,9 +74,8 @@ def test_cronitor_does_nothing_if_cronitor_not_enabled(notify_api, rmock):
     assert rmock.called is False
 
 
-def test_cronitor_does_nothing_if_name_not_recognised(notify_api, rmock, caplog):
-    # ignore "INFO" log about task starting
-    caplog.set_level(logging.ERROR)
+def test_cronitor_does_nothing_if_name_not_recognised(notify_api, rmock, mocker):
+    mock_logger = mocker.patch('app.cronitor.current_app.logger')
 
     with set_config_values(notify_api, {
         'CRONITOR_ENABLED': True,
@@ -85,9 +83,10 @@ def test_cronitor_does_nothing_if_name_not_recognised(notify_api, rmock, caplog)
     }):
         assert successful_task() == 1
 
-    error_log = caplog.records[0]
-    assert error_log.levelname == 'ERROR'
-    assert error_log.msg == 'Cronitor enabled but task_name hello not found in environment'
+    mock_logger.error.assert_called_with(
+        'Cronitor enabled but task_name hello not found in environment'
+    )
+
     assert rmock.called is False
 
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180344153

This appears to not be thread safe: it started failing when run in
parallel with other tests in this PR [1]. We don't get much out of
using caplog over patching - it just proves our logging config isn't
swallowing the error logs, which we shouldn't need to test here.

[1]: https://github.com/alphagov/notifications-api/pull/3383