### PR TITLE
Optimise the queries powering the org dashboard page

### DIFF
--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -8,7 +8,7 @@ from app.config import QueueNames
 from app.cronitor import cronitor
 from app.dao.fact_billing_dao import (
     fetch_billing_data_for_day,
-    update_fact_billing,
+    update_ft_billing,
 )
 from app.dao.fact_notification_status_dao import update_fact_notification_status
 from app.dao.notifications_dao import get_service_ids_with_notifications_on_date
@@ -40,17 +40,17 @@ def create_nightly_billing_for_day(process_day):
     current_app.logger.info(f"create-nightly-billing-for-day task for {process_day}: started")
 
     start = datetime.utcnow()
-    transit_data = fetch_billing_data_for_day(process_day=process_day)
+    billing_data = fetch_billing_data_for_day(process_day=process_day)
     end = datetime.utcnow()
 
     current_app.logger.info(
         f"create-nightly-billing-for-day task for {process_day}: data fetched in {(end - start).seconds} seconds"
     )
 
-    update_fact_billing(transit_data, process_day)
+    update_ft_billing(billing_data, process_day)
 
     current_app.logger.info(
-        f"create-nightly-billing-for-day task for {process_day}: " f"task complete. {len(transit_data)} rows updated"
+        f"create-nightly-billing-for-day task for {process_day}: " f"task complete. {len(billing_data)} rows updated"
     )
 
 

--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -47,8 +47,7 @@ def create_nightly_billing_for_day(process_day):
         f"create-nightly-billing-for-day task for {process_day}: data fetched in {(end - start).seconds} seconds"
     )
 
-    for data in transit_data:
-        update_fact_billing(data, process_day)
+    update_fact_billing(transit_data, process_day)
 
     current_app.logger.info(
         f"create-nightly-billing-for-day task for {process_day}: " f"task complete. {len(transit_data)} rows updated"

--- a/app/commands.py
+++ b/app/commands.py
@@ -297,9 +297,7 @@ def rebuild_ft_billing_for_day(service_id, day):
         )
         transit_data = fetch_billing_data_for_day(process_day=process_day, service_ids=service_ids)
         # transit_data = every row that should exist
-        for data in transit_data:
-            # upsert existing rows
-            update_fact_billing(data, process_day)
+        update_fact_billing(transit_data, process_day)
         current_app.logger.info(
             "added/updated {} billing rows for service_ids {} on {}".format(len(transit_data), service_ids, process_day)
         )

--- a/app/commands.py
+++ b/app/commands.py
@@ -37,7 +37,7 @@ from app.dao.fact_billing_dao import (
     delete_billing_data_for_services_for_day,
     fetch_billing_data_for_day,
     get_service_ids_that_need_billing_populated,
-    update_fact_billing,
+    update_ft_billing,
 )
 from app.dao.jobs_dao import dao_get_job_by_id
 from app.dao.notifications_dao import move_notifications_to_notification_history
@@ -303,11 +303,11 @@ def rebuild_ft_billing_for_day(service_id, day):
         current_app.logger.info(
             "deleted {} existing billing rows for service_ids {} on {}".format(deleted_rows, service_ids, process_day)
         )
-        transit_data = fetch_billing_data_for_day(process_day=process_day, service_ids=service_ids)
-        # transit_data = every row that should exist
-        update_fact_billing(transit_data, process_day)
+        billing_data = fetch_billing_data_for_day(process_day=process_day, service_ids=service_ids)
+        # billing_data = every row that should exist
+        update_ft_billing(billing_data, process_day)
         current_app.logger.info(
-            "added/updated {} billing rows for service_ids {} on {}".format(len(transit_data), service_ids, process_day)
+            "added/updated {} billing rows for service_ids {} on {}".format(len(billing_data), service_ids, process_day)
         )
 
     if service_id:
@@ -1021,8 +1021,8 @@ def generate_bulktest_data(user_id):
     for dt in daily_dates_since_last_new_year:
         dt_date = dt.date()
         delete_billing_data_for_services_for_day(dt_date, service_ids)
-        transit_data = fetch_billing_data_for_day(process_day=dt_date, service_ids=service_ids)
-        update_fact_billing(transit_data, dt_date)
+        billing_data = fetch_billing_data_for_day(process_day=dt_date, service_ids=service_ids)
+        update_ft_billing(billing_data, dt_date)
         pprint(f" -> Done {dt_date}")
 
     pprint("Committing...")

--- a/app/config.py
+++ b/app/config.py
@@ -476,7 +476,7 @@ class Test(Development):
 
     # this is overriden in jenkins and on cloudfoundry
     SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI", "postgresql://localhost/test_notification_api")
-    SQLALCHEMY_RECORD_QUERIES = True
+    SQLALCHEMY_RECORD_QUERIES = False
 
     CELERY = {**Config.CELERY, "broker_url": "you-forgot-to-mock-celery-in-your-tests://"}
 

