### PR TITLE
Org user permissions

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -1,4 +1,5 @@
 # Notification status values
+import enum
 
 NOTIFICATION_CANCELLED = "cancelled"
 NOTIFICATION_CREATED = "created"
@@ -210,10 +211,18 @@ PERMISSION_LIST = [
     CANCEL_BROADCASTS,
     REJECT_BROADCASTS,
 ]
+
+
 CAN_ASK_TO_JOIN_SERVICE = "can_ask_to_join_a_service"
 ORGANISATION_PERMISSION_TYPES = [
     CAN_ASK_TO_JOIN_SERVICE,
 ]
+
+
+# Organisation user permissions
+class OrganisationUserPermissionTypes(enum.Enum):
+    can_make_services_live = "can_make_services_live"
+
 
 # Prioritisation for template processing
 # PRIORITY queue is now archived and should be ripe for cleanup.

--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -3,7 +3,7 @@ from sqlalchemy import and_
 from sqlalchemy.sql.expression import func
 
 from app import db
-from app.constants import NHS_ORGANISATION_TYPES
+from app.constants import NHS_ORGANISATION_TYPES, OrganisationUserPermissionTypes
 from app.dao.dao_utils import VersionOptions, autocommit, version_class
 from app.dao.email_branding_dao import dao_get_email_branding_by_id
 from app.dao.letter_branding_dao import dao_get_letter_branding_by_id
@@ -14,7 +14,6 @@ from app.models import (
     EmailBranding,
     Organisation,
     OrganisationUserPermissions,
-    OrganisationUserPermissionTypes,
     Service,
     User,
 )

--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -7,11 +7,14 @@ from app.constants import NHS_ORGANISATION_TYPES
 from app.dao.dao_utils import VersionOptions, autocommit, version_class
 from app.dao.email_branding_dao import dao_get_email_branding_by_id
 from app.dao.letter_branding_dao import dao_get_letter_branding_by_id
+from app.dao.organisation_user_permissions_dao import organisation_user_permissions_dao
 from app.models import (
     AnnualBilling,
     Domain,
     EmailBranding,
     Organisation,
+    OrganisationUserPermissions,
+    OrganisationUserPermissionTypes,
     Service,
     User,
 )
@@ -200,6 +203,17 @@ def dao_add_user_to_organisation(organisation_id, user_id):
     organisation = dao_get_organisation_by_id(organisation_id)
     user = User.query.filter_by(id=user_id).one()
     user.organisations.append(organisation)
+
+    # temporary: to remove after admin can set permission
+    new_permissions = [
+        OrganisationUserPermissions(
+            user=user,
+            organisation=organisation,
+            permission=OrganisationUserPermissionTypes.can_make_services_live.value,
+        )
+    ]
+    organisation_user_permissions_dao.set_user_organisation_permission(user, organisation, new_permissions)
+
     db.session.add(organisation)
     return user
 
@@ -207,6 +221,7 @@ def dao_add_user_to_organisation(organisation_id, user_id):
 @autocommit
 def dao_remove_user_from_organisation(organisation, user):
     organisation.users.remove(user)
+    organisation_user_permissions_dao.remove_user_organisation_permissions(user, organisation)
 
 
 @autocommit

--- a/app/dao/organisation_user_permissions_dao.py
+++ b/app/dao/organisation_user_permissions_dao.py
@@ -1,0 +1,57 @@
+from app import db
+from app.dao import DAOClass
+from app.models import Organisation, OrganisationUserPermissions, User
+
+
+class OrganisationUserPermissionsDao(DAOClass):
+    class Meta:
+        model = OrganisationUserPermissions
+
+    def remove_user_organisation_permissions(self, user: User, organisation: Organisation):
+        query = self.Meta.model.query.filter_by(user=user, organisation=organisation)
+        query.delete()
+
+    def set_user_organisation_permission(
+        self,
+        user: User,
+        organisation: Organisation,
+        permissions: list[OrganisationUserPermissions],
+        _commit=False,
+        replace=False,
+    ):
+        try:
+            if replace:
+                query = self.Meta.model.query.filter_by(user=user, organisation=organisation)
+                query.delete()
+            for p in permissions:
+                p.user = user
+                p.organisation = organisation
+                self.create_instance(p, _commit=False)
+        except Exception as e:
+            if _commit:
+                db.session.rollback()
+            raise e
+        else:
+            if _commit:
+                db.session.commit()
+
+    def get_permissions_by_user_id(self, user_id):
+        return (
+            self.Meta.model.query.filter_by(user_id=user_id)
+            .join(OrganisationUserPermissions.organisation)
+            .filter(Organisation.active.is_(True))
+            .order_by(OrganisationUserPermissions.permission)
+            .all()
+        )
+
+    def get_permissions_by_user_id_and_organisation_id(self, user_id, organisation_id):
+        return (
+            self.Meta.model.query.filter_by(user_id=user_id)
+            .join(OrganisationUserPermissions.organisation)
+            .filter(Organisation.active.is_(True), Organisation.id == organisation_id)
+            .order_by(OrganisationUserPermissions.permission)
+            .all()
+        )
+
+
+organisation_user_permissions_dao = OrganisationUserPermissionsDao()

