### PR TITLE
Revert "Bump gunicorn to 21.2.0"

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,8 @@ Flask-Migrate==3.1.0
 flask-sqlalchemy==3.0.2
 Flask==2.3.2
 click-datetime==0.2
-gunicorn[eventlet]>=21.2.0
+# We originally pinned this due to eventlet v0.33 compatibility issues. That was supposedly fixed in version v21.0.0 and we merged v21.2.0 for a while. Until we ran a load test again, and identified that the bumped version of gunicorn led to a 33%+ drop-off in performance/requests per second that the API was able to handle. If a version greater than 21.2.0 is released, and it either gives us something we need or we think it addresses said performance issues, make sure to run a load test in staging before releasing to production.
+git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0
 iso8601==1.1.0
 itsdangerous==2.1.2
 jsonschema[format]==4.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -114,7 +114,7 @@ govuk-bank-holidays==0.11
     # via notifications-utils
 greenlet==1.1.3
     # via eventlet
-gunicorn[eventlet]==21.2.0
+gunicorn[eventlet] @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
     # via -r requirements.in
 idna==3.4
     # via
@@ -171,7 +171,6 @@ orderedset==2.0.3
     # via notifications-utils
 packaging==21.3
     # via
-    #   gunicorn
     #   marshmallow
     #   marshmallow-sqlalchemy
 phonenumbers==8.13.18
@@ -285,3 +284,6 @@ werkzeug==2.3.3
     # via flask
 zipp==3.16.2
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
This reverts the changes introduced by commit
6d80b03c577bb47cd09ac3e49a4b30284179832b.

In a recent load test we identified a huge drop-off in performance that has been traced back to this dependency bump. Until we can investigate further and work out exactly why - and potentially get it fixed up stream - we will go back to our previously-pinned version.