### PR TITLE
Tweak SMS alert to make it worth the effort

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -553,7 +553,7 @@ def dao_find_services_sending_to_tv_numbers(start_date, end_date, threshold=500)
     ).all()
 
 
-def dao_find_services_with_high_failure_rates(start_date, end_date, threshold=1000):
+def dao_find_services_with_high_failure_rates(start_date, end_date, threshold=10000):
     subquery = db.session.query(
         func.count(Notification.id).label('total_count'),
         Notification.service_id.label('service_id')


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/4896284

Currently we alert if a service wastes £16 of SMS. It may cost us
around that amount just to deal with the alert, especially if the
service refuses to clean up their data.

This bumps the threshold to something more alarming, which should
make it more reasonable to suspend the service if we can show that
they've already wasted public money. £160 seems like a reasonable
compromise between have wasted vs could waste.

Note: we previously compromised on 1000 [1] down from 63K [2]. I
think we can afford to go a little bit higher.

[1]: https://github.com/alphagov/notifications-api/pull/3234
[2]: https://github.com/alphagov/notifications-api/pull/3221