### PR TITLE
Update where to get creds for sms providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Things to change:
 * Run the following in the credentials repo to get the API keys.
 
 ```
-notify-pass credentials/providers/api_keys
+notify-pass credentials/firetext
+notify-pass credentials/mmg
 ```
 
 ### Postgres


### PR DESCRIPTION
Due to change in https://github.com/alphagov/notifications-credentials/pull/261