### PR TITLE
Change threshold for slow sms delivery and add more delivery metrics

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -118,7 +118,7 @@ def switch_current_sms_provider_on_slow_delivery():
     last ten minutes, then don't update them again either.
     """
     slow_delivery_notifications = is_delivery_slow_for_providers(
-        created_within_minutes=10,
+        created_within_minutes=15,
         delivered_within_minutes=5,
         threshold=0.15,
     )
@@ -136,7 +136,7 @@ def switch_current_sms_provider_on_slow_delivery():
 def generate_sms_delivery_stats():
     for delivery_interval in (1, 5, 10):
         providers_slow_delivery_ratios = get_ratio_of_messages_delivered_slowly_per_provider(
-            created_within_minutes=10, delivered_within_minutes=delivery_interval
+            created_within_minutes=15, delivered_within_minutes=delivery_interval
         )
 
         for provider, ratio in providers_slow_delivery_ratios.items():

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -117,9 +117,9 @@ def switch_current_sms_provider_on_slow_delivery():
     last ten minutes, then don't update them again either.
     """
     slow_delivery_notifications = is_delivery_slow_for_providers(
+        created_within_minutes=10,
+        delivered_within_minutes=5,
         threshold=0.15,
-        created_at=datetime.utcnow() - timedelta(minutes=10),
-        delivery_time=timedelta(minutes=5),
     )
 
     # only adjust if some values are true and some are false - ie, don't adjust if all providers are fast or

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -10,7 +10,7 @@ from notifications_utils.timezones import convert_utc_to_bst
 from sqlalchemy import between
 from sqlalchemy.exc import SQLAlchemyError
 
-from app import db, notify_celery, zendesk_client
+from app import db, notify_celery, statsd_client, zendesk_client
 from app.aws import s3
 from app.celery.broadcast_message_tasks import trigger_link_test
 from app.celery.letters_pdf_tasks import get_pdf_for_templated_letter
