### PR TITLE
Optimise query to populate notification statuses

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -10,6 +10,8 @@ from sqlalchemy.types import DateTime, Integer
 from app import db
 from app.dao.dao_utils import autocommit
 from app.models import (
+    KEY_TYPE_NORMAL,
+    KEY_TYPE_TEAM,
     KEY_TYPE_TEST,
     NOTIFICATION_CANCELLED,
     NOTIFICATION_CREATED,
@@ -72,7 +74,7 @@ def query_for_fact_status_data(table, start_date, end_date, notification_type, s
         table.created_at < end_date,
         table.notification_type == notification_type,
         table.service_id == service_id,
-        table.key_type != KEY_TYPE_TEST
+        table.key_type.in_((KEY_TYPE_NORMAL, KEY_TYPE_TEAM)),
     ).group_by(
         table.template_id,
         table.service_id,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180693991

Investigation with EXPLAIN and EXPLAIN ANALYZE for the notification history
table shows this is another instance of [1] but for the key type column.
Swapping "!=" for "IN" solves the problem.

## Query plans (EXPLAIN ANALYZE)

Before:

```
 GroupAggregate  (cost=48285296.89..48304545.97 rows=699630 width=72) (actual time=382883.029..383541.435 rows=80 loops=1)
   Group Key: template_id, service_id, job_id, key_type, notification_status
   ->  Sort  (cost=48285296.89..48287047.29 rows=700159 width=64) (actual time=382734.683..383303.675 rows=1464049 loops=1)
         Sort Key: template_id, job_id, key_type, notification_status
         Sort Method: external merge  Disk: 84736kB
         ->  Index Scan using ix_notification_history_service_id_composite on notification_history  (cost=0.70..48190993.82 rows=700159 width=64) (actual time=166574.747..381321.318 rows=1464049 loops=1)
               Index Cond: ((service_id = 'c5956607-20b1-48b4-8983-85d11404e61f'::uuid) AND (notification_type = 'email'::notification_type) AND (created_at >= '2021-12-20 00:00:00'::timestamp without time zone) AND (created_at < '2021-12-21 00:00:00'::timestamp without time zone))
               Filter: ((key_type)::text <> 'test'::text)
 Planning Time: 0.115 ms
 Execution Time: 383553.795 ms
```

After:

```
 GroupAggregate  (cost=2513920.30..2533169.38 rows=699630 width=72) (actual time=14248.780..14864.704 rows=80 loops=1)
   Group Key: template_id, service_id, job_id, key_type, notification_status
   ->  Sort  (cost=2513920.30..2515670.69 rows=700159 width=64) (actual time=14110.324..14638.207 rows=1464049 loops=1)
         Sort Key: template_id, job_id, key_type, notification_status
         Sort Method: external merge  Disk: 84736kB
         ->  Index Scan using ix_notification_history_service_id_composite on notification_history  (cost=0.70..2419617.23 rows=700159 width=64) (actual time=1.883..12851.183 rows=1464049 loops=1)
               Index Cond: ((service_id = 'c5956607-20b1-48b4-8983-85d11404e61f'::uuid) AND ((key_type)::text = ANY ('{normal,team}'::text[])) AND (notification_type = 'email'::notification_type) AND (created_at >= '2021-12-20 00:00:00'::timestamp without time zone) AND (created_at < '2021-12-21 00:00:00'::timestamp without time zone))
 Planning Time: 0.168 ms
 Execution Time: 14876.781 ms
```

(The plan is actually slightly more complex with the subquery approach, but the outcome is the same.)

[1]: https://github.com/alphagov/notifications-api/pull/3360