### PR TITLE
Dvla error handling

### DIFF
--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -51,6 +51,8 @@ class DvlaThrottlingException(DvlaRetryableException):
 def _handle_common_dvla_errors(custom_httperror_exc_handler: Callable[[requests.HTTPError], None] = lambda x: None):
     try:
         yield
+    except (ConnectionError, requests.ConnectionError, requests.Timeout) as e:
+        raise DvlaRetryableException() from e
     except requests.HTTPError as e:
         custom_httperror_exc_handler(e)
 

--- a/tests/app/clients/test_dvla.py
+++ b/tests/app/clients/test_dvla.py
@@ -203,7 +203,6 @@ def test_authenticate_raises_retryable_exception_if_credentials_are_invalid(dvla
     }.items(),
 )
 def test_authenticate_handles_generic_errors(dvla_client, rmock, status_code, exc_class):
-
     error_response = [{"status": status_code, "title": "Authentication Failure", "detail": "Some detail"}]
     endpoint = "https://test-dvla-api.com/thirdparty-access/v1/authenticate"
     rmock.request("POST", endpoint, json=error_response, status_code=status_code)
@@ -729,12 +728,10 @@ def test_send_letter_when_throttling_error_is_raised(dvla_authenticate, dvla_cli
 
 
 def test_send_letter_when_5xx_status_code_is_returned(dvla_authenticate, dvla_client, rmock):
-    rmock.post(
-        f"{current_app.config['DVLA_API_BASE_URL']}/print-request/v1/print/jobs",
-        status_code=500,
-    )
+    url = f"{current_app.config['DVLA_API_BASE_URL']}/print-request/v1/print/jobs"
+    rmock.post(url, status_code=500)
 
-    with pytest.raises(DvlaRetryableException):
+    with pytest.raises(DvlaRetryableException) as exc:
         dvla_client.send_letter(
             notification_id="1",
             reference="ABCDEFGHIJKL",
@@ -744,6 +741,7 @@ def test_send_letter_when_5xx_status_code_is_returned(dvla_authenticate, dvla_cl
             organisation_id="org_id",
             pdf_file=b"pdf",
         )
+    assert str(exc.value) == f"Received 500 from {url}"
 
 
 def test_send_letter_when_unknown_exception_is_raised(dvla_authenticate, dvla_client, rmock):


### PR DESCRIPTION
Couple of things that became apparent from load test:

* we don't catch connection errors or timeouts currently, they just sent a letter into temp failure
* we didn't have any code blocks for sending a letter that isn't created, or isn't a normal type. technically the collate task won't gather them, but thought it wise to put some extra checks in the deliver_letter task