### PR TITLE
Bump Flask and itsdangerous

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -283,48 +283,34 @@ def register_blueprint(application):
 
 def register_v2_blueprints(application):
     from app.authentication.auth import requires_auth
-    from app.v2.broadcast.post_broadcast import (
-        v2_broadcast_blueprint as post_broadcast,
+    from app.v2.broadcast.post_broadcast import v2_broadcast_blueprint
+    from app.v2.inbound_sms.get_inbound_sms import v2_inbound_sms_blueprint
+    from app.v2.notifications import (  # noqa
+        get_notifications,
+        post_notifications,
+        v2_notification_blueprint,
     )
-    from app.v2.inbound_sms.get_inbound_sms import (
-        v2_inbound_sms_blueprint as get_inbound_sms,
+    from app.v2.template import (  # noqa
+        get_template,
+        post_template,
+        v2_template_blueprint,
     )
-    from app.v2.notifications.get_notifications import (
-        v2_notification_blueprint as get_notifications,
-    )
-    from app.v2.notifications.post_notifications import (
-        v2_notification_blueprint as post_notifications,
-    )
-    from app.v2.template.get_template import (
-        v2_template_blueprint as get_template,
-    )
-    from app.v2.template.post_template import (
-        v2_template_blueprint as post_template,
-    )
-    from app.v2.templates.get_templates import (
-        v2_templates_blueprint as get_templates,
-    )
+    from app.v2.templates.get_templates import v2_templates_blueprint
 
-    post_notifications.before_request(requires_auth)
-    application.register_blueprint(post_notifications)
+    v2_notification_blueprint.before_request(requires_auth)
+    application.register_blueprint(v2_notification_blueprint)
 
-    get_notifications.before_request(requires_auth)
-    application.register_blueprint(get_notifications)
+    v2_templates_blueprint.before_request(requires_auth)
+    application.register_blueprint(v2_templates_blueprint)
 
-    get_templates.before_request(requires_auth)
-    application.register_blueprint(get_templates)
+    v2_template_blueprint.before_request(requires_auth)
+    application.register_blueprint(v2_template_blueprint)
 
-    get_template.before_request(requires_auth)
-    application.register_blueprint(get_template)
+    v2_inbound_sms_blueprint.before_request(requires_auth)
+    application.register_blueprint(v2_inbound_sms_blueprint)
 
-    post_template.before_request(requires_auth)
-    application.register_blueprint(post_template)
-
-    get_inbound_sms.before_request(requires_auth)
-    application.register_blueprint(get_inbound_sms)
-
-    post_broadcast.before_request(requires_auth)
-    application.register_blueprint(post_broadcast)
+    v2_broadcast_blueprint.before_request(requires_auth)
+    application.register_blueprint(v2_broadcast_blueprint)
 
 
 def init_app(app):

--- a/app/v2/notifications/get_notifications.py
+++ b/app/v2/notifications/get_notifications.py
@@ -55,7 +55,7 @@ def get_pdf_for_notification(notification_id):
     except Exception:
         raise PDFNotReadyError()
 
-    return send_file(filename_or_fp=BytesIO(pdf_data), mimetype='application/pdf')
+    return send_file(path_or_file=BytesIO(pdf_data), mimetype='application/pdf')
 
 
 @v2_notification_blueprint.route("", methods=['GET'])

--- a/requirements.in
+++ b/requirements.in
@@ -7,12 +7,12 @@ Flask-Bcrypt==0.7.1
 flask-marshmallow==0.14.0
 Flask-Migrate==3.1.0
 git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262#egg=Flask-SQLAlchemy==2.3.2.dev20190108
-Flask==1.1.2
+Flask==2.1.0
 click-datetime==0.2
 # Should be pinned until a new gunicorn release greater than 20.1.0 comes out. (Due to eventlet v0.33 compatibility issues)
 git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0
 iso8601==1.0.2
-itsdangerous==1.1.0
+itsdangerous==2.1.2
 jsonschema==3.2.0
 marshmallow-sqlalchemy==0.23.1 # pyup: <0.24.0 # marshmallow v3 throws errors
 marshmallow==2.21.0 # pyup: <3 # v3 throws errors

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ docutils==0.15.2
     # via awscli
 eventlet==0.33.0
     # via gunicorn
-flask==1.1.2
+flask==2.1.0
     # via
     #   -r requirements.in
     #   flask-bcrypt
@@ -103,16 +103,16 @@ geojson==2.5.0
 govuk-bank-holidays==0.10
     # via notifications-utils
 greenlet==1.1.2
-    # via
-    #   eventlet
-    #   sqlalchemy
+    # via eventlet
 gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
     # via -r requirements.in
 idna==3.3
     # via requests
+importlib-metadata==4.11.3
+    # via flask
 iso8601==1.0.2
     # via -r requirements.in
-itsdangerous==1.1.0
+itsdangerous==2.1.2
     # via
     #   -r requirements.in
     #   flask
@@ -252,6 +252,8 @@ werkzeug==2.0.3
     # via
     #   -r requirements.in
     #   flask
+zipp==3.8.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/tests/app/v2/test_errors.py
+++ b/tests/app/v2/test_errors.py
@@ -128,7 +128,7 @@ def test_bad_method(app_for_test):
 
             assert response.status_code == 405
 
-            assert response.json == {
+            assert response.get_json(force=True) == {
                 "result": "error",
                 "message": "The method is not allowed for the requested URL."
             }


### PR DESCRIPTION
This bumps Flask to version 2.1.0, which requires some minor changes to the app code and itsdangerous to also be bumped.

This change is similar to https://github.com/alphagov/notifications-api/pull/3250, which got reverted due to a memory leak. However, since that PR there have been later versions of the code released and we have also been running Flask 2 in template preview with no issues.