### PR TITLE
Bump gunicorn

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,8 +9,8 @@ Flask-Migrate==2.7.0
 git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262#egg=Flask-SQLAlchemy==2.3.2.dev20190108
 Flask==1.1.2
 click-datetime==0.2
-eventlet==0.30.2 # pyup: ignore # 0.31 breaks Gunicorn
-gunicorn==20.1.0
+# Should be pinned until a new gunicorn release greater than 20.1.0 comes out. (Due to eventlet v0.33 compatibility issues)
+git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0
 iso8601==0.1.14
 itsdangerous==1.1.0
 jsonschema==3.2.0

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-cffi==1.14.5
+cffi==1.15.0
 celery[sqs]==5.2.0
 Flask-Bcrypt==0.7.1
 flask-marshmallow==0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ certifi==2021.10.8
     # via
     #   pyproj
     #   requests
-cffi==1.14.5
+cffi==1.15.0
     # via
     #   -r requirements.in
     #   bcrypt

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,14 +67,14 @@ click-repl==0.2.0
     # via celery
 colorama==0.4.3
     # via awscli
-dnspython==1.16.0
+dnspython==2.2.0
     # via eventlet
 docopt==0.6.2
     # via notifications-python-client
 docutils==0.15.2
     # via awscli
-eventlet==0.30.2
-    # via -r requirements.in
+eventlet==0.33.0
+    # via gunicorn
 flask==1.1.2
     # via
     #   -r requirements.in
@@ -106,7 +106,7 @@ greenlet==1.1.2
     # via
     #   eventlet
     #   sqlalchemy
-gunicorn==20.1.0
+gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
     # via -r requirements.in
 idna==3.3
     # via requests


### PR DESCRIPTION
Gunicorn has a bug where it is incompatible with eventlet>0.30.2

The code to fix this itself was merged into master in gunicorn's repo (https://github.com/benoitc/gunicorn/pull/2581) - however, that master code hasn't been released since it was merged 9 months ago.

There's a [security advisory for eventlet<=0.31.0](https://github.com/eventlet/eventlet/security/advisories/GHSA-9p9m-jm8w-94p2) which doesn't affect us as it only involves websockets, however, it'd be nice to be able to not have that as a lingering issue on our repo.

To fix this, pin github to the merge commit for the PR above. This can revert to a regular pypi requirement for gunicorn once 0.21.1 or higher is released.

The pinned commit adds nothing to gunicorn 20.1.0 other than the eventlet fix and some docs changes.

also note, i've changed the requirement to `gunicorn[eventlet]` - this means we don't need to explicitly list eventlet in reqs.in.

also note locally that you may need to run `pip install -r requirements.txt --no-cache-dir` to ensure you get the version from github (since the version # hasn't changed, pip will try and use the old wheel in the cache dir). That said we don't normally run under gunicorn/eventlet locally