### PR TITLE
Create functional test seeded users endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -117,10 +117,15 @@ def create_app(application):
     return application
 
 
+def _should_register_functional_testing_blueprint(environment):
+    return environment in {"development", "test", "preview"}
+
+
 def register_blueprint(application):
     from app.authentication.auth import (
         requires_admin_auth,
         requires_auth,
+        requires_functional_test_auth,
         requires_govuk_alerts_auth,
         requires_no_auth,
     )
@@ -129,6 +134,7 @@ def register_blueprint(application):
     from app.complaint.complaint_rest import complaint_blueprint
     from app.email_branding.rest import email_branding_blueprint
     from app.events.rest import events as events_blueprint
+    from app.functional_tests import test_blueprint
     from app.govuk_alerts.rest import govuk_alerts_blueprint
     from app.inbound_number.rest import inbound_number_blueprint
     from app.inbound_sms.rest import inbound_sms as inbound_sms_blueprint
@@ -273,6 +279,10 @@ def register_blueprint(application):
 
     letter_attachment_blueprint.before_request(requires_admin_auth)
     application.register_blueprint(letter_attachment_blueprint)
+
+    if _should_register_functional_testing_blueprint(application.config["NOTIFY_ENVIRONMENT"]):
+        test_blueprint.before_request(requires_functional_test_auth)
+        application.register_blueprint(test_blueprint)
 
 
 def register_v2_blueprints(application):

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -64,6 +64,10 @@ def requires_admin_auth():
     requires_internal_auth(current_app.config.get("ADMIN_CLIENT_ID"))
 
 
+def requires_functional_test_auth():
+    requires_internal_auth(current_app.config.get("FUNCTIONAL_TESTS_CLIENT_ID"))
+
+
 def requires_internal_auth(expected_client_id):
     if expected_client_id not in current_app.config.get("INTERNAL_CLIENT_API_KEYS"):
         raise TypeError("Unknown client_id for internal auth")

--- a/app/config.py
+++ b/app/config.py
@@ -91,6 +91,7 @@ class Config(object):
     # secrets that internal apps, such as the admin app or document download, must use to authenticate with the API
     ADMIN_CLIENT_ID = "notify-admin"
     GOVUK_ALERTS_CLIENT_ID = "govuk-alerts"
+    FUNCTIONAL_TESTS_CLIENT_ID = "notify-functional-tests"
 
     INTERNAL_CLIENT_API_KEYS = json.loads(os.environ.get("INTERNAL_CLIENT_API_KEYS", "{}"))
 
@@ -490,6 +491,7 @@ class Development(Config):
     INTERNAL_CLIENT_API_KEYS = {
         Config.ADMIN_CLIENT_ID: ["dev-notify-secret-key"],
         Config.GOVUK_ALERTS_CLIENT_ID: ["govuk-alerts-secret-key"],
+        Config.FUNCTIONAL_TESTS_CLIENT_ID: ["functional-tests-secret-key"],
     }
 
     SECRET_KEY = "dev-notify-secret-key"

--- a/app/functional_tests/__init__.py
+++ b/app/functional_tests/__init__.py
@@ -1,0 +1,62 @@
+import datetime
+import uuid
+
+from flask import Blueprint, request
+
+from app import db
+from app.dao.organisation_dao import dao_add_user_to_organisation, dao_get_organisation_by_id
+from app.dao.permissions_dao import permission_dao
+from app.dao.services_dao import dao_add_user_to_service
+from app.errors import register_errors
+from app.functional_tests.testing_schemas import create_functional_test_users_schema
+from app.models import Permission, Service, User
+from app.schema_validation import validate
+
+test_blueprint = Blueprint("functional_tests", __name__, url_prefix="/__testing/functional")
+register_errors(test_blueprint)
+
+
+@test_blueprint.route("/users", methods=["PUT"])
+def create_functional_test_users():
+    users_info = request.get_json()
+    validate(users_info, create_functional_test_users_schema)
+
+    for user_info in users_info:
+        created = False
+        if not (user := User.query.filter_by(email_address=user_info["email_address"]).one_or_none()):
+            created = True
+            user = User()
+            user.id = uuid.uuid4()
+            user.created_at = datetime.datetime.utcnow()
+            user.email_access_validated_at = datetime.datetime.utcnow()
+            db.session.add(user)
+
+        user.name = user_info["name"]
+        user.email_address = user_info["email_address"]
+        user.mobile_number = user_info["mobile_number"]
+        user.auth_type = user_info["auth_type"]
+        user.password = user_info["password"]
+        user.state = user_info["state"]
+        user.platform_admin = False
+
+        permissions = [
+            Permission(service_id=user_info["service_id"], user_id=user.id, permission=p)
+            for p in user_info["permissions"]
+        ]
+
+        service = Service.query.filter_by(id=user_info["service_id"]).one()
+        if created:
+            dao_add_user_to_service(service, user, permissions)
+        else:
+            permission_dao.set_user_service_permission(user, service, permissions, replace=True)
+
+        organisation = dao_get_organisation_by_id(user_info["organisation_id"])
+        if organisation not in user.organisations:
+            user.organisations.append(organisation)
+
+        if created:
+            dao_add_user_to_organisation(user_info["organisation_id"], str(user.id), [])
+
+        db.session.commit()
+
+    return "ok", 201

--- a/app/functional_tests/testing_schemas.py
+++ b/app/functional_tests/testing_schemas.py
@@ -1,0 +1,19 @@
+create_functional_test_users_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "schema for creating functional test users",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "required": True},
+            "email_address": {"type": "string", "format": "email_address", "required": True},
+            "mobile_number": {"type": "string", "required": True},
+            "auth_type": {"type": "string", "required": True},
+            "password": {"type": "string", "required": True},
+            "state": {"type": "string", "required": True},
+            "permissions": {"type": "array", "items": {"type": "string"}, "required": True},
+            "service_id": {"type": "string", "required": True},
+            "organisation_id": {"type": "string", "required": False},
+        },
+    },
+}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -31,6 +31,11 @@ def create_admin_authorization_header():
     return create_internal_authorization_header(client_id)
 
 
