### PR TITLE
cf manifest: remove notify-splunk service binding

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -109,9 +109,6 @@ applications:
       - notify-db
       - notify-redis
       - logit-ssl-syslog-drain
-      {% if CF_APP == 'notify-api' %}
-      - notify-splunk
-      {% endif %}
 
     env:
       NOTIFY_APP_NAME: {{ app.get('NOTIFY_APP_NAME', CF_APP.replace('notify-', '')) }}


### PR DESCRIPTION
https://trello.com/c/IXguDClO/467-stop-trying-to-send-logs-from-our-apps-into-splunk

We no longer need to log to splunk.