### PR TITLE
Populate AnnualBilling automatically each year

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -591,7 +591,6 @@ def populate_annual_billing(year, missing_services_only):
         active_services = Service.query.filter(Service.active).all()
 
     for service in active_services:
-        print(f"update service {service.id} with default")
         set_default_free_allowance_for_service(service, year)
 
 

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -596,6 +596,7 @@ def populate_annual_billing(year, missing_services_only):
 
 
 @notify_celery.task(name="run-populate-annual-billing")
+@cronitor("run-populate-annual-billing")
 def run_populate_annual_billing():
     year = get_current_financial_year_start_year()
     run_populate_annual_billing(year=year, missing_services_only=True)

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -13,7 +13,7 @@ from notifications_utils.clients.zendesk.zendesk_client import (
 )
 from notifications_utils.timezones import convert_utc_to_bst
 from redis.exceptions import LockError
-from sqlalchemy import between
+from sqlalchemy import and_, between
 from sqlalchemy.exc import SQLAlchemyError
 
 from app import db, dvla_client, notify_celery, statsd_client, zendesk_client
@@ -36,6 +36,8 @@ from app.constants import (
     SMS_TYPE,
 )
 from app.cronitor import cronitor
+from app.dao.annual_billing_dao import set_default_free_allowance_for_service
+from app.dao.date_util import get_current_financial_year_start_year
 from app.dao.inbound_numbers_dao import dao_get_available_inbound_numbers
 from app.dao.invited_org_user_dao import (
     delete_org_invitations_created_more_than_two_days_ago,
@@ -68,12 +70,14 @@ from app.dao.services_dao import (
 from app.dao.users_dao import delete_codes_older_created_more_than_a_day_ago
 from app.letters.utils import generate_letter_pdf_filename
 from app.models import (
+    AnnualBilling,
     BroadcastMessage,
     BroadcastStatusType,
     EmailBranding,
     Event,
     Job,
     Organisation,
+    Service,
     User,
 )
 from app.notifications.process_notifications import send_notification_to_queue
@@ -561,3 +565,37 @@ def change_dvla_api_key(self):
     except DvlaRetryableException:
         current_app.logger.info("change-dvla-api-key DvlaRetryableException - retrying")
         self.retry()
+
+
+def populate_annual_billing(year, missing_services_only):
+    """
+    Add or update annual billing with free allowance defaults for all active services.
+    The default free allowances are stored in the DB in a table called `default_annual_allowance`.
+
+    If missing_services_only is true then only add rows for services that do not have annual billing for that year yet.
+    This is useful to prevent overriding any services that have a free allowance that is not the default.
+
+    If missing_services_only is false then add or update annual billing for all active services.
+    This is useful to ensure all services start the new year with the correct annual billing.
+    """
+    if missing_services_only:
+        active_services = (
+            Service.query.filter(Service.active)
+            .outerjoin(
+                AnnualBilling, and_(Service.id == AnnualBilling.service_id, AnnualBilling.financial_year_start == year)
+            )
+            .filter(AnnualBilling.id == None)  # noqa
+            .all()
+        )
+    else:
+        active_services = Service.query.filter(Service.active).all()
+
+    for service in active_services:
+        print(f"update service {service.id} with default")
+        set_default_free_allowance_for_service(service, year)
+
+
+@notify_celery.task(name="run-populate-annual-billing")
+def run_populate_annual_billing():
+    year = get_current_financial_year_start_year()
+    run_populate_annual_billing(year=year, missing_services_only=True)

--- a/app/commands.py
+++ b/app/commands.py
@@ -26,7 +26,6 @@ from app.celery.letters_pdf_tasks import (
     get_pdf_for_templated_letter,
     resanitise_pdf,
 )
-from app.celery.scheduled_tasks import populate_annual_billing
 from app.celery.tasks import process_row, record_daily_sorted_counts
 from app.config import QueueNames
 from app.constants import KEY_TYPE_TEST, NOTIFICATION_CREATED, SMS_TYPE
@@ -785,22 +784,6 @@ def populate_annual_billing_with_the_previous_years_allowance(year):
         dao_create_or_update_annual_billing_for_year(
             service_id=row.id, free_sms_fragment_limit=free_allowance[0], financial_year_start=int(year)
         )
-
-
-@notify_command(name="populate-annual-billing-with-defaults")
-@click.option(
-    "-y", "--year", required=True, type=int, help="""The year to populate the annual billing data for, i.e. 2021"""
-)
-@click.option(
-    "-m",
-    "--missing-services-only",
-    default=True,
-    type=bool,
-    help="""If true then only populate services missing from annual billing for the year.
-                      If false populate the default values for all active services.""",
-)
-def populate_annual_billing_with_defaults(year, missing_services_only):
-    populate_annual_billing(year, missing_services_only=missing_services_only)
 
 
 @click.option("-u", "--user-id", required=True)

--- a/app/config.py
+++ b/app/config.py
@@ -253,6 +253,11 @@ class Config(object):
                 "schedule": crontab(minute="0, 15, 30, 45"),
                 "options": {"queue": QueueNames.PERIODIC},
             },
+            "run-populate-annual-billing": {
+                "task": "run-populate-annual-billing",
+                "schedule": crontab(minute=1, hour=2, day_of_month=1, month_of_year=4),
+                "options": {"queue": QueueNames.PERIODIC},
+            },
             # app/celery/nightly_tasks.py
             "timeout-sending-notifications": {
                 "task": "timeout-sending-notifications",

--- a/app/dao/annual_billing_dao.py
+++ b/app/dao/annual_billing_dao.py
@@ -85,4 +85,13 @@ def set_default_free_allowance_for_service(service, year_start=None):
             )
         free_sms_fragment_allowance = default_free_sms_fragment_allowance.allowance
 
+    current_app.logger.info(
+        (
+            "Set default free allowances for service %s "
+            "(valid_from_financial_year_start=%s, free_sms_fragment_allowance=%s)"
+        ),
+        service.id,
+        year_start,
+        free_sms_fragment_allowance,
+    )
     return dao_create_or_update_annual_billing_for_year(service.id, free_sms_fragment_allowance, year_start)

--- a/tests/app/test_commands.py
+++ b/tests/app/test_commands.py
@@ -1,14 +1,10 @@
-import pytest
-
 from app.commands import (
     insert_inbound_numbers_from_file,
     local_dev_broadcast_permissions,
-    populate_annual_billing_with_defaults,
 )
 from app.dao.inbound_numbers_dao import dao_get_available_inbound_numbers
 from app.dao.services_dao import dao_add_user_to_service
-from app.models import AnnualBilling
-from tests.app.db import create_annual_billing, create_service, create_user
+from tests.app.db import create_user
 
 
 def test_insert_inbound_numbers_from_file(notify_db_session, notify_api, tmpdir):
@@ -38,34 +34,3 @@ def test_local_dev_broadcast_permissions(
 
     assert len(user.get_permissions(sample_service.id)) == 0
     assert len(user.get_permissions(sample_broadcast_service.id)) > 0
-
-
-@pytest.mark.parametrize(
-    "organisation_type, expected_allowance", [("central", 40000), ("local", 20000), ("nhs_gp", 10000)]
-)
-def test_populate_annual_billing_with_defaults(notify_db_session, notify_api, organisation_type, expected_allowance):
-    service = create_service(service_name=organisation_type, organisation_type=organisation_type)
-
-    notify_api.test_cli_runner().invoke(populate_annual_billing_with_defaults, ["-y", 2022])
-
-    results = AnnualBilling.query.filter(
-        AnnualBilling.financial_year_start == 2022, AnnualBilling.service_id == service.id
-    ).all()
-
-    assert len(results) == 1
-    assert results[0].free_sms_fragment_limit == expected_allowance
-
-
-def test_populate_annual_billing_with_defaults_sets_free_allowance_to_zero_if_previous_year_is_zero(
-    notify_db_session, notify_api
-):
-    service = create_service(organisation_type="central")
-    create_annual_billing(service_id=service.id, free_sms_fragment_limit=0, financial_year_start=2021)
-    notify_api.test_cli_runner().invoke(populate_annual_billing_with_defaults, ["-y", 2022])
-
-    results = AnnualBilling.query.filter(
-        AnnualBilling.financial_year_start == 2022, AnnualBilling.service_id == service.id
-    ).all()
-
-    assert len(results) == 1
-    assert results[0].free_sms_fragment_limit == 0


### PR DESCRIPTION
At the start of each financial year, let's automatically populate AnnualBilling for all services that exist.

This will ensure that the org usage dashboard immediately reflects free allowances for all of its services.

Newly-created services get an AnnualBilling entry added upon creation.

Creds PR: https://github.com/alphagov/notifications-credentials/pull/338