### PR TITLE
Improve query performance

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -558,6 +558,7 @@ def is_delivery_slow_for_providers(
         ProviderDetails
     ).outerjoin(
         Notification, and_(
+            Notification.notification_type == SMS_TYPE,
             Notification.sent_by == ProviderDetails.identifier,
             Notification.created_at >= created_at,
             Notification.sent_at.isnot(None),


### PR DESCRIPTION
Adding a filter to `app.dao.notifications_dao.is_delivery_slow_for_providers` query to improve the performance. By added Notifications.notification_type = 'sms' to the query it will improve the performance some analyse shows 500ms improvement, which is a good thing especially when the query is run once a minute.