### PR TITLE
reduce concurrency of dvla api worker

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,8 @@
 if [ "$1" == "api-worker-periodic" ] || [ "$1" == "api-worker-broadcasts" ]
 then
   CONCURRENCY=2
+elif [ "$1" == "api-worker-sender-letters" ]
+  CONCURRENCY=3
 else
   CONCURRENCY=4
 fi
@@ -34,15 +36,15 @@ then
 
 elif [ "$1" == "api-worker-letters" ]
 then
-  $COMMON_CMD create-letters-pdf-tasks,letter-tasks 
- 
+  $COMMON_CMD create-letters-pdf-tasks,letter-tasks
+
 elif [ "$1" == "api-worker-jobs" ]
 then
-  $COMMON_CMD database-tasks,job-tasks 
+  $COMMON_CMD database-tasks,job-tasks
 
 elif [ "$1" == "api-worker-research" ]
 then
-  $COMMON_CMD research-mode-tasks 
+  $COMMON_CMD research-mode-tasks
 
 elif [ "$1" == "api-worker-sender" ]
 then

--- a/scripts/paas_app_wrapper.sh
+++ b/scripts/paas_app_wrapper.sh
@@ -25,7 +25,8 @@ case $NOTIFY_APP_NAME in
     --logfile=/dev/null --pidfile=/tmp/celery%N.pid -Q send-sms-tasks,send-email-tasks
     ;;
   delivery-worker-sender-letters)
-    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \
+    # at the default of 2 instances with 4 concurrent workers, we hit DVLA's 50rps rate limit 
+    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=3 \
     -Q send-letter-tasks 2> /dev/null
     ;;
   delivery-worker-periodic)


### PR DESCRIPTION
when sending 100k letters with 2 instances of 4 concurrency, we saw 177k requests (77k requests hit the rate limit).

reducing the number of processes from 8 to 6 should help manage this.

if we continue having issues we may want to look at a more sophisticated way of throttling