### PR TITLE
Limit provider history to 100 results

### DIFF
--- a/app/dao/provider_details_dao.py
+++ b/app/dao/provider_details_dao.py
@@ -36,6 +36,8 @@ def dao_get_provider_versions(provider_id):
         id=provider_id
     ).order_by(
         desc(ProviderDetailsHistory.version)
+    ).limit(
+        100  # limit results instead of adding pagination
     ).all()
 
 


### PR DESCRIPTION
This stops the pages being slow to load and defers the need to add
any pagination. Only the most recent data is likely to be relevant.