### PR TITLE
Unpin setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -282,4 +282,4 @@ zipp==3.8.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==65.1.1
+# setuptools


### PR DESCRIPTION
setuptools was pinned in #3596 to avoid an issue building python
packages from source when using the CloudFoundry Python buildpack.

This has been resolved in the latest buildpack release v1.7.58

https://github.com/cloudfoundry/python-buildpack/releases/tag/v1.7.58

🚨 **Note:** Only deploy after PaaS have confirmed buildpack update