### PR TITLE
Platform admin billing report

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -61,6 +61,7 @@ def fetch_sms_billing_for_all_services(start_date, end_date):
         func.coalesce(sms_billable_units, 0).label('sms_billable_units'),
         func.coalesce(chargeable_sms, 0).label("chargeable_billable_sms"),
         func.coalesce(sms_cost, 0).label('sms_cost'),
+        Service.active
     ).select_from(
         Service
     ).outerjoin(
@@ -79,6 +80,7 @@ def fetch_sms_billing_for_all_services(start_date, end_date):
         Organisation.id,
         Service.id,
         Service.name,
+        Service.active,
         AnnualBilling.free_sms_fragment_limit
     ).order_by(
         Organisation.name,

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -51,7 +51,7 @@ def fetch_sms_billing_for_all_services(start_date, end_date):
 
     chargeable_sms = func.sum(ft_billing_subquery.c.charged_units)
     sms_cost = func.sum(ft_billing_subquery.c.cost)
-    query = db.session.query(
+    return db.session.query(
         Organisation.name.label('organisation_name'),
         Organisation.id.label('organisation_id'),
         Service.name.label("service_name"),
@@ -84,8 +84,6 @@ def fetch_sms_billing_for_all_services(start_date, end_date):
         Organisation.name,
         Service.name
     )
-
-    return query.all()
 
 
 def fetch_letter_costs_and_totals_for_all_services(start_date, end_date):

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -92,6 +92,9 @@ def _query_sms_usage_for_range_per_service(financial_year, start_date, end_date)
         free_allowance_used_to_date.label("free_allowance_used_to_date")
     ).select_from(
         ft_billing_subquery,
+    ).filter(
+        # if we don't include this we might capture sms billing rows after (inflating free_allowance_used_to_date)
+        ft_billing_subquery.c.bst_date <= end_date
     ).group_by(
         ft_billing_subquery.c.service_id,
     ).subquery()

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 
 from flask import current_app
 from notifications_utils.timezones import convert_utc_to_bst
@@ -34,90 +34,19 @@ from app.models import (
 from app.utils import get_london_midnight_in_utc
 
 
-def fetch_sms_free_allowance_remainder_until_date(end_date):
-    # ASSUMPTION: AnnualBilling has been populated for year.
-    billing_year = get_financial_year_for_datetime(end_date)
-    start_of_year = date(billing_year, 4, 1)
-
-    billable_units = func.coalesce(func.sum(FactBilling.billable_units * FactBilling.rate_multiplier), 0)
-
-    query = db.session.query(
-        AnnualBilling.service_id.label("service_id"),
-        AnnualBilling.free_sms_fragment_limit,
-        billable_units.label('billable_units'),
-        func.greatest((AnnualBilling.free_sms_fragment_limit - billable_units).cast(Integer), 0).label('sms_remainder')
-    ).outerjoin(
-        # if there are no ft_billing rows for a service we still want to return the annual billing so we can use the
-        # free_sms_fragment_limit)
-        FactBilling, and_(
-            AnnualBilling.service_id == FactBilling.service_id,
-            FactBilling.bst_date >= start_of_year,
-            FactBilling.bst_date < end_date,
-            FactBilling.notification_type == SMS_TYPE,
-        )
-    ).filter(
-        AnnualBilling.financial_year_start == billing_year,
-    ).group_by(
-        AnnualBilling.service_id,
-        AnnualBilling.free_sms_fragment_limit,
-    )
-    return query
-
-
 def fetch_sms_billing_for_all_services(start_date, end_date):
-
-    # ASSUMPTION: AnnualBilling has been populated for year.
-    allowance_left_at_start_date_query = fetch_sms_free_allowance_remainder_until_date(start_date).subquery()
-
-    sms_billable_units = func.sum(FactBilling.billable_units * FactBilling.rate_multiplier)
-
-    # subtract sms_billable_units units accrued since report's start date to get up-to-date
-    # allowance remainder
-    sms_allowance_left = func.greatest(allowance_left_at_start_date_query.c.sms_remainder - sms_billable_units, 0)
-
-    # billable units here are for period between start date and end date only, so to see
-    # how many are chargeable, we need to see how much free allowance was used up in the
-    # period up until report's start date and then do a subtraction
-    chargeable_sms = func.greatest(sms_billable_units - allowance_left_at_start_date_query.c.sms_remainder, 0)
-    sms_cost = chargeable_sms * FactBilling.rate
-
-    query = db.session.query(
-        Organisation.name.label('organisation_name'),
-        Organisation.id.label('organisation_id'),
-        Service.name.label("service_name"),
-        Service.id.label("service_id"),
-        allowance_left_at_start_date_query.c.free_sms_fragment_limit,
-        FactBilling.rate.label('sms_rate'),
-        sms_allowance_left.label("sms_remainder"),
-        sms_billable_units.label('sms_billable_units'),
-        chargeable_sms.label("chargeable_billable_sms"),
-        sms_cost.label('sms_cost'),
-    ).select_from(
-        Service
-    ).outerjoin(
-        allowance_left_at_start_date_query, Service.id == allowance_left_at_start_date_query.c.service_id
-    ).outerjoin(
-        Service.organisation
-    ).join(
-        FactBilling, FactBilling.service_id == Service.id,
-    ).filter(
-        FactBilling.bst_date >= start_date,
-        FactBilling.bst_date <= end_date,
-        FactBilling.notification_type == SMS_TYPE,
-    ).group_by(
-        Organisation.name,
-        Organisation.id,
-        Service.id,
-        Service.name,
-        allowance_left_at_start_date_query.c.free_sms_fragment_limit,
-        allowance_left_at_start_date_query.c.sms_remainder,
-        FactBilling.rate,
-    ).order_by(
-        Organisation.name,
-        Service.name
-    )
-
-    return query.all()
+    # TODO: replace with new aggregate function containing the following columns:
+    # organisation_name
+    # organisation_id
+    # service_name
+    # service_id
+    # free_sms_fragment_limit
+    # sms_rate
+    # sms_remainder
+    # sms_billable_units
+    # chargeable_billable_sms
+    # sms_cost
+    raise NotImplementedError
 
 
 def fetch_letter_costs_and_totals_for_all_services(start_date, end_date):

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -720,7 +720,9 @@ def fetch_email_usage_for_organisation(organisation_id, start_date, end_date):
 
 def fetch_sms_billing_for_organisation(organisation_id, financial_year):
     # ASSUMPTION: AnnualBilling has been populated for year.
-    ft_billing_subquery = query_organisation_sms_usage_for_year(organisation_id, financial_year).subquery()
+    ft_billing_subquery = query_sms_usage_for_year_per_service(financial_year).filter(
+        Service.organisation_id == organisation_id
+    ).subquery()
 
     sms_billable_units = func.sum(func.coalesce(ft_billing_subquery.c.chargeable_units, 0))
 
@@ -761,7 +763,7 @@ def fetch_sms_billing_for_organisation(organisation_id, financial_year):
     return query.all()
 
 
-def query_organisation_sms_usage_for_year(organisation_id, year):
+def query_sms_usage_for_year_per_service(year):
     """
     See docstring for query_service_sms_usage_for_year()
     """
@@ -813,7 +815,6 @@ def query_organisation_sms_usage_for_year(organisation_id, year):
             FactBilling.notification_type == SMS_TYPE,
         )
     ).filter(
-        Service.organisation_id == organisation_id,
         AnnualBilling.financial_year_start == year,
     )
 

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -66,7 +66,6 @@ def validate_date_range_is_within_a_financial_year(start_date, end_date):
     return start_date, end_date
 
 
