### PR TITLE
Execute independent DB requests concurrently

### DIFF
--- a/app/concurrency.py
+++ b/app/concurrency.py
@@ -1,0 +1,13 @@
+from typing import Any, Callable, Sequence
+
+import eventlet
+
+
+def run_concurrently(*partials: Callable) -> Sequence[Any]:
+    pool = eventlet.GreenPool(size=len(partials))
+
+    results = [pool.spawn(partial) for partial in partials]
+
+    pool.waitall()
+
+    return tuple(result.wait() for result in results)

--- a/tests/app/test_concurrency.py
+++ b/tests/app/test_concurrency.py
@@ -1,0 +1,52 @@
+import time as stdlib_time
+from functools import partial
+
+import pytest
+from eventlet.green import time as green_time
+
+from app.concurrency import run_concurrently
+
+
+class TestRunConcurrently:
+    def test_ordering_of_results_matches_input_order(self, notify_api):
+        def sleep(duration):
+            green_time.sleep(duration)
+            return duration
+
+        results = run_concurrently(
+            partial(sleep, 0.05),
+            partial(sleep, 0.04),
+            partial(sleep, 0.03),
+            partial(sleep, 0.02),
+            partial(sleep, 0.01),
+        )
+
+        assert results == (0.05, 0.04, 0.03, 0.02, 0.01)
+
+    # Mark this test as flaky. It's possible that some CPU hiccups could cause the test to artificially take
+    # longer than expected. As long as at least one of the three runs is reasonably fast, we have proof that
+    # the tasks are executing concurrently.
+    @pytest.mark.flaky(max_runs=3, min_passes=1)
+    def test_duration_indicates_actual_concurrency(self, notify_api):
+        def sleep(duration):
+            green_time.sleep(duration)
+            return duration
+
+        start = stdlib_time.perf_counter()
+        run_concurrently(
+            partial(sleep, 0.10),
+            partial(sleep, 0.10),
+            partial(sleep, 0.10),
+            partial(sleep, 0.10),
+            partial(sleep, 0.10),
+            partial(sleep, 0.10),
+            partial(sleep, 0.10),
+            partial(sleep, 0.10),
+            partial(sleep, 0.10),
+            partial(sleep, 0.10),
+        )
+        end = stdlib_time.perf_counter()
+
+        assert (
+            0.1 <= end - start <= 0.2
+        ), "This should take about 0.1s to run - all of the functions should be sleeping together"


### PR DESCRIPTION
These three DB requests are independent of each other, so let's send them to the DB to process concurrently to reduce the amount of time we're waiting around.

---

In draft as trying to validate this actually improves performance. For the orgs on preview, which are all small with limited usage, it actually increases execution time. That's probably expected due to the overhead of copying request context and setting up the threads. Need to confirm that for larger orgs it provides a notable improvement.

Timings before:
```
ms = [13.71691469103098, 18.4657727368176, 15.746321063488722, 19.105040933936834, 14.857509173452854, 29.95260339230299, 14.35889769345522, 14.07127408310771, 20.775950979441404, 30.716242734342813, 14.191071968525648, 27.550247963517904, 33.87315524742007]
mean_ms = 20.56776944
```

Timings after:
```
ms = [25.631853844970465, 14.663321897387505, 30.156017281115055, 36.220604088157415, 19.98046785593033, 65.99025707691908, 14.637816231697798, 25.759401731193066, 66.31842814385891, 25.9149638004601, 15.833205077797174, 50.2742906101048, 50.63053173944354]
mean_ms = 34.00085841
```