### PR TITLE
Further refactoring for billing tests

### DIFF
--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -229,6 +229,8 @@ def _sample_service_custom_letter_contact_block(sample_service):
 
 @pytest.fixture(scope='function')
 def sample_template(sample_user):
+    # This will be the same service as the one returned by the sample_service fixture as we look for a
+    # service with the same name - "Sample service" - before creating a new one.
     service = create_service(service_permissions=[EMAIL_TYPE, SMS_TYPE], check_if_service_exists=True)
 
     data = {
@@ -245,6 +247,11 @@ def sample_template(sample_user):
     dao_create_template(template)
 
     return template
+
+
+@pytest.fixture
+def sample_sms_template(sample_template):
+    return sample_template
 
 
 @pytest.fixture(scope='function')

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -39,11 +39,6 @@ from tests.app.db import (
 
 
 @pytest.fixture
-def sample_service_sms_template(sample_service):
-    return create_template(service=sample_service, template_type="sms")
-
-
-@pytest.fixture
 def sample_service_billing_fy_2016(sample_service):
     sms_template = create_template(service=sample_service, template_type="sms")
     email_template = create_template(service=sample_service, template_type="email")
@@ -677,10 +672,10 @@ def test_fetch_usage_for_all_services_variable_rates(
 
 def test_fetch_usage_for_all_services_sms_remainder(
     sample_service,
-    sample_service_sms_template,
+    sample_sms_template,
     notify_db_session
 ):
-    create_ft_billing(template=sample_service_sms_template, bst_date=datetime(2016, 4, 22), billable_unit=1)
+    create_ft_billing(template=sample_sms_template, bst_date=datetime(2016, 4, 22), billable_unit=1)
     create_annual_billing(service_id=sample_service.id, free_sms_fragment_limit=3, financial_year_start=2016)
     results = fetch_usage_for_all_services_sms(datetime(2016, 4, 1), datetime(2017, 3, 31))
 
@@ -700,10 +695,10 @@ def test_fetch_usage_for_all_services_sms_no_usage(
 
 def test_fetch_usage_for_all_services_sms_no_usage_in_period(
     sample_service,
-    sample_service_sms_template,
+    sample_sms_template,
     notify_db_session,
 ):
-    create_ft_billing(template=sample_service_sms_template, bst_date=datetime(2016, 4, 22), billable_unit=5)
+    create_ft_billing(template=sample_sms_template, bst_date=datetime(2016, 4, 22), billable_unit=5)
     create_annual_billing(service_id=sample_service.id, free_sms_fragment_limit=25000, financial_year_start=2016)
 
     results = fetch_usage_for_all_services_sms(datetime(2016, 11, 1), datetime(2017, 1, 31))
@@ -712,10 +707,10 @@ def test_fetch_usage_for_all_services_sms_no_usage_in_period(
 
 def test_fetch_usage_for_all_services_sms_includes_trial_services(
     sample_service,
-    sample_service_sms_template,
+    sample_sms_template,
     notify_db_session
 ):
-    create_ft_billing(template=sample_service_sms_template, bst_date=datetime(2016, 4, 22), billable_unit=5)
+    create_ft_billing(template=sample_sms_template, bst_date=datetime(2016, 4, 22), billable_unit=5)
     create_annual_billing(service_id=sample_service.id, free_sms_fragment_limit=1000, financial_year_start=2016)
 
     sample_service.restricted = True
@@ -737,11 +732,11 @@ def test_fetch_usage_for_all_services_sms_excludes_email(
 
 def test_fetch_usage_for_all_services_sms_partially_billable(
     sample_service,
-    sample_service_sms_template,
+    sample_sms_template,
     notify_db_session
 ):
     create_annual_billing(service_id=sample_service.id, free_sms_fragment_limit=3, financial_year_start=2019)
-    create_ft_billing(template=sample_service_sms_template, bst_date=datetime(2019, 4, 20), billable_unit=5, rate=0.11)
+    create_ft_billing(template=sample_sms_template, bst_date=datetime(2019, 4, 20), billable_unit=5, rate=0.11)
 
     results = fetch_usage_for_all_services_sms(datetime(2019, 4, 1), datetime(2019, 5, 31))
     assert len(results) == 1
@@ -783,11 +778,11 @@ def test_fetch_usage_for_all_services_sms_multiple_services(notify_db_session):
 
 def test_fetch_usage_for_all_services_sms_no_org(
     sample_service,
-    sample_service_sms_template,
+    sample_sms_template,
     notify_db_session
 ):
     create_annual_billing(service_id=sample_service.id, free_sms_fragment_limit=1000, financial_year_start=2016)
-    create_ft_billing(template=sample_service_sms_template, bst_date=datetime(2016, 4, 20), billable_unit=5)
+    create_ft_billing(template=sample_sms_template, bst_date=datetime(2016, 4, 20), billable_unit=5)
 
     results = fetch_usage_for_all_services_sms(datetime(2016, 4, 15), datetime(2016, 5, 31))
     assert len(results) == 1
@@ -937,12 +932,12 @@ def test_fetch_usage_for_organisation_variable_rates(
 def test_fetch_usage_for_organisation_sms_remainder(
     sample_service,
     sample_organisation,
-    sample_service_sms_template,
+    sample_sms_template,
     notify_db_session
 ):
     dao_add_service_to_organisation(service=sample_service, organisation_id=sample_organisation.id)
     create_annual_billing(service_id=sample_service.id, free_sms_fragment_limit=3, financial_year_start=2016)
-    create_ft_billing(template=sample_service_sms_template, bst_date=datetime(2016, 4, 20), billable_unit=1)
+    create_ft_billing(template=sample_sms_template, bst_date=datetime(2016, 4, 20), billable_unit=1)
 
     results = fetch_usage_for_organisation(organisation_id=sample_organisation.id, year=2016)
     assert len(results) == 1
@@ -973,7 +968,7 @@ def test_fetch_usage_for_organisation_no_usage(
 def test_fetch_usage_for_organisation_excludes_trial_services(
     sample_service,
     sample_organisation,
-    sample_service_sms_template,
+    sample_sms_template,
     notify_db_session,
 ):
     dao_add_service_to_organisation(service=sample_service, organisation_id=sample_organisation.id)
@@ -990,12 +985,12 @@ def test_fetch_usage_for_organisation_excludes_trial_services(
 def test_fetch_usage_for_organisation_partially_billable(
     sample_service,
     sample_organisation,
-    sample_service_sms_template,
+    sample_sms_template,
     notify_db_session,
 ):
     dao_add_service_to_organisation(service=sample_service, organisation_id=sample_organisation.id)
     create_annual_billing(service_id=sample_service.id, free_sms_fragment_limit=3, financial_year_start=2019)
-    create_ft_billing(template=sample_service_sms_template, bst_date=datetime(2019, 4, 20), billable_unit=5, rate=0.11)
+    create_ft_billing(template=sample_sms_template, bst_date=datetime(2019, 4, 20), billable_unit=5, rate=0.11)
 
     results = fetch_usage_for_organisation(sample_organisation.id, 2019)
     assert len(results) == 1
@@ -1040,7 +1035,7 @@ def test_fetch_usage_for_organisation_multiple_services(
 def test_fetch_usage_for_organisation_without_annual_billing(
     sample_service,
     sample_organisation,
-    sample_service_sms_template,
+    sample_sms_template,
     notify_db_session
 ):
     # Example: we don't continue populating annual_billing for inactive services

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -89,6 +89,13 @@ def set_up_yearly_data_variable_rates():
         postage='second'
     )
 
+    # This amounts to a total SMS cost of 0.045:
+    #
+    #  - 5 free units on the 16th (rate=0.162)
+    #  - 1 free unit on the 17th (rate=0.015)
+    #  - 3 paid units on the 17th (rate=0.015)
+    #
+    create_annual_billing(service_id=service.id, free_sms_fragment_limit=6, financial_year_start=2018)
     return service
 
 
@@ -469,7 +476,6 @@ def test_fetch_usage_for_service_by_month(
 
 def test_fetch_usage_for_service_by_month_variable_rates(notify_db_session):
     service = set_up_yearly_data_variable_rates()
-    create_annual_billing(service_id=service.id, free_sms_fragment_limit=6, financial_year_start=2018)
     results = fetch_usage_for_service_by_month(service.id, 2018)
 
     # Test data is only for the month of May
@@ -498,7 +504,6 @@ def test_fetch_usage_for_service_by_month_variable_rates(notify_db_session):
     assert results[2].notifications_sent == 1
     assert results[2].chargeable_units == 4
     assert results[2].rate == Decimal('0.015')
-    # 1 free units on the 17th
     assert results[2].cost == Decimal('0.045')
     assert results[2].free_allowance_used == 1
     assert results[2].charged_units == 3
@@ -508,7 +513,6 @@ def test_fetch_usage_for_service_by_month_variable_rates(notify_db_session):
     assert results[3].notifications_sent == 2
     assert results[3].chargeable_units == 5
     assert results[3].rate == Decimal('0.162')
-    # 5 free units on the 16th
     assert results[3].cost == Decimal('0')
     assert results[3].free_allowance_used == 5
     assert results[3].charged_units == 0
@@ -569,7 +573,6 @@ def test_fetch_usage_for_service_annual(
 
 def test_fetch_usage_for_service_annual_variable_rates(notify_db_session):
     service = set_up_yearly_data_variable_rates()
-    create_annual_billing(service_id=service.id, free_sms_fragment_limit=6, financial_year_start=2018)
     results = fetch_usage_for_service_annual(service_id=service.id, year=2018)
 
     assert len(results) == 4
@@ -593,7 +596,6 @@ def test_fetch_usage_for_service_annual_variable_rates(notify_db_session):
     assert results[2].notifications_sent == 1
     assert results[2].chargeable_units == 4
     assert results[2].rate == Decimal('0.015')
-    # 1 free unit on the 17th
     assert results[2].cost == Decimal('0.045')
     assert results[2].free_allowance_used == 1
     assert results[2].charged_units == 3
@@ -602,7 +604,6 @@ def test_fetch_usage_for_service_annual_variable_rates(notify_db_session):
     assert results[3].notifications_sent == 2
     assert results[3].chargeable_units == 5
     assert results[3].rate == Decimal('0.162')
-    # 5 free units on the 16th
     assert results[3].cost == Decimal('0')
     assert results[3].free_allowance_used == 5
     assert results[3].charged_units == 0
@@ -655,22 +656,16 @@ def test_fetch_usage_for_all_services_sms(
 
 def test_fetch_usage_for_all_services_variable_rates(notify_db_session):
     service = set_up_yearly_data_variable_rates()
-    create_annual_billing(service_id=service.id, free_sms_fragment_limit=3, financial_year_start=2018)
     results = fetch_usage_for_all_services_sms(datetime(2018, 4, 1), datetime(2019, 3, 31))
 
     assert len(results) == 1
     row = results[0]
 
-    assert row['free_allowance'] == 3
+    assert row['free_allowance'] == 6
     assert row['free_allowance_left'] == 0
-    # 4 SMS (rate multiplier=2) + 1 SMS (rate_multiplier=1)
     assert row['chargeable_units'] == 9
-    assert row['charged_units'] == 6
-    # 1 SMS free (rate_multiplier=1, rate=0.162) +
-    # 1 SMS free (rate_multiplier=2, rate=0.162) +
-    # 1 SMS paid (rate_multiplier=2, rate=0.162) +
-    # 2 SMS paid (rate_multiplier=2, rate=0.0150)
-    assert row['cost'] == Decimal('0.384')
+    assert row['charged_units'] == 3
+    assert row['cost'] == Decimal('0.045')
 
 
 def test_fetch_usage_for_all_services_sms_remainder(
@@ -917,22 +912,16 @@ def test_fetch_usage_for_organisation_variable_rates(notify_db_session):
     service = set_up_yearly_data_variable_rates()
     org = create_organisation()
     dao_add_service_to_organisation(service=service, organisation_id=org.id)
-    create_annual_billing(service_id=service.id, free_sms_fragment_limit=3, financial_year_start=2018)
     results = fetch_usage_for_organisation(organisation_id=org.id, year=2018)
 
     assert len(results) == 1
     row = results[str(service.id)]
 
-    assert row['free_sms_limit'] == 3
+    assert row['free_sms_limit'] == 6
     assert row['sms_remainder'] == 0
-    # 4 SMS (rate multiplier=2) + 1 SMS (rate_multiplier=1)
     assert row['sms_billable_units'] == 9
-    assert row['chargeable_billable_sms'] == 6
-    # 1 SMS free (rate_multiplier=1, rate=0.162) +
-    # 1 SMS free (rate_multiplier=2, rate=0.162) +
-    # 1 SMS paid (rate_multiplier=2, rate=0.162) +
-    # 2 SMS paid (rate_multiplier=2, rate=0.0150)
-    assert row['sms_cost'] == 0.384
+    assert row['chargeable_billable_sms'] == 3
+    assert row['sms_cost'] == 0.045
 
 
 def test_fetch_usage_for_organisation_sms_remainder(


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181934973

In response to [^1].

This pushes some of the test setup back into each of the
tests for the 4 billing report functions we're working on
at the moment. We can still use some fixtures to make the
setup more focussed e.g. sample_service vs. create_service.

In the remaining commits, I've also converted the "set_up"
functions into fixtures, to match how we write most tests.

[^1]: https://github.com/alphagov/notifications-api/pull/3559#discussion_r902390463