### PR TITLE
flask_env is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ export FIRETEXT_API_KEY='FIRETEXT_ACTUAL_KEY'
 export NOTIFICATION_QUEUE_PREFIX='YOUR_OWN_PREFIX'
 
 export FLASK_APP=application.py
-export FLASK_ENV=development
+export FLASK_DEBUG=1
 export WERKZEUG_DEBUG_PIN=off
 "> environment.sh
 ```


### PR DESCRIPTION
FLASK_DEBUG=1 is the proper way to have the debug stack trace screen appear

(this is a very underwhelming code change - the key thing is I also renamed the environment variable in my `environment.sh`)