### PR TITLE
Add letter attachment table

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -383,12 +383,16 @@ class NotificationModelSchema(BaseSchema):
 class BaseTemplateSchema(BaseSchema):
     reply_to = fields.Method("get_reply_to", allow_none=True)
     reply_to_text = fields.Method("get_reply_to_text", allow_none=True)
+    letter_attachment = fields.Method("get_letter_attachment", allow_none=True)
 
     def get_reply_to(self, template):
         return template.reply_to
 
     def get_reply_to_text(self, template):
         return template.get_reply_to_text()
+
+    def get_letter_attachment(self, template):
+        return template.letter_attachment_id
 
     class Meta(BaseSchema.Meta):
         model = models.Template
@@ -434,6 +438,7 @@ class TemplateSchemaNoDetail(TemplateSchema):
             "created_by",
             "created_by_id",
             "hidden",
+            "letter_attachment",
             "postage",
             "process_type",
             "redact_personalisation",

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0406_1_april_2023_sms_rates
+0407_letter_attachments

--- a/migrations/versions/0407_letter_attachments.py
+++ b/migrations/versions/0407_letter_attachments.py
@@ -1,0 +1,65 @@
+"""
+
+Revision ID: 0407_letter_attachments
+Revises: 0406_1_april_2023_sms_rates
+Create Date: 2023-03-09 08:45:00.990562
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0407_letter_attachments"
+down_revision = "0406_1_april_2023_sms_rates"
+
+
+def upgrade():
+    op.create_table(
+        "letter_attachment",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("created_by_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("archived_at", sa.DateTime(), nullable=True),
+        sa.Column("archived_by_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("original_filename", sa.String(), nullable=False),
+        sa.Column("page_count", sa.SmallInteger(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["created_by_id"],
+            ["users.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["archived_by_id"],
+            ["users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.add_column("templates", sa.Column("letter_attachment_id", postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key(
+        "templates_letter_attachment_id_fkey", "templates", "letter_attachment", ["letter_attachment_id"], ["id"]
+    )
+    op.add_column("templates_history", sa.Column("letter_attachment_id", postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key(
+        "templates_history_letter_attachment_id_fkey",
+        "templates_history",
+        "letter_attachment",
+        ["letter_attachment_id"],
+        ["id"],
+    )
+    op.create_check_constraint(
+        "ck_templates_letter_attachments", "templates", "template_type = 'letter' OR letter_attachment_id IS NULL"
+    )
+    op.create_check_constraint(
+        "ck_templates_history_letter_attachments",
+        "templates_history",
+        "template_type = 'letter' OR letter_attachment_id IS NULL",
+    )
+
+
+def downgrade():
+    op.drop_constraint("ck_templates_history_letter_attachments", "templates_history")
+    op.drop_constraint("templates_history_letter_attachment_id_fkey", "templates_history", type_="foreignkey")
+    op.drop_constraint("ck_templates_letter_attachments", "templates")
+    op.drop_column("templates_history", "letter_attachment_id")
+    op.drop_constraint("templates_letter_attachment_id_fkey", "templates", type_="foreignkey")
+    op.drop_column("templates", "letter_attachment_id")
+    op.drop_table("letter_attachment")

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -541,6 +541,7 @@ def test_should_get_return_all_fields_by_default(
         "folder",
         "hidden",
         "id",
+        "letter_attachment",
         "name",
         "postage",
         "process_type",


### PR DESCRIPTION
Build out the DB model for letter attachments with basic fields. This table represents another PDF that has been uploaded to Notify and can be 'attached' to the end of a letter template. This will allow reusable formatted content (eg a form) to be attached to a letter.

---

~The orginal ticket suggests an `archived` field. I've left that off here as I don't think we need to denormalise this information - if there are no records with `template.letter_attachment_id == this_letter_attachment.id` then `this_letter_attachment` isn't in use. It saves us from a potentially-weird situation where we have `archived=true` on a letter attachment but it's still referred to by a live template.~ Added back archived_at/archived_by_id after some discussion