### PR TITLE
Run celery beat in UTC

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -197,7 +197,7 @@ class Config(object):
             "visibility_timeout": 310,
             "queue_name_prefix": NOTIFICATION_QUEUE_PREFIX,
         },
-        "timezone": "Europe/London",
+        "timezone": "UTC",
         "imports": [
             "app.celery.tasks",
             "app.celery.scheduled_tasks",
@@ -324,7 +324,7 @@ class Config(object):
             },
             "raise-alert-if-no-letter-ack-file": {
                 "task": "raise-alert-if-no-letter-ack-file",
-                "schedule": crontab(hour=23, minute=00),
+                "schedule": crontab(hour=22, minute=45),
                 "options": {"queue": QueueNames.PERIODIC},
             },
             "trigger-link-tests": {


### PR DESCRIPTION
We currently schedule celery beat tasks in Europe/London, which means they are scheduled in GMT/BST as appropriate. This means that the hour/minute set in the crontab is the wall-clock time that they will run in reality. This is nice for us as it's predictable and easy to reason about (we don't need to really consider timezones).

Unfortunately, that means celery-beat needs to consider timezones, and it hates doing that: `https://github.com/celery/celery/issues/6438`. This issue has been open on celery for 2.5 years as of writing, and talks about how the celery-beat scheduler can crap the bed when a timezone change occurs, leading to scheduled tasks being skipped. Restarting the celery beat scheduler once the new time zone happens is a workaround, but we don't have a good way to do that.

After some discussion we've agreed that we're happy to run tasks in UTC to get things running consistently.

We should be careful not to schedule anything between 11pm and midnight UTC, as this is 11pm-midnight GMT but midnight-1am BST - ie could run on different local days. For our reporting or processing tasks, this could be really awkward or broken, eg some notifications sent between 11pm and midnight could be counted in the next day's report. Let's add a test that makes sure nothing is scheduled to _only_ run between 11pm and midnight UTC.