### PR TITLE
Add 'is_precompiled_letter' to template history

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -456,6 +456,7 @@ class TemplateHistorySchema(BaseSchema):
     reply_to = fields.Method("get_reply_to", allow_none=True)
     reply_to_text = fields.Method("get_reply_to_text", allow_none=True)
     process_type = field_for(models.Template, "process_type")
+    is_precompiled_letter = fields.Method("get_is_precompiled_letter")
     letter_attachment = fields.Method("get_letter_attachment", allow_none=True)
 
     created_by = fields.Nested(UserSchema, only=["id", "name", "email_address"], dump_only=True)
@@ -470,6 +471,9 @@ class TemplateHistorySchema(BaseSchema):
 
     def get_letter_attachment(self, template):
         return template.letter_attachment.serialize() if template.letter_attachment_id else None
+
+    def get_is_precompiled_letter(self, template):
+        return template.is_precompiled_letter
 
     class Meta(BaseSchema.Meta):
         model = models.TemplateHistory

--- a/tests/app/template/test_rest_history.py
+++ b/tests/app/template/test_rest_history.py
@@ -26,6 +26,7 @@ def test_template_history_version(notify_api, sample_user, sample_template):
             assert json_resp["data"]["version"] == 1
             assert json_resp["data"]["process_type"] == "normal"
             assert json_resp["data"]["created_by"]["name"] == sample_user.name
+            assert json_resp["data"]["is_precompiled_letter"] is False
             assert datetime.strptime(json_resp["data"]["created_at"], "%Y-%m-%d %H:%M:%S.%f").date() == date.today()
 
 


### PR DESCRIPTION
We now rely on this attribute when rendering letter template history versions.

Fixes: https://govuk-notify-gds.sentry.io/issues/4586197393/?end=2023-10-30T23%3A59%3A59&project=4504949328838656&referrer=issue-stream&start=2023-10-01T00%3A00%3A00&stream_index=0&utc=true

Tested locally and does fix the admin pages.