### PR TITLE
Stop sending notifications to the ‘priority’ queue

### DIFF
--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -2,16 +2,9 @@ from flask import Blueprint, current_app, jsonify, request
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
 
 from app import api_user, authenticated_service
-from app.config import QueueNames
 from app.dao import notifications_dao
 from app.errors import InvalidRequest, register_errors
-from app.models import (
-    EMAIL_TYPE,
-    KEY_TYPE_TEAM,
-    LETTER_TYPE,
-    PRIORITY,
-    SMS_TYPE,
-)
+from app.models import EMAIL_TYPE, KEY_TYPE_TEAM, LETTER_TYPE, SMS_TYPE
 from app.notifications.process_notifications import (
     persist_notification,
     send_notification_to_queue,
@@ -122,8 +115,7 @@ def send_notification(notification_type):
         reply_to_text=template.reply_to_text,
     )
     if not simulated:
-        queue_name = QueueNames.PRIORITY if template.process_type == PRIORITY else None
-        send_notification_to_queue(notification=notification_model, queue=queue_name)
+        send_notification_to_queue(notification=notification_model)
     else:
         current_app.logger.debug("POST simulated notification for id: {}".format(notification_model.id))
     notification_form.update({"template_version": template.version})

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -6,7 +6,6 @@ from notifications_utils.s3 import s3download as utils_s3download
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import create_random_identifier
-from app.config import QueueNames
 from app.dao.notifications_dao import get_notification_by_id
 from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_id
 from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id
@@ -22,13 +21,7 @@ from app.letters.utils import (
     get_page_count,
     move_uploaded_pdf_to_letters_bucket,
 )
-from app.models import (
-    EMAIL_TYPE,
-    KEY_TYPE_NORMAL,
-    LETTER_TYPE,
-    PRIORITY,
-    SMS_TYPE,
-)
+from app.models import EMAIL_TYPE, KEY_TYPE_NORMAL, LETTER_TYPE, SMS_TYPE
 from app.notifications.process_notifications import (
     persist_notification,
     send_notification_to_queue,
@@ -112,9 +105,7 @@ def send_one_off_notification(service_id, post_data):
         client_reference=client_reference,
     )
 
-    queue_name = QueueNames.PRIORITY if template.process_type == PRIORITY else None
-
-    send_notification_to_queue(notification=notification, queue=queue_name)
+    send_notification_to_queue(notification=notification)
 
     return {"id": str(notification.id)}
 

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -36,7 +36,6 @@ from app.models import (
     NOTIFICATION_DELIVERED,
     NOTIFICATION_PENDING_VIRUS_CHECK,
     NOTIFICATION_SENDING,
-    PRIORITY,
     SMS_TYPE,
     Notification,
 )
@@ -254,12 +253,10 @@ def process_sms_or_email_notification(
     )
 
     if not simulated:
-        queue_name = QueueNames.PRIORITY if template_process_type == PRIORITY else None
         send_notification_to_queue_detached(
             key_type=api_user.key_type,
             notification_type=notification_type,
             notification_id=notification_id,
-            queue=queue_name,
         )
     else:
         current_app.logger.debug("POST simulated notification for id: {}".format(notification_id))

--- a/tests/app/service/send_notification/test_send_notification.py
+++ b/tests/app/service/send_notification/test_send_notification.py
@@ -825,34 +825,6 @@ def test_create_template_raises_invalid_request_when_content_too_large(sample_se
 
 
 @pytest.mark.parametrize("notification_type, send_to", [("sms", "07700 900 855"), ("email", "sample@email.com")])
-def test_send_notification_uses_priority_queue_when_template_is_marked_as_priority(
-    client,
-    sample_service,
-    mocker,
-    notification_type,
-    send_to,
-):
-    sample = create_template(sample_service, template_type=notification_type, process_type="priority")
-    mocked = mocker.patch("app.celery.provider_tasks.deliver_{}.apply_async".format(notification_type))
-
-    data = {"to": send_to, "template": str(sample.id)}
-
-    auth_header = create_service_authorization_header(service_id=sample.service_id)
-
-    response = client.post(
-        path="/notifications/{}".format(notification_type),
-        data=json.dumps(data),
-        headers=[("Content-Type", "application/json"), auth_header],
-    )
-
-    response_data = json.loads(response.data)["data"]
-    notification_id = response_data["notification"]["id"]
-
-    assert response.status_code == 201
-    mocked.assert_called_once_with([notification_id], queue="priority-tasks")
-
-
-@pytest.mark.parametrize("notification_type, send_to", [("sms", "07700 900 855"), ("email", "sample@email.com")])
 def test_returns_a_429_limit_exceeded_if_rate_limit_exceeded(
     client, sample_service, mocker, notification_type, send_to
 ):

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -603,32 +603,6 @@ def test_should_not_persist_or_send_notification_if_simulated_recipient(
     "notification_type, key_send_to, send_to",
     [("sms", "phone_number", "07700 900 855"), ("email", "email_address", "sample@email.com")],
 )
-def test_send_notification_uses_priority_queue_when_template_is_marked_as_priority(
-    api_client_request, sample_service, mocker, notification_type, key_send_to, send_to
-):
-    mocker.patch("app.celery.provider_tasks.deliver_{}.apply_async".format(notification_type))
-
-    sample = create_template(service=sample_service, template_type=notification_type, process_type="priority")
-    mocked = mocker.patch("app.celery.provider_tasks.deliver_{}.apply_async".format(notification_type))
-
-    data = {key_send_to: send_to, "template_id": str(sample.id)}
-
-    resp_json = api_client_request.post(
-        sample_service.id,
-        "v2_notifications.post_notification",
-        notification_type=notification_type,
-        _data=data,
-    )
-
-    notification_id = resp_json["id"]
-
-    mocked.assert_called_once_with([notification_id], queue="priority-tasks")
-
-
-@pytest.mark.parametrize(
-    "notification_type, key_send_to, send_to",
-    [("sms", "phone_number", "07700 900 855"), ("email", "email_address", "sample@email.com")],
-)
 def test_returns_a_429_limit_exceeded_if_rate_limit_exceeded(
     api_client_request, sample_service, mocker, notification_type, key_send_to, send_to
 ):


### PR DESCRIPTION
Originally we had the idea that we could set certain templates (for example two factor codes) as ‘priority’ and try to deliver them more quickly.

We only ever let platform admins decide whether a template was priority.

Since then we discovered that:
- Celery 3 was slower to deliver messages from an often-empty queue (which the priority queue was) so this feature had the opposite effect to what was intended
- Celery 4 is so fast it obviates the need for a priority queue
- We have so many templates that it’s beyond the capacity of our team to review which ones should or shouldn’t be ‘priority’

By not sending any notifications to the priority queue, we can safely remove (in a followup PR):
- the queue
- the column on the templates table and model

This will affect about 10 templates in production which belong to real, live services.
