### PR TITLE
Bump utils to 70.0.1

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -312,3 +312,16 @@ class CacheKeys:
 
 # Admin API error codes
 QR_CODE_TOO_LONG = "qr-code-too-long"
+
+
+# We updated the content for phone number validation messages in https://github.com/alphagov/notifications-utils/pull/1054,
+# but these are returned from our API. We don't want to make any breaking changes, so we will map them back to our
+# original errors.
+# We can decide as/when we want to remove this and update the messages to end users.
+PHONE_NUMBER_VALIDATION_ERROR_MAP = {
+    "Mobile numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -": "Must not contain letters or symbols",
+    "Mobile number is too long": "Too many digits",
+    "Mobile number is too short": "Not enough digits",
+    "Country code not found - double check the mobile number you entered": "Not a valid country prefix",
+    "This does not look like a UK mobile number - double check the mobile number you entered": "Not a UK mobile number",
+}

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -21,6 +21,7 @@ from app.constants import (
     KEY_TYPE_TEAM,
     KEY_TYPE_TEST,
     LETTER_TYPE,
+    PHONE_NUMBER_VALIDATION_ERROR_MAP,
     SMS_TYPE,
 )
 from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_id
@@ -284,3 +285,7 @@ def check_template_can_contain_documents(template_type, personalisation):
         isinstance(v, dict) and "file" in v for v in (personalisation or {}).values()
     ):
         raise BadRequestError(message="Can only send a file by email")
+
+
+def remap_phone_number_validation_messages(error_message):
+    return PHONE_NUMBER_VALIDATION_ERROR_MAP.get(error_message, error_message)

--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -12,6 +12,8 @@ from notifications_utils.recipients import (
     validate_phone_number,
 )
 
+from app.notifications.validators import remap_phone_number_validation_messages
+
 format_checker = FormatChecker()
 
 
@@ -25,7 +27,10 @@ def validate_uuid(instance):
 @format_checker.checks("phone_number", raises=InvalidPhoneError)
 def validate_schema_phone_number(instance):
     if isinstance(instance, str):
-        validate_phone_number(instance, international=True)
+        try:
+            validate_phone_number(instance, international=True)
+        except InvalidPhoneError as error:
+            raise InvalidPhoneError(remap_phone_number_validation_messages(str(error))) from error
     return True
 
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -27,6 +27,7 @@ import app.constants
 from app import ma, models
 from app.dao.permissions_dao import permission_dao
 from app.models import ServicePermission
+from app.notifications.validators import remap_phone_number_validation_messages
 from app.utils import DATETIME_FORMAT_NO_TIMEZONE, get_template_instance
 
 
@@ -144,7 +145,8 @@ class UserSchema(BaseSchema):
             if value is not None:
                 validate_phone_number(value, international=True)
         except InvalidPhoneError as error:
-            raise ValidationError("Invalid phone number: {}".format(error)) from error
+            error_message = remap_phone_number_validation_messages(str(error))
+            raise ValidationError(f"Invalid phone number: {error_message}") from error
 
 
 class UserUpdateAttributeSchema(BaseSchema):
@@ -184,7 +186,8 @@ class UserUpdateAttributeSchema(BaseSchema):
             if value is not None:
                 validate_phone_number(value, international=True)
         except InvalidPhoneError as error:
-            raise ValidationError("Invalid phone number: {}".format(error)) from error
+            error_message = remap_phone_number_validation_messages(str(error))
+            raise ValidationError(f"Invalid phone number: {error_message}") from error
 
     @validates_schema(pass_original=True)
     def check_unknown_fields(self, data, original_data, **kwargs):
@@ -543,7 +546,8 @@ class SmsNotificationSchema(NotificationSchema):
         try:
             validate_phone_number(value, international=True)
         except InvalidPhoneError as error:
-            raise ValidationError("Invalid phone number: {}".format(error)) from error
+            error_message = remap_phone_number_validation_messages(str(error))
+            raise ValidationError(f"Invalid phone number: {error_message}") from error
 
     @post_load
     def format_phone_number(self, item, **kwargs):

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@69.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -165,7 +165,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.1
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -165,7 +165,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@69.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
70.0.0: updates validation messages for invalid phone numbers; we override these to retain API backwards compatibility
70.0.1: fixes `<strong>` tagging around QR codes during validation

---

We override the updated content for invalid phone errors so as to keep our API interface the same. We may unroll this in the future.