### PR TITLE
Fix bug in organisation report for its services and usages.

### DIFF
--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -736,7 +736,7 @@ def test_fetch_usage_year_for_organisation(notify_db_session):
                       notifications_sent=1100)
     results = fetch_usage_year_for_organisation(fixtures["org_1"].id, 2019)
 
-    assert len(results) == 2
+    assert len(results) == 3
     first_row = results[str(fixtures["service_1_sms_and_letter"].id)]
     assert first_row['service_id'] == fixtures["service_1_sms_and_letter"].id
     assert first_row['service_name'] == fixtures["service_1_sms_and_letter"].name
@@ -756,6 +756,16 @@ def test_fetch_usage_year_for_organisation(notify_db_session):
     assert second_row['sms_cost'] == 0
     assert second_row['letter_cost'] == 0
     assert second_row['emails_sent'] == 1100
+
+    third_row = results[str(fixtures["service_with_out_ft_billing_this_year"].id)]
+    assert third_row['service_id'] == fixtures["service_with_out_ft_billing_this_year"].id
+    assert third_row['service_name'] == fixtures["service_with_out_ft_billing_this_year"].name
+    assert third_row['free_sms_limit'] == 10
+    assert third_row['sms_remainder'] == 10
+    assert third_row['chargeable_billable_sms'] == 0
+    assert third_row['sms_cost'] == 0
+    assert third_row['letter_cost'] == 0
+    assert third_row['emails_sent'] == 0
 
 
 def test_fetch_usage_year_for_organisation_populates_ft_billing_for_today(notify_db_session):

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -1054,6 +1054,19 @@ def set_up_usage_data(start_date):
     )
     create_ft_billing(bst_date=one_week_later, template=sms_template_2, billable_unit=2, rate=0.11)
 
+    # service without ft_billing this year
+    service_with_out_ft_billing_this_year = create_service(
+        service_name='f - without ft_billing',
+        purchase_order_number="sms purchase order number",
+        billing_contact_names="sms billing contact names",
+        billing_contact_email_addresses="sms@billing.contact email@addresses.gov.uk",
+        billing_reference="sms billing reference"
+    )
+    create_annual_billing(
+        service_id=service_with_out_ft_billing_this_year.id, free_sms_fragment_limit=10, financial_year_start=year
+    )
+    dao_add_service_to_organisation(service=service_with_out_ft_billing_this_year, organisation_id=org_1.id)
+
     # dictionary with services and orgs to return
     return {
         "org_1": org_1,
@@ -1065,6 +1078,7 @@ def set_up_usage_data(start_date):
         "service_with_letters_without_org": service_with_letters_without_org,
         "service_with_sms_without_org": service_with_sms_without_org,
         "service_with_sms_within_allowance": service_with_sms_within_allowance,
+        "service_with_out_ft_billing_this_year": service_with_out_ft_billing_this_year,
     }
 
 


### PR DESCRIPTION
If a service has not sent any SMS for the financial year the free allowance was showing up as 0 rather than the number in annual billing. The query has been updated to use an outer join so that the free allow will be returned when there is no ft_billing.

There is a potential performance enhancement to only return the data for the services of the organisation in the `fetch_sms_free_allowance_remainder_until_date` subquery. I will investigate in a subsequent PR.