### PR TITLE
Update document-download security defaults

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -256,6 +256,9 @@ MOBILE_TYPE = "mobile"
 # Guest lists
 GUEST_LIST_RECIPIENT_TYPE = [MOBILE_TYPE, EMAIL_TYPE]
 
+# Document download constants
+DEFAULT_DOCUMENT_DOWNLOAD_RETENTION_PERIOD = "26 weeks"
+
 
 # S3 tags
 class Retention:

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -24,6 +24,7 @@ from app.celery.tasks import save_api_email, save_api_sms
 from app.clients.document_download import DocumentDownloadError
 from app.config import QueueNames, TaskNames
 from app.constants import (
+    DEFAULT_DOCUMENT_DOWNLOAD_RETENTION_PERIOD,
     EMAIL_TYPE,
     KEY_TYPE_NORMAL,
     KEY_TYPE_TEAM,
@@ -328,8 +329,10 @@ def process_document_uploads(personalisation_data, service, send_to: str, simula
         if simulated:
             personalisation_data[key] = document_download_client.get_upload_url(service.id) + "/test-document"
         else:
-            confirm_email = personalisation_data[key].get("confirm_email_before_download") or False
-            retention_period = personalisation_data[key].get("retention_period", None)
+            confirm_email = personalisation_data[key].get("confirm_email_before_download", True)
+            retention_period = (
+                personalisation_data[key].get("retention_period") or DEFAULT_DOCUMENT_DOWNLOAD_RETENTION_PERIOD
+            )
 
             try:
                 personalisation_data[key] = document_download_client.upload_document(


### PR DESCRIPTION
**NOTE**: to be merged Wednesday 12 April.

We announced email-as-a-password and retention period changes about 6 months ago, giving services plenty of time to adapt to the new features. Now that this time has passed, we want to update these features to enable email-as-a-password by default and set the default retention period to 26 weeks.