### PR TITLE
Don't restart the app if 0 instances are required

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -65,7 +65,11 @@ cf apply-manifest -f ${CF_MANIFEST_PATH}
 echo "Set the new droplet for the app"
 cf set-droplet ${CF_APP} ${DROPLET_GUID}
 
-if [[ "${CF_APP}" != "notify-api-db-migration" ]]; then
+DESIRED_INSTANCES=$(cf app ${CF_APP} | grep instances: | cut -d'/' -f2)
+
+if [[ "$DESIRED_INSTANCES" != "0" ]]; then
   echo "Restart the app to pickup the new droplet"
   CF_STARTUP_TIMEOUT=15 cf restart ${CF_APP} --strategy rolling
+else
+  echo "0 instances required so app is not restarted to avoid scaling up"
 fi


### PR DESCRIPTION
https://github.com/alphagov/notifications-api/pull/3837 In this PR we previously found out that `cf restart` will scale up to 1 instance the notify-api-db-migration app when we don't want that to happen (it should run 0 instances). The solution was to add the if statement based on the app name.

In https://github.com/alphagov/notifications-api/pull/3844 we now desire 0 instances of celery beat for preview and 1 instance for staging and production. When we deploy the API using this script, it will scale preview up to 1 instance when it runs the `cf restart` command.

We put in place a flexible solution that checks how many instances are desired (set in the apply-manifest step above) and decides not to restart if the desired number of instances is 0. This should nicely handle both the case where an app should have 0 instances in all environments, but also the case where an app should have 0 instances in just a single environment.