### PR TITLE
Add new SMS rates for 1 April 2023

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0405_template_formatting_flags
+0406_1_april_2023_sms_rates

--- a/migrations/versions/0406_1_april_2023_sms_rates.py
+++ b/migrations/versions/0406_1_april_2023_sms_rates.py
@@ -1,0 +1,25 @@
+"""
+
+Revision ID: 0406_1_april_2023_sms_rates
+Revises: 0405_template_formatting_flags
+Create Date: 2023-03-06 11:32:20.588364
+
+"""
+import uuid
+
+from alembic import op
+
+
+revision = "0406_1_april_2023_sms_rates"
+down_revision = "0405_template_formatting_flags"
+
+
+def upgrade():
+    op.execute(
+        "INSERT INTO rates(id, valid_from, rate, notification_type) "
+        f"VALUES('{uuid.uuid4()}', '2023-03-31 23:00:00', 0.0197, 'sms')"
+    )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
These can be added before they are needed since we check the `valid_from` column when deciding which rate to use.