### PR TITLE
Only look for address in `to` field for letters we send by DVLA api

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 from botocore.exceptions import ClientError as BotoClientError
 from flask import current_app
-from notifications_utils.insensitive_dict import InsensitiveDict
 from notifications_utils.postal_address import PostalAddress
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -95,14 +94,7 @@ def deliver_letter(self, notification_id):
     # 55 retries with exponential backoff gives a retry time of approximately 4 hours
     current_app.logger.info(f"Start sending letter for notification id: {notification_id}")
     notification = notifications_dao.get_notification_by_id(notification_id, _raise=True)
-
-    if notification.template.is_precompiled_letter:
-        postal_address = PostalAddress(notification.to, allow_international_letters=True)
-    else:
-        postal_address = PostalAddress.from_personalisation(
-            InsensitiveDict(notification.personalisation),
-            allow_international_letters=True,
-        )
+    postal_address = PostalAddress(notification.to, allow_international_letters=True)
 
     try:
         file_bytes = find_letter_pdf_in_s3(notification).get()["Body"].read()

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -263,8 +263,6 @@ class DVLAClient:
     ):
         """
         Sends a letter to the DVLA for printing
-
-        address should be normalised address lines, e.g. ['A. User', 'London', 'SW1 1AA']
         """
 
         try:


### PR DESCRIPTION
We were getting the recipient address from the `to` field of the notification if the letter was precompiled, and the personalisation if it wasn't. This was because one-off letters only stored the first line of the address in the `to` field - all other types had the full address in that field.

We've now made a change to store the whole address in the `to` field for one-off letters (https://github.com/alphagov/notifications-admin/pull/4655). This means that we don't need to check how the letter was created in order to see where the address is stored - it will always be in the `to` field.