### PR TITLE
Import pycurl early to help run celery locally

### DIFF
--- a/run_celery.py
+++ b/run_celery.py
@@ -5,6 +5,16 @@
 # prometheus will simply store the metrics in memory
 import prometheus_client  # noqa
 
+# We have lots of issues related to using pycurl locally on (M1?) macs.
+# We have specific installation instructions for pycurl here:
+#   https://github.com/alphagov/notifications-manuals/wiki/Getting-started#pycurl
+# However this sometimes still doesn't seem to be enough for pycurl when running the celery workers.
+# Importing pycurl here - notably before the import at kombu.asynchronous.http.curl:15 - seems to mitigate the error
+# I've seen a lot lately:
+#   ImportError: pycurl: libcurl link-time version (7.76.1) is older than compile-time version (7.85.0)
+# See https://github.com/alphagov/notifications-api/pull/3687 for a little more of the investigation/notes
+import pycurl  # noqa: F401
+
 # notify_celery is referenced from manifest_delivery_base.yml, and cannot be removed
 from app import create_app, notify_celery  # noqa
 from app.notify_api_flask_app import NotifyApiFlaskApp


### PR DESCRIPTION
Am interested to know if this helps anyone else with running celery locally?


## PYTHONVERBOSE=3 - show debugging info on module imports. Not sure if this actually tells us anything useful though.
### With this patch (works)
```
# trying /Users/sam/work/gds/notifications-api/pycurl.cpython-39-darwin.so
# trying /Users/sam/work/gds/notifications-api/pycurl.abi3.so
# trying /Users/sam/work/gds/notifications-api/pycurl.so
# trying /Users/sam/work/gds/notifications-api/pycurl.py
# trying /Users/sam/work/gds/notifications-api/pycurl.pyc
# trying /Users/sam/work/gds/notifications-api/venv/bin/pycurl.cpython-39-darwin.so
# trying /Users/sam/work/gds/notifications-api/venv/bin/pycurl.abi3.so
# trying /Users/sam/work/gds/notifications-api/venv/bin/pycurl.so
# trying /Users/sam/work/gds/notifications-api/venv/bin/pycurl.py
# trying /Users/sam/work/gds/notifications-api/venv/bin/pycurl.pyc
# trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/pycurl.cpython-39-darwin.so
# trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/pycurl.abi3.so
# trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/pycurl.so
# trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/pycurl.py
# trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/pycurl.pyc
# trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/lib-dynload/pycurl.cpython-39-darwin.so
# trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/lib-dynload/pycurl.abi3.so
# trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/lib-dynload/pycurl.so
# trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/lib-dynload/pycurl.py
# trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/lib-dynload/pycurl.pyc
# trying /Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/pycurl.cpython-39-darwin.so
# extension module 'pycurl' loaded from '/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/pycurl.cpython-39-darwin.so'
# extension module 'pycurl' executed from '/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/pycurl.cpython-39-darwin.so'
import 'pycurl' # <_frozen_importlib_external.ExtensionFileLoader object at 0x104dd7a60>

...

[2022-12-29 20:14:49,626: INFO/MainProcess] celery@anima.local ready.
[2022-12-29 20:12:36,698: WARNING/MainProcess] # trying /Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/curl.cpython-39-darwin.so
[2022-12-29 20:12:36,698: WARNING/MainProcess] # trying /Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/curl.abi3.so
[2022-12-29 20:12:36,698: WARNING/MainProcess] # trying /Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/curl.so
[2022-12-29 20:12:36,698: WARNING/MainProcess] # trying /Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/curl.py
[2022-12-29 20:12:36,701: WARNING/MainProcess] # /Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/__pycache__/curl.cpython-39.pyc matches /Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/curl.py
[2022-12-29 20:12:36,702: WARNING/MainProcess] # code object from '/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/__pycache__/curl.cpython-39.pyc'
[2022-12-29 20:12:36,702: WARNING/MainProcess] import 'kombu.asynchronous.http.curl' # <_frozen_importlib_external.SourceFileLoader object at 0x126fc96d0>
```

