### PR TITLE
Add celery task to delete one quarter of old notification history

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -11,7 +11,7 @@ from notifications_utils.letter_timings import (
     get_dvla_working_day_offset_by,
     is_dvla_working_day,
 )
-from notifications_utils.timezones import convert_utc_to_bst
+from notifications_utils.timezones import convert_bst_to_utc, convert_utc_to_bst
 from sqlalchemy import func
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -340,32 +340,53 @@ def save_daily_notification_processing_time(bst_date=None):
 
 @notify_celery.task(name="delete-oldest-quarter-of-unneeded-notification-history")
 def delete_oldest_quarter_of_unneeded_notification_history():
-    # This retention limit is hardcoded for the moment. It is picked from
+    # This function will delete either 1 or 0 quarters of notifications from the notification_history
+    # table. It will pick the oldest quarter available before our retention limit and delete that.
+    # If there are no notifications older than our retention limit, then it won't do anything.
+    # By running this task several nights in a row, it will slowly delete a quarter of notification_history
+    # per night until we reach out retention limit
+    #
+    # We do everything in this function in BST up until the final point
+    # This is because we care about quarters in the BST timezone because this is
+    # how we bill our users and is easier to reason about.
+    # When we finally figure out which BST quarter we can delete, we convert the time
+    # to UTC so that we delete the correct notifications from our database
+    #
+    # This retention limit is hardcoded and picked from
     # https://github.com/alphagov/notifications-aws/blob/main/decisions/2022-12-01-notification-history-retention-period.md
     # and can be increased in the future when we move 3 months into the next financial year
-    retention_limit = datetime(2023, 4, 1)
+    retention_limit_bst = datetime(2023, 4, 1)
 
-    oldest_record = db.session.query(func.min(NotificationHistory.created_at)).one()[0]
-    if oldest_record >= retention_limit:
+    oldest_notification_bst = convert_utc_to_bst(db.session.query(func.min(NotificationHistory.created_at)).one()[0])
+    if oldest_notification_bst >= retention_limit_bst:
         current_app.logger.info(
-            "No notifications older than retention date of %s so nothing to delete", retention_limit
+            "No notifications older than retention date of %s so nothing to delete", retention_limit_bst
         )
         return
 
-    # Pick a potential deletion date to start, that we know is older than the oldest notification
-    # in notification_history at the time of writing this code
+    deletion_date_bst = pick_bst_quarter_to_delete_back_from(oldest_notification_bst)
+
+    # in case there is an error in our logic above, let us just double check that we aren't trying to delete for
+    # anything after our retention limit
+    if deletion_date_bst > retention_limit_bst:
+        current_app.logger.exception("Attempted to delete past our notification_history retention limit")
+        raise
+
+    deletion_date_utc = convert_bst_to_utc(deletion_date_bst)
+
+    delete_notification_history_older_than_datetime(deletion_date_utc)
+
+
+def pick_bst_quarter_to_delete_back_from(oldest_notification_bst):
+    # We've picked a potential deletion date to start that we know is older than the oldest notification
+    # in notification_history at the time of writing this code.
+    # The potential deletion date to start is intentionally the BST start of a new quarter
     deletion_date = datetime(2019, 10, 1)
-    while deletion_date <= oldest_record:
+    while deletion_date <= oldest_notification_bst:
         # There are no notifications older than our deletion date, lets add 3 months
         # and see if that is still true
         # When we finally find a deletion date that has notifications older than the deletion date
         # we can then delete anything older (ie the previous quarters data)
         deletion_date = deletion_date + dateutil.relativedelta.relativedelta(months=3)
 
-    # in case there is an error in our logic above, let us just double check that we aren't trying to delete for
-    # anything after our retention limit
-    if deletion_date > retention_limit:
-        current_app.logger.exception("Attempted to delete past our notification_history retention limit")
-        raise
-
-    delete_notification_history_older_than_datetime(deletion_date)
+    return deletion_date

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -352,10 +352,17 @@ def delete_oldest_quarter_of_unneeded_notification_history():
     # When we finally figure out which BST quarter we can delete, we convert the time
     # to UTC so that we delete the correct notifications from our database
     #
-    # This retention limit is hardcoded and picked from
+    # This retention limit is hardcoded and was originally picked from
     # https://github.com/alphagov/notifications-aws/blob/main/decisions/2022-12-01-notification-history-retention-period.md
