### PR TITLE
Bump utils to 63.0.0

### DIFF
--- a/app/broadcast_message/utils.py
+++ b/app/broadcast_message/utils.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from flask import current_app
 from notifications_utils.clients.zendesk.zendesk_client import (
     NotifySupportTicket,
+    NotifyTicketType,
 )
 
 from app import zendesk_client
@@ -92,7 +93,7 @@ def _create_p1_zendesk_alert(broadcast_message):
         subject="Live broadcast sent",
         message=message,
         ticket_type=NotifySupportTicket.TYPE_INCIDENT,
-        technical_ticket=True,
+        notify_ticket_type=NotifyTicketType.TECHNICAL,
         org_id=current_app.config["BROADCAST_ORGANISATION_ID"],
         org_type="central",
         service_id=str(broadcast_message.service_id),

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -4,6 +4,7 @@ import pytz
 from flask import current_app
 from notifications_utils.clients.zendesk.zendesk_client import (
     NotifySupportTicket,
+    NotifyTicketType,
 )
 from notifications_utils.letter_timings import (
     get_dvla_working_day_offset_by,
@@ -208,7 +209,7 @@ def raise_alert_if_letter_notifications_still_sending():
                 email_ccs=current_app.config["DVLA_EMAIL_ADDRESSES"],
                 message=message,
                 ticket_type=NotifySupportTicket.TYPE_INCIDENT,
-                technical_ticket=True,
+                notify_ticket_type=NotifyTicketType.TECHNICAL,
                 ticket_categories=["notify_letters"],
             )
             zendesk_client.send_ticket_to_zendesk(ticket)
@@ -281,7 +282,7 @@ def letter_raise_alert_if_no_ack_file_for_zip():
                 subject="Letter acknowledge error",
                 message=message,
                 ticket_type=NotifySupportTicket.TYPE_INCIDENT,
-                technical_ticket=True,
+                notify_ticket_type=NotifyTicketType.TECHNICAL,
                 ticket_categories=["notify_letters"],
             )
             zendesk_client.send_ticket_to_zendesk(ticket)

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -10,6 +10,7 @@ from notifications_utils.clients.zendesk.zendesk_client import (
     NotifySupportTicketAttachment,
     NotifySupportTicketComment,
     NotifySupportTicketStatus,
+    NotifyTicketType,
 )
 from notifications_utils.timezones import convert_utc_to_bst
 from redis.exceptions import LockError
@@ -273,7 +274,7 @@ def check_if_letters_still_pending_virus_check():
                 subject=f"[{current_app.config['NOTIFY_ENVIRONMENT']}] Letters still pending virus check",
                 message=msg,
                 ticket_type=NotifySupportTicket.TYPE_INCIDENT,
-                technical_ticket=True,
+                notify_ticket_type=NotifyTicketType.TECHNICAL,
                 ticket_categories=["notify_letters"],
             )
             zendesk_client.send_ticket_to_zendesk(ticket)
@@ -297,7 +298,7 @@ def check_if_letters_still_in_created():
                 subject=f"[{current_app.config['NOTIFY_ENVIRONMENT']}] Letters still in 'created' status",
                 message=msg,
                 ticket_type=NotifySupportTicket.TYPE_INCIDENT,
-                technical_ticket=True,
+                notify_ticket_type=NotifyTicketType.TECHNICAL,
                 ticket_categories=["notify_letters"],
             )
             zendesk_client.send_ticket_to_zendesk(ticket)
@@ -360,7 +361,7 @@ def check_for_services_with_high_failure_rates_or_sending_to_tv_numbers():
                 subject=f"[{current_app.config['NOTIFY_ENVIRONMENT']}] High failure rates for sms spotted for services",
                 message=message,
                 ticket_type=NotifySupportTicket.TYPE_INCIDENT,
-                technical_ticket=True,
+                notify_ticket_type=NotifyTicketType.TECHNICAL,
             )
             zendesk_client.send_ticket_to_zendesk(ticket)
 
@@ -458,7 +459,7 @@ def zendesk_new_email_branding_report():
             subject="Review new email brandings",
             message=message,
             ticket_type=NotifySupportTicket.TYPE_TASK,
-            technical_ticket=False,
+            notify_ticket_type=NotifyTicketType.NON_TECHNICAL,
             ticket_categories=["notify_no_ticket_category"],
             message_as_html=True,
         )
@@ -488,7 +489,7 @@ def check_for_low_available_inbound_sms_numbers():
         subject="Request more inbound SMS numbers",
         message=message,
         ticket_type=NotifySupportTicket.TYPE_TASK,
-        technical_ticket=True,
+        notify_ticket_type=NotifyTicketType.TECHNICAL,
         ticket_categories=["notify_no_ticket_category"],
     )
     zendesk_client.send_ticket_to_zendesk(ticket)

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.3.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -163,7 +163,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.3.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.0.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -7,6 +7,7 @@ from flask import current_app
 from freezegun import freeze_time
 from notifications_utils.clients.zendesk.zendesk_client import (
     NotifySupportTicket,
+    NotifyTicketType,
 )
 
 from app.celery import nightly_tasks
