### PR TITLE
Use Sentry to monitor celery beat tasks

### DIFF
--- a/app/performance.py
+++ b/app/performance.py
@@ -1,6 +1,8 @@
 import os
 from functools import partial
 
+from sentry_sdk.integrations.celery import CeleryIntegration
+
 
 def sentry_sampler(sampling_context, sample_rate: float = 0.0):
     if sampling_context["parent_sampled"]:
@@ -40,6 +42,10 @@ def init_performance_monitoring():
             send_default_pii=send_pii,
             request_bodies=send_request_bodies,
             traces_sampler=traces_sampler,
+            # We explicitly enable the celery integration here so that we can toggle `monitor_beat_tasks` on (default
+            # is off). This doesn't stop a number of other integrations being automatically enabled, eg Flask, Redis,
+            # SQLAlchemy.
+            integrations=[CeleryIntegration(monitor_beat_tasks=True)],
             release=release,
         )
 


### PR DESCRIPTION
Trial using Sentry to automatically monitor our scheduled tasks. At the moment this is _in addition_ to Cronitor, so we can just test whether Sentry meets all of our needs without interrupting our current workflow with Cronitor.

https://govuk-notify-gds.sentry.io/crons/?environment=development&project=4504949325824000&statsPeriod=7d

## Screenshots
<img width="1498" alt="image" src="https://github.com/alphagov/notifications-api/assets/2920760/666e9df2-770f-4635-a05d-a204cfd1fa85">

<img width="1504" alt="image" src="https://github.com/alphagov/notifications-api/assets/2920760/b87f36b8-250a-428e-a40e-a76f90284650">

### When tasks are missed, they are raised as native issues in Sentry
<img width="1501" alt="image" src="https://github.com/alphagov/notifications-api/assets/2920760/9e9a6641-5dce-4497-a6ce-82f569d87f63">

