### PR TITLE
Add new queue and worker for sending API letters

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -19,6 +19,7 @@ class QueueNames(object):
     DATABASE = "database-tasks"
     SEND_SMS = "send-sms-tasks"
     SEND_EMAIL = "send-email-tasks"
+    SEND_LETTER = "send-letter-tasks"
     RESEARCH_MODE = "research-mode-tasks"
     REPORTING = "reporting-tasks"
     JOBS = "job-tasks"
@@ -45,6 +46,7 @@ class QueueNames(object):
             QueueNames.DATABASE,
             QueueNames.SEND_SMS,
             QueueNames.SEND_EMAIL,
+            QueueNames.SEND_LETTER,
             QueueNames.RESEARCH_MODE,
             QueueNames.REPORTING,
             QueueNames.JOBS,

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -53,6 +53,7 @@
   'notify-delivery-worker-jobs': {'memory': '2G'},
   'notify-delivery-worker-research': {},
   'notify-delivery-worker-sender': {'disk_quota': '2G', 'memory': '4G'},
+  'notify-delivery-worker-sender-letters': {},
   'notify-delivery-worker-periodic': {},
   'notify-delivery-worker-reporting': {
     'additional_env_vars': {

--- a/scripts/paas_app_wrapper.sh
+++ b/scripts/paas_app_wrapper.sh
@@ -24,6 +24,10 @@ case $NOTIFY_APP_NAME in
     exec scripts/run_multi_worker_app_paas.sh celery multi start 3 -c 4 -A run_celery.notify_celery --loglevel=INFO \
     --logfile=/dev/null --pidfile=/tmp/celery%N.pid -Q send-sms-tasks,send-email-tasks
     ;;
+  delivery-worker-sender-letters)
+    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \
+    -Q send-letter-tasks 2> /dev/null
+    ;;
   delivery-worker-periodic)
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=2 \
     -Q periodic-tasks 2> /dev/null

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -60,7 +60,7 @@ def test_load_config_if_cloudfoundry_not_available(reload_config):
 def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()
-    assert len(queues) == 18
+    assert len(queues) == 19
     assert set(
         [
             QueueNames.PRIORITY,
@@ -68,6 +68,7 @@ def test_queue_names_all_queues_correct():
             QueueNames.DATABASE,
             QueueNames.SEND_SMS,
             QueueNames.SEND_EMAIL,
+            QueueNames.SEND_LETTER,
             QueueNames.RESEARCH_MODE,
             QueueNames.REPORTING,
             QueueNames.JOBS,


### PR DESCRIPTION
This adds a new queue, `send-letter-tasks`, and worker `delivery-worker-sender-letters` that will be used for sending letters to the DVLA via the new API.