### PR TITLE
Bump isort to 5.12.0 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   - id: flake8
     name: flake8 (python)
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
     - id: isort
       name: isort (python)

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,9 +1,9 @@
 -r requirements.txt
-black==22.8.0
-flake8==5.0.4
+black==22.8.0  # Also update `.pre-commit-config.yaml` if this changes
+flake8==5.0.4  # Also update `.pre-commit-config.yaml` if this changes
 flake8-bugbear==22.9.23
 flaky==3.7.0
-isort==5.12.0
+isort==5.12.0  # Also update `.pre-commit-config.yaml` if this changes
 moto==4.0.11
 pytest==7.1.3
 pytest-env==0.6.2

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -3,7 +3,7 @@ black==22.8.0
 flake8==5.0.4
 flake8-bugbear==22.9.23
 flaky==3.7.0
-isort==5.10.1
+isort==5.12.0
 moto==4.0.11
 pytest==7.1.3
 pytest-env==0.6.2


### PR DESCRIPTION
Installing isort from scratch via pre-commit has broken due to a release from Poetry.

https://levelup.gitconnected.com/fix-runtimeerror-poetry-isort-5db7c67b60ff

The solution is to bump to the latest isort version.