### PR TITLE
Fix some auto-generated migrations

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2238,7 +2238,7 @@ class BroadcastMessage(db.Model):
     template = db.relationship("TemplateHistory", backref="broadcast_messages")
 
     _personalisation = db.Column(db.String, nullable=True)
-    content = db.Column(db.String, nullable=False)
+    content = db.Column(db.Text, nullable=False)
     # defaults to empty list
     areas = db.Column(JSONB(none_as_null=True), nullable=False, default=list)
 

--- a/app/models.py
+++ b/app/models.py
@@ -2531,6 +2531,12 @@ class BroadcastProviderTypes(db.Model):
     name = db.Column(db.String(255), primary_key=True)
 
 
+class BroadcastProviderMessageStatusType(db.Model):
+    __tablename__ = "broadcast_provider_message_status_type"
+
+    name = db.Column(db.String(), primary_key=True)
+
+
 class ServiceBroadcastProviderRestriction(db.Model):
     """
     TODO: Drop this table as no longer used

--- a/app/models.py
+++ b/app/models.py
@@ -1875,7 +1875,7 @@ class Rate(db.Model):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     valid_from = db.Column(db.DateTime, nullable=False)
-    rate = db.Column(db.Float(asdecimal=False), nullable=False)
+    rate = db.Column(db.Numeric(asdecimal=False), nullable=False)
     notification_type = db.Column(notification_types, index=True, nullable=False)
 
     def __str__(self):

--- a/app/models.py
+++ b/app/models.py
@@ -1395,6 +1395,10 @@ class NotificationAllTimeView(db.Model):
 
     __tablename__ = "notifications_all_time_view"
 
+    # Tell alembic not to create this as a table. We have a migration where we manually set this up as a view.
+    # This is custom logic we apply - not built-in logic. See `migrations/env.py`
+    __table_args__ = {"info": {"managed_by_alembic": False}}
+
     id = db.Column(UUID(as_uuid=True), primary_key=True)
     job_id = db.Column(UUID(as_uuid=True))
     job_row_number = db.Column(db.Integer)

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0401_prefix_sms_non_null
+0402_inbound_sms_history

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0400_non_nullable_ids
+0401_prefix_sms_non_null

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0399_nullable_message_limit
+0400_non_nullable_ids

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -27,6 +27,14 @@ target_metadata = current_app.extensions["migrate"].db.metadata
 # ... etc.
 
 
+def include_object(object, name, type_, reflected, compare_to):
+    """
+    Exclude views from Alembic's consideration.
+    """
+
+    return object.info.get("managed_by_alembic", True)
+
+
 def run_migrations_offline():
     """Run migrations in 'offline' mode.
 
@@ -40,7 +48,7 @@ def run_migrations_offline():
 
     """
     url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url)
+    context.configure(url=url, include_object=include_object)
 
     with context.begin_transaction():
         context.run_migrations()
@@ -58,7 +66,9 @@ def run_migrations_online():
     )
 
     connection = engine.connect()
-    context.configure(connection=connection, target_metadata=target_metadata, compare_type=True)
+    context.configure(
+        connection=connection, target_metadata=target_metadata, compare_type=True, include_object=include_object
+    )
 
     try:
         with context.begin_transaction():

--- a/migrations/versions/0400_non_nullable_ids.py
+++ b/migrations/versions/0400_non_nullable_ids.py
@@ -1,0 +1,22 @@
+"""
+
+Revision ID: 0400_non_nullable_ids
+Revises: 0399_nullable_message_limit
+Create Date: 2023-01-19 16:13:38.601465
+
+"""
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0400_non_nullable_ids"
+down_revision = "0399_nullable_message_limit"
+
+
+def upgrade():
+    op.alter_column("user_to_service", "user_id", existing_type=postgresql.UUID(), nullable=False)
+    op.alter_column("user_to_service", "service_id", existing_type=postgresql.UUID(), nullable=False)
+
+
+def downgrade():
+    op.alter_column("user_to_service", "service_id", existing_type=postgresql.UUID(), nullable=True)
+    op.alter_column("user_to_service", "user_id", existing_type=postgresql.UUID(), nullable=True)

--- a/migrations/versions/0401_prefix_sms_non_null.py
+++ b/migrations/versions/0401_prefix_sms_non_null.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 0401_prefix_sms_non_null
+Revises: 0400_non_nullable_ids
+Create Date: 2023-01-19 16:56:49.635251
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0401_prefix_sms_non_null"
+down_revision = "0400_non_nullable_ids"
+
+
+def upgrade():
+    op.execute("UPDATE services_history SET prefix_sms = FALSE WHERE prefix_sms IS NULL")
+    op.alter_column("services_history", "prefix_sms", existing_type=sa.BOOLEAN(), nullable=False)
+
+
+def downgrade():
+    op.alter_column("services_history", "prefix_sms", existing_type=sa.BOOLEAN(), nullable=True)

--- a/migrations/versions/0402_inbound_sms_history.py
+++ b/migrations/versions/0402_inbound_sms_history.py
@@ -1,0 +1,19 @@
+"""
+
+Revision ID: 0402_inbound_sms_history
+Revises: 0401_prefix_sms_non_null
+Create Date: 2023-01-19 17:32:56.494917
+
+"""
+from alembic import op
+
+revision = "0402_inbound_sms_history"
+down_revision = "0401_prefix_sms_non_null"
+
+
+def upgrade():
+    op.create_index(op.f("ix_inbound_sms_history_created_at"), "inbound_sms_history", ["created_at"], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_inbound_sms_history_created_at"), table_name="inbound_sms_history")


### PR DESCRIPTION
When we make model changes it's nice to be able to use alembic to autogenerate the migration changes.

Unfortunately for a while now it's been generating instructions unrelated to the changes a dev picks up, because things have fallen out of sync over time.

This removes all of the differences except 2 indexes, which are slightly trickier to unpick because we haven't got naming conventions for indexes (see: https://alembic.sqlalchemy.org/en/latest/naming.html).

It also leaves alone the `research_mode` columns that are addressed here: https://github.com/alphagov/notifications-api/pull/3703