### PR TITLE
Inject user_id into log messages

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -170,6 +170,11 @@ def register_blueprint(application):
     from app.user.rest import user_blueprint
     from app.webauthn.rest import webauthn_blueprint
 
+    def ensure_user_id_attribute_before_request():
+        g.user_id = None
+
+    application.before_request(ensure_user_id_attribute_before_request)
+
     service_blueprint.before_request(requires_admin_auth)
     application.register_blueprint(service_blueprint, url_prefix="/service")
 

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -78,6 +78,7 @@ def requires_internal_auth(expected_client_id):
 
     _decode_jwt_token(auth_token, api_keys, client_id)
     g.service_id = client_id
+    g.user_id = request.headers.get("X-Notify-User-Id")
 
 
 def requires_auth():

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==6.3.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -160,7 +160,7 @@ newrelic==8.5.0
     # via -r requirements.in
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.1.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils

--- a/tests/app/test_logging_filters.py
+++ b/tests/app/test_logging_filters.py
@@ -1,0 +1,57 @@
+from flask import url_for
+
+from tests import create_admin_authorization_header
+
+
+class TestUserIdFilter:
+    def test_no_user_id_attribute_outside_request(self, caplog, notify_api):
+        caplog.set_level("INFO")
+
+        notify_api.logger.info("blah")
+        assert caplog.records[-1].user_id is None
+
+    def test_user_id_for_non_admin_requests(self, caplog, notify_api):
+        caplog.set_level("INFO")
+
+        content_type_header = ("Content-Type", "application/json")
+        admin_auth_header = create_admin_authorization_header()
+        user_id_header = ("x-notify-user-id", "abcdabcd-1234-1234-1234-abcdabcdabcd")
+
+        with notify_api.test_request_context():
+            with notify_api.test_client() as client:
+                client.get(url_for("test.log_view"), headers=[content_type_header])
+                assert caplog.records[-1].user_id is None
+
+                client.get(url_for("test.log_view"), headers=[content_type_header, admin_auth_header])
+                assert caplog.records[-1].user_id is None
+
+                # X-Notify-User-Id provided but we're not in an admin request so it's untrusted
+                client.get(url_for("test.log_view"), headers=[content_type_header, user_id_header])
+                assert caplog.records[-1].user_id is None
+
+                # Admin auth has been provided here, but we're not in an admin request so it's not been validated
+                client.get(url_for("test.log_view"), headers=[content_type_header, admin_auth_header, user_id_header])
+                assert caplog.records[-1].user_id is None
+
+    def test_user_id_for_admin_requests(self, caplog, notify_api):
+        caplog.set_level("INFO")
+
+        content_type_header = ("Content-Type", "application/json")
+        admin_auth_header = create_admin_authorization_header()
+        user_id_header = ("x-notify-user-id", "abcdabcd-1234-1234-1234-abcdabcdabcd")
+
+        with notify_api.test_request_context():
+            with notify_api.test_client() as client:
+                # No user_id - header not passed
+                client.get(
+                    url_for("admin_test.admin_log_view"),
+                    headers=[content_type_header, admin_auth_header],
+                )
+                assert caplog.records[-1].user_id is None
+
+                # Confirmed user ID - it's an authenticated admin view with a user id
+                client.get(
+                    url_for("admin_test.admin_log_view"),
+                    headers=[content_type_header, admin_auth_header, user_id_header],
+                )
+                assert caplog.records[-1].user_id == "abcdabcd-1234-1234-1234-abcdabcdabcd"

--- a/tests/app/test_logging_filters.py
+++ b/tests/app/test_logging_filters.py
@@ -1,8 +1,10 @@
+import pytest
 from flask import url_for
 
 from tests import create_admin_authorization_header
 
 
+@pytest.mark.usefixtures("_notify_db")
 class TestUserIdFilter:
     def test_no_user_id_attribute_outside_request(self, caplog, notify_api):
         caplog.set_level("INFO")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,10 @@ import pytest
 import sqlalchemy
 
 from app import create_app, db
