### PR TITLE
Simplify `add_service_sms_sender` endpoint

### DIFF
--- a/app/service/service_senders_schema.py
+++ b/app/service/service_senders_schema.py
@@ -1,5 +1,3 @@
-from app.schema_validation.definitions import uuid
-
 add_service_email_reply_to_request = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST service email reply to address",
@@ -25,6 +23,6 @@ add_service_sms_sender_request = {
     "description": "POST add service SMS sender",
     "type": "object",
     "title": "Add new SMS sender for service",
-    "properties": {"sms_sender": {"type": "string"}, "is_default": {"type": "boolean"}, "inbound_number_id": uuid},
+    "properties": {"sms_sender": {"type": "string"}, "is_default": {"type": "boolean"}},
     "required": ["sms_sender", "is_default"],
 }

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -9,7 +9,6 @@ from freezegun import freeze_time
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.dao.organisation_dao import dao_add_service_to_organisation
-from app.dao.service_sms_sender_dao import dao_get_sms_senders_by_service_id
 from app.dao.service_user_dao import dao_get_service_user
 from app.dao.services_dao import (
     dao_add_user_to_service,
@@ -34,7 +33,6 @@ from app.models import (
     UPLOAD_LETTERS,
     AnnualBilling,
     EmailBranding,
-    InboundNumber,
     Notification,
     Permission,
     Service,
@@ -3044,54 +3042,6 @@ def test_add_service_sms_sender_can_add_multiple_senders(client, notify_db_sessi
     assert not resp_json["is_default"]
     senders = ServiceSmsSender.query.all()
     assert len(senders) == 2
-
-
-def test_add_service_sms_sender_when_it_is_an_inbound_number_updates_the_only_existing_non_archived_sms_sender(
-    client, notify_db_session
-):
-    service = create_service_with_defined_sms_sender(sms_sender_value="GOVUK")
-    create_service_sms_sender(service=service, sms_sender="archived", is_default=False, archived=True)
-    inbound_number = create_inbound_number(number="12345")
-    data = {"sms_sender": str(inbound_number.id), "is_default": True, "inbound_number_id": str(inbound_number.id)}
-    response = client.post(
-        "/service/{}/sms-sender".format(service.id),
-        data=json.dumps(data),
-        headers=[("Content-Type", "application/json"), create_admin_authorization_header()],
-    )
-    assert response.status_code == 201
-    updated_number = InboundNumber.query.get(inbound_number.id)
-    assert updated_number.service_id == service.id
-    resp_json = json.loads(response.get_data(as_text=True))
-    assert resp_json["sms_sender"] == inbound_number.number
-    assert resp_json["inbound_number_id"] == str(inbound_number.id)
-    assert resp_json["is_default"]
-
-    senders = dao_get_sms_senders_by_service_id(service.id)
-    assert len(senders) == 1
-
-
-def test_add_service_sms_sender_when_it_is_an_inbound_number_inserts_new_sms_sender_when_more_than_one(
-    client, notify_db_session
-):
-    service = create_service_with_defined_sms_sender(sms_sender_value="GOVUK")
-    create_service_sms_sender(service=service, sms_sender="second", is_default=False)
-    inbound_number = create_inbound_number(number="12345")
-    data = {"sms_sender": str(inbound_number.id), "is_default": True, "inbound_number_id": str(inbound_number.id)}
-    response = client.post(
-        "/service/{}/sms-sender".format(service.id),
-        data=json.dumps(data),
-        headers=[("Content-Type", "application/json"), create_admin_authorization_header()],
-    )
-    assert response.status_code == 201
-    updated_number = InboundNumber.query.get(inbound_number.id)
-    assert updated_number.service_id == service.id
-    resp_json = json.loads(response.get_data(as_text=True))
-    assert resp_json["sms_sender"] == inbound_number.number
-    assert resp_json["inbound_number_id"] == str(inbound_number.id)
-    assert resp_json["is_default"]
-
-    senders = ServiceSmsSender.query.filter_by(service_id=service.id).all()
-    assert len(senders) == 3
 
 
 def test_add_service_sms_sender_switches_default(client, notify_db_session):


### PR DESCRIPTION
We've added a new endpoint for adding an inbound number to a service (either a specific inbound number or a random one). This means that we can simplify the `add_service_sms_sender` endpoint so that it only deals with adding a "normal" sms sender to a service.