### PR TITLE
Dvla change password/api key scheduled tasks

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -15,7 +15,7 @@ from notifications_utils.timezones import convert_utc_to_bst
 from sqlalchemy import between
 from sqlalchemy.exc import SQLAlchemyError
 
-from app import db, notify_celery, statsd_client, zendesk_client
+from app import db, dvla_client, notify_celery, statsd_client, zendesk_client
 from app.aws import s3
 from app.celery.broadcast_message_tasks import trigger_link_test
 from app.celery.letters_pdf_tasks import get_pdf_for_templated_letter
@@ -533,3 +533,13 @@ def weekly_dwp_report():
         ),
         due_at=convert_utc_to_bst(datetime.utcnow()) + timedelta(days=7),
     )
+
+
+@notify_celery.task(name="change-dvla-password")
+def change_dvla_password():
+    dvla_client.change_password()
+
+
+@notify_celery.task(name="change-dvla-api-key")
+def change_dvla_api_key():
+    dvla_client.change_api_key()

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -55,6 +55,9 @@ class SSMParameter:
         self.ssm_client.put_parameter(Name=self.key, Value=value, Overwrite=True)
         self._value = value
 
+    def clear(self):
+        self._value = None
+
 
 class DVLAClient:
     """

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -118,10 +118,6 @@ class DVLAClient:
                     "x-api-key": self.dvla_api_key.get(),
                     "Authorization": self.jwt_token,
                 },
-                json={
-                    "userName": self.dvla_username.get(),
-                    "password": self.dvla_password.get(),
-                },
             )
             response.raise_for_status()
 

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -115,6 +115,9 @@ class DVLAClient:
             )
             response.raise_for_status()
         except requests.HTTPError as e:
+            if e.response.status_code == 401:
+                raise DvlaRetryableException(e.response.json()[0]["detail"]) from e
+
             self._handle_common_dvla_errors(e)
 
         return response.json()["id-token"]
@@ -130,6 +133,9 @@ class DVLAClient:
                 )
                 response.raise_for_status()
             except requests.HTTPError as e:
+                if e.response.status_code == 401:
+                    raise DvlaNonRetryableException(e.response.json()[0]["detail"]) from e
+
                 self._handle_common_dvla_errors(e)
 
             self.dvla_api_key.set(response.json()["newApiKey"])
@@ -151,6 +157,9 @@ class DVLAClient:
                 )
                 response.raise_for_status()
             except requests.HTTPError as e:
+                if e.response.status_code == 401:
+                    raise DvlaNonRetryableException(e.response.json()[0]["detail"]) from e
+
                 self._handle_common_dvla_errors(e)
 
             self.dvla_password.set(new_password)

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -87,7 +87,9 @@ class DVLAClient:
 
     @property
     def jwt_token(self):
-        if not self._jwt_token or time.time() >= self._jwt_expires_at:
+        # if the jwt is about to expire, just reset it ourselves to avoid unnecessary 401s
+        buffer = 60
+        if not self._jwt_token or time.time() + buffer >= self._jwt_expires_at:
             self._jwt_token = self.authenticate()
             jwt_dict = jwt.decode(self._jwt_token, options={"verify_signature": False})
             self._jwt_expires_at = jwt_dict["exp"]

--- a/app/config.py
+++ b/app/config.py
@@ -360,6 +360,18 @@ class Config(object):
                 "schedule": crontab(hour=9, minute=0, day_of_week="mon"),
                 "options": {"queue": QueueNames.REPORTING},
             },
+            # first tuesday of every month
+            "change-dvla-api-key": {
+                "task": "change-dvla-api-key",
+                "schedule": crontab(hour=9, minute=0, day_of_week="tue", day_of_month="1-7"),
+                "options": {"queue": QueueNames.PERIODIC},
+            },
+            # the wednesday immediately following the first tuesday of every month
+            "change-dvla-password": {
+                "task": "change-dvla-password",
+                "schedule": crontab(hour=9, minute=0, day_of_week="wed", day_of_month="2-8"),
+                "options": {"queue": QueueNames.PERIODIC},
+            },
         },
     }
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, call
 
 import dateutil
 import pytest
+from celery.exceptions import Retry
 from freezegun import freeze_time
 from notifications_utils.clients.zendesk.zendesk_client import (
     NotifySupportTicket,
@@ -13,6 +14,7 @@ from notifications_utils.clients.zendesk.zendesk_client import (
     NotifySupportTicketComment,
     NotifySupportTicketStatus,
 )
+from redis.exceptions import LockError
 
 from app.celery import scheduled_tasks
 from app.celery.scheduled_tasks import (
@@ -36,6 +38,10 @@ from app.celery.scheduled_tasks import (
     trigger_link_tests,
     weekly_dwp_report,
     zendesk_new_email_branding_report,
+)
+from app.clients.letter.dvla import (
+    DvlaNonRetryableException,
+    DvlaThrottlingException,
 )
 from app.config import Config, QueueNames, TaskNames
 from app.dao.jobs_dao import dao_get_job_by_id
@@ -1058,20 +1064,58 @@ def test_check_for_low_available_inbound_sms_numbers_does_not_proceed_if_enough_
     assert mock_send_ticket.call_args_list == []
 
 
-def test_change_dvla_password_task(mocker):
-    mock_change_password = mocker.patch("app.dvla_client.change_password")
+class TestChangeDvlaPasswordTask:
+    def test_calls_dvla_succesfully(self, mocker):
+        mock_change_password = mocker.patch("app.dvla_client.change_password")
 
-    change_dvla_password()
+        change_dvla_password()
 
-    mock_change_password.assert_called_once_with()
+        mock_change_password.assert_called_once_with()
+
+    def test_silently_quits_if_lock_is_held(self, mocker):
+        mocker.patch("app.dvla_client.change_password", side_effect=LockError)
+
+        # does not raise any exceptions
+        change_dvla_password()
+
+    def test_retries_if_dvla_throws_retryable_exception(self, mocker):
+        mocker.patch("app.dvla_client.change_password", side_effect=DvlaThrottlingException)
+
+        with pytest.raises(Retry):
+            change_dvla_password()
+
+    def test_reraises_if_dvla_raises_non_retryable_exception(self, mocker):
+        mocker.patch("app.dvla_client.change_password", side_effect=DvlaNonRetryableException)
+
+        with pytest.raises(DvlaNonRetryableException):
+            change_dvla_password()
 
 
-def test_change_dvla_api_key_task(mocker):
-    mock_change_api_key = mocker.patch("app.dvla_client.change_api_key")
+class TestChangeDvlaApiKeyTask:
+    def test_calls_dvla_succesfully(self, mocker):
+        mock_change_api_key = mocker.patch("app.dvla_client.change_api_key")
 
-    change_dvla_api_key()
+        change_dvla_api_key()
 
-    mock_change_api_key.assert_called_once_with()
+        mock_change_api_key.assert_called_once_with()
+
+    def test_silently_quits_if_lock_is_held(self, mocker):
+        mocker.patch("app.dvla_client.change_api_key", side_effect=LockError)
+
+        # does not raise any exceptions
+        change_dvla_api_key()
+
+    def test_retries_if_dvla_throws_retryable_exception(self, mocker):
+        mocker.patch("app.dvla_client.change_api_key", side_effect=DvlaThrottlingException)
+
+        with pytest.raises(Retry):
+            change_dvla_api_key()
+
+    def test_reraises_if_dvla_raises_non_retryable_exception(self, mocker):
+        mocker.patch("app.dvla_client.change_api_key", side_effect=DvlaNonRetryableException)
+
+        with pytest.raises(DvlaNonRetryableException):
+            change_dvla_api_key()
 
 
 class TestWeeklyDWPReport:

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -17,6 +17,8 @@ from notifications_utils.clients.zendesk.zendesk_client import (
 from app.celery import scheduled_tasks
 from app.celery.scheduled_tasks import (
     auto_expire_broadcast_messages,
+    change_dvla_api_key,
+    change_dvla_password,
     check_for_low_available_inbound_sms_numbers,
     check_for_missing_rows_in_completed_jobs,
     check_for_services_with_high_failure_rates_or_sending_to_tv_numbers,
@@ -1054,6 +1056,22 @@ def test_check_for_low_available_inbound_sms_numbers_does_not_proceed_if_enough_
         check_for_low_available_inbound_sms_numbers()
 
     assert mock_send_ticket.call_args_list == []
+
+
+def test_change_dvla_password_task(mocker):
+    mock_change_password = mocker.patch("app.dvla_client.change_password")
+
+    change_dvla_password()
+
+    mock_change_password.assert_called_once_with()
+
+
+def test_change_dvla_api_key_task(mocker):
+    mock_change_api_key = mocker.patch("app.dvla_client.change_api_key")
+
+    change_dvla_api_key()
+
+    mock_change_api_key.assert_called_once_with()
 
 
 class TestWeeklyDWPReport:

--- a/tests/app/clients/test_dvla.py
+++ b/tests/app/clients/test_dvla.py
@@ -246,13 +246,8 @@ def test_change_api_key_calls_dvla(dvla_client, rmock):
     dvla_client.change_api_key()
 
     assert mock_change_api_key.called_once is True
-    assert rmock.last_request.json() == {
-        "userName": "some username",
-        "password": "some password",
-    }
     assert rmock.last_request.headers["x-api-key"] == "some api key"
     assert rmock.last_request.headers["Authorization"] == "some jwt token"
-    assert rmock.last_request.headers["Content-Type"] == "application/json"
 
 
 def test_change_api_key_updates_ssm(dvla_client, rmock, mocker):

--- a/tests/app/clients/test_dvla.py
+++ b/tests/app/clients/test_dvla.py
@@ -91,6 +91,17 @@ def test_get_ssm_creds_fetches_value_and_saves_in_cache_if_not_set(ssm):
     assert param._value == "bar"
 
 
+def test_clear_ssm_creds_removes_locally_cached_value(ssm):
+    param = SSMParameter(key="/foo", ssm_client=ssm)
+    ssm.put_parameter(Name="/foo", Value="bar", Type="SecureString")
+
+    param._value = "old value"
+
+    param.clear()
+
+    assert param._value is None
+
+
 def test_get_ssm_creds(dvla_client, ssm):
     assert dvla_client.dvla_username.get() == "some username"
     assert dvla_client.dvla_password.get() == "some password"

--- a/tests/app/clients/test_dvla.py
+++ b/tests/app/clients/test_dvla.py
@@ -11,7 +11,6 @@ import pytest
 from flask import current_app
 from moto import mock_ssm
 from redis.exceptions import LockError
-from requests import HTTPError
 
 from app.clients.letter.dvla import (
     DVLAClient,
@@ -220,7 +219,7 @@ def test_change_password_does_not_update_ssm_if_dvla_throws_error(dvla_client, r
     endpoint = "https://test-dvla-api.com/thirdparty-access/v1/password"
     rmock.request("POST", endpoint, json={"message": "Unauthorized."}, status_code=401)
 
-    with pytest.raises(HTTPError):
+    with pytest.raises(DvlaException):
         dvla_client.change_password()
 
     assert mock_set_password.called is False
@@ -271,7 +270,7 @@ def test_change_api_key_does_not_update_ssm_if_dvla_throws_error(dvla_client, rm
     endpoint = "https://test-dvla-api.com/thirdparty-access/v1/new-api-key"
     rmock.request("POST", endpoint, json={"message": "Unauthorized"}, status_code=401)
 
-    with pytest.raises(HTTPError):
+    with pytest.raises(DvlaException):
         dvla_client.change_api_key()
 
     assert mock_set_api_key.called is False
@@ -570,7 +569,7 @@ def test_send_letter_when_unknown_exception_is_raised(dvla_authenticate, dvla_cl
         status_code=418,
     )
 
-    with pytest.raises(DvlaException):
+    with pytest.raises(DvlaNonRetryableException):
         dvla_client.send_letter(
             notification_id="1",
             reference="ABCDEFGHIJKL",


### PR DESCRIPTION
Take a look commit by commit cos there's a lot of nuance here that I'm not sure I've got right

### Authenticate

If we get a 401 when creating a jwt token, we should assume the password is out of date. Clear that password from the cache and throw a Retryable exception. Nice and simple.

### Change password

If we get a 401 when changing our password, we should assume that is because the old password is out of date. The problem is there are two cases here and we can't distinguish between each:

* it expired naturally - we'll need to manually reset it by email. This is a bad state. This should never happen ideally since we reset the password every month (and it normally expires every ninety days)
* it has already been reset by a different process from "old" to "new". Because we clear the cache within the lock, we know that we'll have the latest value from SSM. This means we have the "new" password in our request but dvla hasn't made consistent yet (it takes a few seconds for changes to reflect on dvla systems), so dvla gives us an error.

Since we can't distinguish between either of these, I've decided to throw a loud and noisy exception - we'll need to look at the logs and the updated at timestamp of the value in SSM to work out what's happened.

question: should we retry, maybe, once or twice, with a healthy delay (at least fifteen seconds), if we get a password invalid error?

### Change api key

Firstly, we create a JWT token. If the process doesn't have one cached, we need to generate one from the username/password combo. If the password is out of date then this will throw a Retryable as mentioned above - if so, then lets just raise that and the task will retry. The `authenticate` method clears down the password cache already so the next attempt should work.

If the API key has expired, the two potential reasons are exactly the same as the password logic above (either very old and in a bad state, or it's just been reset and we've got the new value.


### Questions

Retries: I copy and pasted the retry definition from deliver_letter but we almost certainly don't want to retry that much.

Clearing the cache _before_ sending a change password/api key request seems sensible, so I included it. but there might be some nuance I'm missing there around if tasks run soon after each other.