### PR TITLE
Restrict org users that get 'go live' emails

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2,7 +2,6 @@ import datetime
 import enum
 import itertools
 import uuid
-from collections import defaultdict
 
 from flask import current_app, url_for
 from notifications_utils.insensitive_dict import InsensitiveDict
@@ -177,9 +176,15 @@ class User(db.Model):
     def get_organisation_permissions(self) -> dict[str, list[str]]:
         from app.dao.organisation_user_permissions_dao import organisation_user_permissions_dao
 
-        retval = defaultdict(list)
+        retval = {}
+
+        # Make sure that every org the user is in, is presented in the return value.
+        for org in self.organisations:
+            retval[str(org.id)] = []
+
         for p in organisation_user_permissions_dao.get_permissions_by_user_id(self.id):
-            retval[str(p.organisation_id)].append(p.permission.value)
+            org_id = str(p.organisation_id)
+            retval[org_id].append(p.permission.value)
 
         return retval
 

--- a/app/organisation/rest.py
+++ b/app/organisation/rest.py
@@ -2,7 +2,7 @@ from flask import Blueprint, abort, current_app, jsonify, request
 from sqlalchemy.exc import IntegrityError
 
 from app.config import QueueNames
-from app.constants import INVITE_PENDING, KEY_TYPE_NORMAL, NHS_ORGANISATION_TYPES
+from app.constants import INVITE_PENDING, KEY_TYPE_NORMAL, NHS_ORGANISATION_TYPES, OrganisationUserPermissionTypes
 from app.dao.annual_billing_dao import set_default_free_allowance_for_service
 from app.dao.dao_utils import transaction
 from app.dao.fact_billing_dao import fetch_usage_for_organisation
@@ -308,6 +308,7 @@ def notify_users_of_request_to_go_live(service_id):
         organisation=organisation,
         template=template,
         reply_to_text=service.go_live_user.email_address,
+        with_permission=OrganisationUserPermissionTypes.can_make_services_live,
         personalisation={
             "service_name": service.name,
             "requester_name": service.go_live_user.name,


### PR DESCRIPTION
We are rolling out an org-user level permission to say who can make services live. Given this, we should only send emails about services requesting to go live to users with the relevant permission.