### PR TITLE
Chown /opt/venv faster

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,6 @@ ENTRYPOINT [ "/home/vcap/app/entrypoint.sh" ]
 FROM production as test
 
 USER root
-RUN chown -R notify:notify /opt/venv
 RUN echo "Install OS dependencies for test build" && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -75,6 +74,9 @@ USER notify
 
 # Make sure the app/ directory is there so that "make bootstrap" can create app/version.py
 RUN mkdir -p app
+
+# Copying to overwrite is faster than RUN chown notify:notify ...
+COPY --from=python_build --chown=notify:notify /opt/venv /opt/venv
 
 # Install dev/test requirements
 COPY --chown=notify:notify Makefile requirements.txt requirements_for_test.txt ./


### PR DESCRIPTION
Copying the directory via a Dockerfile command is faster than running a command inside the build container to update ownership

```
 => [notify-api test 3/6] COPY --from=python_build --chown=notify:notify /opt/venv /opt/venv        2.8s
```

vs

```
 => [notify-api test 1/6] RUN chown -R notify:notify /opt/venv                                      9.2s
```