### PR TITLE
Redis tally spike

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,18 @@ export PATH=${PATH}:/Applications/Postgres.app/Contents/Versions/11/bin/
 
 ### Redis
 
-To switch redis on you'll need to install it locally. On a OSX we've used brew for this. To use redis caching you need to switch it on by changing the config for development:
+You can run redis locally using
 
-        REDIS_ENABLED = True
+```
+brew install redis
+redis-server
+```
 
+To get the API to use redis locally you need to change the config for development:
+
+```
+REDIS_ENABLED = True
+```
 
 ##  To run the application
 

--- a/app/config.py
+++ b/app/config.py
@@ -428,7 +428,7 @@ class Development(Config):
     NOTIFY_EMAIL_DOMAIN = "notify.tools"
 
     SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI', 'postgresql://localhost/notification_api')
-    REDIS_URL = 'redis://localhost:6379/0'
+    REDIS_URL = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
 
     ANTIVIRUS_ENABLED = os.getenv('ANTIVIRUS_ENABLED') == '1'
 

--- a/app/config.py
+++ b/app/config.py
@@ -114,7 +114,7 @@ class Config(object):
 
     # URL of redis instance
     REDIS_URL = os.getenv('REDIS_URL')
-    REDIS_ENABLED = os.getenv('REDIS_ENABLED') == '1'
+    REDIS_ENABLED = True
     EXPIRE_CACHE_TEN_MINUTES = 600
     EXPIRE_CACHE_EIGHT_DAYS = 8 * 24 * 60 * 60
 

--- a/scripts/run_with_docker.sh
+++ b/scripts/run_with_docker.sh
@@ -9,11 +9,13 @@ source environment.sh
 AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-"$(aws configure get aws_access_key_id)"}
 AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-"$(aws configure get aws_secret_access_key)"}
 : "${SQLALCHEMY_DATABASE_URI:=postgresql://postgres@host.docker.internal/notification_api}"
+REDIS_URL="redis://host.docker.internal:6379"
 
 docker run -it --rm \
   -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
   -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
   -e SQLALCHEMY_DATABASE_URI=$SQLALCHEMY_DATABASE_URI \
+  -e REDIS_URL=$REDIS_URL \
   -v $(pwd):/home/vcap/app \
   ${DOCKER_IMAGE_NAME} \
   ${@}


### PR DESCRIPTION
This is a proof of concept for how we might use redis for our service dashboard page. Before looking at this, you should read https://github.com/alphagov/notifications-admin/pull/4154

Note, I haven't implemented updating the tallys when a notification moves from 'sending' in to 'delivered' or 'failed' but that shouldn't be too hard (the only interesting bit would be making sure we do it everywhere, consistently).

Note, this also contains one commit at the beginning which can be reviewed at a future date for how we run redis locally when we are running celery using docker.