### PR TITLE
Add endpoint and dao function to remove letter branding from pool

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -246,3 +246,13 @@ def dao_add_letter_branding_list_to_organisation_pool(organisation_id, letter_br
     organisation.letter_branding_pool.extend(letter_brandings)
 
     db.session.add(organisation)
+
+
+@autocommit
+def dao_remove_letter_branding_from_organisation_pool(organisation_id, letter_branding_id):
+    organisation = dao_get_organisation_by_id(organisation_id)
+    letter_branding = dao_get_letter_branding_by_id(letter_branding_id)
+
+    organisation.letter_branding_pool.remove(letter_branding)
+
+    return letter_branding

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -21,6 +21,7 @@ from app.dao.organisation_dao import (
     dao_get_organisations,
     dao_get_users_for_organisation,
     dao_remove_email_branding_from_organisation_pool,
+    dao_remove_letter_branding_from_organisation_pool,
     dao_remove_user_from_organisation,
     dao_update_organisation,
 )
@@ -258,6 +259,24 @@ def update_organisation_letter_branding_pool(organisation_id):
     validate(data, post_update_org_letter_branding_pool_schema)
 
     dao_add_letter_branding_list_to_organisation_pool(organisation_id, data["branding_ids"])
+
+    return {}, 204
+
+
+@organisation_blueprint.route(
+    "/<uuid:organisation_id>/letter-branding-pool/<uuid:letter_branding_id>", methods=["DELETE"]
+)
+def remove_letter_branding_from_organisation_pool(organisation_id, letter_branding_id):
+    organisation = dao_get_organisation_by_id(organisation_id)
+    letter_branding_ids = {branding.id for branding in organisation.letter_branding_pool}
+
+    if letter_branding_id not in letter_branding_ids:
+        raise InvalidRequest(f"Letter branding {letter_branding_id} not in {organisation.name}'s pool", status_code=404)
+
+    if organisation.letter_branding_id == letter_branding_id:
+        raise InvalidRequest("You cannot remove an organisation's default letter branding", status_code=400)
+
+    dao_remove_letter_branding_from_organisation_pool(organisation_id, letter_branding_id)
 
     return {}, 204
 

--- a/tests/app/dao/test_organisation_dao.py
+++ b/tests/app/dao/test_organisation_dao.py
@@ -23,6 +23,7 @@ from app.dao.organisation_dao import (
     dao_get_organisations,
     dao_get_users_for_organisation,
     dao_remove_email_branding_from_organisation_pool,
+    dao_remove_letter_branding_from_organisation_pool,
     dao_update_organisation,
 )
 from app.errors import InvalidRequest
@@ -493,12 +494,12 @@ def test_dao_remove_email_branding_from_organisation_pool(sample_organisation):
     # Error if trying to remove an email branding that's not in the pool
     with pytest.raises(ValueError):
         dao_remove_email_branding_from_organisation_pool(sample_organisation.id, branding_1.id)
-        assert sample_organisation.email_branding_pool == [branding_2, branding_3]
+    assert sample_organisation.email_branding_pool == [branding_2, branding_3]
 
     # Error if trying to remove the org's default email branding
     with pytest.raises(InvalidRequest):
         dao_remove_email_branding_from_organisation_pool(sample_organisation.id, branding_2.id)
-        assert sample_organisation.email_branding_pool == [branding_2, branding_3]
+    assert sample_organisation.email_branding_pool == [branding_2, branding_3]
 
     dao_remove_email_branding_from_organisation_pool(sample_organisation.id, branding_3.id)
     assert sample_organisation.email_branding_pool == [branding_2]
@@ -548,3 +549,26 @@ def test_dao_add_letter_branding_list_to_organisation_pool_does_not_error_when_b
     dao_add_letter_branding_list_to_organisation_pool(sample_organisation.id, [branding_2.id, branding_3.id])
 
     assert sample_organisation.letter_branding_pool == [branding_1, branding_2, branding_3]
+
+
+def test_dao_remove_letter_branding_from_organisation_pool(sample_organisation):
+    branding_1 = create_letter_branding("branding_1", "filename_1")
+    branding_2 = create_letter_branding("branding_2", "filename_2")
+    branding_3 = create_letter_branding("branding_3", "filename_3")
+
+    dao_add_letter_branding_list_to_organisation_pool(
+        sample_organisation.id, [branding_1.id, branding_2.id, branding_3.id]
+    )
+
+    # branding_1 is the default for the org
+    sample_organisation.letter_branding_id = branding_1.id
+
+    # any branding in the pool can be removed
+    dao_remove_letter_branding_from_organisation_pool(sample_organisation.id, branding_1.id)
+    dao_remove_letter_branding_from_organisation_pool(sample_organisation.id, branding_2.id)
+
+    # branding not in the pool raises an error
+    with pytest.raises(ValueError):
+        dao_remove_letter_branding_from_organisation_pool(sample_organisation.id, branding_2.id)
+
+    assert sample_organisation.letter_branding_pool == [branding_3]


### PR DESCRIPTION
This adds a new endpoint to remove a particular letter brand from the letter branding pool for an organisation. As with the email branding equivalent, there is a check that you're not removing the default and that the brand you're trying to remove is in the pool. However, we do also do the same checks in admin, so do not expect these errors to be raised.