### PR TITLE
find a unique name for letter branding.

### DIFF
--- a/app/dao/letter_branding_dao.py
+++ b/app/dao/letter_branding_dao.py
@@ -3,12 +3,29 @@ from app.dao.dao_utils import autocommit
 from app.models import LetterBranding
 
 
+def dao_get_existing_alternate_letter_branding_for_name(name):
+    """
+    Returns any letter branding with name of format `{name} (alternate {x})`
+
+    where name is the provided name and x is an integer starting at 1
+    """
+    return (
+        LetterBranding.query.filter(LetterBranding.name.ilike(f"{name} (alternate %)"))
+        .order_by(LetterBranding.name)
+        .all()
+    )
+
+
 def dao_get_letter_branding_by_id(letter_branding_id):
     return LetterBranding.query.filter(LetterBranding.id == letter_branding_id).one()
 
 
 def dao_get_letter_branding_by_name(letter_branding_name):
     return LetterBranding.query.filter_by(name=letter_branding_name).first()
+
+
+def dao_get_letter_branding_by_name_case_insensitive(letter_branding_name):
+    return LetterBranding.query.filter(LetterBranding.name.ilike(letter_branding_name)).all()
 
 
 def dao_get_all_letter_branding():

--- a/app/email_branding/email_branding_schema.py
+++ b/app/email_branding/email_branding_schema.py
@@ -31,6 +31,7 @@ post_update_email_branding_schema = {
     },
     "required": [],
 }
+
 post_get_email_branding_name_for_alt_text_schema = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST schema for getting email_branding",

--- a/app/letter_branding/letter_branding_schema.py
+++ b/app/letter_branding/letter_branding_schema.py
@@ -8,3 +8,13 @@ post_letter_branding_schema = {
     },
     "required": ["name", "filename"],
 }
+
+post_get_unique_name_for_letter_branding_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "POST schema for getting unique name for letter branding",
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+    },
+    "required": ["name"],
+}

--- a/tests/app/dao/test_letter_branding_dao.py
+++ b/tests/app/dao/test_letter_branding_dao.py
@@ -6,7 +6,9 @@ from sqlalchemy.exc import SQLAlchemyError
 from app.dao.letter_branding_dao import (
     dao_create_letter_branding,
     dao_get_all_letter_branding,
+    dao_get_existing_alternate_letter_branding_for_name,
     dao_get_letter_branding_by_id,
+    dao_get_letter_branding_by_name_case_insensitive,
     dao_update_letter_branding,
 )
 from app.models import LetterBranding
@@ -61,3 +63,29 @@ def test_dao_update_letter_branding(notify_db_session):
     assert letter_branding.name == "original"
     dao_update_letter_branding(letter_branding.id, name="new name")
     assert LetterBranding.query.first().name == "new name"
+
+
+def test_get_letter_branding_by_name_case_insensitive_gets_correct_letter_branding(notify_db_session):
+    title_case = create_letter_branding(name="Department Name", filename="1")
+    upper_case = create_letter_branding(name="DEPARTMENT NAME", filename="2")
+    lower_case = create_letter_branding(name="department name", filename="3")
+    # without a space, doesn't match
+    create_letter_branding(name="departmentname", filename="4")
+
+    brandings = dao_get_letter_branding_by_name_case_insensitive("dEpArTmEnT nAmE")
+    assert len(brandings) == 3
+    assert title_case in brandings
+    assert upper_case in brandings
+    assert lower_case in brandings
+
+
+def test_dao_get_existing_alternate_letter_branding_for_name(notify_db_session):
+    original = create_letter_branding(name="Department Name", filename="1")
+    create_letter_branding(name="Department Name (alternate 1)", filename="2")
+    create_letter_branding(name="department name (alternate 2)", filename="3")
+    create_letter_branding(name="Department Name (alternate 40)", filename="4")
+
+    alt_brandings = dao_get_existing_alternate_letter_branding_for_name("dEpArTmEnT nAmE")
+
+    assert len(alt_brandings) == 3
+    assert original not in alt_brandings

--- a/tests/app/letter_branding/test_letter_branding_rest.py
+++ b/tests/app/letter_branding/test_letter_branding_rest.py
@@ -1,6 +1,8 @@
 import json
 import uuid
 
+import pytest
+
 from app.models import LetterBranding
 from tests import create_admin_authorization_header
 from tests.app.db import create_letter_branding
@@ -72,3 +74,51 @@ def test_update_letter_branding_returns_400_when_integrity_error_is_thrown(clien
     assert response.status_code == 400
     json_resp = json.loads(response.get_data(as_text=True))
     assert json_resp["message"] == {"name": ["Name already in use"]}
+
+
+def test_get_letter_branding_unique_name_returns_name_if_nothing_in_db_with_that_name(
+    admin_request,
+    notify_db_session,
+):
+    create_letter_branding(name="Other Department")
+
+    response = admin_request.post("letter_branding.get_letter_branding_unique_name", _data={"name": "Department Name"})
+    assert response == {"name": "Department Name"}
+
+
+def test_get_letter_branding_unique_name_returns_alternate_option_if_name_already_used(
+    admin_request,
+    notify_db_session,
+):
+    create_letter_branding(name="DEPARTMENT name")
+
+    response = admin_request.post("letter_branding.get_letter_branding_unique_name", _data={"name": "Department Name"})
+    assert response == {"name": "Department Name (alternate 1)"}
+
+
+def test_get_letter_branding_unique_name_returns_first_available_alternate_option(
+    admin_request,
+    notify_db_session,
+):
+    create_letter_branding(name="Department Name", filename="1")
+    create_letter_branding(name="Department Name (alternate 1)", filename="2")
+    create_letter_branding(name="Department Name (alternate 2)", filename="3")
+    create_letter_branding(name="Department Name (alternate 4)", filename="4")
+    # we've already renamed one of the options
+    create_letter_branding(name="Department Name (blue banner)", filename="5")
+
+    response = admin_request.post("letter_branding.get_letter_branding_unique_name", _data={"name": "Department Name"})
+    assert response == {"name": "Department Name (alternate 3)"}
+
+
+def test_get_letter_branding_unique_name_gives_up_if_100_options_assigned(
+    admin_request,
+    notify_db_session,
+):
+    create_letter_branding(name="Department Name", filename="first")
+    for x in range(1, 100):
+        create_letter_branding(name=f"Department Name (alternate {x})", filename=str(x))
+
+    with pytest.raises(ValueError) as exc:
+        admin_request.post("letter_branding.get_letter_branding_unique_name", _data={"name": "Department Name"})
+    assert "Couldnt assign a unique name for Department Name" in str(exc.value)


### PR DESCRIPTION
this is almost identical to the email branding[^1], except we don't have the concept of alt text for letter branding so we can rename the endpoint slightly.

unfortunately with the separate db models for both of them, it wasn't trivial to DRY these up with our current patterns.

[^1]: https://github.com/alphagov/notifications-api/pull/3651