### PR TITLE
Delete user data and migrate historical archive_user events

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime, timedelta
 from random import SystemRandom
 
+from flask import current_app
 from sqlalchemy import func
 from sqlalchemy.orm import joinedload
 
@@ -163,9 +164,11 @@ def dao_archive_user(user):
     user.organisations = []
 
     user.auth_type = EMAIL_AUTH_TYPE
-    user.email_address = get_archived_db_column_value(user.email_address)
+    user.name = "Archived user"
+    user.email_address = get_archived_db_column_value(f"{user.id}@{current_app.config['NOTIFY_EMAIL_DOMAIN']}")
     user.mobile_number = None
     user.password = str(uuid.uuid4())
+
     # Changing the current_session_id signs the user out
     user.current_session_id = "00000000-0000-0000-0000-000000000000"
     user.state = "inactive"

--- a/migrations/versions/0379_update_archived_users.py
+++ b/migrations/versions/0379_update_archived_users.py
@@ -37,12 +37,14 @@ def upgrade():
                 SELECT
                     users.id as user_id,
                     events.id AS event_id,
-                    substring(users.email_address, '_archived_(\d{4}-\d{2}-\d{2})_.*') AS archival_date,
-                    substring(users.email_address, '_archived_\d{4}-\d{2}-\d{2}_(.*)') AS original_email_address
+                    substring(users.email_address, '_archived_(\d{4}[-_]\d{1,2}[-_]\d{1,2})_.*')
+                    AS archival_date,
+                    substring(users.email_address, '_archived_\d{4}[-_]\d{1,2}[-_]\d{1,2}_(.*)')
+                    AS original_email_address
                 FROM users
                 LEFT JOIN events on users.id = (events.data->>'user_id')::uuid AND events.event_type = 'archive_user'
                 WHERE
-                    users.email_address ~ '_archived_\d{4}-\d{2}-\d{2}_(.*)'
+                    users.state = 'inactive'
                     AND NOT users.email_address LIKE CONCAT('_archived_%@', :notify_email_domain)
                 ORDER BY
                     users.id;

--- a/migrations/versions/0379_update_archived_users.py
+++ b/migrations/versions/0379_update_archived_users.py
@@ -1,0 +1,112 @@
+"""
+
+Revision ID: 0379_update_archived_users
+Revises: 0378_remove_doc_download_perm
+Create Date: 2022-10-10 12:45:47.519550
+
+"""
+import textwrap
+
+from alembic import op
+from flask import current_app
+from sqlalchemy import text
+
+revision = "0379_update_archived_users"
+down_revision = "0378_remove_doc_download_perm"
+
+
+def get_archived_db_column_value(column, date):
+    return f"_archived_{date}_{column}"
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # Get all users with an archived email address (but not a "new style" redacted email address - this should be 0
+    # anyway).
+    # For each user:
+    #   Get their user id
+    #   If they have an archive_user event in the events table, get the event_id
+    #   Get their current user email address (_archived_ format)
+    #   Get the date they were archived by extracting it from their archived email address
+    #   Get their original email address by extracting it from the un-redacted archived email address.
+    results = conn.execute(
+        text(
+            textwrap.dedent(
+                """
+                SELECT
+                    users.id as user_id,
+                    events.id AS event_id,
+                    substring(users.email_address, '_archived_(\d{4}-\d{2}-\d{2})_.*') AS archival_date,
+                    substring(users.email_address, '_archived_\d{4}-\d{2}-\d{2}_(.*)') AS original_email_address
+                FROM users
+                LEFT JOIN events on users.id = (events.data->>'user_id')::uuid AND events.event_type = 'archive_user'
+                WHERE
+                    users.email_address ~ '_archived_\d{4}-\d{2}-\d{2}_(.*)'
+                    AND NOT users.email_address LIKE CONCAT('_archived_%@', :notify_email_domain)
+                ORDER BY
+                    users.id;
+                """  # noqa: W605
+            )
+        ),
+        notify_email_domain=current_app.config["NOTIFY_EMAIL_DOMAIN"],
+    )
+
+    rows = results.fetchall()
+
+    email_domain = current_app.config["NOTIFY_EMAIL_DOMAIN"]
+    users_to_update = [
+        {
+            "user_id": user_id,
+            "desired_email_address": get_archived_db_column_value(f"{user_id}@{email_domain}", date=archival_date),
+        }
+        for user_id, _, archival_date, _ in rows
+    ]
+    print(f"Updating {len(users_to_update)} users.")
+    if users_to_update:
+        conn.execute(
+            text(
+                textwrap.dedent(
+                    """
+                    UPDATE users
+                    SET
+                        name = 'Archived user',
+                        email_address = :desired_email_address,
+                        updated_at = now()
+                    WHERE
+                        id = :user_id
+                    """
+                )
+            ),
+            users_to_update,
+        )
+
+    events_to_update = [
+        {
+            "event_id": event_id,
+            "original_email_address": original_email_address,
+        }
+        for _, event_id, _, original_email_address in rows
+        if event_id is not None
+    ]
+    print(f"Updating {len(events_to_update)} events.")
+    if events_to_update:
+        conn.execute(
+            text(
+                textwrap.dedent(
+                    """
+                    UPDATE events
+                    SET
+                        data = events.data::jsonb || jsonb_build_object('user_email_address', :original_email_address)
+                    WHERE
+                        id = :event_id
+                        AND events.data->>'user_email_address' IS NULL
+                    """
+                )
+            ),
+            events_to_update,
+        )
+
+
+def downgrade():
+    pass

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -234,7 +234,8 @@ def test_dao_archive_user(sample_user, sample_organisation, fake_uuid):
     assert sample_user.services == []
     assert sample_user.organisations == []
     assert sample_user.auth_type == EMAIL_AUTH_TYPE
