### PR TITLE
Add validation for send-a-file upload dicts

### DIFF
--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -1,4 +1,5 @@
 import json
+import re
 from datetime import datetime, timedelta
 from uuid import UUID
 
@@ -56,6 +57,32 @@ def validate_schema_date_with_hour(instance):
             raise ValidationError("datetime format is invalid. It must be a valid ISO8601 date time format, "
                                   "https://en.wikipedia.org/wiki/ISO_8601")
     return True
+
+
+@format_checker.checks('send_a_file_retention_period', raises=ValidationError)
+def validate_schema_retention_period(instance):
+    if instance is None:
+        return True
+
+    if isinstance(instance, str):
+        period = instance.strip().lower()
+        match = re.match(r'^(\d+) weeks?$', period)
+        if match and 1 <= int(match.group(1)) <= 78:
+            return True
+
+    raise ValidationError(
+        f"Unsupported value for retention_period: {instance}. Supported periods are from 1 to 78 weeks."
+    )
+
+
+@format_checker.checks('send_a_file_confirm_email', raises=ValidationError)
+def validate_schema_send_a_file_confirm_email(instance):
+    if instance is None or isinstance(instance, bool):
+        return True
+
+    raise ValidationError(
+        f"Unsupported value for confirm_email_before_download: {instance}. Use a boolean true or false value."
+    )
 
 
 @format_checker.checks('datetime', raises=ValidationError)

--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -75,8 +75,18 @@ def validate_schema_retention_period(instance):
     )
 
 
-@format_checker.checks('send_a_file_confirm_email', raises=ValidationError)
-def validate_schema_send_a_file_confirm_email(instance):
+@format_checker.checks('send_a_file_is_csv', raises=ValidationError)
+def send_a_file_is_csv(instance):
+    if instance is None or isinstance(instance, bool):
+        return True
+
+    raise ValidationError(
+        f"Unsupported value for is_csv: {instance}. Use a boolean true or false value."
+    )
+
+
+@format_checker.checks('send_a_file_confirm_email_before_download', raises=ValidationError)
+def send_a_file_confirm_email_before_download(instance):
     if instance is None or isinstance(instance, bool):
         return True
 

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -122,7 +122,29 @@ get_notifications_response = {
     "definitions": {
         "notification": get_notification_response
     },
+}
 
