### PR TITLE
Rename live to prod

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -531,9 +531,9 @@ class Staging(Config):
     CHECK_PROXY_HEADER = True
 
 
-class Live(Config):
+class Production(Config):
     NOTIFY_EMAIL_DOMAIN = "notifications.service.gov.uk"
-    NOTIFY_ENVIRONMENT = "live"
+    NOTIFY_ENVIRONMENT = "production"
     CSV_UPLOAD_BUCKET_NAME = "live-notifications-csv-upload"
     CONTACT_LIST_BUCKET_NAME = "production-contact-list"
     TEST_LETTERS_BUCKET_NAME = "production-test-letters"
@@ -573,8 +573,7 @@ class Sandbox(CloudFoundryConfig):
 configs = {
     "development": Development,
     "test": Test,
-    "live": Live,
-    "production": Live,
+    "production": Production,
     "staging": Staging,
     "preview": Preview,
     "sandbox": Sandbox,

--- a/app/notify_api_flask_app.py
+++ b/app/notify_api_flask_app.py
@@ -4,7 +4,7 @@ from flask import Flask
 class NotifyApiFlaskApp(Flask):
     @property
     def is_prod(self):
-        return self.config["NOTIFY_ENVIRONMENT"] in {"live", "production"}
+        return self.config["NOTIFY_ENVIRONMENT"] == "production"
 
     @property
     def is_test(self):

--- a/tests/app/broadcast_message/test_utils.py
+++ b/tests/app/broadcast_message/test_utils.py
@@ -335,7 +335,7 @@ def test_update_broadcast_message_status_creates_zendesk_ticket(mocker, notify_a
         autospec=True,
     )
 
-    with set_config(notify_api, "NOTIFY_ENVIRONMENT", "live"):
+    with set_config(notify_api, "NOTIFY_ENVIRONMENT", "production"):
         update_broadcast_message_status(broadcast_message, BroadcastStatusType.BROADCASTING, approver)
 
     mock_send_ticket_to_zendesk.assert_called_once()
@@ -354,7 +354,7 @@ def test_create_p1_zendesk_alert(sample_broadcast_service, mocker, notify_api):
         autospec=True,
     )
 
-    with set_config(notify_api, "NOTIFY_ENVIRONMENT", "live"):
+    with set_config(notify_api, "NOTIFY_ENVIRONMENT", "production"):
         _create_p1_zendesk_alert(broadcast_message)
 
     ticket = mock_send_ticket_to_zendesk.call_args_list[0].args[0]
@@ -378,7 +378,7 @@ def test_create_p1_zendesk_alert_doesnt_alert_when_cancelling(mocker, notify_api
         autospec=True,
     )
 
-    with set_config(notify_api, "NOTIFY_ENVIRONMENT", "live"):
+    with set_config(notify_api, "NOTIFY_ENVIRONMENT", "production"):
         _create_p1_zendesk_alert(broadcast_message)
 
     mock_send_ticket_to_zendesk.assert_not_called()
@@ -417,7 +417,7 @@ def test_create_p1_zendesk_alert_doesnt_alert_for_stubbed_messages(mocker, notif
         autospec=True,
     )
 
-    with set_config(notify_api, "NOTIFY_ENVIRONMENT", "live"):
+    with set_config(notify_api, "NOTIFY_ENVIRONMENT", "production"):
         _create_p1_zendesk_alert(broadcast_message)
 
     mock_send_ticket_to_zendesk.assert_not_called()

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1232,7 +1232,7 @@ def test_save_sms_uses_non_default_sms_sender_reply_to_text_if_provided(mocker, 
     assert persisted_notification.reply_to_text == "new-sender"
 
 
-@pytest.mark.parametrize("env", ["staging", "live"])
+@pytest.mark.parametrize("env", ["staging", "production"])
 def test_save_letter_sets_delivered_letters_as_pdf_permission_in_research_mode_in_staging_live(
     notify_api, mocker, notify_db_session, sample_letter_job, env
 ):

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -228,13 +228,7 @@ def test_post_letter_notification_throws_error_for_bad_address(
     assert error_json["errors"] == [{"error": "ValidationError", "message": expected_error}]
 
 
-@pytest.mark.parametrize(
-    "env",
-    [
-        "staging",
-        "live",
-    ],
-)
+@pytest.mark.parametrize("env", ["staging", "production"])
 def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_delivered(
     notify_api, api_client_request, sample_letter_template, mocker, env
 ):


### PR DESCRIPTION
#### ["Calling `production` `live` is a remain of an old time that still makes our lives difficult today." - Sakis, Apr 2022](https://github.com/alphagov/notifications-cf-monitoring/commit/70264883f56e99acca9cc055bd2276a86efd70b6)

Confusingly, the OS environment variable `NOTIFY_ENVIRONMENT` is set to equal the paas space, so is `production`, however we then set `current_app.config["NOTIFY_ENVIRONMENT"]` to equal `live`. This has led to lots of confusion, as seen in all the places in code where we're checking if the environment is one of those two values. Not even we are certain which environment we're on!

This PR fixes that by renaming that variable to "production" and ensuring that wherever it is used we refer to `production` instead of `live`.

Note, the variable goes in to our statsd mappings as the `space` value. Then, our prometheus config replaces `live` with `production`.

Note, there's two other notable places that still talk about "live" with regards to the environment:

1. The celery queues. Migrating celery queues in a zero downtime way would be non-trivial, so lets not poke that beast right now.
2. The `live-notifications-csv-upload` bucket. All the other buckets are prefixed with `production`.

--------