### PR TITLE
Recalculate billing rows for 10 days (prev. 4)

### DIFF
--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -25,7 +25,7 @@ def create_nightly_billing(day_start=None):
     else:
         # When calling the task its a string in the format of "YYYY-MM-DD"
         day_start = datetime.strptime(day_start, "%Y-%m-%d").date()
-    for i in range(0, 4):
+    for i in range(0, 10):
         process_day = (day_start - timedelta(days=i)).isoformat()
 
         create_nightly_billing_for_day.apply_async(

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -49,15 +49,15 @@ def mocker_get_rate(
 
 @freeze_time('2019-08-01')
 @pytest.mark.parametrize('day_start, expected_kwargs', [
-    (None, ['2019-07-31', '2019-07-30', '2019-07-29', '2019-07-28']),
-    ('2019-07-21', ['2019-07-21', '2019-07-20', '2019-07-19', '2019-07-18']),
+    (None, [f'2019-07-{31-i}' for i in range(10)]),
+    ('2019-07-21', [f'2019-07-{21-i}' for i in range(10)]),
 ])
 def test_create_nightly_billing_triggers_tasks_for_days(notify_api, mocker, day_start, expected_kwargs):
     mock_celery = mocker.patch('app.celery.reporting_tasks.create_nightly_billing_for_day')
     create_nightly_billing(day_start)
 
-    assert mock_celery.apply_async.call_count == 4
-    for i in range(4):
+    assert mock_celery.apply_async.call_count == 10
+    for i in range(10):
         assert mock_celery.apply_async.call_args_list[i][1]['kwargs'] == {'process_day': expected_kwargs[i]}
 
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178125825

This effectively reverts [^1], which was only a temporary change.
I suspect the performance problem will go away with [^2].

While we've clearly been managing without this change, it resulted
in several rows being left as incorrect when letter receipts were
delayed. It makes sense for us to run this task for the same period
as we do to aggregate statuses, as status affects billing.

Having manually re-run this job for historic data, I'm confident the 
runtime for individual jobs is fairly low. Currently the overall billing 
job set takes about 15 mins to run, so there's plenty of headroom to 
add a few more days / jobs to the set that are run.

[^1]: https://github.com/alphagov/notifications-api/commit/e5c76ffda732dcb572c6f3d4cd0c89464d41b82f
[^2]: https://github.com/alphagov/notifications-api/pull/3542