### PR TITLE
Record letter despatch dates

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1,4 +1,3 @@
-import enum
 import json
 from collections import defaultdict
 from dataclasses import dataclass
@@ -53,7 +52,7 @@ from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
 from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id
 from app.dao.templates_dao import dao_get_template_by_id
 from app.exceptions import DVLAException, NotificationTechnicalFailureException
-from app.models import DailySortedLetter
+from app.models import DailySortedLetter, LetterCostThreshold
 from app.notifications.process_notifications import persist_notification
 from app.notifications.validators import check_service_over_daily_message_limit
 from app.serialised_models import SerialisedService, SerialisedTemplate
@@ -489,11 +488,6 @@ def persist_daily_sorted_letter_counts(day, file_name, sorted_letter_counts):
         sorted_count=sorted_letter_counts["sorted"],
     )
     dao_create_or_update_daily_sorted_letter(daily_letter_count)
-
-
-class LetterCostThreshold(enum.Enum):
-    sorted = "sorted"
-    unsorted = "unsorted"
 
 
 @dataclass

--- a/app/models.py
+++ b/app/models.py
@@ -1642,6 +1642,7 @@ class NotificationLetterDespatch(db.Model):
     notification = db.relationship(
         "NotificationAllTimeView",
         primaryjoin="NotificationLetterDespatch.notification_id == foreign(NotificationAllTimeView.id)",
+        uselist=False,
     )
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,5 @@
 import datetime
+import enum
 import itertools
 import uuid
 
@@ -1618,6 +1619,30 @@ class NotificationHistory(db.Model, HistoryModel):
     def update_from_original(self, original):
         super().update_from_original(original)
         self.status = original.status
+
+
+class LetterCostThreshold(enum.Enum):
+    sorted = "sorted"
+    unsorted = "unsorted"
+
+
+class NotificationLetterDespatch(db.Model):
+    __tablename__ = "notifications_letter_despatch"
+
+    notification_id = db.Column(UUID(as_uuid=True), primary_key=True)
+    despatched_on = db.Column(db.Date, index=True)
+    cost_threshold = db.Column(
+        db.Enum(LetterCostThreshold, name="letter_despatch_cost_threshold"), nullable=False, index=True
+    )
+
+    # WIP:
+    # Ignoring a strict foreign key relationship here for now. Notifications are archived to the NotificationHistory
+    # table by a nightly job and I haven't investigated whether that might break a strict FK yet or if it would
+    # work smoothly. We can still have a relationship using an explicit join condition.
+    notification = db.relationship(
+        "NotificationAllTimeView",
+        primaryjoin="NotificationLetterDespatch.notification_id == foreign(NotificationAllTimeView.id)",
+    )
 
 
 class InviteStatusType(db.Model):

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0411_contact_list_idx
+0412_letter_despatch

