### PR TITLE
Fix PyUp insecure-only version bumps.

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -7,5 +7,7 @@ update: insecure
 
 search: False
 requirements:
-  - requirements.in
-  - requirements_for_test.txt
+  - requirements.in:
+    update: insecure
+  - requirements_for_test.txt:
+    update: insecure


### PR DESCRIPTION
PyUp docs:

```
requirements:
  - requirements/staging.txt:
      # update all dependencies and pin them
      update: all
      pin: True
  - requirements/dev.txt:
      # don't update dependencies, use global 'pin' default
      update: False
  - requirements/prod.txt:
      # update insecure only, pin all
      update: insecure
      pin: True
```

Despite their own documentation implying settings configured at a global level apply everywhere, it's not true.

https://github.com/pyupio/pyup/issues/238