### PR TITLE
Make volumes by service report return one row per service

### DIFF
--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -1251,3 +1251,14 @@ def test_fetch_volumes_by_service(notify_db_session):
     assert results[6].letter_totals == 0
     assert results[6].letter_sheet_totals == 0
     assert float(results[6].letter_cost) == 0
+
+
+def test_fetch_volumes_by_service_returns_free_allowance_for_end_date(sample_service):
+    create_annual_billing(service_id=sample_service.id, free_sms_fragment_limit=1000, financial_year_start=2023)
+    create_annual_billing(service_id=sample_service.id, free_sms_fragment_limit=50, financial_year_start=2022)
+    create_annual_billing(service_id=sample_service.id, free_sms_fragment_limit=7, financial_year_start=2021)
+
+    results = fetch_volumes_by_service(start_date=datetime(2021, 4, 1), end_date=datetime(2022, 2, 28))
+
+    assert len(results) == 1
+    assert results[0].free_allowance == 50

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -928,6 +928,13 @@ def set_up_usage_data(start_date):
     letter_template_1 = create_template(service=service_1_sms_and_letter, template_type="letter")
     sms_template_1 = create_template(service=service_1_sms_and_letter, template_type="sms")
     create_annual_billing(service_id=service_1_sms_and_letter.id, free_sms_fragment_limit=10, financial_year_start=year)
+    create_annual_billing(
+        service_id=service_1_sms_and_letter.id, free_sms_fragment_limit=100, financial_year_start=year - 1
+    )
+    create_annual_billing(
+        service_id=service_1_sms_and_letter.id, free_sms_fragment_limit=50, financial_year_start=year - 2
+    )
+
     org_1 = create_organisation(
         name="Org for {}".format(service_1_sms_and_letter.name),
         purchase_order_number="org1 purchase order number",


### PR DESCRIPTION
This report was returning multiple rows for each service where the only difference between them was the free allowance data. We only want it to return one row per service and we only care about the free allowance at the time of the specified end date for the report.

The annual_billing subquery in the `fetch_volumes_by_service` was returning a row for each row in the annual billing table like this:

```
financial_year_start, service_id, free_allowance
(2022, service_1_id, 40000),
(2021, service_1_id, 150000),
(2022, service_2_id, 40000),
(2022, service_3_id, 10000),
(2020, service_3_id, 25000),
(2021, service_3_id, 150000),
```

We now use a window function in the subquery so that it also returns the latest (maximum) financial_year_start for each service ID:

```
latest_billing_year_for_service, financial_year_start, service_id, free_allowance
(2022, 2022, service_1_id, 40000),
(2022, 2021, service_1_id, 150000),
(2022, 2022, service_2_id, 40000),
(2022, 2022, service_3_id, 10000),
(2022, 2020, service_3_id, 25000),
(2022, 2021, service_3_id, 150000),
```

Then in the main query, we add a filter to only return rows where the `annual_billing.latest_billing_year_for_service` equals the `annual_billing.financial_year_start`, which acts to remove all rows for annual billing older than the end date for the report.
