### PR TITLE
Rewrite tests for billing report usage functions

### DIFF
--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -53,6 +53,10 @@ def set_up_yearly_data():
         create_ft_billing(bst_date=dt, template=email_template, rate=0, billable_unit=0)
         create_ft_billing(bst_date=dt, template=letter_template, rate=0.31, postage='second')
 
+    # also add annual billing for these adjacent years, which should not be used
+    create_annual_billing(service_id=service.id, free_sms_fragment_limit=9999, financial_year_start=2015)
+    create_annual_billing(service_id=service.id, free_sms_fragment_limit=8888, financial_year_start=2017)
+
     # a selection of dates that represent the extreme ends of the financial year
     # and some arbitrary dates in between
     for dt in (date(2016, 4, 1), date(2016, 4, 29), date(2017, 2, 6), date(2017, 3, 31)):
@@ -555,21 +559,6 @@ def test_fetch_usage_for_service_annual(notify_db_session):
     assert results[2].cost == Decimal('0')
     assert results[2].free_allowance_used == 4
     assert results[2].charged_units == 0
-
-
-def test_fetch_usage_for_service_annual_uses_current_annual_billing(notify_db_session):
-    service = set_up_yearly_data()
-    create_annual_billing(service_id=service.id, free_sms_fragment_limit=400, financial_year_start=2015)
-    create_annual_billing(service_id=service.id, free_sms_fragment_limit=0, financial_year_start=2016)
-
-    result = next(
-        result for result in
-        fetch_usage_for_service_annual(service_id=service.id, year=2016)
-        if result.notification_type == 'sms'
-    )
-
-    assert result.chargeable_units == 4
-    assert result.cost > 0
 
 
 def test_fetch_usage_for_service_annual_variable_rates(notify_db_session):

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -679,6 +679,15 @@ def test_fetch_usage_for_all_services_sms_no_usage(notify_db_session):
     assert len(results) == 0
 
 
