### PR TITLE
update InvalidRequest error message for reply-to email address

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -998,7 +998,7 @@ def check_if_reply_to_address_already_in_use(service_id, email_address):
     existing_reply_to_addresses = dao_get_reply_to_by_service_id(service_id)
     if email_address in [i.email_address for i in existing_reply_to_addresses]:
         raise InvalidRequest(
-            "Your service already uses ‘{}’ as an email reply-to address.".format(email_address), status_code=409
+            f"‘{email_address}’ is already a reply-to email address for this service.", status_code=409
         )
 
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2732,7 +2732,7 @@ def test_verify_reply_to_email_address_doesnt_allow_duplicates(admin_request, no
     response = admin_request.post(
         "service.verify_reply_to_email_address", service_id=service.id, _data=data, _expected_status=409
     )
-    assert response["message"] == "Your service already uses ‘reply-here@example.gov.uk’ as an email reply-to address."
+    assert response["message"] == "‘reply-here@example.gov.uk’ is already a reply-to email address for this service."
 
 
 def test_add_service_reply_to_email_address(admin_request, sample_service):
@@ -2753,7 +2753,7 @@ def test_add_service_reply_to_email_address_doesnt_allow_duplicates(admin_reques
     response = admin_request.post(
         "service.add_service_reply_to_email_address", service_id=service.id, _data=data, _expected_status=409
     )
-    assert response["message"] == "Your service already uses ‘reply-here@example.gov.uk’ as an email reply-to address."
+    assert response["message"] == "‘reply-here@example.gov.uk’ is already a reply-to email address for this service."
 
 
 def test_add_service_reply_to_email_address_can_add_multiple_addresses(admin_request, sample_service):


### PR DESCRIPTION
This PR is for [this](https://trello.com/c/3JRlqM43/496-update-reply-to-email-address-already-in-use-validation-error-message) ticket.

It updates the InvalidRequest error message for reply-to email address validation.