### PR TITLE
Add cronitor for run-scheduled-jobs

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -63,6 +63,7 @@ from app.notifications.process_notifications import send_notification_to_queue
 
 
 @notify_celery.task(name="run-scheduled-jobs")
+@cronitor("run-scheduled-jobs")
 def run_scheduled_jobs():
     try:
         for job in dao_set_scheduled_jobs_to_pending():


### PR DESCRIPTION
https://trello.com/c/qLP6Skv2/65-add-cronitor-task-for-watching-scheduled-jobs

This will ensure it will be run every 15 minutes and if it doesn't then we will get an alert.

How to review
- first review https://github.com/alphagov/notifications-credentials/pull/304
- take a look at the job in Cronitor, click 'edit' and review all of the settings. 
- ensure the name of the cronitor job in this PR matches the key in the credentials repo in https://github.com/alphagov/notifications-credentials/pull/304