-    # and can be increased in the future when we move 3 months into the next financial year
-    retention_limit_bst = datetime(2023, 4, 1)
+    # It was supposed to be 2023-4-1.
+    # However, at the time of writing this code we realised the FtBillingLetterDispatch table has been introduced
+    # which means we need to store letters older than 2023-4-1 in order to rebuild that table (because that table
+    # uses the date of dispatch, not the date of creation for which date to bill for). To keep it simple, we keep
+    # an extra quarters worth of data giving us plenty of buffer
+    #
+    # In the future, we will be able to update this retention_limit_bst value when we have progressed 3 quarters
+    # into the next financial year
+    retention_limit_bst = datetime(2023, 1, 1)
 
     oldest_notification_bst = convert_utc_to_bst(db.session.query(func.min(NotificationHistory.created_at)).one()[0])
     if oldest_notification_bst >= retention_limit_bst:

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -342,7 +342,7 @@ def delete_oldest_quarter_of_unneeded_notification_history():
     # This retention limit is hardcoded for the moment. It is picked from
     # https://github.com/alphagov/notifications-aws/blob/main/decisions/2022-12-01-notification-history-retention-period.md
     # and can be increased in the future when we move 3 months into the next financial year
-    retention_limit = datetime(2022, 4, 1)
+    retention_limit = datetime(2023, 4, 1)
 
     oldest_record = db.session.query(func.min(NotificationHistory.created_at)).one()[0]
     if oldest_record >= retention_limit:

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -376,8 +376,7 @@ def delete_oldest_quarter_of_unneeded_notification_history():
     # in case there is an error in our logic above, let us just double check that we aren't trying to delete for
     # anything after our retention limit
     if deletion_date_bst > retention_limit_bst:
-        current_app.logger.exception("Attempted to delete past our notification_history retention limit")
-        raise
+        raise Exception("Attempted to delete past our notification_history retention limit")
 
     deletion_date_utc = convert_bst_to_utc(deletion_date_bst)
 

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -32,6 +32,7 @@ from app.dao.jobs_dao import (
     dao_archive_job,
     dao_get_jobs_older_than_data_retention,
 )
+from app.dao.notification_history_dao import delete_notification_history_older_than_datetime
 from app.dao.notifications_dao import (
     dao_get_notifications_processing_time_stats,
     dao_timeout_notifications,
@@ -368,15 +369,3 @@ def delete_oldest_quarter_of_unneeded_notification_history():
         raise
 
     delete_notification_history_older_than_datetime(deletion_date)
-
-
-def delete_notification_history_older_than_datetime(older_than_datetime):
-    current_app.logger.info("Beginning to delete notification_history older than %s", older_than_datetime)
-
-    num_rows_deleted = NotificationHistory.query.filter(
-        NotificationHistory.sent_at < older_than_datetime,
-    ).delete()
-
-    current_app.logger.info(
-        "Deleted %s rows from notification_history older than %s", num_rows_deleted, older_than_datetime
-    )

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -354,7 +354,7 @@ def delete_oldest_quarter_of_unneeded_notification_history():
     # Pick a potential deletion date to start, that we know is older than the oldest notification
     # in notification_history at the time of writing this code
     deletion_date = datetime(2019, 10, 1)
-    while deletion_date < oldest_record:
+    while deletion_date <= oldest_record:
         # There are no notifications older than our deletion date, lets add 3 months
         # and see if that is still true
         # When we finally find a deletion date that has notifications older than the deletion date

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -361,6 +361,12 @@ def delete_oldest_quarter_of_unneeded_notification_history():
         # we can then delete anything older (ie the previous quarters data)
         deletion_date = deletion_date + dateutil.relativedelta.relativedelta(months=3)
 
+    # in case there is an error in our logic above, let us just double check that we aren't trying to delete for
+    # anything after our retention limit
+    if deletion_date > retention_limit:
+        current_app.logger.exception("Attempted to delete past our notification_history retention limit")
+        raise
+
     delete_notification_history_older_than_datetime(deletion_date)
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -262,6 +262,11 @@ class Config(object):
                 "options": {"queue": QueueNames.PERIODIC},
             },
             # app/celery/nightly_tasks.py
