### PR TITLE
Force BeautifulSoup to use utf-8 encoding

### DIFF
--- a/app/broadcast_message/translators.py
+++ b/app/broadcast_message/translators.py
@@ -3,7 +3,10 @@ from bs4 import BeautifulSoup
 
 def cap_xml_to_dict(cap_xml):
     # This function assumes that it’s being passed valid CAP XML
-    cap = BeautifulSoup(cap_xml, "xml")
+    # We explicitly tell BS4 that we're expecting utf-8 here, otherwise it uses encoding detection heuristics that
+    # can sometimes make the wrong call.
+    cap = BeautifulSoup(cap_xml, "xml", from_encoding="utf-8")
+
     return {
         "msgType": cap.alert.msgType.text,
         "reference": cap.alert.identifier.text,


### PR DESCRIPTION
If not explicitly told what the encoding of the data is, BeautifulSoup
tries a few different ways to guess what it is, using things like
cchardet/charset_normalizer. On one of our "broadcast alert content too
long" tests, this returns iso_8859_16 for the data.

This character encoding is known on most developer machines and so the
text is treated as being this encoding. However, that is actually the
wrong encoding - it's actually a utf-8 string.

This test passes on CI because the instances running the tests don't
recognise the iso_8859_16, and so disregard that encoding and try the
next suggested one - utf-8.

We expect all of our broadcast messages to be sent in utf-8, so let's
tell BeautifulSoup that explicitly.

## CI build:
Ctrl+f for "ENCODING: "

We load the doc into beautifulsoup 3 times: one with `from_encoding` unset, once with `from_encoding='iso8859_16`, and once with `from_encoding=utf-8`
https://concourse.notify.tools/teams/notify/pipelines/apps/jobs/build-api-pr/builds/597