### PR TITLE
Iterate local development with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,11 @@ export PATH=${PATH}:/Applications/Postgres.app/Contents/Versions/11/bin/
 
 ### Redis
 
-To switch redis on you'll need to install it locally. On a OSX we've used brew for this. To use redis caching you need to switch it on by changing the config for development:
+To switch redis on you'll need to install it locally e.g. `brew install redis`. To use redis caching you need to switch it on with an environment variable:
 
 ```
-REDIS_ENABLED = 1
+export REDIS_ENABLED=1
 ```
-
-Note that if you're running Celery with Docker locally, then you'll also need to set `REDIS_URL=redis://host.docker.internal:6379`.
 
 ##  To run the application
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,11 @@ export PATH=${PATH}:/Applications/Postgres.app/Contents/Versions/11/bin/
 
 To switch redis on you'll need to install it locally. On a OSX we've used brew for this. To use redis caching you need to switch it on by changing the config for development:
 
-        REDIS_ENABLED = True
+```
+REDIS_ENABLED = 1
+```
 
+Note that if you're running Celery with Docker locally, then you'll also need to set `REDIS_URL=redis://host.docker.internal:6379`.
 
 ##  To run the application
 
@@ -81,6 +84,18 @@ make run-celery
 # run scheduled tasks (optional)
 make run-celery-beat
 ```
+
+We've had problems running Celery locally due to one of its dependencies: pycurl. Due to the complexity of the issue, we also support running Celery via Docker:
+
+```
+# install dependencies, etc.
+make bootstrap-with-docker
+
+# run the background tasks
+make run-celery-with-docker
+
+# run scheduled tasks
+make run-celery-beat-with-docker
 
 ##  To test the application
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,15 @@ export PATH=${PATH}:/Applications/Postgres.app/Contents/Versions/11/bin/
 
 ### Redis
 
-To switch redis on you'll need to install it locally e.g. `brew install redis`. To use redis caching you need to switch it on with an environment variable:
+To switch redis on you'll need to install it locally. On a Mac you can do:
+
+```
+# assuming you use Homebrew
+brew install redis
+brew services start redis
+```
+
+To use redis caching you need to switch it on with an environment variable:
 
 ```
 export REDIS_ENABLED=1

--- a/app/config.py
+++ b/app/config.py
@@ -428,7 +428,7 @@ class Development(Config):
     NOTIFY_EMAIL_DOMAIN = "notify.tools"
 
     SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI', 'postgresql://localhost/notification_api')
-    REDIS_URL = 'redis://localhost:6379/0'
+    REDIS_URL = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
 
     ANTIVIRUS_ENABLED = os.getenv('ANTIVIRUS_ENABLED') == '1'
 

--- a/scripts/run_with_docker.sh
+++ b/scripts/run_with_docker.sh
@@ -9,13 +9,14 @@ source environment.sh
 AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-"$(aws configure get aws_access_key_id)"}
 AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-"$(aws configure get aws_secret_access_key)"}
 : "${SQLALCHEMY_DATABASE_URI:=postgresql://postgres@host.docker.internal/notification_api}"
+REDIS_URL="redis://host.docker.internal:6379"
 
 docker run -it --rm \
   -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
   -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
   -e SQLALCHEMY_DATABASE_URI=$SQLALCHEMY_DATABASE_URI \
   -e REDIS_ENABLED=${REDIS_ENABLED:-0} \
-  -e REDIS_URL=${REDIS_URL:-''} \
+  -e REDIS_URL=$REDIS_URL \
   -v $(pwd):/home/vcap/app \
   ${DOCKER_IMAGE_NAME} \
   ${@}

--- a/scripts/run_with_docker.sh
+++ b/scripts/run_with_docker.sh
@@ -14,6 +14,8 @@ docker run -it --rm \
   -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
   -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
   -e SQLALCHEMY_DATABASE_URI=$SQLALCHEMY_DATABASE_URI \
+  -e REDIS_ENABLED=${REDIS_ENABLED:-0} \
+  -e REDIS_URL=${REDIS_URL:-''} \
   -v $(pwd):/home/vcap/app \
   ${DOCKER_IMAGE_NAME} \
   ${@}


### PR DESCRIPTION
This makes a few changes to:

- Make local development consistent with our other apps. It's now
faster to start Celery locally since we don't try to build the
image each time - this is usually quick, but unnecessary.

- Add support for connecting to a local Redis instance. Note that
the previous suggestion of "REDIS = True" was incorrect as this
would be turned into the literal string "True".

I've also co-located and extended the recipes in the Makefile to
make them a bit more visible.