### PR TITLE
Mark letters as validation-failed if the templated letter is too long.

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -123,8 +123,7 @@ def update_validation_failed_for_templated_letter(self, notification_id, page_co
     notification = get_notification_by_id(notification_id, _raise=True)
     notification.status = NOTIFICATION_VALIDATION_FAILED
     dao_update_notification(notification)
-    current_app.logger.info(f"Letter notification id: {notification_id} reference {notification.reference}: "
-                            f"validation failed: letter is too long {page_count}")
+    current_app.logger.info(f"Validation failed: letter is too long {page_count} for letter with id: {notification_id}")
 
 
 @notify_celery.task(name='collate-letter-pdfs-to-be-sent')

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -4,7 +4,6 @@ from hashlib import sha512
 
 from botocore.exceptions import ClientError as BotoClientError
 from flask import current_app
-from notifications_utils import LETTER_MAX_PAGE_COUNT
 from notifications_utils.letter_timings import LETTER_PROCESSING_DEADLINE
 from notifications_utils.postal_address import PostalAddress
 from notifications_utils.timezones import convert_utc_to_bst
@@ -102,27 +101,30 @@ def get_pdf_for_templated_letter(self, notification_id):
 
 
 @notify_celery.task(bind=True, name="update-billable-units-for-letter", max_retries=15, default_retry_delay=300)
-def update_billable_units_or_validation_failed_for_templated_letter(self, notification_id, page_count,
-                                                                    create_fake_letter_response_file=None):
+def update_billable_units_for_letter(self, notification_id, page_count):
     notification = get_notification_by_id(notification_id, _raise=True)
-    if page_count > LETTER_MAX_PAGE_COUNT:
-        notification.status = NOTIFICATION_VALIDATION_FAILED
+
+    billable_units = get_billable_units_for_letter_page_count(page_count)
+
+    if notification.key_type != KEY_TYPE_TEST:
+        notification.billable_units = billable_units
         dao_update_notification(notification)
-        current_app.logger.info(f"Letter notification id: {notification_id} reference {notification.reference}: "
-                                f"validation failed: letter is too long {page_count}")
-    else:
-        if notification.key_type != KEY_TYPE_TEST:
-            notification.billable_units = get_billable_units_for_letter_page_count(page_count)
-            dao_update_notification(notification)
-            current_app.logger.info(f"Letter notification id: {notification_id} reference {notification.reference}: "
-                                    f"billable units set to {notification.billable_units}")
-        if notification.key_type == KEY_TYPE_TEST \
-                and current_app.config['NOTIFY_ENVIRONMENT'] in ['preview', 'development']:
-            # For test letters send a fake letter response
-            create_fake_letter_response_file.apply_async(
-                (notification.reference,),
-                queue=QueueNames.RESEARCH_MODE
-            )
+
+        current_app.logger.info(
+            f"Letter notification id: {notification_id} reference {notification.reference}: "
+            f"billable units set to {billable_units}"
+        )
+
+
+@notify_celery.task(
+    bind=True, name="update-validation-failed-for-templated-letter", max_retries=15, default_retry_delay=300
+)
+def update_validation_failed_for_templated_letter(self, notification_id, page_count):
+    notification = get_notification_by_id(notification_id, _raise=True)
+    notification.status = NOTIFICATION_VALIDATION_FAILED
+    dao_update_notification(notification)
+    current_app.logger.info(f"Letter notification id: {notification_id} reference {notification.reference}: "
+                            f"validation failed: letter is too long {page_count}")
 
 
 @notify_celery.task(name='collate-letter-pdfs-to-be-sent')

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -711,7 +711,8 @@ def dao_get_letters_to_be_printed(print_run_deadline, postage, query_limit=10000
         Notification.notification_type == LETTER_TYPE,
         Notification.status == NOTIFICATION_CREATED,
         Notification.key_type == KEY_TYPE_NORMAL,
-        Notification.postage == postage
+        Notification.postage == postage,
+        Notification.billable_units > 0
     ).order_by(
         Notification.service_id,
         Notification.created_at
@@ -729,6 +730,7 @@ def dao_get_letters_and_sheets_volume_by_postage(print_run_deadline):
         Notification.notification_type == LETTER_TYPE,
         Notification.status == NOTIFICATION_CREATED,
         Notification.key_type == KEY_TYPE_NORMAL,
+        Notification.billable_units > 0
     ).group_by(
         Notification.postage
     ).order_by(

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -19,7 +19,6 @@ from app.celery.letters_pdf_tasks import (
     get_pdf_for_templated_letter,
     sanitise_letter,
 )
-from app.celery.research_mode_tasks import create_fake_letter_response_file
 from app.celery.tasks import save_api_email, save_api_sms
 from app.clients.document_download import DocumentDownloadError
 from app.config import QueueNames, TaskNames
@@ -389,11 +388,6 @@ def process_letter_notification(
         queue=queue
     )
 
-    if test_key and current_app.config['NOTIFY_ENVIRONMENT'] in ['preview', 'development']:
-        create_fake_letter_response_file.apply_async(
-            (notification.reference,),
-            queue=queue
-        )
     resp = create_response_for_post_notification(
         notification_id=notification.id,
         client_reference=notification.client_reference,

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -19,6 +19,7 @@ from app.celery.letters_pdf_tasks import (
     get_pdf_for_templated_letter,
     sanitise_letter,
 )
+from app.celery.research_mode_tasks import create_fake_letter_response_file
 from app.celery.tasks import save_api_email, save_api_sms
 from app.clients.document_download import DocumentDownloadError
 from app.config import QueueNames, TaskNames
@@ -387,6 +388,12 @@ def process_letter_notification(
         [str(notification.id)],
         queue=queue
     )
+
+    if test_key and current_app.config['NOTIFY_ENVIRONMENT'] in ['preview', 'development']:
+        create_fake_letter_response_file.apply_async(
+            (notification.reference,),
+            queue=queue
+        )
 
     resp = create_response_for_post_notification(
         notification_id=notification.id,

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -190,8 +190,7 @@ def test_update_validation_failed_for_templated_letter_with_too_many_pages(
     assert sample_letter_notification.billable_units == 0
     assert sample_letter_notification.status == NOTIFICATION_VALIDATION_FAILED
     mock_logger.assert_called_once_with(
-         f"Letter notification id: {sample_letter_notification.id} reference {sample_letter_notification.reference}: "
-         f"validation failed: letter is too long 11"
+         f"Validation failed: letter is too long 11 for letter with id: {sample_letter_notification.id}"
     )
 
 

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1698,20 +1698,35 @@ def test_letters_to_be_printed_sort_by_service(notify_db_session):
     assert [x.id for x in results] == [x.id for x in letters_ordered_by_service_then_time]
 
 
+def test_letters_to_be_printed_does_not_include_letters_without_billable_units_set(
+        notify_db_session, sample_letter_template):
+    included_letter = create_notification(
+        template=sample_letter_template, created_at=datetime(2020, 12, 1, 9, 30), billable_units=3)
+    create_notification(
+        template=sample_letter_template, created_at=datetime(2020, 12, 1, 9, 31), billable_units=0)
+
+    results = list(
+        dao_get_letters_to_be_printed(print_run_deadline=datetime(2020, 12, 1, 17, 30), postage='second', query_limit=4)
+    )
+    assert len(results) == 1
+    assert results[0].id == included_letter.id
+
+
 def test_dao_get_letters_and_sheets_volume_by_postage(notify_db_session):
     first_service = create_service(service_name='first service', service_id='3a5cea08-29fd-4bb9-b582-8dedd928b149')
     second_service = create_service(service_name='second service', service_id='642bf33b-54b5-45f2-8c13-942a46616704')
     first_template = create_template(service=first_service, template_type='letter', postage='second')
     second_template = create_template(service=second_service, template_type='letter', postage='second')
-    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 9, 30), postage='first'),
-    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 12, 30), postage='europe'),
-    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 13, 30), postage='rest-of-world'),
-    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 14, 30), billable_units=3),
-    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 15, 30)),
-    create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 30), postage='first'),
-    create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 31), postage='first'),
-    create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 32)),
-    create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 33)),
+    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 9, 30), postage='first')
+    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 12, 30), postage='europe')
+    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 13, 30), postage='rest-of-world')
+    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 14, 30), billable_units=3)
+    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 14, 30), billable_units=0)
+    create_notification(template=first_template, created_at=datetime(2020, 12, 1, 15, 30))
+    create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 30), postage='first')
+    create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 31), postage='first')
+    create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 32))
+    create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 33))
     create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 34))
 
     results = dao_get_letters_and_sheets_volume_by_postage(print_run_deadline=datetime(2020, 12, 1, 17, 30))

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -12,6 +12,7 @@ from app.letters.utils import (
     ScanErrorType,
     find_letter_pdf_in_s3,
     generate_letter_pdf_filename,
+    get_billable_units_for_letter_page_count,
     get_bucket_name_and_prefix_for_notification,
     get_folder_name,
     get_letter_pdf_and_metadata,
@@ -433,3 +434,9 @@ def test_letter_print_day_returns_today_if_letter_was_printed_today():
 @freeze_time('2017-07-07 16:30:00')
 def test_letter_print_day_returns_formatted_date_if_letter_printed_before_1730_yesterday(created_at, formatted_date):
     assert letter_print_day(created_at) == formatted_date
+
+
+@pytest.mark.parametrize('number_of_pages, expected_billable_units', [(2, 1), (3, 2), (10, 5)])
+def test_get_billable_units_for_letter_page_count(number_of_pages, expected_billable_units):
+    result = get_billable_units_for_letter_page_count(number_of_pages)
+    assert result == expected_billable_units

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -296,7 +296,7 @@ def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_d
     'development',
     'preview',
 ])
