### PR TITLE
Fully populate letter branding pools

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0387_migrate_alt_text
+0388_populate_letter_branding

--- a/migrations/versions/0388_populate_letter_branding.py
+++ b/migrations/versions/0388_populate_letter_branding.py
@@ -1,0 +1,31 @@
+"""
+
+Revision ID: 0388_populate_letter_branding
+Revises: 0387_migrate_alt_text
+Create Date: 2022-11-24 14:04:41.456302
+
+"""
+from alembic import op
+
+revision = '0388_populate_letter_branding'
+down_revision = '0387_migrate_alt_text'
+
+
+def upgrade():
+    op.execute(
+        """
+        INSERT INTO letter_branding_to_organisation
+        (organisation_id, letter_branding_id)
+        (SELECT organisation_id, letter_branding_id FROM services
+        JOIN service_letter_branding
+        ON services.id = service_id
+        WHERE letter_branding_id IS NOT NULL
+        AND organisation_id IS NOT NULL
+        AND count_as_live = true)
+        ON CONFLICT DO NOTHING;
+        """
+    )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Previous migrations partially populated the letter branding pools by
- adding NHS branding to the pool for NHS organisations
- adding the default brand for each service to the pool

This migration adds every letter branding being used by a service to the pool for that service's organisation. We'll need to manually check the letter branding pool contents after this to remove any brands we don't think should be there.