### PR TITLE
Add new endpoint for adding inbound number to a service

### DIFF
--- a/app/inbound_number/inbound_number_schema.py
+++ b/app/inbound_number/inbound_number_schema.py
@@ -1,0 +1,9 @@
+from app.schema_validation.definitions import uuid
+
+add_inbound_number_to_service_request = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "POST add service inbound number",
+    "type": "object",
+    "title": "Assign inbound number to service",
+    "properties": {"inbound_number_id": uuid},
+}

--- a/app/inbound_number/rest.py
+++ b/app/inbound_number/rest.py
@@ -1,12 +1,22 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 
 from app.dao.inbound_numbers_dao import (
+    dao_allocate_number_for_service,
     dao_get_available_inbound_numbers,
     dao_get_inbound_number_for_service,
     dao_get_inbound_numbers,
     dao_set_inbound_number_active_flag,
 )
+from app.dao.service_sms_sender_dao import (
+    dao_add_sms_sender_for_service,
+    dao_get_sms_senders_by_service_id,
+    update_existing_sms_sender_with_inbound_number,
+)
 from app.errors import register_errors
+from app.inbound_number.inbound_number_schema import (
+    add_inbound_number_to_service_request,
+)
+from app.schema_validation import validate
 
 inbound_number_blueprint = Blueprint("inbound_number", __name__, url_prefix="/inbound-number")
 register_errors(inbound_number_blueprint)
@@ -37,3 +47,40 @@ def get_available_inbound_numbers():
     inbound_numbers = [i.serialize() for i in dao_get_available_inbound_numbers()]
 
     return jsonify(data=inbound_numbers if inbound_numbers else [])
+
+
+@inbound_number_blueprint.route("/service/<uuid:service_id>", methods=["POST"])
+def add_inbound_number_to_service(service_id):
+    """
+    Route to add an inbound number to a service. If inbound_number_id is provided we
+    add that specific number, otherwise we add a random available number.
+    """
+    form = validate(request.get_json(), add_inbound_number_to_service_request)
+
+    if form.get("inbound_number_id"):
+        inbound_number_id = form["inbound_number_id"]
+    else:
+        try:
+            available_number = dao_get_available_inbound_numbers()[0]
+            inbound_number_id = available_number.id
+        except IndexError:
+            raise Exception("There are no available inbound numbers")
+
+    new_inbound_number = dao_allocate_number_for_service(service_id=service_id, inbound_number_id=inbound_number_id)
+
+    existing_sms_sender = dao_get_sms_senders_by_service_id(service_id)
+    if len(existing_sms_sender) == 1:
+        new_sms_sender = update_existing_sms_sender_with_inbound_number(
+            service_sms_sender=existing_sms_sender[0],
+            sms_sender=new_inbound_number.number,
+            inbound_number_id=new_inbound_number.id,
+        )
+    else:
+        new_sms_sender = dao_add_sms_sender_for_service(
+            service_id=service_id,
+            sms_sender=new_inbound_number.number,
+            is_default=True,
+            inbound_number_id=new_inbound_number.id,
+        )
+
+    return jsonify(new_sms_sender.serialize()), 201

--- a/tests/app/inbound_number/test_rest.py
+++ b/tests/app/inbound_number/test_rest.py
@@ -1,8 +1,17 @@
-from app.dao.inbound_numbers_dao import dao_get_inbound_number_for_service
+import pytest
+
+from app.dao.inbound_numbers_dao import (
+    dao_get_available_inbound_numbers,
+    dao_get_inbound_number_for_service,
+)
+from app.dao.service_sms_sender_dao import (
+    dao_add_sms_sender_for_service,
+    dao_get_sms_senders_by_service_id,
+)
 from tests.app.db import create_inbound_number, create_service
 
 
