### PR TITLE
Redis

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -11,4 +11,5 @@ def extract_cloudfoundry_config():
             "postgres", "postgresql"
         )
     # Redis config
-    os.environ["REDIS_URL"] = vcap_services["redis"][0]["credentials"]["uri"]
+    if "REDIS_URL" not in os.environ:
+        os.environ["REDIS_URL"] = vcap_services["redis"][0]["credentials"]["uri"]

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -126,6 +126,9 @@ applications:
       {% if SQLALCHEMY_DATABASE_URI is defined %}
       SQLALCHEMY_DATABASE_URI: '{{ SQLALCHEMY_DATABASE_URI }}'
       {% endif %}
+      {% if REDIS_URL is defined %}
+      REDIS_URL: '{{ REDIS_URL }}'
+      {% endif %}
 
       HIGH_VOLUME_SERVICE: '{{ HIGH_VOLUME_SERVICE | tojson }}'
 


### PR DESCRIPTION
Added redis_url variable to allow the api app to call redis.
Modified two files:
1. cloudfoundry_config.py where we added and IF statement to check if the variable is in the environment. If not it will use the VCAP_SERVICES one
2. manifest.yml.j2 where we check if redis_url variable is defined and take its value from the env variable set