### PR TITLE
Allow `get_all_notifications_for_service` to accept POST requests 

### DIFF
--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -38,20 +38,19 @@ def test_api_key_should_return_error_when_service_does_not_exist(notify_api, sam
             assert response.status_code == 404
 
 
-def test_create_api_key_without_key_type_rejects(notify_api, sample_service):
-    with notify_api.test_request_context(), notify_api.test_client() as client:
-        data = {
-            'name': 'some secret name',
-            'created_by': str(sample_service.created_by.id)
-        }
-        auth_header = create_admin_authorization_header()
-        response = client.post(url_for('service.create_api_key', service_id=sample_service.id),
-                               data=json.dumps(data),
-                               headers=[('Content-Type', 'application/json'), auth_header])
-        assert response.status_code == 400
-        json_resp = json.loads(response.get_data(as_text=True))
-        assert json_resp['result'] == 'error'
-        assert json_resp['message'] == {'key_type': ['Missing data for required field.']}
+def test_create_api_key_without_key_type_rejects(client, sample_service):
+    data = {
+        'name': 'some secret name',
+        'created_by': str(sample_service.created_by.id)
+    }
+    auth_header = create_admin_authorization_header()
+    response = client.post(url_for('service.create_api_key', service_id=sample_service.id),
+                           data=json.dumps(data),
+                           headers=[('Content-Type', 'application/json'), auth_header])
+    assert response.status_code == 400
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert json_resp['result'] == 'error'
+    assert json_resp['message'] == {'key_type': ['Missing data for required field.']}
 
 
 def test_revoke_should_expire_api_key_for_service(notify_api, sample_api_key):

--- a/tests/app/template_statistics/test_rest.py
+++ b/tests/app/template_statistics/test_rest.py
@@ -8,22 +8,6 @@ from freezegun import freeze_time
 from app.utils import DATETIME_FORMAT
 from tests.app.db import create_ft_notification_status, create_notification
 
-
-def set_up_get_all_from_hash(mock_redis, side_effect):
-    """
-    redis returns binary strings for both keys and values - so given a list of side effects (return values),
-    make sure
-    """
-    assert type(side_effect) == list
-    side_effects = []
-    for ret_val in side_effect:
-        if ret_val is None:
-            side_effects.append(None)
-        else:
-            side_effects += [{str(k).encode('utf-8'): str(v).encode('utf-8') for k, v in ret_val.items()}]
-
-    mock_redis.get_all_from_hash.side_effect = side_effects
-
 # get_template_statistics_for_service_by_day
 
 


### PR DESCRIPTION
We want admin to send a POST request to this route if the data contains
a message recipient (a phone number or email address) so that this does
not show in the logs. This changes the route to accept both GET and POST
requests.

(Plus a couple of small test tidy-ups)

[Pivotal story](https://www.pivotaltracker.com/story/show/180637866)