### PR TITLE
Adding archive endpoint for letter-attachment

### DIFF
--- a/app/letter_attachment/schema.py
+++ b/app/letter_attachment/schema.py
@@ -13,3 +13,13 @@ post_create_letter_attachment_schema = {
     },
     "required": ["upload_id", "created_by_id", "original_filename", "page_count", "template_id"],
 }
+
+post_archive_letter_attachment_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "POST schema for archiving letter_attachment",
+    "type": "object",
+    "properties": {
+        "archived_by": uuid,
+    },
+    "required": ["archived_by"],
+}

--- a/tests/app/letter_attachment/test_rest.py
+++ b/tests/app/letter_attachment/test_rest.py
@@ -103,3 +103,120 @@ def test_create_letter_attachment_returns_400_if_template_already_has_attachment
     }
 
     admin_request.post("letter_attachment.create_letter_attachment", _data=data, _expected_status=400)
+
+
+def test_archive_letter_attachment_creates_new_template_version(
+    admin_request, notify_db_session, sample_letter_template
+):
+    assert sample_letter_template.version == 1
+
+    upload_id = uuid.uuid4()
+
+    response = admin_request.post(
+        "letter_attachment.create_letter_attachment",
+        _data={
+            "upload_id": str(upload_id),
+            "created_by_id": str(sample_letter_template.created_by_id),
+            "original_filename": "filename.pdf",
+            "page_count": 2,
+            "template_id": str(sample_letter_template.id),
+        },
+        _expected_status=201,
+    )
+
+    user = create_user()
+    data = {
+        "template_id": str(sample_letter_template.id),
+        "archived_by": str(user.id),
+    }
+
+    admin_request.post(
+        "letter_attachment.archive_letter_attachment",
+        _data=data,
+        letter_attachment_id=response["id"],
+        _expected_status=204,
+    )
+
+    attached_version = dao_get_template_by_id(sample_letter_template.id, version=2)
+    new_version = dao_get_template_by_id(sample_letter_template.id, version=3)
+
+    assert attached_version.version == 2
+    assert new_version.version == 3
+    assert new_version.letter_attachment_id is None
+    # make sure we didn't add a third version
+    assert sample_letter_template.version == 3
+
+
+def test_archive_letter_attachment_updates_db(admin_request, notify_db_session, sample_letter_template):
+    assert sample_letter_template.version == 1
+
+    upload_id = uuid.uuid4()
+
+    response = admin_request.post(
+        "letter_attachment.create_letter_attachment",
+        _data={
+            "upload_id": str(upload_id),
+            "created_by_id": str(sample_letter_template.created_by_id),
+            "original_filename": "filename.pdf",
+            "page_count": 2,
+            "template_id": str(sample_letter_template.id),
+        },
+        _expected_status=201,
+    )
+
+    user = create_user()
+    data = {
+        "archived_by": str(user.id),
+    }
+
+    admin_request.post(
+        "letter_attachment.archive_letter_attachment",
+        _data=data,
+        letter_attachment_id=response["id"],
+        _expected_status=204,
+    )
+
+    letter_attachment = LetterAttachment.query.one()
+    assert letter_attachment.archived_by_id == user.id
+    assert letter_attachment.archived_at is not None
+
+
+def test_archive_letter_attachment_returns_404_if_template_id_doesnt_exist(admin_request, sample_letter_template):
+    upload_id = uuid.uuid4()
+    response = admin_request.post(
+        "letter_attachment.create_letter_attachment",
+        _data={
+            "upload_id": str(upload_id),
+            "created_by_id": str(sample_letter_template.created_by_id),
+            "original_filename": "filename.pdf",
+            "page_count": 2,
+            "template_id": str(sample_letter_template.id),
+        },
+        _expected_status=201,
+    )
+    user = create_user()
+    attachment = dao_get_template_by_id(sample_letter_template.id).letter_attachment
+    attachment.template = None
+    data = {
+        "archived_by": str(user.id),
+    }
+    admin_request.post(
+        "letter_attachment.archive_letter_attachment",
+        _data=data,
+        letter_attachment_id=response["id"],
+        _expected_status=400,
+    )
+
+
+def test_archive_letter_attachment_returns_404_if_attachment_doesnt_exist(admin_request, sample_letter_template):
+    random_uuid = uuid.uuid4()
+
+    data = {
+        "archived_by": str(random_uuid),
+    }
+    admin_request.post(
+        "letter_attachment.archive_letter_attachment",
+        _data=data,
+        letter_attachment_id=random_uuid,
+        _expected_status=404,
+    )


### PR DESCRIPTION
This endpoint is the one called when removing an attachment from a
template.

As there are multiple versions of the template, which might be reverted
to, the attachment is kept. So this archive endpoint just does a soft
delete.

It does this by removing it from template and updating the
archived_at and archived_by_id in the letter-attachment
db row.