### PR TITLE
normalised_service_name migration

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -533,7 +533,7 @@ class Service(db.Model, Versioned):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String(255), nullable=False, unique=True)
-    normalised_service_name = db.Column(db.String, nullable=True, unique=True)
+    normalised_service_name = db.Column(db.String, nullable=False, unique=True)
     created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.datetime.utcnow)
     active = db.Column(db.Boolean, index=False, unique=False, nullable=False, default=True)
@@ -541,7 +541,7 @@ class Service(db.Model, Versioned):
     sms_message_limit = db.Column(db.BigInteger, index=False, unique=False, nullable=False, default=999_999_999)
     email_message_limit = db.Column(db.BigInteger, index=False, unique=False, nullable=False, default=999_999_999)
     restricted = db.Column(db.Boolean, index=False, unique=False, nullable=False)
-    email_from = db.Column(db.Text, index=False, unique=True, nullable=False)
+    email_from = db.Column(db.Text, index=False, nullable=True)
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=False)
     created_by = db.relationship("User", foreign_keys=[created_by_id])
     prefix_sms = db.Column(db.Boolean, nullable=False, default=True)

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -79,6 +79,7 @@ class SerialisedService(SerialisedModel):
         "active",
         "contact_link",
         "email_from",
+        "normalised_service_name",
         "email_message_limit",
         "letter_message_limit",
         "sms_message_limit",

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -165,16 +165,15 @@ def handle_integrity_error(exc):
     """
     if any(
         'duplicate key value violates unique constraint "{}"'.format(constraint) in str(exc)
-        for constraint in {"services_name_key", "services_email_from_key"}
+        for constraint in {"services_name_key", "services_email_from_key", "services_normalised_service_name_key"}
     ):
+        duplicate_name = (
+            exc.params.get("name") or exc.params.get("normalised_service_name") or exc.params.get("email_from", "")
+        )
         return (
             jsonify(
                 result="error",
-                message={
-                    "name": [
-                        "Duplicate service name '{}'".format(exc.params.get("name", exc.params.get("email_from", "")))
-                    ]
-                },
+                message={"name": [f"Duplicate service name '{duplicate_name}'"]},
             ),
             400,
         )

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0424_n_history_created_at
+0425_unique_service_name_2

--- a/migrations/versions/0425_unique_service_name_2.py
+++ b/migrations/versions/0425_unique_service_name_2.py
@@ -1,0 +1,37 @@
+"""
+
+Revision ID: 0425_unique_service_name_2
+Revises: 0424_n_history_created_at
+Create Date: 2023-09-01 10:10:19.011060
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0425_unique_service_name_2"
+down_revision = "0424_n_history_created_at"
+
+
+def upgrade():
+    op.execute("UPDATE services SET normalised_service_name = email_from WHERE normalised_service_name IS NULL")
+    op.execute("UPDATE services_history SET normalised_service_name = email_from WHERE normalised_service_name IS NULL")
+    op.alter_column("services", "normalised_service_name", existing_type=sa.VARCHAR(), nullable=False)
+    op.alter_column("services_history", "normalised_service_name", existing_type=sa.VARCHAR(), nullable=False)
+    op.alter_column("services", "email_from", existing_type=sa.VARCHAR(), nullable=True)
+    op.alter_column("services_history", "email_from", existing_type=sa.VARCHAR(), nullable=True)
+    op.drop_constraint("services_email_from_key", "services", type_="unique")
+
+
+def downgrade():
+    op.alter_column("services_history", "normalised_service_name", existing_type=sa.VARCHAR(), nullable=True)
+    op.alter_column("services", "normalised_service_name", existing_type=sa.VARCHAR(), nullable=True)
+
+    # back-fill any null email_from from normalised
+    op.execute("UPDATE services SET email_from = normalised_service_name")
+    op.execute("UPDATE services_history SET email_from = normalised_service_name")
+
+    # now we can restore null constraint and unique index
+    op.alter_column("services", "email_from", existing_type=sa.VARCHAR(), nullable=True)
+    op.alter_column("services_history", "email_from", existing_type=sa.VARCHAR(), nullable=True)
+    op.create_unique_constraint("services_email_from_key", "services", columns=["email_from"])

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -149,6 +149,7 @@ def sample_service(sample_user):
         "letter_message_limit": 1000,
         "restricted": False,
         "email_from": email_from,
