### PR TITLE
Weekly report on low free inbound sms numbers

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -433,6 +433,10 @@ def zendesk_new_email_branding_report():
 @notify_celery.task(name="check-for-low-available-inbound-sms-numbers")
 @cronitor("check-for-low-available-inbound-sms-numbers")
 def check_for_low_available_inbound_sms_numbers():
+    if (env := current_app.config["NOTIFY_ENVIRONMENT"].lower()) not in {"live", "production", "test"}:
+        current_app.logger.info(f"Skipping report run on in {env}")
+        return
+
     num_available_inbound_numbers = len(dao_get_available_inbound_numbers())
     current_app.logger.info(f"There are {num_available_inbound_numbers} available inbound SMS numbers.")
     if num_available_inbound_numbers > current_app.config["LOW_INBOUND_SMS_NUMBER_THRESHOLD"]:

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -21,6 +21,7 @@ from app.celery.tasks import (
 )
 from app.config import QueueNames, TaskNames
 from app.cronitor import cronitor
+from app.dao.inbound_numbers_dao import dao_get_available_inbound_numbers
 from app.dao.invited_org_user_dao import (
     delete_org_invitations_created_more_than_two_days_ago,
 )
@@ -425,5 +426,30 @@ def zendesk_new_email_branding_report():
         technical_ticket=False,
         ticket_categories=["notify_no_ticket_category"],
         message_as_html=True,
+    )
+    zendesk_client.send_ticket_to_zendesk(ticket)
+
+
+@notify_celery.task(name="check-for-low-available-inbound-sms-numbers")
+@cronitor("check-for-low-available-inbound-sms-numbers")
+def check_for_low_available_inbound_sms_numbers():
+    num_available_inbound_numbers = len(dao_get_available_inbound_numbers())
+    current_app.logger.info(f"There are {num_available_inbound_numbers} available inbound SMS numbers.")
+    if num_available_inbound_numbers > current_app.config["LOW_INBOUND_SMS_NUMBER_THRESHOLD"]:
+        return
+
+    message = (
+        f"There are only {num_available_inbound_numbers} inbound SMS numbers currently available for services.\n\n"
+        "Request more from our provider (MMG) and load them into the database.\n\n"
+        "Follow the guidance here: "
+        "https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#Add-new-inbound-SMS-numbers"
+    )
+
+    ticket = NotifySupportTicket(
+        subject="Request more inbound SMS numbers",
+        message=message,
+        ticket_type=NotifySupportTicket.TYPE_TASK,
+        technical_ticket=True,
+        ticket_categories=["notify_no_ticket_category"],
     )
     zendesk_client.send_ticket_to_zendesk(ticket)

--- a/app/config.py
+++ b/app/config.py
@@ -342,6 +342,11 @@ class Config(object):
                 "schedule": crontab(hour=0, minute=30, day_of_week="mon-fri"),
                 "options": {"queue": QueueNames.PERIODIC},
             },
+            "check-for-low-available-inbound-sms-numbers": {
+                "task": "check-for-low-available-inbound-sms-numbers",
+                "schedule": crontab(hour=9, minute=0, day_of_week="mon"),
+                "options": {"queue": QueueNames.PERIODIC},
+            },
         },
     }
 
@@ -371,6 +376,7 @@ class Config(object):
     FIRETEXT_INBOUND_SMS_AUTH = json.loads(os.environ.get("FIRETEXT_INBOUND_SMS_AUTH", "[]"))
     MMG_INBOUND_SMS_AUTH = json.loads(os.environ.get("MMG_INBOUND_SMS_AUTH", "[]"))
     MMG_INBOUND_SMS_USERNAME = json.loads(os.environ.get("MMG_INBOUND_SMS_USERNAME", "[]"))
