### PR TITLE
add an endpoint to generate a name for a provided alt text

### DIFF
--- a/app/dao/email_branding_dao.py
+++ b/app/dao/email_branding_dao.py
@@ -3,6 +3,17 @@ from app.dao.dao_utils import autocommit
 from app.models import EmailBranding
 
 
+def dao_get_existing_alternate_email_branding_for_name(name):
+    """
+    Returns any email branding with name of format `{name} (alternate {x})`
+
+    where name is the provided name and x is an integer starting at 1
+    """
+    return (
+        EmailBranding.query.filter(EmailBranding.name.ilike(f"{name} (alternate %)")).order_by(EmailBranding.name).all()
+    )
+
+
 def dao_get_email_branding_options():
     return EmailBranding.query.all()
 
@@ -13,6 +24,10 @@ def dao_get_email_branding_by_id(email_branding_id):
 
 def dao_get_email_branding_by_name(email_branding_name):
     return EmailBranding.query.filter_by(name=email_branding_name).first()
+
+
+def dao_get_email_branding_by_name_case_insensitive(email_branding_name):
+    return EmailBranding.query.filter(EmailBranding.name.ilike(email_branding_name)).all()
 
 
 @autocommit

--- a/app/email_branding/email_branding_schema.py
+++ b/app/email_branding/email_branding_schema.py
@@ -31,3 +31,12 @@ post_update_email_branding_schema = {
     },
     "required": [],
 }
+post_get_email_branding_name_for_alt_text_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "POST schema for getting email_branding",
+    "type": "object",
+    "properties": {
+        "alt_text": {"type": "string"},
+    },
+    "required": ["alt_text"],
+}

--- a/app/email_branding/rest.py
+++ b/app/email_branding/rest.py
@@ -11,6 +11,7 @@ from app.dao.email_branding_dao import (
 )
 from app.email_branding.email_branding_schema import (
     post_create_email_branding_schema,
+    post_get_email_branding_name_for_alt_text_schema,
     post_update_email_branding_schema,
 )
 from app.errors import register_errors
@@ -77,8 +78,14 @@ def update_email_branding(email_branding_id):
     return jsonify(data=fetched_email_branding.serialize()), 200
 
 
-@email_branding_blueprint.route("/get-name-for-alt-text/<alt_text>", methods=["GET"])
-def get_email_branding_name_for_alt_text(alt_text):
+@email_branding_blueprint.route("/get-name-for-alt-text/", methods=["POST"])
+def get_email_branding_name_for_alt_text():
+    data = request.get_json()
+
+    validate(data, post_get_email_branding_name_for_alt_text_schema)
+
+    alt_text = data["alt_text"]
+
     existing_branding = dao_get_email_branding_by_name_case_insensitive(alt_text)
     if not existing_branding:
         chosen_name = alt_text

--- a/app/email_branding/rest.py
+++ b/app/email_branding/rest.py
@@ -4,7 +4,9 @@ from sqlalchemy.exc import IntegrityError
 from app.dao.email_branding_dao import (
     dao_create_email_branding,
     dao_get_email_branding_by_id,
+    dao_get_email_branding_by_name_case_insensitive,
     dao_get_email_branding_options,
+    dao_get_existing_alternate_email_branding_for_name,
     dao_update_email_branding,
 )
 from app.email_branding.email_branding_schema import (
@@ -73,3 +75,24 @@ def update_email_branding(email_branding_id):
     dao_update_email_branding(fetched_email_branding, **data)
 
     return jsonify(data=fetched_email_branding.serialize()), 200
+
+
+@email_branding_blueprint.route("/get-name-for-alt-text/<alt_text>", methods=["GET"])
+def get_email_branding_name_for_alt_text(alt_text):
+    existing_branding = dao_get_email_branding_by_name_case_insensitive(alt_text)
+    if not existing_branding:
+        chosen_name = alt_text
+    else:
+        existing_alternate_branding_options = {
+            x.name for x in dao_get_existing_alternate_email_branding_for_name(alt_text)
+        }
+
+        for i in range(1, 100):
+            potential_name = f"{alt_text} (alternate {i})"
+            if potential_name not in existing_alternate_branding_options:
+                chosen_name = potential_name
+                break
+        else:
+            raise ValueError(f"Couldnt assign a unique name for {alt_text} - already too many options")
+
+    return jsonify(name=chosen_name), 200

--- a/tests/app/dao/test_email_branding_dao.py
+++ b/tests/app/dao/test_email_branding_dao.py
@@ -1,7 +1,9 @@
 from app.dao.email_branding_dao import (
     dao_get_email_branding_by_id,
     dao_get_email_branding_by_name,
+    dao_get_email_branding_by_name_case_insensitive,
     dao_get_email_branding_options,
+    dao_get_existing_alternate_email_branding_for_name,
     dao_update_email_branding,
 )
 from app.models import EmailBranding
@@ -35,6 +37,20 @@ def test_get_email_branding_by_name_gets_correct_email_branding(notify_db_sessio
     assert email_branding_from_db == email_branding
 
 
+def test_get_email_branding_by_name_case_insensitive_gets_correct_email_branding(notify_db_session):
+    title_case = create_email_branding(name="Department Name")
+    upper_case = create_email_branding(name="DEPARTMENT NAME")
+    lower_case = create_email_branding(name="department name")
+    # without a space, doesn't match
+    create_email_branding(name="departmentname")
+
+    brandings = dao_get_email_branding_by_name_case_insensitive("dEpArTmEnT nAmE")
+    assert len(brandings) == 3
+    assert title_case in brandings
+    assert upper_case in brandings
+    assert lower_case in brandings
+
+
 def test_update_email_branding(notify_db_session):
     updated_name = "new name"
     create_email_branding()
@@ -56,3 +72,15 @@ def test_email_branding_has_no_domain(notify_db_session):
     create_email_branding()
     email_branding = EmailBranding.query.all()
     assert not hasattr(email_branding, "domain")
+
+
+def test_dao_get_existing_alternate_email_branding_for_name(notify_db_session):
+    original = create_email_branding(name="Department Name")
+    create_email_branding(name="Department Name (alternate 1)")
+    create_email_branding(name="department name (alternate 2)")
+    create_email_branding(name="Department Name (alternate 40)")
+
+    alt_brandings = dao_get_existing_alternate_email_branding_for_name("dEpArTmEnT nAmE")
+
+    assert len(alt_brandings) == 3
+    assert original not in alt_brandings

--- a/tests/app/email_branding/test_rest.py
+++ b/tests/app/email_branding/test_rest.py
@@ -332,7 +332,9 @@ def test_get_email_branding_name_for_alt_text_returns_alt_text_if_nothing_in_db_
 ):
     create_email_branding(name="Other Department")
 
-    response = admin_request.get("email_branding.get_email_branding_name_for_alt_text", alt_text="Department Name")
+    response = admin_request.post(
+        "email_branding.get_email_branding_name_for_alt_text", _data={"alt_text": "Department Name"}
+    )
     assert response == {"name": "Department Name"}
 
 
@@ -342,7 +344,9 @@ def test_get_email_branding_name_for_alt_text_returns_alternate_option_if_name_a
 ):
     create_email_branding(name="DEPARTMENT name")
 
