### PR TITLE
When creating a new NHS org, set default email branding to NHS

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -185,6 +185,7 @@ class Config(object):
     MOU_SIGNED_ON_BEHALF_ON_BEHALF_RECEIPT_TEMPLATE_ID = '522b6657-5ca5-4368-a294-6b527703bd0b'
     NOTIFY_INTERNATIONAL_SMS_SENDER = '07984404008'
     LETTERS_VOLUME_EMAIL_TEMPLATE_ID = '11fad854-fd38-4a7c-bd17-805fb13dfc12'
+    NHS_EMAIL_BRANDING_ID = 'a7dc4e56-660b-4db7-8cff-12c37b12b5ea'
     # we only need real email in Live environment (production)
     DVLA_EMAIL_ADDRESSES = json.loads(os.environ.get('DVLA_EMAIL_ADDRESSES', '[]'))
 

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -105,6 +105,12 @@ def create_organisation():
 def update_organisation(organisation_id):
     data = request.get_json()
     validate(data, post_update_organisation_schema)
+
+    organisation = dao_get_organisation_by_id(organisation_id)
+
+    if data.get('organisation_type') in NHS_ORGANISATION_TYPES and not organisation.email_branding_id:
+        data["email_branding_id"] = current_app.config['NHS_EMAIL_BRANDING_ID']
+
     result = dao_update_organisation(organisation_id, **data)
 
     if data.get('agreement_signed') is True:

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -22,7 +22,7 @@ from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.templates_dao import dao_get_template_by_id
 from app.dao.users_dao import get_user_by_id
 from app.errors import InvalidRequest, register_errors
