### PR TITLE
Letter despatch billing facts

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1869,6 +1869,25 @@ class DailySortedLetter(db.Model):
     __table_args__ = (UniqueConstraint("file_name", "billing_day", name="uix_file_name_billing_day"),)
 
 
+class FactBillingLetterDespatch(db.Model):
+    __tablename__ = "ft_billing_letter_despatch"
+
+    bst_date = db.Column(db.Date, nullable=False, primary_key=True)
+    postage = db.Column(db.String, nullable=False, primary_key=True)
+    cost_threshold = db.Column(
+        # Reuse enum from NotificationLetterDespatch as the values are intrinsically linked
+        db.Enum(LetterCostThreshold, name="letter_despatch_cost_threshold"),
+        nullable=False,
+        index=True,
+        primary_key=True,
+    )
+    rate = db.Column(db.Numeric(), nullable=False, primary_key=True)
+    billable_units = db.Column(db.Integer(), nullable=True, primary_key=True)
+    notifications_sent = db.Column(db.Integer(), nullable=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+
+
 class FactBilling(db.Model):
     __tablename__ = "ft_billing"
 

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0412_letter_despatch
+0413_ft_billing_letter_despatch

--- a/migrations/versions/0413_ft_billing_letter_despatch.py
+++ b/migrations/versions/0413_ft_billing_letter_despatch.py
@@ -1,0 +1,34 @@
+"""
+
+Revision ID: 0413_ft_billing_letter_despatch
+Revises: 0412_letter_despatch
+Create Date: 2023-05-24 08:42:11.354797
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0413_ft_billing_letter_despatch"
+down_revision = "0412_letter_despatch"
+
+
+def upgrade():
+    op.create_table(
+        "ft_billing_letter_despatch",
+        sa.Column("bst_date", sa.Date(), nullable=False),
+        sa.Column("postage", sa.String(), nullable=False),
+        sa.Column(
+            "cost_threshold", postgresql.ENUM(name="letter_despatch_cost_threshold", create_type=False), nullable=False
+        ),
+        sa.Column("rate", sa.Numeric(), nullable=False),
+        sa.Column("billable_units", sa.Integer(), nullable=True),
+        sa.Column("notifications_sent", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("bst_date", "postage", "rate", "billable_units", "cost_threshold"),
+    )
+
+
+def downgrade():
+    op.drop_table("ft_billing_letter_despatch")

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -128,7 +128,7 @@ def test_update_letter_notifications_statuses_builds_updates_from_content(notify
 
     update_letter_notifications_statuses(filename="NOTIFY-20170823160812-RSP.TXT")
 
-    update_mock.assert_called_with(valid_file)
+    update_mock.assert_called_with(valid_file, filename="NOTIFY-20170823160812-RSP.TXT")
 
 
 def test_update_letter_notifications_statuses_creates_letter_despatch_record(
@@ -156,7 +156,7 @@ def test_update_letter_notifications_statuses_creates_letter_despatch_record(
 
 def test_update_letter_notifications_statuses_builds_updates_list(notify_api):
     valid_file = "ref-foo|Sent|1|Unsorted|2023-02-23\nref-bar|Sent|2|Sorted|2023-02-22"
-    updates, invalid_statuses = process_updates_from_file(valid_file)
+    updates = process_updates_from_file(valid_file, filename="file.txt")
 
     assert len(updates) == 2
 

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -53,12 +53,16 @@ def mocker_get_rate(
     ],
 )
 def test_create_nightly_billing_triggers_tasks_for_days(notify_api, mocker, day_start, expected_kwargs):
-    mock_celery = mocker.patch("app.celery.reporting_tasks.create_or_update_ft_billing_for_day")
+    mock_ft_billing = mocker.patch("app.celery.reporting_tasks.create_or_update_ft_billing_for_day")
+    mock_ft_billing_letter_despatch = mocker.patch(
+        "app.celery.reporting_tasks.create_or_update_ft_billing_letter_despatch_for_day"
+    )
     create_nightly_billing(day_start)
 
-    assert mock_celery.apply_async.call_count == 10
-    for i in range(10):
-        assert mock_celery.apply_async.call_args_list[i][1]["kwargs"] == {"process_day": expected_kwargs[i]}
+    for mock in [mock_ft_billing, mock_ft_billing_letter_despatch]:
+        assert mock.apply_async.call_count == 10
+        for i in range(10):
+            assert mock.apply_async.call_args_list[i][1]["kwargs"] == {"process_day": expected_kwargs[i]}
 
 
 @freeze_time("2019-08-01T00:30")


### PR DESCRIPTION
Add a fact table for billing letters based on despatch date, which we started recording in https://github.com/alphagov/notifications-api/pull/3807. This will run as part of the nightly billing job in a separate celery task.

We then expose the new billing facts on an admin endpoint so that platform admins can download the report via the admin interface (https://github.com/alphagov/notifications-admin/pull/4734).