--- a/migrations/versions/0412_letter_despatch.py
+++ b/migrations/versions/0412_letter_despatch.py
@@ -1,0 +1,44 @@
+"""
+
+Revision ID: 0412_letter_despatch
+Revises: 0411_contact_list_idx
+Create Date: 2023-05-22 15:41:45.251681
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0412_letter_despatch"
+down_revision = "0411_contact_list_idx"
+
+
+def upgrade():
+    op.create_table(
+        "notifications_letter_despatch",
+        sa.Column("notification_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("despatched_on", sa.Date(), nullable=True),
+        sa.Column(
+            "cost_threshold", sa.Enum("sorted", "unsorted", name="letter_despatch_cost_threshold"), nullable=False
+        ),
+        sa.PrimaryKeyConstraint("notification_id"),
+    )
+    op.create_index(
+        op.f("ix_notifications_letter_despatch_cost_threshold"),
+        "notifications_letter_despatch",
+        ["cost_threshold"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_notifications_letter_despatch_despatched_on"),
+        "notifications_letter_despatch",
+        ["despatched_on"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_notifications_letter_despatch_despatched_on"), table_name="notifications_letter_despatch")
+    op.drop_index(op.f("ix_notifications_letter_despatch_cost_threshold"), table_name="notifications_letter_despatch")
+    op.drop_table("notifications_letter_despatch")
+    sa.Enum(name="letter_despatch_cost_threshold").drop(op.get_bind(), checkfirst=False)

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -102,7 +102,7 @@ def test_update_letter_notifications_statuses_calls_with_correct_bucket_location
 
 
 def test_update_letter_notifications_statuses_builds_updates_from_content(notify_api, mocker):
-    valid_file = "ref-foo|Sent|1|Unsorted|23-02-2023\nref-bar|Sent|2|Sorted|22-02-2023"
+    valid_file = "ref-foo|Sent|1|Unsorted|2023-02-23\nref-bar|Sent|2|Sorted|2023-02-22"
     mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=valid_file)
     update_mock = mocker.patch("app.celery.tasks.process_updates_from_file", wraps=process_updates_from_file)
     mocker.patch("app.celery.tasks.check_billable_units")
@@ -114,7 +114,7 @@ def test_update_letter_notifications_statuses_builds_updates_from_content(notify
 
 
 def test_update_letter_notifications_statuses_builds_updates_list(notify_api):
-    valid_file = "ref-foo|Sent|1|Unsorted|23-02-2023\nref-bar|Sent|2|Sorted|22-02-2023"
+    valid_file = "ref-foo|Sent|1|Unsorted|2023-02-23\nref-bar|Sent|2|Sorted|2023-02-22"
     updates, invalid_statuses = process_updates_from_file(valid_file)
 
     assert len(updates) == 2
@@ -123,13 +123,13 @@ def test_update_letter_notifications_statuses_builds_updates_list(notify_api):
     assert updates[0].status == "Sent"
     assert updates[0].page_count == "1"
     assert updates[0].cost_threshold == LetterCostThreshold.unsorted
-    assert updates[0].despatch_date == "23-02-2023"
+    assert updates[0].despatch_date == "2023-02-23"
 
     assert updates[1].reference == "ref-bar"
     assert updates[1].status == "Sent"
     assert updates[1].page_count == "2"
     assert updates[1].cost_threshold == LetterCostThreshold.sorted
-    assert updates[1].despatch_date == "22-02-2023"
+    assert updates[1].despatch_date == "2023-02-22"
 
 
 def test_update_letter_notifications_statuses_persisted(notify_api, mocker, sample_letter_template):
@@ -141,7 +141,7 @@ def test_update_letter_notifications_statuses_persisted(notify_api, mocker, samp
     )
     create_service_callback_api(service=sample_letter_template.service, url="https://original_url.com")
     valid_file = (
-        f"{sent_letter.reference}|Sent|1|Unsorted|23-02-2023\n{failed_letter.reference}|Failed|2|Sorted|23-02-2023"
+        f"{sent_letter.reference}|Sent|1|Unsorted|2023-02-23\n{failed_letter.reference}|Failed|2|Sorted|2023-02-23"
     )
     mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=valid_file)
     with pytest.raises(expected_exception=DVLAException) as e:

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -26,7 +26,7 @@ from app.dao.daily_sorted_letter_dao import (
     dao_get_daily_sorted_letter_by_billing_day,
 )
 from app.exceptions import DVLAException, NotificationTechnicalFailureException
-from app.models import DailySortedLetter, LetterCostThreshold, NotificationHistory
+from app.models import DailySortedLetter, LetterCostThreshold, NotificationHistory, NotificationLetterDespatch
 from tests.app.db import (
     create_notification,
     create_notification_history,
@@ -41,7 +41,8 @@ def notification_update():
     Returns an instance of the  NotificationUpdate dataclass to use as the argument
     for the check_billable_units function
     """
-    from app.celery.tasks import LetterCostThreshold, NotificationUpdate
+    from app.celery.tasks import NotificationUpdate
+    from app.models import LetterCostThreshold
 
     return NotificationUpdate("REFERENCE_ABC", "sent", "1", LetterCostThreshold("sorted"), "2023-03-07")
 
