### PR TITLE
Support variable rates for all service SMS report

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -87,7 +87,6 @@ def fetch_usage_for_all_services_sms(start_date, end_date):
         Service.name.label("service_name"),
         Service.id.label("service_id"),
         allowance_left_at_start_date_query.c.free_sms_fragment_limit,
-        FactBilling.rate.label('sms_rate'),
         sms_allowance_left.label("sms_remainder"),
         sms_billable_units.label('sms_billable_units'),
         chargeable_sms.label("chargeable_billable_sms"),

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -35,8 +35,7 @@ from app.utils import get_london_midnight_in_utc
 
 
 def fetch_usage_for_all_services_sms(start_date, end_date):
-
-    # ASSUMPTION: AnnualBilling has been populated for year.
+    # ASSUMPTION: start_date and end_date are in the same financial year
     year = get_financial_year_for_datetime(get_london_midnight_in_utc(start_date))
     ft_billing_subquery = _fetch_usage_for_all_services_sms_query(year).subquery()
 
@@ -82,6 +81,7 @@ def _fetch_usage_for_all_services_sms_query(year):
     """
     See docstring for _fetch_usage_for_service_sms()
     """
+    # ASSUMPTION: AnnualBilling has been populated for year.
     year_start, year_end = get_financial_year_dates(year)
 
     # We still return a single row even if a service has no rows in ft_billing
@@ -754,7 +754,6 @@ def _fetch_usage_for_organisation_email(organisation_id, start_date, end_date):
 
 
 def _fetch_usage_for_organisation_sms(organisation_id, financial_year):
-    # ASSUMPTION: AnnualBilling has been populated for year.
     ft_billing_subquery = _fetch_usage_for_organisation_sms_query(organisation_id, financial_year).subquery()
 
     free_allowance = func.max(ft_billing_subquery.c.free_allowance)
@@ -793,6 +792,7 @@ def _fetch_usage_for_organisation_sms_query(organisation_id, year):
     """
     See docstring for _fetch_usage_for_service_sms()
     """
+    # ASSUMPTION: AnnualBilling has been populated for year.
     year_start, year_end = get_financial_year_dates(year)
 
     # We still return a single row even if a service has no rows in ft_billing

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -50,11 +50,11 @@ def fetch_usage_for_all_services_sms(start_date, end_date):
         Organisation.id.label('organisation_id'),
         Service.name.label("service_name"),
         Service.id.label("service_id"),
-        free_allowance.label("free_sms_fragment_limit"),
-        free_allowance_left.label("sms_remainder"),
-        chargeable_units.label('sms_billable_units'),
-        charged_units.label("chargeable_billable_sms"),
-        cost.label('sms_cost'),
+        free_allowance.label("free_allowance"),
+        free_allowance_left.label("free_allowance_left"),
+        chargeable_units.label('chargeable_units'),
+        charged_units.label("charged_units"),
+        cost.label('cost'),
     ).select_from(
         Service
     ).outerjoin(

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -84,14 +84,14 @@ def get_data_for_billing_report():
     ]
     combined = {}
     for s in sms_costs:
