### PR TITLE
Allow tests to run in or out of docker

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -538,8 +538,8 @@ class Test(Development):
     S3_BUCKET_TRANSIENT_UPLOADED_LETTERS = "test-transient-uploaded-letters"
     S3_BUCKET_LETTER_SANITISE = "test-letters-sanitise"
 
-    # this is overriden in jenkins and on cloudfoundry
-    SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI", "postgresql://localhost/test_notification_api")
+    # when testing, the SQLALCHEMY_DATABASE_URI is used for the postgres server's location
+    # but the database name is set in the _notify_db fixture
     SQLALCHEMY_RECORD_QUERIES = False
 
     CELERY = {**Config.CELERY, "broker_url": "you-forgot-to-mock-celery-in-your-tests://"}

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -187,7 +187,7 @@ def get_logo_url(base_url, logo_file):
     base_url = parse.urlparse(base_url)
     netloc = base_url.netloc
 
-    if base_url.netloc.startswith("localhost"):
+    if base_url.hostname.split(".")[-1] == "localhost":
         netloc = "notify.tools"
     elif base_url.netloc.startswith("www"):
         # strip "www."

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -827,7 +827,7 @@ def test_delete_old_records_from_events_table(notify_db_session):
 
 
 @freeze_time("2022-11-01 00:30:00", tick=True)
