### PR TITLE
Promote use of specific notifications index

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -221,7 +221,7 @@ def get_notification_by_id(notification_id, service_id=None, _raise=False):
     return query.one() if _raise else query.first()
 
 
-def get_notifications_for_service(
+def get_notifications_for_service(  # noqa: C901
     service_id,
     filter_dict=None,
     page=1,
@@ -269,6 +269,25 @@ def get_notifications_for_service(
     query = _filter_query(query, filter_dict)
     if personalisation:
         query = query.options(joinedload("template"))
+
+    # If we are filtering on all of the columns in our composite index (service_id, type, status, created_at), let's
+    # strongly suggest to the query planner that it always use that index. This is to tackle an issue that we've seen
+    # on some high-volume services when the filters we apply end up matching few results (eg failed letters). Quite
+    # often that query ends up ignoring this index and doing a backwards index scan on
+    # ix_notifications_service_created_at instead, which can end up being very slow.
+    # The reason it does this is because our page_size is relatively small (50 by default), so it thinks that it can
+    # just do a quick scan backwards on that index and it will quickly find 50 rows. In some cases, eg failed letters,
+    # this can quite often not be the case, and so it ends up scanning _all_ notifications for that service within
+    # limit_days. This can mean scanning millions of emails/text messages even when we know we're only looking for
+    # letters. This has ended up timing out the "view notifications" page for eg NHS.
+    if (
+        (limit_days or older_than)
+        and filter_dict
+        and "status" in filter_dict
+        and "template_type" in filter_dict
+        and not client_reference
+    ):
+        query = query.prefix_with("/*+ IndexScan(notifications ix_notifications_service_id_composite) */")
 
     return query.order_by(desc(Notification.created_at)).paginate(
         page=page,


### PR DESCRIPTION
We've seen a lot of timeouts on the NHS service "view notifications" page, when they try to view failed letters.

The pseudo-SQL query for this page is:

select * from notifications where service_id=x, key_type in (a,b), status in (a, b, c), created_at >= date limit x offset y;

We have a composite index on these fields and the query will occasionally make use of this, which is great.

However, sometimes it instead chooses to do a backwards index scan on another index with just (service_id, created_at). The reason it does this is that it seems to think that, when fetching only a few results (ie for low limit values), it should be quick to just go back through that index and find the first few matches. Where there are only very few matches, this ends up not working. For example, NHS sends a ton of text messages and emails, but relatively few letters, and very few of those letters fail. So when it tries to do that backwards scan, it ends up checking a load of texts and emails which it has to discard.

We have the
[pg_hint_plan](https://github.com/ossc-db/pg_hint_plan/tree/master) extension available in our database by default. This allows us to inject some comment-style hints into the query, which can adjust how the query planner executes the query.

This patch updates the 'get all notifications for service' function to inject that query hint, if we know we're querying all of the fields that are present in our composite index. This should give us a more reliable query execution for the 'view notifications' dashboard page - and indeed anything else which makes similar queries.

# Comparison using staging load test service
## Before 
https://govuk-notify-gds.sentry.io/performance/notifications-api:b986d4f52a254883be3007c4a794540a
<img width="1140" alt="image" src="https://github.com/alphagov/notifications-api/assets/2920760/f6022734-7f0a-4b54-a9e7-e7d42dcc62cd">

## After
https://govuk-notify-gds.sentry.io/performance/notifications-api:d2cfb76eceba4d179bfc1f678f835afe
<img width="1140" alt="image" src="https://github.com/alphagov/notifications-api/assets/2920760/cdc11cd1-fa3b-4125-b3d9-adb24fff6a1a">

---

Note: we can also do a tweak to this specific query by just fetching page_size+1 in a single query, and then checking if that +1 is present in the result set to determine if there's another page of results to fetch. That will let us do a single query rather than doing two. But I leave that to a separate PR for now so that we can focus on just this pg_hint_plan approach.