### PR TITLE
Bump sentry-sdk to 1.35.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -235,7 +235,7 @@ s3transfer==0.6.0
     #   boto3
 segno==1.5.2
     # via notifications-utils
-sentry-sdk[celery,flask,sqlalchemy]==1.32.0
+sentry-sdk[celery,flask,sqlalchemy]==1.35.0
     # via -r requirements.in
 shapely==1.8.4
     # via notifications-utils


### PR DESCRIPTION
This should fix an issue with cron monitoring not pulling timezones correctly, leading to inconsistent reporting on our cron jobs.

https://github.com/getsentry/sentry-python/pull/2497