### PR TITLE
Fix default letter address not being set on new letter templates

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -563,7 +563,7 @@ class Service(db.Model, Versioned):
 
     def get_default_letter_contact(self):
         default_letter_contact = [x for x in self.letter_contacts if x.is_default]
-        return default_letter_contact[0].contact_block if default_letter_contact else None
+        return default_letter_contact[0] if default_letter_contact else None
 
     def has_permission(self, permission):
         return permission in [p.permission for p in self.permissions]

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -246,9 +246,6 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
     def service_permissions(self, service):
         return [p.permission for p in service.permissions]
 
-    def get_letter_contact(self, service):
-        return service.get_default_letter_contact()
-
     class Meta(BaseSchema.Meta):
         model = models.Service
         exclude = (

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -96,8 +96,11 @@ def create_template(service_id):
         errors = {'template_type': [message]}
         raise InvalidRequest(errors, 403)
 
-    if not new_template.postage and new_template.template_type == LETTER_TYPE:
-        new_template.postage = SECOND_CLASS
+    if new_template.template_type == LETTER_TYPE:
+        if default_letter_contact := fetched_service.get_default_letter_contact():
+            new_template.reply_to = default_letter_contact.id
+        if not new_template.postage:
+            new_template.postage = SECOND_CLASS
 
     new_template.service = fetched_service
 

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -274,9 +274,9 @@ def test_service_get_default_reply_to_email_address(sample_service):
 
 
 def test_service_get_default_contact_letter(sample_service):
-    create_letter_contact(service=sample_service, contact_block='London,\nNW1A 1AA')
+    letter_contact = create_letter_contact(service=sample_service, contact_block='London,\nNW1A 1AA')
 
-    assert sample_service.get_default_letter_contact() == 'London,\nNW1A 1AA'
+    assert sample_service.get_default_letter_contact() == letter_contact
 
 
 def test_service_get_default_sms_sender(notify_db_session):


### PR DESCRIPTION
We spotted that when you create a new letter template, it doesn't have the default sender address set. Chris agrees that this is a bug. This PR fixes that so when you create a new letter template, it uses the default. If you don't have a default then no sender address is set.

<img width="804" alt="image" src="https://user-images.githubusercontent.com/7228605/162788421-a9458aba-c37a-4602-a358-d35cc35c607f.png">


It is worth being aware of the impact of this change on a related letter sender address bug. There is a bug where if you copy a letter template, then the new template does not have the sender address of the copied template and is left blank. This PR changes the behaviour of that bug such that if you copy a letter template, then regardless of the value of the sender address for that template, the new template ends up with the services default sender address. Maybe this is an improvement or it could equally be seen as worse. Hopefully Chris has an opinion on whether this is fine or if this PR should only be merged if we also fix that bug too. I have done a quick bit of looking into fixing that bug but it looks like a harder thing to fix and is something I'm not going to try and tackle now.