-def test_zendesk_new_email_branding_report(notify_db_session, mocker, notify_user):
+def test_zendesk_new_email_branding_report(notify_db_session, mocker, notify_user, hostnames):
     org_1 = create_organisation(organisation_id=uuid.UUID("113d51e7-f204-44d0-99c6-020f3542a527"), name="org-1")
     org_2 = create_organisation(organisation_id=uuid.UUID("d6bc2309-9f79-4779-b864-46c2892db90e"), name="org-2")
     email_brand_1 = create_email_branding(
@@ -879,25 +879,25 @@ def test_zendesk_new_email_branding_report(notify_db_session, mocker, notify_use
         "<h2>New email branding to review</h2>\n<p>Uploaded since Monday 31 October 2022:</p>",
         (
             "<p>"
-            '<a href="http://localhost:6012/organisations/'
+            f'<a href="{hostnames.admin}/organisations/'
             '113d51e7-f204-44d0-99c6-020f3542a527/settings/email-branding">org-1</a> (no default):'
             "</p>"
             "<ul>"
             "<li>"
-            '<a href="http://localhost:6012/email-branding/bc5b45e0-af3c-4e3d-a14c-253a56b77480">brand-1</a>'
+            f'<a href="{hostnames.admin}/email-branding/bc5b45e0-af3c-4e3d-a14c-253a56b77480">brand-1</a>'
             "</li>"
             "<li>"
-            '<a href="http://localhost:6012/email-branding/c9c265b3-14ec-42f1-8ae9-4749ffc6f5b0">brand-2</a>'
+            f'<a href="{hostnames.admin}/email-branding/c9c265b3-14ec-42f1-8ae9-4749ffc6f5b0">brand-2</a>'
             "</li>"
             "</ul>"
             "<hr>"
             "<p>"
-            '<a href="http://localhost:6012/organisations/'
+            f'<a href="{hostnames.admin}/organisations/'
             'd6bc2309-9f79-4779-b864-46c2892db90e/settings/email-branding">org-2</a>:'
             "</p>"
             "<ul>"
             "<li>"
-            '<a href="http://localhost:6012/email-branding/c9c265b3-14ec-42f1-8ae9-4749ffc6f5b0">brand-2</a>'
+            f'<a href="{hostnames.admin}/email-branding/c9c265b3-14ec-42f1-8ae9-4749ffc6f5b0">brand-2</a>'
             "</li>"
             "</ul>"
         ),
@@ -905,7 +905,7 @@ def test_zendesk_new_email_branding_report(notify_db_session, mocker, notify_use
             "<p>These new brands are not associated with any organisation and do not need reviewing:</p>"
             "<ul>"
             "<li>"
-            '<a href="http://localhost:6012/email-branding/1b7deb1f-ff1f-4d00-a7a7-05b0b57a185e">brand-3</a>'
+            f'<a href="{hostnames.admin}/email-branding/1b7deb1f-ff1f-4d00-a7a7-05b0b57a185e">brand-3</a>'
             "</li>"
             "</ul>"
         ),
@@ -914,7 +914,9 @@ def test_zendesk_new_email_branding_report(notify_db_session, mocker, notify_use
 
 
 @freeze_time("2022-11-01 00:30:00")
-def test_zendesk_new_email_branding_report_for_unassigned_branding_only(notify_db_session, mocker, notify_user):
+def test_zendesk_new_email_branding_report_for_unassigned_branding_only(
+    notify_db_session, mocker, notify_user, hostnames
+):
     create_organisation(organisation_id=uuid.UUID("113d51e7-f204-44d0-99c6-020f3542a527"), name="org-1")
     create_organisation(organisation_id=uuid.UUID("d6bc2309-9f79-4779-b864-46c2892db90e"), name="org-2")
     create_email_branding(
@@ -936,11 +938,11 @@ def test_zendesk_new_email_branding_report_for_unassigned_branding_only(notify_d
         "<p>These new brands are not associated with any organisation and do not need reviewing:</p>"
         "<ul>"
         "<li>"
-        '<a href="http://localhost:6012/email-branding/bc5b45e0-af3c-4e3d-a14c-253a56b77480">brand-1</a>'
+        f'<a href="{hostnames.admin}/email-branding/bc5b45e0-af3c-4e3d-a14c-253a56b77480">brand-1</a>'
         "</li><li>"
-        '<a href="http://localhost:6012/email-branding/c9c265b3-14ec-42f1-8ae9-4749ffc6f5b0">brand-2</a>'
+        f'<a href="{hostnames.admin}/email-branding/c9c265b3-14ec-42f1-8ae9-4749ffc6f5b0">brand-2</a>'
         "</li><li>"
-        '<a href="http://localhost:6012/email-branding/1b7deb1f-ff1f-4d00-a7a7-05b0b57a185e">brand-3</a>'
+        f'<a href="{hostnames.admin}/email-branding/1b7deb1f-ff1f-4d00-a7a7-05b0b57a185e">brand-3</a>'
         "</li>"
         "</ul>"
     )

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -446,7 +446,7 @@ def test_get_html_email_renderer_with_branding_details_and_render_govuk_banner_o
     assert options == {"govuk_banner": True, "brand_banner": False}
 
 
-def test_get_html_email_renderer_prepends_logo_path(notify_api):
+def test_get_html_email_renderer_prepends_logo_path(notify_api, hostnames):
     Service = namedtuple("Service", ["email_branding"])
     EmailBranding = namedtuple("EmailBranding", ["brand_type", "colour", "name", "logo", "text", "alt_text"])
 

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -649,7 +649,7 @@ def test_check_reply_to_letter_type(sample_service):
     assert check_reply_to(sample_service.id, letter_contact.id, LETTER_TYPE) == "123456"
 
 
-def test_check_if_service_can_send_files_by_email_raises_if_no_contact_link_set(sample_service):
+def test_check_if_service_can_send_files_by_email_raises_if_no_contact_link_set(sample_service, hostnames):
     with pytest.raises(BadRequestError) as e:
         check_if_service_can_send_files_by_email(
             service_contact_link=sample_service.contact_link, service_id=sample_service.id
@@ -657,7 +657,7 @@ def test_check_if_service_can_send_files_by_email_raises_if_no_contact_link_set(
 
     message = (
         f"Send files by email has not been set up - add contact details for your service at "
-        f"http://localhost:6012/services/{sample_service.id}/service-settings/send-files-by-email"
+        f"{hostnames.admin}/services/{sample_service.id}/service-settings/send-files-by-email"
     )
     assert e.value.status_code == 400
     assert e.value.message == message

--- a/tests/app/organisation/test_invite_rest.py
+++ b/tests/app/organisation/test_invite_rest.py
@@ -17,7 +17,7 @@ from tests.app.db import create_invited_org_user
 @pytest.mark.parametrize(
     "extra_args, expected_start_of_invite_url",
     [
-        ({}, "http://localhost:6012/organisation-invitation/"),
+        ({}, "{hostnames.admin}/organisation-invitation/"),
         ({"invite_link_host": "https://www.example.com"}, "https://www.example.com/organisation-invitation/"),
     ],
 )
@@ -31,6 +31,7 @@ def test_create_invited_org_user(
     expected_start_of_invite_url,
     platform_admin,
     expected_invited_by,
+    hostnames,
 ):
     mocked = mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
     email_address = "invited_user@example.com"
@@ -65,8 +66,8 @@ def test_create_invited_org_user(
     assert len(notification.personalisation.keys()) == 3
     assert notification.personalisation["organisation_name"] == "sample organisation"
     assert notification.personalisation["user_name"] == expected_invited_by
-    assert notification.personalisation["url"].startswith(expected_start_of_invite_url)
-    assert len(notification.personalisation["url"]) > len(expected_start_of_invite_url)
+    assert notification.personalisation["url"].startswith(expected_start_of_invite_url.format(hostnames=hostnames))
+    assert len(notification.personalisation["url"]) > len(expected_start_of_invite_url.format(hostnames=hostnames))
 
     mocked.assert_called_once_with([(str(notification.id))], queue="notify-internal-tasks")
 

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -548,6 +548,7 @@ def test_post_update_organisation_set_mou_emails_signed_by(
     on_behalf_of_name,
     on_behalf_of_email_address,
     templates_and_recipients,
+    hostnames,
 ):
     queue_mock = mocker.patch("app.organisation.rest.send_notification_to_queue")
     sample_organisation.agreement_signed_on_behalf_of_name = on_behalf_of_name
@@ -566,9 +567,9 @@ def test_post_update_organisation_set_mou_emails_signed_by(
     for n in notifications:
         # we pass in the same personalisation for all templates (though some templates don't use all fields)
         assert n.personalisation == {
-            "mou_link": "http://localhost:6012/agreement/non-crown.pdf",
+            "mou_link": f"{hostnames.admin}/agreement/non-crown.pdf",
             "org_name": "sample organisation",
-            "org_dashboard_link": "http://localhost:6012/organisations/{}".format(sample_organisation.id),
+            "org_dashboard_link": f"{hostnames.admin}/organisations/{sample_organisation.id}",
             "signed_by_name": "Test User",
             "on_behalf_of_name": on_behalf_of_name,
         }
@@ -1196,6 +1197,7 @@ def test_notify_org_users_of_request_to_go_live(
     sample_organisation,
     sample_service,
     organisation_has_new_go_live_request_template,
+    hostnames,
 ):
     notify_service = dao_fetch_service_by_id(current_app.config["NOTIFY_SERVICE_ID"])
 
@@ -1244,8 +1246,8 @@ def test_notify_org_users_of_request_to_go_live(
                 "service_name": "Sample service",
                 "requester_name": "Go live user",
                 "requester_email_address": "go-live-user@example.gov.uk",
-                "make_service_live_link": f"http://localhost:6012/services/{sample_service.id}/make-service-live",
-                "support_page_link": "http://localhost:6012/support",
+                "make_service_live_link": f"{hostnames.admin}/services/{sample_service.id}/make-service-live",
+                "support_page_link": f"{hostnames.admin}/support",
                 "organisation_name": "sample organisation",
                 "name": ANY,
             },

--- a/tests/app/service_invite/test_service_invite_rest.py
+++ b/tests/app/service_invite/test_service_invite_rest.py
@@ -15,7 +15,7 @@ from tests.app.db import create_invited_user
 @pytest.mark.parametrize(
     "extra_args, expected_start_of_invite_url",
     [
-        ({}, "http://localhost:6012/invitation/"),
+        ({}, "{hostnames.admin}/invitation/"),
         ({"invite_link_host": "https://www.example.com"}, "https://www.example.com/invitation/"),
     ],
 )
@@ -26,6 +26,7 @@ def test_create_invited_user(
     invitation_email_template,
     extra_args,
     expected_start_of_invite_url,
+    hostnames,
 ):
     mocked = mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
     email_address = "invited_user@service.gov.uk"
@@ -60,8 +61,8 @@ def test_create_invited_user(
     assert len(notification.personalisation.keys()) == 3
     assert notification.personalisation["service_name"] == "Sample service"
     assert notification.personalisation["user_name"] == "Test User"
-    assert notification.personalisation["url"].startswith(expected_start_of_invite_url)
-    assert len(notification.personalisation["url"]) > len(expected_start_of_invite_url)
+    assert notification.personalisation["url"].startswith(expected_start_of_invite_url.format(hostnames=hostnames))
+    assert len(notification.personalisation["url"]) > len(expected_start_of_invite_url.format(hostnames=hostnames))
     assert str(notification.template_id) == current_app.config["INVITATION_EMAIL_TEMPLATE_ID"]
 
     mocked.assert_called_once_with([(str(notification.id))], queue="notify-internal-tasks")
@@ -70,7 +71,7 @@ def test_create_invited_user(
 @pytest.mark.parametrize(
     "extra_args, expected_start_of_invite_url",
     [
-        ({}, "http://localhost:6012/invitation/"),
+        ({}, "{hostnames.admin}/invitation/"),
         ({"invite_link_host": "https://www.example.com"}, "https://www.example.com/invitation/"),
     ],
 )
@@ -81,6 +82,7 @@ def test_invited_user_for_broadcast_service_receives_broadcast_invite_email(
     broadcast_invitation_email_template,
     extra_args,
     expected_start_of_invite_url,
+    hostnames,
 ):
     mocked = mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
     email_address = "invited_user@service.gov.uk"
@@ -107,8 +109,8 @@ def test_invited_user_for_broadcast_service_receives_broadcast_invite_email(
     assert len(notification.personalisation.keys()) == 3
     assert notification.personalisation["service_name"] == "Sample broadcast service"
     assert notification.personalisation["user_name"] == "Test User"
-    assert notification.personalisation["url"].startswith(expected_start_of_invite_url)
-    assert len(notification.personalisation["url"]) > len(expected_start_of_invite_url)
+    assert notification.personalisation["url"].startswith(expected_start_of_invite_url.format(hostnames=hostnames))
+    assert len(notification.personalisation["url"]) > len(expected_start_of_invite_url.format(hostnames=hostnames))
     assert str(notification.template_id) == current_app.config["BROADCAST_INVITATION_EMAIL_TEMPLATE_ID"]
 
     mocked.assert_called_once_with([(str(notification.id))], queue="notify-internal-tasks")

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -666,7 +666,7 @@ def test_send_user_reset_password_should_send_reset_password_link(
             {
                 "email": "notify@digital.cabinet-office.gov.uk",
             },
-            ("http://localhost:6012/new-password/"),
+            ("{hostnames.admin}/new-password/"),
         ),
         (
             {
@@ -685,6 +685,7 @@ def test_send_user_reset_password_should_use_provided_base_url(
     mocker,
     data,
     expected_url,
+    hostnames,
 ):
     mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
 
@@ -694,7 +695,7 @@ def test_send_user_reset_password_should_use_provided_base_url(
         _expected_status=204,
     )
 
-    assert Notification.query.first().personalisation["url"].startswith(expected_url)
+    assert Notification.query.first().personalisation["url"].startswith(expected_url.format(hostnames=hostnames))
 
 
 @freeze_time("2016-01-01 11:09:00.061258")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from collections import namedtuple
 from contextlib import contextmanager
 
 import freezegun
@@ -173,6 +174,17 @@ def os_environ():
     os.environ.clear()
     for k, v in old_env.items():
         os.environ[k] = v
+
+
+@pytest.fixture(scope="session")
+def hostnames(notify_api):
+    api_url = notify_api.config["API_HOST_NAME"]
+    admin_url = notify_api.config["ADMIN_BASE_URL"]
+    template_preview_url = notify_api.config["TEMPLATE_PREVIEW_API_HOST"]
+
+    return namedtuple("NotifyHostnames", ["api", "admin", "template_preview"])(
+        api=api_url, admin=admin_url, template_preview=template_preview_url
+    )
 
 
 def pytest_generate_tests(metafunc):


### PR DESCRIPTION
When running inside docker we have different hostnames for our apps, so we can't hardcode them inside tests. We can add a fixture that pulls the hostnames for our apps from environment variables, allowing tests to pass either locally or inside docker.