### PR TITLE
Add endpoint to allow org team members to be removed

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -137,3 +137,8 @@ def dao_add_user_to_organisation(organisation_id, user_id):
     user.organisations.append(organisation)
     db.session.add(organisation)
     return user
+
+
+@autocommit
+def dao_remove_user_from_organisation(organisation, user):
+    organisation.users.remove(user)

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -15,10 +15,12 @@ from app.dao.organisation_dao import (
     dao_get_organisation_services,
     dao_get_organisations,
     dao_get_users_for_organisation,
+    dao_remove_user_from_organisation,
     dao_update_organisation,
 )
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.templates_dao import dao_get_template_by_id
+from app.dao.users_dao import get_user_by_id
 from app.errors import InvalidRequest, register_errors
 from app.models import KEY_TYPE_NORMAL, Organisation
 from app.notifications.process_notifications import (
@@ -150,6 +152,20 @@ def get_organisation_services_usage(organisation_id):
 def add_user_to_organisation(organisation_id, user_id):
     new_org_user = dao_add_user_to_organisation(organisation_id, user_id)
     return jsonify(data=new_org_user.serialize())
+
+
+@organisation_blueprint.route('/<uuid:organisation_id>/users/<uuid:user_id>', methods=['DELETE'])
+def remove_user_from_organisation(organisation_id, user_id):
+    organisation = dao_get_organisation_by_id(organisation_id)
+    user = get_user_by_id(user_id=user_id)
+
+    if user not in organisation.users:
+        error = 'User not found'
+        raise InvalidRequest(error, status_code=404)
+
+    dao_remove_user_from_organisation(organisation, user)
+
+    return {}, 204
 
 
 @organisation_blueprint.route('/<uuid:organisation_id>/users', methods=['GET'])

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -694,6 +694,32 @@ def test_add_user_to_organisation_returns_404_if_user_does_not_exist(admin_reque
     )
 
 
+def test_remove_user_from_organisation(admin_request, sample_organisation, sample_user):
+    dao_add_user_to_organisation(organisation_id=sample_organisation.id, user_id=sample_user.id)
+
+    admin_request.delete(
+        'organisation.remove_user_from_organisation',
+        organisation_id=sample_organisation.id,
+        user_id=sample_user.id
+    )
+
+    assert sample_organisation.users == []
+
+
+def test_remove_user_from_organisation_when_user_is_not_an_org_member(admin_request, sample_organisation, sample_user):
+    resp = admin_request.delete(
+        'organisation.remove_user_from_organisation',
+        organisation_id=sample_organisation.id,
+        user_id=sample_user.id,
+        _expected_status=404
+    )
+
+    assert resp == {
+        'result': 'error',
+        'message': 'User not found'
+    }
+
+
 def test_get_organisation_users_returns_users_for_organisation(admin_request, sample_organisation):
     first = create_user(email='first@invited.com')
     second = create_user(email='another@invited.com')


### PR DESCRIPTION
This is similar to the corresponding endpoint for services. However,
it is a little simpler since we don't need to worry about always having
at least one team member for an organisation.

The new dao function added, `dao_remove_user_from_organisation`, is also
simpler than `dao_remove_user_from_service` since we don't have any
organisation permissions to deal with.

[Pivotal story](https://www.pivotaltracker.com/story/show/180573449)