### PR TITLE
Remove redundant fields from service usage APIs

### DIFF
--- a/app/billing/billing_schemas.py
+++ b/app/billing/billing_schemas.py
@@ -17,8 +17,6 @@ def serialize_ft_billing_remove_emails(rows):
         {
             "month": (datetime.strftime(row.month, "%B")),
             "notification_type": row.notification_type,
-            # TEMPORARY: while we migrate away from "billing_units"
-            "billing_units": row.billable_units,
             "chargeable_units": row.chargeable_units,
             "notifications_sent": row.notifications_sent,
             "rate": float(row.rate),
@@ -36,13 +34,9 @@ def serialize_ft_billing_yearly_totals(rows):
     return [
         {
             "notification_type": row.notification_type,
-            # TEMPORARY: while we migrate away from "billing_units"
-            "billing_units": row.billable_units,
             "chargeable_units": row.chargeable_units,
             "notifications_sent": row.notifications_sent,
             "rate": float(row.rate),
-            # TEMPORARY: while we migrate to "cost" in the Admin app
-            "letter_total": float(row.billable_units * row.rate) if row.notification_type == 'letter' else 0,
             "cost": float(row.cost),
             "free_allowance_used": row.free_allowance_used,
             "charged_units": row.charged_units,

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -220,8 +220,6 @@ def fetch_billing_totals_for_year(service_id, year):
                 query.c.rate.label("rate"),
 
                 func.sum(query.c.notifications_sent).label("notifications_sent"),
-                # TEMPORARY: while we migrate away from "billing_units"
-                func.sum(query.c.billable_units).label("billable_units"),
                 func.sum(query.c.chargeable_units).label("chargeable_units"),
                 func.sum(query.c.cost).label("cost"),
                 func.sum(query.c.free_allowance_used).label("free_allowance_used"),
@@ -280,8 +278,6 @@ def fetch_monthly_billing_for_year(service_id, year):
                 func.date_trunc('month', query.c.bst_date).cast(Date).label("month"),
 
                 func.sum(query.c.notifications_sent).label("notifications_sent"),
-                # TEMPORARY: while we migrate away from "billing_units"
-                func.sum(query.c.billable_units).label("billable_units"),
                 func.sum(query.c.chargeable_units).label("chargeable_units"),
                 func.sum(query.c.cost).label("cost"),
                 func.sum(query.c.free_allowance_used).label("free_allowance_used"),
@@ -312,8 +308,6 @@ def query_service_email_usage_for_year(service_id, year):
         FactBilling.bst_date,
         FactBilling.postage,  # should always be "none"
         FactBilling.notifications_sent,
-        # TEMPORARY: while we migrate away from "billing_units"
-        FactBilling.notifications_sent.label("billable_units"),
         FactBilling.billable_units.label("chargeable_units"),
         FactBilling.rate,
         FactBilling.notification_type,
@@ -335,8 +329,6 @@ def query_service_letter_usage_for_year(service_id, year):
         FactBilling.bst_date,
         FactBilling.postage,
         FactBilling.notifications_sent,
-        # TEMPORARY: while we migrate away from "billing_units"
-        FactBilling.notifications_sent.label("billable_units"),
         # We can't use billable_units here as it represents the
         # sheet count for letters, which is already accounted for
         # in the rate. We actually charge per letter, not sheet.
@@ -418,8 +410,6 @@ def query_service_sms_usage_for_year(service_id, year):
         FactBilling.bst_date,
         FactBilling.postage,  # should always be "none"
         FactBilling.notifications_sent,
-        # TEMPORARY: while we migrate away from "billing_units"
-        chargeable_units.label("billable_units"),
         chargeable_units.label("chargeable_units"),
         FactBilling.rate,
         FactBilling.notification_type,

--- a/tests/app/billing/test_rest.py
+++ b/tests/app/billing/test_rest.py
@@ -150,7 +150,6 @@ def test_get_yearly_usage_by_monthly_from_ft_billing(admin_request, notify_db_se
 
     assert letter_row["month"] == "April"
     assert letter_row["notification_type"] == "letter"
-    assert letter_row["billing_units"] == 1
     assert letter_row["chargeable_units"] == 1
     assert letter_row["notifications_sent"] == 1
     assert letter_row["rate"] == 0.33
@@ -161,7 +160,6 @@ def test_get_yearly_usage_by_monthly_from_ft_billing(admin_request, notify_db_se
 
     assert sms_row["month"] == "April"
     assert sms_row["notification_type"] == "sms"
-    assert sms_row["billing_units"] == 1
     assert sms_row["chargeable_units"] == 1
     assert sms_row["notifications_sent"] == 1
     assert sms_row["rate"] == 0.0162
@@ -216,31 +214,25 @@ def test_get_yearly_billing_usage_summary_from_ft_billing(admin_request, notify_
     assert len(json_response) == 3
 
     assert json_response[0]['notification_type'] == 'email'
-    assert json_response[0]['billing_units'] == 3
     assert json_response[0]['chargeable_units'] == 0
     assert json_response[0]['notifications_sent'] == 3
     assert json_response[0]['rate'] == 0
-    assert json_response[0]['letter_total'] == 0
     assert json_response[0]['cost'] == 0
     assert json_response[0]['free_allowance_used'] == 0
     assert json_response[0]['charged_units'] == 0
 
     assert json_response[1]['notification_type'] == 'letter'
-    assert json_response[1]['billing_units'] == 3
     assert json_response[1]['chargeable_units'] == 3
     assert json_response[1]['notifications_sent'] == 3
     assert json_response[1]['rate'] == 0.33
-    assert json_response[1]['letter_total'] == 0.99
     assert json_response[1]['cost'] == 0.99
     assert json_response[1]['free_allowance_used'] == 0
     assert json_response[1]['charged_units'] == 3
 
     assert json_response[2]['notification_type'] == 'sms'
-    assert json_response[2]['billing_units'] == 3
     assert json_response[2]['chargeable_units'] == 3
     assert json_response[2]['notifications_sent'] == 3
     assert json_response[2]['rate'] == 0.0162
-    assert json_response[2]['letter_total'] == 0
     assert json_response[2]['cost'] == 0.0324
     assert json_response[2]['free_allowance_used'] == 1
     assert json_response[2]['charged_units'] == 2

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -429,7 +429,6 @@ def test_fetch_monthly_billing_for_year(notify_db_session):
     assert str(results[0].month) == "2016-04-01"
     assert results[0].notification_type == 'email'
     assert results[0].notifications_sent == 2
-    assert results[0].billable_units == 2
     assert results[0].chargeable_units == 0
     assert results[0].rate == Decimal('0')
     assert results[0].cost == Decimal('0')
@@ -439,7 +438,6 @@ def test_fetch_monthly_billing_for_year(notify_db_session):
     assert str(results[1].month) == "2016-04-01"
     assert results[1].notification_type == 'letter'
     assert results[1].notifications_sent == 2
-    assert results[1].billable_units == 2
     assert results[1].chargeable_units == 2
     assert results[1].rate == Decimal('0.30')
     assert results[1].cost == Decimal('0.60')
@@ -449,7 +447,6 @@ def test_fetch_monthly_billing_for_year(notify_db_session):
     assert str(results[2].month) == "2016-04-01"
     assert results[2].notification_type == 'sms'
     assert results[2].notifications_sent == 2
-    assert results[2].billable_units == 2
     assert results[2].chargeable_units == 2
     assert results[2].rate == Decimal('0.162')
     # free allowance is 1
@@ -472,7 +469,6 @@ def test_fetch_monthly_billing_for_year_variable_rates(notify_db_session):
     assert str(results[0].month) == "2018-05-01"
     assert results[0].notification_type == 'letter'
     assert results[0].notifications_sent == 1
-    assert results[0].billable_units == 1
     assert results[0].chargeable_units == 1
     assert results[0].rate == Decimal('0.33')
     assert results[0].cost == Decimal('0.33')
@@ -482,7 +478,6 @@ def test_fetch_monthly_billing_for_year_variable_rates(notify_db_session):
     assert str(results[1].month) == "2018-05-01"
     assert results[1].notification_type == 'letter'
     assert results[1].notifications_sent == 2
-    assert results[1].billable_units == 2
     assert results[1].chargeable_units == 2
     assert results[1].rate == Decimal('0.36')
     assert results[1].cost == Decimal('0.72')
@@ -492,7 +487,6 @@ def test_fetch_monthly_billing_for_year_variable_rates(notify_db_session):
     assert str(results[2].month) == "2018-05-01"
     assert results[2].notification_type == 'sms'
     assert results[2].notifications_sent == 1
-    assert results[2].billable_units == 4
     assert results[2].chargeable_units == 4
     assert results[2].rate == Decimal('0.015')
     # 1 free units on the 17th
@@ -503,7 +497,6 @@ def test_fetch_monthly_billing_for_year_variable_rates(notify_db_session):
     assert str(results[3].month) == "2018-05-01"
     assert results[3].notification_type == 'sms'
     assert results[3].notifications_sent == 2
-    assert results[3].billable_units == 5
     assert results[3].chargeable_units == 5
     assert results[3].rate == Decimal('0.162')
     # 5 free units on the 16th
@@ -540,7 +533,6 @@ def test_fetch_billing_totals_for_year(notify_db_session):
     assert len(results) == 3
     assert results[0].notification_type == 'email'
     assert results[0].notifications_sent == 4
-    assert results[0].billable_units == 4
     assert results[0].chargeable_units == 0
     assert results[0].rate == Decimal('0')
     assert results[0].cost == Decimal('0')
@@ -549,7 +541,6 @@ def test_fetch_billing_totals_for_year(notify_db_session):
 
     assert results[1].notification_type == 'letter'
     assert results[1].notifications_sent == 4
-    assert results[1].billable_units == 4
     assert results[1].chargeable_units == 4
     assert results[1].rate == Decimal('0.3')
     assert results[1].cost == Decimal('1.2')
@@ -558,7 +549,6 @@ def test_fetch_billing_totals_for_year(notify_db_session):
 
     assert results[2].notification_type == 'sms'
     assert results[2].notifications_sent == 4
-    assert results[2].billable_units == 4
     assert results[2].chargeable_units == 4
     assert results[2].rate == Decimal('0.162')
     assert results[2].cost == Decimal('0')
@@ -589,7 +579,6 @@ def test_fetch_billing_totals_for_year_variable_rates(notify_db_session):
     assert len(results) == 4
     assert results[0].notification_type == 'letter'
     assert results[0].notifications_sent == 1
-    assert results[0].billable_units == 1
     assert results[0].chargeable_units == 1
     assert results[0].rate == Decimal('0.33')
     assert results[0].cost == Decimal('0.33')
@@ -598,7 +587,6 @@ def test_fetch_billing_totals_for_year_variable_rates(notify_db_session):
 
     assert results[1].notification_type == 'letter'
     assert results[1].notifications_sent == 2
-    assert results[1].billable_units == 2
     assert results[1].chargeable_units == 2
     assert results[1].rate == Decimal('0.36')
     assert results[1].cost == Decimal('0.72')
@@ -607,7 +595,6 @@ def test_fetch_billing_totals_for_year_variable_rates(notify_db_session):
 
     assert results[2].notification_type == 'sms'
     assert results[2].notifications_sent == 1
-    assert results[2].billable_units == 4
     assert results[2].chargeable_units == 4
     assert results[2].rate == Decimal('0.015')
     # 1 free unit on the 17th
@@ -617,7 +604,6 @@ def test_fetch_billing_totals_for_year_variable_rates(notify_db_session):
 
     assert results[3].notification_type == 'sms'
     assert results[3].notifications_sent == 2
-    assert results[3].billable_units == 5
     assert results[3].chargeable_units == 5
     assert results[3].rate == Decimal('0.162')
     # 5 free units on the 16th


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181935935

These are no longer used since [^1] and [^2].

[^1]: https://github.com/alphagov/notifications-admin/pull/4225
[^2]: https://github.com/alphagov/notifications-admin/pull/4229