### PR TITLE
Bump utils to version 56.0.0

### DIFF
--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -9,7 +9,7 @@ from notifications_utils.template import (
     BroadcastMessageTemplate,
     SMSMessageTemplate,
 )
-from PyPDF2.utils import PdfReadError
+from PyPDF2.errors import PdfReadError
 from requests import post as requests_post
 from sqlalchemy.orm.exc import NoResultFound
 

--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ notifications-python-client==6.3.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@56.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -160,7 +160,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@56.0.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -189,7 +189,7 @@ pyjwt==2.4.0
     #   notifications-python-client
 pyparsing==3.0.9
     # via packaging
-pypdf2==1.28.2
+pypdf2==2.0.0
     # via notifications-utils
 pyproj==3.3.1
     # via notifications-utils
@@ -250,6 +250,8 @@ sqlalchemy==1.4.36
     #   marshmallow-sqlalchemy
 statsd==3.3.0
     # via notifications-utils
+typing-extensions==4.2.0
+    # via pypdf2
 uri-template==1.2.0
     # via jsonschema
 urllib3==1.26.9

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -10,7 +10,7 @@ import pytest
 import requests_mock
 from freezegun import freeze_time
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
-from PyPDF2.utils import PdfReadError
+from PyPDF2.errors import PdfReadError
 
 from app.dao.templates_dao import (
     dao_get_template_by_id,


### PR DESCRIPTION
The only impactful change is the major version itself, where I've
fixed the breaking changes due to the upgrade of PyPDF2 [^1] and
checked there are no deprecation warnings when I run the tests.

[^1]: https://github.com/alphagov/notifications-utils/pull/973