-from app.models import KEY_TYPE_NORMAL, Organisation
+from app.models import KEY_TYPE_NORMAL, NHS_ORGANISATION_TYPES, Organisation
 from app.notifications.process_notifications import (
     persist_notification,
     send_notification_to_queue,
@@ -92,6 +92,9 @@ def create_organisation():
     data = request.get_json()
 
     validate(data, post_create_organisation_schema)
+
+    if data["organisation_type"] in NHS_ORGANISATION_TYPES:
+        data["email_branding_id"] = current_app.config['NHS_EMAIL_BRANDING_ID']
 
     organisation = Organisation(**data)
     dao_create_organisation(organisation)

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -53,6 +53,7 @@ from app.models import (
 from tests import create_admin_authorization_header
 from tests.app.db import (
     create_api_key,
+    create_email_branding,
     create_inbound_number,
     create_invited_org_user,
     create_job,
@@ -917,6 +918,19 @@ def broadcast_organisation(notify_db_session):
         dao_create_organisation(org)
 
     return org
+
+
+@pytest.fixture
+def nhs_email_branding(notify_db_session):
+    # we wipe email_branding table in test db between the tests, so we have to recreate this branding
+    # that is normally present on all environments and applied through migration
+    nhs_email_branding_id = current_app.config['NHS_EMAIL_BRANDING_ID']
+
+    return create_email_branding(
+        id=nhs_email_branding_id,
+        logo='1ac6f483-3105-4c9e-9017-dd7fb2752c44-nhs-blue_x2.png',
+        name='NHS'
+    )
 
 
 @pytest.fixture

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -675,6 +675,7 @@ def create_organisation(
     billing_contact_names=None,
     billing_contact_email_addresses=None,
     billing_reference=None,
+    email_branding_id=None,
 ):
     data = {
         'id': organisation_id,
@@ -685,6 +686,7 @@ def create_organisation(
         'billing_contact_names': billing_contact_names,
         'billing_contact_email_addresses': billing_contact_email_addresses,
         'billing_reference': billing_reference,
+        'email_branding_id': email_branding_id
     }
     organisation = Organisation(**data)
     dao_create_organisation(organisation)

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -502,13 +502,17 @@ def create_service_callback_api(
     return service_callback_api
 
 
-def create_email_branding(colour='blue', logo='test_x2.png', name='test_org_1', text='DisplayName'):
+def create_email_branding(
+    id=None, colour='blue', logo='test_x2.png', name='test_org_1', text='DisplayName'
+):
     data = {
         'colour': colour,
         'logo': logo,
         'name': name,
         'text': text,
     }
+    if id:
+        data['id'] = id
     email_branding = EmailBranding(**data)
     dao_create_email_branding(email_branding)
 

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -192,17 +192,8 @@ def test_post_create_organisation(admin_request, notify_db_session, crown):
 
 @pytest.mark.parametrize('org_type', ["nhs_central", "nhs_local", "nhs_gp"])
 def test_post_create_organisation_sets_default_nhs_branding_for_nhs_orgs(
-    admin_request, notify_db_session, org_type
+    admin_request, notify_db_session, nhs_email_branding, org_type
 ):
-    # we wipe email_branding table in test db between the tests, so we have to recreate this branding
-    # that is normally present on all environments and applied through migration
-    nhs_email_branding_id = current_app.config['NHS_EMAIL_BRANDING_ID']
-    create_email_branding(
-        id=nhs_email_branding_id,
-        logo='1ac6f483-3105-4c9e-9017-dd7fb2752c44-nhs-blue_x2.png',
-        name='NHS'
-    )
-
     data = {
         'name': 'test organisation',
         'active': True,
@@ -219,7 +210,7 @@ def test_post_create_organisation_sets_default_nhs_branding_for_nhs_orgs(
     organisations = Organisation.query.all()
 
     assert len(organisations) == 1
-    assert organisations[0].email_branding_id == uuid.UUID(nhs_email_branding_id)
+    assert organisations[0].email_branding_id == uuid.UUID(current_app.config['NHS_EMAIL_BRANDING_ID'])
 
 
 def test_post_create_organisation_existing_name_raises_400(admin_request, sample_organisation):
@@ -382,18 +373,10 @@ def test_update_other_organisation_attributes_doesnt_clear_domains(
 @pytest.mark.parametrize('new_org_type', ["nhs_central", "nhs_local", "nhs_gp"])
 def test_post_update_organisation_to_nhs_type_updates_branding_if_none_present(
     admin_request,
+    nhs_email_branding,
     notify_db_session,
     new_org_type
 ):
-    # we wipe email_branding table in test db between the tests, so we have to recreate this branding
-    # that is normally present on all environments and applied through migration
-    nhs_email_branding_id = current_app.config['NHS_EMAIL_BRANDING_ID']
-    create_email_branding(
-        id=nhs_email_branding_id,
-        logo='1ac6f483-3105-4c9e-9017-dd7fb2752c44-nhs-blue_x2.png',
-        name='NHS'
-    )
-
     org = create_organisation(organisation_type='central')
     data = {
         'organisation_type': new_org_type,
@@ -411,24 +394,16 @@ def test_post_update_organisation_to_nhs_type_updates_branding_if_none_present(
     assert len(organisation) == 1
     assert organisation[0].id == org.id
     assert organisation[0].organisation_type == new_org_type
-    assert organisation[0].email_branding_id == uuid.UUID(nhs_email_branding_id)
+    assert organisation[0].email_branding_id == uuid.UUID(current_app.config['NHS_EMAIL_BRANDING_ID'])
 
 
 @pytest.mark.parametrize('new_org_type', ["nhs_central", "nhs_local", "nhs_gp"])
 def test_post_update_organisation_to_nhs_type_does_not_update_branding_if_default_branding_set(
     admin_request,
+    nhs_email_branding,
     notify_db_session,
     new_org_type
 ):
-    # we wipe email_branding table in test db between the tests, so we have to recreate this branding
-    # that is normally present on all environment and applied through migration
-    nhs_email_branding_id = current_app.config['NHS_EMAIL_BRANDING_ID']
-    create_email_branding(
-        id=nhs_email_branding_id,
-        logo='1ac6f483-3105-4c9e-9017-dd7fb2752c44-nhs-blue_x2.png',
-        name='NHS'
-    )
-
     current_branding = create_email_branding(
         logo='example.png',
         name='custom branding'


### PR DESCRIPTION
Also when updating existing organisation type to an NHS type, update email branding to NHS branding if none set.

This is part of this story: https://www.pivotaltracker.com/story/show/181415981

Next step: write a migration that will update branding for existing NHS type orgs.