### PR TITLE
Add new go live columns to model

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -392,6 +392,7 @@ class Organisation(db.Model):
         nullable=True,
     )
     request_to_go_live_notes = db.Column(db.Text)
+    can_approve_own_go_live_requests = db.Column(db.Boolean, default=False)
 
     domains = db.relationship(
         "Domain",
@@ -460,6 +461,7 @@ class Organisation(db.Model):
             "billing_contact_names": self.billing_contact_names,
             "billing_contact_email_addresses": self.billing_contact_email_addresses,
             "billing_reference": self.billing_reference,
+            "can_approve_own_go_live_requests": self.can_approve_own_go_live_requests,
         }
 
     def serialize_for_list(self):
@@ -530,6 +532,7 @@ class Service(db.Model, Versioned):
     go_live_user_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
     go_live_user = db.relationship("User", foreign_keys=[go_live_user_id])
     go_live_at = db.Column(db.DateTime, nullable=True)
+    has_active_go_live_request = db.Column(db.Boolean, default=False)
 
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), index=True, nullable=True)
     organisation = db.relationship("Organisation", backref="services")

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -94,6 +94,7 @@ def test_get_organisation_by_id(admin_request, notify_db_session):
         "billing_contact_email_addresses",
         "billing_reference",
         "purchase_order_number",
+        "can_approve_own_go_live_requests",
     }
     assert response["id"] == str(org.id)
     assert response["name"] == "test_org_1"
@@ -115,6 +116,7 @@ def test_get_organisation_by_id(admin_request, notify_db_session):
     assert response["billing_contact_email_addresses"] is None
     assert response["billing_reference"] is None
     assert response["purchase_order_number"] is None
+    assert response["can_approve_own_go_live_requests"] is False
 
 
 def test_get_organisation_by_id_returns_domains(admin_request, notify_db_session):
@@ -295,10 +297,12 @@ def test_post_create_organisation_with_missing_data_gives_validation_error(
 
 
 @pytest.mark.parametrize("crown", (None, True, False))
+@pytest.mark.parametrize("can_approve_own_go_live_requests", (True, False))
 def test_post_update_organisation_updates_fields(
     admin_request,
     notify_db_session,
     crown,
+    can_approve_own_go_live_requests,
 ):
     org = create_organisation()
     data = {
@@ -306,6 +310,7 @@ def test_post_update_organisation_updates_fields(
         "active": False,
         "crown": crown,
         "organisation_type": "central",
+        "can_approve_own_go_live_requests": can_approve_own_go_live_requests,
     }
     assert org.crown is None
 
@@ -320,6 +325,7 @@ def test_post_update_organisation_updates_fields(
     assert organisation[0].crown == crown
     assert organisation[0].domains == []
     assert organisation[0].organisation_type == "central"
+    assert organisation[0].can_approve_own_go_live_requests == can_approve_own_go_live_requests
 
 
 @pytest.mark.parametrize(

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -249,6 +249,7 @@ def test_get_service_by_id(admin_request, sample_service):
         "email_message_limit",
         "go_live_at",
         "go_live_user",
+        "has_active_go_live_request",
         "id",
         "inbound_api",
         "letter_branding",
@@ -692,7 +693,8 @@ def test_create_service_allows_only_lowercase_digits_and_fullstops_in_email_from
         )
 
 
-def test_update_service(client, notify_db_session, sample_service):
+@pytest.mark.parametrize("has_active_go_live_request", (True, False))
+def test_update_service(client, notify_db_session, sample_service, has_active_go_live_request):
     brand = EmailBranding(colour="#000000", logo="justice-league.png", name="Justice League", alt_text="Justice League")
     notify_db_session.add(brand)
     notify_db_session.commit()
@@ -705,6 +707,7 @@ def test_update_service(client, notify_db_session, sample_service):
         "created_by": str(sample_service.created_by.id),
         "email_branding": str(brand.id),
         "organisation_type": "school_or_college",
+        "has_active_go_live_request": has_active_go_live_request,
     }
 
     auth_header = create_admin_authorization_header()
@@ -720,6 +723,7 @@ def test_update_service(client, notify_db_session, sample_service):
     assert result["data"]["email_from"] == "updated.service.name"
     assert result["data"]["email_branding"] == str(brand.id)
     assert result["data"]["organisation_type"] == "school_or_college"
+    assert result["data"]["has_active_go_live_request"] == has_active_go_live_request
 
 
 def test_cant_update_service_org_type_to_random_value(client, sample_service):


### PR DESCRIPTION
We need to add the columns to the model so that they can be written and read by the REST endpoints.

By setting a default value we know that any new services or organisations will have a value for these fields while we are migrating them to be nonnullable in subsequent pull requests.