### PR TITLE
Try to debug and speed up delete_notification_history_older_than_datetime

### DIFF
--- a/app/dao/notification_history_dao.py
+++ b/app/dao/notification_history_dao.py
@@ -22,9 +22,6 @@ def delete_notification_history_older_than_datetime(older_than_datetime, query_l
 
         num_rows_deleted = NotificationHistory.query.filter(
             NotificationHistory.id.in_(notification_ids_to_delete),
-            # Restrict on created_at again, just in case there was a problem
-            # with the query above
-            NotificationHistory.created_at < older_than_datetime,
         ).delete(synchronize_session=False)
 
         current_app.logger.info("Deleted chunk of %s rows from notification_history", num_rows_deleted)

--- a/app/dao/notification_history_dao.py
+++ b/app/dao/notification_history_dao.py
@@ -18,12 +18,16 @@ def delete_notification_history_older_than_datetime(older_than_datetime, query_l
             .limit(query_limit)
         )
 
+        current_app.logger.info("Found chunk of rows from notification_history to delete")
+
         num_rows_deleted = NotificationHistory.query.filter(
             NotificationHistory.id.in_(notification_ids_to_delete),
             # Restrict on created_at again, just in case there was a problem
             # with the query above
             NotificationHistory.created_at < older_than_datetime,
         ).delete(synchronize_session=False)
+
+        current_app.logger.info("Deleted chunk of %s rows from notification_history", num_rows_deleted)
 
         deleted_this_iteration = num_rows_deleted
         total_deleted += num_rows_deleted


### PR DESCRIPTION
Getting some mixed results still in our logs where this isn't super speedy and sometimes doesn't appear to finish.

These two small changes may help us.

Best reviewed commit by commit

<img width="1167" alt="image" src="https://github.com/alphagov/notifications-api/assets/7228605/af1b2a12-4707-4fb1-b5e5-b269908fa068">
