### PR TITLE
Switch to using cflinuxfs4

### DIFF
--- a/manifest-droplet.yml
+++ b/manifest-droplet.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: ((app_name))
-  stack: cflinuxfs3
+  stack: cflinuxfs4
   processes:
   - type: web
     instances: 0

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -95,6 +95,7 @@ applications:
     {%- endif %}
     memory: {{ app.get('memory', '1G') }}
     disk_quota: {{ app.get('disk_quota', '1G')}}
+    stack: cflinuxfs4
 
     routes:
       {%- for route in app.get('routes', {}).get(environment, []) %}

--- a/paas-failwhale/manifest.yml
+++ b/paas-failwhale/manifest.yml
@@ -6,3 +6,4 @@ applications:
       - nginx_buildpack
     memory: 256M
     no-route: true
+    stack: cflinuxfs4


### PR DESCRIPTION
What
----

Switch to use the PaaS cflinuxfs4 stack.

Why
----

cflinuxfs3 is currently the default on the PaaS. This is based off ubuntu 18.04. This stopped receiving updates after Apr 2023.

cflinuxfs4 will become the default on the PaaS after 27 Nov 2023.

The intention is to migrate all applications to cflinuxfs4 eventually.