### PR TITLE
Add endpoint to remove email branding from org pool

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -212,3 +212,17 @@ def dao_get_email_branding_pool_for_organisation(organisation_id):
     ).filter(
         Organisation.id == organisation_id,
     ).order_by(EmailBranding.name).all()
+
+
+@autocommit
+def dao_remove_email_branding_from_organisation_pool(organisation_id, email_branding_id):
+    organisation = dao_get_organisation_by_id(organisation_id)
+    email_branding = EmailBranding.query.filter_by(id=email_branding_id).one()
+
+    if organisation.email_branding_id == email_branding_id:
+        from app.errors import InvalidRequest
+        raise InvalidRequest("You cannot remove an organisation's default email branding", status_code=400)
+
+    organisation.email_branding_pool.remove(email_branding)
+    db.session.add(organisation)
+    return email_branding

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -19,6 +19,7 @@ from app.dao.organisation_dao import (
     dao_get_organisation_services,
     dao_get_organisations,
     dao_get_users_for_organisation,
+    dao_remove_email_branding_from_organisation_pool,
     dao_remove_user_from_organisation,
     dao_update_organisation,
 )
@@ -232,6 +233,23 @@ def update_organisation_email_branding_pool(organisation_id):
     validate(data, post_update_org_email_branding_pool_schema)
 
     dao_add_email_branding_list_to_organisation_pool(organisation_id, data['branding_ids'])
+
+    return {}, 204
+
+
+@organisation_blueprint.route(
+    '/<uuid:organisation_id>/email-branding-pool/<uuid:email_branding_id>',
+    methods=['DELETE']
+)
+def remove_email_branding_from_organisation_pool(organisation_id, email_branding_id):
+    organisation = dao_get_organisation_by_id(organisation_id)
+    email_branding_ids = {eb.id for eb in organisation.email_branding_pool}
+
+    if email_branding_id not in email_branding_ids:
+        error = f"Email branding {email_branding_id} not in {organisation}'s pool"
+        raise InvalidRequest(error, status_code=404)
+
+    dao_remove_email_branding_from_organisation_pool(organisation_id, email_branding_id)
 
     return {}, 204
 

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -1050,3 +1050,72 @@ def test_update_organisation_email_branding_pool_updates_branding_pool(
         _expected_status=204
     )
     assert len(sample_organisation.email_branding_pool) == 2
+
+
+def test_remove_email_branding_from_organisation_pool(
+    admin_request,
+    sample_organisation,
+):
+    first_branding = create_email_branding(colour='blue', logo='test_x1.png', name='email_branding_1')
+    second_branding = create_email_branding(colour='indigo', logo='test_x2.png', name='email_branding_2')
+
+    dao_add_email_branding_to_organisation_pool(
+        organisation_id=sample_organisation.id,
+        email_branding_id=first_branding.id
+    )
+    dao_add_email_branding_to_organisation_pool(
+        organisation_id=sample_organisation.id,
+        email_branding_id=second_branding.id
+    )
+    assert sample_organisation.email_branding_pool == [first_branding, second_branding]
+
+    admin_request.delete(
+        'organisation.remove_email_branding_from_organisation_pool',
+        organisation_id=sample_organisation.id,
+        email_branding_id=first_branding.id,
+        _expected_status=204
+    )
+    assert sample_organisation.email_branding_pool == [second_branding]
+
+
+def test_remove_email_branding_from_organisation_pool_cannot_remove_branding_not_in_pool(
+    admin_request,
+    sample_organisation,
+):
+    first_branding = create_email_branding(colour='blue', logo='test_x1.png', name='email_branding_1')
+    second_branding = create_email_branding(colour='indigo', logo='test_x2.png', name='email_branding_2')
+
+    dao_add_email_branding_to_organisation_pool(
+        organisation_id=sample_organisation.id,
+        email_branding_id=first_branding.id
+    )
+    assert sample_organisation.email_branding_pool == [first_branding]
+
+    admin_request.delete(
+        'organisation.remove_email_branding_from_organisation_pool',
+        organisation_id=sample_organisation.id,
+        email_branding_id=second_branding.id,
+        _expected_status=404
+    )
+    assert sample_organisation.email_branding_pool == [first_branding]
+
+
+def test_remove_email_branding_from_organisation_pool_cannot_remove_default_branding(
+    admin_request,
+    sample_organisation,
+):
+    branding = create_email_branding(colour='blue', logo='test_x1.png', name='email_branding_1')
+
+    dao_add_email_branding_to_organisation_pool(
+        organisation_id=sample_organisation.id,
+        email_branding_id=branding.id
+    )
+    sample_organisation.email_branding_id = branding.id
+
+    admin_request.delete(
+        'organisation.remove_email_branding_from_organisation_pool',
+        organisation_id=sample_organisation.id,
+        email_branding_id=branding.id,
+        _expected_status=400
+    )
+    assert sample_organisation.email_branding_pool == [branding]


### PR DESCRIPTION
Implements a new organisation DELETE endpoint to remove an email
branding from an organisation's pool.

Ticket: https://www.pivotaltracker.com/n/projects/1443052/stories/182880012