### PR TITLE
Migrate to using caplog instead of mocking loggers

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -54,7 +54,8 @@ def process_ses_results(self, response):
 
         if bounce_message:
             current_app.logger.info(
-                f"SES bounce for notification ID {notification.id}", extra=dict(bounce_message=bounce_message)
+                f"SES bounce for notification ID {notification.id}",
+                extra=dict(bounce_message=json.dumps(bounce_message)),
             )
 
         if notification.status not in [NOTIFICATION_SENDING, NOTIFICATION_PENDING]:

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -53,7 +53,9 @@ def process_ses_results(self, response):
             return
 
         if bounce_message:
-            current_app.logger.info(f"SES bounce for notification ID {notification.id}: {bounce_message}")
+            current_app.logger.info(
+                f"SES bounce for notification ID {notification.id}", extra=dict(bounce_message=bounce_message)
+            )
 
         if notification.status not in [NOTIFICATION_SENDING, NOTIFICATION_PENDING]:
             notifications_dao._duplicate_update_warning(notification=notification, status=notification_status)

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -105,23 +105,24 @@ def test_get_pdf_for_templated_letter_happy_path(mocker, sample_letter_notificat
     )
 
 
-def test_get_pdf_for_templated_letter_non_existent_notification(notify_db_session, mocker, fake_uuid):
+def test_get_pdf_for_templated_letter_non_existent_notification(notify_db_session, fake_uuid):
     with pytest.raises(expected_exception=NoResultFound):
         get_pdf_for_templated_letter(fake_uuid)
 
 
-def test_get_pdf_for_templated_letter_retries_upon_error(mocker, sample_letter_notification):
+def test_get_pdf_for_templated_letter_retries_upon_error(mocker, sample_letter_notification, caplog):
     mock_celery = mocker.patch("app.celery.letters_pdf_tasks.notify_celery.send_task", side_effect=Exception())
     mocker.patch("app.celery.letters_pdf_tasks.generate_letter_pdf_filename", return_value="LETTER.PDF")
     mock_retry = mocker.patch("app.celery.letters_pdf_tasks.get_pdf_for_templated_letter.retry")
-    mock_logger = mocker.patch("app.celery.tasks.current_app.logger.exception")
 
-    get_pdf_for_templated_letter(sample_letter_notification.id)
+    with caplog.at_level("ERROR"):
+        get_pdf_for_templated_letter(sample_letter_notification.id)
 
     assert mock_celery.called
     assert mock_retry.called
