### PR TITLE
Set `result_expires` to 0 in Celery config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ run-celery-beat: ## Run celery beat
 
 .PHONY: run-celery-beat-with-docker
 run-celery-beat-with-docker: ## Run celery beat in Docker container (useful if you can't install pycurl locally)
-	./scripts/run_locally_with_docker.sh beat
+	./scripts/run_locally_with_docker.sh celery-beat
 
 .PHONY: run-migrations-with-docker
 run-migrations-with-docker: ## Run alembic migrations in Docker container

--- a/app/config.py
+++ b/app/config.py
@@ -198,6 +198,7 @@ class Config(object):
             "queue_name_prefix": NOTIFICATION_QUEUE_PREFIX,
             "is_secure": True,
         },
+        "result_expires": 0,
         "timezone": "UTC",
         "imports": [
             "app.celery.tasks",


### PR DESCRIPTION
When running Celery beat on ECS we've noticed the `backend_cleanup` task
running at 0400 each morning and being put on the default queue. This
task is a built in Celery task that cleans up expired results ("task
tombstones") from the results backend database. We don't have a results
backend, so don't need the task to run - there's nothing for it to clean up.
We can disable it by setting the value of `results_expires` to 0 to
show that task results never expire and so don't need cleaning.

https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-expires

It's not clear why this task is running on ECS but wasn't running on the PaaS
since we've not changed any settings when migrating.