### PR TITLE
Run 0 instances of celery beat in preview and run 1 in other envs

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -49,7 +49,14 @@
     },
   },
 
-  'notify-delivery-celery-beat': {'memory': '512M'},
+  'notify-delivery-celery-beat': {
+    'memory': '512M',
+    'instances': {
+      'preview': 0,
+      'staging': 1,
+      'production': 1
+    },
+  },
   'notify-delivery-worker-jobs': {'memory': '2G'},
   'notify-delivery-worker-research': {},
   'notify-delivery-worker-sender': {'disk_quota': '2G', 'memory': '4G'},


### PR DESCRIPTION
We want 0 in preview because we are now running 1 instance in preview ECS and we only want 1 instance in total.

For staging and production, they stay on their default behaviour which is 1 instance per environment (this isn't defined in code but I checked how many we run in staging and prod and it is currently 1). We only want 1 instance so we don't have multiple of the same tasks being created at the same time.

For context, see
https://github.com/alphagov/notifications-aws/pull/1579