### PR TITLE
Update beautifulsoup4 to 4.11.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ SQLAlchemy==1.4.35
 strict-rfc3339==0.7
 rfc3987==1.3.8
 cachetools==5.0.0
-beautifulsoup4==4.10.0
+beautifulsoup4==4.11.1
 lxml==4.8.0
 Werkzeug==2.0.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ awscli-cwlogs==1.4.6
     # via -r requirements.in
 bcrypt==3.2.0
     # via flask-bcrypt
-beautifulsoup4==4.10.0
+beautifulsoup4==4.11.1
     # via -r requirements.in
 billiard==3.6.4.0
     # via celery

--- a/tests/app/v2/broadcast/sample_cap_xml_documents.py
+++ b/tests/app/v2/broadcast/sample_cap_xml_documents.py
@@ -248,5 +248,5 @@ WINDEMERE = """
 """
 
 LONG_GSM7 = WITH_PLACEHOLDER_FOR_CONTENT.format('a' * 1396)
-LONG_UCS2 = WITH_PLACEHOLDER_FOR_CONTENT.format('ŵ' * 616)
+LONG_UCS2 = WITH_PLACEHOLDER_FOR_CONTENT.format('ŵyl' * 205 + 'a')
 MISSING_AREA_NAMES = re.sub("<areaDesc>.*</areaDesc>", "<areaDesc> </areaDesc>", WAINFLEET)


### PR DESCRIPTION
`charset-normalizer` is now used by default if installed instead of `chardet` (https://pyup.io/changelogs/beautifulsoup4/#4.11.0). We do have `charset-normalizer` installed because it's a subdependency of the requests library, so it is being used.

This caused the `test_content_too_long_returns_400` to fail since it now thought that the encoding of `ŵ` is
`{'encoding': 'Big5', 'language': 'Chinese', 'confidence': 1.0}`.

There are two options for fixing this
1. change the test content so that it doesn't just contain a single letter - the docs state that you shouldn't run character detection on very tiny content
2. add `chardet` as a requirement, so that the code functions exactly the same as before

I've chose the first option, since this avoids adding a dependency and we should never have messages consisting of a single character. Happy to change if others disagree though.