### PR TITLE
Revert "Split out letter scheduling and collation"

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -131,14 +131,38 @@ def update_validation_failed_for_templated_letter(self, notification_id, page_co
 
 @notify_celery.task(name="collate-letter-pdfs-to-be-sent")
 @cronitor("collate-letter-pdfs-to-be-sent")
-def collate_letter_pdfs_to_be_sent(print_run_deadline):
+def collate_letter_pdfs_to_be_sent(print_run_deadline_utc=None, check_expected_execution_window=True):
     """
     Finds all letters which are still waiting to be sent to DVLA for printing
 
     This would usually be run at 5.50pm and collect up letters created between before 5:30pm today
     that have not yet been sent.
     If run after midnight, it will collect up letters created before 5:30pm the day before.
+
+    You can specify a specific print_run_deadline_utc as an ISO format datetime if you want to. This is primarily
+    useful for load testing or running locally. Make sure to consider UTC to BST.
+
+    Set `check_expected_execution_window` to False if you are running manually - otherwise the internals of this task
+    will assert that it is being run between 5:50 and 6:49pm local time. This is because we schedule the task twice in
+    celery-beat; once at 4:50pm UTC and once at 5:50pm UTC. We only want to actually process this job automatically
+    once - at 5:50pm Europe/London local time.
+    NOTE: this argument has no effect if you have specified a custom `print_run_deadline_utc`.
     """
+    if print_run_deadline_utc:
+        print_run_deadline = convert_utc_to_bst(dateutil.parser.parse(print_run_deadline_utc))
+    else:
+        print_run_date = convert_utc_to_bst(datetime.utcnow())
+
+        if check_expected_execution_window and not (dt_time(17, 50) <= print_run_date.time() < dt_time(18, 50)):
+            current_app.logger.info(
+                "Ignoring collate_letter_pdfs_to_be_sent task outside of expected celery task window"
+            )
+            return
+
+        if print_run_date.time() < LETTER_PROCESSING_DEADLINE:
+            print_run_date = print_run_date - timedelta(days=1)
+
+        print_run_deadline = print_run_date.replace(hour=17, minute=30, second=0, microsecond=0)
     _get_letters_and_sheets_volumes_and_send_to_dvla(print_run_deadline)
 
     if current_app.config["DVLA_API_ENABLED"]:
@@ -179,36 +203,6 @@ def collate_letter_pdfs_to_be_sent(print_run_deadline):
         current_app.logger.info(f"finished collate-letter-pdfs-to-be-sent processing for postage class {postage}")
 
     current_app.logger.info("finished collate-letter-pdfs-to-be-sent")
-
-
-@notify_celery.task(name="check-time-to-collate-letters")
-def check_time_to_collate_letters(print_run_deadline_utc=None):
-    """Check whether we need to start collating letters and sending them to DVLA for processing.
-
-    This task is scheduled via celery-beat to run at 16:50 and 17:50 UTC every day. This task is responsible for working
-    out whether it's running at 17:50 local time: if it is, then letter collation itself will be triggered and all
-    letters submitted to Notify before 17:30 local time will be collated and sent over.
-
-    You can specify a specific print_run_deadline_utc as an ISO format datetime if you want to. This is primarily
-    useful for load testing or running locally. Make sure to consider UTC to BST.
-    """
-    if print_run_deadline_utc:
-        print_run_deadline = convert_utc_to_bst(dateutil.parser.parse(print_run_deadline_utc))
-    else:
-        print_run_date = convert_utc_to_bst(datetime.utcnow())
-
-        if not (dt_time(17, 50) <= print_run_date.time() < dt_time(18, 50)):
-            current_app.logger.info(
-                "Ignoring collate_letter_pdfs_to_be_sent task outside of expected celery task window"
-            )
-            return
-
-        if print_run_date.time() < LETTER_PROCESSING_DEADLINE:
-            print_run_date = print_run_date - timedelta(days=1)
-
-        print_run_deadline = print_run_date.replace(hour=17, minute=30, second=0, microsecond=0)
-
-    collate_letter_pdfs_to_be_sent.apply_async([print_run_deadline], queue=QueueNames.PERIODIC)
 
 
 def _get_letters_and_sheets_volumes_and_send_to_dvla(print_run_deadline):

--- a/app/config.py
+++ b/app/config.py
@@ -320,14 +320,14 @@ class Config(object):
                 "schedule": crontab(hour=17, minute=00),
                 "options": {"queue": QueueNames.PERIODIC},
             },
