### PR TITLE
Check file upload personalisation dicts

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -320,10 +320,14 @@ def process_document_uploads(personalisation_data, service, send_to: str, simula
     """
     # SW: Temporary logging to get an idea of whether services are providing `dict` values in personalisation outside
     # of the file-upload use-case. If they are, we can't upgrade the personalisation JSON schema to do some param
-    # validation for us without notifying services / creating a new API version. Feel free to remove after 01/09/2022.
-    non_file_dicts = [k for k, v in (personalisation_data or {}).items() if isinstance(v, dict) and 'file' not in v]
-    if non_file_dicts:
-        current_app.logger.info('Notification personalisation contains a dict value without `file` key.')
+    # validation for us without notifying services / creating a new API version. Feel free to remove after 08/09/2022.
+    bad_file_dicts = [
+        k
+        for k, v in (personalisation_data or {}).items()
+        if isinstance(v, dict) and 'file' in v and not all(k2 in {'file', 'is_csv'} for k2 in v)
+    ]
+    if bad_file_dicts:
+        current_app.logger.info('Notification personalisation contains incompatible `file` dict.')
 
     file_keys = [k for k, v in (personalisation_data or {}).items() if isinstance(v, dict) and 'file' in v]
     if not file_keys:


### PR DESCRIPTION
Before merging and releasing
https://github.com/alphagov/notifications-api/pull/3591, let's check to
make sure that any existing personalisation dicts with `file` keys don't
contain any non-file-upload keys. If they do, we can't use the
`additionalProperties=False` check on the JSON schema and we'll have to
allow clients to send other values (which will be ignored).