### PR TITLE
Optimise one of the org dashboard queries

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -147,6 +147,15 @@ def _fetch_usage_for_all_services_sms_query(year, organisation_id=None):
                 FactBilling.bst_date >= year_start,
                 FactBilling.bst_date <= year_end,
                 FactBilling.notification_type == SMS_TYPE,
+                *(
+                    [
+                        FactBilling.service_id.in_(
+                            db.session.query(Service.id).filter(Service.organisation_id == organisation_id)
+                        )
+                    ]
+                    if organisation_id
+                    else []
+                ),
             ),
         )
     ).filter(*([Service.organisation_id == organisation_id] if organisation_id else []))

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -689,6 +689,45 @@ def test_fetch_usage_for_all_services_sms(
     assert row_1["cost"] == Decimal("0.486")
 
 
+def test_fetch_usage_for_all_services_sms_with_organisation_id_filter(
+    sample_service,
+    sample_organisation,
+    sample_service_billing_fy_2016,
+    notify_db_session,
+):
+    dao_add_service_to_organisation(service=sample_service, organisation_id=sample_organisation.id)
+    results = fetch_usage_for_all_services_sms(
+        datetime(2016, 4, 1), datetime(2017, 3, 31), organisation_id=sample_organisation.id
+    ).all()
+
+    assert len(results) == 1
+    row_1 = results[0]
+
+    assert row_1["organisation_name"] == sample_organisation.name
+    assert row_1["organisation_id"] == sample_organisation.id
+    assert row_1["service_name"] == sample_service.name
+    assert row_1["service_id"] == sample_service.id
+    assert row_1["free_allowance"] == 1
+    assert row_1["free_allowance_left"] == 0
+    assert row_1["chargeable_units"] == 4
+    assert row_1["charged_units"] == 3
+    assert row_1["cost"] == Decimal("0.486")
+
+
+def test_fetch_usage_for_all_services_sms_with_organisation_id_filter_for_a_different_organisation(
+    sample_service,
+    sample_organisation,
+    sample_service_billing_fy_2016,
+    notify_db_session,
+):
+    dao_add_service_to_organisation(service=sample_service, organisation_id=sample_organisation.id)
+    results = fetch_usage_for_all_services_sms(
+        datetime(2016, 4, 1), datetime(2017, 3, 31), organisation_id="aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb"
+    ).all()
+
+    assert len(results) == 0
+
+
 def test_fetch_usage_for_all_services_variable_rates(
     sample_service, sample_organisation, sample_service_billing_fy_2018_variable_rates, notify_db_session
 ):


### PR DESCRIPTION
Ticket: https://trello.com/c/V6vkvxon/254-review-loading-time-for-organisation-page

This is the first in a series of small, incremental improvements to the org dashboard page. This PR focuses on optimising one of the slower queries. This specific query adds a flat latency to the page regardless of which organisation you're viewing, so for small orgs this query takes up a disproportionate amount of the page load. Optimising this query will provide a significant relative increase in page loading for smaller orgs.

**Note**: query plans/timings are from our semi-representative large staging DB

## Baseline

<details><summary>Baseline - SQL</summary>

```sql
 SELECT organisation.name               AS organisation_name,
        organisation.id                 AS organisation_id,
        services.name                   AS service_name,
        services.id                     AS service_id,
        max(anon_1.free_allowance)      AS free_allowance,
        min(anon_1.free_allowance_left) AS free_allowance_left,
        sum(anon_1.chargeable_units)    AS chargeable_units,
        sum(anon_1.charged_units)       AS charged_units,
        sum(anon_1.cost)                AS cost,
        services.active
 FROM services
          LEFT OUTER JOIN (SELECT services.id                                                         AS service_id,
                                  ft_billing.bst_date                                                 AS bst_date,
                                  annual_billing.free_sms_fragment_limit                              AS free_allowance,
                                  greatest(greatest(annual_billing.free_sms_fragment_limit - coalesce(
                                          CAST(sum(coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0))
                                               OVER (PARTITION BY ft_billing.service_id ORDER BY ft_billing.bst_date ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS INTEGER),
                                          0), 0) - coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0),
                                           0)                                                         AS free_allowance_left,
                                  coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0) AS chargeable_units,
                                  greatest(coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0) -
                                           greatest(annual_billing.free_sms_fragment_limit - coalesce(CAST(sum(
                                                                                                           coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0))
                                                                                                           OVER (PARTITION BY ft_billing.service_id ORDER BY ft_billing.bst_date ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS INTEGER),
                                                                                                      0), 0), 0) *
                                  coalesce(ft_billing.rate, 0.0)                                      AS cost,
                                  greatest(coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0) -
                                           greatest(annual_billing.free_sms_fragment_limit - coalesce(CAST(sum(
                                                                                                           coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0))
                                                                                                           OVER (PARTITION BY ft_billing.service_id ORDER BY ft_billing.bst_date ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS INTEGER),
                                                                                                      0), 0),
                                           0)                                                         AS charged_units
                           FROM services
                                    LEFT OUTER JOIN annual_billing ON annual_billing.service_id = services.id AND
                                                                      annual_billing.financial_year_start = 2022
                                    LEFT OUTER JOIN ft_billing ON services.id = ft_billing.service_id AND
                                                                  ft_billing.bst_date >= '2022-04-01' AND
                                                                  ft_billing.bst_date <= '2023-03-31' AND
                                                                  ft_billing.notification_type = 'sms') AS anon_1
                          ON services.id = anon_1.service_id
          LEFT OUTER JOIN organisation ON organisation.id = services.organisation_id
 WHERE anon_1.bst_date >= '2022-04-01'
   AND anon_1.bst_date <= '2023-03-31'
   AND services.organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::UUID
   AND services.restricted IS false
 GROUP BY organisation.name, organisation.id, services.id, services.name
 ORDER BY organisation.name, services.name;
```
</details>
<details><summary>Baseline - Plan</summary>

```
 Sort  (cost=282586.21..282586.53 rows=129 width=141) (actual time=1949.972..1949.982 rows=31 loops=1)
   Sort Key: organisation.name, services.name
   Sort Method: quicksort  Memory: 29kB
   ->  GroupAggregate  (cost=282577.50..282581.69 rows=129 width=141) (actual time=1947.203..1949.935 rows=31 loops=1)
         Group Key: organisation.id, services.id
         ->  Sort  (cost=282577.50..282577.82 rows=129 width=133) (actual time=1947.127..1947.676 rows=11774 loops=1)
               Sort Key: organisation.id, services.id
               Sort Method: quicksort  Memory: 2040kB
               ->  Hash Left Join  (cost=206586.92..282572.97 rows=129 width=133) (actual time=1129.299..1943.096 rows=11774 loops=1)
                     Hash Cond: (services.organisation_id = organisation.id)
                     ->  Hash Join  (cost=206578.61..282562.89 rows=129 width=105) (actual time=1129.255..1940.738 rows=11774 loops=1)
                           Hash Cond: (anon_1.service_id = services.id)
                           ->  Subquery Scan on anon_1  (cost=204002.84..279350.84 rows=242391 width=64) (actual time=1112.211..1876.579 rows=834803 loops=1)
                                 Filter: ((anon_1.bst_date >= '2022-04-01'::date) AND (anon_1.bst_date <= '2023-03-31'::date))
                                 Rows Removed by Filter: 17790
                                 ->  WindowAgg  (cost=204002.84..266792.84 rows=837200 width=84) (actual time=1112.210..1799.328 rows=852593 loops=1)
                                       ->  Sort  (cost=204002.84..206095.84 rows=837200 width=51) (actual time=1112.188..1230.604 rows=852593 loops=1)
                                             Sort Key: ft_billing.service_id, ft_billing.bst_date
                                             Sort Method: external merge  Disk: 52040kB
                                             ->  Hash Left Join  (cost=4933.11..64410.40 rows=837200 width=51) (actual time=17.093..665.850 rows=852593 loops=1)
                                                   Hash Cond: (services_1.id = annual_billing.service_id)
                                                   ->  Hash Right Join  (cost=3198.33..60477.56 rows=837200 width=47) (actual time=8.016..492.546 rows=852593 loops=1)
                                                         Hash Cond: (ft_billing.service_id = services_1.id)
                                                         ->  Index Scan using ix_ft_billing_bst_date_sms_only on ft_billing  (cost=0.43..55081.60 rows=837200 width=31) (actual time=0.019..317.871 rows=834803 loops=1)
                                                               Index Cond: ((bst_date >= '2022-04-01'::date) AND (bst_date <= '2023-03-31'::date))
                                                         ->  Hash  (cost=2915.18..2915.18 rows=22618 width=16) (actual time=7.956..7.957 rows=22618 loops=1)
                                                               Buckets: 32768  Batches: 1  Memory Usage: 1317kB
                                                               ->  Seq Scan on services services_1  (cost=0.00..2915.18 rows=22618 width=16) (actual time=0.005..5.421 rows=22618 loops=1)
                                                   ->  Hash  (cost=1473.49..1473.49 rows=20903 width=20) (actual time=9.000..9.001 rows=21034 loops=1)
                                                         Buckets: 32768  Batches: 1  Memory Usage: 1325kB
                                                         ->  Seq Scan on annual_billing  (cost=0.00..1473.49 rows=20903 width=20) (actual time=0.954..5.805 rows=21034 loops=1)
                                                               Filter: (financial_year_start = 2022)
                                                               Rows Removed by Filter: 46285
                           ->  Hash  (cost=2570.22..2570.22 rows=444 width=57) (actual time=1.098..1.099 rows=260 loops=1)
                                 Buckets: 1024  Batches: 1  Memory Usage: 32kB
                                 ->  Bitmap Heap Scan on services  (cost=223.32..2570.22 rows=444 width=57) (actual time=0.182..1.050 rows=260 loops=1)
                                       Recheck Cond: (organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::uuid)
                                       Filter: (restricted IS FALSE)
                                       Rows Removed by Filter: 1180
                                       Heap Blocks: exact=633
                                       ->  Bitmap Index Scan on ix_services_organisation_id  (cost=0.00..223.21 rows=1440 width=0) (actual tim
e=0.107..0.107 rows=1440 loops=1)
                                             Index Cond: (organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::uuid)
                     ->  Hash  (cost=8.30..8.30 rows=1 width=44) (actual time=0.024..0.025 rows=1 loops=1)
                           Buckets: 1024  Batches: 1  Memory Usage: 9kB
                           ->  Index Scan using organisation_pkey on organisation  (cost=0.28..8.30 rows=1 width=44) (actual time=0.020..0.021 rows=1 loops=1)
                                 Index Cond: (id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::uuid)
 Planning Time: 0.615 ms
 Execution Time: 1957.183 ms
(48 rows)
```
</details>

##  Commit 1: Passing organisation_id into subquery

This function collates billing data for services in a given organisation. It calls 
`fetch_usage_for_all_services_sms` and applies a filter for live services in the specified organisation. This would 
be ok if not for the fact that `fetch_usage_for_all_services_sms` builds a subquery using 
`_fetch_usage_for_all_services_sms_query`. The subquery doesn't get 
filtered, and so it ends up first running a query joining all services to all ft_billing data. This is way more data 
than we need to be querying when looking up billing for a single organisation. We currently emit a query like this:

This patch feeds an optional `organisation_id` through the relevant functions so that we can finally end up with a 
single extra filter clause and a query like this:

<details><summary>Commit 1 - SQL</summary>

```sql
SELECT organisation.name               AS organisation_name,
        organisation.id                 AS organisation_id,
        services.name                   AS service_name,
        services.id                     AS service_id,
        max(anon_1.free_allowance)      AS free_allowance,
        min(anon_1.free_allowance_left) AS free_allowance_left,
        sum(anon_1.chargeable_units)    AS chargeable_units,
        sum(anon_1.charged_units)       AS charged_units,
        sum(anon_1.cost)                AS cost,
        services.active
 FROM services
          LEFT OUTER JOIN (SELECT services.id                                                         AS service_id,
                                  ft_billing.bst_date                                                 AS bst_date,
                                  annual_billing.free_sms_fragment_limit                              AS free_allowance,
                                  greatest(greatest(annual_billing.free_sms_fragment_limit - coalesce(
                                          CAST(sum(coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0))
                                               OVER (PARTITION BY ft_billing.service_id ORDER BY ft_billing.bst_date ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS INTEGER),
                                          0), 0) - coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0),
                                           0)                                                         AS free_allowance_left,
                                  coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0) AS chargeable_units,
                                  greatest(coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0) -
                                           greatest(annual_billing.free_sms_fragment_limit - coalesce(CAST(sum(
                                                                                                           coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0))
                                                                                                           OVER (PARTITION BY ft_billing.service_id ORDER BY ft_billing.bst_date ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS INTEGER),
                                                                                                      0), 0), 0) *
                                  coalesce(ft_billing.rate, 0.0)                                      AS cost,
                                  greatest(coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0) -
                                           greatest(annual_billing.free_sms_fragment_limit - coalesce(CAST(sum(
                                                                                                           coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0))
                                                                                                           OVER (PARTITION BY ft_billing.service_id ORDER BY ft_billing.bst_date ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS INTEGER),
                                                                                                      0), 0),
                                           0)                                                         AS charged_units
                           FROM services
                                    LEFT OUTER JOIN annual_billing ON annual_billing.service_id = services.id AND
                                                                      annual_billing.financial_year_start = 2022
                                    LEFT OUTER JOIN ft_billing ON services.id = ft_billing.service_id AND
                                                                  ft_billing.bst_date >= '2022-04-01' AND
                                                                  ft_billing.bst_date <= '2023-03-31' AND
                                                                  ft_billing.notification_type = 'sms'

-- the new bit: start
                           WHERE services.organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::UUID) AS anon_1
-- the new bit: end

                          ON services.id = anon_1.service_id
          LEFT OUTER JOIN organisation ON organisation.id = services.organisation_id
 WHERE anon_1.bst_date >= '2022-04-01'
   AND anon_1.bst_date <= '2023-03-31'
   AND services.organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::UUID
   AND services.restricted IS false
 GROUP BY organisation.name, organisation.id, services.id, services.name
 ORDER BY organisation.name, services.name;
```
</details>

<details><summary>Commit 1 - Plan</summary>

```
 Sort  (cost=59376.90..59376.91 rows=1 width=141) (actual time=330.758..330.763 rows=5 loops=1)
   Sort Key: organisation.name, services.name
   Sort Method: quicksort  Memory: 26kB
   ->  GroupAggregate  (cost=59376.86..59376.89 rows=1 width=141) (actual time=330.612..330.753 rows=5 loops=1)
         Group Key: organisation.id, services.id
         ->  Sort  (cost=59376.86..59376.86 rows=1 width=133) (actual time=330.560..330.598 rows=723 loops=1)
               Sort Key: organisation.id, services.id
               Sort Method: quicksort  Memory: 198kB
               ->  Nested Loop Left Join  (cost=59188.56..59376.85 rows=1 width=133) (actual time=328.652..330.358 rows=723 loops=1)
                     ->  Hash Join  (cost=59188.28..59369.71 rows=1 width=105) (actual time=328.639..329.511 rows=723 loops=1)
                           Hash Cond: (anon_1.service_id = services.id)
                           ->  Subquery Scan on anon_1  (cost=58985.53..59165.44 rows=579 width=64) (actual time=328.535..329.258 rows=743 loops=1)
                                 Filter: ((anon_1.bst_date >= '2022-04-01'::date) AND (anon_1.bst_date <= '2023-03-31'::date))
                                 Rows Removed by Filter: 47
                                 ->  WindowAgg  (cost=58985.53..59135.46 rows=1999 width=84) (actual time=328.534..329.174 rows=790 loops=1)
                                       ->  Sort  (cost=58985.53..58990.53 rows=1999 width=51) (actual time=328.520..328.567 rows=790 loops=1)
                                             Sort Key: ft_billing.service_id, ft_billing.bst_date
                                             Sort Method: quicksort  Memory: 133kB
                                             ->  Hash Right Join  (cost=635.28..58875.94 rows=1999 width=51) (actual time=0.342..328.085 rows=790 loops=1)
                                                   Hash Cond: (ft_billing.service_id = services_1.id)
                                                   ->  Index Scan using ix_ft_billing_bst_date_sms_only on ft_billing  (cost=0.43..55081.60 rows=837200 width=31) (actual time=0.014..270.877 rows=834803 loops=1)
                                                         Index Cond: ((bst_date >= '2022-04-01'::date) AND (bst_date <= '2023-03-31'::date))
                                                   ->  Hash  (cost=634.17..634.17 rows=54 width=20) (actual time=0.225..0.226 rows=54 loops=1)
                                                         Buckets: 1024  Batches: 1  Memory Usage: 11kB
                                                         ->  Nested Loop Left Join  (cost=9.25..634.17 rows=54 width=20) (actual time=0.018..0.216 rows=54 loops=1)
                                                               ->  Bitmap Heap Scan on services services_1  (cost=8.83..202.55 rows=54 width=16) (actual time=0.010..0.034 rows=54 loops=1)
                                                                     Recheck Cond: (organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::uuid)
                                                                     Heap Blocks: exact=47
                                                                     ->  Bitmap Index Scan on ix_services_organisation_id  (cost=0.00..8.82 rows=54 width=0) (actual time=0.006..0.006 rows=54 loops=1)
                                                                           Index Cond: (organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::uuid)
                                                               ->  Index Scan using uix_service_id_financial_year_start on annual_billing  (cost=0.42..7.99 rows=1 width=20) (actual time=0.003..0.003 rows=1 loops=54)
                                                                     Index Cond: ((service_id = services_1.id) AND (financial_year_start = 2022))
                           ->  Hash  (cost=202.54..202.54 rows=17 width=57) (actual time=0.085..0.086 rows=24 loops=1)
                                 Buckets: 1024  Batches: 1  Memory Usage: 11kB
                                 ->  Bitmap Heap Scan on services  (cost=8.82..202.54 rows=17 width=57) (actual time=0.024..0.079 rows=24 loops=1)
                                       Recheck Cond: (organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::uuid)
                                       Filter: (restricted IS FALSE)
                                       Rows Removed by Filter: 30
                                       Heap Blocks: exact=47
                                       ->  Bitmap Index Scan on ix_services_organisation_id  (cost=0.00..8.82 rows=54 width=0) (actual time=0.012..0.012 rows=54 loops=1)
                                             Index Cond: (organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::uuid)
                     ->  Index Scan using organisation_pkey on organisation  (cost=0.28..7.12 rows=1 width=44) (actual time=0.001..0.001 rows=1 loops=723)
                           Index Cond: ((id = services.organisation_id) AND (id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::uuid))
 Planning Time: 0.617 ms
 Execution Time: 330.876 ms
(45 rows)
```

</details>

### Performance changes

This reduces query execution in a fairly flat way across a variety of services. The new query runs in approximately 
30% of the time.

| Organisation            | Query execution time: baseline (ms) | Query execution time: commit 1 (ms) |
|-------------------------|-------------------------------------|-------------------------------------|
| Cabinet Office          | Time: 1904.782 ms (00:01.905)       | Time: 589.321 ms                    |
| HMRC                    | Time: 1928.833 ms (00:01.929)       | Time: 547.078 ms                    |
| DWP                     | Time: 1849.638 ms (00:01.850)       | Time: 570.952 ms                    |
| MK Council              | Time: 1837.129 ms (00:01.837)       | Time: 570.980 ms                    |
| Brighton & Hove Council | Time: 1840.022 ms (00:01.840)       | Time: 544.516 ms                    |

Definitely still room for improvement to come, but a good start with quite an isolated change.

## Commit 2 - Optimising the join between `services` and `ft_billing`

In the subquery, when joining between `services` and `ft_billing` we still join the full combination of both tables. 
We can alter the join to pre-filter `ft_billing` down to only the services we're interested in by adding a condition 
to the join statement. This will give us a query that scales better depending on the organisation being queried - 
smaller organisations will deal with fewer rows, larger organisations will deal with more rows and remain slower. 
But let's crystallise that benefit for smaller orgs. For large orgs, the org dashboard has another query that is 
massively slow already - so the slowness on this query represents a much smaller impact overall than on small orgs.

<details><summary>Commit 2 - SQL</summary>

```sql
SELECT organisation.name               AS organisation_name,
       organisation.id                 AS organisation_id,
       services.name                   AS service_name,
       services.id                     AS service_id,
       max(anon_1.free_allowance)      AS free_allowance,
       min(anon_1.free_allowance_left) AS free_allowance_left,
       sum(anon_1.chargeable_units)    AS chargeable_units,
       sum(anon_1.charged_units)       AS charged_units,
       sum(anon_1.cost)                AS cost,
       services.active
FROM services
         LEFT OUTER JOIN (SELECT services.id                                                         AS service_id,
                                 ft_billing.bst_date                                                 AS bst_date,
                                 annual_billing.free_sms_fragment_limit                              AS free_allowance,
                                 greatest(greatest(annual_billing.free_sms_fragment_limit - coalesce(
                                         CAST(sum(coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0))
                                              OVER (PARTITION BY ft_billing.service_id ORDER BY ft_billing.bst_date ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS INTEGER),
                                         0), 0) - coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0),
                                          0)                                                         AS free_allowance_left,
                                 coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0) AS chargeable_units,
                                 greatest(coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0) -
                                          greatest(annual_billing.free_sms_fragment_limit - coalesce(CAST(sum(
                                                                                                          coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0))
                                                                                                          OVER (PARTITION BY ft_billing.service_id ORDER BY ft_billing.bst_date ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS INTEGER),
                                                                                                     0), 0), 0) *
                                 coalesce(ft_billing.rate, 0.0)                                      AS cost,
                                 greatest(coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0) -
                                          greatest(annual_billing.free_sms_fragment_limit - coalesce(CAST(sum(
                                                                                                          coalesce(ft_billing.billable_units * ft_billing.rate_multiplier, 0))
                                                                                                          OVER (PARTITION BY ft_billing.service_id ORDER BY ft_billing.bst_date ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS INTEGER),
                                                                                                     0), 0),
                                          0)                                                         AS charged_units
                          FROM services
                                   LEFT OUTER JOIN annual_billing ON annual_billing.service_id = services.id AND
                                                                     annual_billing.financial_year_start = 2022
                                   LEFT OUTER JOIN ft_billing ON services.id = ft_billing.service_id AND

--- the new bit: start
                                                                 ft_billing.service_id IN (SELECT services.id
                                                                                           FROM services
                                                                                           WHERE services.organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::UUID) AND
--- the new bit: end

                                                                 ft_billing.bst_date >= '2022-04-01' AND
                                                                 ft_billing.bst_date <= '2023-03-31' AND
                                                                 ft_billing.notification_type = 'sms'
                          WHERE services.organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::UUID) AS anon_1
                         ON services.id = anon_1.service_id
         LEFT OUTER JOIN organisation ON organisation.id = services.organisation_id
WHERE anon_1.bst_date >= '2022-04-01'
  AND anon_1.bst_date <= '2023-03-31'
  AND services.organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::UUID
  AND services.restricted IS false
GROUP BY organisation.name, organisation.id, services.id, services.name
ORDER BY organisation.name, services.name;

```
</details>

<details><summary>Commit 2 - Plan</summary>

```
 Sort  (cost=67335.47..67335.52 rows=19 width=141) (actual time=398.001..398.012 rows=31 loops=1)
   Sort Key: organisation.name, services.name
   Sort Method: quicksort  Memory: 29kB
   ->  GroupAggregate  (cost=67334.45..67335.07 rows=19 width=141) (actual time=395.236..397.959 rows=31 loops=1)
         Group Key: organisation.id, services.id
         ->  Sort  (cost=67334.45..67334.50 rows=19 width=133) (actual time=395.163..395.699 rows=11774 loops=1)
               Sort Key: organisation.id, services.id
               Sort Method: quicksort  Memory: 2040kB
               ->  Hash Left Join  (cost=64985.03..67334.05 rows=19 width=133) (actual time=386.511..390.800 rows=11774 loops=1)
                     Hash Cond: (services.organisation_id = organisation.id)
                     ->  Hash Join  (cost=64976.72..67325.48 rows=19 width=105) (actual time=386.487..388.699 rows=11774 loops=1)
                           Hash Cond: (services.id = anon_1.service_id)
                           ->  Bitmap Heap Scan on services  (cost=223.32..2570.22 rows=444 width=57) (actual time=0.178..1.206 rows=260 loops=1)
                                 Recheck Cond: (organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::uuid)
                                 Filter: (restricted IS FALSE)
                                 Rows Removed by Filter: 1180
                                 Heap Blocks: exact=633
                                 ->  Bitmap Index Scan on ix_services_organisation_id  (cost=0.00..223.21 rows=1440 width=0) (actual time=0.104..0.105 rows=1440 loops=1)
                                       Index Cond: (organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::uuid)
                           ->  Hash  (cost=64741.12..64741.12 rows=982 width=64) (actual time=385.964..385.970 rows=12978 loops=1)
                                 Buckets: 16384 (originally 1024)  Batches: 1 (originally 1)  Memory Usage: 999kB
                                 ->  Subquery Scan on anon_1  (cost=64435.75..64741.12 rows=982 width=64) (actual time=371.254..383.492 rows=12978 loops=1)
                                       Filter: ((anon_1.bst_date >= '2022-04-01'::date) AND (anon_1.bst_date <= '2023-03-31'::date))
                                       Rows Removed by Filter: 1343
                                       ->  WindowAgg  (cost=64435.75..64690.23 rows=3393 width=84) (actual time=371.253..381.872 rows=14321 loops=1)
                                             ->  Sort  (cost=64435.75..64444.23 rows=3393 width=51) (actual time=371.238..372.138 rows=14321 loops=1)
                                                   Sort Key: ft_billing.service_id, ft_billing.bst_date
                                                   Sort Method: quicksort  Memory: 2306kB
                                                   ->  Hash Right Join  (cost=6723.74..64236.78 rows=3393 width=51) (actual time=9.435..363.896 rows=14321 loops=1)
                                                         Hash Cond: (ft_billing.service_id = services_1.id)
                                                         ->  Hash Join  (cost=2588.90..59868.13 rows=53301 width=31) (actual time=1.156..352.538 rows=12978 loops=1)
                                                               Hash Cond: (ft_billing.service_id = services_2.id)
                                                               ->  Index Scan using ix_ft_billing_bst_date_sms_only on ft_billing  (cost=0.43..55081.60 rows=837200 width=31) (actual time=0.020..284.687 rows=834803 loops=1)
                                                                     Index Cond: ((bst_date >= '2022-04-01'::date) AND (bst_date <= '2023-03-31'::date))
                                                               ->  Hash  (cost=2570.47..2570.47 rows=1440 width=16) (actual time=1.077..1.078 rows=1440 loops=1)
                                                                     Buckets: 2048  Batches: 1  Memory Usage: 84kB
                                                                     ->  Bitmap Heap Scan on services services_2  (cost=223.57..2570.47 rows=1440 width=16) (actual time=0.162..0.904 rows=1440 loops=1)
                                                                           Recheck Cond: (organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::uuid)
                                                                           Heap Blocks: exact=633
                                                                           ->  Bitmap Index Scan on ix_services_organisation_id  (cost=0.00..223.21 rows=1440 width=0) (actual time=0.099..0.099 rows=1440 loops=1)
                                                                                 Index Cond: (organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::uuid)
                                                         ->  Hash  (cost=4116.84..4116.84 rows=1440 width=20) (actual time=8.266..8.268 rows=1440 loops=1)
                                                               Buckets: 2048  Batches: 1  Memory Usage: 89kB
                                                               ->  Hash Right Join  (cost=2588.47..4116.84 rows=1440 width=20) (actual time=4.108..8.067 rows=1440 loops=1)
                                                                     Hash Cond: (annual_billing.service_id = services_1.id)
                                                                     ->  Seq Scan on annual_billing  (cost=0.00..1473.49 rows=20903 width=20) (actual time=0.954..5.104 rows=21034 loops=1)
                                                                           Filter: (financial_year_start = 2022)
                                                                           Rows Removed by Filter: 46285
                                                                     ->  Hash  (cost=2570.47..2570.47 rows=1440 width=16) (actual time=1.124..1.125 rows=1440 loops=1)
                                                                           Buckets: 2048  Batches: 1  Memory Usage: 84kB
                                                                           ->  Bitmap Heap Scan on services services_1  (cost=223.57..2570.47 rows=1440 width=16) (actual time=0.152..0.932 rows=1440 loops=1)
                                                                                 Recheck Cond: (organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::uuid)
                                                                                 Heap Blocks: exact=633
                                                                                 ->  Bitmap Index Scan on ix_services_organisation_id  (cost=0.00..223.21 rows=1440 width=0) (actual time=0.094..0.094 rows=1440 loops=1)
                                                                                       Index Cond: (organisation_id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::uuid)
                     ->  Hash  (cost=8.30..8.30 rows=1 width=44) (actual time=0.014..0.015 rows=1 loops=1)
                           Buckets: 1024  Batches: 1  Memory Usage: 9kB
                           ->  Index Scan using organisation_pkey on organisation  (cost=0.28..8.30 rows=1 width=44) (actual time=0.009..0.010 rows=1 loops=1)
                                 Index Cond: (id = 'ee0e5030-3a7b-4da8-8685-b6efb770231f'::uuid)
 Planning Time: 0.783 ms
 Execution Time: 398.239 ms
(61 rows)
```

</details>

### Performance changes

This reduces query execution in a variable way depending on how active the organisations's services are.

| Organisation            | Execution time: baseline | Execution time: commit 1 | Execution time: commit 2 |
|-------------------------|--------------------------|--------------------------|--------------------------|
| Cabinet Office          | Time: 1904.782 ms        | Time: 589.321 ms         | Time: 387.585 ms         |
| HMRC                    | Time: 1928.833 ms        | Time: 547.078 ms         | Time: 136.522 ms         |
| DWP                     | Time: 1849.638 ms        | Time: 570.952 ms         | Time: 204.146 ms         |
| MK Council              | Time: 1837.129 ms        | Time: 570.980 ms         | Time: 39.411 ms          |
| Brighton & Hove Council | Time: 1840.022 ms        | Time: 544.516 ms         | Time: 44.034 ms          |