### PR TITLE
Migration to make NHS email branding ID consistent across environments

### DIFF
--- a/migrations/versions/0365_add_nhs_branding.py
+++ b/migrations/versions/0365_add_nhs_branding.py
@@ -1,0 +1,58 @@
+"""
+
+Revision ID: 0365_add_nhs_branding
+Revises: 0364_drop_old_column
+Create Date: 2022-02-17 16:31:21.415065
+
+"""
+import os
+
+from alembic import op
+
+revision = '0365_add_nhs_branding'
+down_revision = '0364_drop_old_column'
+
+environment = os.environ['NOTIFY_ENVIRONMENT']
+
+
+def upgrade():
+    if environment not in ["live", "production"]:
+        op.execute("""
+            DELETE FROM service_email_branding
+            WHERE email_branding_id in (
+                SELECT id
+                FROM email_branding
+                WHERE name = 'NHS'
+            )
+        """)
+
+        op.execute("""
+            UPDATE organisation SET email_branding_id = null
+            WHERE email_branding_id in(
+                SELECT id
+                FROM email_branding
+                WHERE name = 'NHS'
+            )
+        """)
+
+        op.execute("""
+            DELETE FROM email_branding WHERE name = 'NHS'
+        """)
+
+        op.execute("""
+            INSERT INTO email_branding (
+                id, logo, name, brand_type
+            )
+            VALUES (
+                'a7dc4e56-660b-4db7-8cff-12c37b12b5ea',
+                '1ac6f483-3105-4c9e-9017-dd7fb2752c44-nhs-blue_x2.png',
+                'NHS',
+                'org'
+            )
+        """)
+
+
+def downgrade():
+    """
+    No downgrade step since this is not fully reversible, but won't be run in production.
+    """


### PR DESCRIPTION
With the changes we will be making to email branding in admin it's useful to know the ID of the NHS email brand. This makes it easier to show a preview of the branding.

This means that the ID will need to be consistent across environments, so this changes the details of the NHS brand in the dev, preview and staging environments to match the production data.

The migration
- Removes NHS branding from existing services
- Removes NHS branding from any orgs which had it as their default
- Deletes the NHS branding row if it exists
- Inserts a new NHS branding row with details which match those in production

This does have the effect of removing NHS branding from people's local and preview services and orgs (NHS branding doesn't exist on staging), but this does not affect real teams. The NHS logo with a filename of `1ac6f483-3105-4c9e-9017-dd7fb2752c44-nhs-blue_x2.png` exists in the logo S3 bucket for all environments.

[Pivotal story](https://www.pivotaltracker.com/story/show/180807168)