### PR TITLE
Email branding add alt text

### DIFF
--- a/app/email_branding/rest.py
+++ b/app/email_branding/rest.py
@@ -50,8 +50,6 @@ def create_email_branding():
     validate(data, post_create_email_branding_schema)
 
     email_branding = EmailBranding(**data)
-    if "text" not in data.keys():
-        email_branding.text = email_branding.name
 
     dao_create_email_branding(email_branding)
 
@@ -65,8 +63,7 @@ def update_email_branding(email_branding_id):
     validate(data, post_update_email_branding_schema)
 
     fetched_email_branding = dao_get_email_branding_by_id(email_branding_id)
-    if "text" not in data.keys() and "name" in data.keys():
-        data["text"] = data["name"]
+
     dao_update_email_branding(fetched_email_branding, **data)
 
     return jsonify(data=fetched_email_branding.serialize()), 200

--- a/app/models.py
+++ b/app/models.py
@@ -237,6 +237,7 @@ class EmailBranding(db.Model):
     logo = db.Column(db.String(255), nullable=True)
     name = db.Column(db.String(255), unique=True, nullable=False)
     text = db.Column(db.String(255), nullable=True)
+    alt_text = db.Column(db.String(255), nullable=True)
     brand_type = db.Column(
         db.String(255), db.ForeignKey("branding_type.name"), index=True, nullable=False, default=BRANDING_ORG
     )
@@ -253,6 +254,7 @@ class EmailBranding(db.Model):
             "name": self.name,
             "text": self.text,
             "brand_type": self.brand_type,
+            "alt_text": self.alt_text,
         }
 
         return serialized

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0385_letter_branding_pools
+0386_email_branding_alt_text

--- a/migrations/versions/0386_email_branding_alt_text.py
+++ b/migrations/versions/0386_email_branding_alt_text.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 0386_email_branding_alt_text
+Revises: 0385_letter_branding_pools
+Create Date: 2022-10-21 14:26:12.421574
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0386_email_branding_alt_text'
+down_revision = '0385_letter_branding_pools'
+
+
+def upgrade():
+    op.add_column("email_branding", sa.Column("alt_text", sa.String(length=255), nullable=True))
+
+
+def downgrade():
+    op.drop_column("email_branding", "alt_text")


### PR DESCRIPTION
we set the text to equal the name if it's not passed in from the admin app. at the moment we always pass in, but just an empty string. really, we'd much rather just pass in null and set it to null.

also, add alt-text. it's nullable for now but we'll start setting it on the admin app and passing it through (and eventually we'll migrate old values and make it non-nullable.

question for reviewer: should the logic for deciding the name based on alt text be written in the admin app or here?