### PR TITLE
unpin cryptography

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -26,10 +26,6 @@ beautifulsoup4==4.9.3
 lxml==4.7.1
 Werkzeug==2.0.2
 
-# higher version causes build to fail on PaaS due to lack of Rust
-# see https://github.com/pyca/cryptography/issues/5810
-cryptography<3.4 # pyup: <3.4
-
 notifications-python-client==6.0.2
 
 # PaaS

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,6 @@ cffi==1.14.5
     # via
     #   -r requirements.in
     #   bcrypt
-    #   cryptography
 charset-normalizer==2.0.7
     # via requests
 click==8.0.3
@@ -68,8 +67,6 @@ click-repl==0.2.0
     # via celery
 colorama==0.4.3
     # via awscli
-cryptography==3.3.2
-    # via -r requirements.in
 dnspython==1.16.0
     # via eventlet
 docopt==0.6.2
@@ -221,7 +218,6 @@ six==1.16.0
     #   bcrypt
     #   bleach
     #   click-repl
-    #   cryptography
     #   eventlet
     #   flask-marshmallow
     #   jsonschema


### PR DESCRIPTION
we previously pinned cryptography to versions less than 3.4 since after that point, cryptography started using rust as a dependency. This isn't an issue if you install from wheel, but we found that the version of pip bundled with the python buildpack was too old to support this. However, since upgrading from python 3.6 to python 3.9, the pip version has been bumped and we now no longer need to pin cryptography as it installs correctly.

(i tested this by pushing an admin prototype to preview)