### PR TITLE
Reduce timeout for service callback attempt to 5 seconds

### DIFF
--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -68,7 +68,7 @@ def _send_data_to_service_callback_api(self, data, service_callback_url, token, 
                 'Content-Type': 'application/json',
                 'Authorization': 'Bearer {}'.format(token)
             },
-            timeout=60
+            timeout=5
         )
         current_app.logger.info('{} sending {} to {}, response {}'.format(
             function_name,


### PR DESCRIPTION
It is currently 60 seconds but we have had two incidents in the
past week where there is a connection error talking to a service
and the request takes up to 60 seconds before failing. When this
happens, if there are a few of these callbacks then all of them
will completely hog the service callback worker and build up a big
queue of all the other service callbacks.

5 seconds has been chosen as that is still a pretty decent length
time for a simple web request that should just be giving them a
little bit of information for them to store. 5 seconds should be a
sufficient enough reduction that we dramatically reduce this problem
for the moment.

Open to this number
being changed in the future based on how we see it perform.

Note, I could see nothing in the previous git commit for a reason why we needed it to be 60 seconds.