-@platform_stats_blueprint.route('usage-for-all-services')
 @platform_stats_blueprint.route('data-for-billing-report')
 def get_data_for_billing_report():
     start_date = request.args.get('start_date')

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -20,7 +20,6 @@ from app.dao.fact_billing_dao import (
     fetch_volumes_by_service,
     get_rate,
     get_rates_for_billing,
-    query_sms_usage_for_year_per_service,
 )
 from app.dao.organisation_dao import dao_add_service_to_organisation
 from app.models import NOTIFICATION_STATUS_TYPES, FactBilling
@@ -797,6 +796,90 @@ def test_fetch_sms_billing_for_all_services_shows_services_without_billing_in_th
     assert results[0]["sms_cost"] == Decimal('0.00')
 
 
+def test_fetch_sms_billing_for_all_services_handles_multiple_rates(notify_db_session):
+    old_rate_date = date(2022, 4, 29)
+    new_rate_date = date(2022, 5, 1)
+    current_year = datetime.utcnow().year
+
+    service_1 = create_service(restricted=False, service_name="Service 1")
+    sms_template_1 = create_template(service=service_1)
+    create_ft_billing(
+        bst_date=old_rate_date, template=sms_template_1, rate=2,
+        billable_unit=4, notifications_sent=4
+    )
+    create_ft_billing(
+        bst_date=new_rate_date, template=sms_template_1, rate=3,
+        billable_unit=2, notifications_sent=2
+    )
+    create_annual_billing(service_id=service_1.id, free_sms_fragment_limit=3, financial_year_start=current_year)
+
+    results = fetch_sms_billing_for_all_services(start_date=date(2022, 4, 1), end_date=date(2023, 3, 31))
+
+    # 1 charged unit out of 4 with rate 2 from the first day (using up the free allowance part way through the day)
+    # 2 charged units out of 2 with rate 3 from the second day (all charged)
+    assert results[0]["free_sms_fragment_limit"] == 3
+    assert results[0]["sms_remainder"] == 0
+    assert results[0]["sms_chargeable_units"] == 6
+    assert results[0]["chargeable_billable_sms"] == 3
+    assert results[0]["sms_cost"] == 8
+
+
+@freeze_time('2022-04-27 13:30')
+def test_query_sms_usage_for_year_per_service_handles_multiple_services(notify_db_session):
+    today = datetime.utcnow().date()
+    yesterday = datetime.utcnow().date() - timedelta(days=1)
+    current_year = datetime.utcnow().year
+
+    service_1 = create_service(restricted=False, service_name="Service 1")
+    sms_template_1 = create_template(service=service_1)
+    create_ft_billing(
+        bst_date=yesterday, template=sms_template_1, rate=1,
+        billable_unit=4, notifications_sent=4
+    )
+    create_ft_billing(
+        bst_date=today, template=sms_template_1, rate=1,
+        billable_unit=2, notifications_sent=2
+    )
+    create_annual_billing(service_id=service_1.id, free_sms_fragment_limit=5, financial_year_start=current_year)
+
+    service_2 = create_service(restricted=False, service_name="Service 2")
+    sms_template_2 = create_template(service=service_2)
+    create_ft_billing(
+        bst_date=yesterday, template=sms_template_2, rate=1,
+        billable_unit=16, notifications_sent=16
+    )
+    create_ft_billing(
+        bst_date=today, template=sms_template_2, rate=1,
+        billable_unit=8, notifications_sent=8
+    )
+    create_annual_billing(service_id=service_2.id, free_sms_fragment_limit=10, financial_year_start=current_year)
+
+    # ----------
+
+    result = fetch_sms_billing_for_all_services(date(2022, 4, 1), date(2023, 3, 31)).all()
+
+    service_1 = next(row for row in result if row.service_id == service_1.id)
+    service_2 = next(row for row in result if row.service_id == service_2.id)
+
+    # service 1 has allowance of 5
+    # day 1: four fragments in total, all are used
+    # day 2: two in total - one is free, one is charged
+    assert service_1["free_sms_fragment_limit"] == 5
+    assert service_1["sms_remainder"] == 0
+    assert service_1["sms_chargeable_units"] == 6
+    assert service_1["chargeable_billable_sms"] == 1
+    assert service_1["sms_cost"] == 1
+
+    # service 2 has allowance of 10
+    # day 1: sixteen fragments total, allowance is used and six are charged
+    # day 2: eight fragments total, all are charged
+    assert service_2["free_sms_fragment_limit"] == 10
+    assert service_2["sms_remainder"] == 0
+    assert service_2["sms_chargeable_units"] == 24
+    assert service_2["chargeable_billable_sms"] == 14
+    assert service_2["sms_cost"] == 14
+
+
 def test_fetch_letter_costs_and_totals_for_all_services(notify_db_session):
     fixtures = set_up_usage_data(datetime(2019, 6, 1))
 
