### PR TITLE
Hourly ft_billing updates

### DIFF
--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -28,23 +28,23 @@ def create_nightly_billing(day_start=None):
     for i in range(0, 10):
         process_day = (day_start - timedelta(days=i)).isoformat()
 
-        create_nightly_billing_for_day.apply_async(kwargs={"process_day": process_day}, queue=QueueNames.REPORTING)
+        create_or_update_ft_billing_for_day.apply_async(kwargs={"process_day": process_day}, queue=QueueNames.REPORTING)
         current_app.logger.info(
-            f"create-nightly-billing task: create-nightly-billing-for-day task created for {process_day}"
+            f"create-nightly-billing task: create-or-update-ft-billing-for-day task created for {process_day}"
         )
 
 
-@notify_celery.task(name="create-nightly-billing-for-day")
-def create_nightly_billing_for_day(process_day):
+@notify_celery.task(name="create-or-update-ft-billing-for-day")
+def create_or_update_ft_billing_for_day(process_day):
     process_day = datetime.strptime(process_day, "%Y-%m-%d").date()
-    current_app.logger.info(f"create-nightly-billing-for-day task for {process_day}: started")
+    current_app.logger.info(f"create-or-update-ft-billing-for-day task for {process_day}: started")
 
     start = datetime.utcnow()
     billing_data = fetch_billing_data_for_day(process_day=process_day)
     end = datetime.utcnow()
 
     current_app.logger.info(
-        f"create-nightly-billing-for-day task for {process_day}: data fetched in {(end - start).seconds} seconds"
+        f"create-or-update-ft-billing-for-day task for {process_day}: data fetched in {(end - start).seconds} seconds"
     )
 
     update_ft_billing(billing_data, process_day)

--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -42,22 +42,22 @@ def update_ft_billing_for_today():
 
 
 @notify_celery.task(name="create-or-update-ft-billing-for-day")
-def create_or_update_ft_billing_for_day(process_day):
-    process_day = datetime.strptime(process_day, "%Y-%m-%d").date()
-    current_app.logger.info(f"create-or-update-ft-billing-for-day task for {process_day}: started")
+def create_or_update_ft_billing_for_day(process_day: str):
+    process_date = datetime.strptime(process_day, "%Y-%m-%d").date()
+    current_app.logger.info(f"create-or-update-ft-billing-for-day task for {process_date}: started")
 
     start = datetime.utcnow()
-    billing_data = fetch_billing_data_for_day(process_day=process_day)
+    billing_data = fetch_billing_data_for_day(process_day=process_date)
     end = datetime.utcnow()
 
     current_app.logger.info(
-        f"create-or-update-ft-billing-for-day task for {process_day}: data fetched in {(end - start).seconds} seconds"
+        f"create-or-update-ft-billing-for-day task for {process_date}: data fetched in {(end - start).seconds} seconds"
     )
 
-    update_ft_billing(billing_data, process_day)
+    update_ft_billing(billing_data, process_date)
 
     current_app.logger.info(
-        f"create-nightly-billing-for-day task for {process_day}: task complete. {len(billing_data)} rows updated"
+        f"create-nightly-billing-for-day task for {process_date}: task complete. {len(billing_data)} rows updated"
     )
 
 

--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -34,6 +34,13 @@ def create_nightly_billing(day_start=None):
         )
 
 
+@notify_celery.task(name="update-ft-billing-for-today")
+@cronitor("update-ft-billing-for-today")
+def update_ft_billing_for_today():
+    process_day = convert_utc_to_bst(datetime.utcnow()).date().isoformat()
+    create_or_update_ft_billing_for_day(process_day=process_day)
+
+
 @notify_celery.task(name="create-or-update-ft-billing-for-day")
 def create_or_update_ft_billing_for_day(process_day):
     process_day = datetime.strptime(process_day, "%Y-%m-%d").date()

--- a/app/commands.py
+++ b/app/commands.py
@@ -5,7 +5,7 @@ import logging
 import os
 import random
 import uuid
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from time import monotonic
 from unittest import mock
 
@@ -289,12 +289,12 @@ def setup_commands(application):
 @click.option(
     "-d", "--day", help="The date to recalculate, as YYYY-MM-DD", required=True, type=click_dt(format="%Y-%m-%d")
 )
-def rebuild_ft_billing_for_day(service_id, day):
+def rebuild_ft_billing_for_day(service_id, day: date):
     """
     Rebuild the data in ft_billing for a given day, optionally filtering by service_id
     """
 
-    def rebuild_ft_data(process_day, service_ids=None):
+    def rebuild_ft_data(process_day: date, service_ids=None):
         deleted_rows = delete_billing_data_for_day(process_day=day, service_ids=service_ids)
         current_app.logger.info(f"deleted {deleted_rows} existing billing rows for {process_day}")
 

--- a/app/config.py
+++ b/app/config.py
@@ -264,6 +264,11 @@ class Config(object):
                 "schedule": crontab(hour=0, minute=15),
                 "options": {"queue": QueueNames.REPORTING},
             },
+            "update-ft-billing-for-today": {
+                "task": "update-ft-billing-for-today",
+                "schedule": crontab(hour="*", minute=0),
+                "options": {"queue": QueueNames.REPORTING},
+            },
             "create-nightly-notification-status": {
                 "task": "create-nightly-notification-status",
                 "schedule": crontab(hour=0, minute=30),  # after 'timeout-sending-notifications'

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 from flask import current_app
 from notifications_utils.timezones import convert_utc_to_bst
@@ -476,7 +476,7 @@ def _fetch_usage_for_service_sms(service_id, year):
     )
 
 
-def delete_billing_data_for_day(process_day, service_ids=None):
+def delete_billing_data_for_day(process_day: date, service_ids=None):
     """
     Delete all ft_billing data for the given bst_date if no service_ids are provided.
     If service_ids are provided, only the data for specific services will be deleted.
@@ -491,7 +491,7 @@ def delete_billing_data_for_day(process_day, service_ids=None):
     return FactBilling.query.filter(*filters).delete()
 
 
-def fetch_billing_data_for_day(process_day, service_ids=None, check_permissions=False):
+def fetch_billing_data_for_day(process_day: date, service_ids=None, check_permissions=False):
     start_date = get_london_midnight_in_utc(process_day)
     end_date = get_london_midnight_in_utc(process_day + timedelta(days=1))
     current_app.logger.info("Populate ft_billing for {} to {}".format(start_date, end_date))
@@ -666,7 +666,7 @@ def get_rate(
         return 0
 
 
-def update_ft_billing(billing_data: list, process_day):
+def update_ft_billing(billing_data: list, process_day: date):
     if not billing_data:
         return
 


### PR DESCRIPTION
Schedule a new task that updates `ft_billing` with the latest data for today every hour.

Includes a cronitor to make sure this is running hourly.

Ticket: https://trello.com/c/V6vkvxon/254-review-loading-time-for-organisation-page