### PR TITLE
Only report on brands created by non-admins

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -63,6 +63,7 @@ from app.models import (
     Event,
     Job,
     Organisation,
+    User,
 )
 from app.notifications.process_notifications import send_notification_to_queue
 
@@ -391,7 +392,13 @@ def zendesk_new_email_branding_report():
         previous_weekday -= timedelta(days=(previous_weekday.isoweekday() - 5))
 
     new_email_brands = (
-        EmailBranding.query.join(Organisation, isouter=True).filter(EmailBranding.created_at >= previous_weekday).all()
+        EmailBranding.query.join(Organisation, isouter=True)
+        .join(User, User.id == EmailBranding.created_by, isouter=True)
+        .filter(
+            EmailBranding.created_at >= previous_weekday,
+            User.platform_admin.is_(False),
+        )
+        .all()
     )
 
     current_app.logger.info(f"{len(new_email_brands)} new email brands to review since {previous_weekday}.")

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -78,7 +78,7 @@ from app.models import (
 )
 
 
-def create_user(*, mobile_number="+447700900986", email=None, state="active", id_=None, name="Test User"):
+def create_user(*, mobile_number="+447700900986", email=None, state="active", id_=None, name="Test User", **kwargs):
     data = {
         "id": id_ or uuid.uuid4(),
         "name": name,
@@ -86,6 +86,7 @@ def create_user(*, mobile_number="+447700900986", email=None, state="active", id
         "password": "password",
         "mobile_number": mobile_number,
         "state": state,
+        **kwargs,
     }
     user = User.query.filter_by(email_address=email).first()
     if not user:
@@ -483,15 +484,9 @@ def create_service_callback_api(
 
 
 def create_email_branding(
-    id=None, colour="blue", alt_text=None, logo="test_x2.png", name="test_org_1", text="DisplayName"
+    id=None, colour="blue", alt_text=None, logo="test_x2.png", name="test_org_1", text="DisplayName", **kwargs
 ):
-    data = {
-        "colour": colour,
-        "logo": logo,
-        "alt_text": alt_text,
-        "name": name,
-        "text": text,
-    }
+    data = {"colour": colour, "logo": logo, "alt_text": alt_text, "name": name, "text": text, **kwargs}
     if id:
         data["id"] = id
     email_branding = EmailBranding(**data)


### PR DESCRIPTION
For the daily email branding report, it doesn't make sense to show brands created by platform admins because the report goes to platform admins for review.

Let's exclude those brands.