+    LOW_INBOUND_SMS_NUMBER_THRESHOLD = 50
     ROUTE_SECRET_KEY_1 = os.environ.get("ROUTE_SECRET_KEY_1", "")
     ROUTE_SECRET_KEY_2 = os.environ.get("ROUTE_SECRET_KEY_2", "")
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -13,6 +13,7 @@ from notifications_utils.clients.zendesk.zendesk_client import (
 from app.celery import scheduled_tasks
 from app.celery.scheduled_tasks import (
     auto_expire_broadcast_messages,
+    check_for_low_available_inbound_sms_numbers,
     check_for_missing_rows_in_completed_jobs,
     check_for_services_with_high_failure_rates_or_sending_to_tv_numbers,
     check_if_letters_still_in_created,
@@ -40,6 +41,7 @@ from app.models import (
     NOTIFICATION_PENDING_VIRUS_CHECK,
     BroadcastStatusType,
     Event,
+    InboundNumber,
 )
 from tests.app import load_example_csv
 from tests.app.db import (
@@ -895,4 +897,50 @@ def test_zendesk_new_email_branding_report_calculates_last_weekday_correctly(
 def test_zendesk_new_email_branding_report_does_not_create_ticket_if_no_new_brands(notify_db_session, mocker):
     mock_send_ticket = mocker.patch("app.celery.scheduled_tasks.zendesk_client.send_ticket_to_zendesk")
     zendesk_new_email_branding_report()
+    assert mock_send_ticket.call_args_list == []
+
+
+def test_check_for_low_available_inbound_sms_numbers_logs_zendesk_ticket_if_too_few_numbers(
+    notify_api, notify_db_session, mocker
+):
+    mocker.patch(
+        "app.celery.scheduled_tasks.dao_get_available_inbound_numbers",
+        return_value=[InboundNumber() for _ in range(5)],
+    )
+    mock_ticket = mocker.patch("app.celery.scheduled_tasks.NotifySupportTicket")
+    mock_send_ticket = mocker.patch("app.celery.scheduled_tasks.zendesk_client.send_ticket_to_zendesk")
+
+    with set_config(notify_api, "LOW_INBOUND_SMS_NUMBER_THRESHOLD", 10):
+        check_for_low_available_inbound_sms_numbers()
+
+    # Make sure we've built a NotifySupportTicket with the expected params, and passed that ticket to the zendesk client
+    assert mock_ticket.call_args_list == [
+        mocker.call(
+            subject="Request more inbound SMS numbers",
+            message=(
+                "There are only 5 inbound SMS numbers currently available for services.\n\n"
+                "Request more from our provider (MMG) and load them into the database.\n\n"
+                "Follow the guidance here: "
+                "https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#Add-new-inbound-SMS-numbers"
+            ),
+            ticket_type=mock_ticket.TYPE_TASK,
+            technical_ticket=True,
+            ticket_categories=["notify_no_ticket_category"],
+        )
+    ]
+    assert mock_send_ticket.call_args_list == [mocker.call(mock_ticket.return_value)]
+
+
+def test_check_for_low_available_inbound_sms_numbers_does_not_proceed_if_enough_numbers(
+    notify_api, notify_db_session, mocker
+):
+    mocker.patch(
+        "app.celery.scheduled_tasks.dao_get_available_inbound_numbers",
+        return_value=[InboundNumber() for _ in range(11)],
+    )
+    mock_send_ticket = mocker.patch("app.celery.scheduled_tasks.zendesk_client.send_ticket_to_zendesk")
+
+    with set_config(notify_api, "LOW_INBOUND_SMS_NUMBER_THRESHOLD", 10):
+        check_for_low_available_inbound_sms_numbers()
+
     assert mock_send_ticket.call_args_list == []


### PR DESCRIPTION
We're rolling out some changes soon to allow services to enable inbound
SMS by themselves. At the moment they have to contact support and we'll
manually give them a number, which means we are constantly aware of how
many numbers we have left and can spot when we might need more.

If users can take from the pool themselves, without any oversight, we
need some monitoring in place to alert us automatically that we need to
ask for more numbers.

We don't know how quickly numbers will get used, but expect that a
weekly report should be fine, and that 50 numbers are unlikely to be
used up within the (roughly) week that it takes for new numbers to be
given to us.


Related credentials PR: https://github.com/alphagov/notifications-credentials/pull/306