### PR TITLE
Rename fact_billing DAO functions consistently

### DIFF
--- a/app/billing/rest.py
+++ b/app/billing/rest.py
@@ -13,8 +13,8 @@ from app.dao.annual_billing_dao import (
 )
 from app.dao.date_util import get_current_financial_year_start_year
 from app.dao.fact_billing_dao import (
-    fetch_billing_totals_for_year,
-    fetch_monthly_billing_for_year,
+    fetch_usage_for_service_annual,
+    fetch_usage_for_service_by_month,
 )
 from app.errors import register_errors
 from app.models import Service
@@ -36,7 +36,7 @@ def get_yearly_usage_by_monthly_from_ft_billing(service_id):
         year = int(request.args.get('year'))
     except TypeError:
         return jsonify(result='error', message='No valid year provided'), 400
-    results = fetch_monthly_billing_for_year(service_id=service_id, year=year)
+    results = fetch_usage_for_service_by_month(service_id=service_id, year=year)
     data = serialize_ft_billing_remove_emails(results)
     return jsonify(data)
 
@@ -48,7 +48,7 @@ def get_yearly_billing_usage_summary_from_ft_billing(service_id):
     except TypeError:
         return jsonify(result='error', message='No valid year provided'), 400
 
-    billing_data = fetch_billing_totals_for_year(service_id, year)
+    billing_data = fetch_usage_for_service_annual(service_id, year)
     data = serialize_ft_billing_yearly_totals(billing_data)
     return jsonify(data)
 

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -64,7 +64,7 @@ def fetch_sms_free_allowance_remainder_until_date(end_date):
     return query
 
 
-def fetch_sms_billing_for_all_services(start_date, end_date):
+def fetch_usage_for_all_services_sms(start_date, end_date):
 
     # ASSUMPTION: AnnualBilling has been populated for year.
     allowance_left_at_start_date_query = fetch_sms_free_allowance_remainder_until_date(start_date).subquery()
@@ -120,7 +120,7 @@ def fetch_sms_billing_for_all_services(start_date, end_date):
     return query.all()
 
 
-def fetch_letter_costs_and_totals_for_all_services(start_date, end_date):
+def fetch_usage_for_all_services_letter(start_date, end_date):
     query = db.session.query(
         Organisation.name.label("organisation_name"),
         Organisation.id.label("organisation_id"),
@@ -152,7 +152,7 @@ def fetch_letter_costs_and_totals_for_all_services(start_date, end_date):
     return query.all()
 
 
-def fetch_letter_line_items_for_all_services(start_date, end_date):
+def fetch_usage_for_all_services_letter_breakdown(start_date, end_date):
     formatted_postage = case(
         [(FactBilling.postage.in_(INTERNATIONAL_POSTAGE_TYPES), "international")], else_=FactBilling.postage
     ).label("postage")

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -198,7 +198,7 @@ def fetch_usage_for_all_services_letter_breakdown(start_date, end_date):
     return query.all()
 
 
-def fetch_billing_totals_for_year(service_id, year):
+def fetch_usage_for_service_annual(service_id, year):
     """
     Returns a row for each distinct rate and notification_type from ft_billing
     over the specified financial year e.g.
@@ -231,9 +231,9 @@ def fetch_billing_totals_for_year(service_id, year):
                 query.c.notification_type
             )
             for query in [
-                query_service_sms_usage_for_year(service_id, year).subquery(),
-                query_service_email_usage_for_year(service_id, year).subquery(),
-                query_service_letter_usage_for_year(service_id, year).subquery(),
+                _fetch_usage_for_service_sms(service_id, year).subquery(),
+                _fetch_usage_for_service_email(service_id, year).subquery(),
+                _fetch_usage_for_service_letter(service_id, year).subquery(),
             ]
         ]).subquery()
     ).order_by(
@@ -242,7 +242,7 @@ def fetch_billing_totals_for_year(service_id, year):
     ).all()
 
 
-def fetch_monthly_billing_for_year(service_id, year):
+def fetch_usage_for_service_by_month(service_id, year):
     """
     Returns a row for each distinct rate, notification_type, postage and month
     from ft_billing over the specified financial year e.g.
@@ -291,9 +291,9 @@ def fetch_monthly_billing_for_year(service_id, year):
                 'month',
             )
             for query in [
-                query_service_sms_usage_for_year(service_id, year).subquery(),
-                query_service_email_usage_for_year(service_id, year).subquery(),
-                query_service_letter_usage_for_year(service_id, year).subquery(),
+                _fetch_usage_for_service_sms(service_id, year).subquery(),
+                _fetch_usage_for_service_email(service_id, year).subquery(),
+                _fetch_usage_for_service_letter(service_id, year).subquery(),
             ]
         ]).subquery()
     ).order_by(
@@ -303,7 +303,7 @@ def fetch_monthly_billing_for_year(service_id, year):
     ).all()
 
 
