### PR TITLE
Add a make command to bump utils, using the tooling from utils version 59.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ CF_MANIFEST_PATH ?= /tmp/manifest.yml
 
 NOTIFY_CREDENTIALS ?= ~/.notify-credentials
 
+VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
+PYTHON_EXECUTABLE_PREFIX := $(shell test -d "$${VIRTUALENV_ROOT}" && echo "$${VIRTUALENV_ROOT}/bin/" || echo "")
+
 
 ## DEVELOPMENT
 

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ freeze-requirements: ## Pin all requirements including sub dependencies into req
 	pip install --upgrade pip-tools
 	pip-compile requirements.in
 
+.PHONY: bump-utils
+bump-utils:  # Bump notifications-utils package to latest version
+	${PYTHON_EXECUTABLE_PREFIX}python -c "from notifications_utils.version_tools import upgrade_version; upgrade_version()"
+
 .PHONY: clean
 clean:
 	rm -rf node_modules cache target venv .coverage build tests/.cache ${CF_MANIFEST_PATH}

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==6.3.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@59.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@59.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -158,7 +158,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@59.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@59.3.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
59.3.0
---
* Add tooling to bump utils version in apps (which is then used by the makefile)

59.2.0
---
* Add support for creating redis cache keys for a specific notification type.

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/59.1.1...59.3.0