### PR TITLE
More tweaks of broadcast message validation

### DIFF
--- a/app/v2/broadcast/broadcast_schemas.py
+++ b/app/v2/broadcast/broadcast_schemas.py
@@ -52,7 +52,7 @@ post_broadcast_schema = {
         },
         "content": {
             "type": "string",
-            "minLength": 1,
+            "minLength": 0,
         },
         "web": {
             "type": "string",

--- a/tests/app/v2/broadcast/sample_cap_xml_documents.py
+++ b/tests/app/v2/broadcast/sample_cap_xml_documents.py
@@ -9,7 +9,6 @@ WAINFLEET = """
         <msgType>Alert</msgType>
         <source>Flood warning service</source>
         <scope>Public</scope>
-        <references>www.gov.uk/environment-agency,4f6d28b10ab7aa447bbd46d85f1e9effE,2020-02-16T19:20:03+00:00</references>
         <info>
             <language>en-GB</language>
             <category>Met</category>

--- a/tests/app/v2/broadcast/sample_cap_xml_documents.py
+++ b/tests/app/v2/broadcast/sample_cap_xml_documents.py
@@ -54,7 +54,7 @@ WAINFLEET_CANCEL = """
                 <certainty>Likely</certainty>
                 <expires>2020-02-16T23:30:13-00:00</expires>
                 <senderName>Environment Agency</senderName>
-                <description>Cancel Warning</description>
+                <description></description>
                 <web>https://flood-warning-information.service.gov.uk</web>
                 <contact>0345 988 1188</contact>
                 <area>


### PR DESCRIPTION
## Test that alert with no references is OK

References are optional, and we fixed errors when they are not provided in bbc444699a6032ef855959d81aee905775be9862

This commit amends the tests so that they cover the `Alert` message type as well as the `Cancel` (which is already covered).

## Allow cancel of alert via API with empty `<description>`

The XML for an alerts requires a `<description>` field. The XML for a `<cancel>` may have the `<description>` field populated (although we ignore the contents) but it may also be empty.

This commit updates the schema to leave the all the validation to the view layer, which can decide when or when not to validate the content of the `<description>` field.