### PR TITLE
Stop excluding migrations for formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ generate-version-file: ## Generates the app version file
 test: ## Run tests
 	flake8 .
 	isort --check-only ./app ./tests
-	black --check --extend-exclude migrations .
+	black --check .
 	pytest -n4 --maxfail=10
 
 .PHONY: freeze-requirements

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,9 +1,9 @@
 from logging.config import fileConfig
+from pathlib import Path
 
 from alembic import context
+from flask import current_app
 from sqlalchemy import engine_from_config, pool
-
-from pathlib import Path
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -17,7 +17,6 @@ fileConfig(config.config_file_name)
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-from flask import current_app
 
 config.set_main_option("sqlalchemy.url", current_app.config.get("SQLALCHEMY_DATABASE_URI"))
 target_metadata = current_app.extensions["migrate"].db.metadata
@@ -66,7 +65,7 @@ def run_migrations_online():
             context.run_migrations()
 
         # if we're running on the main db (as opposed to the test db)
-        if engine.url.database == 'notification_api':
+        if engine.url.database == "notification_api":
             with open(Path(__file__).parent / ".current-alembic-head", "w") as f:
                 # write the current head to `.current-alembic-head`. This will prevent conflicting migrations
                 # being merged at the same time and breaking the build.

--- a/migrations/versions/0381_letter_branding_to_org.py
+++ b/migrations/versions/0381_letter_branding_to_org.py
@@ -5,24 +5,30 @@ Revises: 0380_email_branding_cols
 Create Date: 2022-10-21 14:26:12.421574
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision = '0381_letter_branding_to_org'
-down_revision = '0380_email_branding_cols'
+revision = "0381_letter_branding_to_org"
+down_revision = "0380_email_branding_cols"
 
 
 def upgrade():
     op.create_table(
-        'letter_branding_to_organisation',
-        sa.Column('organisation_id', postgresql.UUID(as_uuid=True), nullable=False),
-        sa.Column('letter_branding_id', postgresql.UUID(as_uuid=True), nullable=False),
-        sa.ForeignKeyConstraint(['letter_branding_id'], ['letter_branding.id'], ),
-        sa.ForeignKeyConstraint(['organisation_id'], ['organisation.id'], ),
-        sa.PrimaryKeyConstraint('organisation_id', 'letter_branding_id')
+        "letter_branding_to_organisation",
+        sa.Column("organisation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("letter_branding_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["letter_branding_id"],
+            ["letter_branding.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["organisation_id"],
+            ["organisation.id"],
+        ),
+        sa.PrimaryKeyConstraint("organisation_id", "letter_branding_id"),
     )
 
 
 def downgrade():
-    op.drop_table('letter_branding_to_organisation')
+    op.drop_table("letter_branding_to_organisation")

--- a/migrations/versions/0382_nhs_letter_branding_id.py
+++ b/migrations/versions/0382_nhs_letter_branding_id.py
@@ -9,8 +9,8 @@ import os
 
 from alembic import op
 
-revision = '0382_nhs_letter_branding_id'
-down_revision = '0381_letter_branding_to_org'
+revision = "0382_nhs_letter_branding_id"
+down_revision = "0381_letter_branding_to_org"
 
 environment = os.environ["NOTIFY_ENVIRONMENT"]
 

--- a/migrations/versions/0383_webauthn_cred_logged_in_at.py
+++ b/migrations/versions/0383_webauthn_cred_logged_in_at.py
@@ -5,12 +5,11 @@ Revises: 0382_nhs_letter_branding_id
 Create Date: 2022-10-21 14:26:12.421574
 
 """
-from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
+from alembic import op
 
-revision = '0383_webauthn_cred_logged_in_at'
-down_revision = '0382_nhs_letter_branding_id'
+revision = "0383_webauthn_cred_logged_in_at"
+down_revision = "0382_nhs_letter_branding_id"
 
 
 def upgrade():

--- a/migrations/versions/0384_add_nhs_to_letter_pools.py
+++ b/migrations/versions/0384_add_nhs_to_letter_pools.py
@@ -7,20 +7,20 @@ Create Date: 2022-11-17 13:59:56.978865
 """
 from alembic import op
 
-revision = '0384_add_nhs_to_letter_pools'
-down_revision = '0383_webauthn_cred_logged_in_at'
+revision = "0384_add_nhs_to_letter_pools"
+down_revision = "0383_webauthn_cred_logged_in_at"
 
 
 def upgrade():
     op.execute(
-            """
+        """
             INSERT INTO letter_branding_to_organisation
             (organisation_id, letter_branding_id)
             (SELECT id , '2cd354bb-6b85-eda3-c0ad-6b613150459f'
             FROM organisation WHERE organisation_type IN ('nhs_central', 'nhs_local', 'nhs_gp'))
             ON CONFLICT DO NOTHING;
             """
-        )
+    )
 
 
 def downgrade():

--- a/migrations/versions/0385_letter_branding_pools.py
+++ b/migrations/versions/0385_letter_branding_pools.py
@@ -7,19 +7,19 @@ Create Date: 2022-11-18 11:46:27.954516
 """
 from alembic import op
 
-revision = '0385_letter_branding_pools'
-down_revision = '0384_add_nhs_to_letter_pools'
+revision = "0385_letter_branding_pools"
+down_revision = "0384_add_nhs_to_letter_pools"
 
 
 def upgrade():
     op.execute(
-            """
+        """
             INSERT INTO letter_branding_to_organisation
             (organisation_id, letter_branding_id)
             (SELECT id, letter_branding_id FROM organisation WHERE letter_branding_id IS NOT NULL)
             ON CONFLICT DO NOTHING;
             """
-        )
+    )
 
 
 def downgrade():

--- a/migrations/versions/0386_email_branding_alt_text.py
+++ b/migrations/versions/0386_email_branding_alt_text.py
@@ -5,12 +5,11 @@ Revises: 0385_letter_branding_pools
 Create Date: 2022-10-21 14:26:12.421574
 
 """
-from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
+from alembic import op
 
-revision = '0386_email_branding_alt_text'
-down_revision = '0385_letter_branding_pools'
+revision = "0386_email_branding_alt_text"
+down_revision = "0385_letter_branding_pools"
 
 
 def upgrade():

--- a/migrations/versions/0388_populate_letter_branding.py
+++ b/migrations/versions/0388_populate_letter_branding.py
@@ -7,8 +7,8 @@ Create Date: 2022-11-24 14:04:41.456302
 """
 from alembic import op
 
-revision = '0388_populate_letter_branding'
-down_revision = '0387_migrate_alt_text'
+revision = "0388_populate_letter_branding"
+down_revision = "0387_migrate_alt_text"
 
 
 def upgrade():


### PR DESCRIPTION
99% of our migrations were reformatted for black but we are excluded the check on that directory. Let's not do that, and fix the few migrations that have gone in with iffy formatting since.