### PR TITLE
Make go live columns non nullable

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -392,7 +392,7 @@ class Organisation(db.Model):
         nullable=True,
     )
     request_to_go_live_notes = db.Column(db.Text)
-    can_approve_own_go_live_requests = db.Column(db.Boolean, default=False)
+    can_approve_own_go_live_requests = db.Column(db.Boolean, default=False, nullable=False)
 
     domains = db.relationship(
         "Domain",
@@ -532,7 +532,7 @@ class Service(db.Model, Versioned):
     go_live_user_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
     go_live_user = db.relationship("User", foreign_keys=[go_live_user_id])
     go_live_at = db.Column(db.DateTime, nullable=True)
-    has_active_go_live_request = db.Column(db.Boolean, default=False)
+    has_active_go_live_request = db.Column(db.Boolean, default=False, nullable=False)
 
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), index=True, nullable=True)
     organisation = db.relationship("Organisation", backref="services")

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0391_add_go_live_columns
+0392_go_live_cols_non_nullable

--- a/migrations/versions/0392_go_live_cols_non_nullable.py
+++ b/migrations/versions/0392_go_live_cols_non_nullable.py
@@ -1,0 +1,31 @@
+"""
+
+Revision ID: 0392_go_live_cols_non_nullable
+Revises: 0391_add_go_live_columns
+Create Date: 2022-12-20 08:01:58.001061
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0392_go_live_cols_non_nullable"
+down_revision = "0391_add_go_live_columns"
+
+
+columns_to_make_non_nullable = (
+    ("services", "has_active_go_live_request"),
+    ("services_history", "has_active_go_live_request"),
+    ("organisation", "can_approve_own_go_live_requests"),
+)
+
+
+def upgrade():
+    for table, column in columns_to_make_non_nullable:
+        op.execute(f"UPDATE {table} SET {column} = false")
+        op.alter_column(table, column, existing_type=sa.BOOLEAN(), nullable=False)
+
+
+def downgrade():
+    for table, column in columns_to_make_non_nullable:
+        op.alter_column(table, column, existing_type=sa.BOOLEAN(), nullable=True)
+        op.execute(f"UPDATE {table} SET {column} = null")


### PR DESCRIPTION
Null values don’t make sense for these columns – they should either be `true` or `false`

***

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/3678