### PR TITLE
Ignore log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ celerybeat-schedule
 # Local
 docker-compose.yml
 .env
+application.log.json


### PR DESCRIPTION
If you turn off debug mode locally (eg in order to check JSON-formatted logs), a log file called `application.log.json` will be created. Let's ignore it.