### PR TITLE
Fix edge case for bulk sending

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -73,12 +73,13 @@ def check_service_over_daily_message_limit(service, key_type, notification_type,
         limit_value = rate_limits[notification_type_]
 
         cache_key = daily_limit_cache_key(service.id, notification_type=notification_type_)
-        service_stats = redis_store.get(cache_key)
-        if service_stats is None:
+        if (service_stats := redis_store.get(cache_key)) is None:
             # first message of the day, set the cache to 0 and the expiry to 24 hours
             redis_store.set(cache_key, 0, ex=86400)
 
-        elif int(service_stats) + num_notifications > limit_value:
+            service_stats = 0
+
+        if int(service_stats) + num_notifications > limit_value:
             current_app.logger.info(
                 "service {} has been rate limited for {} daily use sent {} limit {}".format(
                     service.id, int(service_stats), limit_name, limit_value


### PR DESCRIPTION
There is a theoretical edge case for the new rate limits when posting bulk jobs.

If the first notifications sent by a service on a given day are a bulk job, and that bulk job exceeds the service's limits, we don't fail the job in advance.

This is unlikely to have ever been hit in reality, as bulk jobs are limited to 100k and our new per-channel limits are going to be 250k, but we should fix this anyway to 1) prevent confusion and 2) not cause any future issues if we dropped the limits in the future.

---

(When we roll out the new rate limits we also need to update the frontend to display the per-channel limits rather than the service-total rate limit if a bulk job hits this limit, but will address that in an admin PR separately/at a later date)