### PR TITLE
Allow SMS fragment limit to be 0

### DIFF
--- a/app/billing/billing_schemas.py
+++ b/app/billing/billing_schemas.py
@@ -6,7 +6,7 @@ create_or_update_free_sms_fragment_limit_schema = {
     "type": "object",
     "title": "Create",
     "properties": {
-        "free_sms_fragment_limit": {"type": "integer", "minimum": 1},
+        "free_sms_fragment_limit": {"type": "integer", "minimum": 0},
     },
     "required": ["free_sms_fragment_limit"]
 }

--- a/tests/app/billing/test_billing.py
+++ b/tests/app/billing/test_billing.py
@@ -29,10 +29,6 @@ IN_MAY_2016 = datetime(2016, 5, 10, 23, 00, 00)
 IN_JUN_2016 = datetime(2016, 6, 3, 23, 00, 00)
 
 
-def _assert_dict_equals(actual, expected_dict):
-    assert actual == expected_dict
-
-
 def test_create_update_free_sms_fragment_limit_invalid_schema(client, sample_service):
 
     response = client.post('service/{}/billing/free-sms-fragment-limit'.format(sample_service.id),

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -260,7 +260,6 @@ def create_notification(
         rate_multiplier=None,
         international=False,
         phone_prefix=None,
-        scheduled_for=None,
         normalised_to=None,
         one_off=False,
         reply_to_text=None,

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -20,7 +20,6 @@ def test_get_notification_by_id_returns_200(
         template=sample_template,
         billable_units=billable_units,
         sent_by=provider,
-        scheduled_for="2017-05-12 15:15"
     )
 
     # another
@@ -28,7 +27,6 @@ def test_get_notification_by_id_returns_200(
         template=sample_template,
         billable_units=billable_units,
         sent_by=provider,
-        scheduled_for="2017-06-12 15:15"
     )
 
     auth_header = create_service_authorization_header(service_id=sample_notification.service_id)


### PR DESCRIPTION
This updates the `create_or_update_free_sms_fragment_limit_schema` to allow the `free_sms_fragment_limit` to have a minimum of 0, not 1.

[Pivotal story](https://www.pivotaltracker.com/story/show/181282523)