@@ -220,7 +221,7 @@ def test_create_ticket_if_letter_notifications_still_sending(notify_api, mocker)
             "https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#deal-with-letters-still-in-sending"
         ),
         ticket_type="incident",
-        technical_ticket=True,
+        notify_ticket_type=NotifyTicketType.TECHNICAL,
         ticket_categories=["notify_letters"],
     )
     mock_send_ticket_to_zendesk.assert_called_once()
@@ -375,7 +376,7 @@ def test_letter_raise_alert_if_ack_files_not_match_zip_list(mocker, notify_db_se
         subject="Letter acknowledge error",
         message=ANY,
         ticket_type="incident",
-        technical_ticket=True,
+        notify_ticket_type=NotifyTicketType.TECHNICAL,
         ticket_categories=["notify_letters"],
     )
     mock_send_ticket_to_zendesk.assert_called_once()

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -13,6 +13,7 @@ from notifications_utils.clients.zendesk.zendesk_client import (
     NotifySupportTicketAttachment,
     NotifySupportTicketComment,
     NotifySupportTicketStatus,
+    NotifyTicketType,
 )
 from redis.exceptions import LockError
 
@@ -483,7 +484,7 @@ def test_check_if_letters_still_pending_virus_check_raises_zendesk_if_files_cant
         subject="[test] Letters still pending virus check",
         message=ANY,
         ticket_type="incident",
-        technical_ticket=True,
+        notify_ticket_type=NotifyTicketType.TECHNICAL,
         ticket_categories=["notify_letters"],
     )
     assert "2 precompiled letters have been pending-virus-check" in mock_create_ticket.call_args.kwargs["message"]
@@ -524,7 +525,7 @@ def test_check_if_letters_still_in_created_during_bst(mocker, sample_letter_temp
         message=message,
         subject="[test] Letters still in 'created' status",
         ticket_type="incident",
-        technical_ticket=True,
+        notify_ticket_type=NotifyTicketType.TECHNICAL,
         ticket_categories=["notify_letters"],
     )
     mock_send_ticket_to_zendesk.assert_called_once()
@@ -562,7 +563,7 @@ def test_check_if_letters_still_in_created_during_utc(mocker, sample_letter_temp
         message=message,
         subject="[test] Letters still in 'created' status",
         ticket_type="incident",
-        technical_ticket=True,
+        notify_ticket_type=NotifyTicketType.TECHNICAL,
         ticket_categories=["notify_letters"],
     )
     mock_send_ticket_to_zendesk.assert_called_once()
@@ -736,7 +737,7 @@ def test_check_for_services_with_high_failure_rates_or_sending_to_tv_numbers(
         message=expected_message + zendesk_actions,
         subject="[test] High failure rates for sms spotted for services",
         ticket_type="incident",
-        technical_ticket=True,
+        notify_ticket_type=NotifyTicketType.TECHNICAL,
     )
     mock_send_ticket_to_zendesk.assert_called_once()
 
@@ -865,11 +866,11 @@ def test_zendesk_new_email_branding_report(notify_db_session, mocker, notify_use
             "tags": ["govuk_notify_support"],
             "type": "task",
             "custom_fields": [
-                {"id": "1900000744994", "value": "notify_ticket_type_non_technical"},
                 {"id": "360022836500", "value": ["notify_no_ticket_category"]},
                 {"id": "360022943959", "value": None},
                 {"id": "360022943979", "value": None},
                 {"id": "1900000745014", "value": None},
+                {"id": "1900000744994", "value": "notify_ticket_type_non_technical"},
             ],
         }
     }
@@ -1044,7 +1045,7 @@ def test_check_for_low_available_inbound_sms_numbers_logs_zendesk_ticket_if_too_
                 "https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#Add-new-inbound-SMS-numbers"
             ),
             ticket_type=mock_ticket.TYPE_TASK,
-            technical_ticket=True,
+            notify_ticket_type=NotifyTicketType.TECHNICAL,
             ticket_categories=["notify_no_ticket_category"],
         )
     ]


### PR DESCRIPTION
 # 63.0.0

* Remove the `technical_ticket` parameter from NotifySupportTicket; replace with an optional `notify_ticket_type` that takes a NotifyTicketType enum value. If provided, this will maintain the existing behaviour where tickets are tagged as technical/non-technical on creation. If omitted, then tickets will have no ticket type, which may help us have a clearer process around triaging tickets.

 ## 62.4.0

* Add `class="page--first"` and `class="page--last"` to the first and last pages (respectively) of letters rendered with `LetterImageTemplate`

 ## 62.3.1

* Change `logger.exception` to `logger.warning` for log formatting error.

 ## 62.3.0

* Adds support for Chinese character sets in letters ***

Complete changes: https://github.com/alphagov/notifications-utils/compare/62.3.1...63.0.0