### PR TITLE
Moved log message inside the if statement where it actually happens.

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -429,10 +429,9 @@ def process_precompiled_letter_notifications(*, letter_data, api_key, service, t
         'postage': notification.postage
     }
 
-    current_app.logger.info('Calling task scan-file for {}'.format(filename))
-
     # call task to add the filename to anti virus queue
     if current_app.config['ANTIVIRUS_ENABLED']:
+        current_app.logger.info('Calling task scan-file for {}'.format(filename))
         notify_celery.send_task(
             name=TaskNames.SCAN_FILE,
             kwargs={'filename': filename},


### PR DESCRIPTION
This caught me out the other day when I was testing. I thought antivirus
was enable, seeing this message didn't help with that assumption. Plus
there is no point in showing the log if we don't actually call the task.