### PR TITLE
Create letter branding pools

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -229,3 +229,9 @@ def dao_remove_email_branding_from_organisation_pool(organisation_id, email_bran
     organisation.email_branding_pool.remove(email_branding)
     db.session.add(organisation)
     return email_branding
+
+
+def dao_get_letter_branding_pool_for_organisation(organisation_id):
+    organisation = dao_get_organisation_by_id(organisation_id)
+
+    return sorted(organisation.letter_branding_pool, key=lambda x: x.name)

--- a/app/models.py
+++ b/app/models.py
@@ -405,6 +405,12 @@ class Organisation(db.Model):
         nullable=True,
     )
 
+    letter_branding_pool = db.relationship(
+        "LetterBranding",
+        secondary="letter_branding_to_organisation",
+        backref="organisations",
+    )
+
     notes = db.Column(db.Text, nullable=True)
     purchase_order_number = db.Column(db.String(255), nullable=True)
     billing_contact_names = db.Column(db.Text, nullable=True)
@@ -463,6 +469,18 @@ class OrganisationEmailBranding(db.Model):
     __table_args__ = (
         UniqueConstraint("organisation_id", "email_branding_id", name="uix_email_branding_to_organisation"),
     )
+
+
+letter_branding_to_organisation = db.Table(
+    "letter_branding_to_organisation",
+    db.Model.metadata,
+    db.Column(
+        "organisation_id", UUID(as_uuid=True), db.ForeignKey("organisation.id"), primary_key=True, nullable=False
+    ),
+    db.Column(
+        "letter_branding_id", UUID(as_uuid=True), db.ForeignKey("letter_branding.id"), primary_key=True, nullable=False
+    ),
+)
 
 
 class Service(db.Model, Versioned):

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -13,6 +13,7 @@ from app.dao.organisation_dao import (
     dao_archive_organisation,
     dao_create_organisation,
     dao_get_email_branding_pool_for_organisation,
+    dao_get_letter_branding_pool_for_organisation,
     dao_get_organisation_by_email_address,
     dao_get_organisation_by_id,
     dao_get_organisation_services,
@@ -241,6 +242,12 @@ def remove_email_branding_from_organisation_pool(organisation_id, email_branding
     dao_remove_email_branding_from_organisation_pool(organisation_id, email_branding_id)
 
     return {}, 204
+
+
+@organisation_blueprint.route("/<uuid:organisation_id>/letter-branding-pool", methods=["GET"])
+def get_organisation_letter_branding_pool(organisation_id):
+    branding_pool = dao_get_letter_branding_pool_for_organisation(organisation_id)
+    return jsonify(data=[branding.serialize() for branding in branding_pool])
 
 
 def check_request_args(request):

--- a/migrations/versions/0381_letter_branding_to_org.py
+++ b/migrations/versions/0381_letter_branding_to_org.py
@@ -1,0 +1,28 @@
+"""
+
+Revision ID: 0381_letter_branding_to_org
+Revises: 0380_email_branding_cols
+Create Date: 2022-10-21 14:26:12.421574
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0381_letter_branding_to_org'
+down_revision = '0380_email_branding_cols'
+
+
+def upgrade():
+    op.create_table(
+        'letter_branding_to_organisation',
+        sa.Column('organisation_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('letter_branding_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(['letter_branding_id'], ['letter_branding.id'], ),
+        sa.ForeignKeyConstraint(['organisation_id'], ['organisation.id'], ),
+        sa.PrimaryKeyConstraint('organisation_id', 'letter_branding_id')
+    )
+
+
+def downgrade():
+    op.drop_table('letter_branding_to_organisation')

--- a/tests/app/dao/test_organisation_dao.py
+++ b/tests/app/dao/test_organisation_dao.py
@@ -13,6 +13,7 @@ from app.dao.organisation_dao import (
     dao_add_user_to_organisation,
     dao_archive_organisation,
     dao_get_email_branding_pool_for_organisation,
+    dao_get_letter_branding_pool_for_organisation,
     dao_get_organisation_by_email_address,
     dao_get_organisation_by_id,
     dao_get_organisation_by_service_id,
@@ -500,3 +501,17 @@ def test_dao_remove_email_branding_from_organisation_pool(sample_organisation):
 
     dao_remove_email_branding_from_organisation_pool(sample_organisation.id, branding_3.id)
     assert sample_organisation.email_branding_pool == [branding_2]
+
+
+def test_dao_get_letter_branding_pool_for_organisation(sample_organisation):
+    branding_1 = create_letter_branding("nhs", "nhs.svg")
+    branding_2 = create_letter_branding("cabinet_office", "cabinet_office.svg")
+
+    sample_organisation.letter_branding_pool.append(branding_1)
+    sample_organisation.letter_branding_pool.append(branding_2)
+    db.session.commit()
+
+    assert dao_get_letter_branding_pool_for_organisation(sample_organisation.id) == [
+        branding_2,
+        branding_1,
+    ]


### PR DESCRIPTION
This creates letter branding pools in the database and adds a REST endpoint to get all items in the pool, since this is the first endpoint that will be needed for the next stage of the work.

**Migration for "letter_branding_to_organisation" table**
This adds a migration for a new table, `letter_branding_to_organisation`, which matches the `email_branding_to_organisation` table.

The table has two columns, `organisation_id` and `letter_branding_id`, and the composite primary key on these means that we don't need to create a separate unique constraint because uniqueness is already enforced.

This uses a `db.Table` instead of a `db.Model` (which is what `email_branding_to_organisation` uses) in models.py. We don't need a model class for the join table since we'll only be accessing the relationship through an organisation or a letter branding object, and we don't need to store extra data about the relationship.

**Add dao function to get letter branding pool for org**

**Add rest endpoint for getting org letter branding pool**