### PR TITLE
Fix requirements (unable to freeze)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ async-timeout==4.0.2
     # via redis
 attrs==22.1.0
     # via jsonschema
-awscli==1.25.85
+awscli==1.29.5
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
@@ -29,9 +29,11 @@ blinker==1.6.2
     #   flask
     #   gds-metrics
     #   sentry-sdk
-boto3==1.24.84
-    # via notifications-utils
-botocore==1.27.84
+boto3==1.28.5
+    # via
+    #   kombu
+    #   notifications-utils
+botocore==1.31.5
     # via
     #   awscli
     #   boto3
@@ -141,7 +143,7 @@ jsonpointer==2.3
     # via jsonschema
 jsonschema[format]==4.16.0
     # via -r requirements.in
-kombu==5.2.4
+kombu[sqs]==5.2.4
     # via celery
 lxml==4.9.1
     # via -r requirements.in
@@ -185,6 +187,8 @@ pyasn1==0.4.8
     # via rsa
 pycparser==2.21
     # via cffi
+pycurl==7.44.1
+    # via kombu
 pyjwt==2.5.0
     # via
     #   -r requirements.in
@@ -208,7 +212,7 @@ pytz==2022.4
     # via
     #   celery
     #   notifications-utils
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
     #   awscli
     #   notifications-utils
@@ -262,6 +266,7 @@ uri-template==1.2.0
 urllib3==1.26.12
     # via
     #   botocore
+    #   kombu
     #   requests
     #   sentry-sdk
 vine==5.0.0


### PR DESCRIPTION
For the last few days we've been unable to run `make freeze-requirements`, getting errors like this:

```
...
            raise AttributeError(attr)
        AttributeError: cython_sources
        [end of output]

    note: This error originates from a subprocess, and is likely not a problem with pip.
...
pip._internal.exceptions.InstallationSubprocessError: Getting requirements to build wheel exited with 1

make: *** [freeze-requirements] Error 1
```

From some searches online this seems related to a release of cython3 that just came out, which PyYAML uses.

https://github.com/yaml/pyyaml/issues/724

There is now a new release of PyYAML (6.0.1) that fixes the issue, so let's bump to that. In order to bump to that, we need to bump awscli, which means bumping boto3 and botocore.