### PR TITLE
Connect to sqs using the new endpoint

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -191,11 +191,13 @@ class Config(object):
     DVLA_EMAIL_ADDRESSES = json.loads(os.environ.get("DVLA_EMAIL_ADDRESSES", "[]"))
 
     CELERY = {
-        "broker_url": "sqs://",
+        "broker_url": "https://sqs.eu-west-1.amazonaws.com",
+        "broker_transport": "sqs",
         "broker_transport_options": {
             "region": AWS_REGION,
             "visibility_timeout": 310,
             "queue_name_prefix": NOTIFICATION_QUEUE_PREFIX,
+            "is_secure": True,
         },
         "timezone": "UTC",
         "imports": [


### PR DESCRIPTION
Use the new SQS endpoints which will allow us to use VPC endpoints in ECS.

It's worth pointing out that the `is_secure` is required for things to work, as otherwise it tries to communicate via `http` which fails with this error message:
```
botocore.exceptions.ClientError: An error occurred (InvalidSecurity) when calling the GetQueueAttributes operation: All requests to this queue must use HTTPS and SigV4.
```

Surpringly/annoyingly, the [`use_ssl`](https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-broker_use_ssl) argument didn't fix it, hence we need to set the `is_secure` flag in the `transport_options`

Relevant issue: https://github.com/celery/celery/issues/5020
Relevant ticket: https://trello.com/c/iswFGj8n/224-make-the-notify-apps-call-the-newer-sqs-endpoint-when-talking-to-sqs