### PR TITLE
Explicitly pin setuptools to work around buildpack build error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -275,4 +275,4 @@ wrapt==1.14.1
     # via deprecated
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools
+setuptools==65.1.1


### PR DESCRIPTION
Droplet builds using the python buildpack stopped working caused
by an error thrown while building pycurl from source.

All buildpack versions (despite pinning) started to supply setuptools
65.0.2 which causes the breaking change.

Until this is fixed we need to explicitly pin a working setuptools
version (this is not recommended).

Buildpack issue thread: https://github.com/cloudfoundry/python-buildpack/issues/574
