### PR TITLE
Add columns for managing go live requests

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0390_require_rate_limit_value
+0391_add_go_live_columns

--- a/migrations/versions/0391_add_go_live_columns.py
+++ b/migrations/versions/0391_add_go_live_columns.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: 0391_add_go_live_columns
+Revises: 0390_require_rate_limit_value
+Create Date: 2022-12-19 08:01:58.001061
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0391_add_go_live_columns"
+down_revision = "0390_require_rate_limit_value"
+
+
+def upgrade():
+    op.add_column("services", sa.Column("has_active_go_live_request", sa.Boolean(), nullable=True))
+    op.add_column("services_history", sa.Column("has_active_go_live_request", sa.Boolean(), nullable=True))
+
+    op.add_column("organisation", sa.Column("can_approve_own_go_live_requests", sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("services_history", "has_active_go_live_request")
+    op.drop_column("services", "has_active_go_live_request")
+
+    op.drop_column("organisation", "can_approve_own_go_live_requests")


### PR DESCRIPTION
This is so we can track:
- which organisations are allowed to approve their own go live requests (this is effectively a feature flag, but we don’t have permissions for organisations like we do for services)
- which services are currently waiting to go live, so we can filter on this attribute

Later we can:
- add default `False` values for these columns
- make them non-nullable 
- have the API return them for use in the admin app