### PR TITLE
lint alembic migrations with squawk

### DIFF
--- a/scripts/lint_sql_migrations.sh
+++ b/scripts/lint_sql_migrations.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+if ! [[ -x "$(command -v squawk)" ]]; then
+    echo "ERR: Squawk not found. Install with npm install -g squawk-cli" >&2
+    exit 1;
+fi
+
+
+# ensure main is up-to-date
+git fetch origin main:main
+
+FILES_COMMITTED_TO_BRANCH=$(git diff --name-only main -- migrations/versions/)
+UNADDED_FILES=$(git ls-files --others --exclude-standard migrations/versions)
+
+if [[ -z "${FILES_COMMITTED_TO_BRANCH}" && -z "${UNADDED_FILES}" ]]; then
+    # no edits to migrations, either added or not added
+    echo "No migrations"
+    exit 0;
+fi
+
+source environment.sh
+
+# what is the database currently pointing at on master?
+CURRENT_VERSION=$(git show main:migrations/.current-alembic-head)
+# what is the most recent version? note this depends on us only ever having one head
+NEWEST_VERSION=$(flask db heads | tail -n 1 | cut -d " " -f 1)
+
+if [[ "${CURRENT_VERSION}" == "${NEWEST_VERSION}" ]]; then
+    # there's changes to migrations, but no new version to test against?
+    # has someone modified an existing migration?
+    echo "Migrations found but can't work out what's different to master"
+    exit 0;
+fi
+
+# tail -n +2 removes the first line of output - the stupid "logging configured" line
+flask db upgrade --sql $CURRENT_VERSION:$NEWEST_VERSION | tail -n +2 > /tmp/upgrade.sql
+
+echo
+# postgres version should match `rds_engine_version` in notifications-aws/terraform/notify-infra/tfvars/globals.tfvars
+squawk /tmp/upgrade.sql --pg-version="15.5"


### PR DESCRIPTION
squawk can take a sql file and lint it for common errors, such as renaming a column in an unsafe way or running a command that might acquire a wide-reaching long-lasting lock.

this commit wraps squawk in a little bash script that gets the alembic upgrades output as sql

there doesn't appear to be an obvious way to `#noqa` style "accept" a squawk warning if we know it's okay (for example, dropping a column we know is no longer written to or read from), so we can't immediately integrate this in to our CI pipeline or pre-commit hooks unfortunately.

typical output:

```
❯ ./scripts/lint_sql_migrations.sh
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Generating static SQL
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 0425_unique_service_name_2 -> 0426_drop_email_from, Revision ID: 0426_drop_email_from
Revises: 0425_unique_service_name_2
Create Date: 2023-09-29 18:47:48.703294
/tmp/upgrade.sql:2:2: warning: ban-drop-column

   2 | -- Running upgrade 0425_unique_service_name_2 -> 0426_drop_email_from
   3 |
   4 | ALTER TABLE services DROP COLUMN email_from;

  note: Dropping a column may break existing clients.

/tmp/upgrade.sql:6:2: warning: ban-drop-column

   6 | ALTER TABLE services_history DROP COLUMN email_from;

  note: Dropping a column may break existing clients.

find detailed examples and solutions for each rule at https://squawkhq.com/docs/rules
```