### PR TITLE
Delete notification_history in hour chunks

### DIFF
--- a/app/dao/notification_history_dao.py
+++ b/app/dao/notification_history_dao.py
@@ -33,3 +33,18 @@ def delete_notification_history_older_than_datetime(older_than_datetime, query_l
     current_app.logger.info(
         "Deleted %s rows from notification_history older than %s", total_deleted, older_than_datetime
     )
+
+
+def delete_notification_history_between_two_datetimes(start, end):
+    # start time is inclusive, end time is exclusive
+    current_app.logger.info("Beginning to delete notification_history between %s and %s", start, end)
+
+    num_rows_deleted = NotificationHistory.query.filter(
+        NotificationHistory.created_at >= start, NotificationHistory.created_at < end
+    ).delete(synchronize_session=False)
+
+    db.session.commit()
+
+    current_app.logger.info(
+        "Finishing deleting %s rows of notification_history between %s and %s", num_rows_deleted, start, end
+    )

--- a/tests/app/dao/test_notification_history_dao.py
+++ b/tests/app/dao/test_notification_history_dao.py
@@ -1,6 +1,9 @@
 from datetime import datetime
 
-from app.dao.notification_history_dao import delete_notification_history_older_than_datetime
+from app.dao.notification_history_dao import (
+    delete_notification_history_between_two_datetimes,
+    delete_notification_history_older_than_datetime,
+)
 from app.models import NotificationHistory
 from tests.app.db import create_notification_history
 
@@ -26,3 +29,35 @@ def test_delete_notification_history_older_than_datetime(notify_db_session, samp
     notification_history_rows = NotificationHistory.query.order_by(NotificationHistory.created_at).all()
     assert len(notification_history_rows) == 2
     assert notification_history_rows[0].created_at == datetime(2022, 7, 1)
+
+
+def test_delete_notification_history_between_two_datetimes(notify_db_session, sample_letter_template):
+    notification_history_datetimes = [
+        datetime(2022, 2, 6, 13, 0, 0),
+        datetime(2022, 2, 7, 12, 59, 59),
+        datetime(2022, 2, 7, 13, 0, 0),
+        datetime(2022, 2, 7, 13, 0, 1),
+        datetime(2022, 2, 7, 13, 7, 0),
+        datetime(2022, 2, 7, 13, 42, 8),
+        datetime(2022, 2, 7, 13, 59, 59),
+        datetime(2022, 2, 7, 14, 0, 0),
+        datetime(2022, 2, 7, 14, 0, 1),
+        datetime(2022, 2, 8, 13, 0, 0),
+    ]
+    for dt in notification_history_datetimes:
+        create_notification_history(
+            sample_letter_template, status="delivered", created_at=dt, sent_at=dt, updated_at=dt
+        )
+    notification_history_rows = NotificationHistory.query.order_by(NotificationHistory.created_at).all()
+    assert len(notification_history_rows) == 10
+
+    delete_notification_history_between_two_datetimes(datetime(2022, 2, 7, 13, 0, 0), datetime(2022, 2, 7, 14, 0, 0))
+
+    notification_history_rows = NotificationHistory.query.order_by(NotificationHistory.created_at).all()
+    assert len(notification_history_rows) == 5
+
+    assert notification_history_rows[0].created_at == notification_history_datetimes[0]
+    assert notification_history_rows[1].created_at == notification_history_datetimes[1]
+    assert notification_history_rows[2].created_at == notification_history_datetimes[7]
+    assert notification_history_rows[3].created_at == notification_history_datetimes[8]
+    assert notification_history_rows[4].created_at == notification_history_datetimes[9]


### PR DESCRIPTION
This changes the approach in
delete_oldest_quarter_of_unneeded_notification_history which was too slow because it couldn't be run in parralell on multiple workers.

Instead, we queue up lots of small tasks that can be run in parraell which will each delete only a single hour of data.

I've tested some of these queries manually on production and for the 4 different 1 hour slots I tried, the queries took less than 10 seconds each.

The plan is to kick this task off once manually by logging into production and creating a task (rather than scheduling a task that we only want to run once which is a bit hard to do with cron).

If people are happy with this pull request, I'll merge it, run it and then come back to delete all the code for the old way of doing things.