+from app.authentication.auth import requires_admin_auth, requires_no_auth
 from app.dao.provider_details_dao import get_provider_details_by_identifier
 from app.notify_api_flask_app import NotifyApiFlaskApp
+from tests.routes import admin_test_blueprint, test_blueprint
 
 # Freezegun has a negative interaction with prompt_toolkit that ends up suppressing text written on the prompt of ipdb
 # so let's ignore that module
@@ -21,6 +23,12 @@ freezegun.configure(extend_ignore_list=["prompt_toolkit"])
 def notify_api():
     app = NotifyApiFlaskApp("test")
     create_app(app)
+
+    # Attach some routes that can be used as helpers for specific tests.
+    test_blueprint.before_request(requires_no_auth)
+    app.register_blueprint(test_blueprint, url_prefix="/test")
+    admin_test_blueprint.before_request(requires_admin_auth)
+    app.register_blueprint(admin_test_blueprint, url_prefix="/admin-test")
 
     # deattach server-error error handlers - error_handler_spec looks like:
     #   {'blueprint_name': {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from app import create_app, db
 from app.authentication.auth import requires_admin_auth, requires_no_auth
 from app.dao.provider_details_dao import get_provider_details_by_identifier
 from app.notify_api_flask_app import NotifyApiFlaskApp
-from tests.routes import admin_test_blueprint, test_blueprint
+from tests.routes import test_admin_auth_blueprint, test_no_auth_blueprint
 
 # Freezegun has a negative interaction with prompt_toolkit that ends up suppressing text written on the prompt of ipdb
 # so let's ignore that module
@@ -25,10 +25,10 @@ def notify_api():
     create_app(app)
 
     # Attach some routes that can be used as helpers for specific tests.
-    test_blueprint.before_request(requires_no_auth)
-    app.register_blueprint(test_blueprint, url_prefix="/test")
-    admin_test_blueprint.before_request(requires_admin_auth)
-    app.register_blueprint(admin_test_blueprint, url_prefix="/admin-test")
+    test_no_auth_blueprint.before_request(requires_no_auth)
+    app.register_blueprint(test_no_auth_blueprint, url_prefix="/test")
+    test_admin_auth_blueprint.before_request(requires_admin_auth)
+    app.register_blueprint(test_admin_auth_blueprint, url_prefix="/admin-test")
 
     # deattach server-error error handlers - error_handler_spec looks like:
     #   {'blueprint_name': {

--- a/tests/routes.py
+++ b/tests/routes.py
@@ -1,0 +1,18 @@
+from flask import Blueprint, current_app
+
+test_blueprint = Blueprint("test", "test")
+admin_test_blueprint = Blueprint("admin_test", "admin_test")
+
+
+@test_blueprint.route("/log")
+def log_view():
+    """A view that emits a log statement"""
+    current_app.logger.info("a log message")
+    return "OK"
+
+
+@admin_test_blueprint.route("/admin-log")
+def admin_log_view():
+    """A view that emits a log statement"""
+    current_app.logger.info("a log message")
+    return "OK"

--- a/tests/routes.py
+++ b/tests/routes.py
@@ -1,17 +1,17 @@
 from flask import Blueprint, current_app
 
-test_blueprint = Blueprint("test", "test")
-admin_test_blueprint = Blueprint("admin_test", "admin_test")
+test_no_auth_blueprint = Blueprint("test", "test")
+test_admin_auth_blueprint = Blueprint("admin_test", "admin_test")
 
 
-@test_blueprint.route("/log")
+@test_no_auth_blueprint.route("/log")
 def log_view():
     """A view that emits a log statement"""
     current_app.logger.info("a log message")
     return "OK"
 
 
-@admin_test_blueprint.route("/admin-log")
+@test_admin_auth_blueprint.route("/admin-log")
 def admin_log_view():
     """A view that emits a log statement"""
     current_app.logger.info("a log message")


### PR DESCRIPTION
If we're handling API requests from the admin app, it might be sending us a header that indicates the responsible user ID. Let's inject this into any log messages emitted so that it's easier to trace all of the actions a specific user has taken/is responsible for.