### PR TITLE
Switch the db migration task to use cflinuxfs4

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -47,6 +47,7 @@
       'staging': 0,
       'production': 0
     },
+    'stack': 'cflinuxfs4'
   },
 
   'notify-delivery-celery-beat': {
@@ -95,6 +96,8 @@ applications:
     {%- endif %}
     memory: {{ app.get('memory', '1G') }}
     disk_quota: {{ app.get('disk_quota', '1G')}}
+
+    stack: {{ app.get('stack', 'cflinuxfs3') }}
 
     routes:
       {%- for route in app.get('routes', {}).get(environment, []) %}


### PR DESCRIPTION
What
----

Switch the db migration task to use cflinuxfs4

Why
----

cflinuxfs3 is currently the default on the PaaS. This is based off ubuntu 18.04. This stopped receiving updates after Apr 2023.

cflinuxfs4 will become the default on the PaaS after 27 Nov 2023.

The intention is to migrate all applications to cflinuxfs4. This change is the start of that process, where the db migration app is our canary.

