### PR TITLE
Select email brandings with ordering

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -398,6 +398,7 @@ def zendesk_new_email_branding_report():
             EmailBranding.created_at >= previous_weekday,
             User.platform_admin.is_(False),
         )
+        .order_by(EmailBranding.created_at)
         .all()
     )
 


### PR DESCRIPTION
It's good practice to provide specific ordering on queries. This also stops flakiness in the `test_zendesk_new_email_branding_report` test.