### PR TITLE
Make conversion from datetimes to strings clearer

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -365,6 +365,8 @@ def delete_unneeded_notification_history_by_hour():
     while start_datetime < retention_limit:
         end_datetime = start_datetime + timedelta(hours=1)
         delete_unneeded_notification_history_for_specific_hour.apply_async(
+            # We pass datetimes as args to the next task but celery will actually call `isoformat` on these
+            # and send them over as strings
             [start_datetime, end_datetime],
             # We use the broadcasts queue temporarily as it pulled from by a worker doing no work
             # We don't want to put the tasks on the periodic queue because they make take up all
@@ -380,7 +382,7 @@ def delete_unneeded_notification_history_by_hour():
 
 
 @notify_celery.task(name="delete_unneeded_notification_history_for_specific_hour")
-def delete_unneeded_notification_history_for_specific_hour(start_datetime, end_datetime):
+def delete_unneeded_notification_history_for_specific_hour(start_datetime: str, end_datetime: str):
     current_app.logger.info(
         "Beginning delete_unneeded_notification_history_for_specific_hour between %s and %s",
         start_datetime,

--- a/app/dao/notification_history_dao.py
+++ b/app/dao/notification_history_dao.py
@@ -4,7 +4,7 @@ from app import db
 from app.models import NotificationHistory
 
 
-def delete_notification_history_between_two_datetimes(start, end):
+def delete_notification_history_between_two_datetimes(start: str, end: str):
     # start time is inclusive, end time is exclusive
     current_app.logger.info("Beginning to delete notification_history between %s and %s", start, end)
 

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -584,8 +584,8 @@ def test_delete_notifications_task_calls_task_for_services_that_have_sent_notifi
 def test_delete_unneeded_notification_history_for_specific_hour(mocker):
     delete_mock = mocker.patch("app.celery.nightly_tasks.delete_notification_history_between_two_datetimes")
 
-    start = datetime(2022, 4, 4, 1, 0, 0)
-    end = datetime(2022, 4, 4, 2, 0, 0)
+    start = "2022-04-04T01:00:00"
+    end = "2022-04-04T02:00:00"
     delete_unneeded_notification_history_for_specific_hour(start, end)
 
     delete_mock.assert_called_once_with(start, end)

--- a/tests/app/dao/test_notification_history_dao.py
+++ b/tests/app/dao/test_notification_history_dao.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from app.dao.notification_history_dao import (
     delete_notification_history_between_two_datetimes,
 )
@@ -9,16 +7,16 @@ from tests.app.db import create_notification_history
 
 def test_delete_notification_history_between_two_datetimes(notify_db_session, sample_letter_template):
     notification_history_datetimes = [
-        datetime(2022, 2, 6, 13, 0, 0),
-        datetime(2022, 2, 7, 12, 59, 59),
-        datetime(2022, 2, 7, 13, 0, 0),
-        datetime(2022, 2, 7, 13, 0, 1),
-        datetime(2022, 2, 7, 13, 7, 0),
-        datetime(2022, 2, 7, 13, 42, 8),
-        datetime(2022, 2, 7, 13, 59, 59),
-        datetime(2022, 2, 7, 14, 0, 0),
-        datetime(2022, 2, 7, 14, 0, 1),
-        datetime(2022, 2, 8, 13, 0, 0),
+        "2022-02-06T13:00:00",
+        "2022-02-07T12:59:59",
+        "2022-02-07T13:00:00",
+        "2022-02-07T13:00:01",
+        "2022-02-07T13:07:00",
+        "2022-02-07T13:42:08",
+        "2022-02-07T13:59:59",
+        "2022-02-07T14:00:00",
+        "2022-02-07T14:00:01",
+        "2022-02-08T13:00:00",
     ]
     for dt in notification_history_datetimes:
         create_notification_history(
@@ -27,13 +25,13 @@ def test_delete_notification_history_between_two_datetimes(notify_db_session, sa
     notification_history_rows = NotificationHistory.query.order_by(NotificationHistory.created_at).all()
     assert len(notification_history_rows) == 10
 
-    delete_notification_history_between_two_datetimes(datetime(2022, 2, 7, 13, 0, 0), datetime(2022, 2, 7, 14, 0, 0))
+    delete_notification_history_between_two_datetimes("2022-02-07T13:00:00", "2022-02-07T14:00:00")
 
     notification_history_rows = NotificationHistory.query.order_by(NotificationHistory.created_at).all()
     assert len(notification_history_rows) == 5
 
-    assert notification_history_rows[0].created_at == notification_history_datetimes[0]
-    assert notification_history_rows[1].created_at == notification_history_datetimes[1]
-    assert notification_history_rows[2].created_at == notification_history_datetimes[7]
-    assert notification_history_rows[3].created_at == notification_history_datetimes[8]
-    assert notification_history_rows[4].created_at == notification_history_datetimes[9]
+    assert notification_history_rows[0].created_at.isoformat() == notification_history_datetimes[0]
+    assert notification_history_rows[1].created_at.isoformat() == notification_history_datetimes[1]
+    assert notification_history_rows[2].created_at.isoformat() == notification_history_datetimes[7]
+    assert notification_history_rows[3].created_at.isoformat() == notification_history_datetimes[8]
+    assert notification_history_rows[4].created_at.isoformat() == notification_history_datetimes[9]


### PR DESCRIPTION
It turns out that when we pass datetimes as args to the next task, celery behind the scenes must be converting them into strings in what appears to be using `isoformat()`.

This makes it explicit that
delete_unneeded_notification_history_for_specific_hour expects and requires strings because this is what it will actually receive from celery.

This updates the tests to correspond as well.