### PR TITLE
Bump utils to 53.0.0

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -3,7 +3,7 @@ from collections import defaultdict, namedtuple
 from datetime import datetime
 
 from flask import current_app
-from notifications_utils.columns import Columns
+from notifications_utils.insensitive_dict import InsensitiveDict
 from notifications_utils.postal_address import PostalAddress
 from notifications_utils.recipients import RecipientCSV
 from notifications_utils.timezones import convert_utc_to_bst
@@ -351,7 +351,7 @@ def save_letter(
     notification = encryption.decrypt(encrypted_notification)
 
     postal_address = PostalAddress.from_personalisation(
-        Columns(notification['personalisation'])
+        InsensitiveDict(notification['personalisation'])
     )
 
     service = SerialisedService.from_id(service_id)

--- a/requirements.in
+++ b/requirements.in
@@ -31,7 +31,7 @@ notifications-python-client==6.0.2
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.3.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@53.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -148,7 +148,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.0.2
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.3.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@53.0.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -7,7 +7,7 @@ import pytest
 import requests_mock
 from celery.exceptions import Retry
 from freezegun import freeze_time
-from notifications_utils.columns import Row
+from notifications_utils.recipients import Row
 from notifications_utils.template import (
     LetterPrintTemplate,
     PlainTextEmailTemplate,


### PR DESCRIPTION
Changes:

53.0.0
---

* `notifications_utils.columns.Columns` has moved to `notifications_utils.insensitive_dict.InsensitiveDict`
* `notifications_utils.columns.Rows` has moved to `notifications_utils.recipients.Rows`
* `notifications_utils.columns.Cell` has moved to `notifications_utils.recipients.Cell`

52.0.0
---

* Deprecate the following unused `redis_client` functions:
  - `redis_client.increment_hash_value`
  - `redis_client.decrement_hash_value`
  - `redis_client.get_all_from_hash`
  - `redis_client.set_hash_and_expire`
  - `redis_client.expire`

51.3.1
---

* Bump govuk-bank-holidays to cache holidays for next year.