### PR TITLE
Explicitly list columns for notification migration

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -346,7 +346,7 @@ def insert_notification_history_delete_notifications(
         """
     # Insert into NotificationHistory if the row already exists do nothing.
     insert_query = f"""
-        insert into notification_history
+        insert into notification_history ({fields_to_transfer_to_notification_history})
          SELECT {fields_to_transfer_to_notification_history} from NOTIFICATION_ARCHIVE
           ON CONFLICT ON CONSTRAINT notification_history_pkey
           DO NOTHING


### PR DESCRIPTION
And add a test to validate this works correctly.

In staging the `notifications_history` table may have columns in a different order because of how we migrate+anonymise the table from production. Our nightly process that moves notifications from the live table to the history table still expects those columns to be in the same order; this patch explicitly lists the columns to insert into