### PR TITLE
Always add NHS branding to pools when updating an org

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -119,17 +119,28 @@ def dao_update_organisation(organisation_id, **kwargs):
     if "email_branding_id" in kwargs:
         _update_organisation_services(organisation, "email_branding")
 
-        # This could be `None` to return an organisation to the default GOV.UK branding (which isn't a real brand).
-        if kwargs["email_branding_id"]:
-            dao_add_email_branding_to_organisation_pool(organisation_id, kwargs["email_branding_id"])
-
     if "letter_branding_id" in kwargs:
         _update_organisation_services(organisation, "letter_branding")
 
-        if kwargs["letter_branding_id"]:
-            dao_add_letter_branding_list_to_organisation_pool(organisation_id, [kwargs["letter_branding_id"]])
+    _add_branding_to_branding_pool(organisation_id, kwargs)
 
     return num_updated
+
+
+def _add_branding_to_branding_pool(organisation_id, kwargs):
+    if kwargs.get("organisation_type") in NHS_ORGANISATION_TYPES:
+        # If we're setting the organisation_type to one of the NHS types we always want to add the NHS branding to the
+        # pool. This should happen regardless of whether we're changing the branding for the org.
+        dao_add_email_branding_to_organisation_pool(organisation_id, current_app.config["NHS_EMAIL_BRANDING_ID"])
+        dao_add_letter_branding_list_to_organisation_pool(
+            organisation_id, [current_app.config["NHS_LETTER_BRANDING_ID"]]
+        )
+    else:
+        if kwargs.get("email_branding_id"):
+            dao_add_email_branding_to_organisation_pool(organisation_id, kwargs["email_branding_id"])
+
+        if kwargs.get("letter_branding_id"):
+            dao_add_letter_branding_list_to_organisation_pool(organisation_id, [kwargs["letter_branding_id"]])
 
 
 @version_class(

--- a/tests/app/dao/test_organisation_dao.py
+++ b/tests/app/dao/test_organisation_dao.py
@@ -2,6 +2,7 @@ import datetime
 import uuid
 
 import pytest
+from flask import current_app
 from freezegun import freeze_time
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
@@ -232,6 +233,28 @@ def test_update_organisation_email_branding_adds_to_pool(sample_organisation):
     assert email_branding in sample_organisation.email_branding_pool
 
 
+@pytest.mark.parametrize("email_branding_id_present", (True, False))
+def test_update_organisation_email_branding_adds_nhs_branding_to_pool(
+    sample_organisation,
+    nhs_email_branding,
+    nhs_letter_branding,
+    email_branding_id_present,
+):
+    email_branding_id = current_app.config["NHS_EMAIL_BRANDING_ID"] if email_branding_id_present else None
+
+    data = {
+        "organisation_type": "nhs_central",
+        "email_branding_id": email_branding_id,
+    }
+
+    assert not sample_organisation.email_branding_pool
+
+    dao_update_organisation(sample_organisation.id, **data)
+
+    assert len(sample_organisation.email_branding_pool) == 1
+    assert sample_organisation.email_branding_pool[0].id == nhs_email_branding.id
+
+
 def test_update_organisation_email_branding_does_not_error_if_already_in_pool(sample_organisation):
     email_branding = create_email_branding()
     sample_organisation.email_branding_pool.append(email_branding)
@@ -254,6 +277,28 @@ def test_update_organisation_letter_branding_adds_to_pool(sample_organisation):
     dao_update_organisation(sample_organisation.id, letter_branding_id=letter_branding.id)
 
     assert letter_branding in sample_organisation.letter_branding_pool
+
+
+@pytest.mark.parametrize("letter_branding_id_present", (True, False))
+def test_update_organisation_letter_branding_adds_nhs_branding_to_pool(
+    sample_organisation,
+    nhs_email_branding,
+    nhs_letter_branding,
+    letter_branding_id_present,
+):
+    letter_branding_id = current_app.config["NHS_LETTER_BRANDING_ID"] if letter_branding_id_present else None
+
+    data = {
+        "organisation_type": "nhs_central",
+        "letter_branding_id": letter_branding_id,
+    }
+
+    assert not sample_organisation.letter_branding_pool
+
+    dao_update_organisation(sample_organisation.id, **data)
+
+    assert len(sample_organisation.letter_branding_pool) == 1
+    assert sample_organisation.letter_branding_pool[0].id == nhs_letter_branding.id
 
 
 def test_update_organisation_letter_branding_does_not_error_if_already_in_pool(sample_organisation):


### PR DESCRIPTION
When we update an organisation to be one of the NHS org types we want to add the NHS branding to the pool. We were already doing this, but had missed one edge case - we weren't adding to the pool in cases where the organisation already had a default branding set.

We now:
* Always add NHS branding to the pool if we're setting the org type to NHS
* Add branding to the pool if it's being set as the default for an org