-    assert sample_user.email_address == "_archived_2018-07-07_notify@digital.cabinet-office.gov.uk"
+    assert sample_user.name == "Archived user"
+    assert sample_user.email_address == f"_archived_2018-07-07_{sample_user.id}@test.notify.com"
     assert sample_user.mobile_number is None
     assert sample_user.current_session_id == uuid.UUID("00000000-0000-0000-0000-000000000000")
     assert sample_user.state == "inactive"


### PR DESCRIPTION
## Summary
We're now storing a user's original email address in the events table (for 1 year) when we archive a user. However, we still have historical information in the users table (email address and name) which we should redact. We should also insert their original email address into their archive events (where we still have an archive event for them, as we delete events over 1 year old).

In prod there are only 140 archived users so I'm not worried about migration efficiency particularly.

## Manual testing steps

We don't have a framework currently for testing migrations in code. There's a library called `pytest-alembic` that should work but it didn't seem trivial to implement, so for now will settle for manual testing.

This is quite laborious and fiddly so please take care :) It tests four cases: an old archived un-redacted user where we don't have an archive event for them anymore, an old archived un-redacted user where we have an event for them but it doesn't contain their email address, an old archived un-redacted user where the event does contain their email address, and archiving a user with this set of changes applied (where we auto-redact their information).

1. Set your system clock back 2 weeks.
1. Run notifications-api and notifications-admin in dev/reload mode.
2. In `notifications-api`, do `git checkout master` (ie **not** this branch).
3. In `notifications-admin` do `git checkout d9ebcbe5f127c9fd36ca1531cc46f8ec39a2cbf4` - which is the commit before @klssmith merged the ticket which adds `user_email_address` to `archive_user` events.
4. In `notifications-api`, run the following script in a `flask shell` to create some users:
    ```
    from app.models import User
    from app import db
    
    db.session.rollback()
    
    user_0 = User(
        id='4f3a8f50-cd5b-4273-be6d-5c2bf74286bd',
        name='0. User w/ wonky email (no event)',
        email_address='_archived_2020_5_1_test-user-5@my.private.domain.com',
        password='my-secure-password',
        state='inactive',
        auth_type='email_auth',
    )
    db.session.add(user_0)
    
    user_1 = User(
        id='78ad42ae-a01e-4fe5-b9cf-e1a99e556d26',
        name='1. Old user with no event',
        email_address='test-user-1@my.private.domain.com',
        password='my-secure-password',
        state='active',
        auth_type='email_auth',
    )
    db.session.add(user_1)
    
    user_2 = User(
        id='cc20e840-22a6-47c7-9d8e-016a06a32309',
        name='2. User with event (no email address)',
        email_address='test-user-2@my.private.domain.com',
        password='my-secure-password',
        state='active',
        auth_type='email_auth',
    )
    db.session.add(user_2)
    
    user_3 = User(
        id='569bd65a-ec1e-459d-a60e-2fcaae4310f5',
        name='3. User with event (containing email address)',
        email_address='test-user-3@my.private.domain.com',
        password='my-secure-password',
        state='active',
        auth_type='email_auth',
    )
    db.session.add(user_3)
    
    user_4 = User(
        id='466d9d98-e6c1-4b8b-aac5-23a6d55e9a26',
        name='4. User (event w/ email address, properly redacted)',
        email_address='test-user-4@my.private.domain.com',
        password='my-secure-password',
        state='active',
        auth_type='email_auth',
    )
    db.session.add(user_4)
    db.session.commit()
    ```
5. Archive user 1 via the admin web UI at http://localhost:6012/users/78ad42ae-a01e-4fe5-b9cf-e1a99e556d26/archive. Note user_1's current archival date (prefix to their email address). The user's real email address should still be visible in the UI. Go into the DB and delete the `archive_user` event generated by this action.
6. Set the system clock forward 1 week (so that it's still 1 week behind now).
8. Archive user 2 via the admin web UI at http://localhost:6012/users/cc20e840-22a6-47c7-9d8e-016a06a32309/archive. Note user_2's current archival date (prefix to their email address). The user's real email address should still be visible in the UI, and in the DB the archive_user event **should not** contain the user's email address.
7. In `notifications-admin`, do `git checkout master`. Check that the app has reloaded the new code.
8. Archive user 3 via the admin web UI at http://localhost:6012/users/569bd65a-ec1e-459d-a60e-2fcaae4310f5/archive. Note user_3's current archival date (prefix to their email address). The user's real email address should still be visible in the UI, and in the DB the archive_user event **should** contain the user's email address.
9. Reset your system clock to the current date/time.
10. In `notifications-api`, do `git checkout SW-delete-user-data`. Check the app code has reloaded.
11. Archive user 4 via the admin web UI at http://localhost:6012/users/466d9d98-e6c1-4b8b-aac5-23a6d55e9a26/archive. The user's name and real email address should not be visible in the UI, and the archive_user event **should** contain their original email address.
12. then run `flask db upgrade`. It should update 3 users and 2 events.
13. In the DB, check that both `archive_user` events for user 2 now contains a `user_email_address` key with the correct **real/original** email address.
14. In the admin UI or the DB, check that user 1, 2 and 3's name and email addresses have been redacted. Check that the archival date in their email address hasn't changed either.