### PR TITLE
Email branding - use the alt text field

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -223,7 +223,7 @@ def get_html_email_options(service):
         "brand_colour": branding.colour,
         "brand_logo": logo_url,
         "brand_text": branding.text,
-        "brand_name": branding.name,
+        "brand_alt_text": branding.alt_text,
     }
 
 

--- a/app/email_branding/rest.py
+++ b/app/email_branding/rest.py
@@ -27,6 +27,12 @@ def handle_integrity_error(exc):
     if "uq_email_branding_name" in str(exc):
         return jsonify(result="error", message={"name": ["An email branding with that name already exists."]}), 400
 
+    if "ck_email_branding_one_of_alt_text_or_text_is_null" in str(exc):
+        return (
+            jsonify(result="error", message="Email branding must have exactly one of alt_text and text."),
+            400,
+        )
+
     current_app.logger.exception(exc)
     return jsonify(result="error", message="Internal server error"), 500
 

--- a/app/email_branding/rest.py
+++ b/app/email_branding/rest.py
@@ -24,10 +24,10 @@ def handle_integrity_error(exc):
     """
     Handle integrity errors caused by the unique constraint
     """
-    if "uq_email_branding_name" in str(exc):
+    if exc.orig.diag.constraint_name == EmailBranding.CONSTRAINT_UNIQUE_NAME:
         return jsonify(result="error", message={"name": ["An email branding with that name already exists."]}), 400
 
-    if "ck_email_branding_one_of_alt_text_or_text_is_null" in str(exc):
+    if exc.orig.diag.constraint_name == EmailBranding.CONSTRAINT_CHECK_ONE_OF_ALT_TEXT_TEXT_NULL:
         return (
             jsonify(result="error", message="Email branding must have exactly one of alt_text and text."),
             400,

--- a/app/models.py
+++ b/app/models.py
@@ -246,6 +246,14 @@ class EmailBranding(db.Model):
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=lambda: datetime.datetime.utcnow())
     updated_by = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
 
+    # one of alt_text or text MUST be supplied
+    __table_args__ = (
+        CheckConstraint(
+            "(text is not null and alt_text is null) or (text is null and alt_text is not null)",
+            name="ck_email_branding_one_of_alt_text_or_text_is_null",
+        ),
+    )
+
     def serialize(self):
         serialized = {
             "id": str(self.id),

--- a/app/models.py
+++ b/app/models.py
@@ -246,6 +246,8 @@ class EmailBranding(db.Model):
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=lambda: datetime.datetime.utcnow())
     updated_by = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
 
