### PR TITLE
Fix log for sending SMS to be generic per client

### DIFF
--- a/app/clients/sms/__init__.py
+++ b/app/clients/sms/__init__.py
@@ -59,7 +59,7 @@ class SmsClient(Client):
         finally:
             elapsed_time = monotonic() - start_time
             self.statsd_client.timing(f"clients.{self.name}.request-time", elapsed_time)
-            self.current_app.logger.info("Reach request for {} finished in {}".format(reference, elapsed_time))
+            self.current_app.logger.info(f"{self.name} request for {reference} finished in {elapsed_time}")
 
         return response
 

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -611,6 +611,7 @@ def test_get_total_notifications_for_date_range(sample_service):
     assert results[0] == ("2021-03-01", 15, 20, 3)
 
 
+@freeze_time('2022-03-31T18:00:00')
 @pytest.mark.parametrize('created_at_utc,process_day,expected_count', [
     # Clocks change on the 27th of March 2022, so the query needs to look at the
     # time range 00:00 - 23:00 (UTC) thereafter.


### PR DESCRIPTION
This was a mistake in [^1].

[^1]: https://github.com/alphagov/notifications-api/commit/3b082477f05588d638a21ce0874356678fd429df#diff-95316b574f974237b3b7ce453fec09628bd1062087154789ff4d0176ea23c460R52