### PR TITLE
Add detect-secrets pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,10 +9,15 @@ repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: 'v0.0.275'
   hooks:
-    - id: ruff
-      args: [--fix, --exit-non-zero-on-fix]
+  - id: ruff
+    args: [--fix, --exit-non-zero-on-fix]
 - repo: https://github.com/psf/black
   rev: 22.8.0
   hooks:
-    - id: black
-      name: black (python)
+  - id: black
+    name: black (python)
+- repo: https://github.com/Yelp/detect-secrets
+  rev: v1.4.0
+  hooks:
+  - id: detect-secrets
+    args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,390 @@
+{
+  "version": "1.4.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "README.md",
+        "hashed_secret": "3bf710d852e4ffb2bf157dccd3e6099d9cd6654f",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "README.md",
+        "hashed_secret": "fc5462be70401cb2f7940d506ff413e722bb9bbd",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ],
+    "app/config.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "app/config.py",
+        "hashed_secret": "577a4c667e4af8682ca431857214b3a920883efc",
+        "is_verified": false,
+        "line_number": 494
+      }
+    ],
+    "app/constants.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "app/constants.py",
+        "hashed_secret": "12322e07b94ee3c7cd65a2952ece441538b53eb3",
+        "is_verified": false,
+        "line_number": 161
+      }
+    ],
+    "pytest.ini": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pytest.ini",
+        "hashed_secret": "e501a39b67f82817f7ec580a36f6932e5377e59c",
+        "is_verified": false,
+        "line_number": 5
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pytest.ini",
+        "hashed_secret": "a3e8fada29009777b0855fa5fadeb0bb91de4ef6",
+        "is_verified": false,
+        "line_number": 6
+      }
+    ],
+    "tests/app/aws/test_s3.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/app/aws/test_s3.py",
+        "hashed_secret": "67a74306b06d0c01624fe0d0249a570f4d093747",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    "tests/app/clients/test_cbc_proxy.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/clients/test_cbc_proxy.py",
+        "hashed_secret": "ba59e920f3d2ebb6a219a8b7e40ecb606ea697dd",
+        "is_verified": false,
+        "line_number": 42
+      }
+    ],
+    "tests/app/clients/test_document_download.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/clients/test_document_download.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 18
+      }
+    ],
+    "tests/app/clients/test_dvla.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/clients/test_dvla.py",
+        "hashed_secret": "34aaa023ed8ae50bb39be2702a0545e7a133a9f5",
+        "is_verified": false,
+        "line_number": 151
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/clients/test_dvla.py",
+        "hashed_secret": "ee6066196c511505bc41b34b03326a992f2388f8",
+        "is_verified": false,
+        "line_number": 248
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/clients/test_dvla.py",
+        "hashed_secret": "b773c4a47fdfe5017ed3ebe64e3a81579d3b60e4",
+        "is_verified": false,
+        "line_number": 343
+      }
+    ],
+    "tests/app/conftest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/conftest.py",
+        "hashed_secret": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
+        "is_verified": false,
+        "line_number": 631
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/conftest.py",
+        "hashed_secret": "4ff75f80957469c4b6af5824cb99bf4919abad98",
+        "is_verified": false,
+        "line_number": 632
+      }
+    ],
+    "tests/app/dao/test_services_dao.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/dao/test_services_dao.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 246
+      }
+    ],
+    "tests/app/dao/test_users_dao.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/dao/test_users_dao.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 50
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/dao/test_users_dao.py",
+        "hashed_secret": "f2c57870308dc87f432e5912d4de6f8e322721ba",
+        "is_verified": false,
+        "line_number": 160
+      }
+    ],
+    "tests/app/db.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/db.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 89
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/app/db.py",
+        "hashed_secret": "2020f1df1bb8bbe6d7f3e6b2d136cd2a38ad7fed",
+        "is_verified": false,
+        "line_number": 855
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/app/db.py",
+        "hashed_secret": "0362114f115be22057673eda269208449bec65ff",
+        "is_verified": false,
+        "line_number": 856
+      }
+    ],
+    "tests/app/letters/test_returned_letters.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/app/letters/test_returned_letters.py",
+        "hashed_secret": "d782ccb6785b5e3cef91a149f946a38cea88fb81",
+        "is_verified": false,
+        "line_number": 7
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/app/letters/test_returned_letters.py",
+        "hashed_secret": "52f1e518a8f64e70f1f443eebe7cdd2e8cdaf83f",
+        "is_verified": false,
+        "line_number": 9
+      }
+    ],
+    "tests/app/notifications/test_notifications_letter_callbacks.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/app/notifications/test_notifications_letter_callbacks.py",
+        "hashed_secret": "1508988ea0735a373719890d5a02b4960ffb1a25",
+        "is_verified": false,
+        "line_number": 104
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/app/notifications/test_notifications_letter_callbacks.py",
+        "hashed_secret": "a6c42040b43905817197ea2c7f12a4f3092460f4",
+        "is_verified": false,
+        "line_number": 104
+      }
+    ],
+    "tests/app/notifications/test_receive_notification.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/notifications/test_receive_notification.py",
+        "hashed_secret": "913a73b565c8e2c8ed94497580f619397709b8b6",
+        "is_verified": false,
+        "line_number": 26
+      }
+    ],
+    "tests/app/notifications/test_validators.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/notifications/test_validators.py",
+        "hashed_secret": "9c2a6e4809aeef7b7712ca4db05a681452f4f748",
+        "is_verified": false,
+        "line_number": 447
+      }
+    ],
+    "tests/app/service/test_rest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/service/test_rest.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 1265
+      }
+    ],
+    "tests/app/template/test_rest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/template/test_rest.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 1145
+      }
+    ],
+    "tests/app/user/test_rest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/user/test_rest.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 104
+      }
+    ],
+    "tests/app/v2/broadcast/test_post_broadcast.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/app/v2/broadcast/test_post_broadcast.py",
+        "hashed_secret": "afddbc89a4e7b99f99eb0b1fad44d7aed566c77f",
+        "is_verified": false,
+        "line_number": 92
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/app/v2/broadcast/test_post_broadcast.py",
+        "hashed_secret": "a1f83866aff48443fffba0f8c6f11da4ad2e6763",
+        "is_verified": false,
+        "line_number": 198
+      }
+    ],
+    "tests/app/v2/notifications/test_post_notifications.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/v2/notifications/test_post_notifications.py",
+        "hashed_secret": "d25187dc137f35c88bc80ec8c3ffbdb17b5eb873",
+        "is_verified": false,
+        "line_number": 772
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/v2/notifications/test_post_notifications.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 1276
+      }
+    ]
+  },
+  "generated_at": "2023-07-22T08:56:12Z"
+}

