### PR TITLE
Upgrade marshmallow-sqlalchemy plus the unpinned dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ SQLAlchemy==1.4.36
 cachetools==5.1.0
 beautifulsoup4==4.11.1
 lxml==4.8.0
-Werkzeug==2.0.3
+Werkzeug==2.0.3  # pyup: <2.1.0 # later versions are not compatible with the version of flask-sqlalchemy we have pinned
 
 notifications-python-client==6.3.0
 

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b86
 iso8601==1.0.2
 itsdangerous==2.1.2
 jsonschema[format]==4.5.1
-marshmallow-sqlalchemy==0.23.1 # pyup: <0.24.0 # marshmallow v3 throws errors
+marshmallow-sqlalchemy==0.28.0
 marshmallow==3.15.0
 psycopg2-binary==2.9.3
 PyJWT==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -150,7 +150,7 @@ marshmallow==3.15.0
     #   -r requirements.in
     #   flask-marshmallow
     #   marshmallow-sqlalchemy
-marshmallow-sqlalchemy==0.23.1
+marshmallow-sqlalchemy==0.28.0
     # via -r requirements.in
 mistune==0.8.4
     # via notifications-utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,19 +4,21 @@
 #
 #    pip-compile requirements.in
 #
-alembic==1.7.4
+alembic==1.7.7
     # via flask-migrate
-amqp==5.0.9
+amqp==5.1.1
     # via kombu
 arrow==1.2.2
     # via isoduration
-attrs==21.2.0
+async-timeout==4.0.2
+    # via redis
+attrs==21.4.0
     # via jsonschema
-awscli==1.21.4
+awscli==1.24.8
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
-bcrypt==3.2.0
+bcrypt==3.2.2
     # via flask-bcrypt
 beautifulsoup4==4.11.1
     # via -r requirements.in
@@ -26,9 +28,9 @@ bleach==4.1.0
     # via notifications-utils
 blinker==1.4
     # via gds-metrics
-boto3==1.19.4
+boto3==1.23.8
     # via notifications-utils
-botocore==1.22.4
+botocore==1.26.8
     # via
     #   awscli
     #   boto3
@@ -39,7 +41,7 @@ cachetools==5.1.0
     #   notifications-utils
 celery[sqs]==5.2.6
     # via -r requirements.in
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   pyproj
     #   requests
@@ -47,9 +49,9 @@ cffi==1.15.0
     # via
     #   -r requirements.in
     #   bcrypt
-charset-normalizer==2.0.7
+charset-normalizer==2.0.12
     # via requests
-click==8.0.3
+click==8.1.3
     # via
     #   celery
     #   click-datetime
@@ -65,15 +67,17 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-colorama==0.4.3
+colorama==0.4.4
     # via awscli
-dnspython==2.2.0
+deprecated==1.2.13
+    # via redis
+dnspython==2.2.1
     # via eventlet
 docopt==0.6.2
     # via notifications-python-client
-docutils==0.15.2
+docutils==0.16
     # via awscli
-eventlet==0.33.0
+eventlet==0.33.1
     # via gunicorn
 flask==2.1.2
     # via
@@ -102,7 +106,7 @@ gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6
     # via -r requirements.in
 geojson==2.5.0
     # via notifications-utils
-govuk-bank-holidays==0.10
+govuk-bank-holidays==0.11
     # via notifications-utils
 greenlet==1.1.2
     # via eventlet
@@ -112,7 +116,7 @@ idna==3.3
     # via
     #   jsonschema
     #   requests
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via flask
 iso8601==1.0.2
     # via -r requirements.in
@@ -123,11 +127,11 @@ itsdangerous==2.1.2
     #   -r requirements.in
     #   flask
     #   notifications-utils
-jinja2==3.0.2
+jinja2==3.1.2
     # via
     #   flask
     #   notifications-utils
-jmespath==0.10.0
+jmespath==1.0.0
     # via
     #   boto3
     #   botocore
@@ -135,13 +139,13 @@ jsonpointer==2.3
     # via jsonschema
 jsonschema[format]==4.5.1
     # via -r requirements.in
-kombu==5.2.3
+kombu==5.2.4
     # via celery
 lxml==4.8.0
     # via -r requirements.in
-mako==1.1.5
+mako==1.2.0
     # via alembic
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   jinja2
     #   mako
@@ -160,35 +164,36 @@ notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
-packaging==21.0
+packaging==21.3
     # via
     #   bleach
     #   marshmallow
-phonenumbers==8.12.36
+    #   redis
+phonenumbers==8.12.48
     # via notifications-utils
 prometheus-client==0.14.1
     # via
     #   -r requirements.in
     #   gds-metrics
-prompt-toolkit==3.0.21
+prompt-toolkit==3.0.29
     # via click-repl
 psycopg2-binary==2.9.3
     # via -r requirements.in
 pyasn1==0.4.8
     # via rsa
-pycparser==2.20
+pycparser==2.21
     # via cffi
 pyjwt==2.4.0
     # via
     #   -r requirements.in
     #   notifications-python-client
-pyparsing==3.0.1
+pyparsing==3.0.9
     # via packaging
-pypdf2==1.27.12
+pypdf2==1.28.2
     # via notifications-utils
-pyproj==3.2.1
+pyproj==3.3.1
     # via notifications-utils
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via jsonschema
 python-dateutil==2.8.2
     # via
@@ -197,7 +202,7 @@ python-dateutil==2.8.2
     #   botocore
 python-json-logger==2.0.2
     # via notifications-utils
-pytz==2021.3
+pytz==2022.1
     # via
     #   celery
     #   notifications-utils
@@ -205,9 +210,9 @@ pyyaml==5.4.1
     # via
     #   awscli
     #   notifications-utils
-redis==3.5.3
+redis==4.3.1
     # via flask-redis
-requests==2.26.0
+requests==2.27.1
     # via
     #   awscli-cwlogs
     #   govuk-bank-holidays
@@ -219,16 +224,15 @@ rfc3987==1.3.8
     # via jsonschema
 rsa==4.7.2
     # via awscli
-s3transfer==0.5.0
+s3transfer==0.5.2
     # via
     #   awscli
     #   boto3
-shapely==1.8.0
+shapely==1.8.2
     # via notifications-utils
 six==1.16.0
     # via
     #   awscli-cwlogs
-    #   bcrypt
     #   bleach
     #   click-repl
     #   eventlet
@@ -237,7 +241,7 @@ six==1.16.0
     #   rfc3339-validator
 smartypants==2.0.1
     # via notifications-utils
-soupsieve==2.2.1
+soupsieve==2.3.2.post1
     # via beautifulsoup4
 sqlalchemy==1.4.36
     # via
@@ -248,7 +252,7 @@ statsd==3.3.0
     # via notifications-utils
 uri-template==1.2.0
     # via jsonschema
-urllib3==1.26.7
+urllib3==1.26.9
     # via
     #   botocore
     #   requests
@@ -259,7 +263,7 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.5
     # via prompt-toolkit
-webcolors==1.11.1
+webcolors==1.12
     # via jsonschema
 webencodings==0.5.1
     # via bleach
@@ -267,6 +271,8 @@ werkzeug==2.0.3
     # via
     #   -r requirements.in
     #   flask
+wrapt==1.14.1
+    # via deprecated
 zipp==3.8.0
     # via importlib-metadata
 


### PR DESCRIPTION
This upgrades marshmallow-sqlalchemy, which can be unpinned now that https://github.com/alphagov/notifications-api/pull/3541 has been merged. It also upgrades all the unpinned dependencies in `requirements.txt`.