### PR TITLE
Add "ses-callbacks" to list of queues

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -29,6 +29,7 @@ class QueueNames(object):
     CALLBACKS = "service-callbacks"
     CALLBACKS_RETRY = "service-callbacks-retry"
     LETTERS = "letter-tasks"
+    SES_CALLBACKS = "ses-callbacks"
     SMS_CALLBACKS = "sms-callbacks"
     ANTIVIRUS = "antivirus-tasks"
     SANITISE_LETTERS = "sanitise-letter-tasks"
@@ -54,6 +55,7 @@ class QueueNames(object):
             QueueNames.CALLBACKS,
             QueueNames.CALLBACKS_RETRY,
             QueueNames.LETTERS,
+            QueueNames.SES_CALLBACKS,
             QueueNames.SMS_CALLBACKS,
             QueueNames.SAVE_API_EMAIL,
             QueueNames.SAVE_API_SMS,

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -61,7 +61,7 @@ def test_load_config_if_cloudfoundry_not_available(reload_config):
 def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()
-    assert len(queues) == 18
+    assert len(queues) == 19
     assert set(
         [
             QueueNames.PERIODIC,
@@ -78,6 +78,7 @@ def test_queue_names_all_queues_correct():
             QueueNames.CALLBACKS,
             QueueNames.CALLBACKS_RETRY,
             QueueNames.LETTERS,
+            QueueNames.SES_CALLBACKS,
             QueueNames.SMS_CALLBACKS,
             QueueNames.SAVE_API_EMAIL,
             QueueNames.SAVE_API_SMS,


### PR DESCRIPTION
In order to run the email-provider-stub locally, the `ses-callbacks` queue needs to be added to the list of queues. The worker watches all queues defined here when running locally.