### PR TITLE
Restrict DVLA API TLS connections to specific ciphers 

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -87,7 +87,7 @@ def create_app(application):
     logging.init_app(application, statsd_client)
     firetext_client.init_app(application, statsd_client=statsd_client)
     mmg_client.init_app(application, statsd_client=statsd_client)
-    dvla_client.init_app(application.config["AWS_REGION"], statsd_client=statsd_client)
+    dvla_client.init_app(application, statsd_client=statsd_client)
     aws_ses_client.init_app(application.config["AWS_REGION"], statsd_client=statsd_client)
     aws_ses_stub_client.init_app(
         application.config["AWS_REGION"], statsd_client=statsd_client, stub_url=application.config["SES_STUB_URL"]

--- a/app/config.py
+++ b/app/config.py
@@ -433,6 +433,7 @@ class Config(object):
 
     DVLA_API_ENABLED = os.environ.get("DVLA_API_ENABLED") == "1"
     DVLA_API_BASE_URL = os.environ.get("DVLA_API_BASE_URL", "https://uat.driver-vehicle-licensing.api.gov.uk")
+    DVLA_API_TLS_CIPHERS = os.environ.get("DVLA_API_TLS_CIPHERS")
 
     # We don't expect to have any zendesk reporting beyond this. If someone is looking here and thinking of adding
     # something new, let's consider a more holistic approach first please. We should be revisiting this approach in
@@ -555,6 +556,7 @@ class Preview(Config):
     FROM_NUMBER = "preview"
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = False
+    DVLA_API_TLS_CIPHERS = os.environ.get("DVLA_API_TLS_CIPHERS", "must-supply-tls-ciphers")
 
 
 class Staging(Config):
@@ -572,6 +574,7 @@ class Staging(Config):
     FROM_NUMBER = "stage"
     API_RATE_LIMIT_ENABLED = True
     CHECK_PROXY_HEADER = True
+    DVLA_API_TLS_CIPHERS = os.environ.get("DVLA_API_TLS_CIPHERS", "must-supply-tls-ciphers")
 
 
 class Production(Config):
@@ -594,6 +597,7 @@ class Production(Config):
     CRONITOR_ENABLED = True
 
     DVLA_API_BASE_URL = os.environ.get("DVLA_API_BASE_URL", "https://driver-vehicle-licensing.api.gov.uk")
+    DVLA_API_TLS_CIPHERS = os.environ.get("DVLA_API_TLS_CIPHERS", "must-supply-tls-ciphers")
 
 
 class CloudFoundryConfig(Config):

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -159,6 +159,8 @@ applications:
       NEW_RELIC_APP_NAME: '{{ environment }}.{{ CF_APP }}'
       NEW_RELIC_LICENSE_KEY: '{{ NEW_RELIC_LICENSE_KEY }}'
 
+      DVLA_API_TLS_CIPHERS: '{{ DVLA_API_TLS_CIPHERS }}'
+
       {% for key, value in app.get('additional_env_vars', {}).items() %}
       {{key}}: '{{value}}'
       {% endfor %}

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -14,3 +14,6 @@ freezegun==1.2.2
 requests-mock==1.10.0
 # used for creating manifest file locally
 jinja2-cli[yaml]==0.8.2
+
+pytest-httpserver==1.0.6
+trustme==0.9.0

--- a/tests/app/clients/test_dvla.py
+++ b/tests/app/clients/test_dvla.py
@@ -48,9 +48,9 @@ def ssm():
 
 
 @pytest.fixture
-def dvla_client(client, ssm):
+def dvla_client(notify_api, client, ssm):
     dvla_client = DVLAClient()
-    dvla_client.init_app(region="eu-west-1", statsd_client=Mock())
+    dvla_client.init_app(notify_api, statsd_client=Mock())
     yield dvla_client
 
 


### PR DESCRIPTION
The DVLA API we will connect to in prod supports a number of insecure
ciphers. It will take some time for them to retire support due to other
clients requiring them, but we want to make sure we aren't able to
connect with those insecure ciphers.

We will supply our own list of acceptable cipher suites via config.