+def create_functional_tests_authorization_header():
+    client_id = current_app.config["FUNCTIONAL_TESTS_CLIENT_ID"]
+    return create_internal_authorization_header(client_id)
+
+
 def create_internal_authorization_header(client_id):
     secret = current_app.config["INTERNAL_CLIENT_API_KEYS"][client_id][0]
     token = create_jwt_token(secret=secret, client_id=client_id)

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -54,6 +54,7 @@ from app.models import (
 )
 from tests import (
     create_admin_authorization_header,
+    create_functional_tests_authorization_header,
     create_service_authorization_header,
 )
 from tests.app.db import (
@@ -1055,6 +1056,28 @@ def admin_request(client):
             return json_resp
 
     return AdminRequest
+
+
+@pytest.fixture
+def functional_tests_request(client):
+    class FunctionalTestsRequest:
+        app = client.application
+
+        @staticmethod
+        def put(endpoint, _data=None, _expected_status=200, **endpoint_kwargs):
+            resp = client.put(
+                url_for(endpoint, **(endpoint_kwargs or {})),
+                data=json.dumps(_data),
+                headers=[("Content-Type", "application/json"), create_functional_tests_authorization_header()],
+            )
+            if resp.get_data():
+                json_resp = resp.json
+            else:
+                json_resp = None
+            assert resp.status_code == _expected_status
+            return json_resp
+
+    return FunctionalTestsRequest
 
 
 @pytest.fixture

--- a/tests/app/functional_tests/test_functional.py
+++ b/tests/app/functional_tests/test_functional.py
@@ -1,0 +1,90 @@
+import pytest
+from flask import url_for
+
+from app.models import User
+from tests.app.db import create_organisation, create_service, create_user
+
+
+class TestCreateFunctionalTestUsers:
+    @pytest.fixture(autouse=True)
+    def notify_db_session(self, notify_db_session):
+        return notify_db_session
+
+    def test_auth_required(self, client):
+        response = client.put(url_for("functional_tests.create_functional_test_users"), data="[]")
+        assert response.status_code == 401
+
+    def test_201(self, functional_tests_request):
+        functional_tests_request.put("functional_tests.create_functional_test_users", _data=[], _expected_status=201)
+
+    def test_user_created(self, functional_tests_request):
+        organisation = create_organisation()
+        service = create_service(organisation=organisation)
+        functional_tests_request.put(
+            "functional_tests.create_functional_test_users",
+            _data=[
+                {
+                    "name": "my test user",
+                    "email_address": "something@example.com",
+                    "mobile_number": "07700900000",
+                    "auth_type": "sms_auth",
+                    "password": "hello",
+                    "state": "active",
+                    "permissions": ["send_emails", "send_letters", "send_texts"],
+                    "service_id": str(service.id),
+                    "organisation_id": str(organisation.id),
+                }
+            ],
+            _expected_status=201,
+        )
+
+        user = User.query.filter_by(email_address="something@example.com").one()
+        assert user.name == "my test user"
+        assert user.mobile_number == "07700900000"
+        assert user.auth_type == "sms_auth"
+        assert user.state == "active"
+        assert set(user.get_permissions()[str(service.id)]) == {"send_emails", "send_letters", "send_texts"}
+        assert service in user.services
+        assert organisation in user.organisations
+
+    def test_user_updated(self, functional_tests_request, notify_db_session):
+        organisation = create_organisation()
+        service = create_service(organisation=organisation)
+        user = create_user(
+            name="my test user",
+            email="something@example.com",
+            mobile_number="07700900000",
+            auth_type="sms_auth",
+            password="bad old password",
+            state="inactive",
+        )
+
+        user.organisations.append(organisation)
+        user.services.append(service)
+        notify_db_session.commit()
+
+        functional_tests_request.put(
+            "functional_tests.create_functional_test_users",
+            _data=[
+                {
+                    "name": "my updated test user",
+                    "email_address": "something@example.com",
+                    "mobile_number": "07700900999",
+                    "auth_type": "email_auth",
+                    "password": "good new password",
+                    "state": "active",
+                    "permissions": ["send_emails", "send_letters", "send_texts"],
+                    "service_id": str(service.id),
+                    "organisation_id": str(organisation.id),
+                }
+            ],
+            _expected_status=201,
+        )
+
+        notify_db_session.refresh(user)
+        assert user.id == user.id
+        assert user.name == "my updated test user"
+        assert user.mobile_number == "07700900999"
+        assert user.auth_type == "email_auth"
+        assert user.state == "active"
+        assert set(user.get_permissions()[str(service.id)]) == {"send_emails", "send_letters", "send_texts"}

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+class TestBlueprint:
+    @pytest.mark.parametrize(
+        "environment, blueprint_should_register",
+        (
+            ("development", True),
+            ("preview", True),
+            ("staging", False),
+            ("production", False),
+        ),
+    )
+    def test_should_register_testing_blueprint(self, environment, blueprint_should_register):
+        from app import _should_register_functional_testing_blueprint
+
+        assert _should_register_functional_testing_blueprint(environment) is blueprint_should_register


### PR DESCRIPTION
Adds an endpoint to the API, only available in development and preview
environments, which can create users for the functional tests.

These users are created against a pre-seeded organisation/service, so
that is expected to exist in the DB already. But creating users on
demand allows us to run tests interacting with that org/service in
parallel, which should lead to much faster run times for our common
journeys