--- a/app/models.py
+++ b/app/models.py
@@ -68,6 +68,7 @@ from app.constants import (
     SMS_TYPE,
     TEMPLATE_TYPES,
     VERIFY_CODE_TYPES,
+    OrganisationUserPermissionTypes,
 )
 from app.hashing import check_hash, hashpw
 from app.history_meta import Versioned
@@ -360,10 +361,6 @@ class OrganisationPermission(db.Model):
         unique=False,
         nullable=False,
     )
-
-
-class OrganisationUserPermissionTypes(enum.Enum):
-    can_make_services_live = "can_make_services_live"
 
 
 class OrganisationUserPermissions(db.Model):
@@ -1719,6 +1716,11 @@ class InvitedOrganisationUser(db.Model):
     invited_by = db.relationship("User")
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), nullable=False)
     organisation = db.relationship("Organisation")
+
+    # We can remove the default value when the admin app has been deployed and is always settings permissions explicitly
+    permissions = db.Column(
+        db.String, nullable=False, default=OrganisationUserPermissionTypes.can_make_services_live.value
+    )
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
 
     status = db.Column(db.String, db.ForeignKey("invite_status_type.name"), nullable=False, default=INVITE_PENDING)
@@ -1730,6 +1732,7 @@ class InvitedOrganisationUser(db.Model):
             "invited_by": str(self.invited_by_id),
             "organisation": str(self.organisation_id),
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
+            "permissions": self.permissions.split(","),
             "status": self.status,
         }
 

--- a/app/models.py
+++ b/app/models.py
@@ -351,6 +351,30 @@ class OrganisationPermission(db.Model):
     )
 
 
+class OrganisationUserPermissionTypes(enum.Enum):
+    can_make_services_live = "can_make_services_live"
+
+
+class OrganisationUserPermissions(db.Model):
+    __tablename__ = "organisation_user_permissions"
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
+    organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), index=True)
+    organisation = db.relationship("Organisation")
+
+    user_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=False)
+    user = db.relationship("User")
+
+    permission = db.Column(
+        db.Enum(OrganisationUserPermissionTypes, name="organisation_user_permission_types"), index=True
+    )
+
+    __table_args__ = (
+        UniqueConstraint("organisation_id", "user_id", "permission", name="uix_organisation_user_permission"),
+    )
+
+
 class Organisation(db.Model):
     __tablename__ = "organisation"
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=False)

--- a/app/organisation/invite_rest.py
+++ b/app/organisation/invite_rest.py
@@ -36,7 +36,11 @@ def invite_user_to_org(organisation_id):
     validate(data, post_create_invited_org_user_status_schema)
 
     invited_org_user = InvitedOrganisationUser(
-        email_address=data["email_address"], invited_by_id=data["invited_by"], organisation_id=organisation_id
+        email_address=data["email_address"],
+        invited_by_id=data["invited_by"],
+        organisation_id=organisation_id,
+        # TODO: Remove the .get/default value when admin is always sending this field
+        permissions=",".join(data.get("permissions", [])),
     )
     save_invited_org_user(invited_org_user)
 

--- a/app/organisation/organisation_schema.py
+++ b/app/organisation/organisation_schema.py
@@ -1,4 +1,9 @@
-from app.constants import INVITED_USER_STATUS_TYPES, ORGANISATION_PERMISSION_TYPES, ORGANISATION_TYPES
+from app.constants import (
+    INVITED_USER_STATUS_TYPES,
+    ORGANISATION_PERMISSION_TYPES,
+    ORGANISATION_TYPES,
+    OrganisationUserPermissionTypes,
+)
 from app.schema_validation.definitions import uuid
 
 post_create_organisation_schema = {
@@ -45,6 +50,10 @@ post_create_invited_org_user_status_schema = {
         "email_address": {"type": "string", "format": "email_address"},
         "invited_by": uuid,
         "invite_link_host": {"type": "string"},
+        "permissions": {
+            "type": "array",
+            "items": {"type": "string", "enum": [OrganisationUserPermissionTypes.can_make_services_live.value]},
+        },
     },
     "required": ["email_address", "invited_by"],
 }

