### PR TITLE
Use notification view for status / billing tasks

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -467,11 +467,9 @@ def fetch_billing_data_for_day(process_day, service_id=None, check_permissions=F
 
 
 def _query_for_billing_data(notification_type, start_date, end_date, service):
-    table = NotificationAllTimeView
-
     def _email_query():
         return db.session.query(
-            table.template_id,
+            NotificationAllTimeView.template_id,
             literal(service.crown).label('crown'),
             literal(service.id).label('service_id'),
             literal(notification_type).label('notification_type'),
@@ -483,22 +481,22 @@ def _query_for_billing_data(notification_type, start_date, end_date, service):
             literal(0).label('billable_units'),
             func.count().label('notifications_sent'),
         ).filter(
-            table.status.in_(NOTIFICATION_STATUS_TYPES_SENT_EMAILS),
-            table.key_type.in_((KEY_TYPE_NORMAL, KEY_TYPE_TEAM)),
-            table.created_at >= start_date,
-            table.created_at < end_date,
-            table.notification_type == notification_type,
-            table.service_id == service.id
+            NotificationAllTimeView.status.in_(NOTIFICATION_STATUS_TYPES_SENT_EMAILS),
+            NotificationAllTimeView.key_type.in_((KEY_TYPE_NORMAL, KEY_TYPE_TEAM)),
+            NotificationAllTimeView.created_at >= start_date,
+            NotificationAllTimeView.created_at < end_date,
+            NotificationAllTimeView.notification_type == notification_type,
+            NotificationAllTimeView.service_id == service.id
         ).group_by(
-            table.template_id,
+            NotificationAllTimeView.template_id,
         )
 
     def _sms_query():
-        sent_by = func.coalesce(table.sent_by, 'unknown')
-        rate_multiplier = func.coalesce(table.rate_multiplier, 1).cast(Integer)
-        international = func.coalesce(table.international, False)
+        sent_by = func.coalesce(NotificationAllTimeView.sent_by, 'unknown')
+        rate_multiplier = func.coalesce(NotificationAllTimeView.rate_multiplier, 1).cast(Integer)
+        international = func.coalesce(NotificationAllTimeView.international, False)
         return db.session.query(
-            table.template_id,
+            NotificationAllTimeView.template_id,
             literal(service.crown).label('crown'),
             literal(service.id).label('service_id'),
             literal(notification_type).label('notification_type'),
@@ -507,50 +505,50 @@ def _query_for_billing_data(notification_type, start_date, end_date, service):
             international.label('international'),
             literal(None).label('letter_page_count'),
             literal('none').label('postage'),
-            func.sum(table.billable_units).label('billable_units'),
+            func.sum(NotificationAllTimeView.billable_units).label('billable_units'),
             func.count().label('notifications_sent'),
         ).filter(
-            table.status.in_(NOTIFICATION_STATUS_TYPES_BILLABLE_SMS),
-            table.key_type.in_((KEY_TYPE_NORMAL, KEY_TYPE_TEAM)),
-            table.created_at >= start_date,
-            table.created_at < end_date,
-            table.notification_type == notification_type,
-            table.service_id == service.id
+            NotificationAllTimeView.status.in_(NOTIFICATION_STATUS_TYPES_BILLABLE_SMS),
+            NotificationAllTimeView.key_type.in_((KEY_TYPE_NORMAL, KEY_TYPE_TEAM)),
+            NotificationAllTimeView.created_at >= start_date,
+            NotificationAllTimeView.created_at < end_date,
+            NotificationAllTimeView.notification_type == notification_type,
+            NotificationAllTimeView.service_id == service.id
         ).group_by(
-            table.template_id,
+            NotificationAllTimeView.template_id,
             sent_by,
             rate_multiplier,
             international,
         )
 
     def _letter_query():
-        rate_multiplier = func.coalesce(table.rate_multiplier, 1).cast(Integer)
-        postage = func.coalesce(table.postage, 'none')
+        rate_multiplier = func.coalesce(NotificationAllTimeView.rate_multiplier, 1).cast(Integer)
+        postage = func.coalesce(NotificationAllTimeView.postage, 'none')
         return db.session.query(
-            table.template_id,
+            NotificationAllTimeView.template_id,
             literal(service.crown).label('crown'),
             literal(service.id).label('service_id'),
             literal(notification_type).label('notification_type'),
             literal('dvla').label('sent_by'),
             rate_multiplier.label('rate_multiplier'),
-            table.international,
-            table.billable_units.label('letter_page_count'),
+            NotificationAllTimeView.international,
+            NotificationAllTimeView.billable_units.label('letter_page_count'),
             postage.label('postage'),
-            func.sum(table.billable_units).label('billable_units'),
+            func.sum(NotificationAllTimeView.billable_units).label('billable_units'),
             func.count().label('notifications_sent'),
         ).filter(
-            table.status.in_(NOTIFICATION_STATUS_TYPES_BILLABLE_FOR_LETTERS),
-            table.key_type.in_((KEY_TYPE_NORMAL, KEY_TYPE_TEAM)),
-            table.created_at >= start_date,
-            table.created_at < end_date,
-            table.notification_type == notification_type,
-            table.service_id == service.id
+            NotificationAllTimeView.status.in_(NOTIFICATION_STATUS_TYPES_BILLABLE_FOR_LETTERS),
+            NotificationAllTimeView.key_type.in_((KEY_TYPE_NORMAL, KEY_TYPE_TEAM)),
+            NotificationAllTimeView.created_at >= start_date,
+            NotificationAllTimeView.created_at < end_date,
+            NotificationAllTimeView.notification_type == notification_type,
+            NotificationAllTimeView.service_id == service.id
         ).group_by(
-            table.template_id,
+            NotificationAllTimeView.template_id,
             rate_multiplier,
-            table.billable_units,
+            NotificationAllTimeView.billable_units,
             postage,
-            table.international
+            NotificationAllTimeView.international
         )
 
     query_funcs = {

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -25,12 +25,13 @@ from app.models import (
     AnnualBilling,
     FactBilling,
     LetterRate,
+    NotificationAllTimeView,
     NotificationHistory,
     Organisation,
     Rate,
     Service,
 )
-from app.utils import get_london_midnight_in_utc, get_notification_table_to_use
+from app.utils import get_london_midnight_in_utc
 
 
 def fetch_sms_free_allowance_remainder_until_date(end_date):
@@ -454,10 +455,7 @@ def fetch_billing_data_for_day(process_day, service_id=None, check_permissions=F
     for service in services:
         for notification_type in (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE):
             if (not check_permissions) or service.has_permission(notification_type):
-                table = get_notification_table_to_use(service, notification_type, process_day,
-                                                      has_delete_task_run=False)
                 results = _query_for_billing_data(
-                    table=table,
                     notification_type=notification_type,
                     start_date=start_date,
                     end_date=end_date,
@@ -468,7 +466,9 @@ def fetch_billing_data_for_day(process_day, service_id=None, check_permissions=F
     return transit_data
 
 
-def _query_for_billing_data(table, notification_type, start_date, end_date, service):
+def _query_for_billing_data(notification_type, start_date, end_date, service):
+    table = NotificationAllTimeView
+
     def _email_query():
         return db.session.query(
             table.template_id,

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -23,13 +23,13 @@ from app.models import (
     NOTIFICATION_TEMPORARY_FAILURE,
     FactNotificationStatus,
     Notification,
+    NotificationAllTimeView,
     Service,
     Template,
 )
 from app.utils import (
     get_london_midnight_in_utc,
     get_london_month_from_utc_column,
-    get_notification_table_to_use,
     midnight_n_days_ago,
 )
 
@@ -47,13 +47,7 @@ def update_fact_notification_status(process_day, notification_type, service_id):
     ).delete()
 
     # query notifications or notification_history for the day, depending on their data retention
-    service = Service.query.get(service_id)
-    source_table = get_notification_table_to_use(
-        service,
-        notification_type,
-        process_day,
-        has_delete_task_run=False
-    )
+    source_table = NotificationAllTimeView
 
     query = db.session.query(
         literal(process_day).label("process_day"),

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -46,30 +46,27 @@ def update_fact_notification_status(process_day, notification_type, service_id):
         FactNotificationStatus.service_id == service_id,
     ).delete()
 
-    # query notifications or notification_history for the day, depending on their data retention
-    source_table = NotificationAllTimeView
-
     query = db.session.query(
         literal(process_day).label("process_day"),
-        source_table.template_id,
+        NotificationAllTimeView.template_id,
         literal(service_id).label("service_id"),
-        func.coalesce(source_table.job_id, '00000000-0000-0000-0000-000000000000').label('job_id'),
+        func.coalesce(NotificationAllTimeView.job_id, '00000000-0000-0000-0000-000000000000').label('job_id'),
         literal(notification_type).label("notification_type"),
-        source_table.key_type,
-        source_table.status,
+        NotificationAllTimeView.key_type,
+        NotificationAllTimeView.status,
         func.count().label('notification_count')
     ).filter(
-        source_table.created_at >= start_date,
-        source_table.created_at < end_date,
-        source_table.notification_type == notification_type,
-        source_table.service_id == service_id,
-        source_table.key_type.in_((KEY_TYPE_NORMAL, KEY_TYPE_TEAM)),
+        NotificationAllTimeView.created_at >= start_date,
+        NotificationAllTimeView.created_at < end_date,
+        NotificationAllTimeView.notification_type == notification_type,
+        NotificationAllTimeView.service_id == service_id,
+        NotificationAllTimeView.key_type.in_((KEY_TYPE_NORMAL, KEY_TYPE_TEAM)),
     ).group_by(
-        source_table.template_id,
-        source_table.template_id,
+        NotificationAllTimeView.template_id,
+        NotificationAllTimeView.template_id,
         'job_id',
-        source_table.key_type,
-        source_table.status
+        NotificationAllTimeView.key_type,
+        NotificationAllTimeView.status
     )
 
     db.session.connection().execute(

--- a/app/models.py
+++ b/app/models.py
@@ -1411,6 +1411,39 @@ class NotificationStatusTypes(db.Model):
     name = db.Column(db.String(), primary_key=True)
 
 
+class NotificationAllTimeView(db.Model):
+    """
+    WARNING: this view is a union of rows in "notifications" and
+    "notification_history". Any query on this view will query both
+    tables and therefore rely on *both* sets of indices.
+    """
+    __tablename__ = 'notifications_all_time_view'
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True)
+    job_id = db.Column(UUID(as_uuid=True))
+    job_row_number = db.Column(db.Integer)
+    service_id = db.Column(UUID(as_uuid=True))
+    template_id = db.Column(UUID(as_uuid=True))
+    template_version = db.Column(db.Integer)
+    api_key_id = db.Column(UUID(as_uuid=True))
+    key_type = db.Column(db.String)
+    billable_units = db.Column(db.Integer)
+    notification_type = db.Column(notification_types)
+    created_at = db.Column(db.DateTime)
+    sent_at = db.Column(db.DateTime)
+    sent_by = db.Column(db.String)
+    updated_at = db.Column(db.DateTime)
+    status = db.Column('notification_status', db.Text)
+    reference = db.Column(db.String)
+    client_reference = db.Column(db.String)
+    international = db.Column(db.Boolean)
+    phone_prefix = db.Column(db.String)
+    rate_multiplier = db.Column(db.Numeric(asdecimal=False))
+    created_by_id = db.Column(UUID(as_uuid=True))
+    postage = db.Column(db.String)
+    document_download_count = db.Column(db.Integer)
+
+
 class Notification(db.Model):
     __tablename__ = 'notifications'
 

--- a/migrations/versions/0373_add_notifications_all_time.py
+++ b/migrations/versions/0373_add_notifications_all_time.py
@@ -1,0 +1,78 @@
+"""
+
+Revision ID: 0373_add_notifications_view
+Revises: 0372_remove_provider_rates
+Create Date: 2022-05-18 09:39:45.260951
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0373_add_notifications_view'
+down_revision = '0372_remove_provider_rates'
+
+
+def upgrade():
+    op.execute("""
+        CREATE VIEW notifications_all_time_view AS
+        (
+            SELECT
+                id,
+                job_id,
+                job_row_number,
+                service_id,
+                template_id,
+                template_version,
+                api_key_id,
+                key_type,
+                billable_units,
+                notification_type,
+                created_at,
+                sent_at,
+                sent_by,
+                updated_at,
+                notification_status,
+                reference,
+                client_reference,
+                international,
+                phone_prefix,
+                rate_multiplier,
+                created_by_id,
+                postage,
+                document_download_count
+            FROM notifications
+        ) UNION
+        (
+            SELECT
+                id,
+                job_id,
+                job_row_number,
+                service_id,
+                template_id,
+                template_version,
+                api_key_id,
+                key_type,
+                billable_units,
+                notification_type,
+                created_at,
+                sent_at,
+                sent_by,
+                updated_at,
+                notification_status,
+                reference,
+                client_reference,
+                international,
+                phone_prefix,
+                rate_multiplier,
+                created_by_id,
+                postage,
+                document_download_count
+            FROM notification_history
+        )
+    """)
+
+
+def downgrade():
+    op.execute("DROP VIEW notifications_all_time_view")

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -31,7 +31,6 @@ from tests.app.db import (
     create_notification_history,
     create_rate,
     create_service,
-    create_service_data_retention,
     create_template,
 )
 
@@ -113,6 +112,38 @@ def test_create_nightly_notification_status_triggers_relevant_tasks(
 
     types = {call.kwargs['kwargs']['notification_type'] for call in mock_celery.mock_calls}
     assert types == expected_types_aggregated
+
+
+def test_create_nightly_billing_for_day_checks_history(
+    sample_service,
+    sample_letter_template,
+    mocker
+):
+    yesterday = datetime.now() - timedelta(days=1)
+    mocker.patch('app.dao.fact_billing_dao.get_rate', side_effect=mocker_get_rate)
+
+    create_notification(
+        created_at=yesterday,
+        template=sample_letter_template,
+        status='sending',
+    )
+
+    create_notification_history(
+        created_at=yesterday,
+        template=sample_letter_template,
+        status='delivered',
+    )
+
+    records = FactBilling.query.all()
+    assert len(records) == 0
+
+    create_nightly_billing_for_day(str(yesterday.date()))
+    records = FactBilling.query.all()
+    assert len(records) == 1
+
+    record = records[0]
+    assert record.notification_type == LETTER_TYPE
+    assert record.notifications_sent == 2
 
 
 @pytest.mark.parametrize('second_rate, records_num, billable_units, multiplier',
@@ -532,20 +563,19 @@ def test_create_nightly_notification_status_for_service_and_day(notify_db_sessio
     second_template = create_template(service=second_service, template_type='email')
     third_template = create_template(service=second_service, template_type='letter')
 
-    create_service_data_retention(second_service, 'email', days_of_retention=3)
-
     process_day = date.today() - timedelta(days=5)
     with freeze_time(datetime.combine(process_day, time.min)):
         create_notification(template=first_template, status='delivered')
-
-        # 2nd service email has 3 day data retention - data has been moved to history and doesn't exist in notifications
-        create_notification_history(template=second_template, status='temporary-failure')
+        create_notification(template=second_template, status='temporary-failure')
 
         # team API key notifications are included
         create_notification(template=third_template, status='sending', key_type=KEY_TYPE_TEAM)
 
         # test notifications are ignored
         create_notification(template=third_template, status='sending', key_type=KEY_TYPE_TEST)
+
+        # historical notifications are included
+        create_notification_history(template=third_template, status='delivered')
 
     # these created notifications from a different day get ignored
     with freeze_time(datetime.combine(date.today() - timedelta(days=4), time.min)):
@@ -560,10 +590,11 @@ def test_create_nightly_notification_status_for_service_and_day(notify_db_sessio
     create_nightly_notification_status_for_service_and_day(str(process_day), second_service.id, 'letter')
 
     new_fact_data = FactNotificationStatus.query.order_by(
-        FactNotificationStatus.notification_type
+        FactNotificationStatus.notification_type,
+        FactNotificationStatus.notification_status,
     ).all()
 
-    assert len(new_fact_data) == 3
+    assert len(new_fact_data) == 4
 
     email_failure_row = new_fact_data[0]
     assert email_failure_row.bst_date == process_day
@@ -575,7 +606,15 @@ def test_create_nightly_notification_status_for_service_and_day(notify_db_sessio
     assert email_failure_row.notification_count == 1
     assert email_failure_row.key_type == KEY_TYPE_NORMAL
 
-    letter_sending_row = new_fact_data[1]
+    letter_delivered_row = new_fact_data[1]
+    assert letter_delivered_row.template_id == third_template.id
+    assert letter_delivered_row.service_id == second_service.id
+    assert letter_delivered_row.notification_type == 'letter'
+    assert letter_delivered_row.notification_status == 'delivered'
+    assert letter_delivered_row.notification_count == 1
+    assert letter_delivered_row.key_type == KEY_TYPE_NORMAL
+
+    letter_sending_row = new_fact_data[2]
     assert letter_sending_row.template_id == third_template.id
     assert letter_sending_row.service_id == second_service.id
     assert letter_sending_row.notification_type == 'letter'
@@ -583,7 +622,7 @@ def test_create_nightly_notification_status_for_service_and_day(notify_db_sessio
     assert letter_sending_row.notification_count == 1
     assert letter_sending_row.key_type == KEY_TYPE_TEAM
 
-    sms_delivered_row = new_fact_data[2]
+    sms_delivered_row = new_fact_data[3]
     assert sms_delivered_row.template_id == first_template.id
     assert sms_delivered_row.service_id == first_service.id
     assert sms_delivered_row.notification_type == 'sms'

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -119,13 +119,14 @@ def test_create_nightly_notification_status_triggers_relevant_tasks(
                          [(1.0, 1, 2, [1]),
                           (2.0, 2, 1, [1, 2])])
 def test_create_nightly_billing_for_day_sms_rate_multiplier(
-        sample_service,
-        sample_template,
-        mocker,
-        second_rate,
-        records_num,
-        billable_units,
-        multiplier):
+    sample_service,
+    sample_template,
+    mocker,
+    second_rate,
+    records_num,
+    billable_units,
+    multiplier
+):
 
     yesterday = datetime.now() - timedelta(days=1)
 
@@ -154,11 +155,10 @@ def test_create_nightly_billing_for_day_sms_rate_multiplier(
     records = FactBilling.query.all()
     assert len(records) == 0
 
-    # Celery expects the arguments to be a string or primitive type.
-    yesterday_str = datetime.strftime(yesterday, "%Y-%m-%d")
-    create_nightly_billing_for_day(yesterday_str)
+    create_nightly_billing_for_day(str(yesterday.date()))
     records = FactBilling.query.order_by('rate_multiplier').all()
     assert len(records) == records_num
+
     for i, record in enumerate(records):
         assert record.bst_date == datetime.date(yesterday)
         assert record.rate == Decimal(1.33)
@@ -170,7 +170,8 @@ def test_create_nightly_billing_for_day_different_templates(
         sample_service,
         sample_template,
         sample_email_template,
-        mocker):
+        mocker
+):
     yesterday = datetime.now() - timedelta(days=1)
 
     mocker.patch('app.dao.fact_billing_dao.get_rate', side_effect=mocker_get_rate)
@@ -196,11 +197,9 @@ def test_create_nightly_billing_for_day_different_templates(
 
     records = FactBilling.query.all()
     assert len(records) == 0
-    # Celery expects the arguments to be a string or primitive type.
-    yesterday_str = datetime.strftime(yesterday, "%Y-%m-%d")
-    create_nightly_billing_for_day(yesterday_str)
-    records = FactBilling.query.order_by('rate_multiplier').all()
+    create_nightly_billing_for_day(str(yesterday.date()))
 
+    records = FactBilling.query.order_by('rate_multiplier').all()
     assert len(records) == 2
     multiplier = [0, 1]
     billable_units = [0, 1]
@@ -214,10 +213,11 @@ def test_create_nightly_billing_for_day_different_templates(
 
 
 def test_create_nightly_billing_for_day_different_sent_by(
-        sample_service,
-        sample_template,
-        sample_email_template,
-        mocker):
+    sample_service,
+    sample_template,
+    sample_email_template,
+    mocker
+):
     yesterday = datetime.now() - timedelta(days=1)
 
     mocker.patch('app.dao.fact_billing_dao.get_rate', side_effect=mocker_get_rate)
@@ -244,13 +244,11 @@ def test_create_nightly_billing_for_day_different_sent_by(
 
     records = FactBilling.query.all()
     assert len(records) == 0
+    create_nightly_billing_for_day(str(yesterday.date()))
 
-    # Celery expects the arguments to be a string or primitive type.
-    yesterday_str = datetime.strftime(yesterday, "%Y-%m-%d")
-    create_nightly_billing_for_day(yesterday_str)
     records = FactBilling.query.order_by('rate_multiplier').all()
-
     assert len(records) == 2
+
     for _, record in enumerate(records):
         assert record.bst_date == datetime.date(yesterday)
         assert record.rate == Decimal(1.33)
@@ -259,9 +257,10 @@ def test_create_nightly_billing_for_day_different_sent_by(
 
 
 def test_create_nightly_billing_for_day_different_letter_postage(
-        notify_db_session,
-        sample_letter_template,
-        mocker):
+    notify_db_session,
+    sample_letter_template,
+    mocker
+):
     yesterday = datetime.now() - timedelta(days=1)
     mocker.patch('app.dao.fact_billing_dao.get_rate', side_effect=mocker_get_rate)
 
@@ -301,9 +300,7 @@ def test_create_nightly_billing_for_day_different_letter_postage(
 
     records = FactBilling.query.all()
     assert len(records) == 0
-    # Celery expects the arguments to be a string or primitive type.
-    yesterday_str = datetime.strftime(yesterday, "%Y-%m-%d")
-    create_nightly_billing_for_day(yesterday_str)
+    create_nightly_billing_for_day(str(yesterday.date()))
 
     records = FactBilling.query.order_by('postage').all()
     assert len(records) == 4
@@ -334,9 +331,10 @@ def test_create_nightly_billing_for_day_different_letter_postage(
 
 
 def test_create_nightly_billing_for_day_letter(
-        sample_service,
-        sample_letter_template,
-        mocker):
+    sample_service,
+    sample_letter_template,
+    mocker
+):
     yesterday = datetime.now() - timedelta(days=1)
 
     mocker.patch('app.dao.fact_billing_dao.get_rate', side_effect=mocker_get_rate)
@@ -353,11 +351,11 @@ def test_create_nightly_billing_for_day_letter(
 
     records = FactBilling.query.all()
     assert len(records) == 0
-    # Celery expects the arguments to be a string or primitive type.
-    yesterday_str = datetime.strftime(yesterday, "%Y-%m-%d")
-    create_nightly_billing_for_day(yesterday_str)
+    create_nightly_billing_for_day(str(yesterday.date()))
+
     records = FactBilling.query.order_by('rate_multiplier').all()
     assert len(records) == 1
+
     record = records[0]
     assert record.notification_type == LETTER_TYPE
     assert record.bst_date == datetime.date(yesterday)
@@ -367,9 +365,10 @@ def test_create_nightly_billing_for_day_letter(
 
 
 def test_create_nightly_billing_for_day_null_sent_by_sms(
-        sample_service,
-        sample_template,
-        mocker):
+    sample_service,
+    sample_template,
+    mocker
+):
     yesterday = datetime.now() - timedelta(days=1)
 
     mocker.patch('app.dao.fact_billing_dao.get_rate', side_effect=mocker_get_rate)
@@ -387,12 +386,10 @@ def test_create_nightly_billing_for_day_null_sent_by_sms(
     records = FactBilling.query.all()
     assert len(records) == 0
 
-    # Celery expects the arguments to be a string or primitive type.
-    yesterday_str = datetime.strftime(yesterday, "%Y-%m-%d")
-    create_nightly_billing_for_day(yesterday_str)
+    create_nightly_billing_for_day(str(yesterday.date()))
     records = FactBilling.query.all()
-
     assert len(records) == 1
+
     record = records[0]
     assert record.bst_date == datetime.date(yesterday)
     assert record.rate == Decimal(1.33)

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -3,15 +3,12 @@ from datetime import date, datetime
 import pytest
 from freezegun import freeze_time
 
-from app.models import Notification, NotificationHistory
 from app.utils import (
     format_sequential_number,
     get_london_midnight_in_utc,
     get_midnight_for_day_before,
-    get_notification_table_to_use,
     midnight_n_days_ago,
 )
-from tests.app.db import create_service_data_retention
 
 
 @pytest.mark.parametrize('date, expected_date', [
@@ -55,50 +52,6 @@ def test_get_midnight_for_day_before_returns_expected_date(date, expected_date):
 def test_midnight_n_days_ago(current_time, arg, expected_datetime):
     with freeze_time(current_time):
         assert midnight_n_days_ago(arg) == expected_datetime
-
-
-@freeze_time('2019-01-10 00:30')
-def test_get_notification_table_to_use(sample_service):
-    # it's currently early morning of Thurs 10th Jan.
-    # When the delete task runs a bit later, it'll delete data from last wednesday 2nd.
-    assert get_notification_table_to_use(sample_service, 'sms', date(2018, 12, 31), False) == NotificationHistory
-    assert get_notification_table_to_use(sample_service, 'sms', date(2019, 1, 1), False) == NotificationHistory
-    assert get_notification_table_to_use(sample_service, 'sms', date(2019, 1, 2), False) == Notification
-    assert get_notification_table_to_use(sample_service, 'sms', date(2019, 1, 3), False) == Notification
-
-
-@freeze_time('2019-01-10 00:30')
-def test_get_notification_table_to_use_knows_if_delete_task_has_run(sample_service):
-    # it's currently early morning of Thurs 10th Jan.
-    # The delete task deletes/moves data from last wednesday 2nd.
-    assert get_notification_table_to_use(sample_service, 'sms', date(2019, 1, 2), False) == Notification
-    assert get_notification_table_to_use(sample_service, 'sms', date(2019, 1, 2), True) == NotificationHistory
-
-
-@freeze_time('2019-06-09 23:30')
-def test_get_notification_table_to_use_respects_daylight_savings_time(sample_service):
-    # current time is 12:30am on 10th july in BST
-    assert get_notification_table_to_use(sample_service, 'sms', date(2019, 6, 1), False) == NotificationHistory
-    assert get_notification_table_to_use(sample_service, 'sms', date(2019, 6, 2), False) == Notification
-
-
-@freeze_time('2019-01-10 00:30')
-def test_get_notification_table_to_use_checks_service_data_retention(sample_service):
-    create_service_data_retention(sample_service, 'email', days_of_retention=3)
-    create_service_data_retention(sample_service, 'letter', days_of_retention=9)
-
-    # it's currently early morning of Thurs 10th Jan.
-    # three days retention means we'll delete sunday 6th's data when the delete task runs (so there's still three full
-    # days of monday, tuesday and wednesday left over)
-    assert get_notification_table_to_use(sample_service, 'email', date(2019, 1, 5), False) == NotificationHistory
-    assert get_notification_table_to_use(sample_service, 'email', date(2019, 1, 6), False) == Notification
-
-    assert get_notification_table_to_use(sample_service, 'letter', date(2018, 12, 30), False) == NotificationHistory
-    assert get_notification_table_to_use(sample_service, 'letter', date(2018, 12, 31), False) == Notification
-
-    # falls back to 7 days if not specified
-    assert get_notification_table_to_use(sample_service, 'sms', date(2019, 1, 1), False) == NotificationHistory
-    assert get_notification_table_to_use(sample_service, 'sms', date(2019, 1, 2), False) == Notification
 
 
 def test_format_sequential_number():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,7 @@ def notify_db_session(_notify_db, sms_providers):
                             "job_status",
                             "provider_details_history",
                             "template_process_type",
+                            "notifications_all_time_view",
                             "notification_status_types",
                             "organisation_types",
                             "service_permission_types",


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178125825

This fixes a bug where (letter) notifications left in sending would
temporarily get excluded from billing and status calculations once the
service retention period had elapsed, and then get included once again when
they finally get marked as delivered.*

Status and billing tasks shouldn't need to have knowledge about which table
their data is in and getting this wrong is the fundamental cause of the bug
here. Adding a view across both tables abstracts this away while keeping
the query complexity the same.

Using a view also has the added benefit that we no longer need to care when
the status / billing tasks run in comparison to the deletion task, since we
will retrieve the same data irrespective (see the commits for a much more 
detailed discussion on data integrity).

*Such a scenario is rare but has happened.