### PR TITLE
Stop task running 60 times per night, rather than once 

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -362,9 +362,12 @@ def delete_oldest_quarter_of_unneeded_notification_history():
     #
     # In the future, we will be able to update this retention_limit_bst value when we have progressed 3 quarters
     # into the next financial year
+    current_app.logger.info("Beginning celery task delete_oldest_quarter_of_unneeded_notification_history")
     retention_limit_bst = datetime(2023, 1, 1)
 
-    oldest_notification_bst = convert_utc_to_bst(db.session.query(func.min(NotificationHistory.created_at)).one()[0])
+    oldest_notification_utc = db.session.query(func.min(NotificationHistory.created_at)).one()[0]
+    current_app.logger.info("Oldest notification in notification_history found is %s UTC", oldest_notification_utc)
+    oldest_notification_bst = convert_utc_to_bst(oldest_notification_utc)
     if oldest_notification_bst >= retention_limit_bst:
         current_app.logger.info(
             "No notifications older than retention date of %s so nothing to delete", retention_limit_bst

--- a/app/config.py
+++ b/app/config.py
@@ -264,7 +264,7 @@ class Config(object):
             # app/celery/nightly_tasks.py
             "delete-oldest-quarter-of-unneeded-notification-history": {
                 "task": "delete-oldest-quarter-of-unneeded-notification-history",
-                "schedule": crontab(hour=21),
+                "schedule": crontab(hour=21, minute=0),
                 "options": {"queue": QueueNames.PERIODIC},
             },
             "timeout-sending-notifications": {


### PR DESCRIPTION
We had lots of email alerts over the weekend. This was because the delete_oldest_quarter_of_unneeded_notification_history task was accidentally being run every minute from 21:00 to 21:59. This was causing a variety of knock on effects as the periodic worker was blocked up running these tasks, rather than the other tasks it should be running.

I've also added in some additional logging for better debugging in the future if needed.

Note, this does not solve the problem of the task failing due to sqlalchemy statement timeout errors (queries can only run for up to 20 minutes) which is going to be addressed in a subsequent PR (but I wanted to get this quick fix in which would stop any further production impact tonight first).