### PR TITLE
Add internal routes for api and api-sms-receipts

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -7,9 +7,9 @@
       'STATSD_HOST': None
     },
     'routes': {
-      'preview': ['api.notify.works'],
-      'staging': ['api.staging-notify.works'],
-      'production': ['api.notifications.service.gov.uk'],
+      'preview': ['api.notify.works', 'notify-api-preview.apps.internal'],
+      'staging': ['api.staging-notify.works', 'notify-api-staging.apps.internal'],
+      'production': ['api.notifications.service.gov.uk', 'notify-api-production.apps.internal'],
     },
     'health-check-type': 'port',
     'health-check-invocation-timeout': 3,
@@ -27,9 +27,9 @@
       'STATSD_HOST': None
     },
     'routes': {
-      'preview': ['api.notify.works/notifications/sms/mmg', 'api.notify.works/notifications/sms/firetext', 'api.notify.works/notifications/sms/reach'],
-      'staging': ['api.staging-notify.works/notifications/sms/mmg', 'api.staging-notify.works/notifications/sms/firetext', 'api.staging-notify.works/notifications/sms/reach'],
-      'production': ['api.notifications.service.gov.uk/notifications/sms/mmg', 'api.notifications.service.gov.uk/notifications/sms/firetext', 'api.notifications.service.gov.uk/notifications/sms/reach'],
+      'preview': ['api.notify.works/notifications/sms/mmg', 'api.notify.works/notifications/sms/firetext', 'api.notify.works/notifications/sms/reach','notify-api-sms-receipts-preview.apps.internal'],
+      'staging': ['api.staging-notify.works/notifications/sms/mmg', 'api.staging-notify.works/notifications/sms/firetext', 'api.staging-notify.works/notifications/sms/reach', 'notify-api-sms-receipts-staging.apps.internal'],
+      'production': ['api.notifications.service.gov.uk/notifications/sms/mmg', 'api.notifications.service.gov.uk/notifications/sms/firetext', 'api.notifications.service.gov.uk/notifications/sms/reach', 'notify-api-sms-receipts-production.apps.internal' ],
     },
     'health-check-type': 'port',
     'health-check-invocation-timeout': 3,


### PR DESCRIPTION
These routes will be used by prometheus to scrape the `/metrics` endpoint.

### Currently:

The shared prometheus scrapes the `/metrics` endpoint using
the public routes.

The `/metrics` endpoint is provided by the [gds_metrics_python][] which
comes with [bearer-token authentication][] where the token is expected
to be equal to the paas app id.

Each app is configured as a separate target in the shared prometheus
with its app id configured as a GET parameter (e.g.
http://notify-api-production.cloudapps.digital/metrics?cf_app_guid=69c87503-6b53-4c35-XXXX-XXXXXXXXXXXX&cf_app_instance=69c87503-6b53-4c35-XXXX-XXXXXXXXXXXX%3A1&cf_app_instance_index=1)

Each scrape request goes through an nginx proxy which retrieves this
argument from the query string and sets it as a header [[source][]]. This way it
passes the authentication and also is able to instruct the gorouter to
target a specific instance of the app.

### In the future:

Since we're moving away from the shared prometheus and towards an
approach where we [run our own prometheus on PaaS][] we can skip the
need for having an nginx proxy and use the internal routes instead, and
have a [preshared-token][] for authentication if we need to.

[gds_metrics_python]: https://github.com/Crown-Commercial-Service/gds_metrics_python
[bearer-token authentication]: https://github.com/Crown-Commercial-Service/gds_metrics_python/blob/master/gds_metrics/__init__.py#L47-L52
[source]: https://github.com/alphagov/prometheus-aws-configuration-beta/blob/master/terraform/modules/prom-ec2/prometheus/cloud.conf#L111-L123
[run our own prometheus on PaaS]: https://github.com/alphagov/notifications-cf-monitoring/pull/1
[preshared-token]: https://github.com/Crown-Commercial-Service/gds_metrics_python/pull/18