### PR TITLE
Fix tests breaking in new financial year

### DIFF
--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -508,6 +508,7 @@ def test_post_link_service_to_organisation(admin_request, sample_service):
     assert sample_service.organisation_type == 'central'
 
 
+@freeze_time('2021-09-24 13:30')
 def test_post_link_service_to_organisation_inserts_annual_billing(admin_request, sample_service):
     data = {
         'service_id': str(sample_service.id)
@@ -551,6 +552,7 @@ def test_post_link_service_to_organisation_rollback_service_if_annual_billing_up
     assert len(AnnualBilling.query.all()) == 0
 
 
+@freeze_time('2021-09-24 13:30')
 def test_post_link_service_to_another_org(
         admin_request, sample_service, sample_organisation):
     data = {


### PR DESCRIPTION
We should lock these tests to run in a particular year [^1].

Fixes e.g.

      >       assert annual_billing[0].free_sms_fragment_limit == 150000
      E       assert 40000 == 150000
      E        +  where 40000 = <AnnualBilling 8851fd4b-6316-4a53-b0e0-8202c803ae97>.free_sms_fragment_limit

[^1]: https://github.com/alphagov/notifications-api/commit/8402e7c97b672c64e2e398abcb1a478d99c33b1b#diff-adcd90bfdc6b7777fdf309037ca6948bef4f4b858e22f8b2e46b71865d580fbaR60