### PR TITLE
Allow any job in scheduled state to be cancelled

### DIFF
--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -12,10 +12,10 @@ from app.dao.jobs_dao import (
     can_letter_job_be_cancelled,
     dao_cancel_letter_job,
     dao_create_job,
-    dao_get_future_scheduled_job_by_id_and_service_id,
     dao_get_job_by_service_id_and_job_id,
     dao_get_jobs_by_service_id,
     dao_get_notification_outcomes_for_job,
+    dao_get_scheduled_job_by_id_and_service_id,
     dao_get_scheduled_job_stats,
     dao_update_job,
 )
@@ -59,7 +59,7 @@ def get_job_by_service_and_job_id(service_id, job_id):
 
 @job_blueprint.route("/<job_id>/cancel", methods=["POST"])
 def cancel_job(service_id, job_id):
-    job = dao_get_future_scheduled_job_by_id_and_service_id(job_id, service_id)
+    job = dao_get_scheduled_job_by_id_and_service_id(job_id, service_id)
     job.job_status = JOB_STATUS_CANCELLED
     dao_update_job(job)
 

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -10,11 +10,11 @@ from app.dao.jobs_dao import (
     can_letter_job_be_cancelled,
     dao_cancel_letter_job,
     dao_create_job,
-    dao_get_future_scheduled_job_by_id_and_service_id,
     dao_get_job_by_service_id_and_job_id,
     dao_get_jobs_by_service_id,
     dao_get_jobs_older_than_data_retention,
     dao_get_notification_outcomes_for_job,
+    dao_get_scheduled_job_by_id_and_service_id,
     dao_set_scheduled_jobs_to_pending,
     dao_update_job,
     find_jobs_with_missing_rows,
@@ -234,8 +234,14 @@ def test_set_scheduled_jobs_to_pending_updates_rows(sample_template):
     assert jobs[1].job_status == "pending"
 
 
-def test_get_future_scheduled_job_gets_a_job_yet_to_send(sample_scheduled_job):
-    result = dao_get_future_scheduled_job_by_id_and_service_id(sample_scheduled_job.id, sample_scheduled_job.service_id)
+def test_get_scheduled_job_gets_a_job_yet_to_send(sample_scheduled_job):
+    result = dao_get_scheduled_job_by_id_and_service_id(sample_scheduled_job.id, sample_scheduled_job.service_id)
+    assert result.id == sample_scheduled_job.id
+
+
+def test_get_scheduled_job_gets_a_job_yet_to_send_even_if_scheduled_to_send_in_the_past(sample_scheduled_job):
+    sample_scheduled_job.scheduled_for = datetime.now() - timedelta(hours=1)
+    result = dao_get_scheduled_job_by_id_and_service_id(sample_scheduled_job.id, sample_scheduled_job.service_id)
     assert result.id == sample_scheduled_job.id
 
 


### PR DESCRIPTION
The function used to find a job to cancel checks two things:

1) That it's in the SCHEDULED state
2) That it's scheduled for the future.

This means that a job which is scheduled to send, but past the scheduled
time, cannot be cancelled. But there are cases where users may want to
cancel these jobs still. We know that a job hasn't started processing if
the state is SCHEDULED, so it should still be safe to cancel even if the
ideal processing start time has passed. Let's remove the check on
scheduled_for and only require that a job's state is SCHEDULED to
determine if it's cancellable.
