### PR TITLE
Enable the SQLAlchemy logger during migrations

### DIFF
--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -20,13 +20,13 @@ keys = console
 keys = generic
 
 [logger_root]
-level = WARN
-handlers =
+level = INFO
+handlers = console
 qualname =
 
 [logger_sqlalchemy]
-level = WARN
-handlers =
+level = INFO
+handlers = console
 qualname = sqlalchemy.engine
 
 [logger_alembic]


### PR DESCRIPTION
This logs all of the actual SQL that runs on the DB and is useful to see. It can get a bit noisy, but since it's only during migrations that's fine - and probably more useful than not.