+            "delete-oldest-quarter-of-unneeded-notification-history": {
+                "task": "delete-oldest-quarter-of-unneeded-notification-history",
+                "schedule": crontab(hour=21),
+                "options": {"queue": QueueNames.PERIODIC},
+            },
             "timeout-sending-notifications": {
                 "task": "timeout-sending-notifications",
                 "schedule": crontab(hour=0, minute=5),

--- a/app/dao/notification_history_dao.py
+++ b/app/dao/notification_history_dao.py
@@ -9,7 +9,7 @@ def delete_notification_history_older_than_datetime(older_than_datetime):
     current_app.logger.info("Beginning to delete notification_history older than %s", older_than_datetime)
 
     num_rows_deleted = NotificationHistory.query.filter(
-        NotificationHistory.sent_at < older_than_datetime,
+        NotificationHistory.created_at < older_than_datetime,
     ).delete()
 
     current_app.logger.info(

--- a/app/dao/notification_history_dao.py
+++ b/app/dao/notification_history_dao.py
@@ -1,8 +1,10 @@
 from flask import current_app
 
+from app.dao.dao_utils import autocommit
 from app.models import NotificationHistory
 
 
+@autocommit
 def delete_notification_history_older_than_datetime(older_than_datetime):
     current_app.logger.info("Beginning to delete notification_history older than %s", older_than_datetime)
 

--- a/app/dao/notification_history_dao.py
+++ b/app/dao/notification_history_dao.py
@@ -1,0 +1,15 @@
+from flask import current_app
+
+from app.models import NotificationHistory
+
+
+def delete_notification_history_older_than_datetime(older_than_datetime):
+    current_app.logger.info("Beginning to delete notification_history older than %s", older_than_datetime)
+
+    num_rows_deleted = NotificationHistory.query.filter(
+        NotificationHistory.sent_at < older_than_datetime,
+    ).delete()
+
+    current_app.logger.info(
+        "Deleted %s rows from notification_history older than %s", num_rows_deleted, older_than_datetime
+    )

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -591,8 +591,8 @@ def test_delete_notifications_task_calls_task_for_services_that_have_sent_notifi
         [datetime(2020, 4, 1), datetime(2020, 7, 1)],
         [datetime(2021, 12, 1), datetime(2022, 1, 1)],
         [datetime(2022, 3, 31), datetime(2022, 4, 1)],
-        [datetime(2023, 1, 1), datetime(2023, 4, 1)],
-        [datetime(2023, 3, 31), datetime(2023, 4, 1)],
+        [datetime(2022, 10, 1), datetime(2023, 1, 1)],
+        [datetime(2022, 12, 31), datetime(2023, 1, 1)],
     ],
 )
 def test_pick_bst_quarter_to_delete_back_from(oldest_notification_datetime, expected_delete_back_from):