--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ We use [pre-commit](https://pre-commit.com/) to ensure that committed code meets
 
 Install pre-commit system-wide with, eg `brew install pre-commit`. Then, install the hooks in this repository with `pre-commit install --install-hooks`.
 
+### detect-secrets
+
+We use [detect-secrets](https://github.com/Yelp/detect-secrets) to help prevent committing secrets to the repository. This runs automatically through `pre-commit` and requires that to be configured with the hooks installed.
+
+The file '.secrets.baseline' contains a list of 'secret' values already in the repository when this was integrated. All of these are false positives.
+
+With pre-commit installed, if you try to commit a secret you will get an error flagging the location of the secret value. If it's a real secret, oops, delete it and carry on. If it's a false positive, you can deal with this in a few ways:
+
+1) Append `# pragma: allowlist secret` to the end of the line
+2) Insert `# pragma: allowlist nextline secret` on the preceding line.
+
+We should not need to generate a new `.secrets.baseline` file as it's intended to only track secrets that were in the repository at the time of integration. If we do need to update it for some reason, you'll need to install `detect-secrets` (either via brew or pip) and run `detect-secrets scan > .secrets.baseline`.
+
 ##  To run the application
 
 ```


### PR DESCRIPTION
This integrates [detect-secret](https://github.com/Yelp/detect-secrets), which scans new commits to the repository for known/suspected secret values.

We integrate this using pre-commit, so that every new commit can be scanned (assuming pre-commit is enabled by the developer) and secrets flagged before they can be pushed and leaked.