### PR TITLE
add new daily sms provider volume report

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -779,6 +779,31 @@ def fetch_daily_volumes_for_platform(start_date, end_date):
     return aggregated_totals
 
 
+def fetch_daily_sms_provider_volumes_for_platform(start_date, end_date):
+    # query to return the total notifications sent per day for each channel. NB start and end dates are inclusive
+
+    daily_volume_stats = db.session.query(
+        FactBilling.bst_date,
+        FactBilling.provider,
+        func.sum(FactBilling.notifications_sent).label('sms_totals'),
+        func.sum(FactBilling.billable_units).label('sms_fragment_totals'),
+        func.sum(FactBilling.billable_units * FactBilling.rate_multiplier).label('sms_chargeable_units'),
+        func.sum(FactBilling.billable_units * FactBilling.rate_multiplier * FactBilling.rate).label('sms_cost'),
+    ).filter(
+        FactBilling.notification_type == SMS_TYPE,
+        FactBilling.bst_date >= start_date,
+        FactBilling.bst_date <= end_date,
+    ).group_by(
+        FactBilling.bst_date,
+        FactBilling.provider,
+    ).order_by(
+        FactBilling.bst_date,
+        FactBilling.provider,
+    ).all()
+
+    return daily_volume_stats
+
+
 def fetch_volumes_by_service(start_date, end_date):
     # query to return the volume totals by service aggregated for the date range given
     # start and end dates are inclusive.

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -5,6 +5,7 @@ from flask import Blueprint, jsonify, request
 from app.dao.date_util import get_financial_year_for_datetime
 from app.dao.fact_billing_dao import (
     fetch_billing_details_for_all_services,
+    fetch_daily_sms_provider_volumes_for_platform,
     fetch_daily_volumes_for_platform,
     fetch_letter_costs_and_totals_for_all_services,
     fetch_letter_line_items_for_all_services,
@@ -157,6 +158,27 @@ def daily_volumes_report():
             "email_totals": int(row.email_totals),
             "letter_totals": int(row.letter_totals),
             "letter_sheet_totals": int(row.letter_sheet_totals)
+        })
+    return jsonify(report)
+
+
+@platform_stats_blueprint.route('daily-sms-provider-volumes-report')
+def daily_sms_provider_volumes_report():
+    start_date = validate_date_format(request.args.get('start_date'))
+    end_date = validate_date_format(request.args.get('end_date'))
+
+    daily_volumes = fetch_daily_sms_provider_volumes_for_platform(start_date, end_date)
+    report = []
+
+    for row in daily_volumes:
+        report.append({
+            'day': row.bst_date.isoformat(),
+            'provider': row.provider,
+            'sms_totals': int(row.sms_totals),
+            'sms_fragment_totals': int(row.sms_fragment_totals),
+            'sms_chargeable_units': int(row.sms_chargeable_units),
+            # convert from Decimal to float as it's not json serialisable
+            'sms_cost': float(row.sms_cost),
         })
     return jsonify(report)
 


### PR DESCRIPTION
code generally lifted almost exactly from the daily_volumes_report, but per provider and only for SMS.

see https://github.com/alphagov/notifications-admin/pull/4206