### PR TITLE
bind to notify-redis automatically

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -9,5 +9,4 @@ def extract_cloudfoundry_config():
     os.environ['SQLALCHEMY_DATABASE_URI'] = vcap_services['postgres'][0]['credentials']['uri'].replace('postgres',
                                                                                                        'postgresql')
     # Redis config
-    if 'redis' in vcap_services:
-        os.environ['REDIS_URL'] = vcap_services['redis'][0]['credentials']['uri']
+    os.environ['REDIS_URL'] = vcap_services['redis'][0]['credentials']['uri']

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -99,6 +99,7 @@ applications:
 
     services:
       - notify-db
+      - notify-redis
       - logit-ssl-syslog-drain
       {% if CF_APP == 'notify-api' %}
       - notify-prometheus
@@ -144,7 +145,6 @@ applications:
       FIRETEXT_INBOUND_SMS_AUTH: '{{ FIRETEXT_INBOUND_SMS_AUTH | tojson }}'
 
       REDIS_ENABLED: '{{ REDIS_ENABLED }}'
-      REDIS_URL: '{{ REDIS_URL }}'
 
       TEMPLATE_PREVIEW_API_HOST: '{{ TEMPLATE_PREVIEW_API_HOST }}'
       TEMPLATE_PREVIEW_API_KEY: '{{ TEMPLATE_PREVIEW_API_KEY }}'

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -29,11 +29,3 @@ def test_extract_cloudfoundry_config_populates_other_vars(os_environ, vcap_servi
 
     assert os.environ['SQLALCHEMY_DATABASE_URI'] == 'postgresql uri'
     assert os.environ['REDIS_URL'] == 'redis uri'
-
-
-def test_extract_cloudfoundry_config_copes_if_redis_not_set(os_environ, vcap_services):
-    del vcap_services['redis']
-    os.environ['VCAP_SERVICES'] = json.dumps(vcap_services)
-
-    extract_cloudfoundry_config()
-    assert 'REDIS_URL' not in os.environ


### PR DESCRIPTION
this ensures all apps are bound to redis (for example any new worker types)

to be merged once manual deploy has been rolled out to all apps/envs.