### PR TITLE
Bump utils to 70.0.5

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.5
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -165,7 +165,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.5
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
See also:
* https://github.com/alphagov/notifications-admin/pull/4822
* https://github.com/alphagov/notifications-utils/pull/1064

v70.0.5 of utils ensures that we always get/set redis cache data using lowercase UUIDs. We store template data in redis to reduce DB load. Previously, when sending notifications, the `template_id` in the JSON paylod would be used as-is to check redis for a cached version of the template. This means that posting with a lowercase template UUID might be in the cache, but an uppercase template UUID might not be present and end up hitting the DB. This could cause older versions of the template to be used to send messages if:

1) A notification is sent via the API using an uppercase UUID, caching v1 in redis with the uppercase ID.
2) The template is updated via admin using a lowercase UUID. We would try to clear the cache for the lowercase UUID and end up not deleting anything.
3) Another notification is sent via the API using an uppercase UUID, which still holds an entry for the v1 template.

We also use a very short-lived in-memory cache for template data. This in-memory cached data only lasts 2 seconds. We do not need to worry about case sensitivity here, because if we get an in-memory cache miss it then goes to redis, which after pulling in the latest utils will do the lowercasing as needed to ensure we do a consistent check in redis. If we get an in-memory cache hit then we may still get some inconsistency, but given we use an in-memory cache which cannot be cleared on a template update anyway, we do not guarantee perfect consistency - just consistency within 2 seconds.

---

 ## 70.0.5

* Ensure UUIDs in Redis cache keys are always lowercase

 ## 70.0.4

* Update the commit message auto-generated by `make bump-utils` (in app repos) to be copy/pastable via eg vim commit message editing.

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/70.0.3...70.0.5