### PR TITLE
Bump notifications-utils to 57.1.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ notifications-python-client==6.3.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@57.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@57.1.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -157,7 +157,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@57.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@57.1.1
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
This pulls in the updated URL escaping that prevents pre-escaped %-encoded URL values ending up rendered as their unescaped characters (eg a URL sent to us as `/blah?redirect=%2Flogin` was ending up in user inboxes as `/blah?redirect=/login` - which can be semantically different to the target server).

Would like to wait 24-48 hours before merging this to give the initial reporter time to acknowledge that this change is going in.

- [x] https://github.com/alphagov/notifications-utils/pull/994