### PR TITLE
Use gunicorn to serve flask app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ run-flask: ## Run flask
 
 .PHONY: run-flask-with-docker
 run-flask-with-docker: ## Run flask
-	./scripts/run_locally_with_docker.sh api
+	./scripts/run_locally_with_docker.sh gunicorn -c gunicorn_config.py -b 0.0.0.0:6011 application
 
 .PHONY: run-celery
 run-celery: ## Run celery

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ bootstrap-with-docker: generate-version-file ## Build the image to run the app i
 
 .PHONY: run-flask
 run-flask: ## Run flask
-	. environment.sh && flask run -p 6011
+	. environment.sh && gunicorn -b 127.0.0.1:6011 application
 
 .PHONY: run-flask-with-docker
 run-flask-with-docker: ## Run flask

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,4 +30,4 @@ RUN chown -R notify:notify /home/vcap/app \
 
 USER notify
 
-ENTRYPOINT [ "/home/vcap/app/entrypoint.sh" ]
+#ENTRYPOINT [ "/home/vcap/app/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ then
   shift 1
   # TODO: This is fine for local development but this file will soon need to change to have
   # gunicorn infront of flask
-  flask run --host 0.0.0.0 --port 6011
+  gunicorn -b 0.0.0.0:6011 application
 elif [ -n "$*" ]
 then
   $*

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -10,8 +10,8 @@ from gds_metrics.gunicorn import child_exit  # noqa
 workers = 4
 worker_class = "eventlet"
 worker_connections = 256
-errorlog = "/home/vcap/logs/gunicorn_error.log"
-bind = "0.0.0.0:{}".format(os.getenv("PORT"))
+# errorlog = "/home/vcap/app/gunicorn_error.log"
+# bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
 gunicorn.SERVER_SOFTWARE = "None"
 

--- a/scripts/run_locally_with_docker.sh
+++ b/scripts/run_locally_with_docker.sh
@@ -20,6 +20,9 @@ else
   EXPOSED_PORTS=""
 fi
 
+EXPOSED_PORTS="-p 6011:6011"
+set -x
+
 docker run -it --rm \
   -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
   -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \


### PR DESCRIPTION
Updates the Makefile, Dockerfile to use gunicorn instead of developmental flask when running locally. This is done for the `run-flask` and the Docker `run-flask-with-docker` Make commands.
There were some errors with the gunicorn config `gunicorn_config.py`. The logging directory and port settings fail.
