### PR TITLE
Bump sqlalchemy statement timeout even higher for reporting worker

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -58,7 +58,7 @@
     'additional_env_vars': {
       'CELERYD_MAX_TASKS_PER_CHILD': 1,
       'CELERYD_PREFETCH_MULTIPLIER': 1,
-      'SQLALCHEMY_STATEMENT_TIMEOUT': 2400
+      'SQLALCHEMY_STATEMENT_TIMEOUT': 7200
     }
   },
   'notify-delivery-worker-priority': {},


### PR DESCRIPTION
We saw it fail again last night to calculate how many notifications
were sent for one of our services to put in the ft_notification_status
table. It ran in to the sqlalchemy statement timeout again.
To get us through the holiday
period lets make it 2 hours as surely that will be enough and then
we can fix this properly