### PR TITLE
Adjust resting positions for SMS providers

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -161,8 +161,8 @@ class Config(object):
 
     # these should always add up to 100%
     SMS_PROVIDER_RESTING_POINTS = {
-        'mmg': 50,
-        'firetext': 50
+        'mmg': 55,
+        'firetext': 45
     }
 
     NOTIFY_SERVICE_ID = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'


### PR DESCRIPTION
It's worth noting this will break the Admin page to edit provider
priorities, which currently works in units of 10. We already have
work planned to fix this [^1] and it's not an immediate problem.

The automatic adjustment algorithm will continue to work properly
as it can cope with increments smaller than 10 [^2].

[^1]: https://www.pivotaltracker.com/story/show/181681739
[^2]: https://github.com/alphagov/notifications-api/blob/b145a299351255c5755ca547629b7936cb7fcf4a/app/dao/provider_details_dao.py#L122