### PR TITLE
Remove redundant conditional for letter branding

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -318,15 +318,17 @@ def dao_create_service(
     if organisation:
         service.organisation_id = organisation.id
         service.organisation_type = organisation.organisation_type
+
         if organisation.email_branding:
             service.email_branding = organisation.email_branding
 
-        if organisation.letter_branding and not service.letter_branding:
+        if organisation.letter_branding:
             service.letter_branding = organisation.letter_branding
 
     elif service.organisation_type in NHS_ORGANISATION_TYPES or email_address_is_nhs(user.email_address):
         service.email_branding = dao_get_email_branding_by_name('NHS')
         service.letter_branding = dao_get_letter_branding_by_name('NHS')
+
     if organisation:
         service.crown = organisation.crown
     elif service.organisation_type in CROWN_ORGANISATION_TYPES:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180477467

This is no longer used when creating a service [1]. It was likely
added at a migration point when Admin _did_ specify branding.

[1]: https://github.com/alphagov/notifications-admin/blob/50c3c3e10cd904d2d17035d7665f14b6a181062e/app/main/views/add_service.py#L15-L22