### PR TITLE
DVLA API letter reference

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -113,6 +113,7 @@ def deliver_letter(self, notification_id):
     try:
         dvla_client.send_letter(
             notification_id=str(notification.id),
+            reference=str(notification.reference),
             address=address_lines,
             postage=notification.postage,
             service_id=str(notification.service_id),

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -203,7 +203,12 @@ class DVLAClient:
                 f"{current_app.config['DVLA_API_BASE_URL']}/print-request/v1/print/jobs",
                 headers=self._get_auth_headers(),
                 json=self._format_create_print_job_json(
-                    notification_id, address, postage, service_id, organisation_id, pdf_file
+                    notification_id=notification_id,
+                    address_lines=address,
+                    postage=postage,
+                    service_id=service_id,
+                    organisation_id=organisation_id,
+                    pdf_file=pdf_file,
                 ),
             )
             response.raise_for_status()
@@ -226,7 +231,7 @@ class DVLAClient:
             return response.json()
 
     def _format_create_print_job_json(
-        self, notification_id, address_lines, postage, service_id, organisation_id, pdf_file
+        self, *, notification_id, address_lines, postage, service_id, organisation_id, pdf_file
     ):
         from app.models import FIRST_CLASS
 

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -180,6 +180,7 @@ class DVLAClient:
         self,
         *,
         notification_id: str,
+        reference: str,
         address: list[str],
         postage: str,
         service_id: str,
