### PR TITLE
Remove use of `select *` in a query

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -321,7 +321,10 @@ def insert_notification_history_delete_notifications(
     # Insert into NotificationHistory if the row already exists do nothing.
     insert_query = """
         insert into notification_history
-         SELECT * from NOTIFICATION_ARCHIVE
+         SELECT id, job_id, job_row_number, service_id, template_id, template_version, api_key_id,
+             key_type, notification_type, created_at, sent_at, sent_by, updated_at, reference, billable_units,
+             client_reference, international, phone_prefix, rate_multiplier, notification_status,
+              created_by_id, postage, document_download_count from NOTIFICATION_ARCHIVE
           ON CONFLICT ON CONSTRAINT notification_history_pkey
           DO NOTHING
     """


### PR DESCRIPTION
This is done for two reasons.

Firstly, it is bad practice to use `select *`, backed up by https://stackoverflow.com/questions/321299/what-is-the-reason-not-to-use-select

Secondly, we've got a new database in our staging environment that has the same columns in the notifications table, but the order of the columns is slightly different. `select *` returns data in the default order and this order is different between the `notifications` and `notifications_history` tables meaning that this query currently errors. This column ordering difference was introduced in:
https://github.com/alphagov/notifications-aws/blob/main/scripts/remove-all-sensitive-and-personal-data/remove-all-sensitive-and-personal-data-part-2.sql