### PR TITLE
Add temporary logging to check personalisation use

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -316,6 +316,13 @@ def process_document_uploads(personalisation_data, service, simulated=False):
     Returns modified personalisation dict and a count of document uploads. If there are no document uploads, returns
     a count of `None` rather than `0`.
     """
+    # SW: Temporary logging to get an idea of whether services are providing `dict` values in personalisation outside
+    # of the file-upload use-case. If they are, we can't upgrade the personalisation JSON schema to do some param
+    # validation for us without notifying services / creating a new API version. Feel free to remove after 01/09/2022.
+    non_file_dicts = [k for k, v in (personalisation_data or {}).items() if isinstance(v, dict) and 'file' not in v]
+    if non_file_dicts:
+        current_app.logger.info('Notification personalisation contains a dict value without `file` key.')
+
     file_keys = [k for k, v in (personalisation_data or {}).items() if isinstance(v, dict) and 'file' in v]
     if not file_keys:
         return personalisation_data, None


### PR DESCRIPTION
Add a short-term log statement to see whether services are sending
`dict` values in the `personalisation` field outside of the file-upload
use-case.