### PR TITLE
Fix letter functional tests to work in Docker

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -432,7 +432,7 @@ class Development(Config):
 
     ANTIVIRUS_ENABLED = os.getenv('ANTIVIRUS_ENABLED') == '1'
 
-    API_HOST_NAME = "http://localhost:6011"
+    API_HOST_NAME = os.getenv('API_HOST_NAME', 'http://localhost:6011')
     API_RATE_LIMIT_ENABLED = True
     DVLA_EMAIL_ADDRESSES = ['success@simulator.amazonses.com']
 

--- a/scripts/run_with_docker.sh
+++ b/scripts/run_with_docker.sh
@@ -8,8 +8,9 @@ source environment.sh
 # this script should be run from within your virtualenv so you can access the aws cli
 AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-"$(aws configure get aws_access_key_id)"}
 AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-"$(aws configure get aws_secret_access_key)"}
-: "${SQLALCHEMY_DATABASE_URI:=postgresql://postgres@host.docker.internal/notification_api}"
+SQLALCHEMY_DATABASE_URI="postgresql://postgres@host.docker.internal/notification_api"
 REDIS_URL="redis://host.docker.internal:6379"
+API_HOST_NAME="http://host.docker.internal:6011"
 
 docker run -it --rm \
   -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
@@ -17,6 +18,7 @@ docker run -it --rm \
   -e SQLALCHEMY_DATABASE_URI=$SQLALCHEMY_DATABASE_URI \
   -e REDIS_ENABLED=${REDIS_ENABLED:-0} \
   -e REDIS_URL=$REDIS_URL \
+  -e API_HOST_NAME=$API_HOST_NAME \
   -v $(pwd):/home/vcap/app \
   ${DOCKER_IMAGE_NAME} \
   ${@}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181498273

Currently "test_send_letter_notification_via_api" fails at the final
stage in create-fake-letter-response-file [^1]:

        requests.exceptions.ConnectionError: HTTPConnectionPool(host='localhost', port=6011): Max retries exceeded with url: /notifications/letter/dvla (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0xffff95ffc460>: Failed to establish a new connection: [Errno 111] Connection refused'))

This only applies when running in Docker so the default should still
be "localhost" for the Flask app itself.

[^1]: https://github.com/alphagov/notifications-api/blob/5093064533e558d48add2c373eb5eeaf752e6b8e/app/celery/research_mode_tasks.py#L57