### PR TITLE
Alert earlier when a broadcast is approved

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -2,13 +2,11 @@ import iso8601
 from flask import Blueprint, jsonify, request
 from notifications_utils.template import BroadcastMessageTemplate
 
+from app.broadcast_message import utils as broadcast_utils
 from app.broadcast_message.broadcast_message_schema import (
     create_broadcast_message_schema,
     update_broadcast_message_schema,
     update_broadcast_message_status_schema,
-)
-from app.broadcast_message.utils import (
-    validate_and_update_broadcast_message_status,
 )
 from app.dao.broadcast_message_dao import (
     dao_get_broadcast_message_by_id_and_service_id,
@@ -162,6 +160,6 @@ def update_broadcast_message_status(service_id, broadcast_message_id):
                 status_code=400
             )
 
-    validate_and_update_broadcast_message_status(broadcast_message, new_status, updating_user)
+    broadcast_utils.update_broadcast_message_status(broadcast_message, new_status, updating_user)
 
     return jsonify(broadcast_message.serialize()), 200

--- a/app/broadcast_message/utils.py
+++ b/app/broadcast_message/utils.py
@@ -90,7 +90,8 @@ def _create_p1_zendesk_alert(broadcast_message):
         technical_ticket=True,
         org_id=current_app.config['BROADCAST_ORGANISATION_ID'],
         org_type='central',
-        service_id=str(broadcast_message.service_id)
+        service_id=str(broadcast_message.service_id),
+        p1=True
     )
     zendesk_client.send_ticket_to_zendesk(ticket)
 

--- a/app/broadcast_message/utils.py
+++ b/app/broadcast_message/utils.py
@@ -74,13 +74,12 @@ def _create_p1_zendesk_alert(broadcast_message):
 
         https://www.notifications.service.gov.uk/services/{broadcast_message.service_id}/current-alerts/{broadcast_message.id}
 
-        This broacast has been sent on channel {broadcast_message.service.broadcast_channel}.
-        This broadcast is targeted at areas {broadcast_message.areas.get("names", [])}.
+        Sent on channel {broadcast_message.service.broadcast_channel} to {broadcast_message.areas["names"]}.
 
-        This broadcast's content starts "{broadcast_message.content[:100]}".
+        Content starts "{broadcast_message.content[:100]}".
 
