### PR TITLE
Run tests on recommended number of CPU cores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ test: ## Run tests
 	flake8 .
 	isort --check-only ./app ./tests
 	black --check .
-	pytest -n4 --maxfail=10
+	pytest -n auto --maxfail=10
 
 .PHONY: freeze-requirements
 freeze-requirements: ## Pin all requirements including sub dependencies into requirements.txt


### PR DESCRIPTION
At the moment we parallelize the tests across 4 cores.

On some machines more cores are available, so using them makes the tests run faster.

pytest-xdist will automatically pick the best number of CPU cores when passed `auto` as the value for the `-n` flag<sup>1</sup>.

This matches what we do in the admin repo:
https://github.com/alphagov/notifications-admin/blob/46b2415fd2a96af4a6503d22f4bad80eaf496f98/Makefile#L67

***

# Before<sup>2</sup> 

<img width="636" alt="image" src="https://user-images.githubusercontent.com/355079/204801983-ddba477c-abb7-4619-82f1-ce6e1304e824.png">

# After<sup>2</sup>

<img width="638" alt="image" src="https://user-images.githubusercontent.com/355079/204802030-bb9ccebb-7b7d-42f0-ab3a-c044b83d46cf.png">


***

1. https://pytest-xdist.readthedocs.io/en/latest/distribution.html
2. Run on a 16 inch Macbook Pro with an Apple M1 Pro chip