+        "normalised_service_name": email_from,
         "created_by": sample_user,
         "crown": True,
     }
@@ -181,6 +182,7 @@ def sample_broadcast_service(broadcast_organisation, sample_user):
         "letter_message_limit": 1000,
         "restricted": False,
         "email_from": email_from,
+        "normalised_service_name": email_from,
         "created_by": sample_user,
         "crown": True,
         "count_as_live": False,
@@ -210,6 +212,7 @@ def sample_broadcast_service_2(broadcast_organisation, sample_user):
         "letter_message_limit": 1000,
         "restricted": False,
         "email_from": email_from,
+        "normalised_service_name": email_from,
         "created_by": sample_user,
         "crown": True,
         "count_as_live": False,
@@ -909,6 +912,7 @@ def notify_service(notify_db_session, sample_user):
             letter_message_limit=1000,
             restricted=False,
             email_from="notify.service",
+            normalised_service_name="notify.service",
             created_by=sample_user,
             prefix_sms=False,
         )

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -132,13 +132,16 @@ def create_service(
     if check_if_service_exists:
         service = Service.query.filter_by(name=service_name).first()
     if (not check_if_service_exists) or (check_if_service_exists and not service):
+        email_from = (email_from or service_name.lower().replace(" ", "."),)
+
         service = Service(
             name=service_name,
             email_message_limit=email_message_limit,
             sms_message_limit=sms_message_limit,
             letter_message_limit=letter_message_limit,
             restricted=restricted,
-            email_from=email_from if email_from else service_name.lower().replace(" ", "."),
+            email_from=email_from,
+            normalised_service_name=email_from,
             created_by=user if user else create_user(email="{}@digital.cabinet-office.gov.uk".format(uuid.uuid4())),
             prefix_sms=prefix_sms,
             organisation_type=organisation_type,
@@ -605,7 +608,6 @@ def create_annual_billing(service_id, free_sms_fragment_limit, financial_year_st
 
 
 def create_domain(domain, organisation_id):
-
     domain = Domain(domain=domain, organisation_id=organisation_id)
 
     db.session.add(domain)
@@ -870,7 +872,6 @@ def create_service_data_retention(service, notification_type="sms", days_of_rete
 
 
 def create_invited_user(service=None, to_email_address=None):
-
     if service is None:
         service = create_service()
     if to_email_address is None:

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -172,7 +172,9 @@ def test_organisation_search_finds_organisations(notify_db_session, admin_reques
     organisation_2 = create_organisation(name="ABCGHT")
     create_organisation(name="ZYSWVU")
     response = admin_request.get("organisation.search", name="ABC")
-    assert response["data"] == [organisation_1.serialize_for_list(), organisation_2.serialize_for_list()]
+    assert sorted(response["data"], key=lambda x: x["id"]) == sorted(
+        [organisation_1.serialize_for_list(), organisation_2.serialize_for_list()], key=lambda x: x["id"]
+    )
 
 
 def test_organisation_search_handles_no_results(notify_db_session, admin_request):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -454,11 +454,8 @@ def test_create_service_populates_email_from_and_normalised_service_name(
 @pytest.mark.parametrize(
     "existing_normalised_service_name, data, expected_normalised_service_name",
     [
-        (None, {}, None),
         ("foo", {}, "foo"),
-        (None, {"email_from": "foo"}, "foo"),
         ("bar", {"email_from": "foo"}, "foo"),
-        (None, {"email_from": "foo", "normalised_service_name": "bar"}, "bar"),
         ("baz", {"email_from": "foo", "normalised_service_name": "bar"}, "bar"),
     ],
 )


### PR DESCRIPTION
Finally getting back at this!

Migrate the old email_from to new normalised_service_name column. 

1. ~~add new column as nullable~~ (https://github.com/alphagov/notifications-api/pull/3865)
2. ~~write new values to both new and old column~~ (https://github.com/alphagov/notifications-admin/pull/4824)
3. **migrate old data. add unique and not null constraints.**
4. delete references to old column in code
5. drop old column