### PR TITLE
QR code validation

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -308,3 +308,7 @@ class Retention:
 # Redis cache keys
 class CacheKeys:
     FT_BILLING_FOR_TODAY_UPDATED_AT_UTC_ISOFORMAT = "update_ft_billing_for_today:updated-at-utc-isoformat"
+
+
+# Admin API error codes
+QR_CODE_TOO_LONG = "qr-code-too-long"

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -69,6 +69,12 @@ def create_content_for_notification(template, personalisation):
             contact_block=template.reply_to_text,
         )
 
+        if error := template_object.has_qr_code_with_too_much_data():
+            raise BadRequestError(
+                message=f"WIP: This notification creates a QR code with too much data (max {error.max_bytes} bytes)",
+                status_code=400,
+            )
+
     check_placeholders(template_object)
 
     return template_object
@@ -103,7 +109,7 @@ def persist_notification(
     billable_units=None,
     postage=None,
     document_download_count=None,
-    updated_at=None
+    updated_at=None,
 ):
     notification_created_at = created_at or datetime.utcnow()
     if not notification_id:

--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -55,6 +55,33 @@ class PDFNotReadyError(BadRequestError):
         super().__init__(message="PDF not available yet, try again later", status_code=400)
 
 
+class QrCodeTooLongError(ValidationError):
+    message = "Cannot create a usable QR code - the link is too long"
+
+    def __init__(self, fields=None, message=None, status_code=400, *, num_bytes, max_bytes, data):
+        super().__init__(fields=fields, message=message, status_code=status_code)
+        self.num_bytes = num_bytes
+        self.max_bytes = max_bytes
+        self.data = data
+
+    def to_dict_v2(self):
+        """
+        Version 2 of the public api error response.
+        """
+        return {
+            "status_code": self.status_code,
+            "errors": [
+                {
+                    "error": "ValidationError",
+                    "message": self.message,
+                    "data": self.data,
+                    "num_bytes": self.num_bytes,
+                    "max_bytes": self.max_bytes,
+                }
+            ],
+        }
+
+
 def register_errors(blueprint):
     @blueprint.errorhandler(InvalidEmailError)
     def invalid_format(error):

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@68.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -165,7 +165,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@68.0.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -20,7 +20,7 @@ from app.notifications.process_notifications import (
     simulated_recipient,
 )
 from app.serialised_models import SerialisedTemplate
-from app.v2.errors import BadRequestError
+from app.v2.errors import BadRequestError, QrCodeTooLongError
 from tests.app.db import create_api_key, create_service, create_template
 from tests.conftest import set_config
 
@@ -59,10 +59,13 @@ def test_create_content_for_notification_raises_error_on_qr_code_too_long(sample
     db_template = create_template(sample_service, template_type="letter", content="qr: ((code))")
     template = SerialisedTemplate.from_id_and_service_id(db_template.id, db_template.service_id)
 
-    with pytest.raises(BadRequestError) as e:
+    with pytest.raises(QrCodeTooLongError) as e:
         create_content_for_notification(template, {"code": "too much data " * 50})
 
-    assert e.value.message == "WIP: This notification creates a QR code with too much data (max 504 bytes)"
+    assert e.value.message == "Cannot create a usable QR code - the link is too long"
+    assert e.value.num_bytes == 700
+    assert e.value.max_bytes == 504
+    assert e.value.data == "too much data " * 50
 
 
 @freeze_time("2016-01-01 11:09:00.061258")

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -55,6 +55,16 @@ def test_create_content_for_notification_allows_additional_personalisation(sampl
     create_content_for_notification(template, {"name": "Bobby", "Additional placeholder": "Data"})
 
 
+def test_create_content_for_notification_raises_error_on_qr_code_too_long(sample_service):
+    db_template = create_template(sample_service, template_type="letter", content="qr: ((code))")
+    template = SerialisedTemplate.from_id_and_service_id(db_template.id, db_template.service_id)
+
+    with pytest.raises(BadRequestError) as e:
+        create_content_for_notification(template, {"code": "too much data " * 50})
+
+    assert e.value.message == "WIP: This notification creates a QR code with too much data (max 504 bytes)"
+
+
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_persist_notification_creates_and_save_to_db(sample_template, sample_api_key, sample_job):
 


### PR DESCRIPTION
Validate QR code length when:

* creating/updating a template
* sending a notification via the API

Importantly, this validation happens up front. If a notification with a
QR code that is 'too long' did manage to get accepted by the API,
template-preview *would* render a QR code for it and the letter would be
sent. This is so that we don't have to handle moving letters with QR
codes into `permanent-failure` and then explain why that has happened.

We may revisit this in the future, but for now we are preferring to stop
'bad QR codes' getting into the system at all, rather than handling
errors further downstream and having to bubble them back up.