### PR TITLE
add a lock timeout of one second to migrations

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,9 +1,14 @@
+from collections.abc import Callable, Iterable, Mapping
+import psycopg2
+import time
+from contextlib import contextmanager
 from logging.config import fileConfig
 from pathlib import Path
 
 from alembic import context
 from flask import current_app
 from sqlalchemy import engine_from_config, pool
+import sqlalchemy
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -99,7 +104,31 @@ def run_migrations_online():
         connection.close()
 
 
+def retry_on_lock_error(
+    *,
+    func: Callable,
+    args: Iterable = [],
+    kwargs: Mapping = {},
+    max_retries: int = 1,
+    delay_secs: int = 0,
+):
+    for i in range(max_retries):
+        try:
+            return func(*args, **kwargs)
+        except sqlalchemy.exc.OperationalError as e:
+            # on the last attempt raise so we get a full stack trace
+            if i + 1 == max_retries:
+                raise
+
+            if not isinstance(e.orig, psycopg2.errors.LockNotAvailable):
+                raise
+
+            print("Retrying due to LockNotAvailable error")
+            print(e)
+            time.sleep(delay_secs)
+
+
 if context.is_offline_mode():
     run_migrations_offline()
 else:
-    run_migrations_online()
+    retry_on_lock_error(func=run_migrations_online, max_retries=10, delay_secs=10)

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -77,7 +77,11 @@ def run_migrations_online():
 
     connection = engine.connect()
     context.configure(
-        connection=connection, target_metadata=target_metadata, compare_type=True, include_object=include_object
+        connection=connection,
+        compare_type=True,
+        include_object=include_object,
+        target_metadata=target_metadata,
+        transaction_per_migration=True,
     )
 
     try:

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -63,8 +63,16 @@ def run_migrations_online():
     and associate a connection with the context.
 
     """
+    # abort any migrations if the lock cannot be acquired after one second.
+    #
+    # if we see issues with this lock timeout failing, we should try running again when there are no locks on that
+    # table, perhaps at a quieter time.
+    options = {"lock_timeout": "1000"}
     engine = engine_from_config(
-        config.get_section(config.config_ini_section), prefix="sqlalchemy.", poolclass=pool.NullPool
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+        connect_args={"options": " ".join(f"-c {opt_key}={opt_value}" for opt_key, opt_value in options.items())},
     )
 
     connection = engine.connect()


### PR DESCRIPTION
Postgres has a variety of lock levels that different commands acquire. Per row or per table. Generally they're in a relatively linear hierarchy (where ACCESS SHARE is the most permissive, up to ACCESS EXCLUSIVE being the most restrictive). You can read more about the specifics and when they're used at the postgres docs [^1].

Many commands have ways to not acquire wide-reaching locks. You should always seek to avoid ACCESS EXCLUSIVE where possible, and where not possible, to minimise time spent with such a lock acquired. For example, using `ADD CONSTRAINT NOT VALID` will skip validating a constraint on existing rows - you can then run `VALIDATE CONSTRAINT <name>` later to validate.

However, ACCESS EXCLUSIVE locks are often hard to avoid altogether.

We've seen cases where:

* long running query with low lock level (eg: an expensive select on a big table) is running
* alembic tries to acquire ACCESS EXCLUSIVE lock, but is blocked and waits in queue.
* other selects are told to wait in the queue behind the alembic query (despite being able to coexist happily with the long running select)
* other queries are blocked, causing timeouts, errors, downtime, etc.

This commit aborts any migrations if any lock cannot be acquired after one second. if we see issues with this lock timeout failing, we should try running again when there are no locks on that table, perhaps at a quieter time, or figure out what is acquiring a long-held lock against that table.

We've set it to one second to start with but this value is up for debate. It's a trade off between "chance of migration succesfully completing" and "how long are other queries blocked for".

Pages that were helpful to me when writing this:

https://medium.com/paypal-tech/postgresql-at-scale-database-schema-changes-without-downtime-20d3749ed680#f0d8
https://medium.com/exness-blog/alembic-migrations-without-downtime-a3507d5da24d#:~:text=Example%20of%20an%20alembic%20configuration%3A
https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-TABLES:~:text=Table%C2%A013.2.%C2%A0Conflicting%20Lock%20Modes

Other discussion points:

* is 1 second appropriate as a value for timeout?
* should we have automated retries on lock fail?
* should we set a statement_timeout? i started writing to set it but wasn't sure what a sensible value is. Some migration commands acquire lower risk locks for long times (for example, updating large volumes of data or validating constraints on large tables).

------------------------------

<details><summary>example alembic output when a select is underway</summary>
<p>

```
❯ flask db upgrade
2023-09-29T19:19:40 app app INFO no-request-id "Logging configured" [in /Users/leo.hemsted/.pyenv/versions/3.9.16/envs/api/lib/python3.9/site-packages/notifications_utils/logging.py:42]
INFO  [sqlalchemy.engine.Engine] select pg_catalog.version()
INFO  [sqlalchemy.engine.Engine] select pg_catalog.version()
INFO  [sqlalchemy.engine.Engine] [raw sql] {}
INFO  [sqlalchemy.engine.Engine] [raw sql] {}
INFO  [sqlalchemy.engine.Engine] select current_schema()
INFO  [sqlalchemy.engine.Engine] select current_schema()
INFO  [sqlalchemy.engine.Engine] [raw sql] {}
INFO  [sqlalchemy.engine.Engine] [raw sql] {}
INFO  [sqlalchemy.engine.Engine] show standard_conforming_strings
INFO  [sqlalchemy.engine.Engine] show standard_conforming_strings
INFO  [sqlalchemy.engine.Engine] [raw sql] {}
INFO  [sqlalchemy.engine.Engine] [raw sql] {}
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [sqlalchemy.engine.Engine] BEGIN (implicit)
INFO  [sqlalchemy.engine.Engine] BEGIN (implicit)
INFO  [sqlalchemy.engine.Engine] select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
INFO  [sqlalchemy.engine.Engine] select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
INFO  [sqlalchemy.engine.Engine] [generated in 0.00007s] {'name': 'alembic_version'}
INFO  [sqlalchemy.engine.Engine] [generated in 0.00007s] {'name': 'alembic_version'}
INFO  [sqlalchemy.engine.Engine] SELECT alembic_version.version_num
FROM alembic_version
INFO  [sqlalchemy.engine.Engine] SELECT alembic_version.version_num
FROM alembic_version
INFO  [sqlalchemy.engine.Engine] [generated in 0.00007s] {}
INFO  [sqlalchemy.engine.Engine] [generated in 0.00007s] {}
INFO  [alembic.runtime.migration] Running upgrade 0425_unique_service_name_2 -> 0426_drop_email_from, Revision ID: 0426_drop_email_from
Revises: 0425_unique_service_name_2
Create Date: 2023-09-29 18:47:48.703294
INFO  [sqlalchemy.engine.Engine] ALTER TABLE services DROP COLUMN email_from
INFO  [sqlalchemy.engine.Engine] ALTER TABLE services DROP COLUMN email_from
INFO  [sqlalchemy.engine.Engine] [no key 0.00006s] {}
INFO  [sqlalchemy.engine.Engine] [no key 0.00006s] {}
INFO  [sqlalchemy.engine.Engine] ROLLBACK
INFO  [sqlalchemy.engine.Engine] ROLLBACK
Traceback (most recent call last):
  File "/Users/leo.hemsted/.pyenv/versions/3.9.16/envs/api/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1900, in _execute_context
    self.dialect.do_execute(
  File "/Users/leo.hemsted/.pyenv/versions/3.9.16/envs/api/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.LockNotAvailable: canceling statement due to lock timeout


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/leo.hemsted/.pyenv/versions/api/bin/flask", line 8, in <module>
    sys.exit(main())

[.....]

  File "/Users/leo.hemsted/dev/api/migrations/versions/0426_drop_email_from.py", line 19, in upgrade
    op.drop_column("services", "email_from")
  File "<string>", line 8, in drop_column
  File "<string>", line 3, in drop_column
  File "/Users/leo.hemsted/.pyenv/versions/3.9.16/envs/api/lib/python3.9/site-packages/alembic/operations/ops.py", line 2189, in drop_column
    return operations.invoke(op)

[.....]

  File "/Users/leo.hemsted/.pyenv/versions/3.9.16/envs/api/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.OperationalError: (psycopg2.errors.LockNotAvailable) canceling statement due to lock timeout

[SQL: ALTER TABLE services DROP COLUMN email_from]
(Background on this error at: https://sqlalche.me/e/14/e3q8)
```

</p>
</details> 

---------------------------------------


[^1]: https://www.postgresql.org/docs/current/explicit-locking.html