@@ -204,6 +205,7 @@ class DVLAClient:
                 headers=self._get_auth_headers(),
                 json=self._format_create_print_job_json(
                     notification_id=notification_id,
+                    reference=reference,
                     address_lines=address,
                     postage=postage,
                     service_id=service_id,
@@ -231,7 +233,7 @@ class DVLAClient:
             return response.json()
 
     def _format_create_print_job_json(
-        self, *, notification_id, address_lines, postage, service_id, organisation_id, pdf_file
+        self, *, notification_id, reference, address_lines, postage, service_id, organisation_id, pdf_file
     ):
         from app.models import FIRST_CLASS
 
@@ -243,7 +245,7 @@ class DVLAClient:
             "standardParams": {
                 "jobType": "NOTIFY",
                 "templateReference": "NOTIFY",
-                "businessIdentifier": notification_id,
+                "businessIdentifier": reference,
                 "recipientName": recipient_name,
                 "address": {"unstructuredAddress": self._build_unstructured_address(address_without_recipient)},
             },

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -272,6 +272,7 @@ def test_deliver_letter(mocker, sample_letter_template, sample_organisation, is_
 
     mock_send_letter.assert_called_once_with(
         notification_id=str(letter.id),
+        reference="ref1",
         address=["A. User", "My Street", "London", "SW1 1AA"],
         postage="second",
         service_id=str(letter.service_id),

--- a/tests/app/clients/test_dvla.py
+++ b/tests/app/clients/test_dvla.py
@@ -304,6 +304,7 @@ def test_change_api_key_raises_if_other_process_holds_lock(dvla_client, rmock, m
 def test_format_create_print_job_json_builds_json_body_to_create_print_job(dvla_client):
     formatted_json = dvla_client._format_create_print_job_json(
         notification_id="my_notification_id",
+        reference="ABCDEFGHIJKL",
         address_lines=["A. User", "The road", "City", "SW1 1AA"],
         postage="second",
         service_id="my_service_id",
@@ -316,7 +317,7 @@ def test_format_create_print_job_json_builds_json_body_to_create_print_job(dvla_
         "standardParams": {
             "jobType": "NOTIFY",
             "templateReference": "NOTIFY",
-            "businessIdentifier": "my_notification_id",
+            "businessIdentifier": "ABCDEFGHIJKL",
             "recipientName": "A. User",
             "address": {"unstructuredAddress": {"line1": "The road", "line2": "City", "postcode": "SW1 1AA"}},
         },
@@ -331,6 +332,7 @@ def test_format_create_print_job_json_builds_json_body_to_create_print_job(dvla_
 def test_format_create_print_job_json_adds_despatchMethod_key_for_first_class_post(dvla_client):
     formatted_json = dvla_client._format_create_print_job_json(
         notification_id="my_notification_id",
+        reference="ABCDEFGHIJKL",
         address_lines=["A. User", "The road", "City", "SW1 1AA"],
         postage="first",
         service_id="my_service_id",
@@ -362,6 +364,7 @@ def test_format_create_print_job_json_formats_address_lines(
 ):
     formatted_json = dvla_client._format_create_print_job_json(
         notification_id="my_notification_id",
+        reference="ABCDEFGHIJKL",
         address_lines=address_lines,
         postage="first",
         service_id="my_service_id",
@@ -382,6 +385,7 @@ def test_send_letter(dvla_client, dvla_authenticate, rmock):
 
     response = dvla_client.send_letter(
         notification_id="noti_id",
+        reference="ABCDEFGHIJKL",
         address=["recipient", "city", "postcode"],
         postage="second",
         service_id="service_id",
@@ -396,7 +400,7 @@ def test_send_letter(dvla_client, dvla_authenticate, rmock):
         "standardParams": {
             "jobType": "NOTIFY",
             "templateReference": "NOTIFY",
-            "businessIdentifier": "noti_id",
+            "businessIdentifier": "ABCDEFGHIJKL",
             "recipientName": "recipient",
             "address": {"unstructuredAddress": {"line1": "city", "postcode": "postcode"}},
         },
@@ -420,6 +424,7 @@ def test_send_letter_raises_an_error_if_postage_is_international(dvla_client, po
     with pytest.raises(NotImplementedError):
         dvla_client.send_letter(
             notification_id="noti_id",
+            reference="ABCDEFGHIJKL",
             address=["line1", "line2", "postcode"],
             postage=postage,
             service_id="service_id",
@@ -453,6 +458,7 @@ def test_send_letter_when_bad_request_error_is_raised(dvla_authenticate, dvla_cl
     with pytest.raises(DvlaNonRetryableException) as exc:
         dvla_client.send_letter(
             notification_id="1",
+            reference="ABCDEFGHIJKL",
             address=["line1", "line2", "postcode"],
             postage="second",
             service_id="s_id",
@@ -482,6 +488,7 @@ def test_send_letter_when_auth_error_is_raised(dvla_authenticate, dvla_client, r
     with pytest.raises(DvlaUnauthorisedRequestException) as exc:
         dvla_client.send_letter(
             notification_id="noti_id",
+            reference="ABCDEFGHIJKL",
             address=["line1", "line2", "postcode"],
             postage="second",
             service_id="s_id",
@@ -514,6 +521,7 @@ def test_send_letter_when_conflict_error_is_raised(dvla_authenticate, dvla_clien
     with pytest.raises(DvlaDuplicatePrintRequestException) as exc:
         dvla_client.send_letter(
             notification_id="1",
+            reference="ABCDEFGHIJKL",
             address=["line1", "line2", "postcode"],
             postage="second",
             service_id="s_id",
@@ -542,6 +550,7 @@ def test_send_letter_when_throttling_error_is_raised(dvla_authenticate, dvla_cli
     with pytest.raises(DvlaThrottlingException):
         dvla_client.send_letter(
             notification_id="1",
+            reference="ABCDEFGHIJKL",
             address=["line1", "line2", "postcode"],
             postage="second",
             service_id="s_id",
@@ -559,6 +568,7 @@ def test_send_letter_when_5xx_status_code_is_returned(dvla_authenticate, dvla_cl
     with pytest.raises(DvlaRetryableException):
         dvla_client.send_letter(
             notification_id="1",
+            reference="ABCDEFGHIJKL",
             address=["line1", "line2", "postcode"],
             postage="second",
             service_id="s_id",
@@ -576,6 +586,7 @@ def test_send_letter_when_unknown_exception_is_raised(dvla_authenticate, dvla_cl
     with pytest.raises(DvlaException):
         dvla_client.send_letter(
             notification_id="1",
+            reference="ABCDEFGHIJKL",
             address=["line1", "line2", "postcode"],
             postage="second",
             service_id="s_id",

--- a/tests/app/clients/test_dvla.py
+++ b/tests/app/clients/test_dvla.py
@@ -303,12 +303,12 @@ def test_change_api_key_raises_if_other_process_holds_lock(dvla_client, rmock, m
 
 def test_format_create_print_job_json_builds_json_body_to_create_print_job(dvla_client):
     formatted_json = dvla_client._format_create_print_job_json(
-        "my_notification_id",
-        ["A. User", "The road", "City", "SW1 1AA"],
-        "second",
-        "my_service_id",
-        "my_organisation_id",
-        b"pdf_content",
+        notification_id="my_notification_id",
+        address_lines=["A. User", "The road", "City", "SW1 1AA"],
+        postage="second",
+        service_id="my_service_id",
+        organisation_id="my_organisation_id",
+        pdf_file=b"pdf_content",
     )
 
     assert formatted_json == {
@@ -330,12 +330,12 @@ def test_format_create_print_job_json_builds_json_body_to_create_print_job(dvla_
 
 def test_format_create_print_job_json_adds_despatchMethod_key_for_first_class_post(dvla_client):
     formatted_json = dvla_client._format_create_print_job_json(
-        "my_notification_id",
-        ["A. User", "The road", "City", "SW1 1AA"],
-        "first",
-        "my_service_id",
-        "my_organisation_id",
-        b"pdf_content",
+        notification_id="my_notification_id",
+        address_lines=["A. User", "The road", "City", "SW1 1AA"],
+        postage="first",
+        service_id="my_service_id",
+        organisation_id="my_organisation_id",
+        pdf_file=b"pdf_content",
     )
 
     assert formatted_json["standardParams"]["despatchMethod"] == "FIRST"
@@ -361,12 +361,12 @@ def test_format_create_print_job_json_formats_address_lines(
     dvla_client, address_lines, recipient, unstructured_address
 ):
     formatted_json = dvla_client._format_create_print_job_json(
-        "my_notification_id",
-        address_lines,
-        "first",
-        "my_service_id",
-        "my_organisation_id",
-        b"pdf_content",
+        notification_id="my_notification_id",
+        address_lines=address_lines,
+        postage="first",
+        service_id="my_service_id",
+        organisation_id="my_organisation_id",
+        pdf_file=b"pdf_content",
     )
 
     assert formatted_json["standardParams"]["recipientName"] == recipient


### PR DESCRIPTION
## Use notification reference for DVLA API 

In calls to the DVLA API, let's pass our notification reference through
as the businessIdentifier. This maps to the 'reference' we get back from
DVLA in the daily delivery receipt files, so if we send the reference
through the API then we should be able to match delivery receipts up
automatically without having to make any specific changes.