### PR TITLE
make delete notification tasks parallel by notification type

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -65,66 +65,54 @@ def _remove_csv_files(job_types):
 
 @notify_celery.task(name="delete-notifications-older-than-retention")
 def delete_notifications_older_than_retention():
-    delete_email_notifications_older_than_retention()
-    delete_sms_notifications_older_than_retention()
-    delete_letter_notifications_older_than_retention()
+    delete_email_notifications_older_than_retention.apply_async(queue=QueueNames.PERIODIC)
+    delete_sms_notifications_older_than_retention.apply_async(queue=QueueNames.PERIODIC)
+    delete_letter_notifications_older_than_retention.apply_async(queue=QueueNames.PERIODIC)
 
 
 @notify_celery.task(name="delete-sms-notifications")
 @cronitor("delete-sms-notifications")
 def delete_sms_notifications_older_than_retention():
-    try:
-        start = datetime.utcnow()
-        deleted = delete_notifications_older_than_retention_by_type('sms')
-        current_app.logger.info(
-            "Delete {} job started {} finished {} deleted {} sms notifications".format(
-                'sms',
-                start,
-                datetime.utcnow(),
-                deleted
-            )
+    start = datetime.utcnow()
+    deleted = delete_notifications_older_than_retention_by_type('sms')
+    current_app.logger.info(
+        "Delete {} job started {} finished {} deleted {} sms notifications".format(
+            'sms',
+            start,
+            datetime.utcnow(),
+            deleted
         )
-    except SQLAlchemyError:
-        current_app.logger.exception("Failed to delete sms notifications")
-        raise
+    )
 
 
 @notify_celery.task(name="delete-email-notifications")
 @cronitor("delete-email-notifications")
 def delete_email_notifications_older_than_retention():
-    try:
-        start = datetime.utcnow()
-        deleted = delete_notifications_older_than_retention_by_type('email')
-        current_app.logger.info(
-            "Delete {} job started {} finished {} deleted {} email notifications".format(
-                'email',
-                start,
-                datetime.utcnow(),
-                deleted
-            )
+    start = datetime.utcnow()
+    deleted = delete_notifications_older_than_retention_by_type('email')
+    current_app.logger.info(
+        "Delete {} job started {} finished {} deleted {} email notifications".format(
+            'email',
+            start,
+            datetime.utcnow(),
+            deleted
         )
-    except SQLAlchemyError:
-        current_app.logger.exception("Failed to delete email notifications")
-        raise
+    )
 
 
 @notify_celery.task(name="delete-letter-notifications")
 @cronitor("delete-letter-notifications")
 def delete_letter_notifications_older_than_retention():
-    try:
-        start = datetime.utcnow()
-        deleted = delete_notifications_older_than_retention_by_type('letter')
-        current_app.logger.info(
-            "Delete {} job started {} finished {} deleted {} letter notifications".format(
-                'letter',
-                start,
-                datetime.utcnow(),
-                deleted
-            )
+    start = datetime.utcnow()
+    deleted = delete_notifications_older_than_retention_by_type('letter')
+    current_app.logger.info(
+        "Delete {} job started {} finished {} deleted {} letter notifications".format(
+            'letter',
+            start,
+            datetime.utcnow(),
+            deleted
         )
-    except SQLAlchemyError:
-        current_app.logger.exception("Failed to delete letter notifications")
-        raise
+    )
 
 
 @notify_celery.task(name='timeout-sending-notifications')


### PR DESCRIPTION
we used to do this until apr 2020. Let's try doing it again. Back then, we had problems with timing. We did two things in spring 2020:

We moved to using an intermediary temp table [1]
We stopped the tasks being parallelised [2]

However, it turned out the real time saving was from changing what services we delete for [3]. The task was actually CPU-bound rather than DB-bound, so that's probably why having the tasks in parallel wasn't helping, since they were all competing for the same CPU. It's worth trying the parallel steps again now that we're no longer CPU bound.

Note: Temporary tables are in their own postgres schema, and are only viewable by the current session (session == connection. Each celery worker process has its own db connection). We don't need to worry about separate workers both trying to use the same table at once.

I've also added a "DROP ON COMMIT" directive to the table definition just to ensure it doesn't persist past the task even if there's an exception. (This also drops on rollback).

Cronitor looks at the three functions separately so we don't need to worry about the main task taking milliseconds where it used to take hours as it isn't monitored itself.

I've also removed some unnecessary redundant exception logs.

[1] https://github.com/alphagov/notifications-api/pull/2767
[2] https://github.com/alphagov/notifications-api/pull/2798
[3] https://github.com/alphagov/notifications-api/pull/3381