-def test_rest_get_inbound_numbers_when_none_set_returns_empty_list(admin_request):
+def test_rest_get_inbound_numbers_when_none_set_returns_empty_list(admin_request, notify_db_session):
     result = admin_request.get("inbound_number.get_inbound_numbers")
 
     assert result["data"] == []
@@ -15,7 +24,7 @@ def test_rest_get_inbound_numbers(admin_request, sample_inbound_numbers):
     assert result["data"] == [i.serialize() for i in sample_inbound_numbers]
 
 
-def test_rest_get_inbound_number(admin_request, notify_db_session, sample_service):
+def test_rest_get_inbound_number(admin_request, sample_service):
     inbound_number = create_inbound_number(number="1", provider="mmg", active=False, service_id=sample_service.id)
 
     result = admin_request.get("inbound_number.get_inbound_number_for_service", service_id=sample_service.id)
@@ -50,3 +59,73 @@ def test_get_available_inbound_numbers(admin_request, sample_inbound_numbers):
 
     assert len(result["data"]) == 1
     assert result["data"] == [i.serialize() for i in sample_inbound_numbers if i.service_id is None]
+
+
+@pytest.mark.parametrize("inbound_number_provided", [True, False])
+def test_add_inbound_number_to_service_when_service_has_one_sms_sender(
+    admin_request,
+    sample_inbound_numbers,
+    inbound_number_provided,
+):
+    service = create_service(service_name="new service")
+    # There is one inbound number which is free to be assigned
+    available_inbound_number = dao_get_available_inbound_numbers()[0]
+
+    data = {"inbound_number_id": str(available_inbound_number.id)} if inbound_number_provided else {}
+
+    admin_request.post(
+        "inbound_number.add_inbound_number_to_service",
+        service_id=service.id,
+        _data=data,
+        _expected_status=201,
+    )
+
+    assert service.inbound_number == available_inbound_number
+
+    sms_senders = dao_get_sms_senders_by_service_id(service.id)
+    assert len(sms_senders) == 1
+    assert sms_senders[0].inbound_number == available_inbound_number
+
+
+@pytest.mark.parametrize("inbound_number_provided", [True, False])
+def test_add_inbound_number_to_service_when_service_has_multiple_senders(
+    admin_request,
+    sample_inbound_numbers,
+    inbound_number_provided,
+):
+    service = create_service(service_name="new service")
+    dao_add_sms_sender_for_service(service.id, "sender two", is_default=True)
+
+    # There is one inbound number which is free to be assigned
+    available_inbound_number = dao_get_available_inbound_numbers()[0]
+
+    data = {"inbound_number_id": str(available_inbound_number.id)} if inbound_number_provided else {}
+
+    admin_request.post(
+        "inbound_number.add_inbound_number_to_service",
+        service_id=service.id,
+        _data=data,
+        _expected_status=201,
+    )
+
+    assert service.inbound_number == available_inbound_number
+
+    sms_senders = dao_get_sms_senders_by_service_id(service.id)
+    assert len(sms_senders) == 3
+
+    default_sender = [sender for sender in sms_senders if sender.is_default][0]
+    assert default_sender.inbound_number == available_inbound_number
+
+
+def test_add_inbound_number_to_service_when_no_number_is_provided_and_no_numbers_are_available(
+    admin_request,
+    sample_service,
+):
+    with pytest.raises(Exception) as exc:
+        admin_request.post(
+            "inbound_number.add_inbound_number_to_service",
+            service_id=sample_service.id,
+            _data={},
+            _expected_status=500,
+        )
+    assert str(exc.value) == "There are no available inbound numbers"


### PR DESCRIPTION
We already have an endpoint to add an inbound number to a service - `.add_service_sms_sender` is used for both adding new sms senders and adding a particular inbound number to a service. We want to be able to add an inbound number to a service without specifying the exact number to add. This adds a new endpoint which handles adding any inbound number and a particular inbound number to the service.

`.add_service_sms_sender` will be changed later so that it doesn't deal with inbound numbers but only deals with adding sms senders.