--- a/app/config.py
+++ b/app/config.py
@@ -476,6 +476,7 @@ class Test(Development):
 
     # this is overriden in jenkins and on cloudfoundry
     SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI", "postgresql://localhost/test_notification_api")
+    SQLALCHEMY_RECORD_QUERIES = True
 
     CELERY = {**Config.CELERY, "broker_url": "you-forgot-to-mock-celery-in-your-tests://"}
 

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -671,7 +671,7 @@ def update_fact_billing(data: list, process_day):
         return
 
     non_letter_rates, letter_rates = get_rates_for_billing()
-    billing_records = [
+    billing_records = (
         create_billing_record(
             d,
             get_rate(
@@ -686,7 +686,7 @@ def update_fact_billing(data: list, process_day):
             process_day,
         )
         for d in data
-    ]
+    )
 
     table = FactBilling.__table__
     """

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -842,6 +842,14 @@ def test_get_organisation_services_usage(admin_request, notify_db_session):
     assert service_usage["sms_cost"] == 0.54
 
 
+@pytest.mark.skip(
+    "Another test (`test_cbc_proxy_vodafone_send_link_test_invokes_function`) fails when we enable "
+    "SQLALCHEMY_RECORD_QUERIES, which is a requirement for this test. So we can't run this for now ... but "
+    "maybe the flask-sqlalchemy/psycopg2 edge case causing the exception (below) will eventually be fixed and we can "
+    "re-enable this. This exception is thrown when trying to record the query result, after sqlalchemy fetches the "
+    "next value from a sequence (sqlalchemy.engine.default.DefaultExecutionContext._execute_scalar).\n\n"
+    "Test error: *** AttributeError: 'PGExecutionContext_psycopg2' object has no attribute 'parameters'"
+)
 @pytest.mark.parametrize("num_services", [1, 5, 10])
 @freeze_time("2020-02-24 13:30")
 def test_get_organisation_services_usage_limit_queries_executed(admin_request, notify_db_session, num_services):

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -1,5 +1,6 @@
+import random
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 from flask import current_app
@@ -32,6 +33,7 @@ from tests.app.db import (
     create_template,
     create_user,
 )
+from tests.utils import count_sqlalchemy_queries
 
 
 def test_get_all_organisations(admin_request, notify_db_session, nhs_email_branding, nhs_letter_branding):
@@ -838,6 +840,35 @@ def test_get_organisation_services_usage(admin_request, notify_db_session):
     assert service_usage["sms_billable_units"] == 19
     assert service_usage["sms_remainder"] == 0
     assert service_usage["sms_cost"] == 0.54
+
+
+@pytest.mark.parametrize("num_services", [1, 5, 10])
+@freeze_time("2020-02-24 13:30")
+def test_get_organisation_services_usage_limit_queries_executed(admin_request, notify_db_session, num_services):
+    org = create_organisation(name="Organisation without live services")
+    for _ in range(num_services):
+        service = create_service(service_name=f"service {_}")
+        template = create_template(service=service)
+        dao_add_service_to_organisation(service=service, organisation_id=org.id)
+        create_annual_billing(service_id=service.id, free_sms_fragment_limit=10, financial_year_start=2019)
+        for num_billing_days in range(random.randint(10, 25)):
+            create_ft_billing(
+                bst_date=datetime.utcnow().date() - timedelta(days=num_billing_days),
+                template=template,
+                billable_unit=num_billing_days + 1,
+                rate=0.060,
+                notifications_sent=num_billing_days + 1,
+            )
+
+    with count_sqlalchemy_queries() as get_query_count:
+        admin_request.get("organisation.get_organisation_services_usage", organisation_id=org.id, **{"year": 2019})
+
+    assert get_query_count() == 9, (
+        "The number of queries executed by this view has changed. The number of queries executed "
+        "shouldn't increase as the number of org services increases. If this has increased by 1 or 2 queries, and "
+        "affects all parameterized versions of this test, you can probably accept the change. If only one of the "
+        "test runs is failing, you may want to look at the new code instead."
+    )
 
 
 @freeze_time("2020-02-24 13:30")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,15 @@
+from contextlib import contextmanager
+
+import flask_sqlalchemy
+
+
+@contextmanager
+def count_sqlalchemy_queries():
+    """Returns a callable that counts the number of SQLAlchemy queries executed since creation"""
+    before = len(flask_sqlalchemy.get_debug_queries())
+
+    def get_query_count():
+        after = len(flask_sqlalchemy.get_debug_queries())
+        return after - before
+
+    yield get_query_count


### PR DESCRIPTION
## Summary
The org dashboard view can be really slow for some orgs with lots of services and notifications. The queries that power this view haven't been optimised much, and so we can make 100s or 1000s of round trips to the DB. Let's refactor some of the supporting logic to make queries in bulk so that we have fewer round trips, and hopefully (much) faster page loads.

With the test case provided below, on my machine we go from ~1250 DB queries to 11, and from 8.6s to 0.3s

This will also speed up the nightly billing fact generation task (create-nightly-billing-for-day). Over the last 7 days in prod it's taken approx 300s each time.

On my machine, with the local test data from below, on `main` it takes 18 seconds and on this branch it takes <1 second. (the log messages don't have any decimal precision, so it comes back as 0 seconds).

## Testing locally
I've added a script to generate an organisation with 100 services and 5,000,000 notifications across them, so that the org dashboard view loads slowly locally.

1) Run: `flask command generate-bulktest-data -u <YOUR_LOCAL_USER_ID>`. This runs pretty slowly - expect to kick it off and walk away for 30 minutes.

    <details><summary>It takes a while...</summary>

    ```
    ~/work/gds/notifications-api [SW-reduce-org-dashboard-queries]$ flask command generate-bulktest-data -u 0c38e85c-b037-4dd8-ae12-09ab2b84c373
    [0.00]: Sending org to DB...
    [0.05]: Done.
    [0.05]: Building services...
    [0.05]: Sending services to DB...
    [0.09]: Done.
    [0.09]: Building templates...
    [0.11]: Sending templates to DB...
    [0.11]: Done.
    [0.11]: Building 5,000,000 notifications...
    [0.18]: Building batch 1...
    [28.20]: Sending batch 1 to DB...
    [370.70]: Done.
    [370.70]: Building batch 2...
    [399.35]: Sending batch 2 to DB...
    
    [920.54]: Done.
    [920.54]: Building batch 3...
    [948.87]: Sending batch 3 to DB...
    [1578.88]: Done.
    [1578.88]: Building batch 4...
    [1607.78]: Sending batch 4 to DB...
    [2292.68]: Done.
    [2292.68]: Building batch 5...
    [2320.96]: Sending batch 5 to DB...
    [3081.49]: Done.
    [3081.49]: Committing...
    [3081.53]: Finished.
    ```
    </details>

    <details><summary>To delete all(?) the data afterwards</summary>

    ```
    delete from notifications where client_reference LIKE 'BULKTEST%';
    delete from notification_history where client_reference LIKE 'BULKTEST%';
    delete from template_redacted where "template_id" IN (select "id" from templates where "name" like 'BULKTEST%');
    delete from templates where "name" like 'BULKTEST%';
    delete from templates_history where "name" like 'BULKTEST%';
    delete from service_permissions where service_id IN (select "id" from services where "name" like 'BULKTEST%');
    delete from permissions where service_id IN (select "id" from services where "name" like 'BULKTEST%');
    delete from user_to_service where service_id in  (select "id" from services where "name" like 'BULKTEST%');
    delete from service_sms_senders where service_id in  (select "id" from services where "name" like 'BULKTEST%');
    delete from annual_billing where service_id in  (select "id" from services where "name" like 'BULKTEST%');
    delete from services where "name" like 'BULKTEST%';
    delete from organisation where "name" like 'BULKTEST%';
    ```
    </details>
2) I've pushed up a commit 7c9a6aeb17feecef9fced26a10a7b7d5603a7f0b on a separate branch that adds a profiler and flask-debugtoolbar, as well as a fake view that replicates the org services-with-usage endpoint used by the org view dashboard.
    `git checkout main`
    `git cherry-pick 7c9a6aeb17feecef9fced26a10a7b7d5603a7f0b`
    `make bootstrap`
3) Open your browser and navigate to http://localhost:6011/organisations/BULKTEST_ORG_ID_HERE/services-with-usage-html?year=2022. Check the toolbar on the side and record the time taken and the number of queries executed.
4) Put your `main` branch back to normal: `git reset --hard main` / `git reset --hard head^` to remove the cherry-picked commit
5) Checkout this branch, `git checkout SW-reduce-org-dashboard-queries` and cherry-pick the profiling commit again:  `git cherry-pick 7c9a6aeb17feecef9fced26a10a7b7d5603a7f0b`
6) Run step 3 again. Compare the time taken and queries executed.

Note: the numbers on the dashboard will feel 'wrong', because they are - we haven't built historical billing data. This could be done by running `create_nightly_billing_for_day(date)` for all dates in the range that the command generates notifications within. However this doesn't, as far as I can see, affect the performance of the dashboard - just the accuracy of the stats.

## Comparison

| Before | After |
|---|---|
| <img width="215" alt="image" src="https://user-images.githubusercontent.com/2920760/206703262-9f5e36c3-cc8c-4b03-99fe-a5fc16201dea.png"> | <img width="209" alt="image" src="https://user-images.githubusercontent.com/2920760/206703323-2881a589-e2f7-42d4-9c01-44ed568ab42a.png"> |