### PR TITLE
Remove extra exception log

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -484,7 +484,6 @@ def process_virus_scan_failed(filename):
         )
 
     error = VirusScanError("notification id {} Virus scan failed: {}".format(notification.id, filename))
-    current_app.logger.exception(error)
     raise error
 
 


### PR DESCRIPTION
We already raise the exception; logging it as well is redundant.