### PR TITLE
Bump utils to 64.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.4.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@64.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -163,7 +163,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.4.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@64.1.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -284,11 +284,11 @@ def test_should_cache_template_and_service_in_redis(mocker, api_client_request, 
 
     assert service_call[0][0] == expected_service_key
     assert json.loads(service_call[0][1]) == {"data": service_dict}
-    assert service_call[1]["ex"] == 604_800
+    assert service_call[1]["ex"] == 2_419_200
 
     assert templates_call[0][0] == expected_templates_key
     assert json.loads(templates_call[0][1]) == {"data": template_dict}
-    assert templates_call[1]["ex"] == 604_800
+    assert templates_call[1]["ex"] == 2_419_200
 
 
 def test_should_return_template_if_found_in_redis(mocker, api_client_request, sample_template):


### PR DESCRIPTION
64.1.0
---

* `RequestCache` now stores items in Redis for 28 days by default (2419200 seconds instead of 7 days or 604800 seconds)

64.0.0
---

_These changes don’t affect the API application._

* Remove the `postage` argument from `LetterImageTemplate` in favour of getting `postage` from the `template` `dict` (can still be overridden by setting `template_instance.postage`)
* The `page_count` argument of `LetterImageTemplate` is now optional until the template is rendered (calling `str(template)`)

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/63.4.0...64.1.0