-        if float(s.sms_cost) > 0:
+        if float(s.cost) > 0:
             entry = {
                 "organisation_id": str(s.organisation_id) if s.organisation_id else "",
                 "organisation_name": s.organisation_name or "",
                 "service_id": str(s.service_id),
                 "service_name": s.service_name,
-                "sms_cost": float(s.sms_cost),
-                "sms_chargeable_units": s.chargeable_billable_sms,
+                "sms_cost": float(s.cost),
+                "sms_chargeable_units": s.charged_units,
                 "total_letters": 0,
                 "letter_cost": 0,
                 "letter_breakdown": ""

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -636,11 +636,11 @@ def test_fetch_usage_for_all_services_sms(notify_db_session):
     assert row_1["organisation_id"] == org.id
     assert row_1["service_name"] == service.name
     assert row_1["service_id"] == service.id
-    assert row_1["free_sms_fragment_limit"] == 25000
-    assert row_1["sms_remainder"] == 24996
-    assert row_1["sms_billable_units"] == 4
-    assert row_1["chargeable_billable_sms"] == 0
-    assert row_1["sms_cost"] == 0
+    assert row_1["free_allowance"] == 25000
+    assert row_1["free_allowance_left"] == 24996
+    assert row_1["chargeable_units"] == 4
+    assert row_1["charged_units"] == 0
+    assert row_1["cost"] == 0
 
 
 def test_fetch_usage_for_all_services_variable_rates(notify_db_session):
@@ -651,16 +651,16 @@ def test_fetch_usage_for_all_services_variable_rates(notify_db_session):
     assert len(results) == 1
     row = results[0]
 
-    assert row['free_sms_fragment_limit'] == 3
-    assert row['sms_remainder'] == 0
+    assert row['free_allowance'] == 3
+    assert row['free_allowance_left'] == 0
     # 4 SMS (rate multiplier=2) + 1 SMS (rate_multiplier=1)
-    assert row['sms_billable_units'] == 9
-    assert row['chargeable_billable_sms'] == 6
+    assert row['chargeable_units'] == 9
+    assert row['charged_units'] == 6
     # 1 SMS free (rate_multiplier=1, rate=0.162) +
     # 1 SMS free (rate_multiplier=2, rate=0.162) +
     # 1 SMS paid (rate_multiplier=2, rate=0.162) +
     # 2 SMS paid (rate_multiplier=2, rate=0.0150)
-    assert row['sms_cost'] == Decimal('0.384')
+    assert row['cost'] == Decimal('0.384')
 
 
 def test_fetch_usage_for_all_services_sms_no_usage(notify_db_session):
@@ -708,10 +708,10 @@ def test_fetch_usage_for_all_services_sms_partially_billable(notify_db_session):
     assert len(results) == 1
 
     row = results[0]
-    assert row["sms_remainder"] == 0
-    assert row["sms_billable_units"] == 5
-    assert row["chargeable_billable_sms"] == 2
-    assert row["sms_cost"] == Decimal('0.22')
+    assert row["free_allowance_left"] == 0
+    assert row["chargeable_units"] == 5
+    assert row["charged_units"] == 2
+    assert row["cost"] == Decimal('0.22')
 
 
 def test_fetch_usage_for_all_services_sms_multiple_services(notify_db_session):
@@ -727,16 +727,16 @@ def test_fetch_usage_for_all_services_sms_multiple_services(notify_db_session):
 
     # both services send 4 * SMS at a rate of 0.162
     service_1_row = results[0]
-    assert service_1_row["sms_remainder"] == 0
-    assert service_1_row["sms_billable_units"] == 4
-    assert service_1_row["chargeable_billable_sms"] == 1
-    assert service_1_row["sms_cost"] == Decimal('0.162')
+    assert service_1_row["free_allowance_left"] == 0
+    assert service_1_row["chargeable_units"] == 4
+    assert service_1_row["charged_units"] == 1
+    assert service_1_row["cost"] == Decimal('0.162')
 
     service_2_row = results[1]
-    assert service_2_row["sms_remainder"] == 2
-    assert service_2_row["sms_billable_units"] == 4
-    assert service_2_row["chargeable_billable_sms"] == 0
-    assert service_2_row["sms_cost"] == 0
+    assert service_2_row["free_allowance_left"] == 2
+    assert service_2_row["chargeable_units"] == 4
+    assert service_2_row["charged_units"] == 0
+    assert service_2_row["cost"] == 0
 
 
 def test_fetch_usage_for_all_services_sms_no_org(notify_db_session):

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -11,7 +11,6 @@ from app.dao.fact_billing_dao import (
     fetch_billing_data_for_day,
     fetch_daily_sms_provider_volumes_for_platform,
     fetch_daily_volumes_for_platform,
-    fetch_sms_free_allowance_remainder_until_date,
     fetch_usage_for_all_services_letter,
     fetch_usage_for_all_services_letter_breakdown,
     fetch_usage_for_all_services_sms,
@@ -621,32 +620,6 @@ def test_delete_billing_data(notify_db_session):
     assert sorted(x.billable_units for x in current_rows) == sorted(
         [other_day.billable_units, other_service.billable_units]
     )
-
-
-def test_fetch_sms_free_allowance_remainder_until_date_with_two_services(notify_db_session):
-    service = create_service(service_name='has free allowance')
-    template = create_template(service=service)
-    org = create_organisation(name="Org for {}".format(service.name))
-    dao_add_service_to_organisation(service=service, organisation_id=org.id)
-    create_annual_billing(service_id=service.id, free_sms_fragment_limit=10, financial_year_start=2016)
-    create_ft_billing(template=template, bst_date=datetime(2016, 4, 20), billable_unit=2, rate=0.11)
-    create_ft_billing(template=template, bst_date=datetime(2016, 5, 20), billable_unit=3, rate=0.11)
-
-    service_2 = create_service(service_name='used free allowance')
-    template_2 = create_template(service=service_2)
-    org_2 = create_organisation(name="Org for {}".format(service_2.name))
-    dao_add_service_to_organisation(service=service_2, organisation_id=org_2.id)
-    create_annual_billing(service_id=service_2.id, free_sms_fragment_limit=20, financial_year_start=2016)
-    create_ft_billing(template=template_2, bst_date=datetime(2016, 4, 20), billable_unit=12, rate=0.11)
-    create_ft_billing(template=template_2, bst_date=datetime(2016, 4, 22), billable_unit=10, rate=0.11)
-    create_ft_billing(template=template_2, bst_date=datetime(2016, 5, 20), billable_unit=3, rate=0.11)
-
-    results = fetch_sms_free_allowance_remainder_until_date(datetime(2016, 5, 1)).all()
-    assert len(results) == 2
-    service_result = [row for row in results if row[0] == service.id]
-    assert service_result[0] == (service.id, 10, 2, 8)
-    service_2_result = [row for row in results if row[0] == service_2.id]
-    assert service_2_result[0] == (service_2.id, 20, 22, 0)
 
 
 def test_fetch_usage_for_all_services_sms(notify_db_session):

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -664,7 +664,6 @@ def test_fetch_usage_for_all_services_sms(notify_db_session):
     assert row_1["service_name"] == service.name
     assert row_1["service_id"] == service.id
     assert row_1["free_sms_fragment_limit"] == 25000
-    assert row_1["sms_rate"] == Decimal('0.162')
     assert row_1["sms_remainder"] == 24996
     assert row_1["sms_billable_units"] == 4
     assert row_1["chargeable_billable_sms"] == 0


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181934973

This makes a few initial changes to the very similar
code we have to calculate SMS usage for organisations,
which we then duplicate for the all service report.

By the end of this PR we have three slightly different
versions of the complex windowing query to calculate SMS
usage. It should be possible to consolidate them into one
query, which we will look at in a follow-up PR.