### PR TITLE
Set `count_pages` as False to stop running of redundant query

### DIFF
--- a/app/v2/notifications/get_notifications.py
+++ b/app/v2/notifications/get_notifications.py
@@ -83,7 +83,8 @@ def get_notifications():
         older_than=data.get('older_than'),
         client_reference=data.get('reference'),
         page_size=current_app.config.get('API_PAGE_SIZE'),
-        include_jobs=data.get('include_jobs')
+        include_jobs=data.get('include_jobs'),
+        count_pages=False
     )
 
     def _build_links(notifications):


### PR DESCRIPTION
This is a similar PR to https://github.com/alphagov/notifications-api/pull/2284.

When using flask-sqlalchemy to get a `Pagination` object, by default
it will run two queries

1. Get the page of results that you are asking for
2. If the number of results is equal to the page size, then it will
  issue a second query that will count the total number of results

Getting the total number of results is only useful if
- you need to show how many results there are
- you need to know if there is a next page of results (flask-sqlalchemy
  uses the total to work out how many pages there are altogether,
  which may not be the most efficient way of working out if there
  is a next page or not but that is what it currently does).

Looking at the `get_notifications` route, it does
not use `paginated_notifications.total` or
`paginated_notifications.has_next` and therefore we have no use
for the second query to get the total number of results.

We can stop this additional query by setting `count_pages=False`
which will hopefully give us some performance improvements, in
particular for services which send a lot of notifications.

Flask sqlalchemy references:
https://github.com/pallets/flask-sqlalchemy/blob/818c947b665206fe8edd8c1680b18ce83d3e4744/src/flask_sqlalchemy/__init__.py#L478
https://github.com/pallets/flask-sqlalchemy/blob/818c947b665206fe8edd8c1680b18ce83d3e4744/src/flask_sqlalchemy/__init__.py#L399

Note, I have checked the other uses of `get_notifications_for_service`
and the other cases are currently using the total or next page so
this approach is not something we can take with them.

Some example requests to this endpoint in the last 4 hours that are taking over a second to respond, hopefully this will cause some improvement in their response times.

![image](https://user-images.githubusercontent.com/7228605/144277871-45a15f13-63d7-4da5-9153-2ce0baf44ded.png)
