### PR TITLE
Add new `deliver_letter` task

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -11,7 +11,6 @@ from app.clients.email import EmailClientNonRetryableException
 from app.clients.email.aws_ses import AwsSesClientThrottlingSendRateException
 from app.clients.letter.dvla import (
     DvlaDuplicatePrintRequestException,
-    DvlaNonRetryableException,
     DvlaRetryableException,
     DvlaThrottlingException,
 )
@@ -135,14 +134,11 @@ def deliver_letter(self, notification_id):
                 "RETRY FAILED: Max retries reached. The task deliver_letter failed for notification "
                 f"{notification_id}. Notification has been updated to technical-failure"
             ) from e
-    except DvlaNonRetryableException as e:
+    except Exception as e:
         if isinstance(e, DvlaDuplicatePrintRequestException):
             current_app.logger.warning(f"Duplicate deliver_letter task called for notification {notification_id}")
             return
 
-        update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)
-        raise NotificationTechnicalFailureException(f"Error when sending letter notification {notification_id}") from e
-    except Exception as e:
         update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)
         raise NotificationTechnicalFailureException(f"Error when sending letter notification {notification_id}") from e
 

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -190,9 +190,6 @@ class DVLAClient:
         Sends a letter to the DVLA for printing
 
         address should be normalised address lines, e.g. ['A. User', 'London', 'SW1 1AA']
