### PR TITLE
Use both internal and external URLs for api and document-download-api

### DIFF
--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -50,7 +50,7 @@ def send_email_response(reference, to):
 
 
 def make_request(notification_type, provider, data, headers):
-    api_call = "{}/notifications/{}/{}".format(current_app.config["API_HOST_NAME"], notification_type, provider)
+    api_call = f"{current_app.config['API_HOST_NAME_INTERNAL']}/notifications/{notification_type}/{provider}"
 
     try:
         response = request("POST", api_call, headers=headers, data=data, timeout=60)

--- a/app/clients/document_download.py
+++ b/app/clients/document_download.py
@@ -18,11 +18,22 @@ class DocumentDownloadError(Exception):
 
 class DocumentDownloadClient:
     def init_app(self, app):
-        self.api_host = app.config["DOCUMENT_DOWNLOAD_API_HOST"]
+        self.api_host_external = app.config["DOCUMENT_DOWNLOAD_API_HOST"]
+        self.api_host_internal = app.config["DOCUMENT_DOWNLOAD_API_HOST_INTERNAL"]
         self.auth_token = app.config["DOCUMENT_DOWNLOAD_API_KEY"]
 
-    def get_upload_url(self, service_id):
-        return "{}/services/{}/documents".format(self.api_host, service_id)
+    def get_upload_url_for_simulated_email(self, service_id):
+        """
+        This is the URL displayed in the API response for emails sent to a simulated email address.
+        """
+        return f"{self.api_host_external}/services/{service_id}/documents"
+
+    def _get_upload_url(self, service_id):
+        """
+        When uploading a document we use the internal route to document-download-api. This internal URL
+        can only be accessed from other apps, so should not be displayed to users.
+        """
+        return f"{self.api_host_internal}/services/{service_id}/documents"
 
     def upload_document(
         self,
@@ -45,7 +56,7 @@ class DocumentDownloadClient:
                 data["retention_period"] = retention_period
 
             response = requests.post(
-                self.get_upload_url(service_id),
+                self._get_upload_url(service_id),
                 headers={
                     "Authorization": "Bearer {}".format(self.auth_token),
                 },

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -327,7 +327,9 @@ def process_document_uploads(personalisation_data, service, send_to: str, simula
 
     for key in file_keys:
         if simulated:
-            personalisation_data[key] = document_download_client.get_upload_url(service.id) + "/test-document"
+            personalisation_data[key] = (
+                document_download_client.get_upload_url_for_simulated_email(service.id) + "/test-document"
+            )
         else:
             confirm_email = personalisation_data[key].get("confirm_email_before_download", True)
             retention_period = (

--- a/scripts/run_locally_with_docker.sh
+++ b/scripts/run_locally_with_docker.sh
@@ -11,6 +11,7 @@ AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-"$(aws configure get aws_secret_a
 SQLALCHEMY_DATABASE_URI=${SQLALCHEMY_DATABASE_URI:-"postgresql://postgres@host.docker.internal/notification_api"}
 REDIS_URL=${REDIS_URL:-"redis://host.docker.internal:6379"}
 API_HOST_NAME=${API_HOST_NAME:-"http://host.docker.internal:6011"}
+API_HOST_NAME_INTERNAL=${API_HOST_NAME_INTERNAL:-"http://host.docker.internal:6011"}
 
 # Only expose port 6011 if we're running the API - anything else is celery which shouldn't bind the port.
 # This lets us run celery via docker and the API locally.
@@ -27,6 +28,7 @@ docker run -it --rm \
   -e REDIS_ENABLED=${REDIS_ENABLED:-0} \
   -e REDIS_URL=$REDIS_URL \
   -e API_HOST_NAME=$API_HOST_NAME \
+  -e API_HOST_NAME_INTERNAL=$API_HOST_NAME_INTERNAL \
   -e NOTIFY_ENVIRONMENT=$NOTIFY_ENVIRONMENT \
   -e MMG_API_KEY=$MMG_API_KEY \
   -e FIRETEXT_API_KEY=$FIRETEXT_API_KEY \

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -964,7 +964,7 @@ def test_post_notification_with_document_upload_simulated(api_client_request, no
 
     mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
     document_download_mock = mocker.patch("app.v2.notifications.post_notifications.document_download_client")
-    document_download_mock.get_upload_url.return_value = "https://document-url"
+    document_download_mock.get_upload_url_for_simulated_email.return_value = "https://document-url"
 
     data = {
         "email_address": "simulate-delivered@notifications.service.gov.uk",


### PR DESCRIPTION
When the apps are deployed on ECS we want to use internal hostnames when talking to other apps where possible, so have split out the environment variables in preparation for this https://github.com/alphagov/notifications-api/pull/3793

This PR changes the code to use the internal hostname where possible when calling itself or document-download-api. When deployed on PaaS both values will be the same, but when deployed on ECS the external and internal hostnames will be different.