### PR TITLE
add api_client_request fixture

### DIFF
--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1041,6 +1041,7 @@ def api_client_request(client):
             )
             json_resp = resp.json
             assert resp.status_code == _expected_status
+            assert resp.headers['Content-type'] == 'application/json'
             return json_resp
 
         @staticmethod
@@ -1056,6 +1057,7 @@ def api_client_request(client):
             )
             if resp.get_data():
                 json_resp = resp.json
+                assert resp.headers['Content-type'] == 'application/json'
             else:
                 json_resp = None
             assert resp.status_code == _expected_status

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1044,7 +1044,8 @@ def api_client_request(client):
             return json_resp
 
         @staticmethod
-        def post(service_id, endpoint, _api_key_type='normal', _data=None, _expected_status=200, **endpoint_kwargs):
+        def post(service_id, endpoint, _api_key_type='normal', _data=None, _expected_status=201, **endpoint_kwargs):
+            # note that _expected_status is 201 since this endpoint is primarily used for create endpoints
             resp = client.post(
                 url_for(endpoint, **(endpoint_kwargs or {})),
                 data=json.dumps(_data, default=uuid_convert),

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1018,7 +1018,7 @@ def admin_request(client):
 
 
 @pytest.fixture
-def api_client_request(client):
+def api_client_request(client, notify_user):
     """
     For v2 endpoints. Same as admin_request, except all functions take a required service_id and an optional
     _api_key_type field.

--- a/tests/app/v2/inbound_sms/test_get_inbound_sms.py
+++ b/tests/app/v2/inbound_sms/test_get_inbound_sms.py
@@ -1,6 +1,5 @@
-from flask import json, url_for
+from flask import url_for
 
-from tests import create_service_authorization_header
 from tests.app.db import (
     create_inbound_sms,
     create_service_callback_api,
@@ -9,7 +8,7 @@ from tests.app.db import (
 
 
 def test_get_inbound_sms_returns_200(
-        client, sample_service
+    api_client_request, sample_service
 ):
     all_inbound_sms = [
         create_inbound_sms(service=sample_service, user_number='447700900111', content='Hi'),
@@ -17,16 +16,12 @@ def test_get_inbound_sms_returns_200(
         create_inbound_sms(service=sample_service, user_number='447700900111', content='Bye'),
         create_inbound_sms(service=sample_service, user_number='07700900113')
     ]
+    json_resp = api_client_request.get(
+        sample_service.id,
+        'v2_inbound_sms.get_inbound_sms',
+    )
 
-    auth_header = create_service_authorization_header(service_id=sample_service.id)
-    response = client.get(
-        path='/v2/received-text-messages',
-        headers=[('Content-Type', 'application/json'), auth_header])
-
-    assert response.status_code == 200
-    assert response.headers['Content-type'] == 'application/json'
-
-    json_response = json.loads(response.get_data(as_text=True))['received_text_messages']
+    json_response = json_resp['received_text_messages']
 
     reversed_all_inbound_sms = sorted(all_inbound_sms, key=lambda sms: sms.created_at, reverse=True)
 
@@ -36,7 +31,7 @@ def test_get_inbound_sms_returns_200(
 
 
 def test_get_inbound_sms_returns_200_when_service_has_callbacks(
-    client, sample_service
+    api_client_request, sample_service
 ):
     create_service_inbound_api(
         service=sample_service,
@@ -47,16 +42,13 @@ def test_get_inbound_sms_returns_200_when_service_has_callbacks(
         url="https://inbound.example.com",
     )
 
-    auth_header = create_service_authorization_header(service_id=sample_service.id)
-    response = client.get(
-        path='/v2/received-text-messages',
-        headers=[('Content-Type', 'application/json'), auth_header],
+    api_client_request.get(
+        sample_service.id,
+        'v2_inbound_sms.get_inbound_sms',
     )
 
-    assert response.status_code == 200
 
-
-def test_get_inbound_sms_generate_page_links(client, sample_service, mocker):
+def test_get_inbound_sms_generate_page_links(api_client_request, sample_service, mocker):
     mocker.patch.dict(
         "app.v2.inbound_sms.get_inbound_sms.current_app.config",
         {"API_PAGE_SIZE": 2}
@@ -69,14 +61,11 @@ def test_get_inbound_sms_generate_page_links(client, sample_service, mocker):
 
     reversed_inbound_sms = sorted(all_inbound_sms, key=lambda sms: sms.created_at, reverse=True)
 
-    auth_header = create_service_authorization_header(service_id=sample_service.id)
-    response = client.get(
-        url_for('v2_inbound_sms.get_inbound_sms'),
-        headers=[('Content-Type', 'application/json'), auth_header])
+    json_response = api_client_request.get(
+        sample_service.id,
+        'v2_inbound_sms.get_inbound_sms',
+    )
 
-    assert response.status_code == 200
-
-    json_response = json.loads(response.get_data(as_text=True))
     expected_inbound_sms_list = [i.serialize() for i in reversed_inbound_sms[:2]]
 
     assert json_response['received_text_messages'] == expected_inbound_sms_list
@@ -89,7 +78,7 @@ def test_get_inbound_sms_generate_page_links(client, sample_service, mocker):
         _external=True) == json_response['links']['next']
 
 
-def test_get_next_inbound_sms_will_get_correct_inbound_sms_list(client, sample_service, mocker):
+def test_get_next_inbound_sms_will_get_correct_inbound_sms_list(api_client_request, sample_service, mocker):
     mocker.patch.dict(
         "app.v2.inbound_sms.get_inbound_sms.current_app.config",
         {"API_PAGE_SIZE": 2}
@@ -102,14 +91,12 @@ def test_get_next_inbound_sms_will_get_correct_inbound_sms_list(client, sample_s
     ]
     reversed_inbound_sms = sorted(all_inbound_sms, key=lambda sms: sms.created_at, reverse=True)
 
-    auth_header = create_service_authorization_header(service_id=sample_service.id)
-    response = client.get(
-        path=url_for('v2_inbound_sms.get_inbound_sms', older_than=reversed_inbound_sms[1].id),
-        headers=[('Content-Type', 'application/json'), auth_header])
+    json_response = api_client_request.get(
+        sample_service.id,
+        'v2_inbound_sms.get_inbound_sms',
+        older_than=reversed_inbound_sms[1].id
+    )
 
-    assert response.status_code == 200
-
-    json_response = json.loads(response.get_data(as_text=True))
     expected_inbound_sms_list = [i.serialize() for i in reversed_inbound_sms[2:]]
 
     assert json_response['received_text_messages'] == expected_inbound_sms_list
@@ -122,21 +109,19 @@ def test_get_next_inbound_sms_will_get_correct_inbound_sms_list(client, sample_s
         _external=True) == json_response['links']['next']
 
 
-def test_get_next_inbound_sms_at_end_will_return_empty_inbound_sms_list(client, sample_service, mocker):
+def test_get_next_inbound_sms_at_end_will_return_empty_inbound_sms_list(api_client_request, sample_service, mocker):
     inbound_sms = create_inbound_sms(service=sample_service)
     mocker.patch.dict(
         "app.v2.inbound_sms.get_inbound_sms.current_app.config",
         {"API_PAGE_SIZE": 1}
     )
 
-    auth_header = create_service_authorization_header(service_id=inbound_sms.service.id)
-    response = client.get(
-        path=url_for('v2_inbound_sms.get_inbound_sms', older_than=inbound_sms.id),
-        headers=[('Content-Type', 'application/json'), auth_header])
+    json_response = api_client_request.get(
+        sample_service.id,
+        'v2_inbound_sms.get_inbound_sms',
+        older_than=inbound_sms.id,
+    )
 
-    assert response.status_code == 200
-
-    json_response = json.loads(response.get_data(as_text=True))
     expected_inbound_sms_list = []
     assert json_response['received_text_messages'] == expected_inbound_sms_list
     assert url_for(
@@ -145,34 +130,22 @@ def test_get_next_inbound_sms_at_end_will_return_empty_inbound_sms_list(client, 
     assert 'next' not in json_response['links'].keys()
 
 
-def test_get_inbound_sms_for_no_inbound_sms_returns_empty_list(
-        client, sample_service
-):
-    auth_header = create_service_authorization_header(service_id=sample_service.id)
-    response = client.get(
-        path='/v2/received-text-messages',
-        headers=[('Content-Type', 'application/json'), auth_header])
+def test_get_inbound_sms_for_no_inbound_sms_returns_empty_list(api_client_request, sample_service):
+    json_response = api_client_request.get(
+        sample_service.id,
+        'v2_inbound_sms.get_inbound_sms',
+    )
 
-    assert response.status_code == 200
-    assert response.headers['Content-type'] == 'application/json'
-
-    json_response = json.loads(response.get_data(as_text=True))['received_text_messages']
-
-    expected_response = []
-
-    assert json_response == expected_response
+    assert json_response['received_text_messages'] == []
 
 
-def test_get_inbound_sms_with_invalid_query_string_returns_400(client, sample_service):
-    auth_header = create_service_authorization_header(service_id=sample_service.id)
-    response = client.get(
-        path='/v2/received-text-messages?user_number=447700900000',
-        headers=[('Content-Type', 'application/json'), auth_header])
-
-    assert response.status_code == 400
-    assert response.headers['Content-type'] == 'application/json'
-
-    json_response = json.loads(response.get_data(as_text=True))
+def test_get_inbound_sms_with_invalid_query_string_returns_400(api_client_request, sample_service):
+    json_response = api_client_request.get(
+        sample_service.id,
+        'v2_inbound_sms.get_inbound_sms',
+        user_number='447700900000',
+        _expected_status=400
+    )
 
     assert json_response['status_code'] == 400
     assert json_response['errors'][0]['error'] == 'ValidationError'

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -48,7 +48,6 @@ def test_post_sms_notification_returns_201(api_client_request, sample_template_w
         'v2_notifications.post_notification',
         notification_type='sms',
         _data=data,
-        _expected_status=201
     )
 
     assert validate(resp_json, post_sms_response) == resp_json
@@ -88,7 +87,6 @@ def test_post_sms_notification_uses_inbound_number_as_sender(api_client_request,
         'v2_notifications.post_notification',
         notification_type='sms',
         _data=data,
-        _expected_status=201
     )
 
     assert validate(resp_json, post_sms_response) == resp_json
@@ -117,7 +115,6 @@ def test_post_sms_notification_uses_inbound_number_reply_to_as_sender(api_client
         'v2_notifications.post_notification',
         notification_type='sms',
         _data=data,
-        _expected_status=201
     )
 
     assert validate(resp_json, post_sms_response) == resp_json
@@ -147,7 +144,6 @@ def test_post_sms_notification_returns_201_with_sms_sender_id(
         'v2_notifications.post_notification',
         notification_type='sms',
         _data=data,
-        _expected_status=201
     )
 
     assert validate(resp_json, post_sms_response) == resp_json
@@ -175,7 +171,6 @@ def test_post_sms_notification_uses_sms_sender_id_reply_to(
         'v2_notifications.post_notification',
         notification_type='sms',
         _data=data,
-        _expected_status=201
     )
 
     assert validate(resp_json, post_sms_response) == resp_json
@@ -203,7 +198,6 @@ def test_notification_reply_to_text_is_original_value_if_sender_is_changed_after
         'v2_notifications.post_notification',
         notification_type='sms',
         _data=data,
-        _expected_status=201
     )
 
     dao_update_service_sms_sender(service_id=sample_template.service_id,
@@ -235,7 +229,6 @@ def test_should_cache_template_lookups_in_memory(mocker, api_client_request, sam
             'v2_notifications.post_notification',
             notification_type='sms',
             _data=data,
-            _expected_status=201
         )
 
     assert mock_get_template.call_count == 1
@@ -269,7 +262,6 @@ def test_should_cache_template_and_service_in_redis(mocker, api_client_request, 
         'v2_notifications.post_notification',
         notification_type='sms',
         _data=data,
-        _expected_status=201
     )
 
     expected_service_key = f'service-{sample_template.service_id}'
@@ -328,7 +320,6 @@ def test_should_return_template_if_found_in_redis(mocker, api_client_request, sa
         'v2_notifications.post_notification',
         notification_type='sms',
         _data=data,
-        _expected_status=201
     )
 
     assert mock_get_template.called is False
@@ -442,7 +433,6 @@ def test_post_email_notification_returns_201(
         'v2_notifications.post_notification',
         notification_type='email',
         _data=data,
-        _expected_status=201
     )
 
     assert validate(resp_json, post_email_response) == resp_json
@@ -504,7 +494,6 @@ def test_should_not_persist_or_send_notification_if_simulated_recipient(
         'v2_notifications.post_notification',
         notification_type=notification_type,
         _data=data,
-        _expected_status=201
     )
 
     apply_async.assert_not_called()
@@ -542,7 +531,6 @@ def test_send_notification_uses_priority_queue_when_template_is_marked_as_priori
         'v2_notifications.post_notification',
         notification_type=notification_type,
         _data=data,
-        _expected_status=201
     )
 
     notification_id = resp_json['id']
@@ -724,7 +712,6 @@ def test_post_sms_notification_returns_201_if_allowed_to_send_int_sms(
         'v2_notifications.post_notification',
         notification_type='sms',
         _data=data,
-        _expected_status=201
     )
 
 
@@ -741,7 +728,6 @@ def test_post_sms_should_persist_supplied_sms_number(api_client_request, sample_
         'v2_notifications.post_notification',
         notification_type='sms',
         _data=data,
-        _expected_status=201
     )
 
     notifications = Notification.query.all()
@@ -818,7 +804,6 @@ def test_post_email_notification_with_valid_reply_to_id_returns_201(api_client_r
         'v2_notifications.post_notification',
         notification_type='email',
         _data=data,
-        _expected_status=201
     )
 
     assert validate(resp_json, post_email_response) == resp_json
@@ -922,7 +907,6 @@ def test_post_notification_with_document_upload(api_client_request, notify_db_se
         'v2_notifications.post_notification',
         notification_type='email',
         _data=data,
-        _expected_status=201
     )
 
     assert validate(resp_json, post_email_response) == resp_json
@@ -967,7 +951,6 @@ def test_post_notification_with_document_upload_simulated(api_client_request, no
         'v2_notifications.post_notification',
         notification_type='email',
         _data=data,
-        _expected_status=201
     )
 
     assert validate(resp_json, post_email_response) == resp_json
@@ -1149,7 +1132,6 @@ def test_post_notifications_saves_email_or_sms_normally_if_saving_to_queue_fails
             'v2_notifications.post_notification',
             notification_type=notification_type,
             _data=data,
-            _expected_status=201
         )
 
         assert json_resp['id']
@@ -1187,7 +1169,6 @@ def test_post_notifications_doesnt_use_save_queue_for_test_notifications(
             _api_key_type='test',
             notification_type=notification_type,
             _data=data,
-            _expected_status=201
         )
 
         assert json_resp['id']
@@ -1220,7 +1201,6 @@ def test_post_notification_does_not_use_save_queue_for_letters(api_client_reques
             'v2_notifications.post_notification',
             notification_type='letter',
             _data=data,
-            _expected_status=201
         )
 
         assert not mock_save.called

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -23,7 +23,6 @@ from app.v2.notifications.notification_schemas import (
 )
 from tests import create_service_authorization_header
 from tests.app.db import (
-    create_api_key,
     create_reply_to_email,
     create_service,
     create_service_sms_sender,
@@ -34,7 +33,7 @@ from tests.conftest import set_config_values
 
 
 @pytest.mark.parametrize("reference", [None, "reference_from_client"])
-def test_post_sms_notification_returns_201(client, sample_template_with_placeholders, mocker, reference):
+def test_post_sms_notification_returns_201(api_client_request, sample_template_with_placeholders, mocker, reference):
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
     data = {
         'phone_number': '+447700900855',
@@ -43,15 +42,15 @@ def test_post_sms_notification_returns_201(client, sample_template_with_placehol
     }
     if reference:
         data.update({"reference": reference})
-    auth_header = create_service_authorization_header(service_id=sample_template_with_placeholders.service_id)
 
-    response = client.post(
-        path='/v2/notifications/sms',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
+    resp_json = api_client_request.post(
+        sample_template_with_placeholders.service_id,
+        'v2_notifications.post_notification',
+        notification_type='sms',
+        _data=data,
+        _expected_status=201
+    )
 
-    assert response.status_code == 201
-    resp_json = json.loads(response.get_data(as_text=True))
     assert validate(resp_json, post_sms_response) == resp_json
     notifications = Notification.query.all()
     assert len(notifications) == 1
@@ -73,7 +72,7 @@ def test_post_sms_notification_returns_201(client, sample_template_with_placehol
     assert mocked.called
 
 
-def test_post_sms_notification_uses_inbound_number_as_sender(client, notify_db_session, mocker):
+def test_post_sms_notification_uses_inbound_number_as_sender(api_client_request, notify_db_session, mocker):
     service = create_service_with_inbound_number(inbound_number='1')
 
     template = create_template(service=service, content="Hello (( Name))\nYour thing is due soon")
@@ -83,14 +82,15 @@ def test_post_sms_notification_uses_inbound_number_as_sender(client, notify_db_s
         'template_id': str(template.id),
         'personalisation': {' Name': 'Jo'}
     }
-    auth_header = create_service_authorization_header(service_id=service.id)
 
-    response = client.post(
-        path='/v2/notifications/sms',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
-    assert response.status_code == 201
-    resp_json = json.loads(response.get_data(as_text=True))
+    resp_json = api_client_request.post(
+        service.id,
+        'v2_notifications.post_notification',
+        notification_type='sms',
+        _data=data,
+        _expected_status=201
+    )
+
     assert validate(resp_json, post_sms_response) == resp_json
     notifications = Notification.query.all()
     assert len(notifications) == 1
@@ -101,7 +101,7 @@ def test_post_sms_notification_uses_inbound_number_as_sender(client, notify_db_s
     mocked.assert_called_once_with([str(notification_id)], queue='send-sms-tasks')
 
 
-def test_post_sms_notification_uses_inbound_number_reply_to_as_sender(client, notify_db_session, mocker):
+def test_post_sms_notification_uses_inbound_number_reply_to_as_sender(api_client_request, notify_db_session, mocker):
     service = create_service_with_inbound_number(inbound_number='07123123123')
 
     template = create_template(service=service, content="Hello (( Name))\nYour thing is due soon")
@@ -111,14 +111,15 @@ def test_post_sms_notification_uses_inbound_number_reply_to_as_sender(client, no
         'template_id': str(template.id),
         'personalisation': {' Name': 'Jo'}
     }
-    auth_header = create_service_authorization_header(service_id=service.id)
 
-    response = client.post(
-        path='/v2/notifications/sms',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
-    assert response.status_code == 201
-    resp_json = json.loads(response.get_data(as_text=True))
+    resp_json = api_client_request.post(
+        service.id,
+        'v2_notifications.post_notification',
+        notification_type='sms',
+        _data=data,
+        _expected_status=201
+    )
+
     assert validate(resp_json, post_sms_response) == resp_json
     notifications = Notification.query.all()
     assert len(notifications) == 1
@@ -130,7 +131,7 @@ def test_post_sms_notification_uses_inbound_number_reply_to_as_sender(client, no
 
 
 def test_post_sms_notification_returns_201_with_sms_sender_id(
-        client, sample_template_with_placeholders, mocker
+    api_client_request, sample_template_with_placeholders, mocker
 ):
     sms_sender = create_service_sms_sender(service=sample_template_with_placeholders.service, sms_sender='123456')
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
@@ -140,14 +141,15 @@ def test_post_sms_notification_returns_201_with_sms_sender_id(
         'personalisation': {' Name': 'Jo'},
         'sms_sender_id': str(sms_sender.id)
     }
-    auth_header = create_service_authorization_header(service_id=sample_template_with_placeholders.service_id)
 
-    response = client.post(
-        path='/v2/notifications/sms',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
-    assert response.status_code == 201
-    resp_json = json.loads(response.get_data(as_text=True))
+    resp_json = api_client_request.post(
+        sample_template_with_placeholders.service_id,
+        'v2_notifications.post_notification',
+        notification_type='sms',
+        _data=data,
+        _expected_status=201
+    )
+
     assert validate(resp_json, post_sms_response) == resp_json
     assert resp_json['content']['from_number'] == sms_sender.sms_sender
     notifications = Notification.query.all()
@@ -157,7 +159,7 @@ def test_post_sms_notification_returns_201_with_sms_sender_id(
 
 
 def test_post_sms_notification_uses_sms_sender_id_reply_to(
-        client, sample_template_with_placeholders, mocker
+    api_client_request, sample_template_with_placeholders, mocker
 ):
     sms_sender = create_service_sms_sender(service=sample_template_with_placeholders.service, sms_sender='07123123123')
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
@@ -167,14 +169,16 @@ def test_post_sms_notification_uses_sms_sender_id_reply_to(
         'personalisation': {' Name': 'Jo'},
         'sms_sender_id': str(sms_sender.id)
     }
-    auth_header = create_service_authorization_header(service_id=sample_template_with_placeholders.service_id)
 
-    response = client.post(
-        path='/v2/notifications/sms',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
-    assert response.status_code == 201
-    resp_json = json.loads(response.get_data(as_text=True))
+    resp_json = api_client_request.post(
+        sample_template_with_placeholders.service_id,
+        'v2_notifications.post_notification',
+        notification_type='sms',
+        _data=data,
+        _expected_status=201
+    )
+
+    assert validate(resp_json, post_sms_response) == resp_json
     assert validate(resp_json, post_sms_response) == resp_json
     assert resp_json['content']['from_number'] == '447123123123'
     notifications = Notification.query.all()
@@ -184,7 +188,7 @@ def test_post_sms_notification_uses_sms_sender_id_reply_to(
 
 
 def test_notification_reply_to_text_is_original_value_if_sender_is_changed_after_post_notification(
-        client, sample_template, mocker
+    api_client_request, sample_template, mocker
 ):
     sms_sender = create_service_sms_sender(service=sample_template.service, sms_sender='123456', is_default=False)
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
@@ -193,25 +197,26 @@ def test_notification_reply_to_text_is_original_value_if_sender_is_changed_after
         'template_id': str(sample_template.id),
         'sms_sender_id': str(sms_sender.id)
     }
-    auth_header = create_service_authorization_header(service_id=sample_template.service_id)
 
-    response = client.post(
-        path='/v2/notifications/sms',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
+    api_client_request.post(
+        sample_template.service_id,
+        'v2_notifications.post_notification',
+        notification_type='sms',
+        _data=data,
+        _expected_status=201
+    )
 
     dao_update_service_sms_sender(service_id=sample_template.service_id,
                                   service_sms_sender_id=sms_sender.id,
                                   is_default=sms_sender.is_default,
                                   sms_sender='updated')
 
-    assert response.status_code == 201
     notifications = Notification.query.all()
     assert len(notifications) == 1
     assert notifications[0].reply_to_text == '123456'
 
 
-def test_should_cache_template_lookups_in_memory(mocker, client, sample_template):
+def test_should_cache_template_lookups_in_memory(mocker, api_client_request, sample_template):
 
     mock_get_template = mocker.patch(
         'app.dao.templates_dao.dao_get_template_by_id_and_service_id',
@@ -225,11 +230,12 @@ def test_should_cache_template_lookups_in_memory(mocker, client, sample_template
     }
 
     for _ in range(5):
-        auth_header = create_service_authorization_header(service_id=sample_template.service_id)
-        client.post(
-            path='/v2/notifications/sms',
-            data=json.dumps(data),
-            headers=[('Content-Type', 'application/json'), auth_header]
+        api_client_request.post(
+            sample_template.service_id,
+            'v2_notifications.post_notification',
+            notification_type='sms',
+            _data=data,
+            _expected_status=201
         )
 
     assert mock_get_template.call_count == 1
@@ -239,7 +245,7 @@ def test_should_cache_template_lookups_in_memory(mocker, client, sample_template
     assert Notification.query.count() == 5
 
 
-def test_should_cache_template_and_service_in_redis(mocker, client, sample_template):
+def test_should_cache_template_and_service_in_redis(mocker, api_client_request, sample_template):
 
     from app.schemas import service_schema, template_schema
 
@@ -258,11 +264,12 @@ def test_should_cache_template_and_service_in_redis(mocker, client, sample_templ
         'template_id': str(sample_template.id),
     }
 
-    auth_header = create_service_authorization_header(service_id=sample_template.service_id)
-    client.post(
-        path='/v2/notifications/sms',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header]
+    api_client_request.post(
+        sample_template.service_id,
+        'v2_notifications.post_notification',
+        notification_type='sms',
+        _data=data,
+        _expected_status=201
     )
 
     expected_service_key = f'service-{sample_template.service_id}'
@@ -289,7 +296,7 @@ def test_should_cache_template_and_service_in_redis(mocker, client, sample_templ
     assert templates_call[1]['ex'] == 604_800
 
 
-def test_should_return_template_if_found_in_redis(mocker, client, sample_template):
+def test_should_return_template_if_found_in_redis(mocker, api_client_request, sample_template):
 
     from app.schemas import service_schema, template_schema
     service_dict = service_schema.dump(sample_template.service)
@@ -316,14 +323,14 @@ def test_should_return_template_if_found_in_redis(mocker, client, sample_templat
         'template_id': str(sample_template.id),
     }
 
-    auth_header = create_service_authorization_header(service_id=sample_template.service_id)
-    response = client.post(
-        path='/v2/notifications/sms',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header]
+    api_client_request.post(
+        sample_template.service_id,
+        'v2_notifications.post_notification',
+        notification_type='sms',
+        _data=data,
+        _expected_status=201
     )
 
-    assert response.status_code == 201
     assert mock_get_template.called is False
     assert mock_get_service.called is False
 
@@ -331,23 +338,26 @@ def test_should_return_template_if_found_in_redis(mocker, client, sample_templat
 @pytest.mark.parametrize("notification_type, key_send_to, send_to",
                          [("sms", "phone_number", "+447700900855"),
                           ("email", "email_address", "sample@email.com")])
-def test_post_notification_returns_400_and_missing_template(client, sample_service,
-                                                            notification_type, key_send_to, send_to):
+def test_post_notification_returns_400_and_missing_template(
+    api_client_request,
+    sample_service,
+    notification_type,
+    key_send_to,
+    send_to
+):
     data = {
         key_send_to: send_to,
         'template_id': str(uuid.uuid4())
     }
-    auth_header = create_service_authorization_header(service_id=sample_service.id)
 
-    response = client.post(
-        path='/v2/notifications/{}'.format(notification_type),
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
+    error_json = api_client_request.post(
+        sample_service.id,
+        'v2_notifications.post_notification',
+        notification_type=notification_type,
+        _data=data,
+        _expected_status=400
+    )
 
-    assert response.status_code == 400
-    assert response.headers['Content-type'] == 'application/json'
-
-    error_json = json.loads(response.get_data(as_text=True))
     assert error_json['status_code'] == 400
     assert error_json['errors'] == [{"error": "BadRequestError",
                                      "message": 'Template not found'}]
@@ -381,22 +391,26 @@ def test_post_notification_returns_401_and_well_formed_auth_error(client, sample
 @pytest.mark.parametrize("notification_type, key_send_to, send_to",
                          [("sms", "phone_number", "+447700900855"),
                           ("email", "email_address", "sample@email.com")])
-def test_notification_returns_400_and_for_schema_problems(client, sample_template, notification_type, key_send_to,
-                                                          send_to):
+def test_notification_returns_400_and_for_schema_problems(
+    api_client_request,
+    sample_template,
+    notification_type,
+    key_send_to,
+    send_to
+):
     data = {
         key_send_to: send_to,
         'template': str(sample_template.id)
     }
-    auth_header = create_service_authorization_header(service_id=sample_template.service_id)
 
-    response = client.post(
-        path='/v2/notifications/{}'.format(notification_type),
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
+    error_resp = api_client_request.post(
+        sample_template.service_id,
+        'v2_notifications.post_notification',
+        notification_type=notification_type,
+        _data=data,
+        _expected_status=400
+    )
 
-    assert response.status_code == 400
-    assert response.headers['Content-type'] == 'application/json'
-    error_resp = json.loads(response.get_data(as_text=True))
     assert error_resp['status_code'] == 400
     assert {'error': 'ValidationError',
             'message': "template_id is a required property"
@@ -408,7 +422,12 @@ def test_notification_returns_400_and_for_schema_problems(client, sample_templat
 
 
 @pytest.mark.parametrize("reference", [None, "reference_from_client"])
-def test_post_email_notification_returns_201(client, sample_email_template_with_placeholders, mocker, reference):
+def test_post_email_notification_returns_201(
+    api_client_request,
+    sample_email_template_with_placeholders,
+    mocker,
+    reference
+):
     mocked = mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
     data = {
         "email_address": sample_email_template_with_placeholders.service.users[0].email_address,
@@ -417,13 +436,15 @@ def test_post_email_notification_returns_201(client, sample_email_template_with_
     }
     if reference:
         data.update({"reference": reference})
-    auth_header = create_service_authorization_header(service_id=sample_email_template_with_placeholders.service_id)
-    response = client.post(
-        path="v2/notifications/email",
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
-    assert response.status_code == 201
-    resp_json = json.loads(response.get_data(as_text=True))
+
+    resp_json = api_client_request.post(
+        sample_email_template_with_placeholders.service_id,
+        'v2_notifications.post_notification',
+        notification_type='email',
+        _data=data,
+        _expected_status=201
+    )
+
     assert validate(resp_json, post_email_response) == resp_json
     notification = Notification.query.one()
     assert notification.status == NOTIFICATION_CREATED
@@ -458,12 +479,13 @@ def test_post_email_notification_returns_201(client, sample_email_template_with_
     ('07700 900222', 'sms')
 ])
 def test_should_not_persist_or_send_notification_if_simulated_recipient(
-        client,
-        recipient,
-        notification_type,
-        sample_email_template,
-        sample_template,
-        mocker):
+    api_client_request,
+    recipient,
+    notification_type,
+    sample_email_template,
+    sample_template,
+    mocker
+):
     apply_async = mocker.patch('app.celery.provider_tasks.deliver_{}.apply_async'.format(notification_type))
 
     if notification_type == 'sms':
@@ -477,16 +499,16 @@ def test_should_not_persist_or_send_notification_if_simulated_recipient(
             'template_id': str(sample_email_template.id)
         }
 
-    auth_header = create_service_authorization_header(service_id=sample_email_template.service_id)
+    resp_json = api_client_request.post(
+        sample_email_template.service_id,
+        'v2_notifications.post_notification',
+        notification_type=notification_type,
+        _data=data,
+        _expected_status=201
+    )
 
-    response = client.post(
-        path='/v2/notifications/{}'.format(notification_type),
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
-
-    assert response.status_code == 201
     apply_async.assert_not_called()
-    assert json.loads(response.get_data(as_text=True))["id"]
+    assert resp_json["id"]
     assert Notification.query.count() == 0
 
 
@@ -494,7 +516,7 @@ def test_should_not_persist_or_send_notification_if_simulated_recipient(
                          [("sms", "phone_number", "07700 900 855"),
                           ("email", "email_address", "sample@email.com")])
 def test_send_notification_uses_priority_queue_when_template_is_marked_as_priority(
-    client,
+    api_client_request,
     sample_service,
     mocker,
     notification_type,
@@ -515,16 +537,16 @@ def test_send_notification_uses_priority_queue_when_template_is_marked_as_priori
         'template_id': str(sample.id)
     }
 
-    auth_header = create_service_authorization_header(service_id=sample.service_id)
+    resp_json = api_client_request.post(
+        sample_service.id,
+        'v2_notifications.post_notification',
+        notification_type=notification_type,
+        _data=data,
+        _expected_status=201
+    )
 
-    response = client.post(
-        path='/v2/notifications/{}'.format(notification_type),
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
+    notification_id = resp_json['id']
 
-    notification_id = json.loads(response.data)['id']
-
-    assert response.status_code == 201
     mocked.assert_called_once_with([notification_id], queue='priority-tasks')
 
 
@@ -533,12 +555,12 @@ def test_send_notification_uses_priority_queue_when_template_is_marked_as_priori
     [("sms", "phone_number", "07700 900 855"), ("email", "email_address", "sample@email.com")]
 )
 def test_returns_a_429_limit_exceeded_if_rate_limit_exceeded(
-        client,
-        sample_service,
-        mocker,
-        notification_type,
-        key_send_to,
-        send_to
+    api_client_request,
+    sample_service,
+    mocker,
+    notification_type,
+    key_send_to,
+    send_to
 ):
     sample = create_template(service=sample_service, template_type=notification_type)
     persist_mock = mocker.patch('app.v2.notifications.post_notifications.persist_notification')
@@ -552,28 +574,27 @@ def test_returns_a_429_limit_exceeded_if_rate_limit_exceeded(
         'template_id': str(sample.id)
     }
 
-    auth_header = create_service_authorization_header(service_id=sample.service_id)
+    resp_json = api_client_request.post(
+        sample_service.id,
+        'v2_notifications.post_notification',
+        notification_type=notification_type,
+        _data=data,
+        _expected_status=429
+    )
 
-    response = client.post(
-        path='/v2/notifications/{}'.format(notification_type),
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
-
-    error = json.loads(response.data)['errors'][0]['error']
-    message = json.loads(response.data)['errors'][0]['message']
-    status_code = json.loads(response.data)['status_code']
-    assert response.status_code == 429
-    assert error == 'RateLimitError'
-    assert message == 'Exceeded rate limit for key type TYPE of LIMIT requests per INTERVAL seconds'
-    assert status_code == 429
+    assert resp_json['errors'][0]['error'] == 'RateLimitError'
+    assert resp_json['errors'][0]['message'] == (
+        'Exceeded rate limit for key type TYPE of LIMIT requests per INTERVAL seconds'
+    )
+    assert resp_json['status_code'] == 429
 
     assert not persist_mock.called
     assert not deliver_mock.called
 
 
 def test_post_sms_notification_returns_400_if_not_allowed_to_send_int_sms(
-        client,
-        notify_db_session,
+    api_client_request,
+    notify_db_session,
 ):
     service = create_service(service_permissions=[SMS_TYPE])
     template = create_template(service=service)
@@ -582,25 +603,22 @@ def test_post_sms_notification_returns_400_if_not_allowed_to_send_int_sms(
         'phone_number': '20-12-1234-1234',
         'template_id': template.id
     }
-    auth_header = create_service_authorization_header(service_id=service.id)
 
-    response = client.post(
-        path='/v2/notifications/sms',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header]
+    error_json = api_client_request.post(
+        service.id,
+        'v2_notifications.post_notification',
+        notification_type='sms',
+        _data=data,
+        _expected_status=400
     )
 
-    assert response.status_code == 400
-    assert response.headers['Content-type'] == 'application/json'
-
-    error_json = json.loads(response.get_data(as_text=True))
     assert error_json['status_code'] == 400
     assert error_json['errors'] == [
         {"error": "BadRequestError", "message": 'Cannot send to international mobile numbers'}
     ]
 
 
-def test_post_sms_notification_with_archived_reply_to_id_returns_400(client, sample_template, mocker):
+def test_post_sms_notification_with_archived_reply_to_id_returns_400(api_client_request, sample_template, mocker):
     archived_sender = create_service_sms_sender(
         sample_template.service,
         '12345',
@@ -612,13 +630,15 @@ def test_post_sms_notification_with_archived_reply_to_id_returns_400(client, sam
         "template_id": sample_template.id,
         'sms_sender_id': archived_sender.id
     }
-    auth_header = create_service_authorization_header(service_id=sample_template.service_id)
-    response = client.post(
-        path="v2/notifications/sms",
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
-    assert response.status_code == 400
-    resp_json = json.loads(response.get_data(as_text=True))
+
+    resp_json = api_client_request.post(
+        sample_template.service_id,
+        'v2_notifications.post_notification',
+        notification_type='sms',
+        _data=data,
+        _expected_status=400
+    )
+
     assert 'sms_sender_id {} does not exist in database for service id {}'. \
         format(archived_sender.id, sample_template.service_id) in resp_json['errors'][0]['message']
     assert 'BadRequestError' in resp_json['errors'][0]['error']
@@ -628,7 +648,13 @@ def test_post_sms_notification_with_archived_reply_to_id_returns_400(client, sam
     ('07700 900000', 'phone_number', 'email', 'sms', 'text messages'),
     ('someone@test.com', 'email_address', 'sms', 'email', 'emails')])
 def test_post_sms_notification_returns_400_if_not_allowed_to_send_notification(
-        notify_db_session, client, recipient, label, permission_type, notification_type, expected_error
+    notify_db_session,
+    api_client_request,
+    recipient,
+    label,
+    permission_type,
+    notification_type,
+    expected_error
 ):
     service = create_service(service_permissions=[permission_type])
     sample_template_without_permission = create_template(service=service, template_type=notification_type)
@@ -636,17 +662,15 @@ def test_post_sms_notification_returns_400_if_not_allowed_to_send_notification(
         label: recipient,
         'template_id': sample_template_without_permission.id
     }
-    auth_header = create_service_authorization_header(service_id=sample_template_without_permission.service.id)
 
-    response = client.post(
-        path='/v2/notifications/{}'.format(sample_template_without_permission.template_type),
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
+    error_json = api_client_request.post(
+        sample_template_without_permission.service_id,
+        'v2_notifications.post_notification',
+        notification_type=notification_type,
+        _data=data,
+        _expected_status=400
+    )
 
-    assert response.status_code == 400
-    assert response.headers['Content-type'] == 'application/json'
-
-    error_json = json.loads(response.get_data(as_text=True))
     assert error_json['status_code'] == 400
     assert error_json['errors'] == [
         {"error": "BadRequestError", "message": "Service is not allowed to send {}".format(expected_error)}
@@ -655,25 +679,27 @@ def test_post_sms_notification_returns_400_if_not_allowed_to_send_notification(
 
 @pytest.mark.parametrize('restricted', [True, False])
 def test_post_sms_notification_returns_400_if_number_not_in_guest_list(
-        notify_db_session, client, restricted
+    notify_db_session,
+    api_client_request,
+    restricted
 ):
     service = create_service(restricted=restricted, service_permissions=[SMS_TYPE, INTERNATIONAL_SMS_TYPE])
     template = create_template(service=service)
-    create_api_key(service=service, key_type='team')
 
     data = {
         "phone_number": '+327700900855',
         "template_id": template.id,
     }
-    auth_header = create_service_authorization_header(service_id=service.id, key_type='team')
 
-    response = client.post(
-        path='/v2/notifications/sms',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
+    error_json = api_client_request.post(
+        service.id,
+        'v2_notifications.post_notification',
+        notification_type='sms',
+        _api_key_type='team',
+        _data=data,
+        _expected_status=400
+    )
 
-    assert response.status_code == 400
-    error_json = json.loads(response.get_data(as_text=True))
     assert error_json['status_code'] == 400
     assert error_json['errors'] == [
         {"error": "BadRequestError", "message": 'Can’t send to this recipient using a team-only API key'}
@@ -681,10 +707,10 @@ def test_post_sms_notification_returns_400_if_number_not_in_guest_list(
 
 
 def test_post_sms_notification_returns_201_if_allowed_to_send_int_sms(
-        sample_service,
-        sample_template,
-        client,
-        mocker,
+    sample_service,
+    sample_template,
+    api_client_request,
+    mocker,
 ):
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
@@ -692,18 +718,17 @@ def test_post_sms_notification_returns_201_if_allowed_to_send_int_sms(
         'phone_number': '20-12-1234-1234',
         'template_id': sample_template.id
     }
-    auth_header = create_service_authorization_header(service_id=sample_service.id)
 
-    response = client.post(
-        path='/v2/notifications/sms',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
+    api_client_request.post(
+        sample_service.id,
+        'v2_notifications.post_notification',
+        notification_type='sms',
+        _data=data,
+        _expected_status=201
+    )
 
-    assert response.status_code == 201
-    assert response.headers['Content-type'] == 'application/json'
 
-
-def test_post_sms_should_persist_supplied_sms_number(client, sample_template_with_placeholders, mocker):
+def test_post_sms_should_persist_supplied_sms_number(api_client_request, sample_template_with_placeholders, mocker):
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
     data = {
         'phone_number': '+(44) 77009-00855',
@@ -711,14 +736,14 @@ def test_post_sms_should_persist_supplied_sms_number(client, sample_template_wit
         'personalisation': {' Name': 'Jo'}
     }
 
-    auth_header = create_service_authorization_header(service_id=sample_template_with_placeholders.service_id)
+    resp_json = api_client_request.post(
+        sample_template_with_placeholders.service_id,
+        'v2_notifications.post_notification',
+        notification_type='sms',
+        _data=data,
+        _expected_status=201
+    )
 
-    response = client.post(
-        path='/v2/notifications/sms',
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
-    assert response.status_code == 201
-    resp_json = json.loads(response.get_data(as_text=True))
     notifications = Notification.query.all()
     assert len(notifications) == 1
     notification_id = notifications[0].id
@@ -727,26 +752,28 @@ def test_post_sms_should_persist_supplied_sms_number(client, sample_template_wit
     assert mocked.called
 
 
-def test_post_notification_raises_bad_request_if_not_valid_notification_type(client, sample_service):
-    auth_header = create_service_authorization_header(service_id=sample_service.id)
-    response = client.post(
-        '/v2/notifications/foo',
-        data='{}',
-        headers=[('Content-Type', 'application/json'), auth_header]
+def test_post_notification_raises_bad_request_if_not_valid_notification_type(api_client_request, sample_service):
+    error_json = api_client_request.post(
+        sample_service.id,
+        'v2_notifications.post_notification',
+        notification_type='foo',
+        _data={},
+        _expected_status=404
     )
-    assert response.status_code == 404
-    error_json = json.loads(response.get_data(as_text=True))
     assert 'The requested URL was not found on the server.' in error_json['message']
 
 
-@pytest.mark.parametrize("notification_type",
-                         ['sms', 'email'])
+@pytest.mark.parametrize(
+    "notification_type",
+    ['sms', 'email']
+)
 def test_post_notification_with_wrong_type_of_sender(
-        client,
-        sample_template,
-        sample_email_template,
-        notification_type,
-        fake_uuid):
+    api_client_request,
+    sample_template,
+    sample_email_template,
+    notification_type,
+    fake_uuid
+):
     if notification_type == EMAIL_TYPE:
         template = sample_email_template
         form_label = 'sms_sender_id'
@@ -755,7 +782,7 @@ def test_post_notification_with_wrong_type_of_sender(
             'template_id': str(sample_email_template.id),
             form_label: fake_uuid
         }
-    elif notification_type == SMS_TYPE:
+    else:
         template = sample_template
         form_label = 'email_reply_to_id'
         data = {
@@ -763,20 +790,21 @@ def test_post_notification_with_wrong_type_of_sender(
             'template_id': str(template.id),
             form_label: fake_uuid
         }
-    auth_header = create_service_authorization_header(service_id=template.service_id)
 
-    response = client.post(
-        path='/v2/notifications/{}'.format(notification_type),
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
-    assert response.status_code == 400
-    resp_json = json.loads(response.get_data(as_text=True))
+    resp_json = api_client_request.post(
+        template.service_id,
+        'v2_notifications.post_notification',
+        notification_type=notification_type,
+        _data=data,
+        _expected_status=400
+    )
+
     assert 'Additional properties are not allowed ({} was unexpected)'.format(form_label) \
            in resp_json['errors'][0]['message']
     assert 'ValidationError' in resp_json['errors'][0]['error']
 
 
-def test_post_email_notification_with_valid_reply_to_id_returns_201(client, sample_email_template, mocker):
+def test_post_email_notification_with_valid_reply_to_id_returns_201(api_client_request, sample_email_template, mocker):
     reply_to_email = create_reply_to_email(sample_email_template.service, 'test@test.com')
     mocked = mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
     data = {
@@ -784,13 +812,15 @@ def test_post_email_notification_with_valid_reply_to_id_returns_201(client, samp
         "template_id": sample_email_template.id,
         'email_reply_to_id': reply_to_email.id
     }
-    auth_header = create_service_authorization_header(service_id=sample_email_template.service_id)
-    response = client.post(
-        path="v2/notifications/email",
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
-    assert response.status_code == 201
-    resp_json = json.loads(response.get_data(as_text=True))
+
+    resp_json = api_client_request.post(
+        sample_email_template.service_id,
+        'v2_notifications.post_notification',
+        notification_type='email',
+        _data=data,
+        _expected_status=201
+    )
+
     assert validate(resp_json, post_email_response) == resp_json
     notification = Notification.query.first()
     assert notification.reply_to_text == 'test@test.com'
@@ -800,26 +830,37 @@ def test_post_email_notification_with_valid_reply_to_id_returns_201(client, samp
     assert notification.reply_to_text == reply_to_email.email_address
 
 
-def test_post_email_notification_with_invalid_reply_to_id_returns_400(client, sample_email_template, mocker, fake_uuid):
+def test_post_email_notification_with_invalid_reply_to_id_returns_400(
+    api_client_request,
+    sample_email_template,
+    mocker,
+    fake_uuid
+):
     mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
     data = {
         "email_address": sample_email_template.service.users[0].email_address,
         "template_id": sample_email_template.id,
         'email_reply_to_id': fake_uuid
     }
-    auth_header = create_service_authorization_header(service_id=sample_email_template.service_id)
-    response = client.post(
-        path="v2/notifications/email",
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
-    assert response.status_code == 400
-    resp_json = json.loads(response.get_data(as_text=True))
+
+    resp_json = api_client_request.post(
+        sample_email_template.service_id,
+        'v2_notifications.post_notification',
+        notification_type='email',
+        _data=data,
+        _expected_status=400
+    )
+
     assert 'email_reply_to_id {} does not exist in database for service id {}'. \
         format(fake_uuid, sample_email_template.service_id) in resp_json['errors'][0]['message']
     assert 'BadRequestError' in resp_json['errors'][0]['error']
 
 
-def test_post_email_notification_with_archived_reply_to_id_returns_400(client, sample_email_template, mocker):
+def test_post_email_notification_with_archived_reply_to_id_returns_400(
+    api_client_request,
+    sample_email_template,
+    mocker
+):
     archived_reply_to = create_reply_to_email(
         sample_email_template.service,
         'reply_to@test.com',
@@ -831,13 +872,15 @@ def test_post_email_notification_with_archived_reply_to_id_returns_400(client, s
         "template_id": sample_email_template.id,
         'email_reply_to_id': archived_reply_to.id
     }
-    auth_header = create_service_authorization_header(service_id=sample_email_template.service_id)
-    response = client.post(
-        path="v2/notifications/email",
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
-    assert response.status_code == 400
-    resp_json = json.loads(response.get_data(as_text=True))
+
+    resp_json = api_client_request.post(
+        sample_email_template.service_id,
+        'v2_notifications.post_notification',
+        notification_type='email',
+        _data=data,
+        _expected_status=400
+    )
+
     assert 'email_reply_to_id {} does not exist in database for service id {}'. \
         format(archived_reply_to.id, sample_email_template.service_id) in resp_json['errors'][0]['message']
     assert 'BadRequestError' in resp_json['errors'][0]['error']
@@ -852,7 +895,7 @@ def test_post_email_notification_with_archived_reply_to_id_returns_400(client, s
         {},
     )
 )
-def test_post_notification_with_document_upload(client, notify_db_session, mocker, csv_param):
+def test_post_notification_with_document_upload(api_client_request, notify_db_session, mocker, csv_param):
     service = create_service(service_permissions=[EMAIL_TYPE])
     service.contact_link = 'contact.me@gov.uk'
     template = create_template(
@@ -874,14 +917,14 @@ def test_post_notification_with_document_upload(client, notify_db_session, mocke
         }
     }
 
-    auth_header = create_service_authorization_header(service_id=service.id)
-    response = client.post(
-        path="v2/notifications/email",
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
+    resp_json = api_client_request.post(
+        service.id,
+        'v2_notifications.post_notification',
+        notification_type='email',
+        _data=data,
+        _expected_status=201
+    )
 
-    assert response.status_code == 201, response.get_data(as_text=True)
-    resp_json = json.loads(response.get_data(as_text=True))
     assert validate(resp_json, post_email_response) == resp_json
 
     assert document_download_mock.upload_document.call_args_list == [
@@ -900,7 +943,7 @@ def test_post_notification_with_document_upload(client, notify_db_session, mocke
     assert resp_json['content']['body'] == 'Document 1: abababab-link. Document 2: cdcdcdcd-link'
 
 
-def test_post_notification_with_document_upload_simulated(client, notify_db_session, mocker):
+def test_post_notification_with_document_upload_simulated(api_client_request, notify_db_session, mocker):
     service = create_service(service_permissions=[EMAIL_TYPE])
     service.contact_link = 'contact.me@gov.uk'
     template = create_template(
@@ -919,20 +962,20 @@ def test_post_notification_with_document_upload_simulated(client, notify_db_sess
         "personalisation": {"document": {"file": "abababab"}}
     }
 
-    auth_header = create_service_authorization_header(service_id=service.id)
-    response = client.post(
-        path="v2/notifications/email",
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
+    resp_json = api_client_request.post(
+        service.id,
+        'v2_notifications.post_notification',
+        notification_type='email',
+        _data=data,
+        _expected_status=201
+    )
 
-    assert response.status_code == 201, response.get_data(as_text=True)
-    resp_json = json.loads(response.get_data(as_text=True))
     assert validate(resp_json, post_email_response) == resp_json
 
     assert resp_json['content']['body'] == 'Document: https://document-url/test-document'
 
 
-def test_post_notification_without_document_upload_permission(client, notify_db_session, mocker):
+def test_post_notification_without_document_upload_permission(api_client_request, notify_db_session, mocker):
     service = create_service(service_permissions=[EMAIL_TYPE])
     template = create_template(
         service=service,
@@ -950,13 +993,13 @@ def test_post_notification_without_document_upload_permission(client, notify_db_
         "personalisation": {"document": {"file": "abababab"}}
     }
 
-    auth_header = create_service_authorization_header(service_id=service.id)
-    response = client.post(
-        path="v2/notifications/email",
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header])
-
-    assert response.status_code == 400, response.get_data(as_text=True)
+    api_client_request.post(
+        service.id,
+        'v2_notifications.post_notification',
+        notification_type='email',
+        _data=data,
+        _expected_status=400
+    )
 
 
 def test_post_notification_returns_400_when_get_json_throws_exception(client, sample_email_template):
@@ -1015,16 +1058,16 @@ def test_post_notification_returns_201_when_content_type_is_missing_but_payload_
 
 
 @pytest.mark.parametrize('notification_type', ['email', 'sms'])
-def test_post_email_notification_when_data_is_empty_returns_400(client, sample_service, notification_type):
-    auth_header = create_service_authorization_header(service_id=sample_service.id)
-    data = None
-    response = client.post(
-        path='/v2/notifications/{}'.format(notification_type),
-        data=json.dumps(data),
-        headers=[('Content-Type', 'application/json'), auth_header],
+def test_post_email_notification_when_data_is_empty_returns_400(api_client_request, sample_service, notification_type):
+    resp_json = api_client_request.post(
+        sample_service.id,
+        'v2_notifications.post_notification',
+        notification_type=notification_type,
+        _data=None,
+        _expected_status=400
     )
-    error_msg = json.loads(response.get_data(as_text=True))["errors"][0]["message"]
-    assert response.status_code == 400
+
+    error_msg = resp_json["errors"][0]["message"]
     if notification_type == 'sms':
         assert error_msg == 'phone_number is a required property'
     else:
@@ -1074,7 +1117,7 @@ def test_post_notifications_saves_email_or_sms_to_queue(client, notify_db_sessio
 ])
 @pytest.mark.parametrize("notification_type", ("email", "sms"))
 def test_post_notifications_saves_email_or_sms_normally_if_saving_to_queue_fails(
-    client,
+    api_client_request,
     notify_db_session,
     mocker,
     notification_type,
@@ -1101,15 +1144,14 @@ def test_post_notifications_saves_email_or_sms_normally_if_saving_to_queue_fails
         data.update({"email_address": "joe.citizen@example.com"}) if notification_type == EMAIL_TYPE \
             else data.update({"phone_number": "+447700900855"})
 
-        response = client.post(
-            path=f'/v2/notifications/{notification_type}',
-            data=json.dumps(data),
-            headers=[('Content-Type', 'application/json'), create_service_authorization_header(service_id=service.id)]
+        json_resp = api_client_request.post(
+            service.id,
+            'v2_notifications.post_notification',
+            notification_type=notification_type,
+            _data=data,
+            _expected_status=201
         )
 
-        json_resp = response.get_json()
-
-        assert response.status_code == 201
         assert json_resp['id']
         assert json_resp['content']['body'] == "Dear citizen, have a nice day"
         assert json_resp['template']['id'] == str(template.id)
@@ -1120,7 +1162,7 @@ def test_post_notifications_saves_email_or_sms_normally_if_saving_to_queue_fails
 
 @pytest.mark.parametrize("notification_type", ("email", "sms"))
 def test_post_notifications_doesnt_use_save_queue_for_test_notifications(
-    client, notify_db_session, mocker, notification_type
+    api_client_request, notify_db_session, mocker, notification_type
 ):
     save_task = mocker.patch(f"app.celery.tasks.save_api_{notification_type}.apply_async")
     mock_send_task = mocker.patch(f'app.celery.provider_tasks.deliver_{notification_type}.apply_async')
@@ -1138,16 +1180,16 @@ def test_post_notifications_doesnt_use_save_queue_for_test_notifications(
         }
         data.update({"email_address": "joe.citizen@example.com"}) if notification_type == EMAIL_TYPE \
             else data.update({"phone_number": "+447700900855"})
-        response = client.post(
-            path=f'/v2/notifications/{notification_type}',
-            data=json.dumps(data),
-            headers=[('Content-Type', 'application/json'),
-                     create_service_authorization_header(service_id=service.id, key_type='test')]
+
+        json_resp = api_client_request.post(
+            service.id,
+            'v2_notifications.post_notification',
+            _api_key_type='test',
+            notification_type=notification_type,
+            _data=data,
+            _expected_status=201
         )
 
-        json_resp = response.get_json()
-
-        assert response.status_code == 201
         assert json_resp['id']
         assert json_resp['content']['body'] == "Dear citizen, have a nice day"
         assert json_resp['template']['id'] == str(template.id)
@@ -1156,7 +1198,7 @@ def test_post_notifications_doesnt_use_save_queue_for_test_notifications(
         assert len(Notification.query.all()) == 1
 
 
-def test_post_notification_does_not_use_save_queue_for_letters(client, sample_letter_template, mocker):
+def test_post_notification_does_not_use_save_queue_for_letters(api_client_request, sample_letter_template, mocker):
     mock_save = mocker.patch("app.v2.notifications.post_notifications.save_email_or_sms_to_queue")
     mock_create_pdf_task = mocker.patch('app.celery.tasks.letters_pdf_tasks.get_pdf_for_templated_letter.apply_async')
 
@@ -1173,13 +1215,13 @@ def test_post_notification_does_not_use_save_queue_for_letters(client, sample_le
                 'postcode': 'SW1 1AA',
             }
         }
-        response = client.post(
-            path='/v2/notifications/letter',
-            data=json.dumps(data),
-            headers=[('Content-Type', 'application/json'),
-                     create_service_authorization_header(service_id=sample_letter_template.service_id)]
+        json_resp = api_client_request.post(
+            sample_letter_template.service_id,
+            'v2_notifications.post_notification',
+            notification_type='letter',
+            _data=data,
+            _expected_status=201
         )
-        assert response.status_code == 201
-        json_resp = response.get_json()
+
         assert not mock_save.called
         mock_create_pdf_task.assert_called_once_with([str(json_resp['id'])], queue='create-letters-pdf-tasks')


### PR DESCRIPTION
in admin tests we have `client_request` fixture for handling boilerplate around testing user-facing requests - logging in the user, json dumping/loading, creating URLs from endpoints and args, etc.

in api tests we have `admin_request` for doing the same for requests coming from the admin.

now in api /v2/ tests, we have `api_client_request`, for requests made by an api client to our public endpoints! The only difference between this and `admin_request` is that it _requires_ a service id (to create a jwt token for), and has an optional _api_key_type arg that can be 'team', 'test' or 'normal' (the default).

if your service has any number of api keys for the given key type, it'll use an arbitrary one of them. If there isn't one, it'll create one of that type.

if your test is simulating a well formed request to a v2 endpoint, it can now use this request to handle boilerplate. Never call `create_service_authorization_header` again!

Except, you might still need to call the old `client` fixture occasionally. Mostly when you're testing:

* What happens if you pass something in that isn't valid json
* What happens if you don't pass in proper authorization header

This PR is pretty big, and adds more lines than it takes away - but most of those new lines are just making the code layout more readable. In terms of lines of executed code this is definitely a reduction.