### PR TITLE
Clear cache when cancelling broadcast via the API

### DIFF
--- a/app/v2/broadcast/post_broadcast.py
+++ b/app/v2/broadcast/post_broadcast.py
@@ -5,7 +5,7 @@ from notifications_utils.polygons import Polygons
 from notifications_utils.template import BroadcastMessageTemplate
 from sqlalchemy.orm.exc import MultipleResultsFound
 
-from app import api_user, authenticated_service
+from app import api_user, authenticated_service, redis_store
 from app.broadcast_message.translators import cap_xml_to_dict
 from app.broadcast_message.utils import (
     validate_and_update_broadcast_message_status,
@@ -125,6 +125,9 @@ def _cancel_or_reject_broadcast(references_to_original_broadcast, service_id):
         broadcast_message,
         new_status,
         api_key_id=api_user.id
+    )
+    redis_store.delete(
+        f'service-{broadcast_message.service_id}-broadcast-message-{broadcast_message.id}'
     )
     return broadcast_message
 

--- a/tests/app/v2/broadcast/test_post_broadcast.py
+++ b/tests/app/v2/broadcast/test_post_broadcast.py
@@ -134,6 +134,8 @@ def test_valid_cancel_broadcast_request_calls_validate_and_update_broadcast_mess
     api_key = create_api_key(service=sample_broadcast_service)
     auth_header = create_service_authorization_header(service_id=sample_broadcast_service.id)
 
+    mock_redis_delete = mocker.patch('app.redis_store.delete')
+
     # create a broadcast
     response_for_create = client.post(
         path='/v2/broadcast',
@@ -164,6 +166,9 @@ def test_valid_cancel_broadcast_request_calls_validate_and_update_broadcast_mess
         broadcast_message,
         expected_status,
         api_key_id=api_key.id
+    )
+    mock_redis_delete.assert_called_once_with(
+        f'service-{sample_broadcast_service.id}-broadcast-message-{broadcast_message.id}'
     )
 
 


### PR DESCRIPTION
Before we implemented ‘cancel’ any updates to a broadcast went through the admin app. This meant the admin app could deal with clearing the cache any time a broadcast was updated by a user performing an action.

Now that a broadcast can be updated without the admin app being involved we have another place we need to clear the cache from.

If we don’t do this then the broadcast can look like it’s still going even though it’s successfully been cancelled.