### PR TITLE
Parallelise status aggregation by service and day

### DIFF
--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -91,30 +91,20 @@ def create_nightly_notification_status():
 
     yesterday = convert_utc_to_bst(datetime.utcnow()).date() - timedelta(days=1)
 
-    # email and sms
-    for i in range(4):
-        process_day = yesterday - timedelta(days=i)
-        for notification_type in [SMS_TYPE, EMAIL_TYPE]:
+    for notification_type in [SMS_TYPE, EMAIL_TYPE, LETTER_TYPE]:
+        days = 10 if notification_type == LETTER_TYPE else 4
+
+        for i in range(days):
+            process_day = yesterday - timedelta(days=i)
+
             create_nightly_notification_status_for_day.apply_async(
                 kwargs={'process_day': process_day.isoformat(), 'notification_type': notification_type},
                 queue=QueueNames.REPORTING
             )
             current_app.logger.info(
-                f"create-nightly-notification-status task: create-nightly-notification-status-for-day task created "
+                f"create-nightly-notification-status-for-day task created "
                 f"for type {notification_type} for {process_day}"
             )
-
-    # letters
-    for i in range(10):
-        process_day = yesterday - timedelta(days=i)
-        create_nightly_notification_status_for_day.apply_async(
-            kwargs={'process_day': process_day.isoformat(), 'notification_type': LETTER_TYPE},
-            queue=QueueNames.REPORTING
-        )
-        current_app.logger.info(
-            f"create-nightly-notification-status task: create-nightly-notification-status-for-day task created "
-            f"for type letter for {process_day}"
-        )
 
 
 @notify_celery.task(name="create-nightly-notification-status-for-day")

