### PR TITLE
Add a GitHub Action check to block fixup commits

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,12 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu
+
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
It can be useful/easy to use fixup commits to make changes to a PR based on review comments. They make it easy for a reviewer to see and only re-review what's changed since they last commented, but we don't want them to be merged to main.

This GitHub action will add a status check to the PR that can block merge if any fixup commits are present, forcing the dev to squash them down sensibly to ensure a cleaner git history. It feels easier than adding a concourse check...

At the moment we have GitHub actions fully disabled. We'd need to enable them, but we can do so in a restrictive manner - i.e. only enabling this github action (see below). The code behind this check is fairly simple and available for review here: https://github.com/13rac1/block-fixup-merge-action/blob/v2.0.0/entrypoint.sh. We pin a specific version of the action so won't eg be exposed to someone injecting a vulnerability in a new version.

<img width="834" alt="image" src="https://user-images.githubusercontent.com/2920760/204822203-88983c08-f367-4395-b9d9-02d32170fe0a.png">