### PR TITLE
Bump notifications-utils to 51.0.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -36,7 +36,7 @@ notifications-python-client==6.0.2
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@49.0.0#egg=notifications-utils==49.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -153,7 +153,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.0.2
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@49.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.0.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
Just so other people don’t have to merge these changes.

The breaking changes don’t affect this repo because the API doesn’t:
- check the service guestlist before sending a message
- do any visual preview of emergency alert messages

Full changes: https://github.com/alphagov/notifications-utils/compare/49.0.0...51.0.0

Chagelog:

> **51.0.0**
> - Initial argument to `RecipientCSV` renamed from `whitelist` to `guestlist`, in other words consuming code should call `RecipientCSV(guestlist=['test@example.com'])`
> - `RecipientCSV.whitelist` property renamed to `RecipientCSV.guestlist`
>
> **50.0.0**
> - Make icon in `broadcast_preview_template.jinja2` an inline SVG (requires changes to the CSS of consumer code)
>
> **49.1.0**
> - Add `ttl_in_seconds` argument to `RequestCache.set` to let users specify a custom TTL

This commit also changes the format of the line in the requirements file, copying https://github.com/alphagov/notifications-admin/pull/4074