### PR TITLE
Upgrade Flask to latest version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ Flask-Bcrypt==1.0.1
 flask-marshmallow==0.14.0
 Flask-Migrate==3.1.0
 flask-sqlalchemy==3.0.2
-Flask==2.3.2
+Flask==3.0.0
 click-datetime==0.2
 # We originally pinned this due to eventlet v0.33 compatibility issues. That was supposedly fixed in version v21.0.0 and we merged v21.2.0 for a while. Until we ran a load test again, and identified that the bumped version of gunicorn led to a 33%+ drop-off in performance/requests per second that the API was able to handle. If a version greater than 21.2.0 is released, and it either gives us something we need or we think it addresses said performance issues, make sure to run a load test in staging before releasing to production.
 git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ docutils==0.16
     # via awscli
 eventlet==0.33.1
     # via gunicorn
-flask==2.3.2
+flask==3.0.0
     # via
     #   -r requirements.in
     #   flask-bcrypt
@@ -281,7 +281,7 @@ wcwidth==0.2.5
     # via prompt-toolkit
 webcolors==1.12
     # via jsonschema
-werkzeug==2.3.3
+werkzeug==3.0.1
     # via flask
 zipp==3.17.0
     # via importlib-metadata

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -14,5 +14,5 @@ requests-mock==1.10.0
 # used for creating manifest file locally
 jinja2-cli[yaml]==0.8.2
 
-pytest-httpserver==1.0.6
+pytest-httpserver==1.0.8
 trustme==0.9.0


### PR DESCRIPTION
Fixes #3936

***

This causes Werkzeug to be upgraded, fixing a security vulnerability.

The newest version of Werkzeug moves some package names around, which means we also need to upgrade pytest-httpserver to avoid a broken import.