@@ -78,6 +79,23 @@ def test_update_letter_notification_statuses_when_notification_does_not_exist_up
     assert updated_history.status == NOTIFICATION_DELIVERED
 
 
+def test_update_letter_notification_statuses_when_notification_does_not_exist_creates_letter_despatch_record(
+    sample_letter_template, mocker
+):
+    valid_file = "ref-foo|Sent|1|Unsorted|2023-01-12"
+    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=valid_file)
+    notification = create_notification_history(
+        sample_letter_template, reference="ref-foo", status=NOTIFICATION_SENDING, billable_units=1
+    )
+
+    update_letter_notifications_statuses(filename="NOTIFY-20170823160812-RSP.TXT")
+
+    letter_despatch = NotificationLetterDespatch.query.first()
+    assert letter_despatch.notification_id == notification.id
+    assert letter_despatch.despatched_on == date(2023, 1, 12)
+    assert letter_despatch.cost_threshold == LetterCostThreshold.unsorted
+
+
 def test_update_letter_notifications_statuses_raises_dvla_exception(notify_api, mocker, sample_letter_template):
     valid_file = "ref-foo|Failed|1|Unsorted|2023-01-12"
     mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=valid_file)
@@ -111,6 +129,29 @@ def test_update_letter_notifications_statuses_builds_updates_from_content(notify
     update_letter_notifications_statuses(filename="NOTIFY-20170823160812-RSP.TXT")
 
     update_mock.assert_called_with(valid_file)
+
+
+def test_update_letter_notifications_statuses_creates_letter_despatch_record(
+    notify_api, mocker, sample_letter_template
+):
+    valid_file = "ref-foo|Sent|1|Unsorted|2023-02-23\nref-bar|Sent|2|Sorted|2023-02-22"
+    mocker.patch("app.celery.tasks.s3.get_s3_file", return_value=valid_file)
+    notification_bar = create_notification(
+        sample_letter_template, reference="ref-bar", status=NOTIFICATION_SENDING, billable_units=1
+    )
+    notification_foo = create_notification(
+        sample_letter_template, reference="ref-foo", status=NOTIFICATION_SENDING, billable_units=1
+    )
+
+    update_letter_notifications_statuses(filename="NOTIFY-20170823160812-RSP.TXT")
+
+    letter_despatches = NotificationLetterDespatch.query.all()
+    assert letter_despatches[0].notification_id == notification_foo.id
+    assert letter_despatches[0].despatched_on == date(2023, 2, 23)
+    assert letter_despatches[0].cost_threshold == LetterCostThreshold.unsorted
+    assert letter_despatches[1].notification_id == notification_bar.id
+    assert letter_despatches[1].despatched_on == date(2023, 2, 22)
+    assert letter_despatches[1].cost_threshold == LetterCostThreshold.sorted
 
 
 def test_update_letter_notifications_statuses_builds_updates_list(notify_api):

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -6,7 +6,6 @@ from flask import current_app
 from freezegun import freeze_time
 
 from app.celery.tasks import (
-    LetterCostThreshold,
     check_billable_units,
     get_billing_date_in_bst_from_filename,
     persist_daily_sorted_letter_counts,
@@ -27,7 +26,7 @@ from app.dao.daily_sorted_letter_dao import (
     dao_get_daily_sorted_letter_by_billing_day,
 )
 from app.exceptions import DVLAException, NotificationTechnicalFailureException
-from app.models import DailySortedLetter, NotificationHistory
+from app.models import DailySortedLetter, LetterCostThreshold, NotificationHistory
 from tests.app.db import (
     create_notification,
     create_notification_history,


### PR DESCRIPTION
Adds a new table `NotificationLetterDespatch` that records when we receive confirmation that a letter has been despatched. In the future we will use this to issue billing reports to our print provider.

There are a few refactors in here so best to go commit-by-commit.

There is one WIP/fixme/todo comment that I'm open for thoughts on but also may leave to address separately. For now the implementation is technically fine but if we can tighten up the FK safely then that's also great.