### PR TITLE
Add support for `retention_period` to API

### DIFF
--- a/app/clients/document_download.py
+++ b/app/clients/document_download.py
@@ -25,7 +25,14 @@ class DocumentDownloadClient:
     def get_upload_url(self, service_id):
         return "{}/services/{}/documents".format(self.api_host, service_id)
 
-    def upload_document(self, service_id, file_contents, is_csv=None, verification_email: Optional[str] = None):
+    def upload_document(
+            self,
+            service_id,
+            file_contents,
+            is_csv=None,
+            verification_email: Optional[str] = None,
+            retention_period: Optional[str] = None
+    ):
         try:
             data = {
                 'document': file_contents,
@@ -34,6 +41,9 @@ class DocumentDownloadClient:
 
             if verification_email:
                 data['verification_email'] = verification_email
+
+            if retention_period:
+                data['retention_period'] = retention_period
 
             response = requests.post(
                 self.get_upload_url(service_id),

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -135,7 +135,10 @@ def error_if_service_using_email_verification_flow_without_permission(
     if DOCUMENT_DOWNLOAD_VERIFY_EMAIL not in service_permissions:
         if verify_email:
             raise BadRequestError(
-                message="Email verification flow for document download has not been enabled for this service."
+                message=(
+                    "Email verification and/or custom retention for 'send files by email' "
+                    "has not been enabled for this service."
+                )
             )
 
 

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -341,9 +341,10 @@ def process_document_uploads(personalisation_data, service, send_to: str, simula
             personalisation_data[key] = document_download_client.get_upload_url(service.id) + '/test-document'
         else:
             verify_email = personalisation_data[key].get('verify_email_before_download') or False
+            retention_period = personalisation_data[key].get('retention_period', None)
 
             error_if_service_using_email_verification_flow_without_permission(
-                verify_email,
+                verify_email or bool(retention_period),
                 service.permissions
             )
 
@@ -353,6 +354,7 @@ def process_document_uploads(personalisation_data, service, send_to: str, simula
                     personalisation_data[key]['file'],
                     personalisation_data[key].get('is_csv'),
                     verification_email=send_to if verify_email else None,
+                    retention_period=retention_period
                 )
             except DocumentDownloadError as e:
                 raise BadRequestError(message=e.message, status_code=e.status_code)

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -881,6 +881,9 @@ def test_post_email_notification_with_archived_reply_to_id_returns_400(
         {'is_csv': True},
         {'verify_email_before_download': False},
         {'verify_email_before_download': True},
+        {'retention_period': None},
+        {'retention_period': '1 week'},
+        {'retention_period': '4 weeks'},
     )
 )
 def test_post_notification_with_document_upload(api_client_request, notify_db_session, mocker, extra):
@@ -895,7 +898,7 @@ def test_post_notification_with_document_upload(api_client_request, notify_db_se
     mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
     document_download_mock = mocker.patch('app.v2.notifications.post_notifications.document_download_client')
     document_download_mock.upload_document.side_effect = (
-        lambda service_id, content, is_csv, verification_email: f'{content}-link'
+        lambda service_id, content, is_csv, verification_email, **kwargs: f'{content}-link'
     )
 
     data = {
@@ -917,9 +920,22 @@ def test_post_notification_with_document_upload(api_client_request, notify_db_se
     assert validate(resp_json, post_email_response) == resp_json
 
     verification_email = data['email_address'] if extra.get('verify_email_before_download') else None
+
     assert document_download_mock.upload_document.call_args_list == [
-        call(str(service.id), 'abababab', extra.get('is_csv'), verification_email=verification_email),
-        call(str(service.id), 'cdcdcdcd', extra.get('is_csv'), verification_email=verification_email)
+        call(
+            str(service.id),
+            'abababab',
+            extra.get('is_csv'),
+            verification_email=verification_email,
+            retention_period=extra.get('retention_period'),
+        ),
+        call(
+            str(service.id),
+            'cdcdcdcd',
+            extra.get('is_csv'),
+            verification_email=verification_email,
+            retention_period=extra.get('retention_period'),
+        )
     ]
 
     notification = Notification.query.one()
@@ -1058,7 +1074,7 @@ def test_post_notification_without_document_email_verification_permission(
 
     assert (
         resp['errors'][0]['message'] ==
-        'Email verification flow for document download has not been enabled for this service.'
+        "Email verification and/or custom retention for 'send files by email' has not been enabled for this service."
     )
 
 


### PR DESCRIPTION
Update the `POST /v2/notification` endpoint to support a
`retention_period` parameter in file upload fields of personalisation.
This just passes the value directly through to the
document-download-api. Validation on the exact value of the
retention_period will happen in document-download-api - although
notify-api does enforce it as a string.

-----

Just reusing the existing service permission toggle ("feature flag") as we expect to release these at the same time, and we will remove the permission from the code shortly afterwards so the potential confusion over the name/value won't persist.

Ticket: https://www.pivotaltracker.com/n/projects/1443052/stories/183092708