### PR TITLE
Allow SQLALCHEMY_DATABASE_URI to override the database settings inside PaaS

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -6,8 +6,9 @@ def extract_cloudfoundry_config():
     vcap_services = json.loads(os.environ["VCAP_SERVICES"])
 
     # Postgres config
-    os.environ["SQLALCHEMY_DATABASE_URI"] = vcap_services["postgres"][0]["credentials"]["uri"].replace(
-        "postgres", "postgresql"
-    )
+    if "SQLALCHEMY_DATABASE_URI" not in os.environ:
+        os.environ["SQLALCHEMY_DATABASE_URI"] = vcap_services["postgres"][0]["credentials"]["uri"].replace(
+            "postgres", "postgresql"
+        )
     # Redis config
     os.environ["REDIS_URL"] = vcap_services["redis"][0]["credentials"]["uri"]

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -123,6 +123,9 @@ applications:
       ROUTE_SECRET_KEY_2: '{{ ROUTE_SECRET_KEY_2 }}'
       CRONITOR_KEYS: '{{ CRONITOR_KEYS | tojson }}'
       METRICS_BASIC_AUTH_TOKEN: {{ METRICS_BASIC_AUTH_TOKEN }}
+      {% if SQLALCHEMY_DATABASE_URI is defined %}
+      SQLALCHEMY_DATABASE_URI: '{{ SQLALCHEMY_DATABASE_URI }}'
+      {% endif %}
 
       HIGH_VOLUME_SERVICE: '{{ HIGH_VOLUME_SERVICE | tojson }}'
 

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -21,3 +21,12 @@ def test_extract_cloudfoundry_config_populates_other_vars(os_environ, vcap_servi
 
     assert os.environ["SQLALCHEMY_DATABASE_URI"] == "postgresql uri"
     assert os.environ["REDIS_URL"] == "redis uri"
+
+
+def test_extract_cloudfoundry_config_populates_other_vars_with_overrides(os_environ, vcap_services):
+    os.environ["VCAP_SERVICES"] = json.dumps(vcap_services)
+    os.environ["SQLALCHEMY_DATABASE_URI"] = "postgresql uri override"
+    extract_cloudfoundry_config()
+
+    assert os.environ["SQLALCHEMY_DATABASE_URI"] == "postgresql uri override"
+    assert os.environ["REDIS_URL"] == "redis uri"


### PR DESCRIPTION
What
----

Currently, when establishing a database connection, the VCAP_SERVICES environment variable is given priority over SQLALCHEMY_DATABASE_URI.

This proposed change would prioritise the SQLALCHEMY_DATABASE_URI variable over VCAP_SERVICES, provided that it is present. In the absence of SQLALCHEMY_DATABASE_URI, VCAP_SERVICES will be used as a fallback.

Why
----

We need to switch to fixed credentials for the database before we do the database cutover, while still using VCAP_SERVICES for Redis. This pull request will facilitate that change.