### PR TITLE
Split out letter scheduling and collation

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -315,14 +315,14 @@ class Config(object):
                 "schedule": crontab(hour=17, minute=00),
                 "options": {"queue": QueueNames.PERIODIC},
             },
-            # The collate-letter-pdf does assume it is called in an hour that BST does not make a
+            # The check-time-to-collate-letters does assume it is called in an hour that BST does not make a
             # difference to the truncate date which translates to the filename to process
-            # We schedule it for 16:50 and 17:50 UTC. The task itself *MUST* appropriately detect that it is running
-            # at 17:50 in local time so that we respect our agreement with DVLA.
+            # We schedule it for 16:50 and 17:50 UTC. This task is then responsible for determining if the local time
+            # is 17:50, and if so, actually kicking off letter collation.
             # If updating the cron schedule, you should update the task as well - at least while we're still processing
             # letters by FTP. With the API changes we should have more flexibility.
-            "collate-letter-pdfs-to-be-sent": {
-                "task": "collate-letter-pdfs-to-be-sent",
+            "check-time-to-collate-letters": {
+                "task": "check-time-to-collate-letters",
                 "schedule": crontab(hour="16,17", minute=50),
                 "options": {"queue": QueueNames.PERIODIC},
             },


### PR DESCRIPTION
Splits our the `collate_letter_pdfs_to_be_sent` task into two tasks:

1) check_time_to_collate_letters
2) collate_letter_pdfs_to_be_sent

The first is scheduled by celery-beat to execute at 16:50 and 17:50 UTC.
It determines whether the local time is 17:50 and, if so, triggers the
actual collation task.