-def query_service_email_usage_for_year(service_id, year):
+def _fetch_usage_for_service_email(service_id, year):
     year_start, year_end = get_financial_year_dates(year)
 
     return db.session.query(
@@ -324,7 +324,7 @@ def query_service_email_usage_for_year(service_id, year):
     )
 
 
-def query_service_letter_usage_for_year(service_id, year):
+def _fetch_usage_for_service_letter(service_id, year):
     year_start, year_end = get_financial_year_dates(year)
 
     return db.session.query(
@@ -348,7 +348,7 @@ def query_service_letter_usage_for_year(service_id, year):
     )
 
 
-def query_service_sms_usage_for_year(service_id, year):
+def _fetch_usage_for_service_sms(service_id, year):
     """
     Returns rows from the ft_billing table with some calculated values like cost,
     incorporating the SMS free allowance e.g.
@@ -763,7 +763,7 @@ def fetch_sms_billing_for_organisation(organisation_id, financial_year):
 
 def query_organisation_sms_usage_for_year(organisation_id, year):
     """
-    See docstring for query_service_sms_usage_for_year()
+    See docstring for _fetch_usage_for_service_sms()
     """
     year_start, year_end = get_financial_year_dates(year)
     this_rows_chargeable_units = FactBilling.billable_units * FactBilling.rate_multiplier

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -868,23 +868,6 @@ def fetch_usage_for_organisation(organisation_id, year):
     return service_with_usage
 
 
-def fetch_billing_details_for_all_services():
-    billing_details = db.session.query(
-        Service.id.label('service_id'),
-        func.coalesce(Service.purchase_order_number, Organisation.purchase_order_number).label('purchase_order_number'),
-        func.coalesce(Service.billing_contact_names, Organisation.billing_contact_names).label('billing_contact_names'),
-        func.coalesce(
-            Service.billing_contact_email_addresses,
-            Organisation.billing_contact_email_addresses
-        ).label('billing_contact_email_addresses'),
-        func.coalesce(Service.billing_reference, Organisation.billing_reference).label('billing_reference'),
-    ).outerjoin(
-        Service.organisation
-    ).all()
-
-    return billing_details
-
-
 def fetch_daily_volumes_for_platform(start_date, end_date):
     # query to return the total notifications sent per day for each channel. NB start and end dates are inclusive
 

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -607,3 +607,18 @@ def get_live_services_with_organisation():
     )
 
     return query.all()
+
+
+def fetch_billing_details_for_all_services():
+    return db.session.query(
+        Service.id.label('service_id'),
+        func.coalesce(Service.purchase_order_number, Organisation.purchase_order_number).label('purchase_order_number'),
+        func.coalesce(Service.billing_contact_names, Organisation.billing_contact_names).label('billing_contact_names'),
+        func.coalesce(
+            Service.billing_contact_email_addresses,
+            Organisation.billing_contact_email_addresses
+        ).label('billing_contact_email_addresses'),
+        func.coalesce(Service.billing_reference, Organisation.billing_reference).label('billing_reference'),
+    ).outerjoin(
+        Service.organisation
+    ).all()

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -5,7 +5,7 @@ from sqlalchemy.exc import IntegrityError
 from app.config import QueueNames
 from app.dao.annual_billing_dao import set_default_free_allowance_for_service
 from app.dao.dao_utils import transaction
-from app.dao.fact_billing_dao import fetch_usage_year_for_organisation
+from app.dao.fact_billing_dao import fetch_usage_for_organisation
 from app.dao.organisation_dao import (
     dao_add_service_to_organisation,
     dao_add_user_to_organisation,
@@ -151,7 +151,7 @@ def get_organisation_services_usage(organisation_id):
         year = int(request.args.get('year', 'none'))
     except ValueError:
         return jsonify(result='error', message='No valid year provided'), 400
-    services = fetch_usage_year_for_organisation(organisation_id, year)
+    services = fetch_usage_for_organisation(organisation_id, year)
     list_services = services.values()
     sorted_services = sorted(list_services, key=lambda s: (-s['active'], s['service_name'].lower()))
     return jsonify(services=sorted_services)

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -4,7 +4,6 @@ from flask import Blueprint, jsonify, request
 
 from app.dao.date_util import get_financial_year_for_datetime
 from app.dao.fact_billing_dao import (
-    fetch_billing_details_for_all_services,
     fetch_daily_sms_provider_volumes_for_platform,
     fetch_daily_volumes_for_platform,
     fetch_usage_for_all_services_letter,
@@ -15,6 +14,7 @@ from app.dao.fact_billing_dao import (
 from app.dao.fact_notification_status_dao import (
     fetch_notification_status_totals_for_all_services,
 )
+from app.dao.services_dao import fetch_billing_details_for_all_services
 from app.errors import InvalidRequest, register_errors
 from app.models import UK_POSTAGE_TYPES
 from app.platform_stats.platform_stats_schema import platform_stats_request

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -7,9 +7,9 @@ from app.dao.fact_billing_dao import (
     fetch_billing_details_for_all_services,
     fetch_daily_sms_provider_volumes_for_platform,
     fetch_daily_volumes_for_platform,
-    fetch_letter_costs_and_totals_for_all_services,
-    fetch_letter_line_items_for_all_services,
-    fetch_sms_billing_for_all_services,
+    fetch_usage_for_all_services_letter,
+    fetch_usage_for_all_services_letter_breakdown,
+    fetch_usage_for_all_services_sms,
     fetch_volumes_by_service,
 )
 from app.dao.fact_notification_status_dao import (
@@ -74,9 +74,9 @@ def get_data_for_billing_report():
 
     start_date, end_date = validate_date_range_is_within_a_financial_year(start_date, end_date)
 
-    sms_costs = fetch_sms_billing_for_all_services(start_date, end_date)
-    letter_overview = fetch_letter_costs_and_totals_for_all_services(start_date, end_date)
-    letter_breakdown = fetch_letter_line_items_for_all_services(start_date, end_date)
+    sms_costs = fetch_usage_for_all_services_sms(start_date, end_date)
+    letter_overview = fetch_usage_for_all_services_letter(start_date, end_date)
+    letter_breakdown = fetch_usage_for_all_services_letter_breakdown(start_date, end_date)
 
     lb_by_service = [
         (lb.service_id,

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -7,6 +7,7 @@ from notifications_utils.timezones import convert_utc_to_bst
 
 from app import db
 from app.dao.fact_billing_dao import (
+    _fetch_usage_for_organisation_sms_query,
     delete_billing_data_for_service_for_day,
     fetch_billing_data_for_day,
     fetch_daily_sms_provider_volumes_for_platform,
@@ -15,13 +16,12 @@ from app.dao.fact_billing_dao import (
     fetch_usage_for_all_services_letter,
     fetch_usage_for_all_services_letter_breakdown,
     fetch_usage_for_all_services_sms,
+    fetch_usage_for_organisation,
     fetch_usage_for_service_annual,
     fetch_usage_for_service_by_month,
-    fetch_usage_year_for_organisation,
     fetch_volumes_by_service,
     get_rate,
     get_rates_for_billing,
-    query_organisation_sms_usage_for_year,
 )
 from app.dao.organisation_dao import dao_add_service_to_organisation
 from app.models import NOTIFICATION_STATUS_TYPES, FactBilling
@@ -842,7 +842,7 @@ def test_fetch_usage_for_all_services_letter_breakdown(notify_db_session):
 
 
 @freeze_time('2019-06-01 13:30')
-def test_fetch_usage_year_for_organisation(notify_db_session):
+def test_fetch_usage_for_organisation(notify_db_session):
     fixtures = set_up_usage_data(datetime(2019, 5, 1))
     service_with_emails_for_org = create_service(service_name='Service with emails for org')
     create_annual_billing(service_with_emails_for_org.id, free_sms_fragment_limit=0, financial_year_start=2019)
@@ -854,7 +854,7 @@ def test_fetch_usage_year_for_organisation(notify_db_session):
     create_ft_billing(bst_date=datetime(2019, 5, 1),
                       template=template,
                       notifications_sent=1100)
-    results = fetch_usage_year_for_organisation(fixtures["org_1"].id, 2019)
+    results = fetch_usage_for_organisation(fixtures["org_1"].id, 2019)
 
     assert len(results) == 3
     first_row = results[str(fixtures["service_1_sms_and_letter"].id)]
@@ -888,7 +888,7 @@ def test_fetch_usage_year_for_organisation(notify_db_session):
     assert third_row['emails_sent'] == 0
 
 
-def test_fetch_usage_year_for_organisation_populates_ft_billing_for_today(notify_db_session):
+def test_fetch_usage_for_organisation_populates_ft_billing_for_today(notify_db_session):
     create_letter_rate(start_date=datetime.utcnow() - timedelta(days=1))
     create_rate(start_date=datetime.utcnow() - timedelta(days=1), value=0.65, notification_type='sms')
     new_org = create_organisation(name='New organisation')
@@ -902,13 +902,13 @@ def test_fetch_usage_year_for_organisation_populates_ft_billing_for_today(notify
 
     create_notification(template=template, status='delivered')
 
-    results = fetch_usage_year_for_organisation(organisation_id=new_org.id, year=current_year)
+    results = fetch_usage_for_organisation(organisation_id=new_org.id, year=current_year)
     assert len(results) == 1
     assert FactBilling.query.count() == 1
 
 
 @freeze_time('2022-05-01 13:30')
-def test_fetch_usage_year_for_organisation_calculates_cost_from_multiple_rates(notify_db_session):
+def test_fetch_usage_for_organisation_calculates_cost_from_multiple_rates(notify_db_session):
     old_rate_date = date(2022, 4, 29)
     new_rate_date = date(2022, 5, 1)
     current_year = datetime.utcnow().year
@@ -928,7 +928,7 @@ def test_fetch_usage_year_for_organisation_calculates_cost_from_multiple_rates(n
     )
     create_annual_billing(service_id=service_1.id, free_sms_fragment_limit=3, financial_year_start=current_year)
 
-    results = fetch_usage_year_for_organisation(organisation_id=org.id, year=current_year)
+    results = fetch_usage_for_organisation(organisation_id=org.id, year=current_year)
 
     assert len(results) == 1
     assert results[str(service_1.id)]['free_sms_limit'] == 3
@@ -939,7 +939,7 @@ def test_fetch_usage_year_for_organisation_calculates_cost_from_multiple_rates(n
 
 
 @freeze_time('2022-05-01 13:30')
-def test_fetch_usage_year_for_organisation_when_no_usage(notify_db_session):
+def test_fetch_usage_for_organisation_when_no_usage(notify_db_session):
     current_year = datetime.utcnow().year
 
     org = create_organisation(name='Organisation 1')
@@ -948,7 +948,7 @@ def test_fetch_usage_year_for_organisation_when_no_usage(notify_db_session):
     dao_add_service_to_organisation(service=service_1, organisation_id=org.id)
     create_annual_billing(service_id=service_1.id, free_sms_fragment_limit=3, financial_year_start=current_year)
 
-    results = fetch_usage_year_for_organisation(organisation_id=org.id, year=current_year)
+    results = fetch_usage_for_organisation(organisation_id=org.id, year=current_year)
 
     assert len(results) == 1
     assert results[str(service_1.id)]['free_sms_limit'] == 3
@@ -959,7 +959,7 @@ def test_fetch_usage_year_for_organisation_when_no_usage(notify_db_session):
 
 
 @freeze_time('2022-05-01 13:30')
-def test_fetch_usage_year_for_organisation_only_queries_present_year(notify_db_session):
+def test_fetch_usage_for_organisation_only_queries_present_year(notify_db_session):
     current_year = datetime.utcnow().year
     last_year = current_year - 1
     date_two_years_ago = date(2021, 3, 31)
@@ -988,7 +988,7 @@ def test_fetch_usage_year_for_organisation_only_queries_present_year(notify_db_s
     create_annual_billing(service_id=service_1.id, free_sms_fragment_limit=0, financial_year_start=last_year)
     create_annual_billing(service_id=service_1.id, free_sms_fragment_limit=8, financial_year_start=current_year)
 
-    results = fetch_usage_year_for_organisation(organisation_id=org.id, year=last_year)
+    results = fetch_usage_for_organisation(organisation_id=org.id, year=last_year)
 
     assert len(results) == 1
     assert results[str(service_1.id)]['sms_billable_units'] == 4
@@ -997,7 +997,7 @@ def test_fetch_usage_year_for_organisation_only_queries_present_year(notify_db_s
 
 
 @freeze_time('2020-02-27 13:30')
-def test_fetch_usage_year_for_organisation_only_returns_data_for_live_services(notify_db_session):
+def test_fetch_usage_for_organisation_only_returns_data_for_live_services(notify_db_session):
     org = create_organisation(name='Organisation without live services')
     live_service = create_service(restricted=False)
     sms_template = create_template(service=live_service)
@@ -1018,7 +1018,7 @@ def test_fetch_usage_year_for_organisation_only_returns_data_for_live_services(n
     create_annual_billing(service_id=live_service.id, free_sms_fragment_limit=0, financial_year_start=2019)
     create_annual_billing(service_id=trial_service.id, free_sms_fragment_limit=0, financial_year_start=2019)
 
-    results = fetch_usage_year_for_organisation(organisation_id=org.id, year=2019)
+    results = fetch_usage_for_organisation(organisation_id=org.id, year=2019)
 
     assert len(results) == 1
     assert results[str(live_service.id)]['sms_billable_units'] == 19
@@ -1026,7 +1026,7 @@ def test_fetch_usage_year_for_organisation_only_returns_data_for_live_services(n
 
 
 @freeze_time('2022-04-27 13:30')
-def test_query_organisation_sms_usage_for_year_handles_multiple_services(notify_db_session):
+def test_fetch_usage_for_organisation_sms_query_handles_multiple_services(notify_db_session):
     today = datetime.utcnow().date()
     yesterday = datetime.utcnow().date() - timedelta(days=1)
     current_year = datetime.utcnow().year
@@ -1061,7 +1061,7 @@ def test_query_organisation_sms_usage_for_year_handles_multiple_services(notify_
 
     # ----------
 
-    result = query_organisation_sms_usage_for_year(org.id, 2022).all()
+    result = _fetch_usage_for_organisation_sms_query(org.id, 2022).all()
 
     service_1_rows = [row for row in result if row.service_id == service_1.id]
     service_2_rows = [row for row in result if row.service_id == service_2.id]
@@ -1095,7 +1095,7 @@ def test_query_organisation_sms_usage_for_year_handles_multiple_services(notify_
 
 
 @freeze_time('2022-05-01 13:30')
-def test_query_organisation_sms_usage_for_year_handles_multiple_rates(notify_db_session):
+def test_fetch_usage_for_organisation_sms_query_handles_multiple_rates(notify_db_session):
     old_rate_date = date(2022, 4, 29)
     new_rate_date = date(2022, 5, 1)
     current_year = datetime.utcnow().year
@@ -1115,7 +1115,7 @@ def test_query_organisation_sms_usage_for_year_handles_multiple_rates(notify_db_
     )
     create_annual_billing(service_id=service_1.id, free_sms_fragment_limit=3, financial_year_start=current_year)
 
-    result = query_organisation_sms_usage_for_year(org.id, 2022).all()
+    result = _fetch_usage_for_organisation_sms_query(org.id, 2022).all()
 
     # al lthe free allowance is used on the first day
     assert result[0]['bst_date'] == date(2022, 4, 29)

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -12,11 +12,11 @@ from app.dao.fact_billing_dao import (
     fetch_billing_totals_for_year,
     fetch_daily_sms_provider_volumes_for_platform,
     fetch_daily_volumes_for_platform,
-    fetch_letter_costs_and_totals_for_all_services,
-    fetch_letter_line_items_for_all_services,
     fetch_monthly_billing_for_year,
-    fetch_sms_billing_for_all_services,
     fetch_sms_free_allowance_remainder_until_date,
+    fetch_usage_for_all_services_letter,
+    fetch_usage_for_all_services_letter_breakdown,
+    fetch_usage_for_all_services_sms,
     fetch_usage_year_for_organisation,
     fetch_volumes_by_service,
     get_rate,
@@ -661,7 +661,7 @@ def test_fetch_sms_free_allowance_remainder_until_date_with_two_services(notify_
     assert service_2_result[0] == (service_2.id, 20, 22, 0)
 
 
-def test_fetch_sms_billing_for_all_services_for_first_quarter(notify_db_session):
+def test_fetch_usage_for_all_services_sms_for_first_quarter(notify_db_session):
     # This test is useful because the inner query resultset is empty.
     service = create_service(service_name='a - has free allowance')
     template = create_template(service=service)
@@ -669,13 +669,13 @@ def test_fetch_sms_billing_for_all_services_for_first_quarter(notify_db_session)
     dao_add_service_to_organisation(service=service, organisation_id=org.id)
     create_annual_billing(service_id=service.id, free_sms_fragment_limit=25000, financial_year_start=2019)
     create_ft_billing(template=template, bst_date=datetime(2019, 4, 20), billable_unit=44, rate=0.11)
-    results = fetch_sms_billing_for_all_services(datetime(2019, 4, 1), datetime(2019, 5, 30))
+    results = fetch_usage_for_all_services_sms(datetime(2019, 4, 1), datetime(2019, 5, 30))
     assert len(results) == 1
     assert results[0] == (org.name, org.id, service.name, service.id, 25000, Decimal('0.11'), 24956, 44, 0,
                           Decimal('0'))
 
 
-def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
+def test_fetch_usage_for_all_services_sms_with_remainder(notify_db_session):
     service_1 = create_service(service_name='a - has free allowance')
     template = create_template(service=service_1)
     org = create_organisation(name="Org for {}".format(service_1.name))
@@ -709,7 +709,7 @@ def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
     create_ft_billing(template=email_template, bst_date=datetime(2019, 5, 22), notifications_sent=5,
                       billable_unit=0, rate=0)
 
-    results = fetch_sms_billing_for_all_services(datetime(2019, 5, 1), datetime(2019, 5, 31))
+    results = fetch_usage_for_all_services_sms(datetime(2019, 5, 1), datetime(2019, 5, 31))
     assert len(results) == 3
 
     expected_results = [
@@ -739,9 +739,9 @@ def test_fetch_sms_billing_for_all_services_with_remainder(notify_db_session):
     assert [dict(result) for result in results] == expected_results
 
 
-def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(notify_db_session):
+def test_fetch_usage_for_all_services_sms_without_an_organisation_appears(notify_db_session):
     fixtures = set_up_usage_data(datetime(2019, 5, 1))
-    results = fetch_sms_billing_for_all_services(datetime(2019, 5, 1), datetime(2019, 5, 31))
+    results = fetch_usage_for_all_services_sms(datetime(2019, 5, 1), datetime(2019, 5, 31))
 
     assert len(results) == 3
     expected_results = [
@@ -775,10 +775,10 @@ def test_fetch_sms_billing_for_all_services_without_an_organisation_appears(noti
     assert [dict(result) for result in results] == expected_results
 
 
-def test_fetch_letter_costs_and_totals_for_all_services(notify_db_session):
+def test_fetch_usage_for_all_services_letter(notify_db_session):
     fixtures = set_up_usage_data(datetime(2019, 6, 1))
 
-    results = fetch_letter_costs_and_totals_for_all_services(datetime(2019, 6, 1), datetime(2019, 9, 30))
+    results = fetch_usage_for_all_services_letter(datetime(2019, 6, 1), datetime(2019, 9, 30))
 
     assert len(results) == 3
     assert results[0] == (
@@ -798,10 +798,10 @@ def test_fetch_letter_costs_and_totals_for_all_services(notify_db_session):
     )
 
 
-def test_fetch_letter_line_items_for_all_service(notify_db_session):
+def test_fetch_usage_for_all_services_letter_breakdown(notify_db_session):
     fixtures = set_up_usage_data(datetime(2019, 6, 1))
 
-    results = fetch_letter_line_items_for_all_services(datetime(2019, 6, 1), datetime(2019, 9, 30))
+    results = fetch_usage_for_all_services_letter_breakdown(datetime(2019, 6, 1), datetime(2019, 9, 30))
 
     assert len(results) == 7
     assert results[0] == (


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181934973

Previously we had a wild variety of overlapping, top-level
and nested function names that made it very hard to navigate
the code used for the ~3 different reports supported here.

This takes each report and renames the associated functions
so they are clearly grouped together, using "_" to indicate
the nested functions that are only used in the file.

Making this change will make it easier to review future PRs.