### PR TITLE
Add NewRelic to dev+preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ export NOTIFICATION_QUEUE_PREFIX='YOUR_OWN_PREFIX'
 export FLASK_APP=application.py
 export FLASK_DEBUG=1
 export WERKZEUG_DEBUG_PIN=off
+
+export NEW_RELIC_ENABLED=[0|1]
+export NEW_RELIC_LICENSE_KEY=<ask for it>>
+export NEW_RELIC_APP_NAME=development.notify-api
 "> environment.sh
 ```
 

--- a/application.py
+++ b/application.py
@@ -1,6 +1,16 @@
 ##!/usr/bin/env python
 from __future__ import print_function
 
+import os
+
+if (environment := os.getenv("NOTIFY_ENVIRONMENT")) in {"development", "preview"} and os.getenv(
+    "NEW_RELIC_ENABLED"
+) == "1":
+    import newrelic.agent
+
+    # Expects NEW_RELIC_LICENSE_KEY set in environment as well.
+    newrelic.agent.initialize("newrelic.ini", environment=environment, ignore_errors=False)
+
 from app import create_app
 from app.notify_api_flask_app import NotifyApiFlaskApp
 

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -149,6 +149,9 @@ applications:
 
       DVLA_EMAIL_ADDRESSES: '{{ DVLA_EMAIL_ADDRESSES | tojson  }}'
 
+      NEW_RELIC_APP_NAME: '{{ environment }}.{{ CF_APP }}'
+      NEW_RELIC_LICENSE_KEY: '{{ NEW_RELIC_LICENSE_KEY }}'
+
       {% for key, value in app.get('additional_env_vars', {}).items() %}
       {{key}}: '{{value}}'
       {% endfor %}

--- a/newrelic.ini
+++ b/newrelic.ini
@@ -1,0 +1,215 @@
+# ---------------------------------------------------------------------------
+
+#
+# This file configures the New Relic Python Agent.
+#
+# The path to the configuration file should be supplied to the function
+# newrelic.agent.initialize() when the agent is being initialized.
+#
+# The configuration file follows a structure similar to what you would
+# find for Microsoft Windows INI files. For further information on the
+# configuration file format see the Python ConfigParser documentation at:
+#
+#    http://docs.python.org/library/configparser.html
+#
+# For further discussion on the behaviour of the Python agent that can
+# be configured via this configuration file see:
+#
+#    http://newrelic.com/docs/python/python-agent-configuration
+#
+
+# ---------------------------------------------------------------------------
+
+# Here are the settings that are common to all environments.
+
+[newrelic]
+
+# You must specify the license key associated with your New
+# Relic account. This key binds the Python Agent's data to your
+# account in the New Relic service.
+# license_key = <provided in environment via NEW_RELIC_LICENSE_KEY>
+
+# The application name. Set this to be the name of your
+# application as you would like it to show up in New Relic UI.
+# The UI will then auto-map instances of your application into a
+# entry on your home dashboard page.
+# app_name = notify-api
+
+# New Relic offers distributed tracing for monitoring and analyzing modern
+# distributed systems.Enable distributed tracing.
+distributed_tracing.enabled = true
+
+# When "true", the agent collects performance data about your
+# application and reports this data to the New Relic UI at
+# newrelic.com. This global switch is normally overridden for
+# each environment below.
+monitor_mode = false
+
+# Sets the name of a file to log agent messages to. Useful for
+# debugging any issues with the agent. This is not set by
+# default as it is not known in advance what user your web
+# application processes will run as and where they have
+# permission to write to. Whatever you set this to you must
+# ensure that the permissions for the containing directory and
+# the file itself are correct, and that the user that your web
+# application runs as can write to the file. If not able to
+# write out a log file, it is also possible to say "stderr" and
+# output to standard error output. This would normally result in
+# output appearing in your web server log.
+#log_file = /tmp/newrelic-python-agent.log
+
+# Sets the level of detail of messages sent to the log file, if
+# a log file location has been provided. Possible values, in
+# increasing order of detail, are: "critical", "error", "warning",
+# "info" and "debug". When reporting any agent issues to New
+# Relic technical support, the most useful setting for the
+# support engineers is "debug". However, this can generate a lot
+# of information very quickly, so it is best not to keep the
+# agent at this level for longer than it takes to reproduce the
+# problem you are experiencing.
+log_level = info
+
+# The Python Agent communicates with the New Relic service using
+# SSL by default. Note that this does result in an increase in
+# CPU overhead, over and above what would occur for a non SSL
+# connection, to perform the encryption involved in the SSL
+# communication. This work is though done in a distinct thread
+# to those handling your web requests, so it should not impact
+# response times. You can if you wish revert to using a non SSL
+# connection, but this will result in information being sent
+# over a plain socket connection and will not be as secure.
+ssl = true
+
+# High Security Mode enforces certain security settings, and
+# prevents them from being overridden, so that no sensitive data
+# is sent to New Relic. Enabling High Security Mode means that
+# SSL is turned on, request parameters are not collected, and SQL
+# can not be sent to New Relic in its raw form. To activate High
+# Security Mode, it must be set to 'true' in this local .ini
+# configuration file AND be set to 'true' in the server-side
+# configuration in the New Relic user interface. For details, see
+# https://docs.newrelic.com/docs/subscriptions/high-security
+high_security = false
+
+# The Python Agent will attempt to connect directly to the New
+# Relic service. If there is an intermediate firewall between
+# your host and the New Relic service that requires you to use a
+# HTTP proxy, then you should set both the "proxy_host" and
+# "proxy_port" settings to the required values for the HTTP
+# proxy. The "proxy_user" and "proxy_pass" settings should
+# additionally be set if proxy authentication is implemented by
+# the HTTP proxy. The "proxy_scheme" setting dictates what
+# protocol scheme is used in talking to the HTTP proxy. This
+# would normally always be set as "http" which will result in the
+# agent then using a SSL tunnel through the HTTP proxy for end to
+# end encryption.
+# proxy_scheme = http
+# proxy_host = hostname
+# proxy_port = 8080
+# proxy_user =
+# proxy_pass =
+
+# Capturing request parameters is off by default. To enable the
+# capturing of request parameters, first ensure that the setting
+# "attributes.enabled" is set to "true" (the default value), and
+# then add "request.parameters.*" to the "attributes.include"
+# setting. For details about attributes configuration, please
+# consult the documentation.
+# attributes.include = request.parameters.*
+
+# The transaction tracer captures deep information about slow
+# transactions and sends this to the UI on a periodic basis. The
+# transaction tracer is enabled by default. Set this to "false"
+# to turn it off.
+transaction_tracer.enabled = true
+
+# Threshold in seconds for when to collect a transaction trace.
+# When the response time of a controller action exceeds this
+# threshold, a transaction trace will be recorded and sent to
+# the UI. Valid values are any positive float value, or (default)
+# "apdex_f", which will use the threshold for a dissatisfying
+# Apdex controller action - four times the Apdex T value.
+transaction_tracer.transaction_threshold = apdex_f
+
+# When the transaction tracer is on, SQL statements can
+# optionally be recorded. The recorder has three modes, "off"
+# which sends no SQL, "raw" which sends the SQL statement in its
+# original form, and "obfuscated", which strips out numeric and
+# string literals.
+transaction_tracer.record_sql = obfuscated
+
+# Threshold in seconds for when to collect stack trace for a SQL
+# call. In other words, when SQL statements exceed this
+# threshold, then capture and send to the UI the current stack
+# trace. This is helpful for pinpointing where long SQL calls
+# originate from in an application.
+transaction_tracer.stack_trace_threshold = 0.15
+
+# Determines whether the agent will capture query plans for slow
+# SQL queries. Only supported in MySQL and PostgreSQL. Set this
+# to "false" to turn it off.
+transaction_tracer.explain_enabled = true
+
+# Threshold for query execution time below which query plans
+# will not not be captured. Relevant only when "explain_enabled"
+# is true.
+transaction_tracer.explain_threshold = 0.15
+
+# Space separated list of function or method names in form
+# 'module:function' or 'module:class.function' for which
+# additional function timing instrumentation will be added.
+transaction_tracer.function_trace =
+
+# The error collector captures information about uncaught
+# exceptions or logged exceptions and sends them to UI for
+# viewing. The error collector is enabled by default. Set this
+# to "false" to turn it off.
+error_collector.enabled = true
+
+# To stop specific errors from reporting to the UI, set this to
+# a space separated list of the Python exception type names to
+# ignore. The exception name should be of the form 'module:class'.
+error_collector.ignore_errors =
+
+# Browser monitoring is the Real User Monitoring feature of the UI.
+# For those Python web frameworks that are supported, this
+# setting enables the auto-insertion of the browser monitoring
+# JavaScript fragments.
+browser_monitoring.auto_instrument = false
+
+# A thread profiling session can be scheduled via the UI when
+# this option is enabled. The thread profiler will periodically
+# capture a snapshot of the call stack for each active thread in
+# the application to construct a statistically representative
+# call tree.
+thread_profiler.enabled = true
+
+# Disable log collection/forwarding
+application_logging.enabled=false
+
+# ---------------------------------------------------------------------------
+
+#
+# The application environments. These are specific settings which
+# override the common environment settings. The settings related to a
+# specific environment will be used when the environment argument to the
+# newrelic.agent.initialize() function has been defined to be either
+# "development", "test", "staging" or "production".
+#
+
+[newrelic:development]
+monitor_mode = true
+
+[newrelic:test]
+monitor_mode = false
+
+[newrelic:preview]
+monitor_mode = true
+
+[newrelic:staging]
+monitor_mode = false
+
+[newrelic:production]
+monitor_mode = false
+
+# ---------------------------------------------------------------------------

--- a/requirements.in
+++ b/requirements.in
@@ -33,3 +33,5 @@ notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@61
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
+
+newrelic

--- a/requirements.txt
+++ b/requirements.txt
@@ -156,6 +156,8 @@ marshmallow-sqlalchemy==0.28.1
     # via -r requirements.in
 mistune==0.8.4
     # via notifications-utils
+newrelic==8.5.0
+    # via -r requirements.in
 notifications-python-client==6.3.0
     # via -r requirements.in
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@61.0.0

--- a/run_celery.py
+++ b/run_celery.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python
 
+import os
+
+if (environment := os.getenv("NOTIFY_ENVIRONMENT")) in {"development", "preview"} and os.getenv(
+    "NEW_RELIC_ENABLED"
+) == "1":
+    import newrelic.agent
+
+    # Expects NEW_RELIC_LICENSE_KEY set in environment as well.
+    newrelic.agent.initialize("newrelic.ini", environment=environment, ignore_errors=False)
+
 # import prometheus before any other code. If gds_metrics is imported first it will write a prometheus file to disk
 # that will never be read from (since we don't have prometheus celery stats). If prometheus is imported first,
 # prometheus will simply store the metrics in memory


### PR DESCRIPTION
We add basic APM instrumentation for NewRelic. This will inject tracing
headers that filter through to any other instrumented apps and send them
to NewRelic so that we can see how requests travel through our services
and how long each span takes. This should help us highlight slower areas
of the codebase which we can then investigate and optimise.

We only send APM information - not logs - here, and we heavily limit the
information sent so that we hopefully aren't gathering much/any PII. We
also only deploy to dev and preview at the moment, so there's no risk of
this code gathering real user data for now. This will allow us to safely
investigate the tool and see whether it's something useful for us.

Required env vars:
`NEW_RELIC_LICENCE_KEY`