### PR TITLE
Return 400 if references missing from cancel broadcast

### DIFF
--- a/app/broadcast_message/translators.py
+++ b/app/broadcast_message/translators.py
@@ -7,7 +7,10 @@ def cap_xml_to_dict(cap_xml):
     return {
         "msgType": cap.alert.msgType.text,
         "reference": cap.alert.identifier.text,
-        "references": cap.alert.references.text,  # references to previous events belonging to the same alert
+        "references": (
+            # references to previous events belonging to the same alert
+            cap.alert.references.text if cap.alert.references else None
+        ),
         "cap_event": cap.alert.info.event.text,
         "category": cap.alert.info.category.text,
         "expires": cap.alert.info.expires.text,

--- a/app/v2/broadcast/post_broadcast.py
+++ b/app/v2/broadcast/post_broadcast.py
@@ -48,6 +48,11 @@ def create_broadcast():
     validate(broadcast_json, post_broadcast_schema)
 
     if broadcast_json["msgType"] == "Cancel":
+        if broadcast_json["references"] is None:
+            raise BadRequestError(
+                message='Missing <references>',
+                status_code=400,
+            )
         broadcast_message = _cancel_or_reject_broadcast(
             broadcast_json["references"].split(","),
             authenticated_service.id

--- a/tests/app/v2/broadcast/sample_cap_xml_documents.py
+++ b/tests/app/v2/broadcast/sample_cap_xml_documents.py
@@ -45,7 +45,7 @@ WAINFLEET_CANCEL = """
         <source>Flood warning service</source>
         <scope>Public</scope>
         <code></code>
-        <references>www.gov.uk/environment-agency,50385fcb0ab7aa447bbd46d848ce8466E,2020-02-16T23:01:13-00:00</references>
+        {}
         <info>
                 <language>en-GB</language>
                 <category>Met</category>
@@ -69,6 +69,16 @@ WAINFLEET_CANCEL = """
         </info>
     </alert>
 """
+
+WAINFLEET_CANCEL_WITH_REFERENCES = WAINFLEET_CANCEL.format(
+    "<references>www.gov.uk/environment-agency,50385fcb0ab7aa447bbd46d848ce8466E,2020-02-16T23:01:13-00:00</references>"
+)
+WAINFLEET_CANCEL_WITH_MISSING_REFERENCES = WAINFLEET_CANCEL.format(
+    ""
+)
+WAINFLEET_CANCEL_WITH_EMPTY_REFERENCES = WAINFLEET_CANCEL.format(
+    "<references></references>"
+)
 
 UPDATE = """
     <alert xmlns="urn:oasis:names:tc:emergency:cap:1.2">


### PR DESCRIPTION
If someone tries to cancel a broadcast but the contents of `<references>` don’t match and existing broadcast we correctly return a `404`.

If they don’t provide any `<references>` then we get an exception. This pull request catches the missing references and returns a `400` instead. I think this is more appropriate than another `404` because it’s malformed request, rather than a
well-formed request that doesn’t match our data. It also lets us write a more specific and helpful error message.