### PR TITLE
Resolve null permissions

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1732,7 +1732,7 @@ class InvitedOrganisationUser(db.Model):
             "invited_by": str(self.invited_by_id),
             "organisation": str(self.organisation_id),
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
-            "permissions": self.permissions.split(","),
+            "permissions": (self.permissions or "").split(","),
             "status": self.status,
         }
 


### PR DESCRIPTION
Until we re-apply the null constraint on permissions they can be null temporarily. Coalesce that to a blank string (the intended target)