### PR TITLE
 Bump utils to 66.0.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -165,7 +165,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.1
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -174,7 +174,7 @@ packaging==21.3
     #   gunicorn
     #   marshmallow
     #   marshmallow-sqlalchemy
-phonenumbers==8.12.56
+phonenumbers==8.13.18
     # via notifications-utils
 prometheus-client==0.14.1
     # via


### PR DESCRIPTION
* Require phonenumbers >= 8.3.18 (changes how some numbers are formatted.
* Render placeholder `((` and `))` as HTML-encoded characters in templates, fixing some display issues for links including placeholders and static text.