### PR TITLE
don't update returned letters

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -28,7 +28,7 @@ from app.dao.notifications_dao import (
 from app.dao.provider_details_dao import (
     get_provider_details_by_notification_type,
 )
-from app.dao.returned_letters_dao import insert_or_update_returned_letters
+from app.dao.returned_letters_dao import insert_returned_letters
 from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_id
 from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
 from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id
@@ -618,7 +618,7 @@ def process_returned_letters_list(notification_references):
         notification_references, {"status": NOTIFICATION_RETURNED_LETTER}
     )
 
-    insert_or_update_returned_letters(notification_references)
+    insert_returned_letters(notification_references)
 
     current_app.logger.info(
         "Updated {} letter notifications ({} history notifications, from {} references) to returned-letter".format(

--- a/app/dao/returned_letters_dao.py
+++ b/app/dao/returned_letters_dao.py
@@ -31,21 +31,20 @@ def _get_notification_ids_for_references(references):
 
 
 @autocommit
-def insert_or_update_returned_letters(references):
+def insert_returned_letters(references):
     data = _get_notification_ids_for_references(references)
     for row in data:
         table = ReturnedLetter.__table__
 
-        stmt = insert(table).values(
-            reported_at=datetime.utcnow().date(),
-            service_id=row.service_id,
-            notification_id=row.id,
-            created_at=datetime.utcnow(),
-        )
-
-        stmt = stmt.on_conflict_do_update(
-            index_elements=[table.c.notification_id],
-            set_={"reported_at": datetime.utcnow().date(), "updated_at": datetime.utcnow()},
+        stmt = (
+            insert(table)
+            .values(
+                reported_at=datetime.utcnow().date(),
+                service_id=row.service_id,
+                notification_id=row.id,
+                created_at=datetime.utcnow(),
+            )
+            .on_conflict_do_nothing(index_elements=[table.c.notification_id])
         )
         db.session.connection().execute(stmt)
 


### PR DESCRIPTION
previously, if a returned letter was referenced in two separate DVLA reports, we would update the existing row in the database - updating the `reported_at` date and setting the `updated_at` timestamp.

However, this leads to confusing behaviour - the user might have downloaded an old report, then when they check again, that report will have _less_ rows, and the new report will have rows that they may have already handled and actioned a month prior.

Change the code so that if the row already exists, it just skips the insert.