### PR TITLE
Show correct sms cost in org view if sms rates change within financial year

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -720,52 +720,42 @@ def fetch_email_usage_for_organisation(organisation_id, start_date, end_date):
     return query.all()
 
 
-def fetch_sms_billing_for_organisation(organisation_id, start_date, end_date):
+def fetch_sms_billing_for_organisation(organisation_id, financial_year):
     # ASSUMPTION: AnnualBilling has been populated for year.
-    allowance_left_at_start_date_query = fetch_sms_free_allowance_remainder_until_date(start_date).subquery()
+    ft_billing_subquery = query_organisation_sms_usage_for_year(organisation_id, financial_year).subquery()
 
-    sms_billable_units = func.coalesce(func.sum(FactBilling.billable_units * FactBilling.rate_multiplier), 0)
+    sms_billable_units = func.sum(func.coalesce(ft_billing_subquery.c.chargeable_units, 0))
 
     # subtract sms_billable_units units accrued since report's start date to get up-to-date
     # allowance remainder
-    sms_allowance_left = func.greatest(allowance_left_at_start_date_query.c.sms_remainder - sms_billable_units, 0)
+    sms_allowance_left = func.greatest(AnnualBilling.free_sms_fragment_limit - sms_billable_units, 0)
 
-    # billable units here are for period between start date and end date only, so to see
-    # how many are chargeable, we need to see how much free allowance was used up in the
-    # period up until report's start date and then do a subtraction
-    chargeable_sms = func.greatest(sms_billable_units - allowance_left_at_start_date_query.c.sms_remainder, 0)
-    sms_cost = chargeable_sms * FactBilling.rate
+    chargeable_sms = func.sum(ft_billing_subquery.c.charged_units)
+    sms_cost = func.sum(ft_billing_subquery.c.cost)
 
     query = db.session.query(
         Service.name.label("service_name"),
         Service.id.label("service_id"),
-        func.coalesce(allowance_left_at_start_date_query.c.free_sms_fragment_limit, 0).label('free_sms_fragment_limit'),
-        func.coalesce(FactBilling.rate, 0).label('sms_rate'),
+        AnnualBilling.free_sms_fragment_limit,
         func.coalesce(sms_allowance_left, 0).label("sms_remainder"),
         func.coalesce(sms_billable_units, 0).label('sms_billable_units'),
         func.coalesce(chargeable_sms, 0).label("chargeable_billable_sms"),
         func.coalesce(sms_cost, 0).label('sms_cost'),
-        Service.active.label("active")
+        Service.active
     ).select_from(
         Service
     ).outerjoin(
-        allowance_left_at_start_date_query, Service.id == allowance_left_at_start_date_query.c.service_id
+        AnnualBilling,
+        and_(Service.id == AnnualBilling.service_id, AnnualBilling.financial_year_start == financial_year)
     ).outerjoin(
-        FactBilling, and_(
-            Service.id == FactBilling.service_id,
-            FactBilling.bst_date >= start_date,
-            FactBilling.bst_date < end_date,
-            FactBilling.notification_type == SMS_TYPE,
-        )
+        ft_billing_subquery, Service.id == ft_billing_subquery.c.service_id
     ).filter(
         Service.organisation_id == organisation_id,
         Service.restricted.is_(False)
     ).group_by(
         Service.id,
         Service.name,
-        allowance_left_at_start_date_query.c.free_sms_fragment_limit,
-        allowance_left_at_start_date_query.c.sms_remainder,
-        FactBilling.rate,
+        AnnualBilling.free_sms_fragment_limit
     ).order_by(
         Service.name
     )
@@ -856,7 +846,7 @@ def fetch_usage_year_for_organisation(organisation_id, year):
             'emails_sent': 0,
             'active': service.active
         }
-    sms_usages = fetch_sms_billing_for_organisation(organisation_id, year_start, year_end)
+    sms_usages = fetch_sms_billing_for_organisation(organisation_id, year)
     letter_usages = fetch_letter_costs_for_organisation(organisation_id, year_start, year_end)
     email_usages = fetch_email_usage_for_organisation(organisation_id, year_start, year_end)
     for usage in sms_usages:

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -773,6 +773,63 @@ def fetch_sms_billing_for_organisation(organisation_id, start_date, end_date):
     return query.all()
 
 