--- a/app/user/users_schema.py
+++ b/app/user/users_schema.py
@@ -66,3 +66,15 @@ post_set_permissions_schema = {
     "required": ["permissions"],
     "additionalProperties": False,
 }
+
+
+post_set_organisation_user_permissions_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "POST schema for setting organisation user permissions",
+    "type": "object",
+    "properties": {
+        "permissions": {"type": "array", "items": {"type": "object", "properties": {"permission": {"type": "string"}}}},
+    },
+    "required": ["permissions"],
+    "additionalProperties": False,
+}

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0414_org_user_permissions
+0415_org_invite_perms

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0415_org_invite_perms
+0416_add_org_user_perms

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0413_ft_billing_letter_despatch
+0414_org_user_permissions

--- a/migrations/versions/0414_org_user_permissions.py
+++ b/migrations/versions/0414_org_user_permissions.py
@@ -1,0 +1,59 @@
+"""
+
+Revision ID: 0414_org_user_permissions
+Revises: 0413_ft_billing_letter_despatch
+Create Date: 2023-06-09 13:27:00.294865
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0414_org_user_permissions"
+down_revision = "0413_ft_billing_letter_despatch"
+
+
+def upgrade():
+    op.create_table(
+        "organisation_user_permissions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("organisation_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "permission", sa.Enum("can_make_services_live", name="organisation_user_permission_types"), nullable=True
+        ),
+        sa.ForeignKeyConstraint(
+            ["organisation_id"],
+            ["organisation.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("organisation_id", "user_id", "permission", name="uix_organisation_user_permission"),
+    )
+    op.create_index(
+        op.f("ix_organisation_user_permissions_organisation_id"),
+        "organisation_user_permissions",
+        ["organisation_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_organisation_user_permissions_permission"),
+        "organisation_user_permissions",
+        ["permission"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_organisation_user_permissions_user_id"), "organisation_user_permissions", ["user_id"], unique=False
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_organisation_user_permissions_user_id"), table_name="organisation_user_permissions")
+    op.drop_index(op.f("ix_organisation_user_permissions_permission"), table_name="organisation_user_permissions")
+    op.drop_index(op.f("ix_organisation_user_permissions_organisation_id"), table_name="organisation_user_permissions")
+    op.drop_table("organisation_user_permissions")
+    op.execute("drop type organisation_user_permission_types")

--- a/migrations/versions/0415_org_invite_perms.py
+++ b/migrations/versions/0415_org_invite_perms.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0415_org_invite_perms
+Revises: 0414_org_user_permissions
+Create Date: 2023-06-14 07:38:10.479332
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0415_org_invite_perms"
+down_revision = "0414_org_user_permissions"
+
+
+def upgrade():
+    op.add_column("invited_organisation_users", sa.Column("permissions", sa.String(), nullable=True))
+    op.execute("UPDATE invited_organisation_users SET permissions = 'can_make_services_live'")
+    op.alter_column("invited_organisation_users", "permissions", existing_nullable=True, nullable=False)
+
+
+def downgrade():
+    op.drop_column("invited_organisation_users", "permissions")

--- a/migrations/versions/0416_add_org_user_perms.py
+++ b/migrations/versions/0416_add_org_user_perms.py
@@ -1,0 +1,44 @@
+"""
+
+Revision ID: 0416_add_org_user_perms
+Revises: 0415_org_invite_perms
+Create Date: 2023-06-19 12:43:09.194732
+
+"""
+import uuid
+from datetime import datetime
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0416_add_org_user_perms"
+down_revision = "0415_org_invite_perms"
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    results = conn.execute(
+        """
+    SELECT user_id, organisation_id FROM user_to_organisation
+    """
+    ).fetchall()
+
+    for user_id, organisation_id in results:
+        conn.execute(
+            sa.sql.text(
+                "INSERT INTO organisation_user_permissions "
+                "(id, created_at, user_id, organisation_id, permission) "
+                "VALUES (:id, :created_at, :user_id, :organisation_id, :permission)"
+            ),
+            id=uuid.uuid4(),
+            created_at=datetime.utcnow(),
+            organisation_id=organisation_id,
+            user_id=user_id,
+            permission="can_make_services_live",
+        )
+
+
+def downgrade():
+    op.execute("DELETE FROM organisation_user_permissions WHERE permission = 'can_make_services_live'")

--- a/tests/app/dao/test_organisation_user_permissions_dao.py
+++ b/tests/app/dao/test_organisation_user_permissions_dao.py
@@ -1,5 +1,6 @@
+from app.constants import OrganisationUserPermissionTypes
 from app.dao.organisation_user_permissions_dao import organisation_user_permissions_dao
-from app.models import OrganisationUserPermissions, OrganisationUserPermissionTypes
+from app.models import OrganisationUserPermissions
 
 
 class TestOrganisationUserPermissionsDao:

--- a/tests/app/dao/test_organisation_user_permissions_dao.py
+++ b/tests/app/dao/test_organisation_user_permissions_dao.py
@@ -1,0 +1,51 @@
+from app.dao.organisation_user_permissions_dao import organisation_user_permissions_dao
+from app.models import OrganisationUserPermissions, OrganisationUserPermissionTypes
+
+
+class TestOrganisationUserPermissionsDao:
+    def test_can_add_and_get_and_remove_permissions(self, notify_db_session, sample_organisation, sample_user):
+        sample_user.organisations = [sample_organisation]
+        notify_db_session.commit()
+
+        new_permissions = [
+            OrganisationUserPermissions(user=sample_user, organisation=sample_organisation, permission=p)
+            for p in [OrganisationUserPermissionTypes.can_make_services_live.value]
+        ]
+        organisation_user_permissions_dao.set_user_organisation_permission(
+            sample_user,
+            sample_organisation,
+            new_permissions,
+            _commit=True,
+        )
+        permissions = organisation_user_permissions_dao.get_permissions_by_user_id(
+            user_id=sample_organisation.users[0].id
+        )
+        assert [i.permission for i in permissions] == [OrganisationUserPermissionTypes.can_make_services_live]
+
+        organisation_user_permissions_dao.remove_user_organisation_permissions(sample_user, sample_organisation)
+        permissions = organisation_user_permissions_dao.get_permissions_by_user_id(
+            user_id=sample_organisation.users[0].id
+        )
+        assert len(permissions) == 0
+
+    def test_get_permissions_by_user_id_returns_only_active_organisations(
+        self, notify_db_session, sample_organisation, sample_user
+    ):
+        sample_organisation.active = False
+        sample_user.organisations = [sample_organisation]
+        notify_db_session.commit()
+
+        new_permissions = [
+            OrganisationUserPermissions(user=sample_user, organisation=sample_organisation, permission=p)
+            for p in [OrganisationUserPermissionTypes.can_make_services_live.value]
+        ]
+        organisation_user_permissions_dao.set_user_organisation_permission(
+            sample_user,
+            sample_organisation,
+            new_permissions,
+            _commit=True,
+        )
+        permissions = organisation_user_permissions_dao.get_permissions_by_user_id(
+            user_id=sample_organisation.users[0].id
+        )
+        assert len(permissions) == 0

--- a/tests/app/organisation/test_invite_rest.py
+++ b/tests/app/organisation/test_invite_rest.py
@@ -40,6 +40,7 @@ def test_create_invited_org_user(
         organisation=str(sample_organisation.id),
         email_address=email_address,
         invited_by=str(sample_user.id),
+        permissions=["can_make_services_live"],
         **extra_args
     )
 
@@ -54,6 +55,7 @@ def test_create_invited_org_user(
     assert json_resp["data"]["email_address"] == email_address
     assert json_resp["data"]["invited_by"] == str(sample_user.id)
     assert json_resp["data"]["status"] == INVITE_PENDING
+    assert json_resp["data"]["permissions"] == ["can_make_services_live"]
     assert json_resp["data"]["id"]
 
     notification = Notification.query.first()

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -11,6 +11,7 @@ from app.constants import (
     MANAGE_SETTINGS,
     MANAGE_TEMPLATES,
     SMS_AUTH_TYPE,
+    OrganisationUserPermissionTypes,
 )
 from app.dao.organisation_user_permissions_dao import organisation_user_permissions_dao
 from app.dao.permissions_dao import default_service_permissions
@@ -18,7 +19,7 @@ from app.dao.service_user_dao import (
     dao_get_service_user,
     dao_update_service_user,
 )
-from app.models import Notification, OrganisationUserPermissions, OrganisationUserPermissionTypes, Permission, User
+from app.models import Notification, OrganisationUserPermissions, Permission, User
 from tests import create_admin_authorization_header, create_service_authorization_header
 from tests.app.db import (
     create_organisation,

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from unittest import mock
 
 import pytest
-from flask import current_app
+from flask import current_app, url_for
 from freezegun import freeze_time
 
 from app.constants import (
@@ -12,12 +12,14 @@ from app.constants import (
     MANAGE_TEMPLATES,
     SMS_AUTH_TYPE,
 )
+from app.dao.organisation_user_permissions_dao import organisation_user_permissions_dao
 from app.dao.permissions_dao import default_service_permissions
 from app.dao.service_user_dao import (
     dao_get_service_user,
     dao_update_service_user,
 )
-from app.models import Notification, Permission, User
+from app.models import Notification, OrganisationUserPermissions, OrganisationUserPermissionTypes, Permission, User
+from tests import create_admin_authorization_header, create_service_authorization_header
 from tests.app.db import (
     create_organisation,
     create_service,
@@ -554,6 +556,87 @@ def test_remove_user_folder_permissions(admin_request, sample_user, sample_servi
     )
 
     assert service_user.folders == []
+
+
+class TestSetOrganisationUserPermissions:
+    def _set_permissions(self, user, organisation, permissions: list[OrganisationUserPermissionTypes]):
+        permission_list = [
+            OrganisationUserPermissions(organisation=organisation, user=user, permission=p) for p in permissions
+        ]
+        organisation_user_permissions_dao.set_user_organisation_permission(
+            user, organisation, permission_list, _commit=True, replace=True
+        )
+        new_permissions = OrganisationUserPermissions.query.filter_by(user=user, organisation=organisation).all()
+        assert sorted([p.permission for p in new_permissions]) == sorted(permissions)
+
+    def test_requires_admin_auth(self, client, sample_user, sample_organisation, sample_service):
+        response = client.post(
+            url_for(
+                "user.set_organisation_permissions",
+                user_id=str(sample_user.id),
+                organisation_id=str(sample_organisation.id),
+            ),
+            data={"permissions": []},
+        )
+        assert response.status_code == 401
+
+        response = client.post(
+            url_for(
+                "user.set_organisation_permissions",
+                user_id=str(sample_user.id),
+                organisation_id=str(sample_organisation.id),
+            ),
+            data={"permissions": []},
+            headers=[create_service_authorization_header(sample_service.id)],
+        )
+        assert response.status_code == 401
+
+        response = client.post(
+            url_for(
+                "user.set_organisation_permissions",
+                user_id=str(sample_user.id),
+                organisation_id=str(sample_organisation.id),
+            ),
+            json={"permissions": []},
+            headers=[create_admin_authorization_header()],
+        )
+        assert response.status_code == 204
+
+    def test_can_add_permissions(self, admin_request, sample_user, sample_organisation):
+        admin_request.post(
+            "user.set_organisation_permissions",
+            user_id=str(sample_user.id),
+            organisation_id=str(sample_organisation.id),
+            _data={"permissions": [{"permission": "can_make_services_live"}]},
+            _expected_status=204,
+        )
+
+        permissions = (
+            OrganisationUserPermissions.query.filter_by(user=sample_user, organisation=sample_organisation)
+            .order_by("permission")
+            .all()
+        )
+        assert [p.permission for p in permissions] == [OrganisationUserPermissionTypes.can_make_services_live]
+
+    def test_can_remove_permissions(self, admin_request, sample_user, sample_organisation):
+        self._set_permissions(
+            sample_user, sample_organisation, [OrganisationUserPermissionTypes.can_make_services_live]
+        )
+
+        admin_request.post(
+            "user.set_organisation_permissions",
+            user_id=str(sample_user.id),
+            organisation_id=str(sample_organisation.id),
+            _data={"permissions": []},
+            _expected_status=204,
+        )
+
+        permissions = (
+            OrganisationUserPermissions.query.filter_by(user=sample_user, organisation=sample_organisation)
+            .order_by("permission")
+            .all()
+        )
+        assert [p.permission for p in permissions] == []
 
 
 @freeze_time("2016-01-01 11:09:00.061258")


### PR DESCRIPTION
API PR 1 of 2 (maybe 3)

## Add organisation user permissions table
Adds the table which stores the actions a user can take for a given organisation. Right now we're only adding one permission (the ability to make services live) and everything else is just implicit if you're a member of the org.

## Update endpoint when adding a user to an org
So that the new permission is automatically set for new org members.

## Add admin endpoint for managing org user permissions
To prepare for the admin pages that will allow adding/removing permissions.

## Store permissions on invited org users
When inviting a user to an org, in the same way that we do with invited service users, store their eventual permissions on the invited user model.

---

To do in the future (after initial admin release):
- read permissions when adding user to the org (admin sends permissions across from the invite ... for some reason - being consistent with how service user invites work here).
- remove default for permissions field