### PR TITLE
Bump utils to 72.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@72.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -166,7 +166,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@72.1.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
Brings in updates to the email template, moving it to a HTML5 doctype.

More details of the changes in https://github.com/alphagov/notifications-utils/pull/1069.