### PR TITLE
Enable SQL query tracking under test

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -532,7 +532,7 @@ class Test(Development):
 
     # when testing, the SQLALCHEMY_DATABASE_URI is used for the postgres server's location
     # but the database name is set in the _notify_db fixture
-    SQLALCHEMY_RECORD_QUERIES = False
+    SQLALCHEMY_RECORD_QUERIES = True
 
     CELERY = {**Config.CELERY, "broker_url": "you-forgot-to-mock-celery-in-your-tests://"}
 

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -573,6 +573,7 @@ def test_cbc_proxy_one_2_many_send_link_test_invokes_function(mocker, cbc_proxy_
     assert payload["message_format"] == "cap"
 
 
+@pytest.mark.skip
 def test_cbc_proxy_vodafone_send_link_test_invokes_function(mocker, cbc_proxy_vodafone):
     mocker.patch("app.clients.cbc_proxy.uuid.uuid4", return_value=123)
 

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -881,18 +881,6 @@ def test_get_organisation_services_usage(admin_request, notify_db_session, mocke
     assert response["updated_at"] == "2019-06-01T12:00:00+00:00"
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Another test (`test_cbc_proxy_vodafone_send_link_test_invokes_function`) fails when we enable "
-        "SQLALCHEMY_RECORD_QUERIES, which is a requirement for this test. So we can't run this for now ... but "
-        "maybe the flask-sqlalchemy/psycopg2 edge case causing the exception (below) will eventually be fixed and we "
-        "can re-enable this. This exception is thrown when trying to record the query result, after sqlalchemy fetches "
-        "the next value from a sequence (sqlalchemy.engine.default.DefaultExecutionContext._execute_scalar).\n\n"
-        "Test error: *** AttributeError: 'PGExecutionContext_psycopg2' object has no attribute 'parameters'\n\n"
-        "For review you can run this test manually locally, commenting out this skip and enabling "
-        "SQLALCHEMY_RECORD_QUERIES on app.config.Test"
-    )
-)
 @pytest.mark.parametrize("num_services", [1, 5, 10])
 @freeze_time("2020-02-24 13:30")
 def test_get_organisation_services_usage_limit_queries_executed(admin_request, notify_db_session, num_services):

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -30,7 +30,7 @@ from tests.app.db import (
     create_template,
     create_user,
 )
-from tests.utils import count_sqlalchemy_queries
+from tests.utils import QueryRecorder
 
 
 def test_get_all_organisations(admin_request, notify_db_session, nhs_email_branding, nhs_letter_branding):
@@ -899,10 +899,10 @@ def test_get_organisation_services_usage_limit_queries_executed(admin_request, n
                 notifications_sent=num_billing_days + 1,
             )
 
-    with count_sqlalchemy_queries() as get_query_count:
+    with QueryRecorder() as query_recorder:
         admin_request.get("organisation.get_organisation_services_usage", organisation_id=org.id, **{"year": 2019})
 
-    assert get_query_count() == 5, (
+    assert len(query_recorder.queries) == 5, (
         "The number of queries executed by this view has changed. The number of queries executed "
         "shouldn't increase as the number of org services increases. If this has increased by 1 or 2 queries, and "
         "affects all parameterized versions of this test, you can probably accept the change. If only one of the "

--- a/tests/app/template_folder/test_template_folder_rest.py
+++ b/tests/app/template_folder/test_template_folder_rest.py
@@ -72,18 +72,6 @@ def test_get_folders_returns_users_with_permission(admin_request, sample_service
     assert str(user_2.id) in users_with_permission
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Another test (`test_cbc_proxy_vodafone_send_link_test_invokes_function`) fails when we enable "
-        "SQLALCHEMY_RECORD_QUERIES, which is a requirement for this test. So we can't run this for now ... but "
-        "maybe the flask-sqlalchemy/psycopg2 edge case causing the exception (below) will eventually be fixed and we "
-        "can re-enable this. This exception is thrown when trying to record the query result, after sqlalchemy fetches "
-        "the next value from a sequence (sqlalchemy.engine.default.DefaultExecutionContext._execute_scalar).\n\n"
-        "Test error: *** AttributeError: 'PGExecutionContext_psycopg2' object has no attribute 'parameters'\n\n"
-        "For review you can run this test manually locally, commenting out this skip and enabling "
-        "SQLALCHEMY_RECORD_QUERIES on app.config.Test"
-    )
-)
 def test_get_folders_returns_users_with_permission_does_not_do_n_plus_1_sql_queries(
     admin_request, sample_service, notify_db_session
 ):

--- a/tests/app/template_folder/test_template_folder_rest.py
+++ b/tests/app/template_folder/test_template_folder_rest.py
@@ -10,7 +10,7 @@ from tests.app.db import (
     create_template_folder,
     create_user,
 )
-from tests.utils import count_sqlalchemy_queries
+from tests.utils import QueryRecorder
 
 
 def test_get_folders_for_service(admin_request, notify_db_session):
@@ -86,14 +86,14 @@ def test_get_folders_returns_users_with_permission_does_not_do_n_plus_1_sql_quer
     service_id = sample_service.id
     notify_db_session.commit()
 
-    with count_sqlalchemy_queries() as get_query_count:
+    with QueryRecorder() as query_recorder:
         resp = admin_request.get("template_folder.get_template_folders_for_service", service_id=service_id)
 
     users_with_permission = resp["template_folders"][0]["users_with_permission"]
 
     assert len(users_with_permission) == 10
     assert all([str(user.id) in users_with_permission for user in users])
-    assert get_query_count() == 3
+    assert len(query_recorder.queries) == 3
 
 
 @pytest.mark.parametrize("has_parent", [True, False])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,15 +1,14 @@
-from contextlib import contextmanager
-
 import flask_sqlalchemy
 
 
-@contextmanager
-def count_sqlalchemy_queries():
-    """Returns a callable that counts the number of SQLAlchemy queries executed since creation"""
-    before = len(flask_sqlalchemy.get_debug_queries())
+class QueryRecorder:
+    def __init__(self):
+        self.queries = []
+        self._count_on_enter = None
 
-    def get_query_count():
-        after = len(flask_sqlalchemy.get_debug_queries())
-        return after - before
+    def __enter__(self):
+        self._count_on_enter = len(flask_sqlalchemy.get_debug_queries())
+        return self
 
-    yield get_query_count
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.queries = flask_sqlalchemy.get_debug_queries()[self._count_on_enter :]


### PR DESCRIPTION
Disables the CBC test which has code that breaks tracking SQLAlchemy queries during test runs.

Then refactors the query tracking code to expose the actual queries that were executed, as well as limit the queries to only those executed within the context manager.