### PR TITLE
Replace pycurl guidance with psycopg2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Contains:
 
 We run python 3.9 both locally and in production.
 
-### pycurl
+### psycopg2
 
-See https://github.com/alphagov/notifications-manuals/wiki/Getting-started#pycurl
+[Follow these instructions on Mac M1 machines](https://github.com/psycopg/psycopg2/issues/1216#issuecomment-1068150544).
 
 ### AWS credentials
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181498273

Since we moved to Dockerised Celery the pycurl guidance should no
longer be necessary and doesn't work on newer Mac M1 machines.

This also adds new guidance for psycopg2, which will hopefully be
temporary (see issue comment).