@@ -603,10 +603,10 @@ def test_pick_bst_quarter_to_delete_back_from(oldest_notification_datetime, expe
 @pytest.mark.parametrize(
     "oldest_notification_datetime,expected_delete_back_from",
     [
+        [datetime(2022, 1, 1), datetime(2022, 3, 31, 23, 0, 0)],
         [datetime(2022, 3, 31, 23, 0, 0), datetime(2022, 6, 30, 23, 0, 0)],
         [datetime(2022, 6, 30, 23, 0, 0), datetime(2022, 9, 30, 23, 0, 0)],
         [datetime(2022, 9, 30, 23, 0, 0), datetime(2023, 1, 1)],
-        [datetime(2023, 1, 1), datetime(2023, 3, 31, 23, 0, 0)],
     ],
 )
 def test_delete_oldest_quarter_of_unneeded_notification_history_deletes_correct_utc_datetime(
@@ -633,9 +633,9 @@ def test_delete_oldest_quarter_of_unneeded_notification_history_doesnt_delete_if
     create_notification_history(
         sample_letter_template,
         status="delivered",
-        created_at=datetime(2023, 3, 31, 23, 0, 0),
-        sent_at=datetime(2023, 3, 31, 23, 0, 0),
-        updated_at=datetime(2023, 3, 31, 23, 0, 0),
+        created_at=datetime(2023, 1, 1),
+        sent_at=datetime(2023, 1, 1),
+        updated_at=datetime(2023, 1, 1),
     )
 
     delete_oldest_quarter_of_unneeded_notification_history()
@@ -651,14 +651,12 @@ def test_delete_notification_history_older_than_retention_limit(notify_db_sessio
         datetime(2022, 6, 29),
         datetime(2022, 6, 30, 23, 59, 59),
         datetime(2022, 7, 1),
-        datetime(2023, 3, 31),
-        datetime(2023, 3, 31, 22, 59, 59),
+        datetime(2022, 12, 31),
+        datetime(2022, 12, 31, 23, 59, 59),
         # should delete everything before here
-        datetime(2023, 3, 31, 23, 0, 0),
-        datetime(2023, 3, 31, 23, 0, 1),
-        datetime(2023, 3, 31, 23, 59, 59),
+        datetime(2023, 1, 1),
+        datetime(2023, 1, 1, 0, 0, 1),
         datetime(2023, 4, 1),
-        datetime(2023, 4, 1, 0, 0, 1),
         datetime(2023, 9, 4),
     ]
     for dt in notification_history_datetimes:
@@ -666,7 +664,7 @@ def test_delete_notification_history_older_than_retention_limit(notify_db_sessio
             sample_letter_template, status="delivered", created_at=dt, sent_at=dt, updated_at=dt
         )
     notification_history_rows = NotificationHistory.query.order_by(NotificationHistory.created_at).all()
-    assert len(notification_history_rows) == 14
+    assert len(notification_history_rows) == 12
     assert notification_history_rows[0].created_at == datetime(2019, 6, 8, 1, 4)
 
     # we run this 15 times to replicate it running many days in a row such that it has done all of its work
@@ -675,5 +673,5 @@ def test_delete_notification_history_older_than_retention_limit(notify_db_sessio
         delete_oldest_quarter_of_unneeded_notification_history()
 
     notification_history_rows = NotificationHistory.query.order_by(NotificationHistory.created_at).all()
-    assert len(notification_history_rows) == 6
-    assert notification_history_rows[0].created_at == datetime(2023, 3, 31, 23, 0, 0)
+    assert len(notification_history_rows) == 4
+    assert notification_history_rows[0].created_at == datetime(2023, 1, 1)

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -614,6 +614,7 @@ def test_delete_notification_history_older_than_datetime(notify_db_session, samp
         [datetime(2020, 6, 1), datetime(2020, 7, 1)],
         [datetime(2021, 12, 1), datetime(2022, 1, 1)],
         [datetime(2022, 3, 31), datetime(2022, 4, 1)],
+        [datetime(2023, 3, 31), datetime(2023, 4, 1)],
     ],
 )
 def test_delete_oldest_quarter_of_unneeded_notification_history_deletes_expected(
@@ -640,9 +641,9 @@ def test_delete_oldest_quarter_of_unneeded_notification_history_doesnt_delete_if
     create_notification_history(
         sample_letter_template,
         status="delivered",
-        created_at=datetime(2022, 4, 1),
-        sent_at=datetime(2022, 4, 1),
-        updated_at=datetime(2022, 4, 1),
+        created_at=datetime(2023, 4, 1),
+        sent_at=datetime(2023, 4, 1),
+        updated_at=datetime(2023, 4, 1),
     )
 
     delete_oldest_quarter_of_unneeded_notification_history()

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -16,7 +16,6 @@ from app.celery.nightly_tasks import (
     delete_email_notifications_older_than_retention,
     delete_inbound_sms,
     delete_letter_notifications_older_than_retention,
-    delete_notification_history_older_than_datetime,
     delete_oldest_quarter_of_unneeded_notification_history,
     delete_sms_notifications_older_than_retention,
     get_letter_notifications_still_sending_when_they_shouldnt_be,
@@ -580,29 +579,6 @@ def test_delete_notifications_task_calls_task_for_services_that_have_sent_notifi
             ),
         ],
     )
-
-
-def test_delete_notification_history_older_than_datetime(notify_db_session, sample_letter_template):
-    notification_history_datetimes = [
-        datetime(2022, 2, 7),
-        datetime(2022, 6, 29),
-        datetime(2022, 6, 30, 23, 59, 59),
-        datetime(2022, 7, 1),
-        datetime(2023, 9, 4),
-    ]
-    for dt in notification_history_datetimes:
-        create_notification_history(
-            sample_letter_template, status="delivered", created_at=dt, sent_at=dt, updated_at=dt
-        )
-    notification_history_rows = NotificationHistory.query.order_by(NotificationHistory.created_at).all()
-    assert len(notification_history_rows) == 5
-    assert notification_history_rows[0].created_at == datetime(2022, 2, 7)
-
-    delete_notification_history_older_than_datetime(datetime(2022, 7, 1))
-
-    notification_history_rows = NotificationHistory.query.order_by(NotificationHistory.created_at).all()
-    assert len(notification_history_rows) == 2
-    assert notification_history_rows[0].created_at == datetime(2022, 7, 1)
 
 
 @pytest.mark.parametrize(

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -611,9 +611,10 @@ def test_delete_notification_history_older_than_datetime(notify_db_session, samp
         # 2019-10-1 is the first possible deletion date so that is why it isnt 2019-7-1 for the start of the
         # next quarter
         [datetime(2019, 6, 1), datetime(2019, 10, 1)],
-        [datetime(2020, 6, 1), datetime(2020, 7, 1)],
+        [datetime(2020, 4, 1), datetime(2020, 7, 1)],
         [datetime(2021, 12, 1), datetime(2022, 1, 1)],
         [datetime(2022, 3, 31), datetime(2022, 4, 1)],
+        [datetime(2023, 1, 1), datetime(2023, 4, 1)],
         [datetime(2023, 3, 31), datetime(2023, 4, 1)],
     ],
 )

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -16,6 +16,8 @@ from app.celery.nightly_tasks import (
     delete_email_notifications_older_than_retention,
     delete_inbound_sms,
     delete_letter_notifications_older_than_retention,
+    delete_notification_history_older_than_datetime,
+    delete_oldest_quarter_of_unneeded_notification_history,
     delete_sms_notifications_older_than_retention,
     get_letter_notifications_still_sending_when_they_shouldnt_be,
     letter_raise_alert_if_no_ack_file_for_zip,
@@ -27,10 +29,11 @@ from app.celery.nightly_tasks import (
     timeout_notifications,
 )
 from app.constants import EMAIL_TYPE, LETTER_TYPE, SMS_TYPE
-from app.models import FactProcessingTime
+from app.models import FactProcessingTime, NotificationHistory
 from tests.app.db import (
     create_job,
     create_notification,
+    create_notification_history,
     create_service,
     create_service_data_retention,
     create_template,
@@ -577,3 +580,71 @@ def test_delete_notifications_task_calls_task_for_services_that_have_sent_notifi
             ),
         ],
     )
