### PR TITLE
Send letters via DVLA api on development, preview and staging

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -2,6 +2,7 @@ from base64 import urlsafe_b64encode
 from datetime import datetime, timedelta
 from hashlib import sha512
 
+import dateutil
 from botocore.exceptions import ClientError as BotoClientError
 from flask import current_app
 from notifications_utils.letter_timings import LETTER_PROCESSING_DEADLINE
@@ -128,19 +129,25 @@ def update_validation_failed_for_templated_letter(self, notification_id, page_co
 
 @notify_celery.task(name="collate-letter-pdfs-to-be-sent")
 @cronitor("collate-letter-pdfs-to-be-sent")
-def collate_letter_pdfs_to_be_sent():
+def collate_letter_pdfs_to_be_sent(print_run_deadline_utc=None):
     """
     Finds all letters which are still waiting to be sent to DVLA for printing
 
     This would usually be run at 5.50pm and collect up letters created between before 5:30pm today
     that have not yet been sent.
     If run after midnight, it will collect up letters created before 5:30pm the day before.
-    """
-    print_run_date = convert_utc_to_bst(datetime.utcnow())
-    if print_run_date.time() < LETTER_PROCESSING_DEADLINE:
-        print_run_date = print_run_date - timedelta(days=1)
 
-    print_run_deadline = print_run_date.replace(hour=17, minute=30, second=0, microsecond=0)
+    You can specify a specific print_run_deadline_utc as an ISO format datetime if you want to. This is primarily
+    useful for load testing or running locally. Make sure to consider UTC to BST.
+    """
+    if print_run_deadline_utc:
+        print_run_deadline = convert_utc_to_bst(dateutil.parser.parse(print_run_deadline_utc))
+    else:
+        print_run_date = convert_utc_to_bst(datetime.utcnow())
+        if print_run_date.time() < LETTER_PROCESSING_DEADLINE:
+            print_run_date = print_run_date - timedelta(days=1)
+
+        print_run_deadline = print_run_date.replace(hour=17, minute=30, second=0, microsecond=0)
     _get_letters_and_sheets_volumes_and_send_to_dvla(print_run_deadline)
 
     for postage in POSTAGE_TYPES:

--- a/app/config.py
+++ b/app/config.py
@@ -431,6 +431,7 @@ class Config(object):
     # as defined in api db migration 0331_add_broadcast_org.py
     BROADCAST_ORGANISATION_ID = "38e4bf69-93b0-445d-acee-53ea53fe02df"
 
+    DVLA_API_ENABLED = os.environ.get("DVLA_API_ENABLED") == "1"
     DVLA_API_BASE_URL = os.environ.get("DVLA_API_BASE_URL", "https://uat.driver-vehicle-licensing.api.gov.uk")
 
     # We don't expect to have any zendesk reporting beyond this. If someone is looking here and thinking of adding

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -25,6 +25,7 @@ from app.celery.letters_pdf_tasks import (
     replay_letters_in_error,
     resanitise_pdf,
     sanitise_letter,
+    send_dvla_letters_via_api,
     send_letters_volume_email_to_dvla,
     update_billable_units_for_letter,
     update_validation_failed_for_templated_letter,
@@ -507,6 +508,47 @@ def test_collate_letter_pdfs_to_be_sent(notify_api, mocker, time_to_run_task, sa
         queue="process-ftp-tasks",
         compression="zlib",
     )
+
+
+@pytest.mark.parametrize(
+    "api_enabled_env_flag", [True, pytest.param(False, marks=pytest.mark.xfail(raises=AssertionError))]
+)
+def test_collate_letter_pdfs_uses_api_on_selected_environments(
+    notify_api,
+    notify_db_session,
+    mocker,
+    api_enabled_env_flag,
+):
+    mocker.patch("app.celery.letters_pdf_tasks.send_letters_volume_email_to_dvla")
+    mocker.patch("app.celery.letters_pdf_tasks.get_key_and_size_of_letters_to_be_sent_to_print", return_value=[])
+    mock_send_via_api = mocker.patch("app.celery.letters_pdf_tasks.send_dvla_letters_via_api")
+    with set_config_values(notify_api, {"DVLA_API_ENABLED": api_enabled_env_flag}):
+
+        with freeze_time("2021-06-01 17:00"):
+            collate_letter_pdfs_to_be_sent()
+
+    mock_send_via_api.assert_called_with(datetime(2021, 6, 1, 17, 30))
+
+
+def test_send_dvla_letters_via_api(sample_letter_template, mocker):
+    mock_celery = mocker.patch("app.celery.provider_tasks.deliver_letter.apply_async")
+
+    with freeze_time("2021-06-01 16:29"):
+        rest_of_world = create_notification(sample_letter_template, postage="rest-of-world")
+        first_class = create_notification(sample_letter_template, postage="first")
+        second_class = create_notification(sample_letter_template, postage="second")
+
+    with freeze_time("2021-06-01 16:31"):
+        create_notification(sample_letter_template)  # too recent
+
+    # note print_run_deadline is in local time
+    send_dvla_letters_via_api(datetime(2021, 6, 1, 17, 30))
+
+    assert mock_celery.call_args_list == [
+        call(kwargs={"notification_id": first_class.id}, queue="send-letter-tasks"),
+        call(kwargs={"notification_id": second_class.id}, queue="send-letter-tasks"),
+        call(kwargs={"notification_id": rest_of_world.id}, queue="send-letter-tasks"),
+    ]
 
 
 def test_send_letters_volume_email_to_dvla(notify_api, notify_db_session, mocker, letter_volumes_email_template):


### PR DESCRIPTION
bypass the ftp app on dev/preview/staging.

This doesn't include any selective enabling (for example per service). The entire env is either FTP or API for now.

also, perhaps slightly more contentious - add an optional print deadline to the collate letter task. This is necessary for running performance tests because when you call `collate-and-send` without any args, it runs for everything ready to send since the _last 5:30 we went past_. So if you run it at midday, it'll only look at letters sent up to 5:30pm yesterday. This makes it tough to manually trigger runs locally/on preview, since you often need to change the created_at in the database, and then move the file in s3, which is a pain.

By allowing us to pass in an optional arg to define when we want the print deadline to be, we can easily trigger this after loading files for load tests etc.

I've had some real headaches understanding which datetimes are UTC and which are local time, and obviously this is super critical to get right when we tell users about 5:30pm local being a cut-off, so for now rather than refactor everything and risk breaking something delicate, I thought I'd just be super explicit with the new variable name