### PR TITLE
Profile org services-with-usage endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -36,6 +36,7 @@ from app.clients.email.aws_ses import AwsSesClient
 from app.clients.email.aws_ses_stub import AwsSesStubClient
 from app.clients.sms.firetext import FiretextClient
 from app.clients.sms.mmg import MMGClient
+from app.utils import TimingContextManager
 
 
 class SQLAlchemy(_SQLAlchemy):
@@ -313,6 +314,7 @@ def init_app(app):
 
         g.start = monotonic()
         g.endpoint = request.endpoint
+        g.profiler = TimingContextManager(app=current_app, enabled=False)
 
     @app.after_request
     def after_request(response):

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -60,6 +60,11 @@ def requires_govuk_alerts_auth():
 def requires_admin_auth():
     requires_internal_auth(current_app.config.get("ADMIN_CLIENT_ID"))
 
+    # If successfully auth'd as the admin app, let's make it possible to enable profiling on the request.
+    # The admin app ensures only platform admins can get this header sent so we don't verify anything else.
+    if request.headers.get("X-Notify-Profile", "0") == "1":
+        g.profiler.enabled = True
+
 
 def requires_internal_auth(expected_client_id):
     if expected_client_id not in current_app.config.get("INTERNAL_CLIENT_API_KEYS"):

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, abort, current_app, jsonify, request
+from flask import Blueprint, abort, current_app, g, jsonify, request
 from sqlalchemy.exc import IntegrityError
 
 from app.config import QueueNames
@@ -182,14 +182,16 @@ def get_organisation_services(organisation_id):
 
 @organisation_blueprint.route("/<uuid:organisation_id>/services-with-usage", methods=["GET"])
 def get_organisation_services_usage(organisation_id):
-    try:
-        year = int(request.args.get("year", "none"))
-    except ValueError:
-        return jsonify(result="error", message="No valid year provided"), 400
-    services = fetch_usage_for_organisation(organisation_id, year)
-    list_services = services.values()
-    sorted_services = sorted(list_services, key=lambda s: (-s["active"], s["service_name"].lower()))
-    return jsonify(services=sorted_services)
+    with g.profiler("get_organisation_services_usage"):
+        try:
+            year = int(request.args.get("year", "none"))
+        except ValueError:
+            return jsonify(result="error", message="No valid year provided"), 400
+        with g.profiler("fetch_usage_for_organisation"):
+            services = fetch_usage_for_organisation(organisation_id, year)
+        list_services = services.values()
+        sorted_services = sorted(list_services, key=lambda s: (-s["active"], s["service_name"].lower()))
+        return jsonify(services=sorted_services)
 
 
 @organisation_blueprint.route("/<uuid:organisation_id>/users/<uuid:user_id>", methods=["POST"])


### PR DESCRIPTION
Build out a very basic stack-based profiler that will print out the time
taken to execute blocks of code, allowing for basic nesting.

We don't have any thorough APM instrumented at the moment (watch this space) so for now this is a very temporary measure to help us understand the runtime profile of codepaths we explicitly inspect. This PR only adds profiling around the `organisations/id/services-with-usage` endpoint which we know is very heavy.

This and the sister admin PR https://github.com/alphagov/notifications-admin/pull/4537 are both likely to just get fully reverted after a while, so don't expect this code to live forever.

---

From local checks this indicates a good thing to look at is the `sms_usages` query, but it'd be nice to be able to validate that in production.