### PR TITLE
Improve logging for adjusting provider priority on API failure

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -24,7 +24,7 @@ def deliver_sms(self, notification_id):
     except Exception as e:
         if isinstance(e, SmsClientResponseException):
             current_app.logger.warning(
-                "SMS notification delivery for id: {} failed".format(notification_id)
+                "SMS notification delivery for id: {} failed due to {}".format(notification_id, e)
             )
         else:
             current_app.logger.exception(

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -82,7 +82,12 @@ def send_sms_to_provider(notification):
             except Exception as e:
                 notification.billable_units = template.fragment_count
                 dao_update_notification(notification)
-                dao_reduce_sms_provider_priority(provider.get_name(), time_threshold=timedelta(minutes=1))
+
+                provider_name = provider.get_name()
+                current_app.logger.info(
+                    "Reducing priority for {provider_name} due to exception raised when calling provider API"
+                )
+                dao_reduce_sms_provider_priority(provider_name, time_threshold=timedelta(minutes=1))
                 raise e
             else:
                 notification.billable_units = template.fragment_count


### PR DESCRIPTION
We can deduce that our traffic is being reduced for one of our providers
but we aren't logging that we are doing it so it is much harder to
tell.

This commit
- makes it explicit what we are doing with a log line
- also gives context on what the error was with the provider API
  so we can tell if it is say a 4xx or a 5xx