### PR TITLE
Don't run notification_history purge task in staging

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -363,6 +363,16 @@ def delete_oldest_quarter_of_unneeded_notification_history():
     # In the future, we will be able to update this retention_limit_bst value when we have progressed 3 quarters
     # into the next financial year
     current_app.logger.info("Beginning celery task delete_oldest_quarter_of_unneeded_notification_history")
+
+    if current_app.config["NOTIFY_ENVIRONMENT"] == "staging":
+        # We don't want to run this in staging as we want to keep some older notifications in there for migration
+        # testing
+        # After we've migrated our database, we should be able to remove this check and let this run in staging
+        current_app.logger.info(
+            "Aborting delete_oldest_quarter_of_unneeded_notification_history as staging environment"
+        )
+        return
+
     retention_limit_bst = datetime(2023, 1, 1)
 
     oldest_notification_utc = db.session.query(func.min(NotificationHistory.created_at)).one()[0]


### PR DESCRIPTION
This will enable us to retain about 1 billion notifications in our staging notification_history table, which is roughly the same number that will be in production after this task has run against prod. This is important for our testing this week of migrating Postgres which will benefit from having staging look similar to production in size.

We did also consider taking a fresh copy of production, redacting the personal data and attaching it to the staging apps, but decided that was too much work and this is a quicker fix.