### PR TITLE
Dvla auth

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -34,6 +34,7 @@ from app.clients.cbc_proxy import CBCProxyClient
 from app.clients.document_download import DocumentDownloadClient
 from app.clients.email.aws_ses import AwsSesClient
 from app.clients.email.aws_ses_stub import AwsSesStubClient
+from app.clients.letter.dvla import DVLAClient
 from app.clients.sms.firetext import FiretextClient
 from app.clients.sms.mmg import MMGClient
 
@@ -58,6 +59,7 @@ firetext_client = FiretextClient()
 mmg_client = MMGClient()
 aws_ses_client = AwsSesClient()
 aws_ses_stub_client = AwsSesStubClient()
+dvla_client = DVLAClient()
 encryption = Encryption()
 zendesk_client = ZendeskClient()
 statsd_client = StatsdClient()
@@ -98,7 +100,7 @@ def create_app(application):
     logging.init_app(application, statsd_client)
     firetext_client.init_app(application, statsd_client=statsd_client)
     mmg_client.init_app(application, statsd_client=statsd_client)
-
+    dvla_client.init_app(application.config["AWS_REGION"], statsd_client=statsd_client)
     aws_ses_client.init_app(application.config["AWS_REGION"], statsd_client=statsd_client)
     aws_ses_stub_client.init_app(
         application.config["AWS_REGION"], statsd_client=statsd_client, stub_url=application.config["SES_STUB_URL"]

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -1,0 +1,38 @@
+import boto3
+
+
+class SSMParameter:
+    def __init__(self, key, ssm_client):
+        self.key = key
+        self.ssm_client = ssm_client
+
+    def get(self):
+        return self.ssm_client.get_parameter(Name=self.key, WithDecryption=True)["Parameter"]["Value"]
+
+    def set(self, value):
+        # this errors if the parameter doesn't exist yet in SSM as we haven't supplied a `Type`
+        # this is fine for our purposes, as we'll always want to pre-seed this data.
+        self.ssm_client.put_parameter(Name=self.key, Value=value, Overwrite=True)
+
+
+class DVLAClient:
+    """
+    DVLA HTTP API letter client.
+    """
+
+    statsd_client = None
+
+    def init_app(self, region, statsd_client):
+        ssm_client = boto3.client("ssm", region_name=region)
+        self.dvla_username = SSMParameter(key="/notify/api/dvla_username", ssm_client=ssm_client)
+        self.dvla_password = SSMParameter(key="/notify/api/dvla_password", ssm_client=ssm_client)
+        self.dvla_api_key = SSMParameter(key="/notify/api/dvla_api_key", ssm_client=ssm_client)
+
+        self.statsd_client = statsd_client
+
+    @property
+    def name(self):
+        return "dvla"
+
+    def send_letter(self):
+        pass

--- a/app/config.py
+++ b/app/config.py
@@ -408,6 +408,8 @@ class Config(object):
     # as defined in api db migration 0331_add_broadcast_org.py
     BROADCAST_ORGANISATION_ID = "38e4bf69-93b0-445d-acee-53ea53fe02df"
 
+    DVLA_API_BASE_URL = os.environ.get("DVLA_API_BASE_URL")
+
 
 ######################
 # Config overrides ###
@@ -501,6 +503,8 @@ class Test(Development):
     CBC_PROXY_ENABLED = True
     DVLA_EMAIL_ADDRESSES = ["success@simulator.amazonses.com", "success+2@simulator.amazonses.com"]
 
+    DVLA_API_BASE_URL = "https://test-dvla-api.com"
+
 
 class Preview(Config):
     NOTIFY_EMAIL_DOMAIN = "notify.works"
@@ -535,6 +539,8 @@ class Staging(Config):
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = True
 
+    DVLA_API_BASE_URL = "https://uat.driver-vehicle-licensing.api.gov.uk"
+
 
 class Production(Config):
     NOTIFY_EMAIL_DOMAIN = "notifications.service.gov.uk"
@@ -554,6 +560,8 @@ class Production(Config):
     SES_STUB_URL = None
 
     CRONITOR_ENABLED = True
+
+    DVLA_API_BASE_URL = "https://driver-vehicle-licensing.api.gov.uk"
 
 
 class CloudFoundryConfig(Config):

--- a/tests/app/clients/test_dvla.py
+++ b/tests/app/clients/test_dvla.py
@@ -1,6 +1,10 @@
+import time
+from datetime import datetime
 from unittest.mock import Mock
 
 import boto3
+import freezegun
+import jwt
 import pytest
 from moto import mock_ssm
 
@@ -52,16 +56,49 @@ def test_set_ssm_creds(dvla_client, ssm):
     assert ssm.get_parameter(Name="/notify/api/dvla_api_key")["Parameter"]["Value"] == "some new api key"
 
 
+def test_jwt_token_returns_jwt_if_set_and_not_expired_yet(client, dvla_client, rmock):
+    curr_time = int(time.time())
+    sample_token = jwt.encode(payload={"exp": curr_time + 3600}, key="foo")
+    dvla_client._jwt_token = sample_token
+    dvla_client._jwt_expires_at = curr_time + 3600
+
+    assert dvla_client.jwt_token == sample_token
+
+
 def test_jwt_token_calls_authenticate_if_not_set(client, dvla_client, rmock):
     assert dvla_client._jwt_token is None
 
-    endpoint = "https://test-dvla-api.com/thirdparty-access/v1/authenticate"
-    mock_authenticate = rmock.request("POST", endpoint, json={"id-token": "abc.123"}, status_code=200)
+    curr_time = int(time.time())
+    sample_token = jwt.encode(payload={"exp": curr_time}, key="foo")
 
-    assert dvla_client.jwt_token == "abc.123"
-    assert dvla_client.jwt_token == "abc.123"
+    endpoint = "https://test-dvla-api.com/thirdparty-access/v1/authenticate"
+    mock_authenticate = rmock.request("POST", endpoint, json={"id-token": sample_token}, status_code=200)
+
+    assert dvla_client.jwt_token == sample_token
+    assert dvla_client._jwt_expires_at == int(time.time())
 
     # despite accessing value twice, we only called authenticate once
     assert mock_authenticate.called_once
     assert rmock.last_request.json() == {"userName": "some username", "password": "some password"}
     assert rmock.last_request.headers["Content-Type"] == "application/json"
+
+
+def test_jwt_token_calls_authenticate_if_expiry_time_passed(client, dvla_client, rmock):
+    prev_token_expiry_time = time.time()
+    one_second_later = prev_token_expiry_time + 1
+    one_hour_later = one_second_later + 3600
+
+    old_token = jwt.encode(payload={"exp": prev_token_expiry_time}, key="foo")
+    next_token = jwt.encode(payload={"exp": one_hour_later}, key="foo")
+
+    dvla_client._jwt_token = jwt.encode(payload={"exp": prev_token_expiry_time}, key="foo")
+    dvla_client._jwt_expires_at = prev_token_expiry_time
+
+    endpoint = "https://test-dvla-api.com/thirdparty-access/v1/authenticate"
+    mock_authenticate = rmock.request("POST", endpoint, json={"id-token": next_token}, status_code=200)
+
+    with freezegun.freeze_time(datetime.fromtimestamp(one_second_later)):
+        assert dvla_client.jwt_token != old_token
+        assert dvla_client._jwt_expires_at == one_hour_later
+
+    assert mock_authenticate.called_once

--- a/tests/app/clients/test_dvla.py
+++ b/tests/app/clients/test_dvla.py
@@ -8,7 +8,7 @@ import jwt
 import pytest
 from moto import mock_ssm
 
-from app.clients.letter.dvla import DVLAClient
+from app.clients.letter.dvla import DVLAClient, SSMParameter
 
 
 @pytest.fixture
@@ -38,6 +38,60 @@ def dvla_client(ssm):
     dvla_client = DVLAClient()
     dvla_client.init_app(region="eu-west-1", statsd_client=Mock())
     yield dvla_client
+
+
+def test_set_ssm_creds_saves_in_cache(ssm):
+    param = SSMParameter(key="/foo", ssm_client=ssm)
+
+    today = datetime(2023, 1, 3, 12, 0, 1)
+
+    assert param.last_read_at is None
+    assert param._value is None
+
+    with freezegun.freeze_time(today):
+        param.set("new value")
+
+    assert param._value == "new value"
+    assert param.last_read_at == today
+
+
+@pytest.mark.parametrize(
+    "current_time, expected_value, expected_last_read_at",
+    [
+        (datetime(2023, 1, 3, 11, 59, 59), "old value", datetime(2023, 1, 2, 12, 0, 0)),
+        (datetime(2023, 1, 3, 12, 0, 0), "new value", datetime(2023, 1, 3, 12, 0, 0)),
+    ],
+)
+def test_get_ssm_creds_respects_ttl_when_fetching_value(ssm, current_time, expected_value, expected_last_read_at):
+    param = SSMParameter(key="/foo", ssm_client=ssm)
+
+    yesterday = datetime(2023, 1, 2, 12, 0, 0)
+
+    param.last_read_at = yesterday
+    param._value = "old value"
+
+    ssm.put_parameter(Name="/foo", Value="new value", Type="SecureString")
+
+    with freezegun.freeze_time(current_time):
+        assert param.get() == expected_value
+
+    assert param.last_read_at == expected_last_read_at
+
+
+def test_get_ssm_creds_fetches_value_and_saves_in_cache_if_not_set(ssm):
+    param = SSMParameter(key="/foo", ssm_client=ssm)
+    ssm.put_parameter(Name="/foo", Value="bar", Type="SecureString")
+
+    curr_time = datetime(2023, 1, 2, 12, 0, 0)
+
+    assert param.last_read_at is None
+    assert param._value is None
+
+    with freezegun.freeze_time(curr_time):
+        assert param.get() == "bar"
+
+    assert param.last_read_at == curr_time
+    assert param._value == "bar"
 
 
 def test_get_ssm_creds(dvla_client, ssm):

--- a/tests/app/clients/test_dvla.py
+++ b/tests/app/clients/test_dvla.py
@@ -1,0 +1,52 @@
+from unittest.mock import Mock
+
+import boto3
+import pytest
+from moto import mock_ssm
+
+from app.clients.letter.dvla import DVLAClient
+
+
+@pytest.fixture
+def ssm():
+    with mock_ssm():
+        ssm_client = boto3.client("ssm", "eu-west-1")
+        ssm_client.put_parameter(
+            Name="/notify/api/dvla_username",
+            Value="some username",
+            Type="SecureString",
+        )
+        ssm_client.put_parameter(
+            Name="/notify/api/dvla_password",
+            Value="some password",
+            Type="SecureString",
+        )
+        ssm_client.put_parameter(
+            Name="/notify/api/dvla_api_key",
+            Value="some api key",
+            Type="SecureString",
+        )
+        yield ssm_client
+
+
+@pytest.fixture
+def dvla_client(ssm):
+    dvla_client = DVLAClient()
+    dvla_client.init_app(region="eu-west-1", statsd_client=Mock())
+    yield dvla_client
+
+
+def test_get_ssm_creds(dvla_client, ssm):
+    assert dvla_client.dvla_username.get() == "some username"
+    assert dvla_client.dvla_password.get() == "some password"
+    assert dvla_client.dvla_api_key.get() == "some api key"
+
+
+def test_set_ssm_creds(dvla_client, ssm):
+    dvla_client.dvla_username.set("some new username")
+    dvla_client.dvla_password.set("some new password")
+    dvla_client.dvla_api_key.set("some new api key")
+
+    assert ssm.get_parameter(Name="/notify/api/dvla_username")["Parameter"]["Value"] == "some new username"
+    assert ssm.get_parameter(Name="/notify/api/dvla_password")["Parameter"]["Value"] == "some new password"
+    assert ssm.get_parameter(Name="/notify/api/dvla_api_key")["Parameter"]["Value"] == "some new api key"


### PR DESCRIPTION
Not tested locally quite yet cos I'm not sure about local IAM permissions but i'll sort that out before merging


this key thing this adds is a `jwt_token` property that can be accessed to return the jwt token. i envisage this property in a future PR handling re-auth if needed. It will possibly (probably?) handle password and api key rotation if needed too. But this will unblock work on the print API