-            # The check-time-to-collate-letters does assume it is called in an hour that BST does not make a
+            # The collate-letter-pdf does assume it is called in an hour that BST does not make a
             # difference to the truncate date which translates to the filename to process
-            # We schedule it for 16:50 and 17:50 UTC. This task is then responsible for determining if the local time
-            # is 17:50, and if so, actually kicking off letter collation.
+            # We schedule it for 16:50 and 17:50 UTC. The task itself *MUST* appropriately detect that it is running
+            # at 17:50 in local time so that we respect our agreement with DVLA.
             # If updating the cron schedule, you should update the task as well - at least while we're still processing
             # letters by FTP. With the API changes we should have more flexibility.
-            "check-time-to-collate-letters": {
-                "task": "check-time-to-collate-letters",
+            "collate-letter-pdfs-to-be-sent": {
+                "task": "collate-letter-pdfs-to-be-sent",
                 "schedule": crontab(hour="16,17", minute=50),
                 "options": {"queue": QueueNames.PERIODIC},
             },

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -1,7 +1,7 @@
 import uuid
 from collections import namedtuple
 from datetime import datetime, timedelta
-from unittest.mock import call
+from unittest.mock import ANY, call
 
 import boto3
 import pytest
@@ -16,7 +16,6 @@ from sqlalchemy.orm.exc import NoResultFound
 from app import encryption
 from app.celery.letters_pdf_tasks import (
     _move_invalid_letter_and_update_status,
-    check_time_to_collate_letters,
     collate_letter_pdfs_to_be_sent,
     get_key_and_size_of_letters_to_be_sent_to_print,
     get_pdf_for_templated_letter,
@@ -334,25 +333,32 @@ def test_get_key_and_size_of_letters_to_be_sent_to_print_handles_file_not_found(
         (None, datetime(2021, 6, 1, 17, 30)),
     ],
 )
-def test_check_time_to_collate_letters_respects_print_run_deadline(
+def test_collate_letter_pdfs_to_be_sent_respects_print_run_deadline(
     notify_db_session,
     mocker,
     print_run_deadline_utc,
     expected_time_called_with,
 ):
     mocker.patch("app.celery.letters_pdf_tasks.send_letters_volume_email_to_dvla")
-    mock_collate = mocker.patch("app.celery.letters_pdf_tasks.collate_letter_pdfs_to_be_sent", return_value=[])
+    mock_get_letters = mocker.patch(
+        "app.celery.letters_pdf_tasks.get_key_and_size_of_letters_to_be_sent_to_print", return_value=[]
+    )
 
     with freeze_time("2021-06-01 17:00"):
-        check_time_to_collate_letters(print_run_deadline_utc=print_run_deadline_utc)
+        collate_letter_pdfs_to_be_sent(print_run_deadline_utc=print_run_deadline_utc)
 
-    assert mock_collate.apply_async.call_args_list == [
-        mocker.call([expected_time_called_with], queue=QueueNames.PERIODIC)
-    ]
+    mock_get_letters.assert_called_with(expected_time_called_with, ANY)
 
 
 @mock_s3
-def test_collate_letter_pdfs_to_be_sent(notify_api, mocker, sample_organisation):
+@pytest.mark.parametrize(
+    "time_to_run_task",
+    [
+        "2020-02-17 18:00:00",  # after 5:30pm
+        "2020-02-18 02:00:00",  # the next day after midnight, before 5:30pm we expect the same results
+    ],
+)
+def test_collate_letter_pdfs_to_be_sent(notify_api, mocker, time_to_run_task, sample_organisation):
     with freeze_time("2020-02-17 18:00:00"):
         service_1 = create_service(service_name="service 1", service_id="f2fe37b0-1301-11eb-aba9-4c3275916899")
         service_1.organisation = sample_organisation
@@ -437,7 +443,8 @@ def test_collate_letter_pdfs_to_be_sent(notify_api, mocker, sample_organisation)
     mock_send_email_to_dvla = mocker.patch("app.celery.letters_pdf_tasks.send_letters_volume_email_to_dvla")
 
     with set_config_values(notify_api, {"MAX_LETTER_PDF_COUNT_PER_ZIP": 2}):
-        collate_letter_pdfs_to_be_sent(datetime(2020, 2, 17, 17, 30, 0))
+        with freeze_time(time_to_run_task):
+            collate_letter_pdfs_to_be_sent(check_expected_execution_window=False)
 
     mock_send_email_to_dvla.assert_called_once_with(
         [(1, 1, "europe"), (1, 1, "first"), (1, 1, "rest-of-world"), (4, 4, "second")], datetime(2020, 2, 17).date()
@@ -507,24 +514,48 @@ def test_collate_letter_pdfs_to_be_sent(notify_api, mocker, sample_organisation)
 
 @mock_s3
 @pytest.mark.parametrize(
-    "time_to_run_task, should_run",
+    "time_to_run_task, call_kwargs, should_run",
     [
-        # GMT - too early, check on - run cancelled
-        ("2020-02-17 16:50:00Z", False),
-        # GMT - just in between the two allowed execution windows, check on - run cancelled
-        ("2020-02-17 17:49:30Z", False),
-        # GMT - on schedule, check on - runs
-        ("2020-02-17 17:50:00Z", True),
-        # GMT - on schedule at the end of the window, check on - runs
-        ("2020-02-17 18:49:00Z", True),
-        # BST - on schedule, check on
-        ("2020-06-01 16:50:00Z", True),
-        # BST - too late, check on - run cancelled
-        ("2020-06-01 17:50:00Z", False),
+        # GMT - too early, check on by default - run cancelled
+        ("2020-02-17 16:50:00Z", dict(), False),
+        # GMT - too early, check forced on - run cancelled
+        ("2020-02-17 16:50:00Z", dict(check_expected_execution_window=True), False),
+        # GMT - too early, check forced off - runs
+        ("2020-02-17 16:50:00Z", dict(check_expected_execution_window=False), True),
+        # GMT - just in between the two allowed execution windows, check on by default - run cancelled
+        ("2020-02-17 17:49:30Z", dict(), False),
+        # GMT - just in between the two allowed execution windows, check forced on - run cancelled
+        ("2020-02-17 17:49:30Z", dict(check_expected_execution_window=True), False),
+        # GMT - just in between the two allowed execution windows, check forced off - runs
+        ("2020-02-17 17:49:30Z", dict(check_expected_execution_window=False), True),
+        # GMT - on schedule, check on by default - runs
+        ("2020-02-17 17:50:00Z", dict(), True),
+        # GMT - on schedule, check forced on
+        ("2020-02-17 17:50:00Z", dict(check_expected_execution_window=True), True),
+        # GMT - on schedule, check forced off
+        ("2020-02-17 17:50:00Z", dict(check_expected_execution_window=False), True),
+        # GMT - on schedule at the end of the window, check on by default - runs
+        ("2020-02-17 18:49:00Z", dict(), True),
+        # GMT - on schedule at the end of the window, check forced on
+        ("2020-02-17 18:49:00Z", dict(check_expected_execution_window=True), True),
+        # GMT - on schedule at the end of the window, check forced off
+        ("2020-02-17 18:49:00Z", dict(check_expected_execution_window=False), True),
+        # BST - on schedule, check on by default
+        ("2020-06-01 16:50:00Z", dict(), True),
+        # BST - on schedule, check forced on
+        ("2020-06-01 16:50:00Z", dict(check_expected_execution_window=True), True),
+        # BST - on schedule, check forced off
+        ("2020-06-01 16:50:00Z", dict(check_expected_execution_window=False), True),
+        # BST - too late, check on by default - run cancelled
+        ("2020-06-01 17:50:00Z", dict(), False),
+        # BST - too late, check forced on - run cancelled
+        ("2020-06-01 17:50:00Z", dict(check_expected_execution_window=True), False),
+        # BST - too late, check forced off - runs
+        ("2020-06-01 17:50:00Z", dict(check_expected_execution_window=False), True),
     ],
 )
 def test_collate_letter_pdfs_to_be_sent_exits_early_outside_of_expected_window(
-    time_to_run_task, should_run, sample_organisation, mocker, notify_api, caplog
+    time_to_run_task, call_kwargs, should_run, sample_organisation, mocker, notify_api, caplog
 ):
     with freeze_time("2020-02-17 18:00:00"):
         service_1 = create_service(service_name="service 1", service_id="f2fe37b0-1301-11eb-aba9-4c3275916899")
@@ -545,21 +576,21 @@ def test_collate_letter_pdfs_to_be_sent_exits_early_outside_of_expected_window(
     s3.put_object(Bucket=bucket_name, Key="2020-02-17/NOTIFY.FIRST_CLASS.D.1.C.20200217140000.PDF", Body=b"f")
 
     mocker.patch("app.celery.letters_pdf_tasks.notify_celery.send_task")
-    mock_collate = mocker.patch("app.celery.letters_pdf_tasks.collate_letter_pdfs_to_be_sent")
+    mock_notify_dvla = mocker.patch("app.celery.letters_pdf_tasks._get_letters_and_sheets_volumes_and_send_to_dvla")
 
     with set_config_values(notify_api, {"MAX_LETTER_PDF_COUNT_PER_ZIP": 2}):
         with freeze_time(time_to_run_task):
-            check_time_to_collate_letters()
+            collate_letter_pdfs_to_be_sent(**call_kwargs)
 
     if should_run:
-        assert mock_collate.apply_async.call_count == 1
+        assert mock_notify_dvla.call_count == 1
         assert (
             "Ignoring collate_letter_pdfs_to_be_sent task outside of expected celery task window" not in caplog.messages
         )
 
     else:
         assert "Ignoring collate_letter_pdfs_to_be_sent task outside of expected celery task window" in caplog.messages
-        assert mock_collate.apply_async.call_count == 0
+        assert mock_notify_dvla.call_count == 0
 
 
 @pytest.mark.parametrize(
@@ -579,8 +610,8 @@ def test_collate_letter_pdfs_to_be_sent_exits_early_outside_of_expected_window(
         ),
     ),
 )
-def test_check_time_to_collate_letters_celery_beat_schedule(notify_api, last_run_at, time_now, due_in_seconds):
-    schedule = notify_api.config["CELERY"]["beat_schedule"]["check-time-to-collate-letters"]["schedule"]
+def test_collate_letter_pdfs_to_be_sent_celery_beat_schedule(notify_api, last_run_at, time_now, due_in_seconds):
+    schedule = notify_api.config["CELERY"]["beat_schedule"]["collate-letter-pdfs-to-be-sent"]["schedule"]
     with freeze_time(time_now):
         assert schedule.is_due(last_run_at).next == due_in_seconds
 
@@ -600,7 +631,7 @@ def test_collate_letter_pdfs_uses_api_on_selected_environments(
     with set_config_values(notify_api, {"DVLA_API_ENABLED": api_enabled_env_flag}):
 
         with freeze_time("2021-06-01 17:00"):
-            collate_letter_pdfs_to_be_sent(datetime(2021, 6, 1, 17, 30))
+            collate_letter_pdfs_to_be_sent()
 
     mock_send_via_api.assert_called_with(datetime(2021, 6, 1, 17, 30))
 


### PR DESCRIPTION
Reverts alphagov/notifications-api#3770

As it errors in production when it runs at 5:50pm

```
AttributeError: 'str' object has no attribute 'tzinfo'
message: Celery task collate-letter-pdfs-to-be-sent (queue: periodic-tasks) failed
```

Can revert and then figure out the problem