### PR TITLE
Require limited charset for `Service.email_from`

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,3 +1,4 @@
+import string
 from datetime import datetime, timedelta
 from uuid import UUID
 
@@ -303,6 +304,15 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
         if len(set(permissions)) != len(permissions):
             duplicates = list(set([x for x in permissions if permissions.count(x) > 1]))
             raise ValidationError('Duplicate Service Permission: {}'.format(duplicates))
+
+    @validates('email_from')
+    def validate_email_from(self, value):
+        if not all(
+            char in string.ascii_lowercase + string.digits + '.' for char in value
+        ):
+            raise ValidationError(
+                'Unacceptable characters: `email_from` may only contain letters, numbers and full stops.'
+            )
 
     @pre_load()
     def format_for_data_model(self, in_data, **kwargs):


### PR DESCRIPTION
Some users have been trying to create services with unicode service
names. When it comes to sending emails, not all unicode characters can
be 'cleaned' to the simple ASCII charset which is currently required to
build a valid local email fragment.

Rich unicode local email names can theoretically be supported by
converting them to punycode, but we don't want to do this currently as
it will lead to very peculiar-looking emails and we haven't researched
the potential consequences of this.

For a service to currently send emails, they must put in a basic ascii
service name. Let's help the user avoid the error case by enforcing this
strictly in the first place.

We leave it to the future to research and design a long-term solution
that will perhaps allow rich Unicode service names.

Note: the notifications-admin app performs some initial 'cleaning' on
service names which will remove diacritics/accents/etc and downcast some
rich characters to plain ascii. What this means is that we aren't
totally banning _all_ unicode characters from service names, but just
those which don't downcast easily to the ascii set - eg cyrillic.