### PR TITLE
Let jobs be scheduled up to 7 days in the future 

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -520,8 +520,8 @@ class JobSchema(BaseSchema):
         if value < datetime.utcnow():
             raise ValidationError("Date cannot be in the past")
 
-        if value > datetime.utcnow() + timedelta(days=4):
-            raise ValidationError("Date cannot be more than 4 days in the future")
+        if value > datetime.utcnow() + timedelta(days=7):
+            raise ValidationError("Date cannot be more than 7 days in the future")
 
     class Meta(BaseSchema.Meta):
         model = models.Job

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -520,8 +520,8 @@ class JobSchema(BaseSchema):
         if value < datetime.utcnow():
             raise ValidationError("Date cannot be in the past")
 
-        if value > datetime.utcnow() + timedelta(hours=96):
-            raise ValidationError("Date cannot be more than 96hrs in the future")
+        if value > datetime.utcnow() + timedelta(days=4):
+            raise ValidationError("Date cannot be more than 4 days in the future")
 
     class Meta(BaseSchema.Meta):
         model = models.Job

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -40,16 +40,6 @@ def _validate_positive_number(value, msg="Not a positive integer"):
         raise ValidationError(msg)
 
 
-def _validate_datetime_not_more_than_96_hours_in_future(dte, msg="Date cannot be more than 96hrs in the future"):
-    if dte > datetime.utcnow() + timedelta(hours=96):
-        raise ValidationError(msg)
-
-
-def _validate_datetime_not_in_past(dte, msg="Date cannot be in the past"):
-    if dte < datetime.utcnow():
-        raise ValidationError(msg)
-
-
 class FlexibleDateTime(fields.DateTime):
     """
     Allows input data to not contain tz info.
@@ -527,8 +517,11 @@ class JobSchema(BaseSchema):
 
     @validates("scheduled_for")
     def validate_scheduled_for(self, value):
-        _validate_datetime_not_in_past(value)
-        _validate_datetime_not_more_than_96_hours_in_future(value)
+        if value < datetime.utcnow():
+            raise ValidationError("Date cannot be in the past")
+
+        if value > datetime.utcnow() + timedelta(hours=96):
+            raise ValidationError("Date cannot be more than 96hrs in the future")
 
     class Meta(BaseSchema.Meta):
         model = models.Job

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -378,7 +378,7 @@ def test_should_not_create_scheduled_job_more_then_96_hours_in_the_future(client
     resp_json = json.loads(response.get_data(as_text=True))
     assert resp_json["result"] == "error"
     assert "scheduled_for" in resp_json["message"]
-    assert resp_json["message"]["scheduled_for"] == ["Date cannot be more than 96hrs in the future"]
+    assert resp_json["message"]["scheduled_for"] == ["Date cannot be more than 4 days in the future"]
 
 
 @freeze_time("2016-01-01 11:09:00.061258")

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -349,8 +349,8 @@ def test_create_job_returns_403_if_letter_template_type_and_service_in_trial(
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
-def test_should_not_create_scheduled_job_more_then_96_hours_in_the_future(client, sample_template, mocker, fake_uuid):
-    scheduled_date = (datetime.utcnow() + timedelta(hours=96, minutes=1)).isoformat()
+def test_should_not_create_scheduled_job_more_then_7_days_in_the_future(client, sample_template, mocker, fake_uuid):
+    scheduled_date = (datetime.utcnow() + timedelta(days=7, minutes=1)).isoformat()
     mocker.patch("app.celery.tasks.process_job.apply_async")
     mocker.patch(
         "app.job.rest.get_job_metadata_from_s3",
@@ -378,7 +378,7 @@ def test_should_not_create_scheduled_job_more_then_96_hours_in_the_future(client
     resp_json = json.loads(response.get_data(as_text=True))
     assert resp_json["result"] == "error"
     assert "scheduled_for" in resp_json["message"]
-    assert resp_json["message"]["scheduled_for"] == ["Date cannot be more than 4 days in the future"]
+    assert resp_json["message"]["scheduled_for"] == ["Date cannot be more than 7 days in the future"]
 
 
 @freeze_time("2016-01-01 11:09:00.061258")


### PR DESCRIPTION
4 days is sometimes not enough if there is a weekend with a bank holiday before and after it.

7 days is a sensible new limit because it:
- accounts for these longer weekends or holiday periods like Christmas
- without introducing any ambiguity about which ‘Thursday’ is meant (because only one of each weekday will ever be shown at once)