### PR TITLE
Run gunicorn in front of flask in Docker entrypoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ run-flask: ## Run flask
 
 .PHONY: run-flask-with-docker
 run-flask-with-docker: ## Run flask
+	./scripts/run_locally_with_docker.sh api-local
+
+.PHONY: run-gunicorn-with-docker
+run-gunicorn-with-docker: ## Run gunicorn
 	./scripts/run_locally_with_docker.sh api
 
 .PHONY: run-celery

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,9 +17,7 @@ then
 elif [ "$1" == "api" ]
 then
   shift 1
-  # TODO: This is fine for local development but this file will soon need to change to have
-  # gunicorn infront of flask
-  flask run --host 0.0.0.0 --port 6011
+  gunicorn -c /home/vcap/app/gunicorn_config.py application
 elif [ -n "$*" ]
 then
   $*

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,10 @@ elif [ "$1" == "api" ]
 then
   shift 1
   gunicorn -c /home/vcap/app/gunicorn_config.py application
+elif [ "$1" == "api-local" ]
+then
+  shift 1
+  flask run --host 0.0.0.0 --port $PORT
 elif [ -n "$*" ]
 then
   $*

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,25 +2,20 @@
 
 if [ "$1" == "worker" ]
 then
-  shift 1
   # TODO: This is fine for local development but this file will soon need to change to have
   # many different celery workers like we currently do in production
   celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=4
 elif [ "$1" == "beat" ]
 then
-  shift 1
   celery -A run_celery.notify_celery beat --loglevel=INFO
 elif [ "$1" == "migration" ]
 then
-  shift 1
   flask db upgrade
 elif [ "$1" == "api" ]
 then
-  shift 1
   gunicorn -c /home/vcap/app/gunicorn_config.py application
 elif [ "$1" == "api-local" ]
 then
-  shift 1
   flask run --host 0.0.0.0 --port $PORT
 elif [ -n "$*" ]
 then

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -10,7 +10,6 @@ from gds_metrics.gunicorn import child_exit  # noqa
 workers = 4
 worker_class = "eventlet"
 worker_connections = 256
-errorlog = "/home/vcap/logs/gunicorn_error.log"
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
 gunicorn.SERVER_SOFTWARE = "None"

--- a/scripts/run_app_paas.sh
+++ b/scripts/run_app_paas.sh
@@ -19,7 +19,6 @@ function check_params {
 
 function configure_aws_logs {
   # create files so that aws logs agent doesn't complain
-  touch ${LOGS_DIR}/gunicorn_error.log
   touch ${LOGS_DIR}/app.log.json
 
   aws configure set plugins.cwlogs cwlogs
@@ -33,10 +32,6 @@ file = ${LOGS_DIR}/app.log.json
 log_group_name = paas-${CW_APP_NAME}-application
 log_stream_name = {hostname}
 
-[${LOGS_DIR}/gunicorn_error.log]
-file = ${LOGS_DIR}/gunicorn_error.log
-log_group_name = paas-${CW_APP_NAME}-gunicorn
-log_stream_name = {hostname}
 EOF
 }
 

--- a/scripts/run_locally_with_docker.sh
+++ b/scripts/run_locally_with_docker.sh
@@ -14,7 +14,7 @@ API_HOST_NAME=${API_HOST_NAME:-"http://host.docker.internal:6011"}
 
 # Only expose port 6011 if we're running the API - anything else is celery which shouldn't bind the port.
 # This lets us run celery via docker and the API locally.
-if [ "${@}" == "api" ]; then
+if [[ "${@}" == "api" || "${@}" == "api-local" ]]; then
   EXPOSED_PORTS="-e PORT=6011 -p 6011:6011"
 else
   EXPOSED_PORTS=""

--- a/scripts/run_locally_with_docker.sh
+++ b/scripts/run_locally_with_docker.sh
@@ -15,7 +15,7 @@ API_HOST_NAME=${API_HOST_NAME:-"http://host.docker.internal:6011"}
 # Only expose port 6011 if we're running the API - anything else is celery which shouldn't bind the port.
 # This lets us run celery via docker and the API locally.
 if [ "${@}" == "api" ]; then
-  EXPOSED_PORTS="-p 6011:6011"
+  EXPOSED_PORTS="-e PORT=6011 -p 6011:6011"
 else
   EXPOSED_PORTS=""
 fi


### PR DESCRIPTION
The command: make run-gunicorn-with-docker now uses the gunicorn server in front of the flask application in Docker.
Gunicorn error logs are no longer written to file, these are now output as stderr.
The server port variable was defined by the EXPOSED_PORTS parameter.