+
+
+def test_delete_notification_history_older_than_datetime(notify_db_session, sample_letter_template):
+    notification_history_datetimes = [
+        datetime(2022, 2, 7),
+        datetime(2022, 6, 29),
+        datetime(2022, 6, 30, 23, 59, 59),
+        datetime(2022, 7, 1),
+        datetime(2023, 9, 4),
+    ]
+    for dt in notification_history_datetimes:
+        create_notification_history(
+            sample_letter_template, status="delivered", created_at=dt, sent_at=dt, updated_at=dt
+        )
+    notification_history_rows = NotificationHistory.query.order_by(NotificationHistory.created_at).all()
+    assert len(notification_history_rows) == 5
+    assert notification_history_rows[0].created_at == datetime(2022, 2, 7)
+
+    delete_notification_history_older_than_datetime(datetime(2022, 7, 1))
+
+    notification_history_rows = NotificationHistory.query.order_by(NotificationHistory.created_at).all()
+    assert len(notification_history_rows) == 2
+    assert notification_history_rows[0].created_at == datetime(2022, 7, 1)
+
+
+@pytest.mark.parametrize(
+    "oldest_notification_datetime,expected_delete_back_from",
+    [
+        # 2019-10-1 is the first possible deletion date so that is why it isnt 2019-7-1 for the start of the
+        # next quarter
+        [datetime(2019, 6, 1), datetime(2019, 10, 1)],
+        [datetime(2020, 6, 1), datetime(2020, 7, 1)],
+        [datetime(2021, 12, 1), datetime(2022, 1, 1)],
+        [datetime(2022, 3, 31), datetime(2022, 4, 1)],
+    ],
+)
+def test_delete_oldest_quarter_of_unneeded_notification_history_deletes_expected(
+    mocker, notify_db_session, sample_letter_template, oldest_notification_datetime, expected_delete_back_from
+):
+    delete_mock = mocker.patch("app.celery.nightly_tasks.delete_notification_history_older_than_datetime")
+    create_notification_history(
+        sample_letter_template,
+        status="delivered",
+        created_at=oldest_notification_datetime,
+        sent_at=oldest_notification_datetime,
+        updated_at=oldest_notification_datetime,
+    )
+
+    delete_oldest_quarter_of_unneeded_notification_history()
+
+    delete_mock.assert_called_once_with(expected_delete_back_from)
+
+
+def test_delete_oldest_quarter_of_unneeded_notification_history_doesnt_delete_if_past_retention_limit(
+    mocker, notify_db_session, sample_letter_template
+):
+    delete_mock = mocker.patch("app.celery.nightly_tasks.delete_notification_history_older_than_datetime")
+    create_notification_history(
+        sample_letter_template,
+        status="delivered",
+        created_at=datetime(2022, 4, 1),
+        sent_at=datetime(2022, 4, 1),
+        updated_at=datetime(2022, 4, 1),
+    )
+
+    delete_oldest_quarter_of_unneeded_notification_history()
+
+    delete_mock.assert_not_called()

