### PR TITLE
Add table for organisation permissions

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -185,6 +185,10 @@ PERMISSION_LIST = [
     CANCEL_BROADCASTS,
     REJECT_BROADCASTS,
 ]
+CAN_ASK_TO_JOIN_SERVICE = "can_ask_to_join_a_service"
+ORGANISATION_PERMISSION_TYPES = [
+    CAN_ASK_TO_JOIN_SERVICE,
+]
 
 # Prioritisation for template processing
 # PRIORITY queue is now archived and should be ripe for cleanup.

--- a/app/dao/organisation_permissions_dao.py
+++ b/app/dao/organisation_permissions_dao.py
@@ -1,0 +1,13 @@
+from app import db
+from app.dao.dao_utils import autocommit
+from app.models import OrganisationPermission
+
+
+@autocommit
+def set_organisation_permission(organisation, permissions):
+    query = OrganisationPermission.query.filter_by(organisation=organisation)
+    query.delete()
+    for p in permissions:
+        o_p = OrganisationPermission(organisation_id=organisation.id, permission=p)
+        o_p.organisation = organisation
+        db.session.add(o_p)

--- a/app/organisation/organisation_schema.py
+++ b/app/organisation/organisation_schema.py
@@ -1,4 +1,4 @@
-from app.constants import INVITED_USER_STATUS_TYPES
+from app.constants import INVITED_USER_STATUS_TYPES, ORGANISATION_PERMISSION_TYPES
 from app.models import ORGANISATION_TYPES
 from app.schema_validation.definitions import uuid
 
@@ -24,6 +24,7 @@ post_update_organisation_schema = {
         "active": {"type": ["boolean", "null"]},
         "crown": {"type": ["boolean", "null"]},
         "organisation_type": {"enum": ORGANISATION_TYPES},
+        "permissions": {"type": "array", "items": {"enum": ORGANISATION_PERMISSION_TYPES}},
     },
     "required": [],
 }

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -78,7 +78,6 @@ def get_organisation_by_id(organisation_id):
 
 @organisation_blueprint.route("/by-domain", methods=["GET"])
 def get_organisation_by_domain():
-
     domain = request.args.get("domain")
 
     if not domain or "@" in domain:
@@ -117,7 +116,11 @@ def update_organisation(organisation_id):
         if not organisation.letter_branding_id:
             data["letter_branding_id"] = current_app.config["NHS_LETTER_BRANDING_ID"]
 
-    result = dao_update_organisation(organisation_id, **data)
+    if data.get("permissions") or data.get("permissions") == []:
+        organisation.set_permissions_list(data.get("permissions"))
+        result = True
+    else:
+        result = dao_update_organisation(organisation_id, **data)
 
     if data.get("agreement_signed") is True:
         # if a platform admin has manually adjusted the organisation, don't tell people

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0407_letter_attachments
+0408_perm_ask_to_join_service

--- a/migrations/versions/0408_perm_ask_to_join_service.py
+++ b/migrations/versions/0408_perm_ask_to_join_service.py
@@ -1,0 +1,40 @@
+"""
+
+Revision ID: 0407_letter_attachments
+Revises: 0406_1_april_2023_sms_rates
+Create Date: 2023-03-09 08:45:00.990562
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0408_perm_ask_to_join_service"
+down_revision = "0407_letter_attachments"
+
+
+def upgrade():
+    op.create_table(
+        "organisation_permissions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "permission",
+            sa.Enum(
+                "can_ask_to_join_a_service",
+                name="organisation_permission_types",
+            ),
+            nullable=False,
+        ),
+        sa.Column("organisation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["organisation_id"],
+            ["organisation.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade():
+    op.drop_table("organisation_permissions")
+    op.execute("drop type organisation_permission_types")

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -92,6 +92,7 @@ def test_get_organisation_by_id(admin_request, notify_db_session):
         "billing_reference",
         "purchase_order_number",
         "can_approve_own_go_live_requests",
+        "permissions",
     }
     assert response["id"] == str(org.id)
     assert response["name"] == "test_org_1"
@@ -117,7 +118,6 @@ def test_get_organisation_by_id(admin_request, notify_db_session):
 
 
 def test_get_organisation_by_id_returns_domains(admin_request, notify_db_session):
-
     org = create_organisation(
         domains=[
             "foo.gov.uk",
@@ -275,7 +275,8 @@ def test_post_create_organisation_existing_name_raises_400(admin_request, sample
             },
             (
                 "organisation_type foo is not one of "
-                "[central, local, nhs_central, nhs_local, nhs_gp, emergency_service, school_or_college, other]"
+                "[central, local, nhs_central, nhs_local, nhs_gp, emergency_service, school_or_college, "
+                "other]"
             ),
         ),
     ),
@@ -418,7 +419,6 @@ def test_update_organisation_default_branding(
     admin_request,
     notify_db_session,
 ):
-
     org = create_organisation(name="Test Organisation")
 
     email_branding = create_email_branding()


### PR DESCRIPTION
This creates a new table with rows with

- organisation_permmission: A type that represents each permission
- enabled: Whether this organisation permission is enabled or not, I think this might be useful if the default behaviour might change. So even though it might default to off, it might be nice to make it explicitly off
- organisation_id: the organisation this permission applies to
- created_at, updated_at: standard timestamps