### PR TITLE
Rediss spike

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -16,6 +16,8 @@ def set_config_env_vars(vcap_services):
     # Postgres config
     os.environ['SQLALCHEMY_DATABASE_URI'] = vcap_services['postgres'][0]['credentials']['uri'].replace('postgres',
                                                                                                        'postgresql')
+    # Redis config
+    os.environ['REDIS_URL'] = vcap_services['redis'][0]['credentials']['uri']
 
     vcap_application = json.loads(os.environ['VCAP_APPLICATION'])
     os.environ['NOTIFY_ENVIRONMENT'] = vcap_application['space_name']

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -2,6 +2,8 @@ import os
 import sys
 import traceback
 import gunicorn
+import eventlet
+import socket
 
 from gds_metrics.gunicorn import child_exit  # noqa
 
@@ -30,3 +32,22 @@ def on_exit(server):
 
 def worker_int(worker):
     worker.log.info("worker: received SIGINT {}".format(worker.pid))
+
+
+def fix_ssl_monkeypatching():
+    """
+    eventlet works by monkey-patching core IO libraries (such as ssl) to be non-blocking. However, there's currently
+    a bug: In the normal socket library it may throw a timeout error as a `socket.timeout` exception. However
+    eventlet.green.ssl's patch raises an ssl.SSLError('timed out',) instead. redispy handles socket.timeout but not
+    ssl.SSLError, so we solve this by monkey patching the monkey patching code to raise the correct exception type
+    :scream:
+
+    https://github.com/eventlet/eventlet/issues/692
+    """
+    # this has probably already been called somewhere in gunicorn internals, however, to be sure, we invoke it again.
+    # eventlet.monkey_patch can be called multiple times without issue
+    eventlet.monkey_patch()
+    eventlet.green.ssl.timeout_exc = socket.timeout
+
+
+fix_ssl_monkeypatching()

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -99,6 +99,7 @@ applications:
 
     services:
       - notify-db
+      - notify-redis
       - logit-ssl-syslog-drain
       {% if CF_APP == 'notify-api' %}
       - notify-prometheus
@@ -142,7 +143,6 @@ applications:
       FIRETEXT_INBOUND_SMS_AUTH: '{{ FIRETEXT_INBOUND_SMS_AUTH | tojson }}'
 
       REDIS_ENABLED: '{{ REDIS_ENABLED }}'
-      REDIS_URL: '{{ REDIS_URL }}'
 
       TEMPLATE_PREVIEW_API_HOST: '{{ TEMPLATE_PREVIEW_API_HOST }}'
       TEMPLATE_PREVIEW_API_KEY: '{{ TEMPLATE_PREVIEW_API_KEY }}'


### PR DESCRIPTION
Spike using a paas provided rediss. succesfully got it working with gunicorn and eventlets (which was previously a stumbling block). see 2nd commit for details of the gnarly fix.

Not to be merged until we've decided if we want to use paas redis or redislabs tls. (either way, second commit is still useful. first commit is only for paas redis support)