### PR TITLE
don't send daily branding review on other envs (and refactor how we access config)

### DIFF
--- a/app/broadcast_message/utils.py
+++ b/app/broadcast_message/utils.py
@@ -64,7 +64,7 @@ def _validate_broadcast_update(broadcast_message, new_status, updating_user):
 
 
 def _create_p1_zendesk_alert(broadcast_message):
-    if current_app.config["NOTIFY_ENVIRONMENT"] != "live":
+    if not current_app.is_prod:
         return
 
     if broadcast_message.status != BroadcastStatusType.BROADCASTING:

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -196,8 +196,8 @@ def raise_alert_if_letter_notifications_still_sending():
         message = "There are {} letters in the 'sending' state from {}".format(
             still_sending_count, sent_date.strftime("%A %d %B")
         )
-        # Only send alerts in production
-        if current_app.config["NOTIFY_ENVIRONMENT"] in ["live", "production", "test"]:
+
+        if current_app.should_send_zendesk_alerts:
             message += ". Resolve using https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#deal-with-letters-still-in-sending"  # noqa
 
             ticket = NotifySupportTicket(
@@ -278,7 +278,7 @@ def letter_raise_alert_if_no_ack_file_for_zip():
     zip_file_set.discard("")
 
     if len(zip_file_set - ack_file_set) > 0:
-        if current_app.config["NOTIFY_ENVIRONMENT"] in ["live", "production", "test"]:
+        if current_app.should_send_zendesk_alerts:
             ticket = NotifySupportTicket(
                 subject="Letter acknowledge error",
                 message=message,

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -419,15 +419,16 @@ def zendesk_new_email_branding_report():
         brands_with_no_organisation=brands_with_no_organisation,
     )
 
-    ticket = NotifySupportTicket(
-        subject="Review new email brandings",
-        message=message,
-        ticket_type=NotifySupportTicket.TYPE_TASK,
-        technical_ticket=False,
-        ticket_categories=["notify_no_ticket_category"],
-        message_as_html=True,
-    )
-    zendesk_client.send_ticket_to_zendesk(ticket)
+    if current_app.config["NOTIFY_ENVIRONMENT"] in ["live", "production", "test"]:
+        ticket = NotifySupportTicket(
+            subject="Review new email brandings",
+            message=message,
+            ticket_type=NotifySupportTicket.TYPE_TASK,
+            technical_ticket=False,
+            ticket_categories=["notify_no_ticket_category"],
+            message_as_html=True,
+        )
+        zendesk_client.send_ticket_to_zendesk(ticket)
 
 
 @notify_celery.task(name="check-for-low-available-inbound-sms-numbers")

--- a/app/notify_api_flask_app.py
+++ b/app/notify_api_flask_app.py
@@ -1,0 +1,15 @@
+from flask import Flask
+
+
+class NotifyApiFlaskApp(Flask):
+    @property
+    def is_prod(self):
+        return self.config["NOTIFY_ENVIRONMENT"] in {"live", "production"}
+
+    @property
+    def is_test(self):
+        return self.config["NOTIFY_ENVIRONMENT"] == "test"
+
+    @property
+    def should_send_zendesk_alerts(self):
+        return self.is_test or self.is_prod

--- a/application.py
+++ b/application.py
@@ -1,10 +1,9 @@
 ##!/usr/bin/env python
 from __future__ import print_function
 
-from flask import Flask
-
 from app import create_app
+from app.notify_api_flask_app import NotifyApiFlaskApp
 
-application = Flask("app")
+application = NotifyApiFlaskApp("app")
 
 create_app(application)

--- a/run_celery.py
+++ b/run_celery.py
@@ -4,11 +4,11 @@
 # that will never be read from (since we don't have prometheus celery stats). If prometheus is imported first,
 # prometheus will simply store the metrics in memory
 import prometheus_client  # noqa
-from flask import Flask
 
 # notify_celery is referenced from manifest_delivery_base.yml, and cannot be removed
 from app import create_app, notify_celery  # noqa
+from app.notify_api_flask_app import NotifyApiFlaskApp
 
-application = Flask("delivery")
+application = NotifyApiFlaskApp("delivery")
 create_app(application)
 application.app_context().push()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,15 +5,15 @@ import pytest
 import sqlalchemy
 from alembic.command import upgrade
 from alembic.config import Config
-from flask import Flask
 
 from app import create_app, db
 from app.dao.provider_details_dao import get_provider_details_by_identifier
+from app.notify_api_flask_app import NotifyApiFlaskApp
 
 
 @pytest.fixture(scope="session")
 def notify_api():
-    app = Flask("test")
+    app = NotifyApiFlaskApp("test")
     create_app(app)
 
     # deattach server-error error handlers - error_handler_spec looks like:


### PR DESCRIPTION
Add the env check to the daily branding review to ensure we don't send it from local/from staging/etc. We already do this check in a bunch of places as seen in the other commits.
--------
I was fed up of us having sketchy config checks everywhere. `current_app` returns the flask app, so create a subclass of `Flask` that has a few helper methods to reduce calls to the config directly for checks like this. Over time we can add more checks elsewhere if we want to.
