### PR TITLE
Bump sentry SDK to latest version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -34,4 +34,4 @@ notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62
 prometheus-client==0.14.1
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 
-sentry-sdk==1.17.0
+sentry-sdk==1.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -224,7 +224,7 @@ s3transfer==0.6.0
     # via
     #   awscli
     #   boto3
-sentry-sdk==1.17.0
+sentry-sdk==1.19.1
     # via -r requirements.in
 shapely==1.8.4
     # via notifications-utils


### PR DESCRIPTION
Support suggested this as a potential fix for the memory leak/high usage we have seen.