### PR TITLE
Rename email_from to normalised_service_name

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -532,6 +532,7 @@ class Service(db.Model, Versioned):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String(255), nullable=False, unique=True)
+    normalised_service_name = db.Column(db.String, nullable=True, unique=True)
     created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.datetime.utcnow)
     active = db.Column(db.Boolean, index=False, unique=False, nullable=False, default=True)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -351,6 +351,7 @@ class DetailedServiceSchema(BaseSchema):
             "inbound_sms",
             "jobs",
             "letter_message_limit",
+            "normalised_service_name",
             "permissions",
             "rate_limit",
             "reply_to_email_addresses",
@@ -769,6 +770,7 @@ class ServiceHistorySchema(ma.Schema):
     letter_message_limit = fields.Integer()
     restricted = fields.Boolean()
     email_from = fields.String()
+    normalised_service_name = fields.String()
     created_by_id = fields.UUID()
     version = fields.Integer()
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -259,6 +259,10 @@ def create_service():
         raise InvalidRequest(errors, status_code=400)
     data.pop("service_domain", None)
 
+    # TODO: remove this once we start passing `normalised_service_name` through from the admin interface
+    if "email_from" in data and "normalised_service_name" not in data:
+        data["normalised_service_name"] = data["email_from"]
+
     # validate json with marshmallow
     service_schema.load(data)
 
@@ -280,6 +284,10 @@ def update_service(service_id):
     fetched_service = dao_fetch_service_by_id(service_id)
     # Capture the status change here as Marshmallow changes this later
     service_going_live = fetched_service.restricted and not req_json.get("restricted", True)
+
+    # TODO: remove this once we start passing `normalised_service_name` through from the admin interface
+    if "email_from" in req_json and "normalised_service_name" not in req_json:
+        req_json["normalised_service_name"] = req_json["email_from"]
     current_data = dict(service_schema.dump(fetched_service).items())
     current_data.update(request.get_json())
 
@@ -499,7 +507,6 @@ def get_all_notifications_for_service(service_id):
 
 @service_blueprint.route("/<uuid:service_id>/notifications/<uuid:notification_id>", methods=["GET"])
 def get_notification_for_service(service_id, notification_id):
-
     notification = notifications_dao.get_notification_with_personalisation(
         service_id,
         notification_id,
@@ -633,7 +640,6 @@ def get_detailed_services(start_date, end_date, only_active=False, include_from_
             include_from_test_key=include_from_test_key, only_active=only_active
         )
     else:
-
         stats = fetch_stats_for_all_services_by_date_range(
             start_date=start_date,
             end_date=end_date,
@@ -998,7 +1004,6 @@ def check_if_reply_to_address_already_in_use(service_id, email_address):
 
 @service_blueprint.route("/<uuid:service_id>/returned-letter-statistics", methods=["GET"])
 def returned_letter_statistics(service_id):
-
     most_recent = fetch_most_recent_returned_letter(service_id)
 
     if not most_recent:

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0419_take_part_in_research
+0420_unique_service_name_1

--- a/migrations/versions/0420_unique_service_name_1.py
+++ b/migrations/versions/0420_unique_service_name_1.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0420_unique_service_name_1
+Revises: 0419_take_part_in_research
+Create Date: 2023-08-24 16:26:03.488048
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0420_unique_service_name_1"
+down_revision = "0419_take_part_in_research"
+
+
+def upgrade():
+    op.add_column("services", sa.Column("normalised_service_name", sa.String(), nullable=True, unique=True))
+    op.add_column("services_history", sa.Column("normalised_service_name", sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("services", "normalised_service_name")
+    op.drop_column("services_history", "normalised_service_name")


### PR DESCRIPTION
this is the first in a process to rename `email_from` to
`normalised_service_name`.

1. **add new column as nullable**
4. **write new values to both new and old column**
6. migrate old data. add unique and not null constraints.
7. delete references to old column in code
8. drop old column
