### PR TITLE
Add new default email branding to pool

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -110,6 +110,10 @@ def dao_update_organisation(organisation_id, **kwargs):
     if 'email_branding_id' in kwargs:
         _update_organisation_services(organisation, 'email_branding')
 
+        # This could be `None` to return an organisation to the default GOV.UK branding (which isn't a real brand).
+        if kwargs['email_branding_id']:
+            dao_add_email_branding_to_organisation_pool(organisation_id, kwargs['email_branding_id'])
+
     if 'letter_branding_id' in kwargs:
         _update_organisation_services(organisation, 'letter_branding')
 

--- a/tests/app/dao/test_organisation_dao.py
+++ b/tests/app/dao/test_organisation_dao.py
@@ -218,6 +218,31 @@ def test_update_organisation_does_not_override_service_branding(
     assert sample_service.letter_branding == custom_letter_branding
 
 
+def test_update_organisation_email_branding_adds_to_pool(sample_organisation):
+    email_branding = create_email_branding()
+    db.session.commit()
+
+    assert email_branding not in sample_organisation.email_branding_pool
+
+    dao_update_organisation(sample_organisation.id, email_branding_id=email_branding.id)
+
+    assert email_branding in sample_organisation.email_branding_pool
+
+
+def test_update_organisation_email_branding_does_not_error_if_already_in_pool(sample_organisation):
+    email_branding = create_email_branding()
+    sample_organisation.email_branding_pool.append(email_branding)
+    db.session.commit()
+
+    assert email_branding in sample_organisation.email_branding_pool
+
+    dao_update_organisation(sample_organisation.id, email_branding_id=email_branding.id)
+
+
+def test_update_organisation_email_branding_does_not_error_if_returning_to_govuk_brand(sample_organisation):
+    dao_update_organisation(sample_organisation.id, email_branding_id=None)
+
+
 def test_update_organisation_updates_services_with_new_crown_type(
     sample_service,
     sample_organisation


### PR DESCRIPTION
When we set the default email branding for an organisation, let's also
add it to the email branding pool for that organisation so that services
can switch out of it and back at a later date if they change their minds
without having to contact us.

Ticket: https://www.pivotaltracker.com/n/projects/1443052/stories/182762788