### PR TITLE
Bump utils to 62.2.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==6.3.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.2.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -157,7 +157,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.2.1
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
* Injects the celery task ID into logging output if no requestId is present.
* Add odd/even class to letter pages

Results in log lines such as:
```
{'application': 'delivery',
 'levelname': 'INFO',
 'lineno': 37,
 'logType': 'application',
 'message': 'Celery task '
            'create-nightly-notification-status-for-service-and-day (queue: '
            'reporting-tasks) took 0.0248',
 'name': 'delivery',
 'pathname': '/Users/sam/work/gds/notifications-api/venv/lib/python3.9/site-packages/notifications_utils/celery.py',
 'requestId': '3618a109-5525-430c-a232-10302a679eaa',
 'service_id': 'no-service-id',
 'time': '2023-04-26T11:40:12',
 'user_id': None}
```