### PR TITLE
Allow inbound sms if sending sms permission is off

### DIFF
--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -8,7 +8,7 @@ from notifications_utils.recipients import try_validate_and_format_phone_number
 
 from app.celery import tasks
 from app.config import QueueNames
-from app.constants import INBOUND_SMS_TYPE, SMS_TYPE
+from app.constants import INBOUND_SMS_TYPE
 from app.dao.inbound_sms_dao import dao_create_inbound_sms
 from app.dao.services_dao import dao_fetch_service_by_inbound_number
 from app.errors import register_errors
@@ -170,7 +170,7 @@ def fetch_potential_service(inbound_number, provider_name):
 
 def has_inbound_sms_permissions(permissions):
     str_permissions = [p.permission for p in permissions]
-    return set([INBOUND_SMS_TYPE, SMS_TYPE]).issubset(set(str_permissions))
+    return INBOUND_SMS_TYPE in str_permissions
 
 
 def strip_leading_forty_four(number):

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -165,7 +165,7 @@ def test_receive_notification_without_permissions_does_not_create_inbound_even_w
     "permissions,expected_response",
     [
         ([SMS_TYPE, INBOUND_SMS_TYPE], True),
-        ([INBOUND_SMS_TYPE], False),
+        ([INBOUND_SMS_TYPE], True),
         ([SMS_TYPE], False),
     ],
 )


### PR DESCRIPTION
We recently encountered the case where a service set up inbound sms and then turned off permission to send sms. This means it has the `inbound-sms` permission but not the `sms` permission.

When you turn off SMS in the admin app for your service, it hides all the SMS related settings, including inbound sms. This is probably not ideal. We should consider changing this in the future so that the admin interface allows you to configure inbound and outbound sms separately.

We also had some discussion about whether turning off outbound sms should also turn off inbound sms but decided this was not the best for the users and we should allow them the flexibility.

Given that we want services to still be able to receive inbound sms, even if they have outbound sms turned off, it requires this change to the permissions required to receive inbound sms.

There was no context in the commit that added this behaviour back in 2017 that this is a very intentional decision that should not be reversed.
https://github.com/alphagov/notifications-api/commit/5a82fe0a70bb86bd0e3df7c16498af66e9888e24