### PR TITLE
Return letter attachment data from template endpoint

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -392,7 +392,7 @@ class BaseTemplateSchema(BaseSchema):
         return template.get_reply_to_text()
 
     def get_letter_attachment(self, template):
-        return template.letter_attachment_id
+        return template.letter_attachment.serialize() if template.letter_attachment else None
 
     class Meta(BaseSchema.Meta):
         model = models.Template
@@ -478,7 +478,7 @@ class TemplateHistorySchema(BaseSchema):
         return template.get_reply_to_text()
 
     def get_letter_attachment(self, template):
-        return template.letter_attachment_id
+        return template.letter_attachment.serialize() if template.letter_attachment else None
 
     class Meta(BaseSchema.Meta):
         model = models.TemplateHistory

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -1067,26 +1067,26 @@ def test_check_for_low_available_inbound_sms_numbers_does_not_proceed_if_enough_
 
 
 class TestChangeDvlaPasswordTask:
-    def test_calls_dvla_succesfully(self, mocker):
+    def test_calls_dvla_succesfully(self, mocker, notify_api):
         mock_change_password = mocker.patch("app.dvla_client.change_password")
 
         change_dvla_password()
 
         mock_change_password.assert_called_once_with()
 
-    def test_silently_quits_if_lock_is_held(self, mocker):
+    def test_silently_quits_if_lock_is_held(self, mocker, notify_api):
         mocker.patch("app.dvla_client.change_password", side_effect=LockError)
 
         # does not raise any exceptions
         change_dvla_password()
 
-    def test_retries_if_dvla_throws_retryable_exception(self, mocker):
+    def test_retries_if_dvla_throws_retryable_exception(self, mocker, notify_api):
         mocker.patch("app.dvla_client.change_password", side_effect=DvlaThrottlingException)
 
         with pytest.raises(Retry):
             change_dvla_password()
 
-    def test_reraises_if_dvla_raises_non_retryable_exception(self, mocker):
+    def test_reraises_if_dvla_raises_non_retryable_exception(self, mocker, notify_api):
         mocker.patch("app.dvla_client.change_password", side_effect=DvlaNonRetryableException)
 
         with pytest.raises(DvlaNonRetryableException):
@@ -1094,7 +1094,7 @@ class TestChangeDvlaPasswordTask:
 
 
 class TestChangeDvlaApiKeyTask:
-    def test_calls_dvla_succesfully(self, mocker):
+    def test_calls_dvla_succesfully(self, mocker, notify_api):
         mock_change_api_key = mocker.patch("app.dvla_client.change_api_key")
 
         change_dvla_api_key()

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -642,7 +642,8 @@ def test_get_template_returns_letter_attachment(admin_request, sample_letter_tem
         **extra_args,
     )
 
-    assert data["data"]["letter_attachment"] == str(attachment.id)
+    assert data["data"]["letter_attachment"]["id"] == str(attachment.id)
+    assert data["data"]["letter_attachment"]["page_count"] == attachment.page_count
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
this is useful, as we typically pass the template json blob straight to template preview without modification when generating letters. If we return the full letter attachment object (note this is just id, metadata, etc, not the actual PDF), then that's one less thing we have to worry about handling separately elsewhere.

The template json now looks like. (note this only affects template json in endpoints where we already returned the letter_attachment id)

```json
{
...
	"id": "59e89e0d-a68e-4d67-9449-0f277042c524",
	"letter_attachment": {
		"archived_at": null,
		"archived_by_id": null,
		"created_at": "2023-05-05T14:25:48.524912Z",
		"created_by_id": "b97004cd-7ab3-4766-b1bd-c9552d4331d7",
		"id": "e0d139f5-0493-4eca-8ec0-da21164a7bed",
		"original_filename": "abc.pdf",
		"page_count": 1
	},
	"name": "letter Template Name",
...
}
```