### PR TITLE
Add default annual allowances table

### DIFF
--- a/app/billing/rest.py
+++ b/app/billing/rest.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, abort, jsonify, request
 
 from app.billing.billing_schemas import (
     create_or_update_free_sms_fragment_limit_schema,
@@ -61,9 +61,12 @@ def get_free_sms_fragment_limit(service_id):
         # An entry does not exist in annual_billing table for that service and year.
         # Set the annual billing to the default free allowance based on the organisation type of the service.
 
-        annual_billing = set_default_free_allowance_for_service(
-            service=service, year_start=int(financial_year_start) if financial_year_start else None
-        )
+        try:
+            annual_billing = set_default_free_allowance_for_service(
+                service=service, year_start=int(financial_year_start) if financial_year_start else None
+            )
+        except ValueError:
+            abort(400)
 
     return jsonify(annual_billing.serialize_free_sms_items()), 200
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -803,7 +803,7 @@ def populate_annual_billing_with_the_previous_years_allowance(year):
 def populate_annual_billing_with_defaults(year, missing_services_only):
     """
     Add or update annual billing with free allowance defaults for all active services.
-    The default free allowance limits are in: app/dao/annual_billing_dao.py:57.
+    The default free allowances are stored in the DB in a table called `default_annual_allowance`.
 
     If missing_services_only is true then only add rows for services that do not have annual billing for that year yet.
     This is useful to prevent overriding any services that have a free allowance that is not the default.
@@ -822,26 +822,10 @@ def populate_annual_billing_with_defaults(year, missing_services_only):
         )
     else:
         active_services = Service.query.filter(Service.active).all()
-    previous_year = year - 1
-    services_with_zero_free_allowance = (
-        db.session.query(AnnualBilling.service_id)
-        .filter(AnnualBilling.financial_year_start == previous_year, AnnualBilling.free_sms_fragment_limit == 0)
-        .all()
-    )
 
     for service in active_services:
-
-        # If a service has free_sms_fragment_limit for the previous year
-        # set the free allowance for this year to 0 as well.
-        # Else use the default free allowance for the service.
-        if service.id in [x.service_id for x in services_with_zero_free_allowance]:
-            print(f"update service {service.id} to 0")
-            dao_create_or_update_annual_billing_for_year(
-                service_id=service.id, free_sms_fragment_limit=0, financial_year_start=year
-            )
-        else:
-            print(f"update service {service.id} with default")
-            set_default_free_allowance_for_service(service, year)
+        print(f"update service {service.id} with default")
+        set_default_free_allowance_for_service(service, year)
 
 
 @click.option("-u", "--user-id", required=True)

--- a/app/constants.py
+++ b/app/constants.py
@@ -125,6 +125,30 @@ TEMPLATE_TYPES = [SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, BROADCAST_TYPE]
 NOTIFICATION_TYPES = [SMS_TYPE, EMAIL_TYPE, LETTER_TYPE]  # not broadcast
 NOTIFICATION_TYPE = [EMAIL_TYPE, SMS_TYPE, LETTER_TYPE]  # duplicate that can probably be cleaned up
 
+# Organisations
+ORG_TYPE_CENTRAL = "central"
+ORG_TYPE_LOCAL = "local"
+ORG_TYPE_NHS_CENTRAL = "nhs_central"
+ORG_TYPE_NHS_LOCAL = "nhs_local"
+ORG_TYPE_NHS_GP = "nhs_gp"
+ORG_TYPE_EMERGENCY_SERVICE = "emergency_service"
+ORG_TYPE_SCHOOL_OR_COLLEGE = "school_or_college"
+ORG_TYPE_OTHER = "other"
+ORGANISATION_TYPES = [
+    ORG_TYPE_CENTRAL,
+    ORG_TYPE_LOCAL,
+    ORG_TYPE_NHS_CENTRAL,
+    ORG_TYPE_NHS_LOCAL,
+    ORG_TYPE_NHS_GP,
+    ORG_TYPE_EMERGENCY_SERVICE,
+    ORG_TYPE_SCHOOL_OR_COLLEGE,
+    ORG_TYPE_OTHER,
+]
+CROWN_ORGANISATION_TYPES = ["nhs_central"]
+NON_CROWN_ORGANISATION_TYPES = ["local", "nhs_local", "nhs_gp", "emergency_service", "school_or_college"]
+NHS_ORGANISATION_TYPES = ["nhs_central", "nhs_local", "nhs_gp"]
+
+
 # Service permissions
 MANAGE_USERS = "manage_users"
 MANAGE_TEMPLATES = "manage_templates"

--- a/app/dao/annual_billing_dao.py
+++ b/app/dao/annual_billing_dao.py
@@ -52,10 +52,11 @@ def set_default_free_allowance_for_service(service, year_start=None):
     elif year_start > current_financial_year_start:
         raise ValueError("year_start cannot be in a future financial year")
 
-    if not service.organisation_type:
+    if not (org_type := service.organisation_type):
         current_app.logger.warning(
             "No organisation type for service %s. Using default for `other` org type.", service.id
         )
+        org_type = ORG_TYPE_OTHER
 
     # If the service had 0 allowance for the previous year, let's pull that forward.
     if (
@@ -69,7 +70,6 @@ def set_default_free_allowance_for_service(service, year_start=None):
     else:
         # Find the default annual allowance for the service's org type with the most recent
         # valid_from_financial_year_start.
-        org_type = service.organisation_type or ORG_TYPE_OTHER
         default_free_sms_fragment_allowance = (
             DefaultAnnualAllowance.query.filter(
                 DefaultAnnualAllowance.valid_from_financial_year_start <= year_start,

--- a/app/dao/annual_billing_dao.py
+++ b/app/dao/annual_billing_dao.py
@@ -1,9 +1,11 @@
 from flask import current_app
+from sqlalchemy import desc
 
 from app import db
+from app.constants import ORG_TYPE_OTHER, SMS_TYPE
 from app.dao.dao_utils import autocommit
 from app.dao.date_util import get_current_financial_year_start_year
-from app.models import AnnualBilling
+from app.models import AnnualBilling, DefaultAnnualAllowance
 
 
 @autocommit
@@ -38,77 +40,49 @@ def dao_get_free_sms_fragment_limit_for_year(service_id, financial_year_start=No
 
 
 def set_default_free_allowance_for_service(service, year_start=None):
-    default_free_sms_fragment_limits = {
-        "central": {
-            2020: 250_000,
-            2021: 150_000,
-            2022: 40_000,
-            2023: 40_000,
-        },
-        "local": {
-            2020: 25_000,
-            2021: 25_000,
-            2022: 20_000,
-            2023: 20_000,
-        },
-        "nhs_central": {
-            2020: 250_000,
-            2021: 150_000,
-            2022: 40_000,
-            2023: 40_000,
-        },
-        "nhs_local": {
-            2020: 25_000,
-            2021: 25_000,
-            2022: 20_000,
-            2023: 20_000,
-        },
-        "nhs_gp": {
-            2020: 25_000,
-            2021: 10_000,
-            2022: 10_000,
-            2023: 10_000,
-        },
-        "emergency_service": {
-            2020: 25_000,
-            2021: 25_000,
-            2022: 20_000,
-            2023: 20_000,
-        },
-        "school_or_college": {
-            2020: 25_000,
-            2021: 10_000,
-            2022: 10_000,
-            2023: 10_000,
-        },
-        "other": {
-            2020: 25_000,
-            2021: 10_000,
-            2022: 10_000,
-            2023: 10_000,
-        },
-    }
+    current_financial_year_start = get_current_financial_year_start_year()
     if not year_start:
-        year_start = get_current_financial_year_start_year()
+        year_start = current_financial_year_start
 
-    use_allowance_from = year_start
+    # Notify came into existence in 2016, so we don't have allowances before then. If someone's querying for an earlier
+    # year, or a year after the current one, they're probably URL hacking: we shouldn't continue. Inserting
+    # AnnualBilling entries for those years doesn't make sense.
+    if year_start < 2016:
+        raise ValueError("year_start before 2016 is invalid")
+    elif year_start > current_financial_year_start:
+        raise ValueError("year_start cannot be in a future financial year")
 
-    if year_start < 2020:
-        use_allowance_from = 2020
-    elif year_start > 2023:
-        current_app.logger.error(
-            f"Annual allowances have not been updated for the current year ({year_start}). Using 2023 allowances."
+    if not service.organisation_type:
+        current_app.logger.warning(
+            "No organisation type for service %s. Using default for `other` org type.", service.id
         )
-        use_allowance_from = 2023
 
-    if service.organisation_type:
-        free_allowance = default_free_sms_fragment_limits[service.organisation_type][use_allowance_from]
+    # If the service had 0 allowance for the previous year, let's pull that forward.
+    if (
+        AnnualBilling.query.filter_by(
+            service_id=service.id, financial_year_start=year_start - 1, free_sms_fragment_limit=0
+        ).count()
+        == 1
+    ):
+        free_sms_fragment_allowance = 0
 
     else:
-        current_app.logger.error(
-            f"no organisation type for service {service.id}. Using other default of "
-            f"{default_free_sms_fragment_limits['other'][use_allowance_from]}"
+        # Find the default annual allowance for the service's org type with the most recent
+        # valid_from_financial_year_start.
+        org_type = service.organisation_type or ORG_TYPE_OTHER
+        default_free_sms_fragment_allowance = (
+            DefaultAnnualAllowance.query.filter(
+                DefaultAnnualAllowance.valid_from_financial_year_start <= year_start,
+                DefaultAnnualAllowance.organisation_type == org_type,
+                DefaultAnnualAllowance.notification_type == SMS_TYPE,
+            )
+            .order_by(desc(DefaultAnnualAllowance.valid_from_financial_year_start))
+            .first()
         )
-        free_allowance = default_free_sms_fragment_limits["other"][use_allowance_from]
+        if not default_free_sms_fragment_allowance:
+            raise RuntimeError(
+                f"No default annual allowance for {org_type=} with valid_from_financial_year_start<={year_start}"
+            )
+        free_sms_fragment_allowance = default_free_sms_fragment_allowance.allowance
 
-    return dao_create_or_update_annual_billing_for_year(service.id, free_allowance, year_start)
+    return dao_create_or_update_annual_billing_for_year(service.id, free_sms_fragment_allowance, year_start)

--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -3,11 +3,11 @@ from sqlalchemy import and_
 from sqlalchemy.sql.expression import func
 
 from app import db
+from app.constants import NHS_ORGANISATION_TYPES
 from app.dao.dao_utils import VersionOptions, autocommit, version_class
 from app.dao.email_branding_dao import dao_get_email_branding_by_id
 from app.dao.letter_branding_dao import dao_get_letter_branding_by_id
 from app.models import (
-    NHS_ORGANISATION_TYPES,
     AnnualBilling,
     Domain,
     EmailBranding,

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -8,11 +8,14 @@ from sqlalchemy.sql.expression import and_, asc, case, func
 
 from app import db
 from app.constants import (
+    CROWN_ORGANISATION_TYPES,
     EMAIL_TYPE,
     INTERNATIONAL_LETTERS,
     INTERNATIONAL_SMS_TYPE,
     KEY_TYPE_TEST,
     LETTER_TYPE,
+    NHS_ORGANISATION_TYPES,
+    NON_CROWN_ORGANISATION_TYPES,
     NOTIFICATION_PERMANENT_FAILURE,
     SMS_TYPE,
     UPLOAD_LETTERS,
@@ -26,9 +29,6 @@ from app.dao.service_sms_sender_dao import insert_service_sms_sender
 from app.dao.service_user_dao import dao_get_service_user
 from app.dao.template_folder_dao import dao_get_valid_template_folders_by_id
 from app.models import (
-    CROWN_ORGANISATION_TYPES,
-    NHS_ORGANISATION_TYPES,
-    NON_CROWN_ORGANISATION_TYPES,
     AnnualBilling,
     ApiKey,
     FactBilling,

--- a/app/models.py
+++ b/app/models.py
@@ -333,7 +333,6 @@ class OrganisationTypes(db.Model):
 
     name = db.Column(db.String(255), primary_key=True)
     is_crown = db.Column(db.Boolean, nullable=True)
-    annual_free_sms_fragment_limit = db.Column(db.BigInteger, nullable=False)
 
 
 class OrganisationPermission(db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -328,22 +328,6 @@ class Domain(db.Model):
     organisation_id = db.Column("organisation_id", UUID(as_uuid=True), db.ForeignKey("organisation.id"), nullable=False)
 
 
-ORGANISATION_TYPES = [
-    "central",
-    "local",
-    "nhs_central",
-    "nhs_local",
-    "nhs_gp",
-    "emergency_service",
-    "school_or_college",
-    "other",
-]
-
-CROWN_ORGANISATION_TYPES = ["nhs_central"]
-NON_CROWN_ORGANISATION_TYPES = ["local", "nhs_local", "nhs_gp", "emergency_service", "school_or_college"]
-NHS_ORGANISATION_TYPES = ["nhs_central", "nhs_local", "nhs_gp"]
-
-
 class OrganisationTypes(db.Model):
     __tablename__ = "organisation_types"
 

--- a/app/models.py
+++ b/app/models.py
@@ -611,6 +611,35 @@ class Service(db.Model, Versioned):
             return current_app.config["ENABLED_CBCS"]
 
 
+class DefaultAnnualAllowance(db.Model):
+    """This table represents default allowances that organisations will get for free notifications.
+
+    Eg central government services get 40,000 free text messages for FY 2023.
+
+    The default rates will be applied to services automatically used when a new financial year begins. They can be
+    overridden on a per-service basis (eg some services may have their allowance reduced or removed).
+    """
+
+    __tablename__ = "default_annual_allowance"
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    valid_from_financial_year_start = db.Column(db.Integer, index=True, nullable=False)
+    organisation_type = db.Column(
+        db.String(255),
+        db.ForeignKey("organisation_types.name"),
+        unique=False,
+        nullable=True,
+    )
+    allowance = db.Column(db.Integer, nullable=False)
+    notification_type = db.Column(notification_types, index=True, nullable=False)
+
+    def __str__(self):
+        return (
+            f"AnnualAllowance({self.allowance:_d}, {self.notification_type}, "
+            f"financial_year_start={self.valid_from_financial_year_start}, organisation_type{self.organisation_type})>"
+        )
+
+
 class AnnualBilling(db.Model):
     __tablename__ = "annual_billing"
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=False)

--- a/app/organisation/organisation_schema.py
+++ b/app/organisation/organisation_schema.py
@@ -1,5 +1,4 @@
-from app.constants import INVITED_USER_STATUS_TYPES, ORGANISATION_PERMISSION_TYPES
-from app.models import ORGANISATION_TYPES
+from app.constants import INVITED_USER_STATUS_TYPES, ORGANISATION_PERMISSION_TYPES, ORGANISATION_TYPES
 from app.schema_validation.definitions import uuid
 
 post_create_organisation_schema = {

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -2,7 +2,7 @@ from flask import Blueprint, abort, current_app, jsonify, request
 from sqlalchemy.exc import IntegrityError
 
 from app.config import QueueNames
-from app.constants import INVITE_PENDING, KEY_TYPE_NORMAL
+from app.constants import INVITE_PENDING, KEY_TYPE_NORMAL, NHS_ORGANISATION_TYPES
 from app.dao.annual_billing_dao import set_default_free_allowance_for_service
 from app.dao.dao_utils import transaction
 from app.dao.fact_billing_dao import fetch_usage_for_organisation
@@ -30,7 +30,7 @@ from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.templates_dao import dao_get_template_by_id
 from app.dao.users_dao import get_user_by_id
 from app.errors import InvalidRequest, register_errors
-from app.models import NHS_ORGANISATION_TYPES, Organisation
+from app.models import Organisation
 from app.notifications.process_notifications import (
     persist_notification,
     send_notification_to_queue,

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0409_annual_allowance
+0410_drop_unused_allowance

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0408_perm_ask_to_join_service
+0409_annual_allowance

--- a/migrations/versions/0409_annual_allowance.py
+++ b/migrations/versions/0409_annual_allowance.py
@@ -1,0 +1,341 @@
+"""
+
+Revision ID: 0409_annual_allowance
+Revises: 0408_perm_ask_to_join_service
+Create Date: 2023-04-20 13:01:09.425646
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0409_annual_allowance"
+down_revision = "0408_perm_ask_to_join_service"
+
+ORIGINAL_ALLOWANCES = {
+    "central": {
+        2016: 250_000,
+        2021: 150_000,
+        2022: 40_000,
+        2023: 40_000,
+    },
+    "local": {
+        2016: 25_000,
+        2021: 25_000,
+        2022: 20_000,
+        2023: 20_000,
+    },
+    "nhs_central": {
+        2016: 250_000,
+        2021: 150_000,
+        2022: 40_000,
+        2023: 40_000,
+    },
+    "nhs_local": {
+        2016: 25_000,
+        2021: 25_000,
+        2022: 20_000,
+        2023: 20_000,
+    },
+    "nhs_gp": {
+        2016: 25_000,
+        2021: 10_000,
+        2022: 10_000,
+        2023: 10_000,
+    },
+    "emergency_service": {
+        2016: 25_000,
+        2021: 25_000,
+        2022: 20_000,
+        2023: 20_000,
+    },
+    "school_or_college": {
+        2016: 25_000,
+        2021: 10_000,
+        2022: 10_000,
+        2023: 10_000,
+    },
+    "other": {
+        2016: 25_000,
+        2021: 10_000,
+        2022: 10_000,
+        2023: 10_000,
+    },
+}
+
+
+def upgrade():
+    annual_allowance_table = op.create_table(
+        "default_annual_allowance",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("valid_from_financial_year_start", sa.Integer(), nullable=False),
+        sa.Column("organisation_type", sa.String(length=255), nullable=True),
+        sa.Column("allowance", sa.Integer(), nullable=False),
+        sa.Column(
+            "notification_type",
+            postgresql.ENUM("email", "sms", "letter", name="notification_type", create_type=False),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["organisation_type"],
+            ["organisation_types.name"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_annual_allowance_notification_type"), "default_annual_allowance", ["notification_type"], unique=False
+    )
+    op.create_index(
+        op.f("ix_annual_allowance_valid_from_financial_year_start"),
+        "default_annual_allowance",
+        ["valid_from_financial_year_start"],
+        unique=False,
+    )
+
+    # import uuid
+    # bootstrap_allowances = [
+    #     dict(
+    #         id=str(uuid.uuid4()),
+    #         valid_from_financial_year_start=valid_from_financial_year_start,
+    #         organisation_type=org_type,
+    #         allowance=allowance,
+    #         notification_type="sms",
+    #     )
+    #     for org_type, allowances in ORIGINAL_ALLOWANCES.items()
+    #     for valid_from_financial_year_start, allowance in allowances.items()
+    # ]
+    # ---
+    # See above code fragment used to generate the below dict
+    bootstrap_allowances = [
+        {
+            "id": "e88573e7-0208-41a0-8151-4de0fac7efcd",
+            "valid_from_financial_year_start": 2016,
+            "organisation_type": "central",
+            "allowance": 250000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "47266278-eb11-43a3-b6d0-320d4cfcaf17",
+            "valid_from_financial_year_start": 2021,
+            "organisation_type": "central",
+            "allowance": 150000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "6ed51647-ffc0-4115-adec-a6593334adbb",
+            "valid_from_financial_year_start": 2022,
+            "organisation_type": "central",
+            "allowance": 40000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "450825e2-927a-4413-9bf6-19a42ed66a37",
+            "valid_from_financial_year_start": 2023,
+            "organisation_type": "central",
+            "allowance": 40000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "916f882c-815c-436b-9cbe-db8569ce0cbc",
+            "valid_from_financial_year_start": 2016,
+            "organisation_type": "local",
+            "allowance": 25000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "96986306-b679-4a70-8fd5-0385e2f4e38c",
+            "valid_from_financial_year_start": 2021,
+            "organisation_type": "local",
+            "allowance": 25000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "a1cf2d1f-a473-4fff-b801-0571938449cf",
+            "valid_from_financial_year_start": 2022,
+            "organisation_type": "local",
+            "allowance": 20000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "4c30519a-48a6-49ad-884b-a30c0b1d0cf9",
+            "valid_from_financial_year_start": 2023,
+            "organisation_type": "local",
+            "allowance": 20000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "8469a139-f6d8-452d-a171-a2decb5b0664",
+            "valid_from_financial_year_start": 2016,
+            "organisation_type": "nhs_central",
+            "allowance": 250000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "f2a0bfa4-ac09-4c32-adee-6410427e0872",
+            "valid_from_financial_year_start": 2021,
+            "organisation_type": "nhs_central",
+            "allowance": 150000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "595e1ae1-b78e-4922-8c3a-ed9100a0356e",
+            "valid_from_financial_year_start": 2022,
+            "organisation_type": "nhs_central",
+            "allowance": 40000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "3a9efa73-7bf6-48e4-b1a1-9baaaef6b902",
+            "valid_from_financial_year_start": 2023,
+            "organisation_type": "nhs_central",
+            "allowance": 40000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "baf655a4-6b7a-47d1-ba92-83f83ee4f3ce",
+            "valid_from_financial_year_start": 2016,
+            "organisation_type": "nhs_local",
+            "allowance": 25000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "5b78c0de-0d77-44d8-bde3-3604bdc7707e",
+            "valid_from_financial_year_start": 2021,
+            "organisation_type": "nhs_local",
+            "allowance": 25000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "32e9d36d-6e60-4387-922d-c5747d26e2d3",
+            "valid_from_financial_year_start": 2022,
+            "organisation_type": "nhs_local",
+            "allowance": 20000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "e169662f-8c2c-4374-b5d1-92e336f7cc5a",
+            "valid_from_financial_year_start": 2023,
+            "organisation_type": "nhs_local",
+            "allowance": 20000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "57a87067-ea42-4e69-9f28-01a4e7f6da5d",
+            "valid_from_financial_year_start": 2016,
+            "organisation_type": "nhs_gp",
+            "allowance": 25000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "a04dfd08-54d7-438a-b437-e3d089b07ed2",
+            "valid_from_financial_year_start": 2021,
+            "organisation_type": "nhs_gp",
+            "allowance": 10000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "245f1c44-a669-486a-9938-6d3281cd556b",
+            "valid_from_financial_year_start": 2022,
+            "organisation_type": "nhs_gp",
+            "allowance": 10000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "aff5e21e-f68a-4864-804c-2ece82adfdde",
+            "valid_from_financial_year_start": 2023,
+            "organisation_type": "nhs_gp",
+            "allowance": 10000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "18b4c13c-c38a-4057-b055-fa00f53283f9",
+            "valid_from_financial_year_start": 2016,
+            "organisation_type": "emergency_service",
+            "allowance": 25000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "2ccf09ce-fb8e-4bbe-afd7-c156718b63ed",
+            "valid_from_financial_year_start": 2021,
+            "organisation_type": "emergency_service",
+            "allowance": 25000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "68514c78-219a-4feb-9993-932a90565ab9",
+            "valid_from_financial_year_start": 2022,
+            "organisation_type": "emergency_service",
+            "allowance": 20000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "e3938653-4ec8-4928-b7c1-2c614a01ee28",
+            "valid_from_financial_year_start": 2023,
+            "organisation_type": "emergency_service",
+            "allowance": 20000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "30ffb21e-f28a-4477-b6cf-09ec9151cdfc",
+            "valid_from_financial_year_start": 2016,
+            "organisation_type": "school_or_college",
+            "allowance": 25000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "194ea847-320e-4663-b06a-bbd63f831aca",
+            "valid_from_financial_year_start": 2021,
+            "organisation_type": "school_or_college",
+            "allowance": 10000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "a310c613-2a7c-42d3-8a95-85e82173b4ee",
+            "valid_from_financial_year_start": 2022,
+            "organisation_type": "school_or_college",
+            "allowance": 10000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "7595f477-18b2-4b75-ab0e-f884ee3a2fe2",
+            "valid_from_financial_year_start": 2023,
+            "organisation_type": "school_or_college",
+            "allowance": 10000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "bee907d7-a39f-474a-a28a-1c454a3a24e1",
+            "valid_from_financial_year_start": 2016,
+            "organisation_type": "other",
+            "allowance": 25000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "98374569-dc8b-469c-be5e-071c634a00a1",
+            "valid_from_financial_year_start": 2021,
+            "organisation_type": "other",
+            "allowance": 10000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "bf6fdc17-d033-4724-bfc5-598470bb2ff8",
+            "valid_from_financial_year_start": 2022,
+            "organisation_type": "other",
+            "allowance": 10000,
+            "notification_type": "sms",
+        },
+        {
+            "id": "65ac216b-7e45-4862-b6fd-35465b39d22e",
+            "valid_from_financial_year_start": 2023,
+            "organisation_type": "other",
+            "allowance": 10000,
+            "notification_type": "sms",
+        },
+    ]
+    op.bulk_insert(annual_allowance_table, bootstrap_allowances)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_annual_allowance_valid_from_financial_year_start"), table_name="default_annual_allowance")
+    op.drop_index(op.f("ix_annual_allowance_notification_type"), table_name="default_annual_allowance")
+    op.drop_table("default_annual_allowance")

--- a/migrations/versions/0410_drop_unused_allowance.py
+++ b/migrations/versions/0410_drop_unused_allowance.py
@@ -1,0 +1,34 @@
+"""
+
+Revision ID: 0410_drop_unused_allowance
+Revises: 0409_annual_allowance
+Create Date: 2023-04-26 07:52:19.822068
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0410_drop_unused_allowance"
+down_revision = "0409_annual_allowance"
+
+
+def upgrade():
+    op.drop_column("organisation_types", "annual_free_sms_fragment_limit")
+
+
+def downgrade():
+    op.add_column(
+        "organisation_types",
+        sa.Column("annual_free_sms_fragment_limit", sa.BIGINT(), autoincrement=False, nullable=True),
+    )
+    op.execute("UPDATE organisation_types SET annual_free_sms_fragment_limit = 250000 WHERE name = 'central'")
+    op.execute("UPDATE organisation_types SET annual_free_sms_fragment_limit = 25000 WHERE name = 'local'")
+    op.execute("UPDATE organisation_types SET annual_free_sms_fragment_limit = 25000 WHERE name = 'nhs'")
+    op.execute("UPDATE organisation_types SET annual_free_sms_fragment_limit = 250000 WHERE name = 'nhs_central'")
+    op.execute("UPDATE organisation_types SET annual_free_sms_fragment_limit = 25000 WHERE name = 'nhs_local'")
+    op.execute("UPDATE organisation_types SET annual_free_sms_fragment_limit = 25000 WHERE name = 'nhs_gp'")
+    op.execute("UPDATE organisation_types SET annual_free_sms_fragment_limit = 25000 WHERE name = 'emergency_service'")
+    op.execute("UPDATE organisation_types SET annual_free_sms_fragment_limit = 25000 WHERE name = 'school_or_college'")
+    op.execute("UPDATE organisation_types SET annual_free_sms_fragment_limit = 25000 WHERE name = 'other'")
+    op.alter_column("organisation_types", "annual_free_sms_fragment_limit", nullable=False)

--- a/tests/app/billing/test_rest.py
+++ b/tests/app/billing/test_rest.py
@@ -90,6 +90,24 @@ def test_get_free_sms_fragment_limit(admin_request, sample_service):
     assert json_response["free_sms_fragment_limit"] == 11000
 
 
+def test_get_free_sms_fragment_limit_for_pre_notify_year_400s(admin_request, sample_service):
+    admin_request.get(
+        "billing.get_free_sms_fragment_limit",
+        service_id=sample_service.id,
+        financial_year_start=2015,
+        _expected_status=400,
+    )
+
+
+def test_get_free_sms_fragment_limit_for_future_year_400s(admin_request, sample_service):
+    admin_request.get(
+        "billing.get_free_sms_fragment_limit",
+        service_id=sample_service.id,
+        financial_year_start=date.today().year + 1,
+        _expected_status=400,
+    )
+
+
 @freeze_time("2021-04-02 13:00")
 def test_get_free_sms_fragment_limit_current_year_creates_new_row_if_annual_billing_is_missing(
     admin_request, sample_service

--- a/tests/app/dao/test_annual_billing_dao.py
+++ b/tests/app/dao/test_annual_billing_dao.py
@@ -76,6 +76,16 @@ def test_dao_update_annual_billing_for_future_years(notify_db_session, sample_se
         ("nhs_local", 2022, 20000),
         ("emergency_service", 2022, 20000),
         ("central", 2023, 40000),
+        # Some test cases that will make valid assertions as time inevitably marches on
+        ("central", datetime.date.today().year, 40_000),
+        ("local", datetime.date.today().year, 20_000),
+        ("nhs_central", datetime.date.today().year, 40_000),
+        ("nhs_local", datetime.date.today().year, 20_000),
+        ("nhs_gp", datetime.date.today().year, 10_000),
+        ("emergency_service", datetime.date.today().year, 20_000),
+        ("school_or_college", datetime.date.today().year, 10_000),
+        ("other", datetime.date.today().year, 10_000),
+        (None, datetime.date.today().year, 10_000),
     ],
 )
 def test_set_default_free_allowance_for_service(notify_db_session, org_type, year, expected_default):

--- a/tests/app/dao/test_annual_billing_dao.py
+++ b/tests/app/dao/test_annual_billing_dao.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from freezegun import freeze_time
 
@@ -74,7 +76,6 @@ def test_dao_update_annual_billing_for_future_years(notify_db_session, sample_se
         ("nhs_local", 2022, 20000),
         ("emergency_service", 2022, 20000),
         ("central", 2023, 40000),
-        ("central", 2030, 40000),
     ],
 )
 def test_set_default_free_allowance_for_service(notify_db_session, org_type, year, expected_default):
@@ -89,6 +90,24 @@ def test_set_default_free_allowance_for_service(notify_db_session, org_type, yea
     assert annual_billing[0].service_id == service.id
     assert annual_billing[0].financial_year_start == year
     assert annual_billing[0].free_sms_fragment_limit == expected_default
+
+
+def test_set_default_free_allowance_for_service_fails_before_2016(notify_db_session):
+    service = create_service(organisation_type="central")
+
+    with pytest.raises(ValueError) as e:
+        set_default_free_allowance_for_service(service=service, year_start=2015)
+
+    assert str(e.value) == "year_start before 2016 is invalid"
+
+
+def test_set_default_free_allowance_for_service_fails_for_future_year(notify_db_session):
+    service = create_service(organisation_type="central")
+
+    with pytest.raises(ValueError) as e:
+        set_default_free_allowance_for_service(service=service, year_start=datetime.date.today().year + 1)
+
+    assert str(e.value) == "year_start cannot be in a future financial year"
 
 
 @freeze_time("2021-03-29 14:02:00")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,6 +152,7 @@ def notify_db_session(_notify_db, sms_providers):
             "service_callback_type",
             "broadcast_channel_types",
             "broadcast_provider_types",
+            "default_annual_allowance",
         ]:
             _notify_db.engine.execute(tbl.delete())
     _notify_db.session.commit()


### PR DESCRIPTION
This moves us from having default annual allowances for free text messages hard-coded to stored in the DB, which more closely follows what we do for text message rates.

Best to go commit-by-commit for this as there's some refactoring in the midst as well.

We also update the function to carry forward 0 allowances. This was previously handled by a special admin command, but it feels like this makes more sense to be default behaviour otherwise we still have to run that command ASAP at the start of each year to make sure zero allowances are carried forward.

---

Ticket: https://trello.com/c/jn2oqao9/335-move-the-default-annual-billing-allowances-from-code-to-the-db-similar-to-billing-rates