### PR TITLE
Fix missing permission for dev broadcast users

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -833,6 +833,7 @@ def local_dev_broadcast_permissions(user_id):
                 'reject_broadcasts', 'cancel_broadcasts',  # required to create / approve
                 'create_broadcasts', 'approve_broadcasts',  # minimum for testing
                 'manage_templates',  # unlikely but might be useful
+                'view_activity',  # normally added on invite / service creation
             ]
         ]
 


### PR DESCRIPTION
This is normally added automatically [^1].

[^1]: https://github.com/alphagov/notifications-api/blob/b145a299351255c5755ca547629b7936cb7fcf4a/app/dao/broadcast_service_dao.py#L69