### PR TITLE
Scale timeout task to work on arbitrary volumes

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -117,9 +117,12 @@ def timeout_notifications():
     # so that we can cope with a high volume that need processing. We've changed
     # dao_timeout_notifications to return up to 100K notifications, so this task
     # will operate on up to 500K - normally we only get around 20K.
+    cutoff_time = datetime.utcnow() - timedelta(
+        seconds=current_app.config.get('SENDING_NOTIFICATIONS_TIMEOUT_PERIOD')
+    )
+
     for _ in range(0, 5):
-        notifications = \
-            dao_timeout_notifications(current_app.config.get('SENDING_NOTIFICATIONS_TIMEOUT_PERIOD'))
+        notifications = dao_timeout_notifications(cutoff_time)
 
         for notification in notifications:
             check_and_queue_callback_task(notification)

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -505,9 +505,6 @@ def dao_timeout_notifications(cutoff_time, limit=100000):
     ).limit(limit).all()
 
     Notification.query.filter(
-        Notification.created_at < cutoff_time,
-        Notification.status.in_(current_statuses),
-        Notification.notification_type.in_([SMS_TYPE, EMAIL_TYPE]),
         Notification.id.in_([n.id for n in notifications]),
     ).update(
         {'status': new_status, 'updated_at': updated_at},

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -491,13 +491,7 @@ def dao_delete_notifications_by_id(notification_id):
 
 def dao_timeout_notifications(timeout_period_in_seconds):
     """
-    Timeout SMS and email notifications by the following rules:
-
-    the notification was sent to the provider but there was not a delivery receipt
-        sending -> temporary-failure
-        pending -> temporary-failure
-
-    Letter notifications are not timed out
+    Set email and SMS notifications (only) to "temporary-failure" status.
     """
     timeout_start = datetime.utcnow() - timedelta(seconds=timeout_period_in_seconds)
     updated_at = datetime.utcnow()

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -165,11 +165,16 @@ def test_delete_letter_notifications_older_than_retention_calls_child_task(notif
 def test_timeout_notifications(mocker, sample_notification):
     mock_update = mocker.patch('app.celery.nightly_tasks.check_and_queue_callback_task')
     mock_dao = mocker.patch('app.celery.nightly_tasks.dao_timeout_notifications')
-    mock_dao.return_value = [sample_notification]
+
+    mock_dao.side_effect = [
+        [sample_notification],  # first batch to time out
+        [sample_notification],  # second batch
+        []  # nothing left to time out
+    ]
 
     timeout_notifications()
-    mock_dao.assert_called_once_with(datetime.fromisoformat('2021-12-10T10:00'))
-    mock_update.assert_called_once_with(sample_notification)
+    mock_dao.assert_called_with(datetime.fromisoformat('2021-12-10T10:00'))
+    assert mock_update.mock_calls == [call(sample_notification), call(sample_notification)]
 
 
 def test_delete_inbound_sms_calls_child_task(notify_api, mocker):

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -161,17 +161,14 @@ def test_delete_letter_notifications_older_than_retention_calls_child_task(notif
     mocked.assert_called_once_with('letter')
 
 
+@freeze_time("2021-12-13T10:00")
 def test_timeout_notifications(mocker, sample_notification):
     mock_update = mocker.patch('app.celery.nightly_tasks.check_and_queue_callback_task')
     mock_dao = mocker.patch('app.celery.nightly_tasks.dao_timeout_notifications')
     mock_dao.return_value = [sample_notification]
 
     timeout_notifications()
-
-    mock_dao.assert_called_once_with(
-        current_app.config.get('SENDING_NOTIFICATIONS_TIMEOUT_PERIOD')
-    )
-
+    mock_dao.assert_called_once_with(datetime.fromisoformat('2021-12-10T10:00'))
     mock_update.assert_called_once_with(sample_notification)
 
 

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -671,16 +671,13 @@ def test_dao_timeout_notifications(sample_template):
         pending = create_notification(sample_template, status='pending')
         delivered = create_notification(sample_template, status='delivered')
 
-    assert Notification.query.get(created.id).status == 'created'
-    assert Notification.query.get(sending.id).status == 'sending'
-    assert Notification.query.get(pending.id).status == 'pending'
-    assert Notification.query.get(delivered.id).status == 'delivered'
     temporary_failure_notifications = dao_timeout_notifications(1)
+
+    assert len(temporary_failure_notifications) == 2
     assert Notification.query.get(created.id).status == 'created'
     assert Notification.query.get(sending.id).status == 'temporary-failure'
     assert Notification.query.get(pending.id).status == 'temporary-failure'
     assert Notification.query.get(delivered.id).status == 'delivered'
-    assert len(temporary_failure_notifications) == 2
 
 
 def test_dao_timeout_notifications_only_updates_for_older_notifications(sample_template):
@@ -690,12 +687,13 @@ def test_dao_timeout_notifications_only_updates_for_older_notifications(sample_t
         pending = create_notification(sample_template, status='pending')
         delivered = create_notification(sample_template, status='delivered')
 
+    temporary_failure_notifications = dao_timeout_notifications(1)
+
+    assert len(temporary_failure_notifications) == 0
     assert Notification.query.get(created.id).status == 'created'
     assert Notification.query.get(sending.id).status == 'sending'
     assert Notification.query.get(pending.id).status == 'pending'
     assert Notification.query.get(delivered.id).status == 'delivered'
-    temporary_failure_notifications = dao_timeout_notifications(1)
-    assert len(temporary_failure_notifications) == 0
 
 
 def test_dao_timeout_notifications_doesnt_affect_letters(sample_letter_template):
@@ -705,12 +703,13 @@ def test_dao_timeout_notifications_doesnt_affect_letters(sample_letter_template)
         pending = create_notification(sample_letter_template, status='pending')
         delivered = create_notification(sample_letter_template, status='delivered')
 
+    temporary_failure_notifications = dao_timeout_notifications(1)
+
+    assert len(temporary_failure_notifications) == 0
     assert Notification.query.get(created.id).status == 'created'
     assert Notification.query.get(sending.id).status == 'sending'
     assert Notification.query.get(pending.id).status == 'pending'
     assert Notification.query.get(delivered.id).status == 'delivered'
-    temporary_failure_notifications = dao_timeout_notifications(1)
-    assert len(temporary_failure_notifications) == 0
 
 
 def test_should_return_notifications_excluding_jobs_by_default(sample_template, sample_job, sample_api_key):

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -671,7 +671,7 @@ def test_dao_timeout_notifications(sample_template):
         pending = create_notification(sample_template, status='pending')
         delivered = create_notification(sample_template, status='delivered')
 
-    temporary_failure_notifications = dao_timeout_notifications(1)
+    temporary_failure_notifications = dao_timeout_notifications(datetime.utcnow())
 
     assert len(temporary_failure_notifications) == 2
     assert Notification.query.get(created.id).status == 'created'
@@ -687,7 +687,7 @@ def test_dao_timeout_notifications_only_updates_for_older_notifications(sample_t
         pending = create_notification(sample_template, status='pending')
         delivered = create_notification(sample_template, status='delivered')
 
-    temporary_failure_notifications = dao_timeout_notifications(1)
+    temporary_failure_notifications = dao_timeout_notifications(datetime.utcnow())
 
     assert len(temporary_failure_notifications) == 0
     assert Notification.query.get(created.id).status == 'created'
@@ -703,7 +703,7 @@ def test_dao_timeout_notifications_doesnt_affect_letters(sample_letter_template)
         pending = create_notification(sample_letter_template, status='pending')
         delivered = create_notification(sample_letter_template, status='delivered')
 
-    temporary_failure_notifications = dao_timeout_notifications(1)
+    temporary_failure_notifications = dao_timeout_notifications(datetime.utcnow())
 
     assert len(temporary_failure_notifications) == 0
     assert Notification.query.get(created.id).status == 'created'

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -682,34 +682,26 @@ def test_dao_timeout_notifications(sample_template):
 
 def test_dao_timeout_notifications_only_updates_for_older_notifications(sample_template):
     with freeze_time(datetime.utcnow() + timedelta(minutes=10)):
-        created = create_notification(sample_template, status='created')
         sending = create_notification(sample_template, status='sending')
         pending = create_notification(sample_template, status='pending')
-        delivered = create_notification(sample_template, status='delivered')
 
     temporary_failure_notifications = dao_timeout_notifications(datetime.utcnow())
 
     assert len(temporary_failure_notifications) == 0
-    assert Notification.query.get(created.id).status == 'created'
     assert Notification.query.get(sending.id).status == 'sending'
     assert Notification.query.get(pending.id).status == 'pending'
-    assert Notification.query.get(delivered.id).status == 'delivered'
 
 
 def test_dao_timeout_notifications_doesnt_affect_letters(sample_letter_template):
     with freeze_time(datetime.utcnow() - timedelta(minutes=2)):
-        created = create_notification(sample_letter_template, status='created')
         sending = create_notification(sample_letter_template, status='sending')
         pending = create_notification(sample_letter_template, status='pending')
-        delivered = create_notification(sample_letter_template, status='delivered')
 
     temporary_failure_notifications = dao_timeout_notifications(datetime.utcnow())
 
     assert len(temporary_failure_notifications) == 0
-    assert Notification.query.get(created.id).status == 'created'
     assert Notification.query.get(sending.id).status == 'sending'
     assert Notification.query.get(pending.id).status == 'pending'
-    assert Notification.query.get(delivered.id).status == 'delivered'
 
 
 def test_should_return_notifications_excluding_jobs_by_default(sample_template, sample_job, sample_api_key):


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180344153

This makes the temporary hack we put in more permanent:
we can now time out any number of notifications, not just
the arbitrary 500K limit we put in.

Please review commit by commit.