### PR TITLE
Make despatch date in DVLA response files required (take 2)

### DIFF
--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -107,7 +107,7 @@ def firetext_callback(notification_id, to):
 @notify_celery.task(bind=True, name="create-fake-letter-response-file", max_retries=5, default_retry_delay=300)
 def create_fake_letter_response_file(self, reference):
     now = datetime.utcnow()
-    dvla_response_data = "{}|Sent|0|Sorted".format(reference)
+    dvla_response_data = f"{reference}|Sent|0|Sorted|{now.date().isoformat()}"
 
     # try and find a filename that hasn't been taken yet - from a random time within the last 30 seconds
     for i in sorted(range(30), key=lambda _: random.random()):

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -2,7 +2,6 @@ import json
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
 
 from flask import current_app
 from notifications_utils.insensitive_dict import InsensitiveDict
@@ -492,14 +491,13 @@ def persist_daily_sorted_letter_counts(day, file_name, sorted_letter_counts):
 class NotificationUpdate:
     """
     A NotificationUpdate is used to wrap a row of a DVLA response file.
-    `despatch_date` is optional to support files which contain it and those that don't
     """
 
     reference: str
     status: str
     page_count: str
     cost_threshold: str
-    despatch_date: Optional[str] = None
+    despatch_date: str
 
 
 def process_updates_from_file(response_file):

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -43,7 +43,7 @@ def notification_update():
     """
     from app.celery.tasks import NotificationUpdate
 
-    return NotificationUpdate("REFERENCE_ABC", "sent", "1", "cost")
+    return NotificationUpdate("REFERENCE_ABC", "sent", "1", "cost", "2023-03-07")
 
 
 def test_update_letter_notifications_statuses_raises_for_invalid_format(notify_api, mocker):
@@ -55,17 +55,11 @@ def test_update_letter_notifications_statuses_raises_for_invalid_format(notify_a
     assert "DVLA response file: {} has an invalid format".format("NOTIFY-20170823160812-RSP.TXT") in str(e.value)
 
 
-@pytest.mark.parametrize(
-    "file_data",
-    [
-        "ref-foo|Sent|1|Unsorted",
-        "ref-foo|Sent|1|Unsorted|2023-01-12",
-    ],
-)
 def test_update_letter_notification_statuses_when_notification_does_not_exist_updates_notification_history(
-    sample_letter_template, mocker, file_data
+    sample_letter_template, mocker
 ):
-    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=file_data)
+    valid_file = "ref-foo|Sent|1|Unsorted|2023-01-12"
+    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=valid_file)
     notification = create_notification_history(
         sample_letter_template, reference="ref-foo", status=NOTIFICATION_SENDING, billable_units=1
     )
@@ -76,17 +70,9 @@ def test_update_letter_notification_statuses_when_notification_does_not_exist_up
     assert updated_history.status == NOTIFICATION_DELIVERED
 
 
-@pytest.mark.parametrize(
-    "file_data",
-    [
-        "ref-foo|Failed|1|Unsorted",
-        "ref-foo|Failed|1|Unsorted|2023-01-12",
-    ],
-)
-def test_update_letter_notifications_statuses_raises_dvla_exception(
-    notify_api, mocker, sample_letter_template, file_data
-):
-    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=file_data)
+def test_update_letter_notifications_statuses_raises_dvla_exception(notify_api, mocker, sample_letter_template):
+    valid_file = "ref-foo|Failed|1|Unsorted|2023-01-12"
+    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=valid_file)
     create_notification(sample_letter_template, reference="ref-foo", status=NOTIFICATION_SENDING, billable_units=0)
 
     with pytest.raises(DVLAException) as e:
@@ -107,31 +93,19 @@ def test_update_letter_notifications_statuses_calls_with_correct_bucket_location
         )
 
 
-@pytest.mark.parametrize(
-    "file_data",
-    [
-        "ref-foo|Sent|1|Unsorted\nref-bar|Sent|2|Sorted",
-        "ref-foo|Sent|1|Unsorted|23/02/2023\nref-bar|Sent|2|Sorted|22/02/2023",
-    ],
-)
-def test_update_letter_notifications_statuses_builds_updates_from_content(notify_api, mocker, file_data):
-    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=file_data)
+def test_update_letter_notifications_statuses_builds_updates_from_content(notify_api, mocker):
+    valid_file = "ref-foo|Sent|1|Unsorted|23-02-2023\nref-bar|Sent|2|Sorted|22-02-2023"
+    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=valid_file)
     update_mock = mocker.patch("app.celery.tasks.process_updates_from_file")
 
     update_letter_notifications_statuses(filename="NOTIFY-20170823160812-RSP.TXT")
 
-    update_mock.assert_called_with(file_data)
+    update_mock.assert_called_with(valid_file)
 
 
-@pytest.mark.parametrize(
-    "file_data",
-    [
-        "ref-foo|Sent|1|Unsorted\nref-bar|Sent|2|Sorted",
-        "ref-foo|Sent|1|Unsorted|23/02/2023\nref-bar|Sent|2|Sorted|22/02/2023",
-    ],
-)
-def test_update_letter_notifications_statuses_builds_updates_list(notify_api, file_data):
-    updates = process_updates_from_file(file_data)
+def test_update_letter_notifications_statuses_builds_updates_list(notify_api):
+    valid_file = "ref-foo|Sent|1|Unsorted|23-02-2023\nref-bar|Sent|2|Sorted|22-02-2023"
+    updates = process_updates_from_file(valid_file)
 
     assert len(updates) == 2
 
@@ -146,14 +120,7 @@ def test_update_letter_notifications_statuses_builds_updates_list(notify_api, fi
     assert updates[1].cost_threshold == "Sorted"
 
 
-@pytest.mark.parametrize(
-    "file_data",
-    [
-        "{}|Sent|1|Unsorted\n{}|Failed|2|Sorted",
-        "{}|Sent|1|Unsorted|23/02/2023\n{}|Failed|2|Sorted|23/02/2023",
-    ],
-)
-def test_update_letter_notifications_statuses_persisted(notify_api, mocker, sample_letter_template, file_data):
+def test_update_letter_notifications_statuses_persisted(notify_api, mocker, sample_letter_template):
     sent_letter = create_notification(
         sample_letter_template, reference="ref-foo", status=NOTIFICATION_SENDING, billable_units=1
     )
@@ -161,10 +128,10 @@ def test_update_letter_notifications_statuses_persisted(notify_api, mocker, samp
         sample_letter_template, reference="ref-bar", status=NOTIFICATION_SENDING, billable_units=2
     )
     create_service_callback_api(service=sample_letter_template.service, url="https://original_url.com")
-    mocker.patch(
-        "app.celery.tasks.s3.get_s3_file", return_value=file_data.format(sent_letter.reference, failed_letter.reference)
+    valid_file = (
+        f"{sent_letter.reference}|Sent|1|Unsorted|23-02-2023\n{failed_letter.reference}|Failed|2|Sorted|23-02-2023"
     )
-
+    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=valid_file)
     with pytest.raises(expected_exception=DVLAException) as e:
         update_letter_notifications_statuses(filename="NOTIFY-20170823160812-RSP.TXT")
 
@@ -185,7 +152,7 @@ def test_update_letter_notifications_does_not_call_send_callback_if_no_db_entry(
     sent_letter = create_notification(
         sample_letter_template, reference="ref-foo", status=NOTIFICATION_SENDING, billable_units=0
     )
-    valid_file = "{}|Sent|1|Unsorted\n".format(sent_letter.reference)
+    valid_file = f"{sent_letter.reference}|Sent|1|Unsorted|2022-08-11\n"
     mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=valid_file)
 
     send_mock = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.apply_async")
@@ -273,20 +240,15 @@ def test_persist_daily_sorted_letter_counts_saves_sorted_and_unsorted_values(cli
     assert day.sorted_count == 1
 
 
-@pytest.mark.parametrize(
-    "file_data",
-    [
-        "Letter1|Sent|1|uNsOrTeD\nLetter2|Sent|2|SORTED\nLetter3|Sent|2|Sorted",
-        "Letter1|Sent|1|uNsOrTeD|2023-01-12\nLetter2|Sent|2|SORTED|2023-01-11\nLetter3|Sent|2|Sorted|2023-01-10",
-    ],
-)
 def test_record_daily_sorted_counts_persists_daily_sorted_letter_count(
     notify_api,
     notify_db_session,
     mocker,
-    file_data,
 ):
-    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=file_data)
+    valid_file = (
+        "Letter1|Sent|1|uNsOrTeD|2023-01-12\nLetter2|Sent|2|SORTED|2023-01-11\nLetter3|Sent|2|Sorted|2023-01-10"
+    )
+    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=valid_file)
 
     assert DailySortedLetter.query.count() == 0
 
@@ -298,19 +260,12 @@ def test_record_daily_sorted_counts_persists_daily_sorted_letter_count(
     assert daily_sorted_counts[0].unsorted_count == 1
 
 
-@pytest.mark.parametrize(
-    "file_data",
-    [
-        "ref-foo|Failed|1|invalid\nrow_2|Failed|1|MM",
-        "ref-foo|Failed|1|invalid|2023-01-01\nrow_2|Failed|1|MM|2023-01-01",
-    ],
-)
 def test_record_daily_sorted_counts_raises_dvla_exception_with_unknown_sorted_status(
     notify_api,
     mocker,
-    file_data,
 ):
-    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=file_data)
+    file_contents = "ref-foo|Failed|1|invalid|2023-01-01\nrow_2|Failed|1|MM|2023-01-01"
+    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=file_contents)
     filename = "failed.txt"
     with pytest.raises(DVLAException) as e:
         record_daily_sorted_counts(filename=filename)
@@ -320,17 +275,11 @@ def test_record_daily_sorted_counts_raises_dvla_exception_with_unknown_sorted_st
     assert "'invalid'" in e.value.message
 
 
-@pytest.mark.parametrize(
-    "file_data",
-    [
-        "Letter1|Sent|1|Unsorted\nLetter2|Sent|2|Unsorted",
-        "Letter1|Sent|1|Unsorted|2023-01-01\nLetter2|Sent|2|Unsorted|2023-01-01",
-    ],
-)
 def test_record_daily_sorted_counts_persists_daily_sorted_letter_count_with_no_sorted_values(
-    notify_api, mocker, notify_db_session, file_data
+    notify_api, mocker, notify_db_session
 ):
-    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=file_data)
+    valid_file = "Letter1|Sent|1|Unsorted|2023-01-01\nLetter2|Sent|2|Unsorted|2023-01-01"
+    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=valid_file)
 
     record_daily_sorted_counts(filename="NOTIFY-20170823160812-RSP.TXT")
 
@@ -340,15 +289,9 @@ def test_record_daily_sorted_counts_persists_daily_sorted_letter_count_with_no_s
     assert daily_sorted_letter.sorted_count == 0
 
 
-@pytest.mark.parametrize(
-    "file_data",
-    [
-        "Letter1|Sent|1|sorted\nLetter2|Sent|2|Unsorted",
-        "Letter1|Sent|1|sorted|2023-01-01\nLetter2|Sent|2|Unsorted|2023-01-01",
-    ],
-)
-def test_record_daily_sorted_counts_can_run_twice_for_same_file(notify_api, mocker, notify_db_session, file_data):
-    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=file_data)
+def test_record_daily_sorted_counts_can_run_twice_for_same_file(notify_api, mocker, notify_db_session):
+    valid_file = "Letter1|Sent|1|sorted|2023-01-01\nLetter2|Sent|2|Unsorted|2023-01-01"
+    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=valid_file)
 
     record_daily_sorted_counts(filename="NOTIFY-20170823160812-RSP.TXT")
 
@@ -357,7 +300,9 @@ def test_record_daily_sorted_counts_can_run_twice_for_same_file(notify_api, mock
     assert daily_sorted_letter.unsorted_count == 1
     assert daily_sorted_letter.sorted_count == 1
 
-    updated_file = "Letter1|Sent|1|sorted\nLetter2|Sent|2|Unsorted\nLetter3|Sent|2|Unsorted"
+    updated_file = (
+        "Letter1|Sent|1|sorted|2023-01-01\nLetter2|Sent|2|Unsorted|2023-01-01\nLetter3|Sent|2|Unsorted|2023-01-01"
+    )
     mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=updated_file)
 
     record_daily_sorted_counts(filename="NOTIFY-20170823160812-RSP.TXT")

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -52,7 +52,7 @@ def mock_s3_get_list_diff(bucket_name, subfolder="", suffix="", last_modified=No
             "NOTIFY.2018-01-11175010.ZIP.TXT",
         ]
     if subfolder == "root/dispatch":
-        return ["root/disoatch/NOTIFY.2018-01-11175007p.ACK.TXT", "root/disoatch/NOTIFY.2018-01-11175008.ACK.TXT"]
+        return ["root/dispatch/NOTIFY.2018-01-11175007p.ACK.TXT", "root/dispatch/NOTIFY.2018-01-11175008.ACK.TXT"]
 
 
 @freeze_time("2016-10-18T10:00:00")

--- a/tests/app/celery/test_research_mode_tasks.py
+++ b/tests/app/celery/test_research_mode_tasks.py
@@ -128,7 +128,7 @@ def test_create_fake_letter_response_file_uploads_response_file_s3(notify_api, m
         create_fake_letter_response_file("random-ref")
 
         mock_s3upload.assert_called_once_with(
-            filedata="random-ref|Sent|0|Sorted",
+            filedata="random-ref|Sent|0|Sorted|2018-01-25",
             region=current_app.config["AWS_REGION"],
             bucket_name=current_app.config["S3_BUCKET_DVLA_RESPONSE"],
             file_location=dvla_response_file_matcher,


### PR DESCRIPTION
This reopens https://github.com/alphagov/notifications-api/pull/3749, which was reverted because the tests failed on preview when deploying. We needed to also update the `create_fake_letter_response_file` task, so that change has now been added in a new commit.