### PR TITLE
Add default letter branding for orgs to branding pools

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0383_webauthn_cred_logged_in_at
+0385_letter_branding_pools

--- a/migrations/versions/0385_letter_branding_pools.py
+++ b/migrations/versions/0385_letter_branding_pools.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: 0385_letter_branding_pools
+Revises: 0384_add_nhs_to_letter_pools
+Create Date: 2022-11-18 11:46:27.954516
+
+"""
+from alembic import op
+
+revision = '0385_letter_branding_pools'
+down_revision = '0384_add_nhs_to_letter_pools'
+
+
+def upgrade():
+    op.execute(
+            """
+            INSERT INTO letter_branding_to_organisation
+            (organisation_id, letter_branding_id)
+            (SELECT id, letter_branding_id FROM organisation WHERE letter_branding_id IS NOT NULL)
+            ON CONFLICT DO NOTHING;
+            """
+        )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
This adds the default letter branding for each organisation to the letter branding pool. We have already added the NHS branding for NHS orgs in a previous migration. In future work, we will look at adding brandings for services to the pool too.