### PR TITLE
Limit client_reference to 1,000 characters

### DIFF
--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -131,7 +131,7 @@ post_sms_request = {
     "type": "object",
     "title": "POST v2/notifications/sms",
     "properties": {
-        "reference": {"type": "string"},
+        "reference": {"type": "string", "maxLength": 1_000},
         "phone_number": {"type": "string", "format": "phone_number"},
         "template_id": uuid,
         "personalisation": personalisation,
@@ -177,7 +177,7 @@ post_email_request = {
     "type": "object",
     "title": "POST v2/notifications/email",
     "properties": {
-        "reference": {"type": "string"},
+        "reference": {"type": "string", "maxLength": 1_000},
         "email_address": {"type": "string", "format": "email_address"},
         "template_id": uuid,
         "personalisation": personalisation,
@@ -223,7 +223,7 @@ post_letter_request = {
     "type": "object",
     "title": "POST v2/notifications/letter",
     "properties": {
-        "reference": {"type": "string"},
+        "reference": {"type": "string", "maxLength": 1_000},
         "template_id": uuid,
         "personalisation": personalisation
     },


### PR DESCRIPTION
We've had a number of 500s thrown today because of references that were
~100k long. Obviously that's not particularly sensible or feasible. Past
a certain length Postgres also just says no. So let's return a more reasonable 400 if the client reference exceeds 1000 characters.

[Sample kibana error](https://kibana.logit.io/s/9423a789-282c-4113-908d-0be3b1bc9d1d/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:'2022-09-30T11:00:26.046Z',mode:absolute,to:'2022-09-30T11:00:44.990Z'))&_a=(columns:!(message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:requestId,negate:!f,type:phrase,value:'2090767d90ab1d8c6d6e39cf9032f606'),query:(match:(requestId:(query:'2090767d90ab1d8c6d6e39cf9032f606',type:phrase))))),index:'logstash-*',interval:auto,query:(match_all:()),sort:!('@timestamp',desc)))