### PR TITLE
Rollback to cflinuxfs3 due to performance issues

### DIFF
--- a/manifest-droplet.yml
+++ b/manifest-droplet.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: ((app_name))
-  stack: cflinuxfs4
+  stack: cflinuxfs3
   processes:
   - type: web
     instances: 0

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -95,7 +95,7 @@ applications:
     {%- endif %}
     memory: {{ app.get('memory', '1G') }}
     disk_quota: {{ app.get('disk_quota', '1G')}}
-    stack: cflinuxfs4
+    stack: cflinuxfs3
 
     routes:
       {%- for route in app.get('routes', {}).get(environment, []) %}

--- a/paas-failwhale/manifest.yml
+++ b/paas-failwhale/manifest.yml
@@ -6,4 +6,4 @@ applications:
       - nginx_buildpack
     memory: 256M
     no-route: true
-    stack: cflinuxfs4
+    stack: cflinuxfs3


### PR DESCRIPTION
What
----

Rollback to cflinuxfs3

Why
----

Unfortunately we are seeing significant performance issues with cflinuxfs4 in production.