### PR TITLE
Bump utils to 66.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -165,7 +165,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.1.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
Shouldn’t mean any functional changes for this repo, but just so some else doesn’t have to do it…

66.1.0
---

* Add a simpler syntax for QR codes in letters (QR: http://example.com)

66.0.2
---

* Style the QR code placeholder so it looks better when the placeholder text is long

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/66.0.1...66.1.0