### PR TITLE
Add app name tag for Sentry

### DIFF
--- a/app/performance.py
+++ b/app/performance.py
@@ -43,3 +43,6 @@ def init_performance_monitoring():
             traces_sampler=traces_sampler,
             release=release,
         )
+
+        if app_name := os.getenv("NOTIFY_APP_NAME"):
+            sentry_sdk.set_tag("app", app_name)


### PR DESCRIPTION
This app can be deployed in a number of different configurations, eg the API itself or one of the celery workers.

Let's add a tag that will make it more apparent which configuration the error has been raised from.