### PR TITLE
Don't create zendesk ticket if broadcast service is in training mode

### DIFF
--- a/app/broadcast_message/utils.py
+++ b/app/broadcast_message/utils.py
@@ -70,6 +70,9 @@ def _create_p1_zendesk_alert(broadcast_message):
     if broadcast_message.status != BroadcastStatusType.BROADCASTING:
         return
 
+    if broadcast_message.stubbed:
+        return
+
     message = inspect.cleandoc(f"""
         Broadcast Sent
 

--- a/tests/app/broadcast_message/test_utils.py
+++ b/tests/app/broadcast_message/test_utils.py
@@ -453,3 +453,23 @@ def test_create_p1_zendesk_alert_doesnt_alert_on_staging(mocker, notify_api, sam
         _create_p1_zendesk_alert(broadcast_message)
 
     mock_send_ticket_to_zendesk.assert_not_called()
+
+
+def test_create_p1_zendesk_alert_doesnt_alert_for_stubbed_messages(mocker, notify_api, sample_broadcast_service):
+    broadcast_message = create_broadcast_message(
+        service=sample_broadcast_service,
+        content='tailor made emergency broadcast content',
+        status=BroadcastStatusType.BROADCASTING,
+        areas={"names": ["England", "Scotland"]},
+        stubbed=True
+    )
+
+    mock_send_ticket_to_zendesk = mocker.patch(
+        'app.broadcast_message.utils.zendesk_client.send_ticket_to_zendesk',
+        autospec=True,
+    )
+
+    with set_config(notify_api, 'NOTIFY_ENVIRONMENT', 'live'):
+        _create_p1_zendesk_alert(broadcast_message)
+
+    mock_send_ticket_to_zendesk.assert_not_called()


### PR DESCRIPTION
Broadcast services in training mode create "stubbed" broadcast messages.

Stubbed messages are not sent to MNO networks and do not result in a real broadcast.

We should not create a ticket or raise an incident when these message types are created as this creates unnecessary noise.
