### PR TITLE
Give NHS letter branding the same ID in each env and give NHS orgs NHS branding when created / updated

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -181,6 +181,7 @@ class Config(object):
     NOTIFY_INTERNATIONAL_SMS_SENDER = "07984404008"
     LETTERS_VOLUME_EMAIL_TEMPLATE_ID = "11fad854-fd38-4a7c-bd17-805fb13dfc12"
     NHS_EMAIL_BRANDING_ID = "a7dc4e56-660b-4db7-8cff-12c37b12b5ea"
+    NHS_LETTER_BRANDING_ID = "2cd354bb-6b85-eda3-c0ad-6b613150459f"
     # we only need real email in Live environment (production)
     DVLA_EMAIL_ADDRESSES = json.loads(os.environ.get("DVLA_EMAIL_ADDRESSES", "[]"))
 

--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -83,12 +83,14 @@ def dao_get_organisation_by_service_id(service_id):
 def dao_create_organisation(organisation):
     if organisation.organisation_type in NHS_ORGANISATION_TYPES:
         organisation.email_branding_id = current_app.config["NHS_EMAIL_BRANDING_ID"]
+        organisation.letter_branding_id = current_app.config["NHS_LETTER_BRANDING_ID"]
 
     db.session.add(organisation)
     db.session.commit()
 
     if organisation.organisation_type in NHS_ORGANISATION_TYPES:
         dao_add_email_branding_to_organisation_pool(organisation.id, organisation.email_branding_id)
+        dao_add_letter_branding_list_to_organisation_pool(organisation.id, [organisation.letter_branding_id])
 
 
 @autocommit

--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -126,6 +126,9 @@ def dao_update_organisation(organisation_id, **kwargs):
     if "letter_branding_id" in kwargs:
         _update_organisation_services(organisation, "letter_branding")
 
+        if kwargs["letter_branding_id"]:
+            dao_add_letter_branding_list_to_organisation_pool(organisation_id, [kwargs["letter_branding_id"]])
+
     return num_updated
 
 

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -114,8 +114,11 @@ def update_organisation(organisation_id):
 
     organisation = dao_get_organisation_by_id(organisation_id)
 
-    if data.get("organisation_type") in NHS_ORGANISATION_TYPES and not organisation.email_branding_id:
-        data["email_branding_id"] = current_app.config["NHS_EMAIL_BRANDING_ID"]
+    if data.get("organisation_type") in NHS_ORGANISATION_TYPES:
+        if not organisation.email_branding_id:
+            data["email_branding_id"] = current_app.config["NHS_EMAIL_BRANDING_ID"]
+        if not organisation.letter_branding_id:
+            data["letter_branding_id"] = current_app.config["NHS_LETTER_BRANDING_ID"]
 
     result = dao_update_organisation(organisation_id, **data)
 

