### PR TITLE
always return is_precompiled_letter

### DIFF
--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -339,7 +339,6 @@ def test_must_have_a_subject_on_an_email_or_letter_template(client, sample_user,
 
 
 def test_update_should_update_a_template(client, sample_user):
-
     service = create_service(service_permissions=[LETTER_TYPE])
     template = create_template(service, template_type="letter", postage="second")
 
@@ -431,6 +430,7 @@ def test_get_precompiled_template_for_service(
     data = json.loads(response.get_data(as_text=True))
     assert data["name"] == "Pre-compiled PDF"
     assert data["hidden"] is True
+    assert data["is_precompiled_letter"] is True
 
 
 def test_get_precompiled_template_for_service_when_service_has_existing_precompiled_template(
@@ -542,6 +542,7 @@ def test_should_get_return_all_fields_by_default(
         "folder",
         "hidden",
         "id",
+        "is_precompiled_letter",
         "letter_attachment",
         "name",
         "postage",
@@ -594,6 +595,7 @@ def test_should_not_return_content_and_subject_if_requested(
         "content",
         "folder",
         "id",
+        "is_precompiled_letter",
         "name",
         "template_type",
     }
@@ -630,7 +632,6 @@ def test_should_get_a_single_template(client, sample_user, sample_service, subje
     [("template.get_template_by_id_and_service_id", {}), ("template.get_template_version", {"version": 2})],
 )
 def test_get_template_returns_letter_attachment(admin_request, sample_letter_template, endpoint, extra_args):
-
     attachment = create_letter_attachment(created_by_id=sample_letter_template.created_by_id)
     sample_letter_template.letter_attachment_id = attachment.id
     dao_update_template(sample_letter_template)
@@ -702,7 +703,6 @@ def test_should_preview_a_single_template(
 
 
 def test_should_return_empty_array_if_no_templates_for_service(client, sample_service):
-
     auth_header = create_admin_authorization_header()
 
     response = client.get("/service/{}/template".format(sample_service.id), headers=[auth_header])
@@ -713,7 +713,6 @@ def test_should_return_empty_array_if_no_templates_for_service(client, sample_se
 
 
 def test_should_return_404_if_no_templates_for_service_with_id(client, sample_service, fake_uuid):
-
     auth_header = create_admin_authorization_header()
 
     response = client.get("/service/{}/template/{}".format(sample_service.id, fake_uuid), headers=[auth_header])
@@ -811,7 +810,6 @@ def test_should_return_all_template_versions_for_service_and_template_id(client,
 
 
 def test_update_does_not_create_new_version_when_there_is_no_change(client, sample_template):
-
     auth_header = create_admin_authorization_header()
     data = {
         "template_type": sample_template.template_type,
@@ -1119,7 +1117,6 @@ def test_update_redact_template_400s_if_no_created_by(admin_request, sample_temp
 
 
 def test_preview_letter_template_by_id_invalid_file_type(sample_letter_notification, admin_request):
-
     resp = admin_request.get(
         "template.preview_letter_template_by_notification_id",
         service_id=sample_letter_notification.service_id,
@@ -1227,7 +1224,6 @@ def test_preview_letter_template_by_id_shows_template_version_used_by_notificati
 def test_preview_letter_template_by_id_template_preview_500(
     notify_api, client, admin_request, sample_letter_notification
 ):
-
     with set_config_values(
         notify_api,
         {
@@ -1261,7 +1257,6 @@ def test_preview_letter_template_by_id_template_preview_500(
 
 
 def test_preview_letter_template_precompiled_pdf_file_type(notify_api, client, admin_request, sample_service, mocker):
-
     template = create_template(
         sample_service,
         template_type="letter",
@@ -1280,7 +1275,6 @@ def test_preview_letter_template_precompiled_pdf_file_type(notify_api, client, a
         },
     ):
         with requests_mock.Mocker():
-
             content = b"\x00\x01"
 
             mock_get_letter_pdf = mocker.patch(
@@ -1300,7 +1294,6 @@ def test_preview_letter_template_precompiled_pdf_file_type(notify_api, client, a
 
 
 def test_preview_letter_template_precompiled_s3_error(notify_api, client, admin_request, sample_service, mocker):
-
     template = create_template(
         sample_service,
         template_type="letter",
@@ -1319,7 +1312,6 @@ def test_preview_letter_template_precompiled_s3_error(notify_api, client, admin_
         },
     ):
         with requests_mock.Mocker():
-
             mocker.patch(
                 "app.template.rest.get_letter_pdf_and_metadata",
                 side_effect=botocore.exceptions.ClientError(
@@ -1369,7 +1361,6 @@ def test_preview_letter_template_precompiled_for_png_shows_overlay_on_pages_with
     message,
     expected_post_url,
 ):
-
     template = create_template(
         sample_service,
         template_type="letter",
@@ -1388,7 +1379,6 @@ def test_preview_letter_template_precompiled_for_png_shows_overlay_on_pages_with
         },
     ):
         with requests_mock.Mocker() as request_mock:
-
             pdf_content = b"\x00\x01"
             expected_returned_content = b"\x00\x02"
 
@@ -1437,7 +1427,6 @@ def test_preview_letter_template_precompiled_for_pdf_shows_overlay_on_all_pages_
     mocker,
     invalid_pages,
 ):
-
     template = create_template(
         sample_service,
         template_type="letter",
@@ -1456,7 +1445,6 @@ def test_preview_letter_template_precompiled_for_pdf_shows_overlay_on_all_pages_
         },
     ):
         with requests_mock.Mocker() as request_mock:
-
             pdf_content = b"\x00\x01"
             expected_returned_content = b"\x00\x02"
 
@@ -1500,7 +1488,6 @@ def test_preview_letter_template_precompiled_for_pdf_shows_overlay_on_all_pages_
 def test_preview_letter_template_precompiled_png_file_type_hide_notify_tag_only_on_first_page(
     notify_api, client, admin_request, sample_service, mocker, page_number, expect_preview_url
 ):
-
     template = create_template(
         sample_service,
         template_type="letter",
@@ -1543,7 +1530,6 @@ def test_preview_letter_template_precompiled_png_file_type_hide_notify_tag_only_
 def test_preview_letter_template_precompiled_png_template_preview_500_error(
     notify_api, client, admin_request, sample_service, mocker
 ):
-
     template = create_template(
         sample_service,
         template_type="letter",
@@ -1562,7 +1548,6 @@ def test_preview_letter_template_precompiled_png_template_preview_500_error(
         },
     ):
         with requests_mock.Mocker() as request_mock:
-
             pdf_content = b"\x00\x01"
             png_content = b"\x00\x02"
 
@@ -1595,7 +1580,6 @@ def test_preview_letter_template_precompiled_png_template_preview_500_error(
 def test_preview_letter_template_precompiled_png_template_preview_400_error(
     notify_api, client, admin_request, sample_service, mocker
 ):
-
     template = create_template(
         sample_service,
         template_type="letter",
@@ -1614,7 +1598,6 @@ def test_preview_letter_template_precompiled_png_template_preview_400_error(
         },
     ):
         with requests_mock.Mocker() as request_mock:
-
             pdf_content = b"\x00\x01"
             png_content = b"\x00\x02"
 
@@ -1647,7 +1630,6 @@ def test_preview_letter_template_precompiled_png_template_preview_400_error(
 def test_preview_letter_template_precompiled_png_template_preview_pdf_error(
     notify_api, client, admin_request, sample_service, mocker
 ):
-
     template = create_template(
         sample_service,
         template_type="letter",
@@ -1666,7 +1648,6 @@ def test_preview_letter_template_precompiled_png_template_preview_pdf_error(
         },
     ):
         with requests_mock.Mocker() as request_mock:
-
             pdf_content = b"\x00\x01"
             png_content = b"\x00\x02"
 


### PR DESCRIPTION
previously this was only returned for the nested template object within the GET /notification endpoints - however, we also want it in other places, including notibly `/template/precompiled` that returns a service's magic precompiled template. This fixes a bug where we used the wrong type of utils LetterTemplate class, and only showed the first page of precompiled letters when previewing them