### Without this patch (doesn't work)
```
[2022-12-29 20:13:10,057: WARNING/MainProcess] # trying /Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/curl.cpython-39-darwin.so
[2022-12-29 20:13:10,058: WARNING/MainProcess] # trying /Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/curl.abi3.so
[2022-12-29 20:13:10,058: WARNING/MainProcess] # trying /Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/curl.so
[2022-12-29 20:13:10,058: WARNING/MainProcess] # trying /Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/curl.py
[2022-12-29 20:13:10,058: WARNING/MainProcess] # /Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/__pycache__/curl.cpython-39.pyc matches /Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/curl.py
[2022-12-29 20:13:10,059: WARNING/MainProcess] # code object from '/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/__pycache__/curl.cpython-39.pyc'
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/work/gds/notifications-api/venv/bin/pycurl.cpython-39-darwin.so
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/work/gds/notifications-api/venv/bin/pycurl.abi3.so
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/work/gds/notifications-api/venv/bin/pycurl.so
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/work/gds/notifications-api/venv/bin/pycurl.py
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/work/gds/notifications-api/venv/bin/pycurl.pyc
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/pycurl.cpython-39-darwin.so
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/pycurl.abi3.so
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/pycurl.so
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/pycurl.py
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/pycurl.pyc
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/lib-dynload/pycurl.cpython-39-darwin.so
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/lib-dynload/pycurl.abi3.so
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/lib-dynload/pycurl.so
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/lib-dynload/pycurl.py
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/.pyenv/versions/3.9.15/lib/python3.9/lib-dynload/pycurl.pyc
[2022-12-29 20:13:10,059: WARNING/MainProcess] # trying /Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/pycurl.cpython-39-darwin.so
[2022-12-29 20:13:10,066: WARNING/MainProcess] import 'kombu.asynchronous.http.curl' # <_frozen_importlib_external.SourceFileLoader object at 0x10f328f70>
[2022-12-29 20:13:10,067: CRITICAL/MainProcess] Unrecoverable error: ImportError('The curl client requires the pycurl library.')
Traceback (most recent call last):
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/__init__.py", line 18, in get_client
    return hub._current_http_client
AttributeError: 'Hub' object has no attribute '_current_http_client'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/celery/worker/worker.py", line 203, in start
    self.blueprint.start(self)
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/celery/bootsteps.py", line 116, in start
    step.start(parent)
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/celery/bootsteps.py", line 365, in start
    return self.obj.start()
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/celery/worker/consumer/consumer.py", line 332, in start
    blueprint.start(self)
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/celery/bootsteps.py", line 116, in start
    step.start(parent)
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/celery/worker/consumer/consumer.py", line 628, in start
    c.loop(*c.loop_args())
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/celery/worker/loops.py", line 97, in asynloop
    next(loop)
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/hub.py", line 299, in create_loop
    item()
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/vine/promises.py", line 160, in __call__
    return self.throw()
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/vine/promises.py", line 157, in __call__
    retval = fun(*final_args, **final_kwargs)
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/transport/SQS.py", line 541, in _schedule_queue
    self._get_bulk_async(
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/transport/SQS.py", line 558, in _get_bulk_async
    return self._get_async(queue, maxcount, callback=callback)
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/transport/SQS.py", line 568, in _get_async
    qname, count=count, connection=self.asynsqs(queue=qname),
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/transport/SQS.py", line 771, in asynsqs
    c = self._asynsqs = AsyncSQSConnection(
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/aws/sqs/connection.py", line 20, in __init__
    super().__init__(
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/aws/connection.py", line 180, in __init__
    super().__init__(sqs_connection, http_client,
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/aws/connection.py", line 134, in __init__
    self._httpclient = http_client or get_client()
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/__init__.py", line 20, in get_client
    client = hub._current_http_client = Client(hub, **kwargs)
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/__init__.py", line 11, in Client
    return CurlClient(hub, **kwargs)
  File "/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/kombu/asynchronous/http/curl.py", line 41, in __init__
    raise ImportError('The curl client requires the pycurl library.')
ImportError: The curl client requires the pycurl library.
```

For reference, it's not that pycurl doesn't exist, but the ImportError is flagging `[2022-12-29 20:16:49,088: WARNING/MainProcess] pycurl: libcurl link-time version (7.76.1) is older than compile-time version (7.85.0)`

## Maybe helpful gist

https://gist.github.com/vidakDK/de86d751751b355ed3b26d69ecdbdb99

Lots of other people are having the same issue. I haven't found a conclusive solution yet. It seems weirdly intermittent. Notably enjoyed find @idavidmcdonald's contribution to the above gist 🙌 