### PR TITLE
Bump utils to 63.4.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.4.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -163,7 +163,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.4.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
Bump utils so that the API can properly send emails with subheadings.

<details><summary>Utils changelog entries</summary>
<p>

 ## 63.4.0

* Allow subheadings via markdown for emails using `##`.

 ## 63.3.0

* Only log a warning and no longer raise an error if creating a Zendesk ticket fails because the user is suspended.

 ## 63.2.0

* `LetterImageTemplate.page_count` is now a property which can be overriden by subclasses
* New attributes and properties on `BaseLetterTemplate` (and its subclasses):
  - `max_page_count`
  - `max_sheet_count`
  - `too_many_pages` (requires subclasses to implement `page_count`)

 ## 63.1.0

* argument `image_url` to `LetterImageTemplate` is now optional unless calling `str(LetterImageTemplate(…))`

</p>
</details> 

<img width="738" alt="image" src="https://github.com/alphagov/notifications-api/assets/2920760/8382a52f-0e3b-4a91-a11d-c0c622274326">
