### PR TITLE
Apply localised fix for n+1 queries

### DIFF
--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -881,13 +881,17 @@ def test_get_organisation_services_usage(admin_request, notify_db_session, mocke
     assert response["updated_at"] == "2019-06-01T12:00:00+00:00"
 
 
-@pytest.mark.skip(
-    "Another test (`test_cbc_proxy_vodafone_send_link_test_invokes_function`) fails when we enable "
-    "SQLALCHEMY_RECORD_QUERIES, which is a requirement for this test. So we can't run this for now ... but "
-    "maybe the flask-sqlalchemy/psycopg2 edge case causing the exception (below) will eventually be fixed and we can "
-    "re-enable this. This exception is thrown when trying to record the query result, after sqlalchemy fetches the "
-    "next value from a sequence (sqlalchemy.engine.default.DefaultExecutionContext._execute_scalar).\n\n"
-    "Test error: *** AttributeError: 'PGExecutionContext_psycopg2' object has no attribute 'parameters'"
+@pytest.mark.xfail(
+    reason=(
+        "Another test (`test_cbc_proxy_vodafone_send_link_test_invokes_function`) fails when we enable "
+        "SQLALCHEMY_RECORD_QUERIES, which is a requirement for this test. So we can't run this for now ... but "
+        "maybe the flask-sqlalchemy/psycopg2 edge case causing the exception (below) will eventually be fixed and we "
+        "can re-enable this. This exception is thrown when trying to record the query result, after sqlalchemy fetches "
+        "the next value from a sequence (sqlalchemy.engine.default.DefaultExecutionContext._execute_scalar).\n\n"
+        "Test error: *** AttributeError: 'PGExecutionContext_psycopg2' object has no attribute 'parameters'\n\n"
+        "For review you can run this test manually locally, commenting out this skip and enabling "
+        "SQLALCHEMY_RECORD_QUERIES on app.config.Test"
+    )
 )
 @pytest.mark.parametrize("num_services", [1, 5, 10])
 @freeze_time("2020-02-24 13:30")
@@ -910,7 +914,7 @@ def test_get_organisation_services_usage_limit_queries_executed(admin_request, n
     with count_sqlalchemy_queries() as get_query_count:
         admin_request.get("organisation.get_organisation_services_usage", organisation_id=org.id, **{"year": 2019})
 
-    assert get_query_count() == 9, (
+    assert get_query_count() == 5, (
         "The number of queries executed by this view has changed. The number of queries executed "
         "shouldn't increase as the number of org services increases. If this has increased by 1 or 2 queries, and "
         "affects all parameterized versions of this test, you can probably accept the change. If only one of the "


### PR DESCRIPTION
I tried to fix an n+1 queries on the `get_template_folders_for_service` endpoint with a generalised change to how the relationship on `TemplateFolder` joins to `User` (in https://github.com/alphagov/notifications-api/pull/3885), but this cascaded to cause massive queries on other endpoints when services have thousands of templates/users.

Let's fix this endpoint more specifically by loading the relationships we know we are going to use, in advance.