### PR TITLE
Bump utils to 62.0.1

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -261,6 +261,8 @@ def validate_address(service, letter_data):
         raise ValidationError(message=f"Address must be at least {PostalAddress.MIN_LINES} lines")
     if address.has_too_many_lines:
         raise ValidationError(message=f"Address must be no more than {PostalAddress.MAX_LINES} lines")
+    if address.has_invalid_country_for_bfpo_address:
+        raise ValidationError(message="The last line of a BFPO address must not be a country.")
     if not address.has_valid_last_line:
         if address.allow_international_letters:
             raise ValidationError(message="Last line of address must be a real UK postcode or another country")

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==6.3.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@61.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.0.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -160,7 +160,7 @@ newrelic==8.5.0
     # via -r requirements.in
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@61.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.0.1
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
This pulls in a new `normalised_lines` format for BFPO addresses. We now put the BFPO number on the last line, after the postcode (if present).

This is more in line with the format for BFPO addresses as recommended on GOV.UK, so should be preferrable for our print provider/Royal Mail. It also includes some additional utility methods for extracting BFPO information so that we can provide normalised data to our print provider's API to mark up BFPO addresses.

---

See also https://github.com/alphagov/notifications-utils/pull/1022