### PR TITLE
Add scheduled nightly task to purge old events

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -338,6 +338,11 @@ class Config(object):
                 'schedule': crontab(hour=00, minute=00),
                 'options': {'queue': QueueNames.PERIODIC}
             },
+            'delete-old-records-from-events-table': {
+                'task': 'delete-old-records-from-events-table',
+                'schedule': crontab(hour=3, minute=4),
+                'options': {'queue': QueueNames.PERIODIC}
+            }
         }
     }
 


### PR DESCRIPTION
Events are used to track certain actions users might take (eg logging in), and contain PII. Because of this we shouldn't keep this data forever. We've agreed a 1-year retention period and should regularly purge any data older than this.

Also needs https://github.com/alphagov/notifications-credentials/pull/295