-
-        normalised address lines can be returned by calling:
-        `PostalAddress.from_personalisation(notification.personalisation).normalised_lines`
         """
         from app.models import INTERNATIONAL_POSTAGE_TYPES
 

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -1,22 +1,41 @@
+from datetime import datetime
+
+import boto3
 import pytest
 from botocore.exceptions import ClientError
 from celery.exceptions import MaxRetriesExceededError
+from flask import current_app
+from freezegun import freeze_time
+from moto import mock_s3
 
 import app
 from app.celery import provider_tasks
-from app.celery.provider_tasks import deliver_email, deliver_sms
+from app.celery.provider_tasks import deliver_email, deliver_letter, deliver_sms
 from app.clients.email import EmailClientNonRetryableException
 from app.clients.email.aws_ses import (
     AwsSesClientException,
     AwsSesClientThrottlingSendRateException,
 )
+from app.clients.letter.dvla import (
+    DvlaDuplicatePrintRequestException,
+    DvlaNonRetryableException,
+    DvlaRetryableException,
+    DvlaThrottlingException,
+)
 from app.clients.sms import SmsClientResponseException
 from app.exceptions import NotificationTechnicalFailureException
+from app.models import (
+    NOTIFICATION_CREATED,
+    NOTIFICATION_TECHNICAL_FAILURE,
+    PRECOMPILED_TEMPLATE_NAME,
+)
+from tests.app.db import create_notification
 
 
 def test_should_have_decorated_tasks_functions():
     assert deliver_sms.__wrapped__.__name__ == "deliver_sms"
     assert deliver_email.__wrapped__.__name__ == "deliver_email"
+    assert deliver_letter.__wrapped__.__name__ == "deliver_letter"
 
 
 def test_should_call_send_sms_to_provider_from_deliver_sms_task(sample_notification, mocker):
@@ -180,3 +199,264 @@ def test_if_ses_send_rate_throttle_then_should_retry_and_log_warning(sample_noti
     assert sample_notification.status == "created"
     assert not mock_logger_exception.called
     assert mock_logger_warning.called
+
+
+@mock_s3
+@freeze_time("2020-02-17 16:00:00")
+@pytest.mark.parametrize(
+    "is_precompiled, to_field, personalisation",
+    [
+        (
+            True,
+            "A. User\nMy Street,\nLondon,\nSW1 1AA",
+            {"address_line_1": "Provided as PDF"},
+        ),
+        (
+            False,
+            "A. User",
+            {
+                "addressline1": "A. User",
+                "addressline2": "My Street",
+                "addressline3": "London",
+                "addressline4": "SW1 1AA",
+                "addressline5": None,
+                "addressline6": None,
+                "addressline7": None,
+            },
+        ),
+    ],
+)
+def test_deliver_letter(mocker, sample_letter_template, sample_organisation, is_precompiled, to_field, personalisation):
+    mock_send_letter = mocker.patch("app.celery.provider_tasks.dvla_client.send_letter")
+
+    letter = create_notification(
+        template=sample_letter_template,
+        to_field=to_field,
+        personalisation=personalisation,
+        status=NOTIFICATION_CREATED,
+        reference="ref1",
+        created_at=datetime.now(),
+    )
+    sample_letter_template.service.organisation = sample_organisation
+    if is_precompiled:
+        letter.template.hidden = True
+        letter.template.name = PRECOMPILED_TEMPLATE_NAME
+
+    pdf_bucket = current_app.config["LETTERS_PDF_BUCKET_NAME"]
+    s3 = boto3.client("s3", region_name="eu-west-1")
+    s3.create_bucket(Bucket=pdf_bucket, CreateBucketConfiguration={"LocationConstraint": "eu-west-1"})
+    s3.put_object(Bucket=pdf_bucket, Key="2020-02-17/NOTIFY.REF1.D.2.C.20200217150000.PDF", Body=b"file"),
+
+    deliver_letter(letter.id)
+
+    mock_send_letter.assert_called_once_with(
+        notification_id=str(letter.id),
+        address=["A. User", "My Street", "London", "SW1 1AA"],
+        postage="second",
+        service_id=str(letter.service_id),
+        organisation_id=str(sample_organisation.id),
+        pdf_file=b"file",
+    )
+
+
+@mock_s3
+@freeze_time("2020-02-17 16:00:00")
+def test_deliver_letter_when_file_is_not_in_S3_logs_an_error(mocker, sample_letter_template, sample_organisation):
+    mock_send_letter = mocker.patch("app.celery.provider_tasks.dvla_client.send_letter")
+    mock_logger_exception = mocker.patch("app.celery.tasks.current_app.logger.exception")
+
+    letter = create_notification(
+        template=sample_letter_template,
+        to_field="A. User",
+        personalisation={
+            "addressline1": "A. User",
+            "addressline2": "My Street",
+            "addressline3": "London",
+            "addressline4": "SW1 1AA",
+            "addressline5": None,
+            "addressline6": None,
+            "addressline7": None,
+        },
+        status=NOTIFICATION_CREATED,
+        reference="ref1",
+        created_at=datetime.now(),
+    )
+    sample_letter_template.service.organisation = sample_organisation
+
+    pdf_bucket = current_app.config["LETTERS_PDF_BUCKET_NAME"]
+    s3 = boto3.client("s3", region_name="eu-west-1")
+    s3.create_bucket(Bucket=pdf_bucket, CreateBucketConfiguration={"LocationConstraint": "eu-west-1"})
+
+    deliver_letter(letter.id)
+
+    mock_logger_exception.assert_called_once_with(
+        f"Error getting letter from bucket for notification: {letter.id}",
+        "File not found in bucket test-letters-pdf with prefix 2020-02-17/NOTIFY.REF1",
+    )
+    assert not mock_send_letter.called
+
+
+@mock_s3
+@freeze_time("2020-02-17 16:00:00")
+@pytest.mark.parametrize(
+    "exception_type, error_class",
+    [
+        ("retryable_error", DvlaRetryableException()),
+        ("throttling_error", DvlaThrottlingException()),
+    ],
+)
+def test_deliver_letter_retries_when_there_is_a_retryable_exception(
+    mocker, sample_letter_template, sample_organisation, exception_type, error_class
+):
+    mocker.patch("app.celery.provider_tasks.dvla_client.send_letter", side_effect=error_class)
+    mock_retry = mocker.patch("app.celery.provider_tasks.deliver_letter.retry")
+    mock_logger_exception = mocker.patch("app.celery.tasks.current_app.logger.exception")
+    mock_logger_warning = mocker.patch("app.celery.tasks.current_app.logger.warning")
+
+    letter = create_notification(
+        template=sample_letter_template,
+        to_field="A. User",
+        personalisation={
+            "addressline1": "A. User",
+            "addressline2": "My Street",
+            "addressline3": "London",
+            "addressline4": "SW1 1AA",
+            "addressline5": None,
+            "addressline6": None,
+            "addressline7": None,
+        },
+        status=NOTIFICATION_CREATED,
+        reference="ref1",
+        created_at=datetime.now(),
+    )
+    sample_letter_template.service.organisation = sample_organisation
+
+    pdf_bucket = current_app.config["LETTERS_PDF_BUCKET_NAME"]
+    s3 = boto3.client("s3", region_name="eu-west-1")
+    s3.create_bucket(Bucket=pdf_bucket, CreateBucketConfiguration={"LocationConstraint": "eu-west-1"})
+    s3.put_object(Bucket=pdf_bucket, Key="2020-02-17/NOTIFY.REF1.D.2.C.20200217150000.PDF", Body=b"file"),
+
+    deliver_letter(letter.id)
+
+    assert mock_retry.called is True
+    assert letter.status == NOTIFICATION_CREATED
+
+    if exception_type == "retryable_error":
+        assert mock_logger_exception.called
+    else:
+        assert mock_logger_warning.called
+
+
+@mock_s3
+@freeze_time("2020-02-17 16:00:00")
+def test_deliver_letter_logs_a_warning_when_the_print_request_is_duplicate(
+    mocker, sample_letter_template, sample_organisation
+):
+    mocker.patch("app.celery.provider_tasks.dvla_client.send_letter", side_effect=DvlaDuplicatePrintRequestException())
+    mock_retry = mocker.patch("app.celery.provider_tasks.deliver_letter.retry")
+    mock_logger_warning = mocker.patch("app.celery.tasks.current_app.logger.warning")
+
+    letter = create_notification(
+        template=sample_letter_template,
+        to_field="A. User",
+        personalisation={
+            "addressline1": "A. User",
+            "addressline2": "My Street",
+            "addressline3": "London",
+            "addressline4": "SW1 1AA",
+            "addressline5": None,
+            "addressline6": None,
+            "addressline7": None,
+        },
+        status=NOTIFICATION_CREATED,
+        reference="ref1",
+        created_at=datetime.now(),
+    )
+    sample_letter_template.service.organisation = sample_organisation
+
+    pdf_bucket = current_app.config["LETTERS_PDF_BUCKET_NAME"]
+    s3 = boto3.client("s3", region_name="eu-west-1")
+    s3.create_bucket(Bucket=pdf_bucket, CreateBucketConfiguration={"LocationConstraint": "eu-west-1"})
+    s3.put_object(Bucket=pdf_bucket, Key="2020-02-17/NOTIFY.REF1.D.2.C.20200217150000.PDF", Body=b"file"),
+
+    deliver_letter(letter.id)
+
+    assert not mock_retry.called
+    assert letter.status == NOTIFICATION_CREATED
+    assert mock_logger_warning.called
+
+
+@mock_s3
+@freeze_time("2020-02-17 16:00:00")
+@pytest.mark.parametrize("exception_class", [DvlaNonRetryableException(), Exception()])
+def test_deliver_letter_when_there_is_a_non_retryable_error(
+    mocker, sample_letter_template, sample_organisation, exception_class
+):
+    mocker.patch("app.celery.provider_tasks.dvla_client.send_letter", side_effect=exception_class)
+    mock_retry = mocker.patch("app.celery.provider_tasks.deliver_letter.retry")
+
+    letter = create_notification(
+        template=sample_letter_template,
+        to_field="A. User",
+        personalisation={
+            "addressline1": "A. User",
+            "addressline2": "My Street",
+            "addressline3": "London",
+            "addressline4": "SW1 1AA",
+            "addressline5": None,
+            "addressline6": None,
+            "addressline7": None,
+        },
+        status=NOTIFICATION_CREATED,
+        reference="ref1",
+        created_at=datetime.now(),
+    )
+    sample_letter_template.service.organisation = sample_organisation
+
+    pdf_bucket = current_app.config["LETTERS_PDF_BUCKET_NAME"]
+    s3 = boto3.client("s3", region_name="eu-west-1")
+    s3.create_bucket(Bucket=pdf_bucket, CreateBucketConfiguration={"LocationConstraint": "eu-west-1"})
+    s3.put_object(Bucket=pdf_bucket, Key="2020-02-17/NOTIFY.REF1.D.2.C.20200217150000.PDF", Body=b"file"),
+
+    with pytest.raises(NotificationTechnicalFailureException) as e:
+        deliver_letter(letter.id)
+
+    assert str(letter.id) in str(e.value)
+    assert not mock_retry.called
+    assert letter.status == NOTIFICATION_TECHNICAL_FAILURE
+
+
+@mock_s3
+@freeze_time("2020-02-17 16:00:00")
+def test_deliver_letter_when_max_retries_are_reached(mocker, sample_letter_template, sample_organisation):
+    mocker.patch("app.celery.provider_tasks.dvla_client.send_letter", side_effect=Exception())
+    mocker.patch("app.celery.provider_tasks.deliver_letter.retry", side_effect=MaxRetriesExceededError())
+
+    letter = create_notification(
+        template=sample_letter_template,
+        to_field="A. User",
+        personalisation={
+            "addressline1": "A. User",
+            "addressline2": "My Street",
+            "addressline3": "London",
+            "addressline4": "SW1 1AA",
+            "addressline5": None,
+            "addressline6": None,
+            "addressline7": None,
+        },
+        status="created",
+        reference="ref1",
+        created_at=datetime.now(),
+    )
+    sample_letter_template.service.organisation = sample_organisation
+
+    pdf_bucket = current_app.config["LETTERS_PDF_BUCKET_NAME"]
+    s3 = boto3.client("s3", region_name="eu-west-1")
+    s3.create_bucket(Bucket=pdf_bucket, CreateBucketConfiguration={"LocationConstraint": "eu-west-1"})
+    s3.put_object(Bucket=pdf_bucket, Key="2020-02-17/NOTIFY.REF1.D.2.C.20200217150000.PDF", Body=b"file"),
+
+    with pytest.raises(NotificationTechnicalFailureException) as e:
+        deliver_letter(letter.id)
+
+    assert str(letter.id) in str(e.value)
+    assert letter.status == NOTIFICATION_TECHNICAL_FAILURE


### PR DESCRIPTION
The `DVLAClient` has a method to send a letter to the DVLA using their api. This adds a task, `deliver_letter`, to call that method. We need to get information about the letter and the file from S3 to pass as arguments to the client.

Some errors are retried using exponential back-off. If the error type can't be retried or we've reached the maximum number of retries, we put the letter into `technical-failure` status and raise a `NotificationTechnicalFailureException`.

If the API call to the DVLA is successful then we update the letter to `sending`.