### PR TITLE
Remove redundant CloudFoundry config code

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -1,25 +1,13 @@
-"""
-Extracts cloudfoundry config from its json and populates the environment variables that we would expect to be populated
-on local/aws boxes
-"""
-
 import json
 import os
 
 
 def extract_cloudfoundry_config():
     vcap_services = json.loads(os.environ['VCAP_SERVICES'])
-    set_config_env_vars(vcap_services)
 
-
-def set_config_env_vars(vcap_services):
     # Postgres config
     os.environ['SQLALCHEMY_DATABASE_URI'] = vcap_services['postgres'][0]['credentials']['uri'].replace('postgres',
                                                                                                        'postgresql')
     # Redis config
     if 'redis' in vcap_services:
         os.environ['REDIS_URL'] = vcap_services['redis'][0]['credentials']['uri']
-
-    vcap_application = json.loads(os.environ['VCAP_APPLICATION'])
-    os.environ['NOTIFY_ENVIRONMENT'] = vcap_application['space_name']
-    os.environ['NOTIFY_LOG_PATH'] = '/home/vcap/logs/app.log'

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -107,8 +107,10 @@ applications:
 
     env:
       NOTIFY_APP_NAME: {{ app.get('NOTIFY_APP_NAME', CF_APP.replace('notify-', '')) }}
+      NOTIFY_LOG_PATH: /home/vcap/logs/app.log
       SQLALCHEMY_POOL_SIZE: {{ app.get('sqlalchemy_pool_size', 1) }}
       FLASK_APP: application.py
+      NOTIFY_ENVIRONMENT: {{ environment }}
 
       # Credentials variables
       ADMIN_BASE_URL: '{{ ADMIN_BASE_URL }}'

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -3,14 +3,11 @@ import os
 
 import pytest
 
-from app.cloudfoundry_config import (
-    extract_cloudfoundry_config,
-    set_config_env_vars,
-)
+from app.cloudfoundry_config import extract_cloudfoundry_config
 
 
 @pytest.fixture
-def cloudfoundry_config():
+def vcap_services():
     return {
         'postgres': [{
             'credentials': {
@@ -26,34 +23,17 @@ def cloudfoundry_config():
     }
 
 
-@pytest.fixture
-def vcap_application(os_environ):
-    os.environ['VCAP_APPLICATION'] = '{"space_name": "🚀🌌"}'
-
-
-def test_extract_cloudfoundry_config_populates_other_vars(cloudfoundry_config, vcap_application):
-    os.environ['VCAP_SERVICES'] = json.dumps(cloudfoundry_config)
+def test_extract_cloudfoundry_config_populates_other_vars(os_environ, vcap_services):
+    os.environ['VCAP_SERVICES'] = json.dumps(vcap_services)
     extract_cloudfoundry_config()
 
     assert os.environ['SQLALCHEMY_DATABASE_URI'] == 'postgresql uri'
     assert os.environ['REDIS_URL'] == 'redis uri'
-    assert os.environ['NOTIFY_ENVIRONMENT'] == '🚀🌌'
-    assert os.environ['NOTIFY_LOG_PATH'] == '/home/vcap/logs/app.log'
 
 
-def test_set_config_env_vars_ignores_unknown_configs(cloudfoundry_config, vcap_application):
-    cloudfoundry_config['foo'] = {'credentials': {'foo': 'foo'}}
-    cloudfoundry_config['user-provided'].append({
-        'name': 'bar', 'credentials': {'bar': 'bar'}
-    })
+def test_extract_cloudfoundry_config_copes_if_redis_not_set(os_environ, vcap_services):
+    del vcap_services['redis']
+    os.environ['VCAP_SERVICES'] = json.dumps(vcap_services)
 
-    set_config_env_vars(cloudfoundry_config)
-
-    assert 'foo' not in os.environ
-    assert 'bar' not in os.environ
-
-
-def test_set_config_env_vars_copes_if_redis_not_set(cloudfoundry_config, vcap_application):
-    del cloudfoundry_config['redis']
-    set_config_env_vars(cloudfoundry_config)
+    extract_cloudfoundry_config()
     assert 'REDIS_URL' not in os.environ


### PR DESCRIPTION
These env vars can be set directly in the manifest, like we do for
Template Preview [^1].

[^1]: https://github.com/alphagov/notifications-template-preview/blob/c08036189bf40b37516f921967dd21943bb72a63/manifest.yml.j2#L23-L26