+def test_fetch_usage_for_all_services_sms_includes_trial_services(notify_db_session):
+    service = set_up_yearly_data()
+    create_annual_billing(service_id=service.id, free_sms_fragment_limit=1000, financial_year_start=2016)
+
+    service.restricted = True
+    results = fetch_usage_for_all_services_sms(datetime(2016, 4, 1), datetime(2017, 3, 31))
+    assert len(results) > 0
+
+
 def test_fetch_usage_for_all_services_sms_excludes_email(notify_db_session):
     service = create_service()
     create_annual_billing(service_id=service.id, free_sms_fragment_limit=25000, financial_year_start=2016)

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -649,8 +649,7 @@ def test_fetch_sms_free_allowance_remainder_until_date_with_two_services(notify_
     assert service_2_result[0] == (service_2.id, 20, 22, 0)
 
 
-def test_fetch_usage_for_all_services_sms_for_first_quarter(notify_db_session):
-    # This test is useful because the inner query resultset is empty.
+def test_fetch_usage_for_all_services_sms(notify_db_session):
     service = create_service(service_name='a - has free allowance')
     template = create_template(service=service)
     org = create_organisation(name="Org for {}".format(service.name))

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -671,6 +671,14 @@ def test_fetch_usage_for_all_services_sms(notify_db_session):
     assert row_1["sms_cost"] == 0
 
 
+def test_fetch_usage_for_all_services_sms_no_usage(notify_db_session):
+    service = create_service()
+    create_annual_billing(service_id=service.id, free_sms_fragment_limit=3, financial_year_start=2016)
+
+    results = fetch_usage_for_all_services_sms(datetime(2016, 4, 1), datetime(2017, 3, 31))
+    assert len(results) == 0
+
+
 def test_fetch_usage_for_all_services_sms_with_remainder(notify_db_session):
     service_1 = create_service(service_name='a - has free allowance')
     template = create_template(service=service_1)

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -679,6 +679,14 @@ def test_fetch_usage_for_all_services_sms_no_usage(notify_db_session):
     assert len(results) == 0
 
 
+def test_fetch_usage_for_all_services_sms_no_usage_in_period(notify_db_session):
+    service = set_up_yearly_data(service_name='Service 1')
+    create_annual_billing(service_id=service.id, free_sms_fragment_limit=25000, financial_year_start=2016)
+
+    results = fetch_usage_for_all_services_sms(datetime(2016, 11, 1), datetime(2017, 1, 31))
+    assert len(results) == 0
+
+
 def test_fetch_usage_for_all_services_sms_includes_trial_services(notify_db_session):
     service = set_up_yearly_data()
     create_annual_billing(service_id=service.id, free_sms_fragment_limit=1000, financial_year_start=2016)

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -511,7 +511,7 @@ def test_fetch_usage_for_service_by_month_variable_rates(notify_db_session):
 
 
 @freeze_time('2018-08-01 13:30:00')
-def test_fetch_usage_for_service_by_month_adds_data_for_today(notify_db_session):
+def test_fetch_usage_for_service_by_month_populates_ft_billing_for_today(notify_db_session):
     service = create_service()
     template = create_template(service=service, template_type="sms")
 

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -891,24 +891,21 @@ def test_fetch_usage_for_organisation_variable_rates(notify_db_session):
     assert row['sms_cost'] == 0.384
 
 
-@freeze_time('2022-05-01 13:30')
-def test_fetch_usage_for_organisation_when_no_usage(notify_db_session):
-    current_year = datetime.utcnow().year
+def test_fetch_usage_for_organisation_no_usage(notify_db_session):
+    org = create_organisation()
+    service = create_service()
+    dao_add_service_to_organisation(service=service, organisation_id=org.id)
+    create_annual_billing(service_id=service.id, free_sms_fragment_limit=3, financial_year_start=2016)
 
-    org = create_organisation(name='Organisation 1')
-
-    service_1 = create_service(restricted=False, service_name="Service 1")
-    dao_add_service_to_organisation(service=service_1, organisation_id=org.id)
-    create_annual_billing(service_id=service_1.id, free_sms_fragment_limit=3, financial_year_start=current_year)
-
-    results = fetch_usage_for_organisation(organisation_id=org.id, year=current_year)
-
+    results = fetch_usage_for_organisation(organisation_id=org.id, year=2016)
     assert len(results) == 1
-    assert results[str(service_1.id)]['free_sms_limit'] == 3
-    assert results[str(service_1.id)]['sms_remainder'] == 3
-    assert results[str(service_1.id)]['sms_billable_units'] == 0
-    assert results[str(service_1.id)]['chargeable_billable_sms'] == 0
-    assert results[str(service_1.id)]['sms_cost'] == 0.0
+
+    row = results[str(service.id)]
+    assert row['free_sms_limit'] == 3
+    assert row['sms_remainder'] == 3
+    assert row['sms_billable_units'] == 0
+    assert row['chargeable_billable_sms'] == 0
+    assert row['sms_cost'] == 0.0
 
 
 @freeze_time('2020-02-27 13:30')


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181934973

This is part of splitting up [^1], where we had to make a lot
of test changes on top of the complex query changes.

I've split the commits into stages:

- The first commits look at the \_for_service\_ tests.
- The next commits look at the _for_organisation tests.
- The last commits look at the _all_services_sms tests.

## Making the tests consistent

By the end of this PR we get to the point where we have a set
of consistent tests for the 4 usage functions we care about:

1. fetch_usage_for_service_annual:
   - test_fetch_usage_for_service_annual
   - test_fetch_usage_for_service_annual_variable_rates

2. fetch_usage_for_service_by_monthly
   - test_fetch_usage_for_service_by_month
   - test_fetch_usage_for_service_by_month_variable_rates
   - test_fetch_usage_for_service_by_month_populates_ft_billing_for_today

3. fetch_usage_for_all_services_sms
   - test_fetch_usage_for_all_services_sms
   - test_fetch_usage_for_all_services_sms_no_usage
   - test_fetch_usage_for_all_services_sms_no_usage_in_period
   - test_fetch_usage_for_all_services_sms_includes_trial_services
   - test_fetch_usage_for_all_services_sms_excludes_email
   - test_fetch_usage_for_all_services_sms_partially_billable
   - test_fetch_usage_for_all_services_sms_multiple_services
   - test_fetch_usage_for_all_services_sms_no_org

4. fetch_usage_for_organisation
   - test_fetch_usage_for_organisation
   - test_fetch_usage_for_organisation_variable_rates
   - test_fetch_usage_for_organisation_populates_ft_billing_for_today
   - test_fetch_usage_for_organisation_no_usage
   - test_fetch_usage_for_organisation_excludes_trial_services
   - test_fetch_usage_for_organisation_partially_billable
   - test_fetch_usage_for_organisation_multiple_services

1 + 2 don't need as many tests as 3 + 4:

- They only test a single service.

- Their two main tests cover all the cases we care about implicitly, 
just because the functions return granular rows that allow us to 
check things like "_partially_billable" rows in the same test.

3 + 4 have basically the same tests except where their behaviour 
differs. Notably, the \_all_services\_ function does not have a test 
for _variable_rates since we don't support this yet.

## Other work (out-of-scope)

I've not made any changes to the tests for the \_letters... functions 
in this PR as these aren't necessary in order to make the changes we 
want to make to the SMS usage functions.

[^1]: https://github.com/alphagov/notifications-api/pull/3548