### PR TITLE
Audit api key id when cancelling broadcast via api - second try

### DIFF
--- a/app/broadcast_message/utils.py
+++ b/app/broadcast_message/utils.py
@@ -13,7 +13,7 @@ from app.models import (
 )
 
 
-def validate_and_update_broadcast_message_status(broadcast_message, new_status, updating_user):
+def validate_and_update_broadcast_message_status(broadcast_message, new_status, updating_user=None, api_key_id=None):
     if new_status not in BroadcastStatusType.ALLOWED_STATUS_TRANSITIONS[broadcast_message.status]:
         raise InvalidRequest(
             f'Cannot move broadcast_message {broadcast_message.id} from {broadcast_message.status} to {new_status}',
@@ -39,6 +39,7 @@ def validate_and_update_broadcast_message_status(broadcast_message, new_status, 
     if new_status == BroadcastStatusType.CANCELLED:
         broadcast_message.cancelled_at = datetime.utcnow()
         broadcast_message.cancelled_by = updating_user
+        broadcast_message.cancelled_by_api_key_id = api_key_id
 
     current_app.logger.info(
         f'broadcast_message {broadcast_message.id} moving from {broadcast_message.status} to {new_status}'

--- a/app/models.py
+++ b/app/models.py
@@ -2322,15 +2322,17 @@ class BroadcastMessage(db.Model):
     approved_by = db.relationship('User', foreign_keys=[approved_by_id])
     cancelled_by = db.relationship('User', foreign_keys=[cancelled_by_id])
 
-    api_key_id = db.Column(UUID(as_uuid=True), db.ForeignKey('api_keys.id'), nullable=True)
-    api_key = db.relationship('ApiKey')
+    created_by_api_key_id = db.Column(UUID(as_uuid=True), db.ForeignKey('api_keys.id'), nullable=True)
+    cancelled_by_api_key_id = db.Column(UUID(as_uuid=True), db.ForeignKey('api_keys.id'), nullable=True)
+    created_by_api_key = db.relationship('ApiKey', foreign_keys=[created_by_api_key_id])
+    cancelled_by_api_key = db.relationship('ApiKey', foreign_keys=[cancelled_by_api_key_id])
 
     reference = db.Column(db.String(255), nullable=True)
     cap_event = db.Column(db.String(255), nullable=True)
 
     stubbed = db.Column(db.Boolean, nullable=False)
 
-    CheckConstraint("created_by_id is not null or api_key_id is not null")
+    CheckConstraint("created_by_id is not null or created_by_api_key_id is not null")
 
     @property
     def personalisation(self):

--- a/app/v2/broadcast/post_broadcast.py
+++ b/app/v2/broadcast/post_broadcast.py
@@ -81,7 +81,7 @@ def create_broadcast():
                 'simple_polygons': simple_polygons.as_coordinate_pairs_lat_long,
             },
             status=BroadcastStatusType.PENDING_APPROVAL,
-            api_key_id=api_user.id,
+            created_by_api_key_id=api_user.id,
             stubbed=authenticated_service.restricted
             # The client may pass in broadcast_json['expires'] but it’s
             # simpler for now to ignore it and have the rules around expiry
@@ -111,7 +111,7 @@ def _cancel_or_reject_broadcast(references_to_original_broadcast, service_id):
     validate_and_update_broadcast_message_status(
         broadcast_message,
         new_status,
-        updating_user=None
+        api_key_id=api_user.id
     )
     return broadcast_message
 

--- a/tests/app/v2/broadcast/test_post_broadcast.py
+++ b/tests/app/v2/broadcast/test_post_broadcast.py
@@ -7,6 +7,7 @@ from app.dao.broadcast_message_dao import (
     dao_get_broadcast_message_by_id_and_service_id,
 )
 from tests import create_service_authorization_header
+from tests.app.db import create_api_key
 
 from . import sample_cap_xml_documents
 
@@ -130,6 +131,7 @@ def test_valid_cancel_broadcast_request_calls_validate_and_update_broadcast_mess
     is_approved,
     expected_status
 ):
+    api_key = create_api_key(service=sample_broadcast_service)
     auth_header = create_service_authorization_header(service_id=sample_broadcast_service.id)
 
     # create a broadcast
@@ -158,7 +160,11 @@ def test_valid_cancel_broadcast_request_calls_validate_and_update_broadcast_mess
         headers=[('Content-Type', 'application/cap+xml'), auth_header],
     )
     assert response_for_cancel.status_code == 201
-    mock_update.assert_called_once_with(broadcast_message, expected_status, updating_user=None)
+    mock_update.assert_called_once_with(
+        broadcast_message,
+        expected_status,
+        api_key_id=api_key.id
+    )
 
 
 def test_cancel_request_does_not_cancel_broadcast_if_reference_does_not_match(


### PR DESCRIPTION
Needs to go in after https://github.com/alphagov/notifications-api/pull/3453

And needs to go in before:  https://github.com/alphagov/notifications-api/pull/3448