### PR TITLE
Rename ‘Notify service user’ to ‘GOV.UK Notify’

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0422_letter_languages_constraint
+0423_notify_user_name

--- a/migrations/versions/0423_notify_user_name.py
+++ b/migrations/versions/0423_notify_user_name.py
@@ -1,0 +1,28 @@
+"""
+
+Revision ID: 0423_notify_user_name
+Revises: 0422_letter_languages_constraint
+Create Date: 2023-09-14 14:00:28.925639
+
+"""
+from alembic import op
+
+
+revision = "0423_notify_user_name"
+down_revision = "0422_letter_languages_constraint"
+
+
+def upgrade():
+    op.execute(
+        """
+        UPDATE users SET name = 'GOV.UK Notify' WHERE id = '6af522d0-2915-4e52-83a3-3690455a5fe6'
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        UPDATE users SET name = 'Notify service user' WHERE id = '6af522d0-2915-4e52-83a3-3690455a5fe6'
+        """
+    )


### PR DESCRIPTION
So that if any actions are ever attributed to this user it’s clearer that they are being done by the platform itself, not some kind of generic/anonymous user.