### PR TITLE
Add endpoint to update email branding pool

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -3,6 +3,7 @@ from sqlalchemy.sql.expression import func
 
 from app import db
 from app.dao.dao_utils import VersionOptions, autocommit, version_class
+from app.dao.email_branding_dao import dao_get_email_branding_by_id
 from app.models import (
     AnnualBilling,
     Domain,
@@ -186,6 +187,17 @@ def dao_add_email_branding_to_organisation_pool(organisation_id, email_branding_
     organisation.email_branding_pool.append(email_branding)
     db.session.add(organisation)
     return email_branding
+
+
+@autocommit
+def dao_add_email_branding_list_to_organisation_pool(organisation_id, email_branding_ids):
+    organisation = dao_get_organisation_by_id(organisation_id)
+    email_brandings = [
+        dao_get_email_branding_by_id(branding_id)
+        for branding_id in email_branding_ids
+    ]
+
+    organisation.email_branding_pool.extend(email_brandings)
 
 
 def dao_get_email_branding_pool_for_organisation(organisation_id):

--- a/app/organisation/organisation_schema.py
+++ b/app/organisation/organisation_schema.py
@@ -60,3 +60,14 @@ post_update_invited_org_user_status_schema = {
     },
     "required": ["status"]
 }
+
+
+post_update_org_email_branding_pool_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "POST update organisation email branding pool schema",
+    "type": "object",
+    "properties": {
+        "branding_ids": {"type": "array", "items": uuid}
+    },
+    "required": ["branding_ids"]
+}

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -8,6 +8,7 @@ from app.dao.dao_utils import transaction
 from app.dao.fact_billing_dao import fetch_usage_for_organisation
 from app.dao.invited_org_user_dao import get_invited_org_users_for_organisation
 from app.dao.organisation_dao import (
+    dao_add_email_branding_list_to_organisation_pool,
     dao_add_service_to_organisation,
     dao_add_user_to_organisation,
     dao_archive_organisation,
@@ -38,6 +39,7 @@ from app.notifications.process_notifications import (
 from app.organisation.organisation_schema import (
     post_create_organisation_schema,
     post_link_service_to_organisation_schema,
+    post_update_org_email_branding_pool_schema,
     post_update_organisation_schema,
 )
 from app.schema_validation import validate
@@ -222,6 +224,16 @@ def get_organisation_users(organisation_id):
 def get_organisation_email_branding_pool(organisation_id):
     branding_pool = dao_get_email_branding_pool_for_organisation(organisation_id)
     return jsonify(data=[branding.serialize() for branding in branding_pool])
+
+
+@organisation_blueprint.route('/<uuid:organisation_id>/email-branding-pool', methods=['POST'])
+def update_organisation_email_branding_pool(organisation_id):
+    data = request.get_json()
+    validate(data, post_update_org_email_branding_pool_schema)
+
+    dao_add_email_branding_list_to_organisation_pool(organisation_id, data['branding_ids'])
+
+    return {}, 204
 
 
 def check_request_args(request):

--- a/tests/app/dao/test_organisation_dao.py
+++ b/tests/app/dao/test_organisation_dao.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from app import db
 from app.dao.organisation_dao import (
+    dao_add_email_branding_list_to_organisation_pool,
     dao_add_email_branding_to_organisation_pool,
     dao_add_service_to_organisation,
     dao_add_user_to_organisation,
@@ -418,6 +419,24 @@ def test_add_to_and_get_email_branding_pool_for_organisation(sample_organisation
     # We test to ensure that branding that belongs to \
     # another Organisation's email branding pool is not returned
     assert third_branding not in results
+
+
+def test_dao_add_email_branding_list_to_organisation_pool(sample_organisation):
+    branding_1 = create_email_branding(logo='test_x1.png', name='branding_1')
+    branding_2 = create_email_branding(logo='test_x2.png', name='branding_2')
+    branding_3 = create_email_branding(logo='test_x3.png', name='branding_3')
+
+    dao_add_email_branding_list_to_organisation_pool(sample_organisation.id, [branding_1.id])
+
+    assert sample_organisation.email_branding_pool == [branding_1]
+
+    dao_add_email_branding_list_to_organisation_pool(sample_organisation.id, [branding_2.id, branding_3.id])
+
+    # existing brandings remain in the pool, while new ones get added
+    assert len(sample_organisation.email_branding_pool) == 3
+    assert branding_1 in sample_organisation.email_branding_pool
+    assert branding_2 in sample_organisation.email_branding_pool
+    assert branding_3 in sample_organisation.email_branding_pool
 
 
 def test_dao_get_organisation_live_services_with_free_allowance(sample_service, sample_organisation):

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -1022,3 +1022,31 @@ def test_get_organisation_email_branding_pool_returns_email_brandings_for_organi
     assert len(response['data']) == 2
     assert response['data'][0]['id'] == str(first_branding.id)
     assert response['data'][1]['id'] == str(second_branding.id)
+
+
+def test_update_organisation_email_branding_pool_raises_an_error_when_data_not_in_required_format(
+    admin_request,
+    sample_organisation,
+):
+    admin_request.post(
+        'organisation.update_organisation_email_branding_pool',
+        organisation_id=sample_organisation.id,
+        _data='invalid',
+        _expected_status=400
+    )
+
+
+def test_update_organisation_email_branding_pool_updates_branding_pool(
+    admin_request,
+    sample_organisation,
+):
+    branding_1 = create_email_branding(logo='test_x1.png', name='email_branding_1')
+    branding_2 = create_email_branding(logo='test_x2.png', name='email_branding_2')
+
+    admin_request.post(
+        'organisation.update_organisation_email_branding_pool',
+        organisation_id=sample_organisation.id,
+        _data={"branding_ids": [str(branding_1.id), str(branding_2.id)]},
+        _expected_status=204
+    )
+    assert len(sample_organisation.email_branding_pool) == 2


### PR DESCRIPTION
This adds an endpoint to update the email branding pool for an
organisation. The form that the data comes from allows multiple email
brandings to be added at once, so the endpoint takes this into account.
I've added a new dao function which allows bulk adding to the email branding
pool - this saves having to iterate through each new branding and doing
a database update for each one.

As with other POST endpoints, we check the data using a JSON schema,
however the request from admin should always have the data in the
required format, so I would not expect this to raise a validation error
in production. Instead, it acts to document the endpoint and to ensure
any future changes don't break things unexpectedly.

[Pivotal story](https://www.pivotaltracker.com/story/show/182771318)