-    response = admin_request.get("email_branding.get_email_branding_name_for_alt_text", alt_text="Department Name")
+    response = admin_request.post(
+        "email_branding.get_email_branding_name_for_alt_text", _data={"alt_text": "Department Name"}
+    )
     assert response == {"name": "Department Name (alternate 1)"}
 
 
@@ -357,7 +361,9 @@ def test_get_email_branding_name_for_alt_text_returns_first_available_alternate_
     # we've already renamed one of the options
     create_email_branding(name="Department Name (blue banner)")
 
-    response = admin_request.get("email_branding.get_email_branding_name_for_alt_text", alt_text="Department Name")
+    response = admin_request.post(
+        "email_branding.get_email_branding_name_for_alt_text", _data={"alt_text": "Department Name"}
+    )
     assert response == {"name": "Department Name (alternate 3)"}
 
 
@@ -370,5 +376,5 @@ def test_get_email_branding_name_for_alt_text_gives_up_if_100_options_assigned(
         create_email_branding(name=f"Department Name (alternate {x})")
 
     with pytest.raises(ValueError) as exc:
-        admin_request.get("email_branding.get_email_branding_name_for_alt_text", alt_text="Department Name")
+        admin_request.post("email_branding.get_email_branding_name_for_alt_text", _data={"alt_text": "Department Name"})
     assert "Couldnt assign a unique name for Department Name" in str(exc.value)

--- a/tests/app/email_branding/test_rest.py
+++ b/tests/app/email_branding/test_rest.py
@@ -324,3 +324,51 @@ def test_post_update_email_branding_400s_if_not_one_of_alt_text_and_text(
         _expected_status=400,
     )
     assert response["message"] == "Email branding must have exactly one of alt_text and text."
+
+
+def test_get_email_branding_name_for_alt_text_returns_alt_text_if_nothing_in_db_with_that_name(
+    admin_request,
+    notify_db_session,
+):
+    create_email_branding(name="Other Department")
+
+    response = admin_request.get("email_branding.get_email_branding_name_for_alt_text", alt_text="Department Name")
+    assert response == {"name": "Department Name"}
+
+
+def test_get_email_branding_name_for_alt_text_returns_alternate_option_if_name_already_used(
+    admin_request,
+    notify_db_session,
+):
+    create_email_branding(name="DEPARTMENT name")
+
+    response = admin_request.get("email_branding.get_email_branding_name_for_alt_text", alt_text="Department Name")
+    assert response == {"name": "Department Name (alternate 1)"}
+
+
+def test_get_email_branding_name_for_alt_text_returns_first_available_alternate_option(
+    admin_request,
+    notify_db_session,
+):
+    create_email_branding(name="Department Name")
+    create_email_branding(name="Department Name (alternate 1)")
+    create_email_branding(name="Department Name (alternate 2)")
+    create_email_branding(name="Department Name (alternate 4)")
+    # we've already renamed one of the options
+    create_email_branding(name="Department Name (blue banner)")
+
+    response = admin_request.get("email_branding.get_email_branding_name_for_alt_text", alt_text="Department Name")
+    assert response == {"name": "Department Name (alternate 3)"}
+
+
+def test_get_email_branding_name_for_alt_text_gives_up_if_100_options_assigned(
+    admin_request,
+    notify_db_session,
+):
+    create_email_branding(name="Department Name")
+    for x in range(1, 100):
+        create_email_branding(name=f"Department Name (alternate {x})")
+
+    with pytest.raises(ValueError) as exc:
+        admin_request.get("email_branding.get_email_branding_name_for_alt_text", alt_text="Department Name")
+    assert "Couldnt assign a unique name for Department Name" in str(exc.value)


### PR DESCRIPTION
alt text is not unique, it doesn't need to be. however, names should be unique so people can distinguish email branding options in a list of them.

this endpoint takes in a prospective alt_text, and checks the DB. if there's nothing in the DB with that name, it returns the alt text as provided.

If there is, it tries `{name} (alternate 1)`, and goes up by 1 each time. It compares case-insensitive, though always returns a name with the same case as the input alt_text.

If a branding has 100 alternates already, it gives up. We should probably look into what's happening before that.