### PR TITLE
Add webauthn_credential.logged_in_at

### DIFF
--- a/app/dao/webauthn_credential_dao.py
+++ b/app/dao/webauthn_credential_dao.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from app import db
 from app.dao.dao_utils import autocommit
 from app.models import WebauthnCredential
@@ -27,6 +29,13 @@ def dao_create_webauthn_credential(
 @autocommit
 def dao_update_webauthn_credential_name(webauthn_credential, new_name):
     webauthn_credential.name = new_name
+    db.session.add(webauthn_credential)
+    return webauthn_credential
+
+
+@autocommit
+def dao_update_webauthn_credential_logged_in_at(webauthn_credential):
+    webauthn_credential.logged_in_at = datetime.utcnow()
     db.session.add(webauthn_credential)
     return webauthn_credential
 

--- a/app/models.py
+++ b/app/models.py
@@ -2547,6 +2547,8 @@ class WebauthnCredential(db.Model):
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
 
+    logged_in_at = db.Column(db.DateTime, nullable=True)
+
     def serialize(self):
         return {
             "id": str(self.id),
@@ -2555,4 +2557,5 @@ class WebauthnCredential(db.Model):
             "credential_data": self.credential_data,
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
             "updated_at": get_dt_string_or_none(self.updated_at),
+            "logged_in_at": get_dt_string_or_none(self.logged_in_at),
         }

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -38,6 +38,10 @@ from app.dao.users_dao import (
     update_user_password,
     use_user_code,
 )
+from app.dao.webauthn_credential_dao import (
+    dao_get_webauthn_credential_by_user_and_id,
+    dao_update_webauthn_credential_logged_in_at,
+)
 from app.errors import InvalidRequest, register_errors
 from app.models import (
     EMAIL_TYPE,
@@ -252,6 +256,10 @@ def complete_login_after_webauthn_authentication_attempt(user_id):
         user.logged_in_at = datetime.utcnow()
         user.failed_login_count = 0
         save_model_user(user)
+
+        if webauthn_credential_id := data.get("webauthn_credential_id"):
+            webauthn_credential = dao_get_webauthn_credential_by_user_and_id(user_id, webauthn_credential_id)
+            dao_update_webauthn_credential_logged_in_at(webauthn_credential)
     else:
         increment_failed_login_count(user)
 

--- a/app/user/users_schema.py
+++ b/app/user/users_schema.py
@@ -1,3 +1,5 @@
+from app.schema_validation.definitions import nullable_uuid
+
 post_verify_code_schema = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST schema for verifying a 2fa code",
@@ -15,7 +17,8 @@ post_verify_webauthn_schema = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST schema for verifying a webauthn login attempt",
     "type": "object",
-    "properties": {"successful": {"type": "boolean"}},
+    "properties": {"successful": {"type": "boolean"}, "webauthn_credential_id": nullable_uuid},
+    # webauthn_credential_id not required until admin is deployed
     "required": ["successful"],
     "additionalProperties": False,
 }

--- a/migrations/versions/0382_webauthn_cred_logged_in_at.py
+++ b/migrations/versions/0382_webauthn_cred_logged_in_at.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 0382_webauthn_cred_logged_in_at
+Revises: 0381_letter_branding_to_org
+Create Date: 2022-10-21 14:26:12.421574
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0382_webauthn_cred_logged_in_at'
+down_revision = '0381_letter_branding_to_org'
+
+
+def upgrade():
+    op.add_column("webauthn_credential", sa.Column("logged_in_at", sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("webauthn_credential", "logged_in_at")

--- a/tests/app/webauthn/test_rest.py
+++ b/tests/app/webauthn/test_rest.py
@@ -28,6 +28,7 @@ def test_get_webauthn_credentials_returns_all_credentials_for_user(admin_request
         "credential_data": "ABC123",
         "created_at": ANY,
         "updated_at": None,
+        "logged_in_at": None,
     }
 
     assert creds[1]["name"] == "2"


### PR DESCRIPTION
If the admin passes through a credential id when logging a user in (which it will once https://github.com/alphagov/notifications-admin/pull/4452 is merged), then set `logged_in_at` to be the current timestamp in the database.