### PR TITLE
Bump utils to 51.3.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -35,7 +35,7 @@ notifications-python-client==6.0.2
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.2.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.0.2
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.2.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.3.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180693991

This brings in new logging for the NotifyCelery base class [1].

[1]: https://github.com/alphagov/notifications-utils/pull/938