--- a/tests/app/dao/test_notification_history_dao.py
+++ b/tests/app/dao/test_notification_history_dao.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+from app.dao.notification_history_dao import delete_notification_history_older_than_datetime
+from app.models import NotificationHistory
+from tests.app.db import create_notification_history
+
+
+def test_delete_notification_history_older_than_datetime(notify_db_session, sample_letter_template):
+    notification_history_datetimes = [
+        datetime(2022, 2, 7),
+        datetime(2022, 6, 29),
+        datetime(2022, 6, 30, 23, 59, 59),
+        datetime(2022, 7, 1),
+        datetime(2023, 9, 4),
+    ]
+    for dt in notification_history_datetimes:
+        create_notification_history(
+            sample_letter_template, status="delivered", created_at=dt, sent_at=dt, updated_at=dt
+        )
+    notification_history_rows = NotificationHistory.query.order_by(NotificationHistory.created_at).all()
+    assert len(notification_history_rows) == 5
+    assert notification_history_rows[0].created_at == datetime(2022, 2, 7)
+
+    delete_notification_history_older_than_datetime(datetime(2022, 7, 1))
+
+    notification_history_rows = NotificationHistory.query.order_by(NotificationHistory.created_at).all()
+    assert len(notification_history_rows) == 2
+    assert notification_history_rows[0].created_at == datetime(2022, 7, 1)


### PR DESCRIPTION
https://trello.com/c/8qFHZC6a/353-delete-data-from-notificationhistory-older-than-april-2023

## For the reviewer
Please pay particular attention to:

- have I got the correct retention limit that matches what is expected in our decision record? If we get this wrong, we could delete a big bunch of data we actually want
- is the logic for knowing when not to delete records correct? If we get this wrong, we could delete a big bunch of data we actually want
- are you happy with the log statements? Will they make these easy to debug if we need to?

## What this does and additional context

This will run at 9pm (a quietish time but hopefully not going to conflict with the other nightly tasks that start around midnight, although if it does conflict it should still be OK).

This will start at 9pm on the day of merging and then should run for 14 days, each time deleting the oldest quarter of data. When it runs on the 15th day (and every day after that), it will see there are no notifications older than 1 April 2023 and do nothing. We could at that point, delete the celery beat configuration for it so we stop running a task that isn't going to do anything every night.

I assume that deleting one quarter of data at a time will be OK. The query will probably take quite a long time to run and delete a quarter of data, probably a few hours. One risk is that the celery work will get scaled down or restarted during this time. That shouldn't be the end of the world as the task will just run again tomorrow. Deleting notification_history isn't some urgent thing that must happen every night, if it gets delayed by a day that is fine. If we do start seeing issues with these queries taking several hours and erroring for some reason, we can take a similar approach to other mass deletion functions we have which run multiple queries, each one deleting 10,000 records at a time. A bit more complex python is all that is needed.

In july of 2024, we will be able to update the retention limit to April 2024 if we want so that this process will happen again for next years deletion.