### PR TITLE
run upgrades in separate transactions to remove deadlock

### DIFF
--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -25,8 +25,8 @@ handlers =
 qualname =
 
 [logger_sqlalchemy]
-level = WARN
-handlers =
+level = INFO
+handlers = console
 qualname = sqlalchemy.engine
 
 [logger_alembic]

--- a/migrations/versions/0425_unique_service_name_2.py
+++ b/migrations/versions/0425_unique_service_name_2.py
@@ -14,24 +14,35 @@ down_revision = "0424_n_history_created_at"
 
 
 def upgrade():
-    op.execute("UPDATE services SET normalised_service_name = email_from WHERE normalised_service_name IS NULL")
-    op.execute("UPDATE services_history SET normalised_service_name = email_from WHERE normalised_service_name IS NULL")
-    op.alter_column("services", "normalised_service_name", existing_type=sa.VARCHAR(), nullable=False)
-    op.alter_column("services_history", "normalised_service_name", existing_type=sa.VARCHAR(), nullable=False)
-    op.alter_column("services", "email_from", existing_type=sa.VARCHAR(), nullable=True)
-    op.alter_column("services_history", "email_from", existing_type=sa.VARCHAR(), nullable=True)
-    op.drop_constraint("services_email_from_key", "services", type_="unique")
+    # run these commands with autocommit outside of a transaction - the main motivation for this is to
+    # ensure we don't try and acquire access-exclusive locks (which the alter column commands need) on both the
+    # services and services_history table at the same time, which can lead to deadlocks
+    with op.get_context().autocommit_block():
+        # update historical values
+        op.execute("UPDATE services SET normalised_service_name = email_from WHERE normalised_service_name IS NULL")
+        op.execute(
+            "UPDATE services_history SET normalised_service_name = email_from WHERE normalised_service_name IS NULL"
+        )
+
+        op.alter_column("services", "normalised_service_name", existing_type=sa.VARCHAR(), nullable=False)
+        op.alter_column("services_history", "normalised_service_name", existing_type=sa.VARCHAR(), nullable=False)
+
+        op.alter_column("services", "email_from", existing_type=sa.VARCHAR(), nullable=True)
+        op.alter_column("services_history", "email_from", existing_type=sa.VARCHAR(), nullable=True)
+
+        op.drop_constraint("services_email_from_key", "services", type_="unique")
 
 
 def downgrade():
-    op.alter_column("services_history", "normalised_service_name", existing_type=sa.VARCHAR(), nullable=True)
-    op.alter_column("services", "normalised_service_name", existing_type=sa.VARCHAR(), nullable=True)
+    with op.get_context().autocommit_block():
+        op.alter_column("services_history", "normalised_service_name", existing_type=sa.VARCHAR(), nullable=True)
+        op.alter_column("services", "normalised_service_name", existing_type=sa.VARCHAR(), nullable=True)
 
-    # back-fill any null email_from from normalised
-    op.execute("UPDATE services SET email_from = normalised_service_name")
-    op.execute("UPDATE services_history SET email_from = normalised_service_name")
+        # back-fill any null email_from from normalised
+        op.execute("UPDATE services SET email_from = normalised_service_name")
+        op.execute("UPDATE services_history SET email_from = normalised_service_name")
 
-    # now we can restore null constraint and unique index
-    op.alter_column("services", "email_from", existing_type=sa.VARCHAR(), nullable=True)
-    op.alter_column("services_history", "email_from", existing_type=sa.VARCHAR(), nullable=True)
-    op.create_unique_constraint("services_email_from_key", "services", columns=["email_from"])
+        # now we can restore null constraint and unique index
+        op.alter_column("services", "email_from", existing_type=sa.VARCHAR(), nullable=True)
+        op.alter_column("services_history", "email_from", existing_type=sa.VARCHAR(), nullable=True)
+        op.create_unique_constraint("services_email_from_key", "services", columns=["email_from"])


### PR DESCRIPTION
we ran into deadlocks when running this script on production. adding a constraint acquires an access-exclusive lock. This is fine on its own, to add a not-null constraint is a relatively quick operation for a table of this size (27k services, 100k services_history). however, because the query was trying to acquire locks to both services and services_history, it ran in to a deadlock with another process where that process was also trying to acquire locks on both tables - each process acquired one of the locks, and was stuck waiting for the other to be released, so a deadlock was identified and the migration failed.

even if the other process wasn't doing anything big and dramatic, nothing can acquire a lock alongside an access-exclusive lock.

normally alembic wraps the entire upgrade script in a transaction (so that if there's an error, it can rollback safely to the previous version and ensure that the db state is consistent). but we can manually enter an autocommit block such that every statement commits separately outside of a transaction.

this has already been applied succesfully without incident to preview and staging so there's no action to do there.

we've mucked around in the past with multiple separate PRs and applying constraints and validating them separately, I don't think that's necessary here - https://github.com/alphagov/notifications-api/pull/2113