@@ -38,6 +38,7 @@ from app.dao.jobs_dao import (
 from app.dao.notifications_dao import (
     dao_old_letters_with_created_status,
     dao_precompiled_letters_still_pending_virus_check,
+    get_ratio_of_messages_delivered_slowly_per_provider,
     is_delivery_slow_for_providers,
     letters_missing_from_sending_bucket,
     notifications_not_yet_sent,
@@ -129,6 +130,17 @@ def switch_current_sms_provider_on_slow_delivery():
             if is_slow:
                 current_app.logger.warning("Slow delivery notifications detected for provider {}".format(provider_name))
                 dao_reduce_sms_provider_priority(provider_name, time_threshold=timedelta(minutes=10))
+
+
+@notify_celery.task(name="generate-sms-delivery-stats")
+def generate_sms_delivery_stats():
+    for delivery_interval in (1, 5, 10):
+        providers_slow_delivery_ratios = get_ratio_of_messages_delivered_slowly_per_provider(
+            created_within_minutes=10, delivered_within_minutes=delivery_interval
+        )
+
+        for provider, ratio in providers_slow_delivery_ratios.items():
+            statsd_client.gauge(f"slow-delivery.{provider}.delivered-within-minutes.{delivery_interval}.ratio", ratio)
 
 
 @notify_celery.task(name="tend-providers-back-to-middle")

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -112,14 +112,14 @@ def delete_invitations():
 @notify_celery.task(name="switch-current-sms-provider-on-slow-delivery")
 def switch_current_sms_provider_on_slow_delivery():
     """
-    Reduce provider's priority if at least 30% of notifications took more than four minutes to be delivered
+    Reduce provider's priority if at least 15% of notifications took more than 5 minutes to be delivered
     in the last ten minutes. If both providers are slow, don't do anything. If we changed the providers in the
     last ten minutes, then don't update them again either.
     """
     slow_delivery_notifications = is_delivery_slow_for_providers(
-        threshold=0.3,
+        threshold=0.15,
         created_at=datetime.utcnow() - timedelta(minutes=10),
-        delivery_time=timedelta(minutes=4),
+        delivery_time=timedelta(minutes=5),
     )
 
     # only adjust if some values are true and some are false - ie, don't adjust if all providers are fast or

--- a/app/config.py
+++ b/app/config.py
@@ -217,6 +217,11 @@ class Config(object):
                 "schedule": timedelta(minutes=66),
                 "options": {"queue": QueueNames.PERIODIC},
             },
+            "generate-sms-delivery-stats": {
+                "task": "generate-sms-delivery-stats",
+                "schedule": crontab(),  # Every minute
+                "options": {"queue": QueueNames.PERIODIC},
+            },
             "switch-current-sms-provider-on-slow-delivery": {
                 "task": "switch-current-sms-provider-on-slow-delivery",
                 "schedule": crontab(),  # Every minute

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -432,9 +432,9 @@ def dao_timeout_notifications(cutoff_time, limit=100000):
 
 
 def is_delivery_slow_for_providers(
-    created_at,
+    created_within_minutes,
+    delivered_within_minutes,
     threshold,
-    delivery_time,
 ):
     """
     Returns a dict of providers and whether they are currently slow or not. eg:
@@ -442,7 +442,36 @@ def is_delivery_slow_for_providers(
         'mmg': True,
         'firetext': False
     }
+
+    A provider is considered slow if more than the `threshold` of their messages
+    sent in the last `created_within_minutes` minutes took over
+    `delivered_within_minutes` minutes to be delivered
     """
+    providers_slow_delivery_ratios = get_ratio_of_messages_delivered_slowly_per_provider(
+        created_within_minutes, delivered_within_minutes
+    )
+
+    slow_providers = {}
+    for provider, ratio in providers_slow_delivery_ratios.items():
+        slow_providers[provider] = ratio >= threshold
+        statsd_client.gauge(f"slow-delivery.{provider}.ratio", ratio)
+
+    return slow_providers
+
+
+def get_ratio_of_messages_delivered_slowly_per_provider(created_within_minutes, delivered_within_minutes):
+    """
+    Returns a dict of providers with the ratio of their messages sent in the
+    last `created_within_minutes` minutes that took over
+    `delivered_within_minutes` minutes to be delivered
+
+    {
+        'mmg': 0.4,
+        'firetext': 0.12
+    }
+    """
+    created_since = datetime.utcnow() - timedelta(minutes=created_within_minutes)
+    delivery_time = timedelta(minutes=delivered_within_minutes)
     slow_notification_counts = (
         db.session.query(
             ProviderDetails.identifier,
@@ -463,7 +492,7 @@ def is_delivery_slow_for_providers(
             and_(
                 Notification.notification_type == SMS_TYPE,
                 Notification.sent_by == ProviderDetails.identifier,
-                Notification.created_at >= created_at,
+                Notification.created_at >= created_since,
                 Notification.sent_at.isnot(None),
                 Notification.status.in_([NOTIFICATION_DELIVERED, NOTIFICATION_PENDING, NOTIFICATION_SENDING]),
                 Notification.key_type != KEY_TYPE_TEST,
@@ -474,16 +503,14 @@ def is_delivery_slow_for_providers(
         .group_by(ProviderDetails.identifier, "slow")
     )
 
-    slow_providers = {}
+    providers_slow_delivery_ratios = {}
     for provider, rows in groupby(slow_notification_counts, key=attrgetter("identifier")):
         rows = list(rows)
         total_notifications = sum(row.count for row in rows)
         slow_notifications = sum(row.count for row in rows if row.slow)
+        providers_slow_delivery_ratios[provider] = slow_notifications / total_notifications
 
-        slow_providers[provider] = slow_notifications / total_notifications >= threshold
-        statsd_client.gauge(f"slow-delivery.{provider}.ratio", slow_notifications / total_notifications)
-
-    return slow_providers
+    return providers_slow_delivery_ratios
 
 
 @autocommit

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -454,6 +454,8 @@ def is_delivery_slow_for_providers(
     slow_providers = {}
     for provider, ratio in providers_slow_delivery_ratios.items():
         slow_providers[provider] = ratio >= threshold
+        # TODO: when we are happy with the new metrics in generate_sms_delivery_stats then this
+        # can be removed as it will be redundant
         statsd_client.gauge(f"slow-delivery.{provider}.ratio", ratio)
 
     return slow_providers

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -135,7 +135,7 @@ def test_switch_current_sms_provider_on_slow_delivery_switches_when_one_provider
     switch_current_sms_provider_on_slow_delivery()
 
     mock_is_slow.assert_called_once_with(
-        threshold=0.3, created_at=datetime(2017, 5, 1, 13, 50), delivery_time=timedelta(minutes=4)
+        threshold=0.15, created_at=datetime(2017, 5, 1, 13, 50), delivery_time=timedelta(minutes=5)
     )
     mock_reduce.assert_called_once_with("firetext", time_threshold=timedelta(minutes=10))
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -134,9 +134,7 @@ def test_switch_current_sms_provider_on_slow_delivery_switches_when_one_provider
 
     switch_current_sms_provider_on_slow_delivery()
 
-    mock_is_slow.assert_called_once_with(
-        threshold=0.15, created_at=datetime(2017, 5, 1, 13, 50), delivery_time=timedelta(minutes=5)
-    )
+    mock_is_slow.assert_called_once_with(created_within_minutes=10, delivered_within_minutes=5, threshold=0.15)
     mock_reduce.assert_called_once_with("firetext", time_threshold=timedelta(minutes=10))
 
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -135,7 +135,7 @@ def test_switch_current_sms_provider_on_slow_delivery_switches_when_one_provider
 
     switch_current_sms_provider_on_slow_delivery()
 
-    mock_is_slow.assert_called_once_with(created_within_minutes=10, delivered_within_minutes=5, threshold=0.15)
+    mock_is_slow.assert_called_once_with(created_within_minutes=15, delivered_within_minutes=5, threshold=0.15)
     mock_reduce.assert_called_once_with("firetext", time_threshold=timedelta(minutes=10))
 
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -23,6 +23,7 @@ from app.celery.scheduled_tasks import (
     delete_invitations,
     delete_old_records_from_events_table,
     delete_verify_codes,
+    generate_sms_delivery_stats,
     remove_yesterdays_planned_tests_on_govuk_alerts,
     replay_created_notifications,
     run_scheduled_jobs,
@@ -156,6 +157,26 @@ def test_switch_current_sms_provider_on_slow_delivery_does_nothing_if_no_need(
     switch_current_sms_provider_on_slow_delivery()
 
     assert mock_reduce.called is False
+
+
+def test_generate_sms_delivery_stats(mocker):
+    mocker.patch(
+        "app.celery.scheduled_tasks.get_ratio_of_messages_delivered_slowly_per_provider",
+        return_value={"mmg": 0.4, "firetext": 0.8},
+    )
+    mock_statsd = mocker.patch("app.celery.scheduled_tasks.statsd_client.gauge")
+
+    generate_sms_delivery_stats()
+
+    calls = [
+        call("slow-delivery.mmg.delivered-within-minutes.1.ratio", 0.4),
+        call("slow-delivery.mmg.delivered-within-minutes.5.ratio", 0.4),
+        call("slow-delivery.mmg.delivered-within-minutes.10.ratio", 0.4),
+        call("slow-delivery.firetext.delivered-within-minutes.1.ratio", 0.8),
+        call("slow-delivery.firetext.delivered-within-minutes.5.ratio", 0.8),
+        call("slow-delivery.firetext.delivered-within-minutes.10.ratio", 0.8),
+    ]
+    mock_statsd.assert_has_calls(calls, any_order=True)
 
 
 def test_check_job_status_task_calls_process_incomplete_jobs(mocker, sample_template):

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -858,7 +858,7 @@ def test_is_delivery_slow_for_providers(
     for _ in range(slow_delivered):
         slow_notification(status="delivered")
 
-    result = is_delivery_slow_for_providers(datetime.utcnow(), threshold, timedelta(minutes=4))
+    result = is_delivery_slow_for_providers(datetime.utcnow(), threshold, timedelta(minutes=5))
     assert result == {"firetext": False, "mmg": expected_result}
 
 
@@ -886,7 +886,7 @@ def test_delivery_is_delivery_slow_for_providers_filters_out_notifications_it_sh
     }
     create_slow_notification_with.update(options)
     create_notification(**create_slow_notification_with)
-    result = is_delivery_slow_for_providers(datetime.utcnow(), 0.1, timedelta(minutes=4))
+    result = is_delivery_slow_for_providers(datetime.utcnow(), 0.1, timedelta(minutes=5))
     assert result["mmg"] == expected_result
 
 

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -858,7 +858,7 @@ def test_is_delivery_slow_for_providers(
     for _ in range(slow_delivered):
         slow_notification(status="delivered")
 
-    result = is_delivery_slow_for_providers(datetime.utcnow(), threshold, timedelta(minutes=5))
+    result = is_delivery_slow_for_providers(10, 5, threshold)
     assert result == {"firetext": False, "mmg": expected_result}
 
 
@@ -886,7 +886,7 @@ def test_delivery_is_delivery_slow_for_providers_filters_out_notifications_it_sh
     }
     create_slow_notification_with.update(options)
     create_notification(**create_slow_notification_with)
-    result = is_delivery_slow_for_providers(datetime.utcnow(), 0.1, timedelta(minutes=5))
+    result = is_delivery_slow_for_providers(10, 5, 0.1)
     assert result["mmg"] == expected_result
 
 


### PR DESCRIPTION
Best reviewed commit by commit

## Required changes to other things

1. [Grafana panel for slow sms delivery](https://grafana-notify.cloudapps.digital/d/icjsQ-MWk2/notify-summary?viewPanel=51&orgId=1) will need relabelling to be 5 minutes rather than 4 minutes

2. New statsd mapping will be need adding to https://github.com/alphagov/notifications-aws/blob/main/paas/statsd/statsd-mapping.yml so the statsd metric can be picked up by prometheus and then added to some panels in Grafana

## 6 Dec slow delivery incident graph
![image](https://user-images.githubusercontent.com/7228605/209983025-32f52f71-03c7-48e4-ba34-78d654262509.png)
