### PR TITLE
Stop on-demand calculation of ft_billing data

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -1,4 +1,5 @@
 # Notification status values
+
 NOTIFICATION_CANCELLED = "cancelled"
 NOTIFICATION_CREATED = "created"
 NOTIFICATION_SENDING = "sending"
@@ -265,3 +266,8 @@ class Retention:
     KEY = "retention"
 
     ONE_WEEK = "ONE_WEEK"
+
+
+# Redis cache keys
+class CacheKeys:
+    FT_BILLING_FOR_TODAY_UPDATED_AT_UTC_ISOFORMAT = "update_ft_billing_for_today:updated-at-utc-isoformat"

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -183,10 +183,10 @@ def get_organisation_services_usage(organisation_id):
         year = int(request.args.get("year", "none"))
     except ValueError:
         return jsonify(result="error", message="No valid year provided"), 400
-    services = fetch_usage_for_organisation(organisation_id, year)
+    services, updated_at = fetch_usage_for_organisation(organisation_id, year)
     list_services = services.values()
     sorted_services = sorted(list_services, key=lambda s: (-s["active"], s["service_name"].lower()))
-    return jsonify(services=sorted_services)
+    return jsonify(services=sorted_services, updated_at=updated_at)
 
 
 @organisation_blueprint.route("/<uuid:organisation_id>/users/<uuid:user_id>", methods=["POST"])

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from typing import Optional
 
 import pytz
 from flask import url_for
@@ -18,6 +19,7 @@ from app.constants import (
     PRECOMPILED_LETTER,
     SMS_TYPE,
     UPLOAD_DOCUMENT,
+    CacheKeys,
 )
 
 DATETIME_FORMAT_NO_TIMEZONE = "%Y-%m-%d %H:%M:%S.%f"
@@ -147,3 +149,12 @@ def get_uuid_string_or_none(val):
 
 def format_sequential_number(sequential_number):
     return format(sequential_number, "x").zfill(8)
+
+
+def get_ft_billing_data_for_today_updated_at() -> Optional[str]:
+    from app import redis_store
+
+    if updated_at_utc_isoformat := redis_store.get(CacheKeys.FT_BILLING_FOR_TODAY_UPDATED_AT_UTC_ISOFORMAT):
+        return updated_at_utc_isoformat.decode()
+
+    return None


### PR DESCRIPTION
To merge after https://github.com/alphagov/notifications-api/pull/3772

Admin PR: https://github.com/alphagov/notifications-admin/pull/4685

---

Remove the on-demand calculations of ft_billing when the API endpoint is
hit, as this can be a set of heavy queries causing slow page loads. We
now have an hourly celery task that calculates this information for the
current day, so we can use the cached information instead.

To indicate when the data was last updated, we'll return the timestamp
for when the cache was last updated.