### PR TITLE
Change email branding report page link

### DIFF
--- a/templates/tasks/scheduled_tasks/new_email_brandings.html
+++ b/templates/tasks/scheduled_tasks/new_email_brandings.html
@@ -5,7 +5,7 @@
 {%- for org, brands in brands_by_organisation.items() -%}
     <p><a href="{{ domain }}/organisations/{{ org.id }}/settings/email-branding">{{ org.name }}</a>{% if not org.email_branding_id %} (no default){% endif %}:</p><ul>
     {%- for brand in brands -%}
-        <li><a href="{{ domain }}/email-branding/{{ brand.id }}/edit">{{ brand.name }}</a></li>
+        <li><a href="{{ domain }}/email-branding/{{ brand.id }}">{{ brand.name }}</a></li>
     {%- endfor -%}
     </ul><hr>
 {%- endfor -%}
@@ -82,7 +82,7 @@
 {%- if brands_with_no_organisation -%}
     <p>These new brands are not associated with any organisation and do not need reviewing:</p><ul>
     {%- for brand in brands_with_no_organisation|sort(attribute='name') -%}
-        <li><a href="{{ domain }}/email-branding/{{ brand.id }}/edit">{{ brand.name }}</a></li>
+        <li><a href="{{ domain }}/email-branding/{{ brand.id }}">{{ brand.name }}</a></li>
     {%- endfor -%}
     </ul>
 {%- endif -%}

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -869,10 +869,10 @@ def test_zendesk_new_email_branding_report(notify_db_session, mocker, notify_use
             "</p>"
             "<ul>"
             "<li>"
-            '<a href="http://localhost:6012/email-branding/bc5b45e0-af3c-4e3d-a14c-253a56b77480/edit">brand-1</a>'
+            '<a href="http://localhost:6012/email-branding/bc5b45e0-af3c-4e3d-a14c-253a56b77480">brand-1</a>'
             "</li>"
             "<li>"
-            '<a href="http://localhost:6012/email-branding/c9c265b3-14ec-42f1-8ae9-4749ffc6f5b0/edit">brand-2</a>'
+            '<a href="http://localhost:6012/email-branding/c9c265b3-14ec-42f1-8ae9-4749ffc6f5b0">brand-2</a>'
             "</li>"
             "</ul>"
             "<hr>"
@@ -882,7 +882,7 @@ def test_zendesk_new_email_branding_report(notify_db_session, mocker, notify_use
             "</p>"
             "<ul>"
             "<li>"
-            '<a href="http://localhost:6012/email-branding/c9c265b3-14ec-42f1-8ae9-4749ffc6f5b0/edit">brand-2</a>'
+            '<a href="http://localhost:6012/email-branding/c9c265b3-14ec-42f1-8ae9-4749ffc6f5b0">brand-2</a>'
             "</li>"
             "</ul>"
         ),
@@ -890,7 +890,7 @@ def test_zendesk_new_email_branding_report(notify_db_session, mocker, notify_use
             "<p>These new brands are not associated with any organisation and do not need reviewing:</p>"
             "<ul>"
             "<li>"
-            '<a href="http://localhost:6012/email-branding/1b7deb1f-ff1f-4d00-a7a7-05b0b57a185e/edit">brand-3</a>'
+            '<a href="http://localhost:6012/email-branding/1b7deb1f-ff1f-4d00-a7a7-05b0b57a185e">brand-3</a>'
             "</li>"
             "</ul>"
         ),
@@ -921,11 +921,11 @@ def test_zendesk_new_email_branding_report_for_unassigned_branding_only(notify_d
         "<p>These new brands are not associated with any organisation and do not need reviewing:</p>"
         "<ul>"
         "<li>"
-        '<a href="http://localhost:6012/email-branding/bc5b45e0-af3c-4e3d-a14c-253a56b77480/edit">brand-1</a>'
+        '<a href="http://localhost:6012/email-branding/bc5b45e0-af3c-4e3d-a14c-253a56b77480">brand-1</a>'
         "</li><li>"
-        '<a href="http://localhost:6012/email-branding/c9c265b3-14ec-42f1-8ae9-4749ffc6f5b0/edit">brand-2</a>'
+        '<a href="http://localhost:6012/email-branding/c9c265b3-14ec-42f1-8ae9-4749ffc6f5b0">brand-2</a>'
         "</li><li>"
-        '<a href="http://localhost:6012/email-branding/1b7deb1f-ff1f-4d00-a7a7-05b0b57a185e/edit">brand-3</a>'
+        '<a href="http://localhost:6012/email-branding/1b7deb1f-ff1f-4d00-a7a7-05b0b57a185e">brand-3</a>'
         "</li>"
         "</ul>"
     )


### PR DESCRIPTION
We've added useful information to the email branding view (not edit) page about whether it's an org default or in use by a service. This feels like more useful overview information to see when reviewing the branding as opposed to immediately seeing the edit branding form.

Probably optional and could be less useful if/when we merge https://github.com/alphagov/notifications-admin/pull/4608

## Old target page
<img width="1068" alt="image" src="https://user-images.githubusercontent.com/2920760/216003473-30c126c5-625e-4ad8-bd7f-7927e4997514.png">


## New target page
<img width="1105" alt="image" src="https://user-images.githubusercontent.com/2920760/216003412-3eb22859-68ab-4be2-bb2d-a49ebbda4f0c.png">