@@ -1045,101 +1128,6 @@ def test_fetch_usage_year_for_organisation_only_returns_data_for_live_services(n
     assert len(results) == 1
     assert results[str(live_service.id)]['sms_billable_units'] == 19
     assert results[str(live_service.id)]['emails_sent'] == 0
-
-
-@freeze_time('2022-04-27 13:30')
-def test_query_sms_usage_for_year_per_service_handles_multiple_services(notify_db_session):
-    today = datetime.utcnow().date()
-    yesterday = datetime.utcnow().date() - timedelta(days=1)
-    current_year = datetime.utcnow().year
-
-    service_1 = create_service(restricted=False, service_name="Service 1")
-    sms_template_1 = create_template(service=service_1)
-    create_ft_billing(
-        bst_date=yesterday, template=sms_template_1, rate=1,
-        billable_unit=4, notifications_sent=4
-    )
-    create_ft_billing(
-        bst_date=today, template=sms_template_1, rate=1,
-        billable_unit=2, notifications_sent=2
-    )
-    create_annual_billing(service_id=service_1.id, free_sms_fragment_limit=5, financial_year_start=current_year)
-
-    service_2 = create_service(restricted=False, service_name="Service 2")
-    sms_template_2 = create_template(service=service_2)
-    create_ft_billing(
-        bst_date=yesterday, template=sms_template_2, rate=1,
-        billable_unit=16, notifications_sent=16
-    )
-    create_ft_billing(
-        bst_date=today, template=sms_template_2, rate=1,
-        billable_unit=8, notifications_sent=8
-    )
-    create_annual_billing(service_id=service_2.id, free_sms_fragment_limit=10, financial_year_start=current_year)
-
-    # ----------
-
-    result = query_sms_usage_for_year_per_service(2022).all()
-
-    service_1_rows = [row for row in result if row.service_id == service_1.id]
-    service_2_rows = [row for row in result if row.service_id == service_2.id]
-
-    assert len(service_1_rows) == 2
-    assert len(service_2_rows) == 2
-
-    # service 1 has allowance of 5
-    # four fragments in total, all are used
-    assert service_1_rows[0]['bst_date'] == date(2022, 4, 26)
-    assert service_1_rows[0]['chargeable_units'] == 4
-    assert service_1_rows[0]['charged_units'] == 0
-    # two in total - one is free, one is charged
-    assert service_1_rows[1]['bst_date'] == date(2022, 4, 27)
-    assert service_1_rows[1]['chargeable_units'] == 2
-    assert service_1_rows[1]['charged_units'] == 1
-
-    # service 2 has allowance of 10
-    # sixteen fragments total, allowance is used and six are charged
-    assert service_2_rows[0]['bst_date'] == date(2022, 4, 26)
-    assert service_2_rows[0]['chargeable_units'] == 16
-    assert service_2_rows[0]['charged_units'] == 6
-    # eight fragments total, all are charged
-    assert service_2_rows[1]['bst_date'] == date(2022, 4, 27)
-    assert service_2_rows[1]['chargeable_units'] == 8
-    assert service_2_rows[1]['charged_units'] == 8
-
-    # assert total costs are accurate
-    assert float(sum(row.cost for row in service_1_rows)) == 1  # rows with 2 and 4, allowance of 5
-    assert float(sum(row.cost for row in service_2_rows)) == 14  # rows with 8 and 16, allowance of 10
-
-
-@freeze_time('2022-05-01 13:30')
-def test_query_sms_usage_for_year_per_service_handles_multiple_rates(notify_db_session):
-    old_rate_date = date(2022, 4, 29)
-    new_rate_date = date(2022, 5, 1)
-    current_year = datetime.utcnow().year
-
-    service_1 = create_service(restricted=False, service_name="Service 1")
-    sms_template_1 = create_template(service=service_1)
-    create_ft_billing(
-        bst_date=old_rate_date, template=sms_template_1, rate=2,
-        billable_unit=4, notifications_sent=4
-    )
-    create_ft_billing(
-        bst_date=new_rate_date, template=sms_template_1, rate=3,
-        billable_unit=2, notifications_sent=2
-    )
-    create_annual_billing(service_id=service_1.id, free_sms_fragment_limit=3, financial_year_start=current_year)
-
-    result = query_sms_usage_for_year_per_service(2022).all()
-
-    # al lthe free allowance is used on the first day
-    assert result[0]['bst_date'] == date(2022, 4, 29)
-    assert result[0]['charged_units'] == 1
-    assert result[0]['cost'] == 2
-
-    assert result[1]['bst_date'] == date(2022, 5, 1)
-    assert result[1]['charged_units'] == 2
-    assert result[1]['cost'] == 6
 
 
 def test_fetch_daily_volumes_for_platform(

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -699,21 +699,21 @@ def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
         {
             "organisation_name": org.name, "organisation_id": org.id, "service_name": service_1.name,
             "service_id": service_1.id, "free_sms_fragment_limit": 10, "sms_remainder": 5,
-            "sms_billable_units": 3, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00')
+            "sms_billable_units": 3, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00'), "active": True
         },
         # sms remainder is 0, because this service sent SMS worth 15 billable units, 12 of which were sent
         # before requested report's start date
         {
             "organisation_name": org_2.name, "organisation_id": org_2.id, "service_name": service_2.name,
             "service_id": service_2.id, "free_sms_fragment_limit": 10, "sms_remainder": 0,
-            "sms_billable_units": 3, "chargeable_billable_sms": 3, "sms_cost": Decimal('0.33')
+            "sms_billable_units": 3, "chargeable_billable_sms": 3, "sms_cost": Decimal('0.33'), "active": True
         },
         # sms remainder is 0, because this service sent SMS worth 12 billable units, 5 of which were sent
         # before requested report's start date
         {
             "organisation_name": org_3.name, "organisation_id": org_3.id, "service_name": service_3.name,
             "service_id": service_3.id, "free_sms_fragment_limit": 10, "sms_remainder": 0,
-            "sms_billable_units": 7, "chargeable_billable_sms": 2, "sms_cost": Decimal('0.22')
+            "sms_billable_units": 7, "chargeable_billable_sms": 2, "sms_cost": Decimal('0.22'), "active": True
         },
     ]
 
@@ -733,7 +733,7 @@ def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(noti
             "service_name": fixtures["service_1_sms_and_letter"].name,
             "service_id": fixtures["service_1_sms_and_letter"].id,
             "free_sms_fragment_limit": 10, "sms_remainder": 5,
-            "sms_billable_units": 3, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00')
+            "sms_billable_units": 3, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00'), "active": True
         },
         # sms remainder is 0, because this service sent SMS worth 15 billable units, 12 of which were sent
         # before requested report's start date
@@ -742,14 +742,14 @@ def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(noti
             "service_name": fixtures["service_with_sms_without_org"].name,
             "service_id": fixtures["service_with_sms_without_org"].id, "free_sms_fragment_limit": 10,
             "sms_remainder": 0,
-            "sms_billable_units": 3, "chargeable_billable_sms": 3, "sms_cost": Decimal('0.33')
+            "sms_billable_units": 3, "chargeable_billable_sms": 3, "sms_cost": Decimal('0.33'), "active": True
         },
         {
             "organisation_name": None, "organisation_id": None,
             "service_name": fixtures["service_with_sms_within_allowance"].name,
             "service_id": fixtures["service_with_sms_within_allowance"].id, "free_sms_fragment_limit": 10,
             "sms_remainder": 8,
-            "sms_billable_units": 2, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00')
+            "sms_billable_units": 2, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00'), "active": True
         },
     ]
 

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -21,7 +21,7 @@ from app.dao.fact_billing_dao import (
     fetch_volumes_by_service,
     get_rate,
     get_rates_for_billing,
-    query_organisation_sms_usage_for_year,
+    query_sms_usage_for_year_per_service,
 )
 from app.dao.organisation_dao import dao_add_service_to_organisation
 from app.models import NOTIFICATION_STATUS_TYPES, FactBilling