-    mock_logger.assert_called_once_with(
+    assert (
         f"RETRY: calling create-letter-pdf task for notification {sample_letter_notification.id} failed"
+        in caplog.messages
     )
 
 
@@ -146,47 +147,48 @@ def test_get_pdf_for_templated_letter_sets_technical_failure_max_retries(mocker,
     mock_update_noti.assert_called_once_with(sample_letter_notification.id, "technical-failure")
 
 
-def test_update_billable_units_for_letter(mocker, sample_letter_notification):
+def test_update_billable_units_for_letter(sample_letter_notification, caplog):
     sample_letter_notification.billable_units = 0
-    mock_logger = mocker.patch("app.celery.tasks.current_app.logger.info")
 
-    update_billable_units_for_letter(sample_letter_notification.id, 4)
+    with caplog.at_level("INFO"):
+        update_billable_units_for_letter(sample_letter_notification.id, 4)
 
     notification = Notification.query.filter(Notification.reference == sample_letter_notification.reference).one()
     assert notification.billable_units == 2
     assert sample_letter_notification.status == NOTIFICATION_CREATED
-    mock_logger.assert_called_once_with(
+    assert (
         f"Letter notification id: {sample_letter_notification.id} reference {sample_letter_notification.reference}:"
         f" billable units set to 2"
-    )
+    ) in caplog.messages
 
 
-def test_update_billable_units_for_letter_doesnt_update_if_sent_with_test_key(mocker, sample_letter_notification):
+def test_update_billable_units_for_letter_doesnt_update_if_sent_with_test_key(sample_letter_notification, caplog):
     sample_letter_notification.billable_units = 0
     sample_letter_notification.key_type = KEY_TYPE_TEST
-    mock_logger = mocker.patch("app.celery.tasks.current_app.logger.info")
 
-    update_billable_units_for_letter(sample_letter_notification.id, 2)
+    with caplog.at_level("INFO"):
+        update_billable_units_for_letter(sample_letter_notification.id, 2)
 
     notification = Notification.query.filter(Notification.reference == sample_letter_notification.reference).one()
     assert notification.billable_units == 0
-    mock_logger.assert_not_called()
+    assert caplog.messages == []
 
 
 @pytest.mark.parametrize("key_type", ["test", "normal", "team"])
 def test_update_validation_failed_for_templated_letter_with_too_many_pages(
-    mocker, sample_letter_notification, key_type
+    sample_letter_notification, key_type, caplog
 ):
     sample_letter_notification.billable_units = 0
     sample_letter_notification.key_type = key_type
-    mock_logger = mocker.patch("app.celery.tasks.current_app.logger.info")
 
-    update_validation_failed_for_templated_letter(sample_letter_notification.id, 11)
+    with caplog.at_level("INFO"):
+        update_validation_failed_for_templated_letter(sample_letter_notification.id, 11)
 
     assert sample_letter_notification.billable_units == 0
     assert sample_letter_notification.status == NOTIFICATION_VALIDATION_FAILED
-    mock_logger.assert_called_once_with(
+    assert (
         f"Validation failed: letter is too long 11 for letter with id: {sample_letter_notification.id}"
+        in caplog.messages
     )
 
 
@@ -194,7 +196,6 @@ def test_update_validation_failed_for_templated_letter_with_too_many_pages(
 @freeze_time("2020-02-17 18:00:00")
 def test_get_key_and_size_of_letters_to_be_sent_to_print(
     notify_api,
-    mocker,
     sample_letter_template,
     sample_organisation,
 ):
@@ -284,7 +285,7 @@ def test_get_key_and_size_of_letters_to_be_sent_to_print(
 @mock_s3
 @freeze_time("2020-02-17 18:00:00")
 def test_get_key_and_size_of_letters_to_be_sent_to_print_handles_file_not_found(
-    notify_api, mocker, sample_letter_template, sample_organisation
+    notify_api, sample_letter_template, sample_organisation
 ):
     pdf_bucket = current_app.config["S3_BUCKET_LETTERS_PDF"]
     s3 = boto3.client("s3", region_name="eu-west-1")
@@ -720,6 +721,7 @@ def test_group_letters_with_no_letters():
 def test_move_invalid_letter_and_update_status_logs_error_and_sets_tech_failure_state_if_s3_error(
     mocker,
     sample_letter_notification,
+    caplog,
 ):
     error_response = {
         "Error": {"Code": "InvalidParameterValue", "Message": "some error message from amazon", "Type": "Sender"}
@@ -728,16 +730,16 @@ def test_move_invalid_letter_and_update_status_logs_error_and_sets_tech_failure_
         "app.celery.letters_pdf_tasks.move_scan_to_invalid_pdf_bucket",
         side_effect=ClientError(error_response, "operation_name"),
     )
-    mock_logger = mocker.patch("app.celery.tasks.current_app.logger.exception")
 
-    with pytest.raises(NotificationTechnicalFailureException):
+    with pytest.raises(NotificationTechnicalFailureException), caplog.at_level("ERROR"):
         _move_invalid_letter_and_update_status(
             notification=sample_letter_notification, filename="filename", scan_pdf_object=mocker.Mock()
         )
 
     assert sample_letter_notification.status == NOTIFICATION_TECHNICAL_FAILURE
-    mock_logger.assert_called_once_with(
+    assert (
         "Error when moving letter with id {} to invalid PDF bucket".format(sample_letter_notification.id)
+        in caplog.messages
     )
 
 

--- a/tests/app/test_cronitor.py
+++ b/tests/app/test_cronitor.py
@@ -67,13 +67,13 @@ def test_cronitor_does_nothing_if_cronitor_not_enabled(notify_api, rmock):
     assert rmock.called is False
 
 
-def test_cronitor_does_nothing_if_name_not_recognised(notify_api, rmock, mocker):
-    mock_logger = mocker.patch("app.cronitor.current_app.logger")
-
-    with set_config_values(notify_api, {"CRONITOR_ENABLED": True, "CRONITOR_KEYS": {"not-hello": "other"}}):
+def test_cronitor_does_nothing_if_name_not_recognised(notify_api, rmock, caplog):
+    with set_config_values(
+        notify_api, {"CRONITOR_ENABLED": True, "CRONITOR_KEYS": {"not-hello": "other"}}
+    ), caplog.at_level("ERROR"):
         assert successful_task() == 1
 
-    mock_logger.error.assert_called_with("Cronitor enabled but task_name hello not found in environment")
+    assert "Cronitor enabled but task_name hello not found in environment" in caplog.messages
 
     assert rmock.called is False
 


### PR DESCRIPTION
And fix a few more parts of the codebase where we just have broken log statements :sad-tear: