### PR TITLE
Add created_at/by, updated_at/by columns to EmailBranding

### DIFF
--- a/app/email_branding/email_branding_schema.py
+++ b/app/email_branding/email_branding_schema.py
@@ -10,6 +10,7 @@ post_create_email_branding_schema = {
         "text": {"type": ["string", "null"]},
         "logo": {"type": ["string", "null"]},
         "brand_type": {"enum": BRANDING_TYPES},
+        "created_by": {"type": ["string"], "required": False},
     },
     "required": ["name"],
 }
@@ -24,6 +25,7 @@ post_update_email_branding_schema = {
         "text": {"type": ["string", "null"]},
         "logo": {"type": ["string", "null"]},
         "brand_type": {"enum": BRANDING_TYPES},
+        "updated_by": {"type": ["string"], "required": False},
     },
     "required": [],
 }

--- a/app/models.py
+++ b/app/models.py
@@ -240,6 +240,10 @@ class EmailBranding(db.Model):
     brand_type = db.Column(
         db.String(255), db.ForeignKey("branding_type.name"), index=True, nullable=False, default=BRANDING_ORG
     )
+    created_at = db.Column(db.DateTime, nullable=True, default=lambda: datetime.datetime.utcnow())
+    created_by = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=lambda: datetime.datetime.utcnow())
+    updated_by = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
 
     def serialize(self):
         serialized = {

--- a/migrations/versions/0380_email_branding_cols_.py
+++ b/migrations/versions/0380_email_branding_cols_.py
@@ -1,0 +1,29 @@
+"""
+Revision ID: 0380_email_branding_cols
+Revises: 0379_update_archived_users
+Create Date: 2022-10-19 12:12:15.225244
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0380_email_branding_cols"
+down_revision = "0379_update_archived_users"
+
+
+def upgrade():
+    op.add_column("email_branding", sa.Column("created_at", sa.DateTime(), nullable=True))
+    op.add_column("email_branding", sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column("email_branding", sa.Column("updated_at", sa.DateTime(), nullable=True))
+    op.add_column("email_branding", sa.Column("updated_by", postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key("email_branding_updated_by_id_fkey", "email_branding", "users", ["updated_by"], ["id"])
+    op.create_foreign_key("email_branding_created_by_id_fkey", "email_branding", "users", ["created_by"], ["id"])
+
+
+def downgrade():
+    op.drop_constraint("email_branding_created_by_id_fkey", "email_branding", type_="foreignkey")
+    op.drop_constraint("email_branding_updated_by_id_fkey", "email_branding", type_="foreignkey")
+    op.drop_column("email_branding", "updated_by")
+    op.drop_column("email_branding", "updated_at")
+    op.drop_column("email_branding", "created_by")
+    op.drop_column("email_branding", "created_at")


### PR DESCRIPTION
Now that we're working to make it possible for users to create their own email branding, let's keep a record of who's created or updated the branding and when in case we ever need to look back and see what's happened.

We also want to emit audit events for changes, but for now we'll do that from the admin app - as that's consistent with our current process. We may look to centralise this back to the API in the future to provide consistency and centralise that responsibility, but not today.