+def query_organisation_sms_usage_for_year(organisation_id, year):
+    """
+    See docstring for query_service_sms_usage_for_year()
+    """
+    year_start, year_end = get_financial_year_dates(year)
+    this_rows_chargeable_units = FactBilling.billable_units * FactBilling.rate_multiplier
+
+    # Subquery for the number of chargeable units in all rows preceding this one,
+    # which might be none if this is the first row (hence the "coalesce").
+    chargeable_units_used_so_far = func.coalesce(
+        func.sum(this_rows_chargeable_units).over(
+            # order is "ASC" by default
+            order_by=[FactBilling.bst_date],
+
+            # partition by service id
+            partition_by=FactBilling.service_id,
+
+            # first row to previous row
+            rows=(None, -1)
+        ).cast(Integer),
+        0
+    )
+
+    # Subquery for how much free allowance we have left before the current row,
+    # so we can work out the cost for this row after taking it into account.
+    remaining_free_allowance_before_this_row = func.greatest(
+        AnnualBilling.free_sms_fragment_limit - chargeable_units_used_so_far,
+        0
+    )
+
+    # Subquery for the number of chargeable_units that we will actually charge
+    # for, after taking any remaining free allowance into account.
+    charged_units = func.greatest(this_rows_chargeable_units - remaining_free_allowance_before_this_row, 0)
+
+    return db.session.query(
+        Service.id.label('service_id'),
+        FactBilling.bst_date,
+        this_rows_chargeable_units.label("chargeable_units"),
+        (charged_units * FactBilling.rate).label("cost"),
+        charged_units.label("charged_units"),
+    ).join(
+        AnnualBilling,
+        AnnualBilling.service_id == Service.id
+    ).outerjoin(
+        FactBilling,
+        and_(
+            Service.id == FactBilling.service_id,
+            FactBilling.bst_date >= year_start,
+            FactBilling.bst_date <= year_end,
+            FactBilling.notification_type == SMS_TYPE,
+        )
+    ).filter(
+        Service.organisation_id == organisation_id,
+        AnnualBilling.financial_year_start == year,
+    )
+
+
 def fetch_usage_year_for_organisation(organisation_id, year):
     year_start, year_end = get_financial_year_dates(year)
     today = convert_utc_to_bst(datetime.utcnow()).date()

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -998,6 +998,7 @@ def set_up_usage_data(start_date):
         name='Org for {}'.format(service_with_emails.name),
     )
     dao_add_service_to_organisation(service=service_with_emails, organisation_id=org_2.id)
+    create_annual_billing(service_id=service_with_emails.id, free_sms_fragment_limit=0, financial_year_start=year)
 
     create_ft_billing(bst_date=start_date, template=email_template, notifications_sent=10)
 
@@ -1012,6 +1013,7 @@ def set_up_usage_data(start_date):
         billing_reference="org3 billing reference"
     )
     dao_add_service_to_organisation(service=service_with_letters, organisation_id=org_for_service_with_letters.id)
+    create_annual_billing(service_id=service_with_letters.id, free_sms_fragment_limit=0, financial_year_start=year)
 
     create_ft_billing(bst_date=start_date, template=letter_template_3,
                       notifications_sent=2, billable_unit=3, rate=.50, postage='first')
@@ -1023,6 +1025,11 @@ def set_up_usage_data(start_date):
     # service with letters, without an organisation:
     service_with_letters_without_org = create_service(service_name='d - service without org')
     letter_template_4 = create_template(service=service_with_letters_without_org, template_type='letter')
+    create_annual_billing(
+        service_id=service_with_letters_without_org.id,
+        free_sms_fragment_limit=0,
+        financial_year_start=year
+    )
 
     create_ft_billing(bst_date=two_days_later, template=letter_template_4,
                       notifications_sent=7, billable_unit=4, rate=1.55, postage='rest-of-world')

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -214,7 +214,9 @@ def test_volumes_by_service_report(
         end_date='2022-03-01'
     )
 
-    assert len(response) == 4
+    assert len(response) == 7
+
+    # since we are using a pre-set up fixture, we only care about some of the results
     assert response[0] == {'email_totals': 0, 'free_allowance': 10, 'letter_cost': 0.0,
                            'letter_sheet_totals': 0, 'letter_totals': 0,
                            'organisation_id': str(fixture['org_1'].id),
@@ -228,12 +230,12 @@ def test_volumes_by_service_report(
                            'service_id': str(fixture['service_with_out_ft_billing_this_year'].id),
                            'service_name': fixture['service_with_out_ft_billing_this_year'].name,
                            'sms_chargeable_units': 0, 'sms_notifications': 0}
-    assert response[2] == {'email_totals': 0, 'free_allowance': 10, 'letter_cost': 0.0, 'letter_sheet_totals': 0,
+    assert response[4] == {'email_totals': 0, 'free_allowance': 10, 'letter_cost': 0.0, 'letter_sheet_totals': 0,
                            'letter_totals': 0, 'organisation_id': '', 'organisation_name': '',
                            'service_id': str(fixture['service_with_sms_without_org'].id),
                            'service_name': fixture['service_with_sms_without_org'].name,
                            'sms_chargeable_units': 0, 'sms_notifications': 0}
-    assert response[3] == {'email_totals': 0, 'free_allowance': 10, 'letter_cost': 0.0, 'letter_sheet_totals': 0,
+    assert response[6] == {'email_totals': 0, 'free_allowance': 10, 'letter_cost': 0.0, 'letter_sheet_totals': 0,
                            'letter_totals': 0, 'organisation_id': '', 'organisation_name': '',
                            'service_id': str(fixture['service_with_sms_within_allowance'].id),
                            'service_name': fixture['service_with_sms_within_allowance'].name,


### PR DESCRIPTION
So far we have only changed sms rates at the start of financial year, now we need to do it more often. This PR improves query that shows usage for services belonging to an org (used on organisation dashboard and organisation usage report), so that it handles multiple sms rates within a single financial year.

As an additional perk, it should make organisation dashboard more performant, as we don't need to call `fetch_sms_free_allowance_remainder_until_date()` anymore. This function queries services for all organisations, so it fetches much more data than we need.

Review commit by commit.

Co-authored-by: Leo Hemsted <leo.hemsted@digital.cabinet-office.gov.uk>
Story ticket: https://www.pivotaltracker.com/story/show/181936289