### PR TITLE
Remove null constraint

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1697,7 +1697,7 @@ class InvitedUser(db.Model):
     status = db.Column(
         db.Enum(*INVITED_USER_STATUS_TYPES, name="invited_users_status_types"), nullable=False, default=INVITE_PENDING
     )
-    permissions = db.Column(db.String, nullable=False)
+    permissions = db.Column(db.String, nullable=True)
     auth_type = db.Column(db.String, db.ForeignKey("auth_type.name"), index=True, nullable=False, default=SMS_AUTH_TYPE)
     folder_permissions = db.Column(JSONB(none_as_null=True), nullable=False, default=[])
 

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0416_add_org_user_perms
+0417_remove_null_constraint

--- a/migrations/versions/0417_remove_null_constraint.py
+++ b/migrations/versions/0417_remove_null_constraint.py
@@ -1,0 +1,20 @@
+"""
+
+Revision ID: 0417_remove_null_constraint
+Revises: 0416_add_org_user_perms
+Create Date: 2023-06-21 12:45:27.185814
+
+"""
+from alembic import op
+
+
+revision = "0417_remove_null_constraint"
+down_revision = "0416_add_org_user_perms"
+
+
+def upgrade():
+    op.alter_column("invited_organisation_users", "permissions", existing_nullable=False, nullable=True)
+
+
+def downgrade():
+    op.alter_column("invited_organisation_users", "permissions", existing_nullable=True, nullable=False)


### PR DESCRIPTION
I had previously accepted that we wouldn't be able to invite users during the app rollout, but forgot we have a functional test step between migrations and app code deployment that would fail.

So we can't immediately enforce a not-null constraint and will need two separate deployments.