### PR TITLE
Bump memory for Celery Beat to 512M

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -49,7 +49,7 @@
     },
   },
 
-  'notify-delivery-celery-beat': {'memory': '128M'},
+  'notify-delivery-celery-beat': {'memory': '512M'},
   'notify-delivery-worker-jobs': {'memory': '2G'},
   'notify-delivery-worker-research': {},
   'notify-delivery-worker-sender': {'disk_quota': '2G', 'memory': '4G'},


### PR DESCRIPTION
This fixes the app crashing - apparently due to a lack of free
memory. Looking over the last month, we can see it's been hovering
at ~90% utilisation. 512M seems like a good compromise to avoid
this happening again vs paying for what we use.

The limit was last changed 5 years ago:

https://github.com/alphagov/notifications-api/pull/882