### PR TITLE
Bump jsonschema package from 3.2.0 to 4.4.0

### DIFF
--- a/app/billing/billing_schemas.py
+++ b/app/billing/billing_schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 create_or_update_free_sms_fragment_limit_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST annual billing schema",
     "type": "object",
     "title": "Create",

--- a/app/broadcast_message/broadcast_message_schema.py
+++ b/app/broadcast_message/broadcast_message_schema.py
@@ -2,7 +2,7 @@ from app.models import BroadcastStatusType
 from app.schema_validation.definitions import uuid
 
 create_broadcast_message_schema = {
-    '$schema': 'http://json-schema.org/draft-04/schema#',
+    '$schema': 'http://json-schema.org/draft-07/schema#',
     'description': 'POST create broadcast_message schema',
     'type': 'object',
     'title': 'Create broadcast_message',
@@ -32,7 +32,7 @@ create_broadcast_message_schema = {
 }
 
 update_broadcast_message_schema = {
-    '$schema': 'http://json-schema.org/draft-04/schema#',
+    '$schema': 'http://json-schema.org/draft-07/schema#',
     'description': 'POST update broadcast_message schema',
     'type': 'object',
     'title': 'Update broadcast_message',
@@ -47,7 +47,7 @@ update_broadcast_message_schema = {
 }
 
 update_broadcast_message_status_schema = {
-    '$schema': 'http://json-schema.org/draft-04/schema#',
+    '$schema': 'http://json-schema.org/draft-07/schema#',
     'description': 'POST update broadcast_message status schema',
     'type': 'object',
     'title': 'Update broadcast_message',

--- a/app/complaint/complaint_schema.py
+++ b/app/complaint/complaint_schema.py
@@ -1,6 +1,6 @@
 
 complaint_count_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "complaint count request schema",
     "type": "object",
     "title": "Complaint count request",

--- a/app/email_branding/email_branding_schema.py
+++ b/app/email_branding/email_branding_schema.py
@@ -1,7 +1,7 @@
 from app.models import BRANDING_TYPES
 
 post_create_email_branding_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST schema for getting email_branding",
     "type": "object",
     "properties": {
@@ -15,7 +15,7 @@ post_create_email_branding_schema = {
 }
 
 post_update_email_branding_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST schema for getting email_branding",
     "type": "object",
     "properties": {

--- a/app/inbound_sms/inbound_sms_schemas.py
+++ b/app/inbound_sms/inbound_sms_schemas.py
@@ -1,5 +1,5 @@
 get_inbound_sms_for_service_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "schema for parameters allowed when searching for to field=",
     "type": "object",
     "properties": {

--- a/app/letter_branding/letter_branding_schema.py
+++ b/app/letter_branding/letter_branding_schema.py
@@ -1,5 +1,5 @@
 post_letter_branding_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST schema for creating or updating a letter brand",
     "type": "object",
     "properties": {

--- a/app/letter_branding/letter_branding_schema.py
+++ b/app/letter_branding/letter_branding_schema.py
@@ -6,5 +6,5 @@ post_letter_branding_schema = {
         "name": {"type": ["string", "null"]},
         "filename": {"type": ["string", "null"]},
     },
-    "required": ("name", "filename")
+    "required": ["name", "filename"]
 }

--- a/app/letters/letter_schemas.py
+++ b/app/letters/letter_schemas.py
@@ -1,5 +1,5 @@
 letter_references = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "list of letter notification references",
     "type": "object",
     "title": "references",

--- a/app/notifications/notifications_letter_callback.py
+++ b/app/notifications/notifications_letter_callback.py
@@ -17,7 +17,7 @@ register_errors(letter_callback_blueprint)
 
 
 dvla_sns_callback_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "sns callback received on s3 update",
     "type": "object",
     "title": "dvla internal sns callback",

--- a/app/organisation/organisation_schema.py
+++ b/app/organisation/organisation_schema.py
@@ -2,7 +2,7 @@ from app.models import INVITED_USER_STATUS_TYPES, ORGANISATION_TYPES
 from app.schema_validation.definitions import uuid
 
 post_create_organisation_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST organisation schema",
     "type": "object",
     "properties": {
@@ -15,7 +15,7 @@ post_create_organisation_schema = {
 }
 
 post_update_organisation_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST organisation schema",
     "type": "object",
     "properties": {
@@ -28,7 +28,7 @@ post_update_organisation_schema = {
 }
 
 post_link_service_to_organisation_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST link service to organisation schema",
     "type": "object",
     "properties": {
@@ -39,7 +39,7 @@ post_link_service_to_organisation_schema = {
 
 
 post_create_invited_org_user_status_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST create organisation invite schema",
     "type": "object",
     "properties": {
@@ -52,7 +52,7 @@ post_create_invited_org_user_status_schema = {
 
 
 post_update_invited_org_user_status_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST update organisation invite schema",
     "type": "object",
     "properties": {

--- a/app/performance_dashboard/performance_dashboard_schema.py
+++ b/app/performance_dashboard/performance_dashboard_schema.py
@@ -1,5 +1,5 @@
 performance_dashboard_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "Performance dashboard request schema",
     "type": "object",
     "title": "Performance dashboard request",

--- a/app/platform_stats/platform_stats_schema.py
+++ b/app/platform_stats/platform_stats_schema.py
@@ -1,5 +1,5 @@
 platform_stats_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "platform stats request schema",
     "type": "object",
     "title": "Platform stats request",

--- a/app/service/send_pdf_letter_schema.py
+++ b/app/service/send_pdf_letter_schema.py
@@ -1,5 +1,5 @@
 send_pdf_letter_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST send uploaded pdf letter",
     "type": "object",
     "title": "Send an uploaded pdf letter",

--- a/app/service/service_broadcast_settings_schema.py
+++ b/app/service/service_broadcast_settings_schema.py
@@ -1,5 +1,5 @@
 service_broadcast_settings_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "Set a services broadcast settings",
     "type": "object",
     "title": "Set a services broadcast settings",

--- a/app/service/service_callback_api_schema.py
+++ b/app/service/service_callback_api_schema.py
@@ -1,7 +1,7 @@
 from app.schema_validation.definitions import https_url, uuid
 
 create_service_callback_api_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST service callback/inbound api schema",
     "type": "object",
     "title": "Create service callback/inbound api",
@@ -14,7 +14,7 @@ create_service_callback_api_schema = {
 }
 
 update_service_callback_api_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST service callback/inbound api schema",
     "type": "object",
     "title": "Create service callback/inbound api",

--- a/app/service/service_contact_list_schema.py
+++ b/app/service/service_contact_list_schema.py
@@ -1,7 +1,7 @@
 from app.schema_validation.definitions import uuid
 
 create_service_contact_list_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST create service contact list schema",
     "type": "object",
     "title": "Create service contact list",

--- a/app/service/service_data_retention_schema.py
+++ b/app/service/service_data_retention_schema.py
@@ -1,5 +1,5 @@
 add_service_data_retention_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST service data retention schema",
     "title": "Add service data retention for notification type api",
     "type": "object",
@@ -12,7 +12,7 @@ add_service_data_retention_request = {
 
 
 update_service_data_retention_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST service data retention schema",
     "title": "Update service data retention for notification type api",
     "type": "object",

--- a/app/service/service_senders_schema.py
+++ b/app/service/service_senders_schema.py
@@ -1,7 +1,7 @@
 from app.schema_validation.definitions import uuid
 
 add_service_email_reply_to_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST service email reply to address",
     "type": "object",
     "title": "Add new email reply to address for service",
@@ -14,7 +14,7 @@ add_service_email_reply_to_request = {
 
 
 add_service_letter_contact_block_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST service letter contact block",
     "type": "object",
     "title": "Add new letter contact block for service",
@@ -27,7 +27,7 @@ add_service_letter_contact_block_request = {
 
 
 add_service_sms_sender_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST add service SMS sender",
     "type": "object",
     "title": "Add new SMS sender for service",

--- a/app/template_folder/template_folder_schema.py
+++ b/app/template_folder/template_folder_schema.py
@@ -1,7 +1,7 @@
 from app.schema_validation.definitions import nullable_uuid, uuid
 
 post_create_template_folder_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST schema for getting template_folder",
     "type": "object",
     "properties": {
@@ -12,7 +12,7 @@ post_create_template_folder_schema = {
 }
 
 post_update_template_folder_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST schema for updating template_folder",
     "type": "object",
     "properties": {
@@ -23,7 +23,7 @@ post_update_template_folder_schema = {
 }
 
 post_move_template_folder_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST schema for renaming template_folder",
     "type": "object",
     "properties": {

--- a/app/user/users_schema.py
+++ b/app/user/users_schema.py
@@ -1,5 +1,5 @@
 post_verify_code_schema = {
-    '$schema': 'http://json-schema.org/draft-04/schema#',
+    '$schema': 'http://json-schema.org/draft-07/schema#',
     'description': 'POST schema for verifying a 2fa code',
     'type': 'object',
     'properties': {
@@ -12,7 +12,7 @@ post_verify_code_schema = {
 
 
 post_verify_webauthn_schema = {
-    '$schema': 'http://json-schema.org/draft-04/schema#',
+    '$schema': 'http://json-schema.org/draft-07/schema#',
     'description': 'POST schema for verifying a webauthn login attempt',
     'type': 'object',
     'properties': {
@@ -24,7 +24,7 @@ post_verify_webauthn_schema = {
 
 
 post_send_user_email_code_schema = {
-    '$schema': 'http://json-schema.org/draft-04/schema#',
+    '$schema': 'http://json-schema.org/draft-07/schema#',
     'description': (
         'POST schema for generating a 2fa email - "to" is required for legacy purposes. '
         '"next" is an optional url to redirect to on sign in'
@@ -43,7 +43,7 @@ post_send_user_email_code_schema = {
 
 
 post_send_user_sms_code_schema = {
-    '$schema': 'http://json-schema.org/draft-04/schema#',
+    '$schema': 'http://json-schema.org/draft-07/schema#',
     'description': 'POST schema for generating a 2fa sms',
     'type': 'object',
     'properties': {

--- a/app/v2/inbound_sms/inbound_sms_schemas.py
+++ b/app/v2/inbound_sms/inbound_sms_schemas.py
@@ -1,7 +1,7 @@
 from app.schema_validation.definitions import uuid
 
 get_inbound_sms_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "schema for query parameters allowed when getting list of received text messages",
     "type": "object",
     "properties": {
@@ -12,7 +12,7 @@ get_inbound_sms_request = {
 
 
 get_inbound_sms_single_response = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "GET inbound sms schema response",
     "type": "object",
     "title": "GET response v2/inbound_sms",
@@ -36,7 +36,7 @@ get_inbound_sms_single_response = {
 }
 
 get_inbound_sms_response = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "GET list of inbound sms response schema",
     "type": "object",
     "properties": {

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -7,7 +7,7 @@ from app.models import (
 from app.schema_validation.definitions import personalisation, uuid
 
 template = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "template schema",
     "type": "object",
     "title": "notification content",
@@ -20,7 +20,7 @@ template = {
 }
 
 notification_by_id = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "GET notification response schema",
     "type": "object",
     "title": "response v2/notification",
@@ -32,7 +32,7 @@ notification_by_id = {
 
 
 get_notification_response = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "GET notification response schema",
     "type": "object",
     "title": "response v2/notification",
@@ -67,7 +67,7 @@ get_notification_response = {
 }
 
 get_notifications_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "schema for query parameters allowed when getting list of notifications",
     "type": "object",
     "properties": {
@@ -92,7 +92,7 @@ get_notifications_request = {
 }
 
 get_notifications_response = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "GET list of notifications response schema",
     "type": "object",
     "properties": {
@@ -126,7 +126,7 @@ get_notifications_response = {
 }
 
 post_sms_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST sms notification schema",
     "type": "object",
     "title": "POST v2/notifications/sms",
@@ -143,7 +143,7 @@ post_sms_request = {
 }
 
 sms_content = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "content schema for SMS notification response schema",
     "type": "object",
     "title": "notification content",
@@ -155,7 +155,7 @@ sms_content = {
 }
 
 post_sms_response = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST sms notification response schema",
     "type": "object",
     "title": "response v2/notifications/sms",
@@ -172,7 +172,7 @@ post_sms_response = {
 
 
 post_email_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST email notification schema",
     "type": "object",
     "title": "POST v2/notifications/email",
@@ -189,7 +189,7 @@ post_email_request = {
 }
 
 email_content = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "Email content for POST email notification",
     "type": "object",
     "title": "notification email content",
@@ -202,7 +202,7 @@ email_content = {
 }
 
 post_email_response = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST email notification response schema",
     "type": "object",
     "title": "response v2/notifications/email",
@@ -218,7 +218,7 @@ post_email_response = {
 }
 
 post_letter_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST letter notification schema",
     "type": "object",
     "title": "POST v2/notifications/letter",
@@ -232,7 +232,7 @@ post_letter_request = {
 }
 
 post_precompiled_letter_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST precompiled letter notification schema",
     "type": "object",
     "title": "POST v2/notifications/letter",
@@ -246,7 +246,7 @@ post_precompiled_letter_request = {
 }
 
 letter_content = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "Letter content for POST letter notification",
     "type": "object",
     "title": "notification letter content",
@@ -258,7 +258,7 @@ letter_content = {
 }
 
 post_letter_response = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST sms notification response schema",
     "type": "object",
     "title": "response v2/notifications/letter",

--- a/app/v2/template/template_schemas.py
+++ b/app/v2/template/template_schemas.py
@@ -2,7 +2,7 @@ from app.models import TEMPLATE_TYPES
 from app.schema_validation.definitions import personalisation, uuid
 
 get_template_by_id_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "schema for parameters allowed when getting template by id",
     "type": "object",
     "properties": {
@@ -14,7 +14,7 @@ get_template_by_id_request = {
 }
 
 get_template_by_id_response = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "GET template by id schema response",
     "type": "object",
     "title": "reponse v2/template",
@@ -42,7 +42,7 @@ get_template_by_id_response = {
 }
 
 post_template_preview_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST template schema",
     "type": "object",
     "title": "POST v2/template/{id}/preview",
@@ -54,7 +54,7 @@ post_template_preview_request = {
 }
 
 post_template_preview_response = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST template preview schema response",
     "type": "object",
     "title": "reponse v2/template/{id}/preview",

--- a/app/v2/templates/templates_schemas.py
+++ b/app/v2/templates/templates_schemas.py
@@ -4,7 +4,7 @@ from app.v2.template.template_schemas import (
 )
 
 get_all_template_request = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "request schema for parameters allowed when getting all templates",
     "type": "object",
     "properties": {
@@ -14,7 +14,7 @@ get_all_template_request = {
 }
 
 get_all_template_response = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "GET response schema when getting all templates",
     "type": "object",
     "properties": {

--- a/requirements.in
+++ b/requirements.in
@@ -13,14 +13,12 @@ click-datetime==0.2
 git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0
 iso8601==1.0.2
 itsdangerous==2.1.2
-jsonschema==4.4.0
+jsonschema[format]==4.4.0
 marshmallow-sqlalchemy==0.23.1 # pyup: <0.24.0 # marshmallow v3 throws errors
 marshmallow==2.21.0 # pyup: <3 # v3 throws errors
 psycopg2-binary==2.9.3
 PyJWT==2.3.0
 SQLAlchemy==1.4.35
-rfc3339-validator==0.1.4
-rfc3987==1.3.8
 cachetools==5.0.0
 beautifulsoup4==4.10.0
 lxml==4.8.0

--- a/requirements.in
+++ b/requirements.in
@@ -13,13 +13,13 @@ click-datetime==0.2
 git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0
 iso8601==1.0.2
 itsdangerous==2.1.2
-jsonschema==3.2.0
+jsonschema==4.4.0
 marshmallow-sqlalchemy==0.23.1 # pyup: <0.24.0 # marshmallow v3 throws errors
 marshmallow==2.21.0 # pyup: <3 # v3 throws errors
 psycopg2-binary==2.9.3
 PyJWT==2.3.0
 SQLAlchemy==1.4.35
-strict-rfc3339==0.7
+rfc3339-validator==0.1.4
 rfc3987==1.3.8
 cachetools==5.0.0
 beautifulsoup4==4.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ alembic==1.7.4
     # via flask-migrate
 amqp==5.0.9
     # via kombu
+arrow==1.2.2
+    # via isoduration
 attrs==21.2.0
     # via jsonschema
 awscli==1.21.4
@@ -94,6 +96,8 @@ flask-sqlalchemy @ git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732
     # via
     #   -r requirements.in
     #   flask-migrate
+fqdn==1.5.1
+    # via jsonschema
 gds-metrics==0.2.4
     # via -r requirements.in
 geojson==2.5.0
@@ -105,11 +109,15 @@ greenlet==1.1.2
 gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
     # via -r requirements.in
 idna==3.3
-    # via requests
+    # via
+    #   jsonschema
+    #   requests
 importlib-metadata==4.11.3
     # via flask
 iso8601==1.0.2
     # via -r requirements.in
+isoduration==20.11.0
+    # via jsonschema
 itsdangerous==2.1.2
     # via
     #   -r requirements.in
@@ -123,7 +131,9 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-jsonschema==4.4.0
+jsonpointer==2.3
+    # via jsonschema
+jsonschema[format]==4.4.0
     # via -r requirements.in
 kombu==5.2.3
     # via celery
@@ -180,6 +190,7 @@ pyrsistent==0.18.0
     # via jsonschema
 python-dateutil==2.8.2
     # via
+    #   arrow
     #   awscli-cwlogs
     #   botocore
 python-json-logger==2.0.2
@@ -201,9 +212,9 @@ requests==2.26.0
     #   notifications-python-client
     #   notifications-utils
 rfc3339-validator==0.1.4
-    # via -r requirements.in
+    # via jsonschema
 rfc3987==1.3.8
-    # via -r requirements.in
+    # via jsonschema
 rsa==4.7.2
     # via awscli
 s3transfer==0.5.0
@@ -233,6 +244,8 @@ sqlalchemy==1.4.35
     #   marshmallow-sqlalchemy
 statsd==3.3.0
     # via notifications-utils
+uri-template==1.2.0
+    # via jsonschema
 urllib3==1.26.7
     # via
     #   botocore
@@ -244,6 +257,8 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.5
     # via prompt-toolkit
+webcolors==1.11.1
+    # via jsonschema
 webencodings==0.5.1
     # via bleach
 werkzeug==2.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-jsonschema==3.2.0
+jsonschema==4.4.0
     # via -r requirements.in
 kombu==5.2.3
     # via celery
@@ -200,6 +200,8 @@ requests==2.26.0
     #   govuk-bank-holidays
     #   notifications-python-client
     #   notifications-utils
+rfc3339-validator==0.1.4
+    # via -r requirements.in
 rfc3987==1.3.8
     # via -r requirements.in
 rsa==4.7.2
@@ -218,8 +220,8 @@ six==1.16.0
     #   click-repl
     #   eventlet
     #   flask-marshmallow
-    #   jsonschema
     #   python-dateutil
+    #   rfc3339-validator
 smartypants==2.0.1
     # via notifications-utils
 soupsieve==2.2.1
@@ -231,8 +233,6 @@ sqlalchemy==1.4.35
     #   marshmallow-sqlalchemy
 statsd==3.3.0
     # via notifications-utils
-strict-rfc3339==0.7
-    # via -r requirements.in
 urllib3==1.26.7
     # via
     #   botocore

--- a/tests/app/complaint/test_complaint_rest.py
+++ b/tests/app/complaint/test_complaint_rest.py
@@ -87,5 +87,4 @@ def test_get_complaint_with_invalid_data_returns_400_status_code(client):
     )
 
     assert response.status_code == 400
-    assert response.json['errors'][0]['message'] == 'start_date time data {} does not match format %Y-%m-%d'.format(
-        start_date)
+    assert response.json['errors'][0]['message'] == 'start_date month must be in 1..12'

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -48,8 +48,7 @@ def test_get_platform_stats_validates_the_date(admin_request):
         _expected_status=400
     )
 
-    assert response['errors'][0]['message'] == 'start_date time data {} does not match format %Y-%m-%d'.format(
-        start_date)
+    assert response['errors'][0]['message'] == 'start_date month must be in 1..12'
 
 
 @freeze_time('2018-10-31 14:00')

--- a/tests/app/public_contracts/__init__.py
+++ b/tests/app/public_contracts/__init__.py
@@ -2,7 +2,7 @@ import os
 
 import jsonschema
 from flask import json
-from jsonschema import Draft4Validator
+from jsonschema import Draft7Validator
 
 
 def return_json_from_response(response):
@@ -22,5 +22,5 @@ def validate_v0(json_to_validate, schema_filename):
 
 
 def validate(json_to_validate, schema):
-    validator = Draft4Validator(schema)
+    validator = Draft7Validator(schema)
     validator.validate(json_to_validate, schema)

--- a/tests/app/public_contracts/schemas/v0/GET_notification_return_email.json
+++ b/tests/app/public_contracts/schemas/v0/GET_notification_return_email.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "GET notification return schema - for email notifications",
   "type" : "object",
   "properties": {

--- a/tests/app/public_contracts/schemas/v0/GET_notification_return_sms.json
+++ b/tests/app/public_contracts/schemas/v0/GET_notification_return_sms.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "GET notification return schema - for sms notifications",
   "type" : "object",
   "properties": {

--- a/tests/app/public_contracts/schemas/v0/GET_notifications_return.json
+++ b/tests/app/public_contracts/schemas/v0/GET_notifications_return.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "GET notification return schema - for sms notifications",
   "type" : "object",
   "properties": {

--- a/tests/app/public_contracts/schemas/v0/POST_notification_return_email.json
+++ b/tests/app/public_contracts/schemas/v0/POST_notification_return_email.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "POST notification return schema - for email notifications",
   "type" : "object",
   "properties": {

--- a/tests/app/public_contracts/schemas/v0/POST_notification_return_sms.json
+++ b/tests/app/public_contracts/schemas/v0/POST_notification_return_sms.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "POST notification return schema - for sms notifications",
   "type" : "object",
   "properties": {

--- a/tests/app/public_contracts/schemas/v0/definitions.json
+++ b/tests/app/public_contracts/schemas/v0/definitions.json
@@ -4,9 +4,5 @@
   "uuid": {
     "type": "string",
     "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-  },
-  "datetime": {
-    "type": "string",
-    "format": "date-time"
   }
 }

--- a/tests/app/public_contracts/schemas/v0/definitions.json
+++ b/tests/app/public_contracts/schemas/v0/definitions.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Common definitions - usage example: {'$ref': 'definitions.json#/uuid'} (swap quotes for double quotes)",
   "uuid": {
     "type": "string",

--- a/tests/app/public_contracts/schemas/v0/email_notification.json
+++ b/tests/app/public_contracts/schemas/v0/email_notification.json
@@ -14,19 +14,13 @@
       "type": "string",
       "enum": ["email"]
     },
-    "created_at": {"$ref": "definitions.json#/datetime"},
-    "sent_at": {"oneOf":[
-      {"$ref": "definitions.json#/datetime"},
-      {"type": "null"}
-    ]},
+    "created_at": {"type": "string", "format": "date-time"},
+    "sent_at": {"type": ["string", "null"], "format": "date-time"},
     "sent_by": {"oneOf":[
       {"type": "string"},
       {"type": "null"}
     ]},
-    "updated_at": {"oneOf":[
-      {"$ref": "definitions.json#/datetime"},
-      {"type": "null"}
-    ]},
+    "updated_at": {"type": ["string", "null"], "format": "date-time"},
     "status": {
       "type": "string",
       "enum": [

--- a/tests/app/public_contracts/schemas/v0/sms_notification.json
+++ b/tests/app/public_contracts/schemas/v0/sms_notification.json
@@ -14,19 +14,13 @@
       "type": "string",
       "enum": ["sms"]
     },
-    "created_at": {"$ref": "definitions.json#/datetime"},
-    "sent_at": {"oneOf":[
-      {"$ref": "definitions.json#/datetime"},
-      {"type": "null"}
-    ]},
+    "created_at": {"type": "string", "format": "date-time"},
+    "sent_at": {"type": ["string", "null"], "format": "date-time"},
     "sent_by": {"oneOf":[
       {"type": "string"},
       {"type": "null"}
     ]},
-    "updated_at": {"oneOf":[
-      {"$ref": "definitions.json#/datetime"},
-      {"type": "null"}
-    ]},
+    "updated_at": {"type": ["string", "null"], "format": "date-time"},
     "status": {
       "type": "string",
       "enum": [


### PR DESCRIPTION
**Use Draft-07 and Draft7Validator everywhere**
We were using the Draft4Validator in one place, so this updates it to the Draft7Validator instead.

The schemas were mostly using draft 4 of the JSON schema, though there were a couple of schemas that were already of version 7. This updates them all to version 7, which is the latest version fully supported by the jsonschema Python package. There are some breaking changes in the newer version of the schema, but I could not see anywhere would these affect us. Some of these schemas were not valid in version 4, but are now valid in version 7 because `"required": []` was not valid in earlier versions.

**Bump jsonschema from 3.2.0 to 4.4.0**
The big breaking change for our code (not mentioned in the changelog) is that the built-in validator for the `date-time` format now requires the `rfc3339-validator` package instead of the `strict-rfc3339` package. This updates the requirements file to use `rfc3339-validator`. Without this change, wrong `date-time` formats would always silently pass validation.

**Remove one of our own jsonschema date-time formatters**
We have three different ways of checking the formats of datetimes.
1. The built-in way that comes with the jsonschema package ("date-time")
2. A new way we added for broadcasts ("datetime") https://github.com/alphagov/notifications-api/commit/61a5730596ca2990851bd4e3b69c9e0c578264c9
3. An old way we defined in [/tests/app/public_contracts/schemas/v0/definitions.json](https://github.com/alphagov/notifications-api/blob/153ffd52c4065643554fc4f363c5e2c538d80b5e/tests/app/public_contracts/schemas/v0/definitions.json#L8)

In order to simplify things and make it clearer how datetimes are being validated, this replaces the few places where we were using option 3 with option 1 instead. Option 3 was only being used to validate code that is no longer used, the initial version of the API.
