### PR TITLE
Update letter-checking task to ignore bank holidays

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==6.3.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@59.3.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@60.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -158,7 +158,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@59.3.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@60.1.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -189,7 +189,7 @@ pyparsing==3.0.9
     # via packaging
 pypdf2==2.11.0
     # via notifications-utils
-pyproj==3.4.0
+pyproj==3.4.1
     # via notifications-utils
 pyrsistent==0.18.1
     # via jsonschema

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -319,6 +319,24 @@ def test_get_letter_notifications_still_sending_when_they_shouldnt_finds_friday_
     assert expected_sent_date == date(2018, 1, 12)
 
 
+@freeze_time("Thursday 29th December 2022 17:00")
+def test_get_letter_notifications_still_sending_when_they_shouldnt_treats_bank_holidays_as_non_working_and_looks_beyond(
+    sample_letter_template, rmock
+):
+    """This test implicitly tests the implementation of `govuk_bank_holidays` - but if we don't do that then
+    we aren't really testing anything different here. It's nice to have some confirmation that it's working as intended,
+    as well."""
+    friday = datetime(2022, 12, 23, 13, 30)
+    yesterday = datetime(2022, 12, 28, 13, 30)
+    create_notification(template=sample_letter_template, status="sending", sent_at=friday, postage="first")
+    create_notification(template=sample_letter_template, status="sending", sent_at=friday, postage="second")
+    create_notification(template=sample_letter_template, status="sending", sent_at=yesterday, postage="first")
+
+    count, expected_sent_date = get_letter_notifications_still_sending_when_they_shouldnt_be()
+    assert count == 2
+    assert expected_sent_date == date(2022, 12, 23)
+
+
 @freeze_time("2018-01-11T23:00:00")
 def test_letter_raise_alert_if_no_ack_file_for_zip_does_not_raise_when_files_match_zip_list(mocker, notify_db_session):
     mock_file_list = mocker.patch("app.aws.s3.get_list_of_files_by_suffix", side_effect=mock_s3_get_list_match)


### PR DESCRIPTION
We've had the letter-checking task run the last few days, which opens a ticket with DVLA suggesting that they've fallen behind processing letters.

This isn't the case, as we've had two bank holidays this week. Let's respect these and properly look beyond them.