### PR TITLE
Fix a tiny typo

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -86,7 +86,7 @@ def check_service_over_daily_message_limit(service, key_type, notification_type,
             )
             # TODO: Remove this - only temporarily logging so it's easy to check/make sure no-one is hitting this
             #  rate limit while we roll it out
-            if notification_type is not None:
+            if notification_type_ is not None:
                 current_app.logger.warning(
                     "notification-specific rate limit hit: {} at {} of {}".format(
                         notification_type, service_stats, limit_value


### PR DESCRIPTION
We should only log this message if we're checking the notification-specific limit.

This probably suggests that the variable name isn't good because it's so easy to miss the trailing underscore. However, this log message is only temporary and the `for` loop is also going to get removed as/when we phase out the general rate limit bucket, so this is only temporary and I don't think it's worth refactoring/renaming more broadly now.