### PR TITLE
Rename `verify email` to `confirm email`

### DIFF
--- a/app/clients/document_download.py
+++ b/app/clients/document_download.py
@@ -30,7 +30,7 @@ class DocumentDownloadClient:
             service_id,
             file_contents,
             is_csv=None,
-            verification_email: Optional[str] = None,
+            confirmation_email: Optional[str] = None,
             retention_period: Optional[str] = None
     ):
         try:
@@ -39,8 +39,8 @@ class DocumentDownloadClient:
                 'is_csv': is_csv or False,
             }
 
-            if verification_email:
-                data['verification_email'] = verification_email
+            if confirmation_email:
+                data['confirmation_email'] = confirmation_email
 
             if retention_period:
                 data['retention_period'] = retention_period

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -129,14 +129,14 @@ def check_if_service_can_send_files_by_email(service_contact_link, service_id):
         )
 
 
-def error_if_service_using_email_verification_flow_without_permission(
-        verify_email: bool, service_permissions: List[str]
+def error_if_service_using_email_confirmation_flow_without_permission(
+        confirm_email: bool, service_permissions: List[str]
 ):
     if DOCUMENT_DOWNLOAD_VERIFY_EMAIL not in service_permissions:
-        if verify_email:
+        if confirm_email:
             raise BadRequestError(
                 message=(
-                    "Email verification and/or custom retention for 'send files by email' "
+                    "Email confirmation and/or custom retention for 'send files by email' "
                     "has not been enabled for this service."
                 )
             )

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -55,7 +55,7 @@ from app.notifications.validators import (
     check_service_email_reply_to_id,
     check_service_has_permission,
     check_service_sms_sender_id,
-    error_if_service_using_email_verification_flow_without_permission,
+    error_if_service_using_email_confirmation_flow_without_permission,
     validate_address,
     validate_and_format_recipient,
     validate_template,
@@ -344,11 +344,11 @@ def process_document_uploads(personalisation_data, service, send_to: str, simula
         if simulated:
             personalisation_data[key] = document_download_client.get_upload_url(service.id) + '/test-document'
         else:
-            verify_email = personalisation_data[key].get('verify_email_before_download') or False
+            confirm_email = personalisation_data[key].get('confirm_email_before_download') or False
             retention_period = personalisation_data[key].get('retention_period', None)
 
-            error_if_service_using_email_verification_flow_without_permission(
-                verify_email or bool(retention_period),
+            error_if_service_using_email_confirmation_flow_without_permission(
+                confirm_email or bool(retention_period),
                 service.permissions
             )
 
@@ -357,7 +357,7 @@ def process_document_uploads(personalisation_data, service, send_to: str, simula
                     service.id,
                     personalisation_data[key]['file'],
                     personalisation_data[key].get('is_csv'),
-                    verification_email=send_to if verify_email else None,
+                    confirmation_email=send_to if confirm_email else None,
                     retention_period=retention_period
                 )
             except DocumentDownloadError as e:

--- a/tests/app/clients/test_document_download.py
+++ b/tests/app/clients/test_document_download.py
@@ -36,8 +36,8 @@ def test_upload_document(document_download):
     assert resp == 'https://document-download/services/service-id/documents/uploaded-url'
 
 
-@pytest.mark.parametrize('verification_email', [None, 'dev@test.notify'])
-def test_upload_document_verify_email(document_download, verification_email):
+@pytest.mark.parametrize('confirmation_email', [None, 'dev@test.notify'])
+def test_upload_document_confirm_email(document_download, confirmation_email):
     with requests_mock.Mocker() as request_mock:
         request_mock.post('https://document-download/services/service-id/documents', json={
             'document': {'url': 'https://document-download/services/service-id/documents/uploaded-url'}
@@ -45,16 +45,16 @@ def test_upload_document_verify_email(document_download, verification_email):
             'Authorization': 'Bearer test-key',
         }, status_code=201)
 
-        resp = document_download.upload_document('service-id', 'abababab', verification_email=verification_email)
+        resp = document_download.upload_document('service-id', 'abababab', confirmation_email=confirmation_email)
 
     assert resp == 'https://document-download/services/service-id/documents/uploaded-url'
 
     request_json = request_mock.request_history[0].json()
-    if verification_email:
-        assert request_json['verification_email'] == verification_email
+    if confirmation_email:
+        assert request_json['confirmation_email'] == confirmation_email
 
     else:
-        assert 'verification_email' not in request_json
+        assert 'confirmation_email' not in request_json
 
 
 @pytest.mark.parametrize('retention_period', [None, '1 week', '5 weeks'])

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -879,8 +879,8 @@ def test_post_email_notification_with_archived_reply_to_id_returns_400(
         {'is_csv': None},
         {'is_csv': False},
         {'is_csv': True},
-        {'verify_email_before_download': False},
-        {'verify_email_before_download': True},
+        {'confirm_email_before_download': False},
+        {'confirm_email_before_download': True},
         {'retention_period': None},
         {'retention_period': '1 week'},
         {'retention_period': '4 weeks'},
@@ -898,7 +898,7 @@ def test_post_notification_with_document_upload(api_client_request, notify_db_se
     mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
     document_download_mock = mocker.patch('app.v2.notifications.post_notifications.document_download_client')
     document_download_mock.upload_document.side_effect = (
-        lambda service_id, content, is_csv, verification_email, **kwargs: f'{content}-link'
+        lambda service_id, content, is_csv, confirmation_email, **kwargs: f'{content}-link'
     )
 
     data = {
@@ -919,21 +919,21 @@ def test_post_notification_with_document_upload(api_client_request, notify_db_se
 
     assert validate(resp_json, post_email_response) == resp_json
 
-    verification_email = data['email_address'] if extra.get('verify_email_before_download') else None
+    confirmation_email = data['email_address'] if extra.get('confirm_email_before_download') else None
 
     assert document_download_mock.upload_document.call_args_list == [
         call(
             str(service.id),
             'abababab',
             extra.get('is_csv'),
-            verification_email=verification_email,
+            confirmation_email=confirmation_email,
             retention_period=extra.get('retention_period'),
         ),
         call(
             str(service.id),
             'cdcdcdcd',
             extra.get('is_csv'),
-            verification_email=verification_email,
+            confirmation_email=confirmation_email,
             retention_period=extra.get('retention_period'),
         )
     ]
@@ -1073,7 +1073,7 @@ def test_post_notification_without_document_email_verification_permission(
     data = {
         "email_address": service.users[0].email_address,
         "template_id": template.id,
-        "personalisation": {"document": {"file": "abababab", "verify_email_before_download": True}}
+        "personalisation": {"document": {"file": "abababab", "confirm_email_before_download": True}}
     }
 
     resp = api_client_request.post(
@@ -1086,7 +1086,7 @@ def test_post_notification_without_document_email_verification_permission(
 
     assert (
         resp['errors'][0]['message'] ==
-        "Email verification and/or custom retention for 'send files by email' has not been enabled for this service."
+        "Email confirmation and/or custom retention for 'send files by email' has not been enabled for this service."
     )
 
 


### PR DESCRIPTION
`Confirm email` is the wording we prefer in documentation and guidance, so let's keep that consistent in the codebase as well.

This will temporarily break the feature until document-download-api is updated, but that should be fine as the feature isn't released yet.