### PR TITLE
don't log if we dont delete anything for a service

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -136,14 +136,15 @@ def delete_notifications_for_service_and_type(service_id, notification_type, dat
         service_id,
         datetime_to_delete_before,
     )
-    end = datetime.utcnow()
-    current_app.logger.info(
-        f'delete-notifications-for-service-and-type: '
-        f'service: {service_id}, '
-        f'notification_type: {notification_type}, '
-        f'count deleted: {num_deleted}, '
-        f'duration: {(end - start).seconds} seconds'
-    )
+    if num_deleted:
+        end = datetime.utcnow()
+        current_app.logger.info(
+            f'delete-notifications-for-service-and-type: '
+            f'service: {service_id}, '
+            f'notification_type: {notification_type}, '
+            f'count deleted: {num_deleted}, '
+            f'duration: {(end - start).seconds} seconds'
+        )
 
 
 @notify_celery.task(name='timeout-sending-notifications')


### PR DESCRIPTION
the new delete-per-service tasks emit lots of boring log lines that look the following:

`delete-notifications-for-service-and-type: service: 64f8dff2-913d-471f-8793-57b9087b6ef3, notification_type: sms, count deleted: 0, duration: 0 seconds`

we try and delete for lots of services. this includes services that don't actually have anything to delete that day. that might be because they had a custom data retention so we always go to check them, or because they only sent test notifications (which we'll delete but not include in the count in the log line). we don't really need to see log lines saying that we didn't delete anything for that service - that's just a long list of boring log messages that will hide the actual interesting stuff - which services we did delete content for.