+    CONSTRAINT_UNIQUE_NAME = "uq_email_branding_name"
+    CONSTRAINT_CHECK_ONE_OF_ALT_TEXT_TEXT_NULL = "ck_email_branding_one_of_alt_text_or_text_is_null"
     # one of alt_text or text MUST be supplied
     __table_args__ = (
         CheckConstraint(

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0386_email_branding_alt_text
+0387_migrate_alt_text

--- a/migrations/versions/0387_migrate_alt_text.py
+++ b/migrations/versions/0387_migrate_alt_text.py
@@ -1,0 +1,69 @@
+"""
+
+Revision ID: 0387_migrate_alt_text
+Revises: 0386_email_branding_alt_text
+Create Date: 2022-11-21 19:05:49.047224
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0387_migrate_alt_text"
+down_revision = "0386_email_branding_alt_text"
+
+
+def upgrade():
+    conn = op.get_bind()
+    # there are some old email_branding rows with empty string. Keep them as null.
+    conn.execute(
+        sa.text(
+            """
+            UPDATE
+                email_branding
+            SET
+                text = null
+            WHERE
+                text = '';
+            """
+        )
+    )
+    # if text is null, we need alt_text, so infer it from the branding name instead
+    conn.execute(
+        sa.text(
+            """
+            UPDATE
+                email_branding
+            SET
+                alt_text = name
+            WHERE
+                text is null;
+            """
+        )
+    )
+    # any rows with alt_text and text, remove alt_text.
+    # i don't expect any rows to be set like this yet, but lets just ensure the constraint creation wont fail
+    conn.execute(
+        sa.text(
+            """
+            UPDATE
+                email_branding
+            SET
+                alt_text = null
+            WHERE
+                text is not null;
+            """
+        )
+    )
+    op.create_check_constraint(
+        "ck_email_branding_one_of_alt_text_or_text_is_null",
+        "email_branding",
+        """
+        (text is not null and alt_text is null) or
+        (text is null and alt_text is not null)
+        """,
+    )
+
+
+def downgrade():
+    op.drop_constraint("ck_email_branding_one_of_alt_text_or_text_is_null", "email_branding")

--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ notifications-python-client==6.3.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@57.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@58.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -157,7 +157,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@57.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@58.0.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -483,7 +483,7 @@ def create_service_callback_api(
 
 
 def create_email_branding(
-    id=None, colour="blue", alt_text="Alt Text", logo="test_x2.png", name="test_org_1", text="DisplayName"
+    id=None, colour="blue", alt_text=None, logo="test_x2.png", name="test_org_1", text="DisplayName"
 ):
     data = {
         "colour": colour,

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -399,7 +399,7 @@ def test_get_html_email_renderer_should_return_for_normal_service(sample_service
     assert "brand_colour" not in options.keys()
     assert "brand_logo" not in options.keys()
     assert "brand_text" not in options.keys()
-    assert "brand_name" not in options.keys()
+    assert "brand_alt_text" not in options.keys()
 
 
 @pytest.mark.parametrize(
@@ -423,7 +423,7 @@ def test_get_html_email_renderer_with_branding_details(branding_type, govuk_bann
     assert options["govuk_banner"] == govuk_banner
     assert options["brand_colour"] == "#000000"
     assert options["brand_text"] == "League of Justice"
-    assert options["brand_name"] == "Justice League"
+    assert options["brand_alt_text"] is None
 
     if branding_type == BRANDING_ORG_BANNER:
         assert options["brand_banner"] is True
@@ -443,7 +443,7 @@ def test_get_html_email_renderer_with_branding_details_and_render_govuk_banner_o
 
 def test_get_html_email_renderer_prepends_logo_path(notify_api):
     Service = namedtuple("Service", ["email_branding"])
-    EmailBranding = namedtuple("EmailBranding", ["brand_type", "colour", "name", "logo", "text"])
+    EmailBranding = namedtuple("EmailBranding", ["brand_type", "colour", "name", "logo", "text", "alt_text"])
 
     email_branding = EmailBranding(
         brand_type=BRANDING_ORG,
@@ -451,6 +451,7 @@ def test_get_html_email_renderer_prepends_logo_path(notify_api):
         logo="justice-league.png",
         name="Justice League",
         text="League of Justice",
+        alt_text=None,
     )
     service = Service(
         email_branding=email_branding,
@@ -463,7 +464,7 @@ def test_get_html_email_renderer_prepends_logo_path(notify_api):
 
 def test_get_html_email_renderer_handles_email_branding_without_logo(notify_api):
     Service = namedtuple("Service", ["email_branding"])
-    EmailBranding = namedtuple("EmailBranding", ["brand_type", "colour", "name", "logo", "text"])
+    EmailBranding = namedtuple("EmailBranding", ["brand_type", "colour", "name", "logo", "text", "alt_text"])
 
     email_branding = EmailBranding(
         brand_type=BRANDING_ORG_BANNER,
@@ -471,6 +472,7 @@ def test_get_html_email_renderer_handles_email_branding_without_logo(notify_api)
         logo=None,
         name="Justice League",
         text="League of Justice",
+        alt_text=None,
     )
     service = Service(
         email_branding=email_branding,
@@ -483,7 +485,7 @@ def test_get_html_email_renderer_handles_email_branding_without_logo(notify_api)
     assert renderer["brand_logo"] is None
     assert renderer["brand_text"] == "League of Justice"
     assert renderer["brand_colour"] == "#000000"
-    assert renderer["brand_name"] == "Justice League"
+    assert renderer["brand_alt_text"] is None
 
 
 @pytest.mark.parametrize(
@@ -790,7 +792,7 @@ def test_get_html_email_options_return_email_branding_from_serialised_service(sa
         "brand_colour": branding.colour,
         "brand_logo": get_logo_url(current_app.config["ADMIN_BASE_URL"], branding.logo),
         "brand_text": branding.text,
-        "brand_name": branding.name,
+        "brand_alt_text": branding.alt_text,
     }
 
 
@@ -805,5 +807,5 @@ def test_get_html_email_options_add_email_branding_from_service(sample_service):
         "brand_colour": branding.colour,
         "brand_logo": get_logo_url(current_app.config["ADMIN_BASE_URL"], branding.logo),
         "brand_text": branding.text,
-        "brand_name": branding.name,
+        "brand_alt_text": branding.alt_text,
     }

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -690,7 +690,7 @@ def test_create_service_allows_only_lowercase_digits_and_fullstops_in_email_from
 
 
 def test_update_service(client, notify_db_session, sample_service):
-    brand = EmailBranding(colour="#000000", logo="justice-league.png", name="Justice League")
+    brand = EmailBranding(colour="#000000", logo="justice-league.png", name="Justice League", alt_text="Justice League")
     notify_db_session.add(brand)
     notify_db_session.commit()
 
@@ -779,7 +779,7 @@ def test_update_service_remove_letter_branding(client, notify_db_session, sample
 
 
 def test_update_service_remove_email_branding(admin_request, notify_db_session, sample_service):
-    brand = EmailBranding(colour="#000000", logo="justice-league.png", name="Justice League")
+    brand = EmailBranding(colour="#000000", logo="justice-league.png", name="Justice League", alt_text="Justice League")
     sample_service.email_branding = brand
     notify_db_session.commit()
 
@@ -788,8 +788,8 @@ def test_update_service_remove_email_branding(admin_request, notify_db_session, 
 
 
 def test_update_service_change_email_branding(admin_request, notify_db_session, sample_service):
-    brand1 = EmailBranding(colour="#000000", logo="justice-league.png", name="Justice League")
-    brand2 = EmailBranding(colour="#111111", logo="avengers.png", name="Avengers")
+    brand1 = EmailBranding(colour="#000000", logo="justice-league.png", name="Justice League", text="Foo")
+    brand2 = EmailBranding(colour="#111111", logo="avengers.png", name="Avengers", text="Foo")
     notify_db_session.add_all([brand1, brand2])
     sample_service.email_branding = brand1
     notify_db_session.commit()


### PR DESCRIPTION
- [x] https://github.com/alphagov/notifications-admin/pull/4458

Once the above PR goes in, we'll be ready to start using the alt text field.

1. Migrate the old data where `text` is `''` to null, to keep our data consistent.
2. Enforce that exactly one of alt_text and text are set. We only use alt_text if text isn't specified. I don't want us setting alt_text when it won't be used and wondering why it isn't working, for example
3. Catch that constraint being tripped and return a nice error message. (It's unlikely this'll ever be tripped since the frontend will also check for this consistency, but still nice to be clean)
4. Update tests to make sure they're also compliant with the constraint