--- a/migrations/versions/0382_nhs_letter_branding_id.py
+++ b/migrations/versions/0382_nhs_letter_branding_id.py
@@ -1,0 +1,76 @@
+"""
+
+Revision ID: 0382_nhs_letter_branding_id
+Revises: 0381_letter_branding_to_org
+Create Date: 2022-11-15 07:57:49.060820
+
+"""
+import os
+
+from alembic import op
+
+revision = '0382_nhs_letter_branding_id'
+down_revision = '0381_letter_branding_to_org'
+
+environment = os.environ["NOTIFY_ENVIRONMENT"]
+
+
+def upgrade():
+    if environment not in ["live", "production"]:
+        op.execute(
+            """
+            DELETE FROM service_letter_branding
+            WHERE letter_branding_id in (
+                SELECT id
+                FROM letter_branding
+                WHERE name = 'NHS'
+            )
+        """
+        )
+
+        op.execute(
+            """
+            DELETE FROM letter_branding_to_organisation
+            WHERE letter_branding_id in (
+                SELECT id
+                FROM letter_branding
+                WHERE name = 'NHS'
+            )
+        """
+        )
+
+        op.execute(
+            """
+            UPDATE organisation SET letter_branding_id = null
+            WHERE letter_branding_id in(
+                SELECT id
+                FROM letter_branding
+                WHERE name = 'NHS'
+            )
+        """
+        )
+
+        op.execute(
+            """
+            DELETE FROM letter_branding WHERE name = 'NHS'
+        """
+        )
+
+        op.execute(
+            """
+            INSERT INTO letter_branding (
+                id, name, filename
+            )
+            VALUES (
+                '2cd354bb-6b85-eda3-c0ad-6b613150459f',
+                'NHS',
+                'nhs'
+            )
+        """
+        )
+
+
+def downgrade():
+    """
+    No downgrade step since this is not fully reversible, but won't be run in production.
+    """

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -59,6 +59,7 @@ from tests.app.db import (
     create_inbound_number,
     create_invited_org_user,
     create_job,
+    create_letter_branding,
     create_letter_contact,
     create_notification,
     create_service,
@@ -913,6 +914,17 @@ def nhs_email_branding(notify_db_session):
 
     return create_email_branding(
         id=nhs_email_branding_id, logo="1ac6f483-3105-4c9e-9017-dd7fb2752c44-nhs-blue_x2.png", name="NHS"
+    )
+
+
+@pytest.fixture
+def nhs_letter_branding(notify_db_session):
+    # We wipe the letter_branding table between tests, so we have to recreate this branding
+    # that is normally always present
+    return create_letter_branding(
+        id=current_app.config["NHS_LETTER_BRANDING_ID"],
+        name="NHS",
+        filename="nhs",
     )
 
 

--- a/tests/app/dao/test_organisation_dao.py
+++ b/tests/app/dao/test_organisation_dao.py
@@ -246,6 +246,30 @@ def test_update_organisation_email_branding_does_not_error_if_returning_to_govuk
     dao_update_organisation(sample_organisation.id, email_branding_id=None)
 
 
+def test_update_organisation_letter_branding_adds_to_pool(sample_organisation):
+    letter_branding = create_letter_branding()
+
+    assert letter_branding not in sample_organisation.letter_branding_pool
+
+    dao_update_organisation(sample_organisation.id, letter_branding_id=letter_branding.id)
+
+    assert letter_branding in sample_organisation.letter_branding_pool
+
+
+def test_update_organisation_letter_branding_does_not_error_if_already_in_pool(sample_organisation):
+    letter_branding = create_letter_branding()
+    sample_organisation.letter_branding_pool.append(letter_branding)
+    db.session.commit()
+
+    assert letter_branding in sample_organisation.letter_branding_pool
+
+    dao_update_organisation(sample_organisation.id, letter_branding_id=letter_branding.id)
+
+
+def test_update_organisation_letter_branding_does_not_error_if_returning_to_no_branding(sample_organisation):
+    dao_update_organisation(sample_organisation.id, letter_branding_id=None)
+
+
 def test_update_organisation_updates_services_with_new_crown_type(sample_service, sample_organisation):
     sample_organisation.services.append(sample_service)
     db.session.commit()

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -442,7 +442,7 @@ def test_get_all_user_services_should_return_empty_list_if_no_services_for_user(
 
 
 @freeze_time("2019-04-23T10:00:00")
-def test_dao_fetch_live_services_data(sample_user, nhs_email_branding):
+def test_dao_fetch_live_services_data(sample_user, nhs_email_branding, nhs_letter_branding):
     org = create_organisation(organisation_type="nhs_central")
     service = create_service(go_live_user=sample_user, go_live_at="2014-04-20T10:00:00")
     sms_template = create_template(service=service)

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -891,11 +891,16 @@ def create_template_folder(service, name="foo", parent=None):
     return tf
 
 
-def create_letter_branding(name="HM Government", filename="hm-government"):
-    test_domain_branding = LetterBranding(
-        name=name,
-        filename=filename,
-    )
+def create_letter_branding(name="HM Government", filename="hm-government", id=None):
+    data = {
+        "name": name,
+        "filename": filename,
+    }
+
+    if id:
+        data["id"] = id
+
+    test_domain_branding = LetterBranding(**data)
     db.session.add(test_domain_branding)
     db.session.commit()
     return test_domain_branding

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -622,6 +622,7 @@ def create_organisation(
     billing_contact_email_addresses=None,
     billing_reference=None,
     email_branding_id=None,
+    letter_branding_id=None,
 ):
     data = {
         "id": organisation_id,
@@ -633,6 +634,7 @@ def create_organisation(
         "billing_contact_email_addresses": billing_contact_email_addresses,
         "billing_reference": billing_reference,
         "email_branding_id": email_branding_id,
+        "letter_branding_id": letter_branding_id,
     }
     organisation = Organisation(**data)
     dao_create_organisation(organisation)

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -7,6 +7,7 @@ from freezegun import freeze_time
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.dao.email_branding_dao import dao_get_email_branding_by_id
+from app.dao.letter_branding_dao import dao_get_letter_branding_by_id
 from app.dao.organisation_dao import (
     dao_add_email_branding_to_organisation_pool,
     dao_add_letter_branding_list_to_organisation_pool,
@@ -33,7 +34,7 @@ from tests.app.db import (
 )
 
 
-def test_get_all_organisations(admin_request, notify_db_session, nhs_email_branding):
+def test_get_all_organisations(admin_request, notify_db_session, nhs_email_branding, nhs_letter_branding):
     create_organisation(name="inactive org", active=False, organisation_type="nhs_central")
     create_organisation(name="active org", domains=["example.com"])
 
@@ -190,7 +191,7 @@ def test_post_create_organisation(admin_request, notify_db_session, crown):
 
 @pytest.mark.parametrize("org_type", ["nhs_central", "nhs_local", "nhs_gp"])
 def test_post_create_organisation_sets_default_nhs_branding_and_adds_it_to_org_pool_for_nhs_org_types(
-    admin_request, notify_db_session, nhs_email_branding, org_type
+    admin_request, notify_db_session, nhs_email_branding, nhs_letter_branding, org_type
 ):
     data = {
         "name": "test organisation",
@@ -201,14 +202,15 @@ def test_post_create_organisation_sets_default_nhs_branding_and_adds_it_to_org_p
 
     admin_request.post("organisation.create_organisation", _data=data, _expected_status=201)
 
-    organisations = Organisation.query.all()
-    nhs_branding_id = current_app.config["NHS_EMAIL_BRANDING_ID"]
-    nhs_branding = dao_get_email_branding_by_id(nhs_branding_id)
+    organisation = Organisation.query.one()
+    email_branding_nhs = dao_get_email_branding_by_id(current_app.config["NHS_EMAIL_BRANDING_ID"])
+    letter_branding_nhs = dao_get_letter_branding_by_id(current_app.config["NHS_LETTER_BRANDING_ID"])
 
-    assert len(organisations) == 1
-    assert organisations[0].email_branding_id == uuid.UUID(nhs_branding_id)
+    assert organisation.email_branding_id == uuid.UUID(current_app.config["NHS_EMAIL_BRANDING_ID"])
+    assert organisation.letter_branding_id == uuid.UUID(current_app.config["NHS_LETTER_BRANDING_ID"])
 
-    assert organisations[0].email_branding_pool == [nhs_branding]
+    assert organisation.email_branding_pool == [email_branding_nhs]
+    assert organisation.letter_branding_pool == [letter_branding_nhs]
 
 
 def test_post_create_organisation_existing_name_raises_400(admin_request, sample_organisation):


### PR DESCRIPTION
**Give NHS letter branding the same ID in each environment**
We gave the NHS email branding the same ID in each environment, which simplifies the code to give it to organisations and to use it on forms.

This does the same for the NHS letter branding ID. The logo exists in all environments. We delete the row in the `letter_branding` table from all environments apart from production, then re-insert it to the other environments with the ID that exists in production.

**Add NHS letter branding to pools and org when creating an NHS org**
When an organisation is created with one of the NHS org types, we now set its letter branding to the NHS brand and add the NHS brand to its branding pool.

We are already setting up NHS branding for services which are NHS services, so this change won't really affect people's experience - it just makes sure that the letter branding pools are set up with the right data.

**When changing an org to NHS type give it NHS letter branding and add the branding to the pool**
When updating an organisation to be an NHS org type, we set its letter branding to the NHS brand if it has no current letter branding.

We also add the branding to the pool. This behaviour is not NHS specific - we add the letter branding for any organisation to the branding pool if it's being made the default for that organisation.