### PR TITLE
Fix calculating remaining free allowance for SMS

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -69,19 +69,14 @@ def fetch_sms_billing_for_all_services(start_date, end_date):
 
     sms_billable_units = func.sum(FactBilling.billable_units * FactBilling.rate_multiplier)
 
-    allowance_left_at_start_date = func.coalesce(
-        allowance_left_at_start_date_query.c.sms_remainder,
-        allowance_left_at_start_date_query.c.free_sms_fragment_limit
-    )
-
     # subtract sms_billable_units units accrued since report's start date to get up-to-date
     # allowance remainder
-    sms_allowance_left = func.greatest(allowance_left_at_start_date - sms_billable_units, 0)
+    sms_allowance_left = func.greatest(allowance_left_at_start_date_query.c.sms_remainder - sms_billable_units, 0)
 
     # billable units here are for period between start date and end date only, so to see
     # how many are chargeable, we need to see how much free allowance was used up in the
     # period up until report's start date and then do a subtraction
-    chargeable_sms = func.greatest(sms_billable_units - allowance_left_at_start_date, 0)
+    chargeable_sms = func.greatest(sms_billable_units - allowance_left_at_start_date_query.c.sms_remainder, 0)
     sms_cost = chargeable_sms * FactBilling.rate
 
     query = db.session.query(
@@ -606,18 +601,14 @@ def fetch_sms_billing_for_organisation(organisation_id, start_date, end_date):
 
     sms_billable_units = func.sum(FactBilling.billable_units * FactBilling.rate_multiplier)
 
-    allowance_left_at_start_date = func.coalesce(
-        allowance_left_at_start_date_query.c.sms_remainder,
-        allowance_left_at_start_date_query.c.free_sms_fragment_limit
-    )
     # subtract sms_billable_units units accrued since report's start date to get up-to-date
     # allowance remainder
-    sms_allowance_left = func.greatest(allowance_left_at_start_date - sms_billable_units, 0)
+    sms_allowance_left = func.greatest(allowance_left_at_start_date_query.c.sms_remainder - sms_billable_units, 0)
 
     # billable units here are for period between start date and end date only, so to see
     # how many are chargeable, we need to see how much free allowance was used up in the
     # period up until report's start date and then do a subtraction
-    chargeable_sms = func.greatest(sms_billable_units - allowance_left_at_start_date, 0)
+    chargeable_sms = func.greatest(sms_billable_units - allowance_left_at_start_date_query.c.sms_remainder, 0)
     sms_cost = chargeable_sms * FactBilling.rate
 
     query = db.session.query(

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -557,11 +557,11 @@ def test_fetch_sms_billing_for_all_services_for_first_quarter(notify_db_session)
 
 
 def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
-    service = create_service(service_name='a - has free allowance')
-    template = create_template(service=service)
-    org = create_organisation(name="Org for {}".format(service.name))
-    dao_add_service_to_organisation(service=service, organisation_id=org.id)
-    create_annual_billing(service_id=service.id, free_sms_fragment_limit=10, financial_year_start=2019)
+    service_1 = create_service(service_name='a - has free allowance')
+    template = create_template(service=service_1)
+    org = create_organisation(name="Org for {}".format(service_1.name))
+    dao_add_service_to_organisation(service=service_1, organisation_id=org.id)
+    create_annual_billing(service_id=service_1.id, free_sms_fragment_limit=10, financial_year_start=2019)
     create_ft_billing(template=template, bst_date=datetime(2019, 4, 20), billable_unit=2, rate=0.11)
     create_ft_billing(template=template, bst_date=datetime(2019, 5, 20), billable_unit=2, rate=0.11)
     create_ft_billing(template=template, bst_date=datetime(2019, 5, 22), billable_unit=1, rate=0.11)
@@ -593,22 +593,31 @@ def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
     results = fetch_sms_billing_for_all_services(datetime(2019, 5, 1), datetime(2019, 5, 31))
     assert len(results) == 3
 
-    # Field names are: organisation_name, organisation_id, service_name, service_id, free_sms_fragment_limit,
-    # sms_rate, sms_remainder, sms_billable_units, chargeable_billable_units, sms_cost
+    expected_results = [
+        # sms_remainder is 5, because "service_1" has 5 sms_billing_units. 2 of them for a period before
+        # the requested report's start date.
+        {
+            "organisation_name": org.name, "organisation_id": org.id, "service_name": service_1.name,
+            "service_id": service_1.id, "free_sms_fragment_limit": 10, "sms_rate": Decimal('0.11'), "sms_remainder": 5,
+            "sms_billable_units": 3, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00')
+        },
+        # sms remainder is 0, because this service sent SMS worth 15 billable units, 12 of which were sent
+        # before requested report's start date
+        {
+            "organisation_name": org_2.name, "organisation_id": org_2.id, "service_name": service_2.name,
+            "service_id": service_2.id, "free_sms_fragment_limit": 10, "sms_rate": Decimal('0.11'), "sms_remainder": 0,
+            "sms_billable_units": 3, "chargeable_billable_sms": 3, "sms_cost": Decimal('0.33')
+        },
+        # sms remainder is 0, because this service sent SMS worth 12 billable units, 5 of which were sent
+        # before requested report's start date
+        {
+            "organisation_name": org_3.name, "organisation_id": org_3.id, "service_name": service_3.name,
+            "service_id": service_3.id, "free_sms_fragment_limit": 10, "sms_rate": Decimal('0.11'), "sms_remainder": 0,
+            "sms_billable_units": 7, "chargeable_billable_sms": 2, "sms_cost": Decimal('0.22')
+        },
+    ]
 
-    # sms_remainder is 5, because service_1_sms_and_letter has 5 sms_billing_units. 2 of them for a period before
-    # the requested report's start date.
-    assert results[0] == (org.name, org.id, service.name, service.id, 10, Decimal('0.11'), 5, 3, 0, Decimal('0'))
-
-    # sms remainder is 0, because this service sent SMS worth 15 billable units, 12 of which were sent
-    # before requested report's start date
-    assert results[1] == (org_2.name, org_2.id, service_2.name, service_2.id, 10, Decimal('0.11'), 0, 3, 3,
-                          Decimal('0.33'))
-
-    # sms remainder is 0, because this service sent SMS worth 12 billable units, 5 of which were sent
-    # before requested report's start date
-    assert results[2] == (org_3.name, org_3.id, service_3.name, service_3.id, 10, Decimal('0.11'), 0, 7, 2,
-                          Decimal('0.22'))
+    assert [dict(result) for result in results] == expected_results
 
 
 def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(notify_db_session):
@@ -616,33 +625,35 @@ def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(noti
     results = fetch_sms_billing_for_all_services(datetime(2019, 5, 1), datetime(2019, 5, 31))
 
     assert len(results) == 3
-    # Field names are: organisation_name, organisation_id, service_name, service_id, free_sms_fragment_limit,
-    # sms_rate, sms_remainder, sms_billable_units, chargeable_billable_units, sms_cost
+    expected_results = [
+        # sms_remainder is 5, because service_1_sms_and_letter has 5 sms_billing_units. 2 of them for a period before
+        # the requested report's start date.
+        {
+            "organisation_name": fixtures["org_1"].name, "organisation_id": fixtures["org_1"].id,
+            "service_name": fixtures["service_1_sms_and_letter"].name,
+            "service_id": fixtures["service_1_sms_and_letter"].id,
+            "free_sms_fragment_limit": 10, "sms_rate": Decimal('0.11'), "sms_remainder": 5,
+            "sms_billable_units": 3, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00')
+        },
+        # sms remainder is 0, because this service sent SMS worth 15 billable units, 12 of which were sent
+        # before requested report's start date
+        {
+            "organisation_name": None, "organisation_id": None,
+            "service_name": fixtures["service_with_sms_without_org"].name,
+            "service_id": fixtures["service_with_sms_without_org"].id, "free_sms_fragment_limit": 10,
+            "sms_rate": Decimal('0.11'), "sms_remainder": 0,
+            "sms_billable_units": 3, "chargeable_billable_sms": 3, "sms_cost": Decimal('0.33')
+        },
+        {
+            "organisation_name": None, "organisation_id": None,
+            "service_name": fixtures["service_with_sms_within_allowance"].name,
+            "service_id": fixtures["service_with_sms_within_allowance"].id, "free_sms_fragment_limit": 10,
+            "sms_rate": Decimal('0.11'), "sms_remainder": 8,
+            "sms_billable_units": 2, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00')
+        },
+    ]
 
-    # sms_remainder is 5, because service_1_sms_and_letter has 5 sms_billing_units. 2 of them for a period before
-    # the requested report's start date.
-    assert results[0] == (
-        fixtures["org_1"].name,
-        fixtures["org_1"].id,
-        fixtures["service_1_sms_and_letter"].name,
-        fixtures["service_1_sms_and_letter"].id,
-        10, Decimal('0.11'), 5, 3, 0, Decimal('0'))
-    # sms remainder is 0, because this service sent SMS worth 15 billable units, 12 of which were sent
-    # before requested report's start date
-    assert results[1] == (
-        None,
-        None,
-        fixtures["service_with_sms_without_org"].name,
-        fixtures["service_with_sms_without_org"].id,
-        10, Decimal('0.11'), 0, 3, 3, Decimal('0.33')
-    )
-    assert results[2] == (
-        None,
-        None,
-        fixtures["service_with_sms_within_allowance"].name,
-        fixtures["service_with_sms_within_allowance"].id,
-        10, Decimal('0.11'), 8, 2, 0, Decimal('0.00')
-    )
+    assert [dict(result) for result in results] == expected_results
 
 
 def test_fetch_letter_costs_and_totals_for_all_services(notify_db_session):

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -831,7 +831,7 @@ def test_get_organisation_services_usage(admin_request, notify_db_session):
     assert service_usage['free_sms_limit'] == 10
     assert service_usage['letter_cost'] == 0
     assert service_usage['sms_billable_units'] == 19
-    assert service_usage['sms_remainder'] == 10
+    assert service_usage['sms_remainder'] == 0
     assert service_usage['sms_cost'] == 0.54
 
 


### PR DESCRIPTION
The way it was done before, the remainder was incorrect in the billing report and in the org usage query - it was the sms remainder left at the start of the report period, not at the end of that period.

This became apparent when we tried to show sms_remainder on the org usage report, where start date is always the start of the financial year.
We saw that sms sent by services did not reduce their free allowance remainder according to the report. As a result of this, we had to temporarily remove of sms_remainder column from the report, until we fix the bug - it has been fixed now, yay!

I think the bug has snuck in partially because our fixtures for testing this part of the code are quite complex, so it was harder to see that numbers don't add up. I have added comments to the tests to try and make it a bit clearer why the results are as they are.

I also added comments to the code, and renamed some variables, to make it easier to understand, as there are quite a few moving parts in it - subqueries and the like. I also renamed the `fetch_sms_free_allowance_remainder` method to `fetch_sms_free_allowance_remainder_until_date` so it is clearer what it does.