### PR TITLE
Downgrade log for letter deletion exceptions

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -428,9 +428,12 @@ def _delete_letters_from_s3(
         try:
             letter_pdf = find_letter_pdf_in_s3(letter)
             letter_pdf.delete()
-        except (ClientError, LetterPDFNotFound):
+        except ClientError:
             current_app.logger.exception(
-                "Could not delete S3 object for letter: {}".format(letter.id))
+                "Error deleting S3 object for letter: {}".format(letter.id))
+        except LetterPDFNotFound:
+            current_app.logger.warning(
+                "No S3 object to delete for letter: {}".format(letter.id))
 
 
 @autocommit


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180692253

If the S3 object is missing [1], then that's what we want, so we
don't need such a severe log for it, but we still want to know as
it's not expected. This is separate to more general "ClientError"
exceptions, which could mean anything.

There weren't any tests to cover missing S3 objects, so I've added
one. I don't think we need a test for ClientErrors:

- If there was no handler, the task would fail and we'd learn about
it that way.

- The scope of the calling task is now much smaller, so it matters 
less than it used to [2].

[1]: https://github.com/alphagov/notifications-api/blob/81a79e56ced891ad58901ea61ce707e907de3363/app/letters/utils.py#L52
[2]: https://github.com/alphagov/notifications-api/commit/f965322f25e37f8125463223eb5b2473e246e8d2