-def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_sending_and_sends_fake_response_file(
+def test_post_letter_notification_with_test_key_creates_pdf(
         notify_api, client, sample_letter_template, mocker, env):
 
     data = {
@@ -312,8 +312,6 @@ def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_s
     }
 
     fake_create_letter_task = mocker.patch('app.celery.letters_pdf_tasks.get_pdf_for_templated_letter.apply_async')
-    fake_create_dvla_response_task = mocker.patch(
-        'app.celery.research_mode_tasks.create_fake_letter_response_file.apply_async')
 
     with set_config_values(notify_api, {
         'NOTIFY_ENVIRONMENT': env
@@ -323,7 +321,6 @@ def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_s
     notification = Notification.query.one()
 
     fake_create_letter_task.assert_called_once_with([str(notification.id)], queue='research-mode-tasks')
-    assert fake_create_dvla_response_task.called
     assert notification.status == NOTIFICATION_SENDING
 
 

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -296,7 +296,7 @@ def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_d
     'development',
     'preview',
 ])
-def test_post_letter_notification_with_test_key_creates_pdf(
+def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_sending_and_sends_fake_response_file(
         notify_api, client, sample_letter_template, mocker, env):
 
     data = {
@@ -312,7 +312,8 @@ def test_post_letter_notification_with_test_key_creates_pdf(
     }
 
     fake_create_letter_task = mocker.patch('app.celery.letters_pdf_tasks.get_pdf_for_templated_letter.apply_async')
-
+    fake_create_dvla_response_task = mocker.patch(
+        'app.celery.research_mode_tasks.create_fake_letter_response_file.apply_async')
     with set_config_values(notify_api, {
         'NOTIFY_ENVIRONMENT': env
     }):
@@ -321,6 +322,7 @@ def test_post_letter_notification_with_test_key_creates_pdf(
     notification = Notification.query.one()
 
     fake_create_letter_task.assert_called_once_with([str(notification.id)], queue='research-mode-tasks')
+    assert fake_create_dvla_response_task.called
     assert notification.status == NOTIFICATION_SENDING
 
 


### PR DESCRIPTION
It is possible that the personalisation for a templated letter can make the letter exceed 10 pages or 5 sheets. We are not validating the letters posted via the API for this validation error. It is only possible to validate the letter once we create the PDF in notifications-template-preview. This means that the letter can only get a validation-failed status after the client has received a 201 from the POST to /v2/notifications.
NOTE: we only validate the preview row of a CSV for this validation error, this change will mean that it is possible for a letter to be marked as validation-failed after a successful file upload.

A new task to update the notification to `validation-failed` has been added to the API. If we find that the letter is too long once we have created the PDF we call the `update-validation-failed-for-templated-letter` task rather than `update-billable-units-for-letter` task. 

New work flow for a letter in brief:
API - receives POST /v2/notifications
:: save to db
:: put CREATE_LETTERS_PDF task on queue for template preview to consume
TEMPLATE-PREVIEW - consumes task CREATE_LETTERS_PDF
:: create PDF
:: count pages of PDF
:: IF page count exceeds 10 pages
	 put in the letters-invalid-pdf S3 bucket with metadata (similar to the precompiled letters)
	 put `update-validation-failed-for-templated-letter` task on the queue for the API to consume
:: ELSE
     put PDF in the `letters-pdf` bucket
     put `update-billable-units-for-letter` task on the queue
API - consumes `update-billable-units-for-letter` OR `update-validation-failed-for-templated-letter` task 
:: IF `update-billable-units-for-letter` task: 
   	update billable units for notification as usual
:: ELSE `update-validation-failed-for-templated-letter`:
   	update notification_status = `validation-failed`
ADMIN - view notification page for letter
:: show validation letter for templated letter

There will be 3 PRs in order to make this change, one for the API, template-preview and the admin app.

### Deployment plan

Deploy Admin first
Deploy API
Deploy template-preview

Related PRs:
alphagov/notifications-template-preview#619
alphagov/notifications-admin#4107

https://www.pivotaltracker.com/story/show/169209742