### PR TITLE
double disc space on paas api apps

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -1,7 +1,7 @@
 {%- set app_vars = {
   'notify-api': {
     'NOTIFY_APP_NAME': 'api',
-    'disk_quota': '2G',
+    'disk_quota': '10G',
     'sqlalchemy_pool_size': 15,
     'additional_env_vars': {
       'STATSD_HOST': None
@@ -22,7 +22,7 @@
 
   'notify-api-sms-receipts': {
     'NOTIFY_APP_NAME': 'api',
-    'disk_quota': '2G',
+    'disk_quota': '4G',
     'additional_env_vars': {
       'STATSD_HOST': None
     },
@@ -58,8 +58,8 @@
     },
   },
   'notify-delivery-worker-jobs': {'memory': '2G'},
-  'notify-delivery-worker-research': {},
-  'notify-delivery-worker-sender': {'disk_quota': '2G', 'memory': '4G'},
+  'notify-delivery-worker-research': {'disk_quota': '10G'},
+  'notify-delivery-worker-sender': {'disk_quota': '4G', 'memory': '4G'},
   'notify-delivery-worker-sender-letters': {},
   'notify-delivery-worker-periodic': {},
   'notify-delivery-worker-reporting': {
@@ -78,8 +78,8 @@
     }
   },
   'notify-delivery-worker-receipts': {},
-  'notify-delivery-worker-service-callbacks': {'disk_quota': '2G'},
-  'notify-delivery-worker-save-api-notifications': {'disk_quota': '2G'},
+  'notify-delivery-worker-service-callbacks': {'disk_quota': '4G'},
+  'notify-delivery-worker-save-api-notifications': {'disk_quota': '4G'},
 } -%}
 
 {%- set app = app_vars[CF_APP] -%}
@@ -94,7 +94,7 @@ applications:
     instances: {{ instance_count }}
     {%- endif %}
     memory: {{ app.get('memory', '1G') }}
-    disk_quota: {{ app.get('disk_quota', '1G')}}
+    disk_quota: {{ app.get('disk_quota', '2G')}}
     stack: cflinuxfs3
 
     routes:


### PR DESCRIPTION
we were seeing paas apps run out of disc spaces and crash. most of our disc space goes on log files that we write to disc so awslogs can send them to AWS. we don't have any file rotation or cleanup on this file.

Normally the only way to clean up this file is to restart the instance - either just wait for it to crash and paas to bring up a new one, or for a new deploy to happen and roll every instance.

We're seeing lots of crashes on the research worker and the api. Crashes on worker apps are "okay", as when the crash happens, our run_app_paas script sends a TERM to the celery process, which will simply stop fetching new tasks, wait til the existing tasks are finished, and then exit. However, the crashes on the main api webserver are tougher to deal with as gorouter continues routing traffic to that API instance.

currently on paas we use ~380GB of disc space out of an available 200GB per cell (30 cells, 9000GB total). So there's plenty of room for growth in disk space without troubling our paas limits

This commit doubles the disc space of everything to give more buffer room between deploys. Our traffic's a lot higher than when we first set these values in jan 2019, and we're filling up disks quicker.

It increases API and research worker even more above the double mark just to make sure those apps are safe.