### PR TITLE
Add index to jobs.contact_list_id field

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1219,7 +1219,7 @@ class Job(db.Model):
         db.String(255), db.ForeignKey("job_status.name"), index=True, nullable=False, default="pending"
     )
     archived = db.Column(db.Boolean, nullable=False, default=False)
-    contact_list_id = db.Column(UUID(as_uuid=True), db.ForeignKey("service_contact_list.id"), nullable=True)
+    contact_list_id = db.Column(UUID(as_uuid=True), db.ForeignKey("service_contact_list.id"), nullable=True, index=True)
 
 
 class VerifyCode(db.Model):

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0410_drop_unused_allowance
+0411_contact_list_idx

--- a/migrations/versions/0411_contact_list_idx.py
+++ b/migrations/versions/0411_contact_list_idx.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0411_contact_list_idx
+Revises: 0410_drop_unused_allowance
+Create Date: 2023-05-11 15:00:59.123645
+
+"""
+from alembic import op
+
+
+revision = "0411_contact_list_idx"
+down_revision = "0410_drop_unused_allowance"
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.create_index(
+            op.f("ix_jobs_contact_list_id"), "jobs", ["contact_list_id"], unique=False, postgresql_concurrently=True
+        )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_jobs_contact_list_id"), table_name="jobs")


### PR DESCRIPTION
We do a lot of lookups on this field and having an index makes sense. This missing index has eventually caused a (poorly optimised) endpoint (get_contact_list) to start timing out for some users with a lot of contact lists.