### PR TITLE
handle KeyError 'checkout_at' in db telemetry

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -421,6 +421,10 @@ def setup_sqlalchemy_events(app):
 
         @event.listens_for(db.engine, "checkin")
         def checkin(dbapi_connection, connection_record):
+            if "checkout_at" not in connection_record.info or "request_data" not in connection_record.info:
+                # we can get in this inconsistent state if the database is shutting down
+                return
+
             try:
                 # connection returned by a web worker
                 TOTAL_CHECKED_OUT_DB_CONNECTIONS.dec()


### PR DESCRIPTION
when the db goes down (for example during maintenance hours), the connection being checked in (ie: closed) might not have all the variables that we use to measure connection count, duration etc. make sure we don't log another exception in this case (we'll already get an OperationalError from the db connection being closed itself)