### PR TITLE
Add index concurrently on created_at to notification_history table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1670,6 +1670,7 @@ class NotificationHistory(db.Model, HistoryModel):
         Index(
             "ix_notification_history_service_id_composite", "service_id", "key_type", "notification_type", "created_at"
         ),
+        Index("ix_notification_history_created_at", "created_at", postgresql_concurrently=True),
     )
 
     @classmethod

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0423_notify_user_name
+0424_n_history_created_at

--- a/migrations/versions/0424_n_history_created_at.py
+++ b/migrations/versions/0424_n_history_created_at.py
@@ -1,0 +1,31 @@
+"""
+
+Revision ID: 0424_n_history_created_at
+Revises: 0423_notify_user_name
+Create Date: 2023-09-17 15:17:58.545277
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0424_n_history_created_at"
+down_revision = "0423_notify_user_name"
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_notification_history_created_at",
+            "notification_history",
+            ["created_at"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_notification_history_created_at", table_name="notification_history", postgresql_concurrently=True
+        )


### PR DESCRIPTION
We want to add this index because at the moment it the table is too big to query based on created_at (we do have some indexes on this table already but those are multi column indexes so are not often able to be used when querying just on created_at).

We choose to create our index concurrently. This is backed by https://medium.com/paypal-tech/postgresql-at-scale-database-schema-changes-without-downtime-20d3749ed680#04b4.

Importantly it says:
This lower lock level allows reads and writes to continue against the table while the index is built.

You can also read the postgres documentation on it at: https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY

Creating an index concurrently needs to be done outside of a transaction. We can use an alembic feature to support the migration being done outside of a transaction:
https://alembic.sqlalchemy.org/en/latest/api/runtime.html#alembic.runtime.migration.MigrationContext.autocommit_block

Because it is done outside of a transaction, the sql should run very quickly and the migration should suceed, leaving the index to be built concurrently happening behind the scenes.

I will need to manually check that
the index is eventually created successfully. If it fails, then it will need to be removed manually, as per the postgres docs.

I'm not too worried about performance by adding this index. We don't care too much about insertion speed for the notification_history table, which an index might affect. It should however speed up our ability to query notification_history for particular queries.

## How to review
Read the above for context, check out the code and then run

```
source environment.sh
flask db upgrade
flask db downgrade
```
and check for no errors