### PR TITLE
Deploy droplets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,12 +87,14 @@ clean:
 preview: ## Set environment to preview
 	$(eval export DEPLOY_ENV=preview)
 	$(eval export DNS_NAME="notify.works")
+	$(eval export USE_DROPLETS="yes")
 	@true
 
 .PHONY: staging
 staging: ## Set environment to staging
 	$(eval export DEPLOY_ENV=staging)
 	$(eval export DNS_NAME="staging-notify.works")
+	$(eval export USE_DROPLETS="yes")
 	@true
 
 .PHONY: production
@@ -135,7 +137,7 @@ cf-deploy: ## Deploys the app to Cloud Foundry
 	# generate manifest (including secrets) and write it to CF_MANIFEST_PATH (in /tmp/)
 	make -s CF_APP=${CF_APP} generate-manifest > ${CF_MANIFEST_PATH}
 
-	CF_APP=${CF_APP} CF_MANIFEST_PATH=${CF_MANIFEST_PATH} ./scripts/deploy.sh
+	$(if ${USE_DROPLETS},CF_APP=${CF_APP} CF_MANIFEST_PATH=${CF_MANIFEST_PATH} ./scripts/deploy.sh,CF_STARTUP_TIMEOUT=15 cf push ${CF_APP} --strategy=rolling -f ${CF_MANIFEST_PATH})
 	# delete old manifest file
 	rm ${CF_MANIFEST_PATH}
 

--- a/Makefile
+++ b/Makefile
@@ -135,9 +135,7 @@ cf-deploy: ## Deploys the app to Cloud Foundry
 	# generate manifest (including secrets) and write it to CF_MANIFEST_PATH (in /tmp/)
 	make -s CF_APP=${CF_APP} generate-manifest > ${CF_MANIFEST_PATH}
 
-	# fails after 15 mins if deploy doesn't work
-	# reads manifest from CF_MANIFEST_PATH
-	CF_STARTUP_TIMEOUT=15 cf push ${CF_APP} --strategy=rolling -f ${CF_MANIFEST_PATH}
+	CF_APP=${CF_APP} CF_MANIFEST_PATH=${CF_MANIFEST_PATH} ./scripts/deploy.sh
 	# delete old manifest file
 	rm ${CF_MANIFEST_PATH}
 

--- a/scripts/create-droplet.sh
+++ b/scripts/create-droplet.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eux
+
+CF_SPACE=${CF_SPACE:-monitoring}
+
+[[ ! -f ./.git/short_ref ]] && $(git rev-parse --short HEAD) > ./.git/short_ref
+GIT_REF=$(cat .git/short_ref)
+DROPLET_BUILD_APP="droplet-build-api-${GIT_REF}"
+
+echo "Creating ${DROPLET_BUILD_APP} in ${CF_SPACE}"
+cf target -s ${CF_SPACE}
+cf create-app ${DROPLET_BUILD_APP}
+
+echo "Creating package..."
+cf create-package ${DROPLET_BUILD_APP} -p .
+PACKAGE_GUID=$(cf packages ${DROPLET_BUILD_APP} | tail -n 1 | cut -d" " -f 1)
+
+echo "Staging package to create droplet..."
+cf stage-package ${DROPLET_BUILD_APP} --package-guid ${PACKAGE_GUID}
+DROPLET_GUID=$(cf droplets ${DROPLET_BUILD_APP} | tail -n 1 | cut -d" " -f 1)
+echo "Created droplet ${DROPLET_GUID}"
+
+CURRENT_TIME=$(date '+%Y-%m-%dT%H-%M-%SZ')
+echo $DROPLET_GUID > api-droplet-guid-${CURRENT_TIME}-${GIT_REF}.txt

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,7 +8,7 @@ GIT_REF=$(cat ./.git/short_ref)
 
 if [[ ! $(ls ./api-droplet-guid-*-${GIT_REF}.txt) ]]; then
   echo "Missing api-droplet-guid file for this commit"
-  echo "Create a droplet, store its guid in a file called 'api-droplet-guid-$(date '+%Y-%m-%d')-${GIT_REF}.txt' and try again"
+  echo "If running locally, run ./scripts/create-droplet.sh and try again"
   exit 1
 fi
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,6 +5,13 @@ set -eu
 [[ ! -f ./.git/short_ref ]] && $(git rev-parse --short HEAD) > ./.git/short_ref
 
 GIT_REF=$(cat ./.git/short_ref)