@@ -1026,15 +1026,12 @@ def test_fetch_usage_year_for_organisation_only_returns_data_for_live_services(n
 
 
 @freeze_time('2022-04-27 13:30')
-def test_query_organisation_sms_usage_for_year_handles_multiple_services(notify_db_session):
+def test_query_sms_usage_for_year_per_service_handles_multiple_services(notify_db_session):
     today = datetime.utcnow().date()
     yesterday = datetime.utcnow().date() - timedelta(days=1)
     current_year = datetime.utcnow().year
 
-    org = create_organisation(name='Organisation 1')
-
     service_1 = create_service(restricted=False, service_name="Service 1")
-    dao_add_service_to_organisation(service=service_1, organisation_id=org.id)
     sms_template_1 = create_template(service=service_1)
     create_ft_billing(
         bst_date=yesterday, template=sms_template_1, rate=1,
@@ -1047,7 +1044,6 @@ def test_query_organisation_sms_usage_for_year_handles_multiple_services(notify_
     create_annual_billing(service_id=service_1.id, free_sms_fragment_limit=5, financial_year_start=current_year)
 
     service_2 = create_service(restricted=False, service_name="Service 2")
-    dao_add_service_to_organisation(service=service_2, organisation_id=org.id)
     sms_template_2 = create_template(service=service_2)
     create_ft_billing(
         bst_date=yesterday, template=sms_template_2, rate=1,
@@ -1061,7 +1057,7 @@ def test_query_organisation_sms_usage_for_year_handles_multiple_services(notify_
 
     # ----------
 
-    result = query_organisation_sms_usage_for_year(org.id, 2022).all()
+    result = query_sms_usage_for_year_per_service(2022).all()
 
     service_1_rows = [row for row in result if row.service_id == service_1.id]
     service_2_rows = [row for row in result if row.service_id == service_2.id]
@@ -1095,15 +1091,12 @@ def test_query_organisation_sms_usage_for_year_handles_multiple_services(notify_
 
 
 @freeze_time('2022-05-01 13:30')
-def test_query_organisation_sms_usage_for_year_handles_multiple_rates(notify_db_session):
+def test_query_sms_usage_for_year_per_service_handles_multiple_rates(notify_db_session):
     old_rate_date = date(2022, 4, 29)
     new_rate_date = date(2022, 5, 1)
     current_year = datetime.utcnow().year
 
-    org = create_organisation(name='Organisation 1')
-
     service_1 = create_service(restricted=False, service_name="Service 1")
-    dao_add_service_to_organisation(service=service_1, organisation_id=org.id)
     sms_template_1 = create_template(service=service_1)
     create_ft_billing(
         bst_date=old_rate_date, template=sms_template_1, rate=2,
@@ -1115,7 +1108,7 @@ def test_query_organisation_sms_usage_for_year_handles_multiple_rates(notify_db_
     )
     create_annual_billing(service_id=service_1.id, free_sms_fragment_limit=3, financial_year_start=current_year)
 
-    result = query_organisation_sms_usage_for_year(org.id, 2022).all()
+    result = query_sms_usage_for_year_per_service(2022).all()
 
     # al lthe free allowance is used on the first day
     assert result[0]['bst_date'] == date(2022, 4, 29)

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -642,7 +642,7 @@ def test_fetch_sms_billing_for_all_services_for_first_quarter(notify_db_session)
     dao_add_service_to_organisation(service=service, organisation_id=org.id)
     create_annual_billing(service_id=service.id, free_sms_fragment_limit=25000, financial_year_start=2019)
     create_ft_billing(template=template, bst_date=datetime(2019, 4, 20), billable_unit=44, rate=0.11)
-    results = fetch_sms_billing_for_all_services(datetime(2019, 4, 1), datetime(2019, 5, 30))
+    results = fetch_sms_billing_for_all_services(datetime(2019, 4, 1), datetime(2019, 5, 30)).all()
     assert len(results) == 1
     assert results[0].organisation_id == org.id
     assert results[0].organisation_name == org.name
@@ -690,7 +690,7 @@ def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
     create_ft_billing(template=email_template, bst_date=datetime(2019, 5, 22), notifications_sent=5,
                       billable_unit=0, rate=0)
 
-    results = fetch_sms_billing_for_all_services(datetime(2019, 5, 1), datetime(2019, 5, 31))
+    results = fetch_sms_billing_for_all_services(datetime(2019, 5, 1), datetime(2019, 5, 31)).all()
     assert len(results) == 3
 
     expected_results = [
@@ -722,7 +722,7 @@ def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
 
 def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(notify_db_session):
     fixtures = set_up_usage_data(datetime(2019, 5, 1))
-    results = fetch_sms_billing_for_all_services(datetime(2019, 5, 1), datetime(2019, 5, 31))
+    results = fetch_sms_billing_for_all_services(datetime(2019, 5, 1), datetime(2019, 5, 31)).all()
 
     assert len(results) == 3
     expected_results = [

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -671,8 +671,16 @@ def test_fetch_sms_billing_for_all_services_for_first_quarter(notify_db_session)
     create_ft_billing(template=template, bst_date=datetime(2019, 4, 20), billable_unit=44, rate=0.11)
     results = fetch_sms_billing_for_all_services(datetime(2019, 4, 1), datetime(2019, 5, 30))
     assert len(results) == 1
-    assert results[0] == (org.name, org.id, service.name, service.id, 25000, Decimal('0.11'), 24956, 44, 0,
-                          Decimal('0'))
+    assert results[0].organisation_id == org.id
+    assert results[0].organisation_name == org.name
+    assert results[0].service_id == service.id
+    assert results[0].service_name == service.name
+    assert results[0].chargeable_billable_sms == 0
+    assert results[0].sms_billable_units == 44
+    assert results[0].free_sms_fragment_limit == 25000
+    assert results[0].sms_remainder == 24956
+    assert results[0].sms_cost == 0
+    assert results[0].sms_rate == 0.11
 
 
 def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -681,6 +681,7 @@ def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
     create_ft_billing(template=template_3, bst_date=datetime(2019, 4, 20), billable_unit=5, rate=0.11)
     create_ft_billing(template=template_3, bst_date=datetime(2019, 5, 20), billable_unit=7, rate=0.11)
 
+    # this isn't included in results as it doesn't have any SMS rows
     service_4 = create_service(service_name='d - email only')
     email_template = create_template(service=service_4, template_type='email')
     org_4 = create_organisation(name="Org for {}".format(service_4.name))

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -653,7 +653,6 @@ def test_fetch_sms_billing_for_all_services_for_first_quarter(notify_db_session)
     assert results[0].free_sms_fragment_limit == 25000
     assert results[0].sms_remainder == 24956
     assert results[0].sms_cost == 0
-    assert results[0].sms_rate == 0.11
 
 
 def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
@@ -698,21 +697,21 @@ def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
         # the requested report's start date.
         {
             "organisation_name": org.name, "organisation_id": org.id, "service_name": service_1.name,
-            "service_id": service_1.id, "free_sms_fragment_limit": 10, "sms_rate": Decimal('0.11'), "sms_remainder": 5,
+            "service_id": service_1.id, "free_sms_fragment_limit": 10, "sms_remainder": 5,
             "sms_billable_units": 3, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00')
         },
         # sms remainder is 0, because this service sent SMS worth 15 billable units, 12 of which were sent
         # before requested report's start date
         {
             "organisation_name": org_2.name, "organisation_id": org_2.id, "service_name": service_2.name,
-            "service_id": service_2.id, "free_sms_fragment_limit": 10, "sms_rate": Decimal('0.11'), "sms_remainder": 0,
+            "service_id": service_2.id, "free_sms_fragment_limit": 10, "sms_remainder": 0,
             "sms_billable_units": 3, "chargeable_billable_sms": 3, "sms_cost": Decimal('0.33')
         },
         # sms remainder is 0, because this service sent SMS worth 12 billable units, 5 of which were sent
         # before requested report's start date
         {
             "organisation_name": org_3.name, "organisation_id": org_3.id, "service_name": service_3.name,
-            "service_id": service_3.id, "free_sms_fragment_limit": 10, "sms_rate": Decimal('0.11'), "sms_remainder": 0,
+            "service_id": service_3.id, "free_sms_fragment_limit": 10, "sms_remainder": 0,
             "sms_billable_units": 7, "chargeable_billable_sms": 2, "sms_cost": Decimal('0.22')
         },
     ]
@@ -732,7 +731,7 @@ def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(noti
             "organisation_name": fixtures["org_1"].name, "organisation_id": fixtures["org_1"].id,
             "service_name": fixtures["service_1_sms_and_letter"].name,
             "service_id": fixtures["service_1_sms_and_letter"].id,
-            "free_sms_fragment_limit": 10, "sms_rate": Decimal('0.11'), "sms_remainder": 5,
+            "free_sms_fragment_limit": 10, "sms_remainder": 5,
             "sms_billable_units": 3, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00')
         },
         # sms remainder is 0, because this service sent SMS worth 15 billable units, 12 of which were sent
@@ -741,14 +740,14 @@ def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(noti
             "organisation_name": None, "organisation_id": None,
             "service_name": fixtures["service_with_sms_without_org"].name,
             "service_id": fixtures["service_with_sms_without_org"].id, "free_sms_fragment_limit": 10,
-            "sms_rate": Decimal('0.11'), "sms_remainder": 0,
+            "sms_remainder": 0,
             "sms_billable_units": 3, "chargeable_billable_sms": 3, "sms_cost": Decimal('0.33')
         },
         {
             "organisation_name": None, "organisation_id": None,
             "service_name": fixtures["service_with_sms_within_allowance"].name,
             "service_id": fixtures["service_with_sms_within_allowance"].id, "free_sms_fragment_limit": 10,
-            "sms_rate": Decimal('0.11'), "sms_remainder": 8,
+            "sms_remainder": 8,
             "sms_billable_units": 2, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00')
         },
     ]

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -649,7 +649,7 @@ def test_fetch_sms_billing_for_all_services_for_first_quarter(notify_db_session)
     assert results[0].service_id == service.id
     assert results[0].service_name == service.name
     assert results[0].chargeable_billable_sms == 0
-    assert results[0].sms_billable_units == 44
+    assert results[0].sms_chargeable_units == 44
     assert results[0].free_sms_fragment_limit == 25000
     assert results[0].sms_remainder == 24956
     assert results[0].sms_cost == 0
@@ -699,21 +699,21 @@ def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
         {
             "organisation_name": org.name, "organisation_id": org.id, "service_name": service_1.name,
             "service_id": service_1.id, "free_sms_fragment_limit": 10, "sms_remainder": 5,
-            "sms_billable_units": 3, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00'), "active": True
+            "sms_chargeable_units": 3, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00'), "active": True
         },
         # sms remainder is 0, because this service sent SMS worth 15 billable units, 12 of which were sent
         # before requested report's start date
         {
             "organisation_name": org_2.name, "organisation_id": org_2.id, "service_name": service_2.name,
             "service_id": service_2.id, "free_sms_fragment_limit": 10, "sms_remainder": 0,
-            "sms_billable_units": 3, "chargeable_billable_sms": 3, "sms_cost": Decimal('0.33'), "active": True
+            "sms_chargeable_units": 3, "chargeable_billable_sms": 3, "sms_cost": Decimal('0.33'), "active": True
         },
         # sms remainder is 0, because this service sent SMS worth 12 billable units, 5 of which were sent
         # before requested report's start date
         {
             "organisation_name": org_3.name, "organisation_id": org_3.id, "service_name": service_3.name,
             "service_id": service_3.id, "free_sms_fragment_limit": 10, "sms_remainder": 0,
-            "sms_billable_units": 7, "chargeable_billable_sms": 2, "sms_cost": Decimal('0.22'), "active": True
+            "sms_chargeable_units": 7, "chargeable_billable_sms": 2, "sms_cost": Decimal('0.22'), "active": True
         },
     ]
 
@@ -733,7 +733,7 @@ def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(noti
             "service_name": fixtures["service_1_sms_and_letter"].name,
             "service_id": fixtures["service_1_sms_and_letter"].id,
             "free_sms_fragment_limit": 10, "sms_remainder": 5,
-            "sms_billable_units": 3, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00'), "active": True
+            "sms_chargeable_units": 3, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00'), "active": True
         },
         # sms remainder is 0, because this service sent SMS worth 15 billable units, 12 of which were sent
         # before requested report's start date
@@ -742,14 +742,14 @@ def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(noti
             "service_name": fixtures["service_with_sms_without_org"].name,
             "service_id": fixtures["service_with_sms_without_org"].id, "free_sms_fragment_limit": 10,
             "sms_remainder": 0,
-            "sms_billable_units": 3, "chargeable_billable_sms": 3, "sms_cost": Decimal('0.33'), "active": True
+            "sms_chargeable_units": 3, "chargeable_billable_sms": 3, "sms_cost": Decimal('0.33'), "active": True
         },
         {
             "organisation_name": None, "organisation_id": None,
             "service_name": fixtures["service_with_sms_within_allowance"].name,
             "service_id": fixtures["service_with_sms_within_allowance"].id, "free_sms_fragment_limit": 10,
             "sms_remainder": 8,
-            "sms_billable_units": 2, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00'), "active": True
+            "sms_chargeable_units": 2, "chargeable_billable_sms": 0, "sms_cost": Decimal('0.00'), "active": True
         },
     ]
 


### PR DESCRIPTION
The platform admin billing report is different to the other two billing reports in one crucial way: It allows you to report on a period of time that doesn't need to be an entire financial year. This means that it needs to be aware of the part of the financial year leading up to the billing period - which it _shouldn't_ include in the results, but it does need to know how many fragments were already spent.

Fortunately we were able to re-use a lot of the existing query code from the organisation usage report. That already has some tests for the complicated subquery magic, so we don't need to re-test them.

However, we ended up having to modify the existing code a bit - i need to have another look now that i've got the existing tests passing to see if there's any sensible refactors/cleanups because I feel like we've got a lot of columns that look very similar but slightly different, so any suggestions that people have i'm keen to hear.

(Also, better ways of testing this than deploying to prod and comparing the sms report results is also welcome)