### PR TITLE
password and api key reset functions

### DIFF
--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -1,3 +1,5 @@
+import secrets
+import string
 import time
 from datetime import datetime, timedelta
 
@@ -79,6 +81,29 @@ class DVLAClient:
         response.raise_for_status()
 
         return response.json()["id-token"]
+
+    @staticmethod
+    def _generate_password():
+        """
+        DVLA api password must be at least 8 characters in length and contain upper, lower, numerical and special
+        characters.
+
+        This function creates a valid password of length 34 characters.
+        """
+
+        password_length = 30
+
+        alphabet = string.ascii_letters + string.digits + string.punctuation
+        while range(100):
+            password = "".join(secrets.choice(alphabet) for i in range(password_length))
+            if (
+                any(c.islower() for c in password)
+                and any(c.isupper() for c in password)
+                and any(c.isdigit() for c in password)
+                and any(not c.isalnum() for c in password)
+            ):
+                return password
+        raise RuntimeError("Unable to generate sufficiently secure password")
 
     def send_letter(self):
         pass

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -82,6 +82,21 @@ class DVLAClient:
 
         return response.json()["id-token"]
 
+    def change_password(self):
+        new_password = self._generate_password()
+        response = self.request.post(
+            f"{current_app.config['DVLA_API_BASE_URL']}/thirdparty-access/v1/password",
+            json={
+                "userName": self.dvla_username.get(),
+                "password": self.dvla_password.get(),
+                "newPassword": new_password,
+            },
+        )
+
+        response.raise_for_status()
+
+        self.dvla_password.set(new_password)
+
     @staticmethod
     def _generate_password():
         """

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -82,6 +82,22 @@ class DVLAClient:
 
         return response.json()["id-token"]
 
+    def change_api_key(self):
+        response = self.request.post(
+            f"{current_app.config['DVLA_API_BASE_URL']}/thirdparty-access/v1/new-api-key",
+            headers={
+                "x-api-key": self.dvla_api_key.get(),
+                "Authorization": self.jwt_token,
+            },
+            json={
+                "userName": self.dvla_username.get(),
+                "password": self.dvla_password.get(),
+            },
+        )
+        response.raise_for_status()
+
+        self.dvla_api_key.set(response.json()["newApiKey"])
+
     def change_password(self):
         new_password = self._generate_password()
         response = self.request.post(

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==6.3.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@61.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@61.2.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -160,7 +160,7 @@ newrelic==8.5.0
     # via -r requirements.in
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@61.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@61.2.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils

--- a/tests/app/clients/test_dvla.py
+++ b/tests/app/clients/test_dvla.py
@@ -1,3 +1,4 @@
+import string
 import time
 from datetime import datetime
 from unittest.mock import Mock
@@ -156,3 +157,15 @@ def test_jwt_token_calls_authenticate_if_expiry_time_passed(client, dvla_client,
         assert dvla_client._jwt_expires_at == one_hour_later
 
     assert mock_authenticate.called_once
+
+
+@pytest.mark.parametrize("_execution_number", range(100))
+def test_generate_password_creates_passwords_that_meet_dvla_criteria(_execution_number):
+    password = DVLAClient._generate_password()
+    for character_set in (string.ascii_uppercase, string.ascii_lowercase, string.digits, string.punctuation):
+        # assert the intersection of the character class, and the chars in the password is not empty to make sure
+        # that all character classes are represented
+        assert any(
+            character in character_set for character in password
+        ), f"{password} missing character from {character_set}"
+    assert len(password) > 8


### PR DESCRIPTION
i've already used these locally to great effect to reset the api keys for the tools account


see https://developer-portal.driver-vehicle-licensing.api.gov.uk/apis/authentication-api/authentication-api-description.html for details - the json version there is a bit more complete too

- [ ] https://github.com/alphagov/notifications-utils/pull/1019