+
+if [[ ! $(ls ./api-droplet-guid-*-${GIT_REF}.txt) ]]; then
+  echo "Missing api-droplet-guid file for this commit"
+  echo "Create a droplet, store its guid in a file called 'api-droplet-guid-$(date '+%Y-%m-%d')-${GIT_REF}.txt' and try again"
+  exit 1
+fi
+
 ORIGINAL_DROPLET_GUID=$(cat ./api-droplet-guid-*-${GIT_REF}.txt)
 APP_GUID=$(cf app ${CF_APP} --guid)
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-echo $(pwd)
+[[ ! -f ./.git/short_ref ]] && $(git rev-parse --short HEAD) > ./.git/short_ref
 
 GIT_REF=$(cat ./.git/short_ref)
 ORIGINAL_DROPLET_GUID=$(cat ./api-droplet-guid-*-${GIT_REF}.txt)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -81,6 +81,6 @@ echo "Deployment GUID: ${DEPLOYMENT_GUID}"
 
 #
 # Wait for 15 minutes for the deployment to reach "FINALIZED" status
-# If it doesn't, then it will exit with an exit status of 124 according to `timeout --help`
+# If it doesn't, then, according to `timeout --help`, it will exit with an exit status of 124
 #
 timeout 15m bash -c -- "until [[ \${STATUS} == FINALIZED ]]; do sleep 5; STATUS=\$(cf curl v3/deployments/${DEPLOYMENT_GUID} | jq -r \".status.value\"); echo \"Deployment status: \${STATUS}\"; done"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -eu
+
+echo $(pwd)
+
+GIT_REF=$(cat ./.git/short_ref)
+ORIGINAL_DROPLET_GUID=$(cat ./api-droplet-guid-*-${GIT_REF}.txt)
+APP_GUID=$(cf app ${CF_APP} --guid)
+
+
+#
+# Copy droplet
+#
+echo "Copying droplet..."
+cat <<END > copy-droplet-${CF_APP}.json
+{
+    "relationships": {
+      "app": {
+        "data": {
+          "guid": "${APP_GUID}"
+        }
+      }
+    }
+}
+END
+
+DROPLET_GUID=$(cf curl "/v3/droplets?source_guid=${ORIGINAL_DROPLET_GUID}" \
+  -X POST \
+  -H "Content-type: application/json" \
+  -d @./copy-droplet-${CF_APP}.json | jq -r ".guid")
+
+echo "Droplet GUID: ${DROPLET_GUID}"
+
+# wait a bit for the droplet to be copied
+sleep 5
+
+#
+# Apply manifest before the deployment
+# docs:
+#   https://v3-apidocs.cloudfoundry.org/version/3.116.0/index.html#apply-a-manifest-to-a-space
+#   https://cli.cloudfoundry.org/en-US/v7/apply-manifest.html
+#
+
+echo "Applying manifest..."
+cf apply-manifest -f ${CF_MANIFEST_PATH}
+
+#
+# Trigger a new deployment using the new droplet guid
+#
+cat <<END > deployment-${CF_APP}.json
+{
+  "droplet": {
+    "guid": "${DROPLET_GUID}"
+  },
+  "strategy": "rolling",
+  "relationships": {
+    "app": {
+      "data": {
+        "guid": "${APP_GUID}"
+      }
+    }
+  }
+}
+END
+
+echo "Triggering a new deployment..."
+DEPLOYMENT_GUID=$(cf curl "/v3/deployments" \
+  -X POST \
+  -H "Content-type: application/json" \
+  -d @./deployment-${CF_APP}.json | jq -r ".guid")
+
+echo "Deployment GUID: ${DEPLOYMENT_GUID}"
+
+#
+# Wait for 15 minutes for the deployment to reach "FINALIZED" status
+# If it doesn't, then it will exit with an exit status of 124 according to `timeout --help`
+#
+timeout 15m bash -c -- "until [[ \${STATUS} == FINALIZED ]]; do sleep 5; STATUS=\$(cf curl v3/deployments/${DEPLOYMENT_GUID} | jq -r \".status.value\"); echo \"Deployment status: \${STATUS}\"; done"


### PR DESCRIPTION
Adds two scripts:

1. `scripts/deploy.sh` which uses the CF API to reuse droplets and trigger deployments
2. `scripts/create-droplet.sh` which is a helper script to run locally if you need to deploy something to preview

Best reviewed commit-by-commit.