### PR TITLE
Add a command to drop all test DBs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,15 @@ help:
 generate-version-file: ## Generates the app version file
 	@echo -e "__git_commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"" > ${APP_VERSION_FILE}
 
+.PHONY: drop-test-dbs
+drop-test-dbs:
+	@echo "Dropping test DBs."
+	@for number in $$(seq 0 $$(python -c 'import os; print(os.cpu_count() - 1)')); do \
+	    dropdb test_notification_api_gw$${number} --if-exists; \
+	done
+	@dropdb test_notification_api_master --if-exists
+	@echo "Done."
+
 .PHONY: test
 test: ## Run tests
 	ruff check .


### PR DESCRIPTION
This can be useful if jumping between branches with different migrations and the test DBs are on a different migration than the code you've currently got checked out.

### Example output
```
sam:~/work/gds/notifications-api [SW-make-reset-test-dbs]$ make drop-test-dbs
Dropping test DBs.
NOTICE:  database "test_notification_api_gw0" does not exist, skipping
NOTICE:  database "test_notification_api_gw1" does not exist, skipping
NOTICE:  database "test_notification_api_gw2" does not exist, skipping
NOTICE:  database "test_notification_api_gw3" does not exist, skipping
NOTICE:  database "test_notification_api_gw4" does not exist, skipping
NOTICE:  database "test_notification_api_gw5" does not exist, skipping
NOTICE:  database "test_notification_api_gw6" does not exist, skipping
NOTICE:  database "test_notification_api_gw7" does not exist, skipping
NOTICE:  database "test_notification_api_gw8" does not exist, skipping
NOTICE:  database "test_notification_api_gw9" does not exist, skipping
NOTICE:  database "test_notification_api_master" does not exist, skipping
Done.
```