### PR TITLE
Add endpoint to update letter branding pool

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -5,6 +5,7 @@ from sqlalchemy.sql.expression import func
 from app import db
 from app.dao.dao_utils import VersionOptions, autocommit, version_class
 from app.dao.email_branding_dao import dao_get_email_branding_by_id
+from app.dao.letter_branding_dao import dao_get_letter_branding_by_id
 from app.models import (
     NHS_ORGANISATION_TYPES,
     AnnualBilling,
@@ -235,3 +236,13 @@ def dao_get_letter_branding_pool_for_organisation(organisation_id):
     organisation = dao_get_organisation_by_id(organisation_id)
 
     return sorted(organisation.letter_branding_pool, key=lambda x: x.name)
+
+
+@autocommit
+def dao_add_letter_branding_list_to_organisation_pool(organisation_id, letter_branding_ids):
+    organisation = dao_get_organisation_by_id(organisation_id)
+    letter_brandings = [dao_get_letter_branding_by_id(branding_id) for branding_id in letter_branding_ids]
+
+    organisation.letter_branding_pool.extend(letter_brandings)
+
+    db.session.add(organisation)

--- a/app/organisation/organisation_schema.py
+++ b/app/organisation/organisation_schema.py
@@ -65,3 +65,12 @@ post_update_org_email_branding_pool_schema = {
     "properties": {"branding_ids": {"type": "array", "items": uuid}},
     "required": ["branding_ids"],
 }
+
+
+post_update_org_letter_branding_pool_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "POST update organisation letter branding pool schema",
+    "type": "object",
+    "properties": {"branding_ids": {"type": "array", "items": uuid}},
+    "required": ["branding_ids"],
+}

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -8,6 +8,7 @@ from app.dao.fact_billing_dao import fetch_usage_for_organisation
 from app.dao.invited_org_user_dao import get_invited_org_users_for_organisation
 from app.dao.organisation_dao import (
     dao_add_email_branding_list_to_organisation_pool,
+    dao_add_letter_branding_list_to_organisation_pool,
     dao_add_service_to_organisation,
     dao_add_user_to_organisation,
     dao_archive_organisation,
@@ -41,6 +42,7 @@ from app.organisation.organisation_schema import (
     post_create_organisation_schema,
     post_link_service_to_organisation_schema,
     post_update_org_email_branding_pool_schema,
+    post_update_org_letter_branding_pool_schema,
     post_update_organisation_schema,
 )
 from app.schema_validation import validate
@@ -248,6 +250,16 @@ def remove_email_branding_from_organisation_pool(organisation_id, email_branding
 def get_organisation_letter_branding_pool(organisation_id):
     branding_pool = dao_get_letter_branding_pool_for_organisation(organisation_id)
     return jsonify(data=[branding.serialize() for branding in branding_pool])
+
+
+@organisation_blueprint.route("/<uuid:organisation_id>/letter-branding-pool", methods=["POST"])
+def update_organisation_letter_branding_pool(organisation_id):
+    data = request.get_json()
+    validate(data, post_update_org_letter_branding_pool_schema)
+
+    dao_add_letter_branding_list_to_organisation_pool(organisation_id, data["branding_ids"])
+
+    return {}, 204
 
 
 def check_request_args(request):

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -262,19 +262,6 @@ def update_organisation_letter_branding_pool(organisation_id):
     return {}, 204
 
 
-def check_request_args(request):
-    org_id = request.args.get("org_id")
-    name = request.args.get("name", None)
-    errors = []
-    if not org_id:
-        errors.append({"org_id": ["Can't be empty"]})
-    if not name:
-        errors.append({"name": ["Can't be empty"]})
-    if errors:
-        raise InvalidRequest(errors, status_code=400)
-    return org_id, name
-
-
 def send_notifications_on_mou_signed(organisation_id):
     organisation = dao_get_organisation_by_id(organisation_id)
     notify_service = dao_fetch_service_by_id(current_app.config["NOTIFY_SERVICE_ID"])

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1004,22 +1004,6 @@ def get_monthly_notification_data_by_service():
     return jsonify(serialized_results)
 
 
-def check_request_args(request):
-    service_id = request.args.get("service_id")
-    name = request.args.get("name", None)
-    email_from = request.args.get("email_from", None)
-    errors = []
-    if not service_id:
-        errors.append({"service_id": ["Can't be empty"]})
-    if not name:
-        errors.append({"name": ["Can't be empty"]})
-    if not email_from:
-        errors.append({"email_from": ["Can't be empty"]})
-    if errors:
-        raise InvalidRequest(errors, status_code=400)
-    return service_id, name, email_from
-
-
 def check_if_reply_to_address_already_in_use(service_id, email_address):
     existing_reply_to_addresses = dao_get_reply_to_by_service_id(service_id)
     if email_address in [i.email_address for i in existing_reply_to_addresses]:

--- a/tests/app/dao/test_organisation_dao.py
+++ b/tests/app/dao/test_organisation_dao.py
@@ -9,6 +9,7 @@ from app import db
 from app.dao.organisation_dao import (
     dao_add_email_branding_list_to_organisation_pool,
     dao_add_email_branding_to_organisation_pool,
+    dao_add_letter_branding_list_to_organisation_pool,
     dao_add_service_to_organisation,
     dao_add_user_to_organisation,
     dao_archive_organisation,
@@ -507,11 +508,43 @@ def test_dao_get_letter_branding_pool_for_organisation(sample_organisation):
     branding_1 = create_letter_branding("nhs", "nhs.svg")
     branding_2 = create_letter_branding("cabinet_office", "cabinet_office.svg")
 
-    sample_organisation.letter_branding_pool.append(branding_1)
-    sample_organisation.letter_branding_pool.append(branding_2)
-    db.session.commit()
+    dao_add_letter_branding_list_to_organisation_pool(sample_organisation.id, [branding_1.id, branding_2.id])
 
     assert dao_get_letter_branding_pool_for_organisation(sample_organisation.id) == [
         branding_2,
         branding_1,
     ]
+
+
+def test_dao_add_letter_branding_list_to_organisation_pool(sample_organisation):
+    branding_1 = create_letter_branding("branding_1", "filename_1")
+    branding_2 = create_letter_branding("branding_2", "filename_2")
+    branding_3 = create_letter_branding("branding_3", "filename_3")
+
+    dao_add_letter_branding_list_to_organisation_pool(sample_organisation.id, [branding_1.id])
+
+    assert sample_organisation.letter_branding_pool == [branding_1]
+
+    dao_add_letter_branding_list_to_organisation_pool(sample_organisation.id, [branding_2.id, branding_3.id])
+
+    # existing brandings remain in the pool, while new ones get added
+    assert len(sample_organisation.letter_branding_pool) == 3
+    assert branding_1 in sample_organisation.letter_branding_pool
+    assert branding_2 in sample_organisation.letter_branding_pool
+    assert branding_3 in sample_organisation.letter_branding_pool
+
+
+def test_dao_add_letter_branding_list_to_organisation_pool_does_not_error_when_brand_already_in_pool(
+    sample_organisation,
+):
+    branding_1 = create_letter_branding("branding_1", "filename_1")
+    branding_2 = create_letter_branding("branding_2", "filename_2")
+    branding_3 = create_letter_branding("branding_3", "filename_3")
+
+    dao_add_letter_branding_list_to_organisation_pool(sample_organisation.id, [branding_1.id, branding_2.id])
+
+    assert sample_organisation.letter_branding_pool == [branding_1, branding_2]
+
+    dao_add_letter_branding_list_to_organisation_pool(sample_organisation.id, [branding_2.id, branding_3.id])
+
+    assert sample_organisation.letter_branding_pool == [branding_1, branding_2, branding_3]


### PR DESCRIPTION
This adds an endpoint and new dao function to update the letter branding
pool for an organisation. The form that the data comes from allows multiple
letter brandings to be added at once, so the endpoint and dao function take
this into account by allowing the new brandings to be added in bulk.

As with other POST endpoints, we check the data using a JSON schema,
however the request from admin should always have the data in the
required format, so this acts more as documentation than a check that
might fail.