### PR TITLE
Add GIN index to improve search performance

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1501,6 +1501,16 @@ class Notification(db.Model):
             'notification_type',
             'status',
             'created_at'
+        ),
+        Index(
+            "ix_notifications_get_by_recipient_or_reference",
+            'normalised_to',
+            'client_reference',
+            postgresql_ops={
+                'normalised_to': 'gin_trgm_ops',
+                'client_reference': 'gin_trgm_ops',
+            },
+            postgresql_using='gin'
         )
     )
 

--- a/migrations/versions/0365_add_gin_index_for_ref_and_to.py
+++ b/migrations/versions/0365_add_gin_index_for_ref_and_to.py
@@ -1,0 +1,33 @@
+"""
+
+Revision ID: 0365_add_gin_index_ref_and_to
+Revises: 0364_drop_old_column
+
+Create Date: 2022-02-14 11:16:27.750234
+
+"""
+import os
+
+from alembic import op
+
+revision = '0365_add_gin_index_ref_and_to'
+down_revision = '0364_drop_old_column'
+environment = os.environ['NOTIFY_ENVIRONMENT']
+
+
+def upgrade():
+    if environment not in ["live", "production"]:
+      conn = op.get_bind()
+      conn.execute("""
+          CREATE INDEX ix_notifications_get_by_recipient_or_reference ON
+          notifications USING GIN
+          (normalised_to gin_trgm_ops, client_reference gin_trgm_ops)
+      """)
+
+
+def downgrade():
+    if environment not in ["live", "production"]:
+      conn = op.get_bind()
+      conn.execute("""
+          DROP INDEX ix_notifications_get_by_recipient_or_reference
+      """)

--- a/migrations/versions/0365_add_gin_index_for_ref_and_to.py
+++ b/migrations/versions/0365_add_gin_index_for_ref_and_to.py
@@ -19,6 +19,9 @@ def upgrade():
     if environment not in ["live", "production"]:
       conn = op.get_bind()
       conn.execute("""
+          CREATE EXTENSION pg_trgm
+      """)
+      conn.execute("""
           CREATE INDEX ix_notifications_get_by_recipient_or_reference ON
           notifications USING GIN
           (normalised_to gin_trgm_ops, client_reference gin_trgm_ops)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180916673

Depends on: https://github.com/alphagov/notifications-aws/pull/1026 (to drop second commit)

This should cut search times from minutes to milliseconds, based
on local testing with representative data. By doing this, we should
fix the majority of 504 errors we get each day [1].

GIN is an "inverted index". For a value like "0330" it will store
multiple entries - e.g. "0", "03", "330" - all pointing to the
same record (and possibly others). This makes partial matching with
"%" - e.g. "%33%" - much faster on the indexed columns.

Note: there's a rival index type called GiST, but testing with this
didn't lead to any performance improvement. Shrug.

Brief overview of how we got here:

- "search" calls the "view_notifications" endpoint in Admin [2].
- This calls "dao_get_notifications_by_recipient_or_reference" [3].
- All the other columns in that query are covered by indices.

GIN indices don't support exact matching, so we can't add in columns
like "service_id", unless we also switched to doing a partial match
on them with "%". But we shouldn't need to: these two columns should
be sufficient to narrow the dataset a lot.

References:

- https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#operator-classes

[1]: https://docs.google.com/document/d/1QZlYKTzFzeUkdDNm8Q_yiHme1edCpPPcA9ak3hvfnUk/edit#heading=h.3d1e0lch74k5
[2]: https://github.com/alphagov/notifications-admin/blob/8d337bdd035ddf37c2d3613dc892ba6e2ac9fc2b/app/main/views/jobs.py#L161
[3]: https://github.com/alphagov/notifications-api/blob/966c4db8c6f96ee5fd3424f403338497a792b712/app/dao/notifications_dao.py#L544