### PR TITLE
Delete rows from notification_history in 50,000 chunks

### DIFF
--- a/tests/app/dao/test_notification_history_dao.py
+++ b/tests/app/dao/test_notification_history_dao.py
@@ -21,7 +21,7 @@ def test_delete_notification_history_older_than_datetime(notify_db_session, samp
     assert len(notification_history_rows) == 5
     assert notification_history_rows[0].created_at == datetime(2022, 2, 7)
 
-    delete_notification_history_older_than_datetime(datetime(2022, 7, 1))
+    delete_notification_history_older_than_datetime(datetime(2022, 7, 1), query_limit=1)
 
     notification_history_rows = NotificationHistory.query.order_by(NotificationHistory.created_at).all()
     assert len(notification_history_rows) == 2


### PR DESCRIPTION
This is because the query is currently taking over 20 minutes which is longer than our statement timeout limit and so is being cancelled.

We split it into smaller chunks so that we don't run into this problem. 50,000 has been chosen fairly arbirtrarily and is used as a query_limit elsewhere in our codebase.

We commit after each one so we commit progress regularly rather than just at the end.

We choose synchronize_session False as we do not need to access those notifications again that have been deleted.
https://docs.sqlalchemy.org/en/14/orm/session_basics.html#selecting-a-synchronization-strategy