-        If this alert is not expected refer to the runbook for instructions.
-        https://docs.google.com/document/d/1J99yOlfp4nQz6et0w5oJVqi-KywtIXkxrEIyq_g2XUs
+        Follow the runbook to check the broadcast went out OK:
+        https://docs.google.com/document/d/1J99yOlfp4nQz6et0w5oJVqi-KywtIXkxrEIyq_g2XUs/edit#heading=h.lzr9aq5b4wg
     """.strip()
 
     ticket = NotifySupportTicket(

--- a/app/broadcast_message/utils.py
+++ b/app/broadcast_message/utils.py
@@ -1,3 +1,4 @@
+import inspect
 from datetime import datetime
 
 from flask import current_app
@@ -69,7 +70,7 @@ def _create_p1_zendesk_alert(broadcast_message):
     if broadcast_message.status != BroadcastStatusType.BROADCASTING:
         return
 
-    message = f"""
+    message = inspect.cleandoc(f"""
         Broadcast Sent
 
         https://www.notifications.service.gov.uk/services/{broadcast_message.service_id}/current-alerts/{broadcast_message.id}
@@ -80,7 +81,7 @@ def _create_p1_zendesk_alert(broadcast_message):
 
         Follow the runbook to check the broadcast went out OK:
         https://docs.google.com/document/d/1J99yOlfp4nQz6et0w5oJVqi-KywtIXkxrEIyq_g2XUs/edit#heading=h.lzr9aq5b4wg
-    """.strip()
+    """)
 
     ticket = NotifySupportTicket(
         subject='Live broadcast sent',

--- a/app/broadcast_message/utils.py
+++ b/app/broadcast_message/utils.py
@@ -13,7 +13,7 @@ from app.models import (
 )
 
 
-def validate_and_update_broadcast_message_status(broadcast_message, new_status, updating_user=None, api_key_id=None):
+def update_broadcast_message_status(broadcast_message, new_status, updating_user=None, api_key_id=None):
     _validate_broadcast_update(broadcast_message, new_status, updating_user)
 
     if new_status == BroadcastStatusType.BROADCASTING:

--- a/app/v2/broadcast/post_broadcast.py
+++ b/app/v2/broadcast/post_broadcast.py
@@ -6,10 +6,8 @@ from notifications_utils.template import BroadcastMessageTemplate
 from sqlalchemy.orm.exc import MultipleResultsFound
 
 from app import api_user, authenticated_service, redis_store
+from app.broadcast_message import utils as broadcast_utils
 from app.broadcast_message.translators import cap_xml_to_dict
-from app.broadcast_message.utils import (
-    validate_and_update_broadcast_message_status,
-)
 from app.dao.broadcast_message_dao import (
     dao_get_broadcast_message_by_references_and_service_id,
 )
@@ -121,7 +119,7 @@ def _cancel_or_reject_broadcast(references_to_original_broadcast, service_id):
         new_status = BroadcastStatusType.REJECTED
     else:
         new_status = BroadcastStatusType.CANCELLED
-    validate_and_update_broadcast_message_status(
+    broadcast_utils.update_broadcast_message_status(
         broadcast_message,
         new_status,
         api_key_id=api_user.id

--- a/tests/app/broadcast_message/test_utils.py
+++ b/tests/app/broadcast_message/test_utils.py
@@ -414,9 +414,8 @@ def test_create_p1_zendesk_alert(sample_broadcast_service, mocker, notify_api):
     assert ticket.subject == 'Live broadcast sent'
     assert ticket.ticket_type == 'incident'
     assert str(broadcast_message.id) in ticket.message
-    assert 'channel severe' in ticket.message
-    assert "areas ['England', 'Scotland']" in ticket.message
-    assert "tailor made emergency" in ticket.message
+    assert "Sent on channel severe to ['England', 'Scotland']" in ticket.message
+    assert 'Content starts "tailor made emergency' in ticket.message
 
 
 def test_create_p1_zendesk_alert_doesnt_alert_when_cancelling(mocker, notify_api, sample_broadcast_service):

--- a/tests/app/v2/broadcast/test_post_broadcast.py
+++ b/tests/app/v2/broadcast/test_post_broadcast.py
@@ -124,7 +124,7 @@ def test_valid_post_cap_xml_broadcast_returns_201(
     [True, "cancelled"],
     [False, "rejected"]
 ])
-def test_valid_cancel_broadcast_request_calls_validate_and_update_broadcast_message_status_and_returns_201(
+def test_valid_cancel_broadcast_request_calls_update_broadcast_message_status_and_returns_201(
     client,
     sample_broadcast_service,
     mocker,
@@ -153,7 +153,9 @@ def test_valid_cancel_broadcast_request_calls_validate_and_update_broadcast_mess
     if is_approved:
         broadcast_message.status = 'broadcasting'
 
-    mock_update = mocker.patch('app.v2.broadcast.post_broadcast.validate_and_update_broadcast_message_status')
+    mock_update = mocker.patch(
+        'app.v2.broadcast.post_broadcast.broadcast_utils.update_broadcast_message_status'
+    )
 
     # cancel broadcast
     response_for_cancel = client.post(


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181423293

Until we are confident that broadcasts are being sent
out regularly we have this alert to prompt us to check.

This moves the alert earlier in the code path for broadcast
sending, so that we can be more confident that it will
fire irrespective of something going wrong later on e.g.
if the Celery task it was run in got lost in SQS.

We don't think it's necessary to move the alert back any
further, as an error in that part of the code should be
visible to the user approving the alert (hopefully).

I've done a couple of initial commits of small refactoring,
so best to review this one commit by commit.