### PR TITLE
Make tests compatible with both Postgres 11 and 15

### DIFF
--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -706,7 +706,8 @@ def test_create_service_and_history_is_transactional(notify_db_session):
     with pytest.raises(IntegrityError) as excinfo:
         dao_create_service(service, user)
 
-    assert 'column "name" violates not-null constraint' in str(excinfo.value)
+    assert 'column "name"' in str(excinfo.value)
+    assert "violates not-null constraint" in str(excinfo.value)
     assert Service.query.count() == 0
     assert Service.get_history_model().query.count() == 0
 

--- a/tests/app/performance_dashboard/test_rest.py
+++ b/tests/app/performance_dashboard/test_rest.py
@@ -1,5 +1,7 @@
 from datetime import date
 
+from pytest import approx
+
 from tests.app.db import (
     create_ft_notification_status,
     create_process_time,
@@ -66,7 +68,7 @@ def test_performance_dashboard(sample_service, admin_request):
         {"date": "2021-03-02", "emails": 25, "sms": 30, "letters": 10},
     ]
     assert results["processing_time"] == [
-        {"date": "2021-03-01", "percentage_under_10_seconds": 97.1428571428571},
+        {"date": "2021-03-01", "percentage_under_10_seconds": approx(97.142857142857)},
         {"date": "2021-03-02", "percentage_under_10_seconds": 80.0},
     ]
     assert results["live_service_count"] == 1


### PR DESCRIPTION
We want to upgrade the database to Postgres 15, but there were a couple of tests that were failing with the new version. These were not failing for any substantial reason, so we can just update the code tests to be compatible with both versions.