### PR TITLE
Run delete notification history task 4 times per night

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -264,7 +264,7 @@ class Config(object):
             # app/celery/nightly_tasks.py
             "delete-oldest-quarter-of-unneeded-notification-history": {
                 "task": "delete-oldest-quarter-of-unneeded-notification-history",
-                "schedule": crontab(hour=21, minute=0),
+                "schedule": crontab(hour=19, minute="0,10,20,30"),
                 "options": {"queue": QueueNames.PERIODIC},
             },
             "timeout-sending-notifications": {

--- a/app/dao/notification_history_dao.py
+++ b/app/dao/notification_history_dao.py
@@ -14,7 +14,6 @@ def delete_notification_history_older_than_datetime(older_than_datetime, query_l
         notification_ids_to_delete = (
             select(NotificationHistory.id)
             .where(NotificationHistory.created_at < older_than_datetime)
-            .order_by(NotificationHistory.created_at)
             .limit(query_limit)
         )
 


### PR DESCRIPTION
The task is currently going fairly slowly, deleting about 6 million rows per hour. It is also at risk of getting disrupted by a deploy which will stop it until it is kicked off again this evening.

At this pace, it will take about 83 nights to delete all the needed notifications (we need it to be done in about 10 days time).

Firstly, I've changed the task to start at 7pm. This will give us an extra 2 hours for it to run overnight before someone comes in the next day and potentially deploys the API.

Secondly, I've got it kicking off the task 4 times per evening. This will mean we get roughly 4 times the deletion which will be quicker. To support this, I've removed the requirement that it deletes the oldest notifications first and instead picks them as it wants. This should mean that 4 concurrent tasks won't all be trying to delete the same notifications (I'm assuming it will pick notifications randomly but could be wrong on that).

If this does speed up 4x, that still means it might take about 20 evenings to delete the data we need which may not be soon enough. My plan is to run it like this for a few evenings, check the speed and evaluate if we need to
- throw even more simultaneous tasks at it
- run some queries manually ourselves by logging into prod
- do something else

To support 4 tasks running concurrently, I will also put up a pull request for the autoscaler to make sure there are minimum 4 more periodic workers at all times because otherwise these will hog all the periodic workers and our other tasks (like sending scheduled jobs) will get blocked and won't happen.