### PR TITLE
Bump to psycopg2==2.9.6

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ itsdangerous==2.1.2
 jsonschema[format]==4.16.0
 marshmallow-sqlalchemy==0.28.1
 marshmallow==3.18.0
-psycopg2-binary==2.9.3
+psycopg2-binary==2.9.6
 PyJWT==2.5.0
 SQLAlchemy==1.4.41
 cachetools==5.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -181,7 +181,7 @@ prometheus-client==0.14.1
     #   gds-metrics
 prompt-toolkit==3.0.31
     # via click-repl
-psycopg2-binary==2.9.3
+psycopg2-binary==2.9.6
     # via -r requirements.in
 pyasn1==0.4.8
     # via rsa


### PR DESCRIPTION
After upgrading from pg11->pg15 locally, we started to see the following error: `sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) SCRAM authentication requires libpq version 10 or above`.

A suggested fix for this is to upgrade to psycopg2(-binary)==2.9.6, so that's what we do here.

---

If using `notifications-local`, you'll need to do a `make down`, `docker-compose build notify-api`, `make <opts> up` again to make sure your API container(s) get updated.