### PR TITLE
Set validation-failed status for letters over 10 pages 

### DIFF
--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -175,6 +175,30 @@ def move_sanitised_letter_to_test_or_live_pdf_bucket(filename, is_test_letter, c
     )
 
 
+def move_invalid_templated_letter_to_invalid_bucket(page_count, key_type, reference, created_at, postage):
+    metadata = {}
+    metadata["message"] = "letter-too-long"
+    metadata["page_count"] = str(page_count)
+    # If the file already exists in S3, it will be overwritten
+    if key_type == "test":
+        bucket_name = current_app.config['TEST_LETTERS_BUCKET_NAME']
+    else:
+        bucket_name = current_app.config['LETTERS_PDF_BUCKET_NAME']
+    filename = generate_letter_pdf_filename(
+        reference=reference,
+        created_at=created_at,
+        ignore_folder=key_type == KEY_TYPE_TEST,
+        postage=postage
+    )
+    _move_s3_object(
+        source_bucket=bucket_name,
+        source_filename=filename,
+        target_bucket=current_app.config['INVALID_PDF_BUCKET_NAME'],
+        target_filename=filename,
+        metadata=metadata
+    )
+
+
 def get_file_names_from_error_bucket():
     s3 = boto3.resource('s3')
     scan_bucket = current_app.config['LETTERS_SCAN_BUCKET_NAME']


### PR DESCRIPTION
If a letters that has been posted via the API has more than 10 pages
it would not get a validation-failed status. This also happens for letters in a CSV upload, only the first row has been validated for having too many pages, because you need to created the pdf before getting an accurate page count.

This PR fixes that. For a job or a letter posted by the API, a task to
create the PDF is put on the queue. Template preview will create that
PDF, save it to S3 then put a task on the queue to update the billable
units for the letter. The `update_billable_units_for_letter` task will
check for a page count over 10, if true it will update the meta data for
the file and move the file to the invalid S3 bucket and update the
notification status to validation failed.

There is another PR to update the UI to display the validation failed
error message.

https://www.pivotaltracker.com/story/show/169209742