### PR TITLE
Bump utils to 70.0.2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.2
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -165,7 +165,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.2
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
70.0.2
---

- Update sanitising of SMS content to include more obscure whitespace

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/70.0.1...70.0.2