### PR TITLE
Remove redundant ternary on SMS client FROM_NUMBER

### DIFF
--- a/app/clients/sms/__init__.py
+++ b/app/clients/sms/__init__.py
@@ -23,7 +23,6 @@ class SmsClient(Client):
     def init_app(self, current_app, statsd_client):
         self.current_app = current_app
         self.statsd_client = statsd_client
-        self.from_number = self.current_app.config.get('FROM_NUMBER')
 
     def record_outcome(self, success):
         log_message = "Provider request for {} {}".format(
@@ -40,15 +39,6 @@ class SmsClient(Client):
 
     def send_sms(self, to, content, reference, international, sender):
         start_time = monotonic()
-
-        if sender is None:
-            # temporary log to see if the following ternary is necessary
-            # or if it's safe to remove it - keep for 1-2 weeks
-            self.current_app.logger.warning(
-                f"send_sms called with 'sender' of 'None' for {reference}"
-            )
-
-        sender = self.from_number if sender is None else sender
 
         try:
             response = self.try_send_sms(to, content, reference, international, sender)

--- a/tests/app/clients/test_sms.py
+++ b/tests/app/clients/test_sms.py
@@ -24,7 +24,7 @@ def test_send_sms(fake_client, mocker):
         content='content',
         reference='reference',
         international=False,
-        sender=None,
+        sender='testing',
     )
 
     mock_send.assert_called_with(
@@ -45,22 +45,3 @@ def test_send_sms_error(fake_client, mocker):
             international=False,
             sender=None,
         )
-
-
-def test_send_sms_override_configured_shortcode_with_sender(
-    fake_client,
-    mocker
-):
-    mock_send = mocker.patch.object(fake_client, 'try_send_sms')
-
-    fake_client.send_sms(
-        to='to',
-        content='content',
-        reference='reference',
-        international=False,
-        sender='sender'
-    )
-
-    mock_send.assert_called_with(
-        'to', 'content', 'reference', False, 'sender'
-    )


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181665654

Logs over the past 14 days confirm we never call this code with
None as the sender, so it's safe to remove the ternary.