### PR TITLE
Resolve an n+1 queries on endpoint

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -946,6 +946,7 @@ class TemplateFolder(db.Model):
         backref=db.backref("folders", foreign_keys="user_folder_permissions.c.template_folder_id"),
         secondary="user_folder_permissions",
         primaryjoin="TemplateFolder.id == user_folder_permissions.c.template_folder_id",
+        lazy="joined",
     )
 
     __table_args__ = (UniqueConstraint("id", "service_id", name="ix_id_service_id"), {})

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -879,13 +879,17 @@ def test_get_organisation_services_usage(admin_request, notify_db_session, mocke
     assert response["updated_at"] == "2019-06-01T12:00:00+00:00"
 
 
-@pytest.mark.skip(
-    "Another test (`test_cbc_proxy_vodafone_send_link_test_invokes_function`) fails when we enable "
-    "SQLALCHEMY_RECORD_QUERIES, which is a requirement for this test. So we can't run this for now ... but "
-    "maybe the flask-sqlalchemy/psycopg2 edge case causing the exception (below) will eventually be fixed and we can "
-    "re-enable this. This exception is thrown when trying to record the query result, after sqlalchemy fetches the "
-    "next value from a sequence (sqlalchemy.engine.default.DefaultExecutionContext._execute_scalar).\n\n"
-    "Test error: *** AttributeError: 'PGExecutionContext_psycopg2' object has no attribute 'parameters'"
+@pytest.mark.xfail(
+    reason=(
+        "Another test (`test_cbc_proxy_vodafone_send_link_test_invokes_function`) fails when we enable "
+        "SQLALCHEMY_RECORD_QUERIES, which is a requirement for this test. So we can't run this for now ... but "
+        "maybe the flask-sqlalchemy/psycopg2 edge case causing the exception (below) will eventually be fixed and we "
+        "can re-enable this. This exception is thrown when trying to record the query result, after sqlalchemy fetches "
+        "the next value from a sequence (sqlalchemy.engine.default.DefaultExecutionContext._execute_scalar).\n\n"
+        "Test error: *** AttributeError: 'PGExecutionContext_psycopg2' object has no attribute 'parameters'\n\n"
+        "For review you can run this test manually locally, commenting out this skip and enabling "
+        "SQLALCHEMY_RECORD_QUERIES on app.config.Test"
+    )
 )
 @pytest.mark.parametrize("num_services", [1, 5, 10])
 @freeze_time("2020-02-24 13:30")
@@ -908,7 +912,7 @@ def test_get_organisation_services_usage_limit_queries_executed(admin_request, n
     with count_sqlalchemy_queries() as get_query_count:
         admin_request.get("organisation.get_organisation_services_usage", organisation_id=org.id, **{"year": 2019})
 
-    assert get_query_count() == 9, (
+    assert get_query_count() == 5, (
         "The number of queries executed by this view has changed. The number of queries executed "
         "shouldn't increase as the number of org services increases. If this has increased by 1 or 2 queries, and "
         "affects all parameterized versions of this test, you can probably accept the change. If only one of the "

--- a/tests/app/template_folder/test_template_folder_rest.py
+++ b/tests/app/template_folder/test_template_folder_rest.py
@@ -10,6 +10,7 @@ from tests.app.db import (
     create_template_folder,
     create_user,
 )
+from tests.utils import count_sqlalchemy_queries
 
 
 def test_get_folders_for_service(admin_request, notify_db_session):
@@ -69,6 +70,37 @@ def test_get_folders_returns_users_with_permission(admin_request, sample_service
     assert len(users_with_permission) == 2
     assert str(user_1.id) in users_with_permission
     assert str(user_2.id) in users_with_permission
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Another test (`test_cbc_proxy_vodafone_send_link_test_invokes_function`) fails when we enable "
+        "SQLALCHEMY_RECORD_QUERIES, which is a requirement for this test. So we can't run this for now ... but "
+        "maybe the flask-sqlalchemy/psycopg2 edge case causing the exception (below) will eventually be fixed and we "
+        "can re-enable this. This exception is thrown when trying to record the query result, after sqlalchemy fetches "
+        "the next value from a sequence (sqlalchemy.engine.default.DefaultExecutionContext._execute_scalar).\n\n"
+        "Test error: *** AttributeError: 'PGExecutionContext_psycopg2' object has no attribute 'parameters'\n\n"
+        "For review you can run this test manually locally, commenting out this skip and enabling "
+        "SQLALCHEMY_RECORD_QUERIES on app.config.Test"
+    )
+)
+def test_get_folders_returns_users_with_permission_does_not_do_n_plus_1_sql_queries(admin_request, sample_service):
+    users = [create_user(email=f"user-{_}@gov.uk") for _ in range(10)]
+    template_folders = [create_template_folder(sample_service) for _ in range(5)]
+    sample_service.users = users
+
+    service_users = [dao_get_service_user(user.id, sample_service.id) for user in users]
+    for service_user in service_users:
+        service_user.folders = template_folders
+
+    with count_sqlalchemy_queries() as get_query_count:
+        resp = admin_request.get("template_folder.get_template_folders_for_service", service_id=sample_service.id)
+
+    users_with_permission = resp["template_folders"][0]["users_with_permission"]
+
+    assert len(users_with_permission) == 10
+    assert all([str(user.id) in users_with_permission for user in users])
+    assert get_query_count() == 3
 
 
 @pytest.mark.parametrize("has_parent", [True, False])


### PR DESCRIPTION
This relationship was set up to perform a SQL query for every template folder individually. By setting the relationship to load via a join we can instead emit a single SQL statement.

https://govuk-notify-gds.sentry.io/issues/4474807382/?project=4504949325824000