### PR TITLE
Verify email before download parameter

### DIFF
--- a/app/clients/document_download.py
+++ b/app/clients/document_download.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import requests
 from flask import current_app
 
@@ -23,17 +25,22 @@ class DocumentDownloadClient:
     def get_upload_url(self, service_id):
         return "{}/services/{}/documents".format(self.api_host, service_id)
 
-    def upload_document(self, service_id, file_contents, is_csv=None):
+    def upload_document(self, service_id, file_contents, is_csv=None, verification_email: Optional[str] = None):
         try:
+            data = {
+                'document': file_contents,
+                'is_csv': is_csv or False,
+            }
+
+            if verification_email:
+                data['verification_email'] = verification_email
+
             response = requests.post(
                 self.get_upload_url(service_id),
                 headers={
                     'Authorization': "Bearer {}".format(self.auth_token),
                 },
-                json={
-                    'document': file_contents,
-                    'is_csv': is_csv or False,
-                }
+                json=data
             )
 
             response.raise_for_status()

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from flask import current_app
 from gds_metrics.metrics import Histogram
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
@@ -18,6 +20,7 @@ from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_id
 from app.dao.service_letter_contact_dao import dao_get_letter_contact_by_id
 from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id
 from app.models import (
+    DOCUMENT_DOWNLOAD_VERIFY_EMAIL,
     EMAIL_TYPE,
     INTERNATIONAL_LETTERS,
     INTERNATIONAL_SMS_TYPE,
@@ -124,6 +127,16 @@ def check_if_service_can_send_files_by_email(service_contact_link, service_id):
             message=f"Send files by email has not been set up - add contact details for your service at "
             f"{current_app.config['ADMIN_BASE_URL']}/services/{service_id}/service-settings/send-files-by-email"
         )
+
+
+def error_if_service_using_email_verification_flow_without_permission(
+        verify_email: bool, service_permissions: List[str]
+):
+    if DOCUMENT_DOWNLOAD_VERIFY_EMAIL not in service_permissions:
+        if verify_email:
+            raise BadRequestError(
+                message="Email verification flow for document download has not been enabled for this service."
+            )
 
 
 def validate_and_format_recipient(send_to, key_type, service, notification_type, allow_guest_list_recipients=True):

--- a/tests/app/clients/test_document_download.py
+++ b/tests/app/clients/test_document_download.py
@@ -36,6 +36,27 @@ def test_upload_document(document_download):
     assert resp == 'https://document-download/services/service-id/documents/uploaded-url'
 
 
+@pytest.mark.parametrize('verification_email', [None, 'dev@test.notify'])
+def test_upload_document_verify_email(document_download, verification_email):
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post('https://document-download/services/service-id/documents', json={
+            'document': {'url': 'https://document-download/services/service-id/documents/uploaded-url'}
+        }, request_headers={
+            'Authorization': 'Bearer test-key',
+        }, status_code=201)
+
+        resp = document_download.upload_document('service-id', 'abababab', verification_email=verification_email)
+
+    assert resp == 'https://document-download/services/service-id/documents/uploaded-url'
+
+    request_json = request_mock.request_history[0].json()
+    if verification_email:
+        assert request_json['verification_email'] == verification_email
+
+    else:
+        assert 'verification_email' not in request_json
+
+
 def test_should_raise_400s_as_DocumentDownloadErrors(document_download):
     with pytest.raises(DocumentDownloadError) as excinfo, requests_mock.Mocker() as request_mock:
         request_mock.post('https://document-download/services/service-id/documents', json={

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -132,6 +132,7 @@ def create_service(
         billing_contact_names=None,
         billing_contact_email_addresses=None,
         billing_reference=None,
+        contact_link=None,
 ):
     if check_if_service_exists:
         service = Service.query.filter_by(name=service_name).first()
@@ -152,6 +153,7 @@ def create_service(
             billing_contact_names=billing_contact_names,
             billing_contact_email_addresses=billing_contact_email_addresses,
             billing_reference=billing_reference,
+            contact_link=contact_link,
         )
         dao_create_service(
             service,


### PR DESCRIPTION
This PR adds support for a new key to the `personalisation` field of email notifications: `verify_email_before_download`. If present this field must be True/False - and defaults to False if not present.

When added, it causes the call to document-download-api to include a `verification_email` parameter, which will later be used to store the hashed email against the document for verification as part of the user download flow.

TIcket: https://www.pivotaltracker.com/n/projects/1443052/stories/182950357