+send_a_file_validation = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "file": {
+            "type": "string",
+            "required": True,
+        },
+        "is_csv": {
+            "type": ["boolean", "null"],
+            "required": False,
+        },
+        "confirm_email_before_download": {
+            "format": "send_a_file_confirm_email",
+            "required": False,
+        },
+        "retention_period": {
+            "format": "send_a_file_retention_period",
+            "required": False,
+        },
+    }
 }
 
 post_sms_request = {

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -133,11 +133,11 @@ send_a_file_validation = {
             "required": True,
         },
         "is_csv": {
-            "type": ["boolean", "null"],
+            "format": "send_a_file_is_csv",
             "required": False,
         },
         "confirm_email_before_download": {
-            "format": "send_a_file_confirm_email",
+            "format": "send_a_file_confirm_email_before_download",
             "required": False,
         },
         "retention_period": {

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -500,6 +500,90 @@ def test_post_email_notification_returns_201(
     assert mocked.called
 
 
+@pytest.mark.parametrize(
+    'personalisation, expected_status, expect_error_message',
+    (
+        ({"doc": 'just some text'}, 201, None),
+        ({"doc": {"file": False}}, 400, None),
+        ({"doc": {"file": "YSxiLGMKMSwyLDMK"}}, 201, None),
+        ({"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": None}}, 201, None),
+        ({"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": True}}, 201, None),
+        ({"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": False}}, 201, None),
+        ({"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": "bad"}}, 400, None),
+        ({"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": True, "confirm_email_before_download": None}}, 201, None),
+        ({"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": True, "confirm_email_before_download": True}}, 201, None),
+        ({"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": True, "confirm_email_before_download": False}}, 201, None),
+        (
+                {"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": True, "confirm_email_before_download": 'potato'}},
+                400,
+                "Unsupported value for confirm_email_before_download: potato"
+        ),
+        ({"doc": {"file": "YSxiLGMKMSwyLDMK", "retention_period": None}}, 201, None),
+        ({"doc": {"file": "YSxiLGMKMSwyLDMK", "retention_period": "1 week"}}, 201, None),
+        ({"doc": {"file": "YSxiLGMKMSwyLDMK", "retention_period": "70 weeks"}}, 201, None),
+        (
+                {"doc": {"file": "YSxiLGMKMSwyLDMK", "retention_period": "9999 weeks"}},
+                400,
+                "Unsupported value for retention_period: 9999 weeks"
+        ),
+        (
+                {"doc": {"file": "YSxiLGMKMSwyLDMK", "retention_period": "1 month"}},
+                400,
+                "Unsupported value for retention_period: 1 month"
+        ),
+        (
+                {"doc": {"file": "YSxiLGMKMSwyLDMK", "retention_period": False}},
+                400,
+                "Unsupported value for retention_period: False"
+        ),
+        ({"doc": {"file": "YSxiLGMKMSwyLDMK", "other": "attribute"}}, 400, None),
+        ({"doc": {"potato": "YSxiLGMKMSwyLDMK"}}, 201, None),
+        ({"doc": {"potato": "YSxiLGMKMSwyLDMK", "is_csv": "cucumber"}}, 201, None),
+    )
+)
+def test_post_email_notification_validates_personalisation_send_a_file_values(
+    api_client_request,
+    mocker,
+    personalisation,
+    expected_status,
+    expect_error_message,
+):
+    mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
+    document_download_mock = mocker.patch('app.v2.notifications.post_notifications.document_download_client')
+    document_download_mock.upload_document.side_effect = (
+        lambda service_id, content, is_csv, confirmation_email, **kwargs: f'{content}-link'
+    )
+
+    service = create_service(
+        contact_link='test@notify.example',
+        service_permissions=[EMAIL_TYPE],
+    )
+
+    template = create_template(
+        service,
+        template_type=EMAIL_TYPE,
+        subject="Hello",
+        content="Hello.\nHere's a file for you: ((doc))",
+    )
+
+    data = {
+        "email_address": template.service.users[0].email_address,
+        "template_id": template.id,
+        "personalisation": personalisation
+    }
+
+    response = api_client_request.post(
+        template.service_id,
+        'v2_notifications.post_notification',
+        notification_type='email',
+        _data=data,
+        _expected_status=expected_status
+    )
+
+    if expect_error_message:
+        assert expect_error_message in response['errors'][0]['message']
+
+
 @pytest.mark.parametrize('recipient, notification_type', [
     ('simulate-delivered@notifications.service.gov.uk', EMAIL_TYPE),
     ('simulate-delivered-2@notifications.service.gov.uk', EMAIL_TYPE),
@@ -937,7 +1021,7 @@ def test_post_notification_with_document_upload(api_client_request, notify_db_se
     mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
     document_download_mock = mocker.patch('app.v2.notifications.post_notifications.document_download_client')
     document_download_mock.upload_document.side_effect = (
-        lambda service_id, content, is_csv, confirmation_email, **kwargs: f'{content}-link'
+        lambda service_id, content, is_csv, **kwargs: f'{content}-link'
     )
 
     data = {
@@ -986,55 +1070,6 @@ def test_post_notification_with_document_upload(api_client_request, notify_db_se
     assert notification.document_download_count == 2
 
     assert resp_json['content']['body'] == 'Document 1: abababab-link. Document 2: cdcdcdcd-link'
-
-
-@pytest.mark.parametrize(
-    'data, should_log',
-    (
-        ({'blah': 'blah'}, False),
-        ('potato', False),
-        ({'file': 'blah', 'is_csv': False}, False),
-        ({'file': 'blah', 'other': 'something'}, True),
-    )
-)
-def test_post_notification_with_document_upload_logs_dict_values(
-        api_client_request, notify_db_session, mocker, data, should_log
-):
-    service = create_service(service_permissions=[EMAIL_TYPE])
-    service.contact_link = 'contact.me@gov.uk'
-    template = create_template(
-        service=service,
-        template_type='email',
-        content="Hmm: ((value))"
-    )
-
-    mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
-    document_download_mock = mocker.patch('app.v2.notifications.post_notifications.document_download_client')
-    document_download_mock.upload_document.return_value = {}
-
-    data = {
-        "email_address": service.users[0].email_address,
-        "template_id": template.id,
-        "personalisation": {
-            "value": data,
-        }
-    }
-
-    with mock.patch('app.v2.notifications.post_notifications.current_app.logger.info') as mock_logger:
-        resp_json = api_client_request.post(
-            service.id,
-            'v2_notifications.post_notification',
-            notification_type='email',
-            _data=data,
-        )
-
-    assert validate(resp_json, post_email_response) == resp_json
-
-    if should_log:
-        assert (
-            mock.call('Notification personalisation contains incompatible `file` dict.')
-            in mock_logger.call_args_list
-        )
 
 
 def test_post_notification_with_document_upload_simulated(api_client_request, notify_db_session, mocker):

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -509,14 +509,18 @@ def test_post_email_notification_returns_201(
         ({"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": None}}, 201, None),
         ({"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": True}}, 201, None),
         ({"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": False}}, 201, None),
-        ({"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": "bad"}}, 400, None),
+        (
+                {"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": "bad"}},
+                400,
+                "Unsupported value for is_csv: bad. Use a boolean true or false value."
+        ),
         ({"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": True, "confirm_email_before_download": None}}, 201, None),
         ({"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": True, "confirm_email_before_download": True}}, 201, None),
         ({"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": True, "confirm_email_before_download": False}}, 201, None),
         (
                 {"doc": {"file": "YSxiLGMKMSwyLDMK", "is_csv": True, "confirm_email_before_download": 'potato'}},
                 400,
-                "Unsupported value for confirm_email_before_download: potato"
+                "Unsupported value for confirm_email_before_download: potato. Use a boolean true or false value."
         ),
         ({"doc": {"file": "YSxiLGMKMSwyLDMK", "retention_period": None}}, 201, None),
         ({"doc": {"file": "YSxiLGMKMSwyLDMK", "retention_period": "1 week"}}, 201, None),


### PR DESCRIPTION
If a user sends the wrong kind of data/value for the new send-a-file/document download security features, let's provide a user-friendly error message.

I would've ideally liked to do this as part of the generic incoming notification JSON schema, but in order to do that we'd need to use a `oneOf` subschema to allow for multiple data types and different validation depending on the vlaue of personalisation fields. When we do this, we lose the ability to (cleanly) provide explicit error messages about what exactly is wrong with the input, because JSON Schema wraps the root error message in some contextual one about all of the sub-schemas failing to validate.

So we've decided to just do the validation on known-file upload personalisation, which allows us to more cleanly present the error to the user.