### PR TITLE
Remove priority queue and delivery-worker-priority

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -15,7 +15,6 @@ if os.environ.get("VCAP_SERVICES"):
 
 class QueueNames(object):
     PERIODIC = "periodic-tasks"
-    PRIORITY = "priority-tasks"
     DATABASE = "database-tasks"
     SEND_SMS = "send-sms-tasks"
     SEND_EMAIL = "send-email-tasks"
@@ -41,7 +40,6 @@ class QueueNames(object):
     @staticmethod
     def all_queues():
         return [
-            QueueNames.PRIORITY,
             QueueNames.PERIODIC,
             QueueNames.DATABASE,
             QueueNames.SEND_SMS,

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,10 +60,6 @@ elif [ "$1" == "delivery-worker-reporting" ]
 then
   $COMMON_CMD reporting-tasks
 
-elif [ "$1" == "delivery-worker-priority" ]
-then
-  $COMMON_CMD priority-tasks
-
 # Only consume the notify-internal-tasks queue on this app so that Notify messages are processed as a priority
 elif [ "$1" == "delivery-worker-internal" ]
 then

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -60,7 +60,6 @@
       'CELERYD_PREFETCH_MULTIPLIER': 1,
     }
   },
-  'notify-delivery-worker-priority': {},
   'notify-delivery-worker-letters': {'memory': '2G'},
   'notify-delivery-worker-retry-tasks': {},
   'notify-delivery-worker-internal': {},

--- a/scripts/paas_app_wrapper.sh
+++ b/scripts/paas_app_wrapper.sh
@@ -36,10 +36,6 @@ case $NOTIFY_APP_NAME in
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \
     -Q reporting-tasks 2> /dev/null
     ;;
-  delivery-worker-priority)
-    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \
-    -Q priority-tasks 2> /dev/null
-    ;;
   # Only consume the notify-internal-tasks queue on this app so that Notify messages are processed as a priority
   delivery-worker-internal)
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -61,10 +61,9 @@ def test_load_config_if_cloudfoundry_not_available(reload_config):
 def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()
-    assert len(queues) == 19
+    assert len(queues) == 18
     assert set(
         [
-            QueueNames.PRIORITY,
             QueueNames.PERIODIC,
             QueueNames.DATABASE,
             QueueNames.SEND_SMS,


### PR DESCRIPTION
We stopped putting tasks on the priority queue in
https://github.com/alphagov/notifications-api/pull/3711

Now we can remove the final references to this queue and the app which we will stop deploying and then delete.