### PR TITLE
Rename sms_fragments to sms_chargeable_units

### DIFF
--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -84,7 +84,7 @@ def get_data_for_billing_report():
                 "service_id": str(s.service_id),
                 "service_name": s.service_name,
                 "sms_cost": float(s.sms_cost),
-                "sms_fragments": s.chargeable_billable_sms,
+                "sms_chargeable_units": s.chargeable_billable_sms,
                 "total_letters": 0,
                 "letter_cost": 0,
                 "letter_breakdown": ""
@@ -104,7 +104,7 @@ def get_data_for_billing_report():
                 "service_id": str(data.service_id),
                 "service_name": data.service_name,
                 "sms_cost": 0,
-                "sms_fragments": 0,
+                "sms_chargeable_units": 0,
                 "total_letters": data.total_letters,
                 "letter_cost": float(data.letter_cost),
                 "letter_breakdown": ""

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -140,7 +140,7 @@ def test_get_data_for_billing_report(notify_db_session, admin_request):
     assert response[0]["organisation_id"] == str(fixtures["org_1"].id)
     assert response[0]["service_id"] == str(fixtures["service_1_sms_and_letter"].id)
     assert response[0]["sms_cost"] == 0
-    assert response[0]["sms_fragments"] == 0
+    assert response[0]["sms_chargeable_units"] == 0
     assert response[0]["total_letters"] == 8
     assert response[0]["letter_cost"] == 3.40
     assert response[0]["letter_breakdown"] == "6 second class letters at 45p\n2 first class letters at 35p\n"
@@ -152,7 +152,7 @@ def test_get_data_for_billing_report(notify_db_session, admin_request):
     assert response[1]["organisation_id"] == str(fixtures["org_for_service_with_letters"].id)
     assert response[1]["service_id"] == str(fixtures["service_with_letters"].id)
     assert response[1]["sms_cost"] == 0
-    assert response[1]["sms_fragments"] == 0
+    assert response[1]["sms_chargeable_units"] == 0
     assert response[1]["total_letters"] == 22
     assert response[1]["letter_cost"] == 14
     assert response[1]["letter_breakdown"] == "20 second class letters at 65p\n2 first class letters at 50p\n"
@@ -164,7 +164,7 @@ def test_get_data_for_billing_report(notify_db_session, admin_request):
     assert response[2]["organisation_id"] == ""
     assert response[2]["service_id"] == str(fixtures["service_with_sms_without_org"].id)
     assert response[2]["sms_cost"] == 0.33
-    assert response[2]["sms_fragments"] == 3
+    assert response[2]["sms_chargeable_units"] == 3
     assert response[2]["total_letters"] == 0
     assert response[2]["letter_cost"] == 0
     assert response[2]["letter_breakdown"] == ""
@@ -176,7 +176,7 @@ def test_get_data_for_billing_report(notify_db_session, admin_request):
     assert response[3]["organisation_id"] == ""
     assert response[3]["service_id"] == str(fixtures["service_with_letters_without_org"].id)
     assert response[3]["sms_cost"] == 0
-    assert response[3]["sms_fragments"] == 0
+    assert response[3]["sms_chargeable_units"] == 0
     assert response[3]["total_letters"] == 18
     assert response[3]["letter_cost"] == 24.45
     assert response[3]["letter_breakdown"] == (


### PR DESCRIPTION
This field caused some confusion and lots of unnecessary work to our colleague because of unclear name.

The field was named sms_fragments, where in fact the value of the field is: those sms fragments that go above free allowance multiplied by the rate multiplier.

 The new name was chosen through consultation with colleagues who use billing report the most.
 
 This change should go out together with: https://github.com/alphagov/notifications-admin/pull/4137