--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -117,11 +117,11 @@ def create_nightly_notification_status_for_service_and_day(process_day, service_
     process_day = datetime.strptime(process_day, "%Y-%m-%d").date()
     current_app.logger.info(
         f'create-nightly-notification-status-for-day task started '
-        f'for {service_id}, {notification_type} and {process_day}'
+        f'for {service_id}, {notification_type} for {process_day}'
     )
 
     start = datetime.utcnow()
-    transit_data = fetch_status_data_for_service_and_day(
+    new_status_rows = fetch_status_data_for_service_and_day(
         process_day=process_day,
         notification_type=notification_type,
         service_id=service_id,
@@ -130,12 +130,12 @@ def create_nightly_notification_status_for_service_and_day(process_day, service_
     end = datetime.utcnow()
     current_app.logger.info(
         f'create-nightly-notification-status-for-day task fetch '
-        f'for {service_id}, {process_day} and {notification_type}: '
+        f'for {service_id}, {notification_type} for {process_day}: '
         f'data fetched in {(end - start).seconds} seconds'
     )
 
     update_fact_notification_status(
-        transit_data=transit_data,
+        new_status_rows=new_status_rows,
         process_day=process_day,
         notification_type=notification_type,
         service_id=service_id
@@ -143,6 +143,6 @@ def create_nightly_notification_status_for_service_and_day(process_day, service_
 
     current_app.logger.info(
         f'create-nightly-notification-status-for-day task finished '
-        f'for {service_id}, {process_day} and {notification_type}: '
-        f'{len(transit_data)} rows updated'
+        f'for {service_id}, {notification_type} for {process_day}: '
+        f'{len(new_status_rows)} rows updated'
     )

--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from flask import current_app
 from notifications_utils.timezones import convert_utc_to_bst
 
-from app import notify_celery
+from app import db, notify_celery
 from app.config import QueueNames
 from app.cronitor import cronitor
 from app.dao.fact_billing_dao import (
@@ -11,10 +11,10 @@ from app.dao.fact_billing_dao import (
     update_fact_billing,
 )
 from app.dao.fact_notification_status_dao import (
-    fetch_notification_status_for_day,
+    fetch_status_data_for_service_and_day,
     update_fact_notification_status,
 )
-from app.models import EMAIL_TYPE, LETTER_TYPE, SMS_TYPE
+from app.models import EMAIL_TYPE, LETTER_TYPE, SMS_TYPE, Service
 
 
 @notify_celery.task(name="create-nightly-billing")
@@ -124,17 +124,28 @@ def create_nightly_notification_status_for_day(process_day, notification_type):
         f'create-nightly-notification-status-for-day task for {process_day} type {notification_type}: started'
     )
 
-    start = datetime.utcnow()
-    transit_data = fetch_notification_status_for_day(process_day=process_day, notification_type=notification_type)
-    end = datetime.utcnow()
-    current_app.logger.info(
-        f'create-nightly-notification-status-for-day task for {process_day} type {notification_type}: '
-        f'data fetched in {(end - start).seconds} seconds'
-    )
+    for (service_id,) in db.session.query(Service.id):
+        start = datetime.utcnow()
+        transit_data = fetch_status_data_for_service_and_day(
+            process_day=process_day,
+            notification_type=notification_type,
+            service_id=service_id,
+        )
 
-    update_fact_notification_status(transit_data, process_day, notification_type)
+        end = datetime.utcnow()
+        current_app.logger.info(
+            f'create-nightly-notification-status-for-day task for {process_day} type {notification_type}: '
+            f'data fetched in {(end - start).seconds} seconds'
+        )
 
-    current_app.logger.info(
-        f'create-nightly-notification-status-for-day task for {process_day} type {notification_type}: '
-        f'task complete - {len(transit_data)} rows updated'
-    )
+        update_fact_notification_status(
+            transit_data=transit_data,
+            process_day=process_day,
+            notification_type=notification_type,
+            service_id=service_id
+        )
+
+        current_app.logger.info(
+            f'create-nightly-notification-status-for-day task for {process_day} type {notification_type}: '
+            f'task complete - {len(transit_data)} rows updated'
+        )

--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -103,7 +103,7 @@ def create_nightly_notification_status():
             )
             current_app.logger.info(
                 f"create-nightly-notification-status-for-day task created "
-                f"for type {notification_type} for {process_day}"
+                f"for {notification_type} and {process_day}"
             )
 
 
@@ -111,7 +111,8 @@ def create_nightly_notification_status():
 def create_nightly_notification_status_for_day(process_day, notification_type):
     process_day = datetime.strptime(process_day, "%Y-%m-%d").date()
     current_app.logger.info(
-        f'create-nightly-notification-status-for-day task for {process_day} type {notification_type}: started'
+        f'create-nightly-notification-status-for-day task started '
+        f'for {notification_type} and {process_day}'
     )
 
     for (service_id,) in db.session.query(Service.id):
@@ -124,7 +125,8 @@ def create_nightly_notification_status_for_day(process_day, notification_type):
 
         end = datetime.utcnow()
         current_app.logger.info(
-            f'create-nightly-notification-status-for-day task for {process_day} type {notification_type}: '
+            f'create-nightly-notification-status-for-day task fetch '
+            f'for {process_day} and {notification_type}: '
             f'data fetched in {(end - start).seconds} seconds'
         )
 
@@ -136,6 +138,7 @@ def create_nightly_notification_status_for_day(process_day, notification_type):
         )
 
         current_app.logger.info(
-            f'create-nightly-notification-status-for-day task for {process_day} type {notification_type}: '
-            f'task complete - {len(transit_data)} rows updated'
+            f'create-nightly-notification-status-for-day task finished '
+            f'for {process_day} and {notification_type}: '
+            f'{len(transit_data)} rows updated'
         )

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -45,7 +45,6 @@ def fetch_status_data_for_service_and_day(process_day, service_id, notification_
 
     return db.session.query(
         table.template_id,
-        table.service_id,
         func.coalesce(table.job_id, '00000000-0000-0000-0000-000000000000').label('job_id'),
         table.key_type,
         table.status,
@@ -58,7 +57,6 @@ def fetch_status_data_for_service_and_day(process_day, service_id, notification_
         table.key_type.in_((KEY_TYPE_NORMAL, KEY_TYPE_TEAM)),
     ).group_by(
         table.template_id,
-        table.service_id,
         'job_id',
         table.key_type,
         table.status
@@ -66,7 +64,7 @@ def fetch_status_data_for_service_and_day(process_day, service_id, notification_
 
 
 @autocommit
-def update_fact_notification_status(transit_data, process_day, notification_type, service_id):
+def update_fact_notification_status(new_status_rows, process_day, notification_type, service_id):
     table = FactNotificationStatus.__table__
     FactNotificationStatus.query.filter(
         FactNotificationStatus.bst_date == process_day,
@@ -74,18 +72,19 @@ def update_fact_notification_status(transit_data, process_day, notification_type
         FactNotificationStatus.service_id == service_id,
     ).delete()
 
-    for row in transit_data:
-        stmt = insert(table).values(
-            bst_date=process_day,
-            template_id=row.template_id,
-            service_id=service_id,
-            job_id=row.job_id,
-            notification_type=notification_type,
-            key_type=row.key_type,
-            notification_status=row.status,
-            notification_count=row.notification_count,
+    for row in new_status_rows:
+        db.session.connection().execute(
+            insert(table).values(
+                bst_date=process_day,
+                template_id=row.template_id,
+                service_id=service_id,
+                job_id=row.job_id,
+                notification_type=notification_type,
+                key_type=row.key_type,
+                notification_status=row.status,
+                notification_count=row.notification_count,
+            )
         )
-        db.session.connection().execute(stmt)
 
 
 def fetch_notification_status_for_service_by_month(start_date, end_date, service_id):

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -43,17 +43,7 @@ def fetch_status_data_for_service_and_day(process_day, service_id, notification_
     service = Service.query.get(service_id)
     table = get_notification_table_to_use(service, notification_type, process_day, has_delete_task_run=False)
 
-    return query_for_fact_status_data(
-        table=table,
-        start_date=start_date,
-        end_date=end_date,
-        notification_type=notification_type,
-        service_id=service.id
-    )
-
-
-def query_for_fact_status_data(table, start_date, end_date, notification_type, service_id):
-    query = db.session.query(
+    return db.session.query(
         table.template_id,
         table.service_id,
         func.coalesce(table.job_id, '00000000-0000-0000-0000-000000000000').label('job_id'),
@@ -72,8 +62,7 @@ def query_for_fact_status_data(table, start_date, end_date, notification_type, s
         'job_id',
         table.key_type,
         table.status
-    )
-    return query.all()
+    ).all()
 
 
 @autocommit

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -1,6 +1,7 @@
 import itertools
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta
 from decimal import Decimal
+from uuid import UUID
 
 import pytest
 from freezegun import freeze_time
@@ -15,6 +16,9 @@ from app.config import QueueNames
 from app.dao.fact_billing_dao import get_rate
 from app.models import (
     EMAIL_TYPE,
+    KEY_TYPE_NORMAL,
+    KEY_TYPE_TEAM,
+    KEY_TYPE_TEST,
     LETTER_TYPE,
     SMS_TYPE,
     FactBilling,
@@ -24,8 +28,10 @@ from app.models import (
 from tests.app.db import (
     create_letter_rate,
     create_notification,
+    create_notification_history,
     create_rate,
     create_service,
+    create_service_data_retention,
     create_template,
 )
 
@@ -495,7 +501,6 @@ def test_create_nightly_billing_for_day_update_when_record_exists(
     assert records[0].updated_at
 
 
-@freeze_time('2019-01-05')
 def test_create_nightly_notification_status_for_day(notify_db_session):
     first_service = create_service(service_name='First Service')
     first_template = create_template(service=first_service)
@@ -504,35 +509,92 @@ def test_create_nightly_notification_status_for_day(notify_db_session):
     third_service = create_service(service_name='third Service')
     third_template = create_template(service=third_service, template_type='letter')
 
-    create_notification(template=first_template, status='delivered')
-    create_notification(template=first_template, status='delivered', created_at=datetime(2019, 1, 1, 12, 0))
+    create_service_data_retention(second_service, 'email', days_of_retention=3)
 
-    create_notification(template=second_template, status='temporary-failure')
-    create_notification(template=second_template, status='temporary-failure', created_at=datetime(2019, 1, 1, 12, 0))
+    process_day = date.today() - timedelta(days=5)
+    with freeze_time(datetime.combine(process_day, time.min)):
+        create_notification(template=first_template, status='delivered')
 
-    create_notification(template=third_template, status='created')
-    create_notification(template=third_template, status='created', created_at=datetime(2019, 1, 1, 12, 0))
+        # 2nd service email has 3 day data retention - data has been moved to history and doesn't exist in notifications
+        create_notification_history(template=second_template, status='temporary-failure')
+
+        # team API key notifications are included
+        create_notification(template=third_template, status='sending', key_type=KEY_TYPE_TEAM)
+
+        # test notifications are ignored
+        create_notification(template=third_template, status='sending', key_type=KEY_TYPE_TEST)
+
+    # these created notifications from a different day get ignored
+    with freeze_time(datetime.combine(date.today() - timedelta(days=4), time.min)):
+        create_notification(template=first_template)
+        create_notification_history(template=second_template)
+        create_notification(template=third_template)
 
     assert len(FactNotificationStatus.query.all()) == 0
 
-    create_nightly_notification_status_for_day('2019-01-01', 'sms')
-    create_nightly_notification_status_for_day('2019-01-01', 'email')
-    create_nightly_notification_status_for_day('2019-01-01', 'letter')
+    create_nightly_notification_status_for_day(str(process_day), 'sms')
+    create_nightly_notification_status_for_day(str(process_day), 'email')
+    create_nightly_notification_status_for_day(str(process_day), 'letter')
 
-    new_data = FactNotificationStatus.query.order_by(FactNotificationStatus.created_at).all()
+    new_fact_data = FactNotificationStatus.query.order_by(
+        FactNotificationStatus.notification_type
+    ).all()
 
-    assert len(new_data) == 3
-    assert new_data[0].bst_date == date(2019, 1, 1)
-    assert new_data[1].bst_date == date(2019, 1, 1)
-    assert new_data[2].bst_date == date(2019, 1, 1)
+    assert len(new_fact_data) == 3
+    assert new_fact_data[0].bst_date == process_day
+    assert new_fact_data[0].template_id == second_template.id
+    assert new_fact_data[0].service_id == second_service.id
+    assert new_fact_data[0].job_id == UUID('00000000-0000-0000-0000-000000000000')
+    assert new_fact_data[0].notification_type == 'email'
+    assert new_fact_data[0].notification_status == 'temporary-failure'
+    assert new_fact_data[0].notification_count == 1
+    assert new_fact_data[0].key_type == KEY_TYPE_NORMAL
 
-    assert new_data[0].notification_type == 'sms'
-    assert new_data[1].notification_type == 'email'
-    assert new_data[2].notification_type == 'letter'
+    assert new_fact_data[1].bst_date == process_day
+    assert new_fact_data[1].template_id == third_template.id
+    assert new_fact_data[1].service_id == third_service.id
+    assert new_fact_data[1].job_id == UUID('00000000-0000-0000-0000-000000000000')
+    assert new_fact_data[1].notification_type == 'letter'
+    assert new_fact_data[1].notification_status == 'sending'
+    assert new_fact_data[1].notification_count == 1
+    assert new_fact_data[1].key_type == KEY_TYPE_TEAM
 
-    assert new_data[0].notification_status == 'delivered'
-    assert new_data[1].notification_status == 'temporary-failure'
-    assert new_data[2].notification_status == 'created'
+    assert new_fact_data[2].bst_date == process_day
+    assert new_fact_data[2].template_id == first_template.id
+    assert new_fact_data[2].service_id == first_service.id
+    assert new_fact_data[2].job_id == UUID('00000000-0000-0000-0000-000000000000')
+    assert new_fact_data[2].notification_type == 'sms'
+    assert new_fact_data[2].notification_status == 'delivered'
+    assert new_fact_data[2].notification_count == 1
+    assert new_fact_data[2].key_type == KEY_TYPE_NORMAL
+
+
+def test_create_nightly_notification_status_for_day_overwrites_old_data(notify_db_session):
+    first_service = create_service(service_name='First Service')
+    first_template = create_template(service=first_service)
+    create_notification(template=first_template, status='delivered')
+
+    process_day = date.today()
+    create_nightly_notification_status_for_day(str(process_day), 'sms')
+
+    new_fact_data = FactNotificationStatus.query.order_by(
+        FactNotificationStatus.bst_date,
+        FactNotificationStatus.notification_type
+    ).all()
+
+    assert len(new_fact_data) == 1
+    assert new_fact_data[0].notification_count == 1
+
+    create_notification(template=first_template, status='delivered')
+    create_nightly_notification_status_for_day(str(process_day), 'sms')
+
+    updated_fact_data = FactNotificationStatus.query.order_by(
+        FactNotificationStatus.bst_date,
+        FactNotificationStatus.notification_type
+    ).all()
+
+    assert len(updated_fact_data) == 1
+    assert updated_fact_data[0].notification_count == 2
 
 
 # the job runs at 12:30am London time. 04/01 is in BST.

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -10,7 +10,7 @@ from app.celery.reporting_tasks import (
     create_nightly_billing,
     create_nightly_billing_for_day,
     create_nightly_notification_status,
-    create_nightly_notification_status_for_day,
+    create_nightly_notification_status_for_service_and_day,
 )
 from app.config import QueueNames
 from app.dao.fact_billing_dao import get_rate
@@ -62,8 +62,8 @@ def test_create_nightly_billing_triggers_tasks_for_days(notify_api, mocker, day_
 
 
 @freeze_time('2019-08-01')
-def test_create_nightly_notification_status_triggers_tasks_for_days(notify_api, mocker):
-    mock_celery = mocker.patch('app.celery.reporting_tasks.create_nightly_notification_status_for_day')
+def test_create_nightly_notification_status_triggers_tasks(notify_api, sample_service, mocker):
+    mock_celery = mocker.patch('app.celery.reporting_tasks.create_nightly_notification_status_for_service_and_day')
     create_nightly_notification_status()
 
     assert mock_celery.apply_async.call_count == (
@@ -77,13 +77,21 @@ def test_create_nightly_notification_status_triggers_tasks_for_days(notify_api, 
         [SMS_TYPE, EMAIL_TYPE, LETTER_TYPE]
     ):
         mock_celery.apply_async.assert_any_call(
-            kwargs={'process_day': process_date, 'notification_type': notification_type},
+            kwargs={
+                'process_day': process_date,
+                'notification_type': notification_type,
+                'service_id': sample_service.id,
+            },
             queue=QueueNames.REPORTING
         )
 
     for process_date in ['2019-07-27', '2019-07-26', '2019-07-25', '2019-07-24', '2019-07-23', '2019-07-22']:
         mock_celery.apply_async.assert_any_call(
-            kwargs={'process_day': process_date, 'notification_type': LETTER_TYPE},
+            kwargs={
+                'process_day': process_date,
+                'notification_type': LETTER_TYPE,
+                'service_id': sample_service.id,
+            },
             queue=QueueNames.REPORTING
         )
 
@@ -501,7 +509,7 @@ def test_create_nightly_billing_for_day_update_when_record_exists(
     assert records[0].updated_at
 
 
-def test_create_nightly_notification_status_for_day(notify_db_session):
+def test_create_nightly_notification_status_for_service_and_day(notify_db_session):
     first_service = create_service(service_name='First Service')
     first_template = create_template(service=first_service)
     second_service = create_service(service_name='second Service')
@@ -532,9 +540,9 @@ def test_create_nightly_notification_status_for_day(notify_db_session):
 
     assert len(FactNotificationStatus.query.all()) == 0
 
-    create_nightly_notification_status_for_day(str(process_day), 'sms')
-    create_nightly_notification_status_for_day(str(process_day), 'email')
-    create_nightly_notification_status_for_day(str(process_day), 'letter')
+    create_nightly_notification_status_for_service_and_day(str(process_day), first_service.id, 'sms')
+    create_nightly_notification_status_for_service_and_day(str(process_day), second_service.id, 'email')
+    create_nightly_notification_status_for_service_and_day(str(process_day), third_service.id, 'letter')
 
     new_fact_data = FactNotificationStatus.query.order_by(
         FactNotificationStatus.notification_type
@@ -569,13 +577,13 @@ def test_create_nightly_notification_status_for_day(notify_db_session):
     assert new_fact_data[2].key_type == KEY_TYPE_NORMAL
 
 
-def test_create_nightly_notification_status_for_day_overwrites_old_data(notify_db_session):
+def test_create_nightly_notification_status_for_service_and_day_overwrites_old_data(notify_db_session):
     first_service = create_service(service_name='First Service')
     first_template = create_template(service=first_service)
     create_notification(template=first_template, status='delivered')
 
     process_day = date.today()
-    create_nightly_notification_status_for_day(str(process_day), 'sms')
+    create_nightly_notification_status_for_service_and_day(str(process_day), first_service.id, 'sms')
 
     new_fact_data = FactNotificationStatus.query.order_by(
         FactNotificationStatus.bst_date,
@@ -586,7 +594,7 @@ def test_create_nightly_notification_status_for_day_overwrites_old_data(notify_d
     assert new_fact_data[0].notification_count == 1
 
     create_notification(template=first_template, status='delivered')
-    create_nightly_notification_status_for_day(str(process_day), 'sms')
+    create_nightly_notification_status_for_service_and_day(str(process_day), first_service.id, 'sms')
 
     updated_fact_data = FactNotificationStatus.query.order_by(
         FactNotificationStatus.bst_date,
@@ -599,7 +607,7 @@ def test_create_nightly_notification_status_for_day_overwrites_old_data(notify_d
 
 # the job runs at 12:30am London time. 04/01 is in BST.
 @freeze_time('2019-04-01T23:30')
-def test_create_nightly_notification_status_for_day_respects_bst(sample_template):
+def test_create_nightly_notification_status_for_service_and_day_respects_bst(sample_template):
     create_notification(sample_template, status='delivered', created_at=datetime(2019, 4, 1, 23, 0))  # too new
 
     create_notification(sample_template, status='created', created_at=datetime(2019, 4, 1, 22, 59))
@@ -607,7 +615,7 @@ def test_create_nightly_notification_status_for_day_respects_bst(sample_template
 
     create_notification(sample_template, status='delivered', created_at=datetime(2019, 3, 31, 22, 59))  # too old
 
-    create_nightly_notification_status_for_day('2019-04-01', 'sms')
+    create_nightly_notification_status_for_service_and_day('2019-04-01', sample_template.service_id, 'sms')
 
     noti_status = FactNotificationStatus.query.order_by(FactNotificationStatus.bst_date).all()
     assert len(noti_status) == 1


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180693991

This follows a similar approach as [1]. Recently we've seen lots of errors
from this task, which we think are a consequence of it doing too much work
and tripping Celery's visibility timeout.

While we can optimise the query [2], it's likely the errors will return as
the number of live services grows. Parallelising the aggregation now will
make it more futureproof.

Because the new logs will be broken down by service, I'll also be able to 
confirm if we can safely revert https://github.com/alphagov/notifications-api/pull/3411 - at the moment, it's unclear what 
the max per-service query time is in the DAO loop.

I've broken down the changes into a few commits.

Tested locally to check the tasks are queued up as expected ✅.

## Deployment

Should only be deployed when today's status aggregation task has
finished. This should be done by the start of the working day, but worth 
checking in Cronitor to make sure it's not got stuck.

The parallelisation will result in a much larger number of tasks being 
generated, which could potentially starve other scheduled tasks. I don't 
think this will be a problem, given the current runtimes:

|         bin(1d)         | avg(duration) | max(duration) |
|-------------------------|---------------|---------------|
| 2022-01-18 00:00:00.000 | 341.0841      | 848.7002      |
| 2022-01-17 00:00:00.000 | 338.8308      | 948.1304      |
| 2022-01-16 00:00:00.000 | 551.6605      | 1684.3972     |
| 2022-01-15 00:00:00.000 | 632.2731      | 2115.1576     |
| 2022-01-14 00:00:00.000 | 794.273       | 2561.2193     |
| 2022-01-13 00:00:00.000 | 593.8976      | 1975.6033     |

With all the work split up, I expect much lower average runtimes per 
task. There also aren't any critical tasks scheduled to execute near 
this one, and we have plenty of workers ([3](https://github.com/alphagov/notifications-paas-autoscaler/blob/c217b56a06d36cd520a6ad868eb140f9257f30bd/Makefile#L109) x [4](https://github.com/alphagov/notifications-api/blob/5cd6fcbb4feec983ae39a7ae8b8ad3132f534e5d/scripts/paas_app_wrapper.sh#L32)).

[1]: https://github.com/alphagov/notifications-api/pull/3397
[2]: https://github.com/alphagov/notifications-api/pull/3417