### PR TITLE
Automate DWP report for zendesk

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -492,13 +492,18 @@ def check_for_low_available_inbound_sms_numbers():
 
 @notify_celery.task(name="weekly-dwp-report")
 def weekly_dwp_report():
-    report_config = current_app.config["ZENDESK_REPORTING"]["weekly-dwp-report"]
+    report_config = current_app.config["ZENDESK_REPORTING"].get("weekly-dwp-report")
 
     if not current_app.should_send_zendesk_alerts:
         current_app.logger.info(f"Skipping DWP report run in {current_app.config['NOTIFY_ENVIRONMENT']}")
         return
 
-    if not report_config.get("query") or not report_config.get("ticket_id"):
+    if (
+        not report_config
+        or not isinstance(report_config, dict)
+        or not report_config.get("query")
+        or not report_config.get("ticket_id")
+    ):
         current_app.logger.info("Skipping DWP report run - invalid configuration.")
         return
 

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -1,3 +1,5 @@
+import csv
+import io
 from collections import defaultdict
 from datetime import datetime, timedelta
 
@@ -5,6 +7,9 @@ import jinja2
 from flask import current_app
 from notifications_utils.clients.zendesk.zendesk_client import (
     NotifySupportTicket,
+    NotifySupportTicketAttachment,
+    NotifySupportTicketComment,
+    NotifySupportTicketStatus,
 )
 from notifications_utils.timezones import convert_utc_to_bst
 from sqlalchemy import between
@@ -483,3 +488,43 @@ def check_for_low_available_inbound_sms_numbers():
         ticket_categories=["notify_no_ticket_category"],
     )
     zendesk_client.send_ticket_to_zendesk(ticket)
+
+
+@notify_celery.task(name="weekly-dwp-report")
+def weekly_dwp_report():
+    report_config = current_app.config["ZENDESK_REPORTING"]["weekly-dwp-report"]
+
+    if not current_app.should_send_zendesk_alerts:
+        current_app.logger.info(f"Skipping DWP report run in {current_app.config['NOTIFY_ENVIRONMENT']}")
+        return
+
+    if not report_config.get("query") or not report_config.get("ticket_id"):
+        current_app.logger.info("Skipping DWP report run - invalid configuration.")
+        return
+
+    attachments = []
+    for csv_name, query in report_config["query"].items():
+        result = db.session.execute(query)
+        headers = result.keys()
+        rows = result.fetchall()
+
+        csv_data = io.StringIO()
+        csv_writer = csv.DictWriter(csv_data, fieldnames=headers, dialect="excel")
+        csv_writer.writeheader()
+
+        for row in rows:
+            csv_writer.writerow(row._asdict())
+
+        csv_data.seek(0)
+
+        attachments.append(NotifySupportTicketAttachment(filename=csv_name, filedata=csv_data, content_type="text/csv"))
+
+    zendesk_client.update_ticket(
+        report_config["ticket_id"],
+        status=NotifySupportTicketStatus.PENDING,
+        comment=NotifySupportTicketComment(
+            body="Please find attached your weekly report.",
+            attachments=attachments,
+        ),
+        due_at=convert_utc_to_bst(datetime.utcnow()) + timedelta(days=7),
+    )

--- a/app/config.py
+++ b/app/config.py
@@ -419,6 +419,16 @@ class Config(object):
 
     DVLA_API_BASE_URL = os.environ.get("DVLA_API_BASE_URL")
 
+    # We don't expect to have any zendesk reporting beyond this. If someone is looking here and thinking of adding
+    # something new, let's consider a more holistic approach first please. We should be revisiting this approach in
+    # Q1 2023.
+    # Our manifest builder takes our JSON string from notifications-credentials and passes it through the Jinja2
+    # `tojson` filter, which escapes things like ' < > to their \uxxxx form. We need to turn those back into
+    # real characters. We do that by turning the env var unicode string to bytes and then decoding that back to
+    # a unicode string via the unicode-escape encoding, which will automatically decode \uxxxx forms back to their
+    # basic representation.
+    ZENDESK_REPORTING = json.loads(os.environ.get("ZENDESK_REPORTING", "{}").encode().decode("unicode-escape"))
+
 
 ######################
 # Config overrides ###
@@ -466,16 +476,6 @@ class Development(Config):
     DVLA_EMAIL_ADDRESSES = ["success@simulator.amazonses.com"]
 
     CBC_PROXY_ENABLED = False
-
-    # We don't expect to have any zendesk reporting beyond this. If someone is looking here and thinking of adding
-    # something new, let's consider a more holistic approach first please. We should be revisiting this approach in
-    # Q1 2023.
-    ZENDESK_REPORTING = {
-        "weekly-dwp-report": {
-            "query": json.loads(os.getenv("ZENDESK_REPORTING_WEEKLY_DWP_QUERY", "null")),
-            "ticket_id": int(os.getenv("ZENDESK_REPORTING_WEEKLY_DWP_TICKET_ID", 0)) or None,
-        }
-    }
 
 
 class Test(Development):

--- a/app/config.py
+++ b/app/config.py
@@ -355,6 +355,11 @@ class Config(object):
                 "schedule": crontab(hour=9, minute=0, day_of_week="mon"),
                 "options": {"queue": QueueNames.PERIODIC},
             },
+            "weekly-dwp-report": {
+                "task": "weekly-dwp-report",
+                "schedule": crontab(hour=9, minute=0, day_of_week="mon"),
+                "options": {"queue": QueueNames.REPORTING},
+            },
         },
     }
 
@@ -461,6 +466,16 @@ class Development(Config):
     DVLA_EMAIL_ADDRESSES = ["success@simulator.amazonses.com"]
 
     CBC_PROXY_ENABLED = False
+
+    # We don't expect to have any zendesk reporting beyond this. If someone is looking here and thinking of adding
+    # something new, let's consider a more holistic approach first please. We should be revisiting this approach in
+    # Q1 2023.
+    ZENDESK_REPORTING = {
+        "weekly-dwp-report": {
+            "query": json.loads(os.getenv("ZENDESK_REPORTING_WEEKLY_DWP_QUERY", "null")),
+            "ticket_id": int(os.getenv("ZENDESK_REPORTING_WEEKLY_DWP_TICKET_ID", 0)) or None,
+        }
+    }
 
 
 class Test(Development):

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -135,6 +135,7 @@ applications:
       STATSD_HOST: "notify-statsd-exporter-{{ environment }}.apps.internal"
 
       ZENDESK_API_KEY: '{{ ZENDESK_API_KEY }}'
+      ZENDESK_REPORTING: '{{ ZENDESK_REPORTING | tojson }}'
 
       MMG_API_KEY: '{{ MMG_API_KEY }}'
       MMG_INBOUND_SMS_AUTH: '{{ MMG_INBOUND_SMS_AUTH | tojson }}'


### PR DESCRIPTION
Adds a task which runs weekly to generate a report for DWP on SMS notifications sent in the last week. The query and zendesk ticket ID are provided through environment variables. We will (🤞) review this way of doing things in Q1 '23 as part of a wider look at reporting.

I've made it so that the entire query for the DWP reject is injected via an environment variable because:
1) It means we can tweak the query without doing a deploy
2) It felt odd to hard-code the query because it contains some service-specific info (the service ID). We could have just injected the service ID via env variables, but that also felt weird and we'd have to make code changes if we altered the query to include some other identifier.
3) Using a dict means we can also provide the report filename as the key

## Todo
 - [x] add the env vars to prod