### PR TITLE
Make email_sender_local_part not null

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0430_go_live_templates
+0436_sh_swap_check_for_not_null

--- a/migrations/versions/0431_migrate_email_local_part.py
+++ b/migrations/versions/0431_migrate_email_local_part.py
@@ -1,0 +1,32 @@
+"""
+
+Revision ID: 0431_migrate_email_local_part
+Revises: 0430_go_live_templates
+Create Date: 2023-11-15 22:27:23.511256
+
+"""
+from alembic import op
+
+revision = "0431_migrate_email_local_part"
+down_revision = "0430_go_live_templates"
+
+
+def upgrade():
+    op.execute(
+        """
+        UPDATE services
+        SET email_sender_local_part = normalised_service_name
+        WHERE email_sender_local_part IS NULL
+        """
+    )
+    op.execute(
+        """
+        UPDATE services_history
+        SET email_sender_local_part = normalised_service_name
+        WHERE email_sender_local_part IS NULL
+        """
+    )
+
+
+def downgrade():
+    pass

--- a/migrations/versions/0432_s_add_not_null_check.py
+++ b/migrations/versions/0432_s_add_not_null_check.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: 0432_s_add_not_null_check
+Revises: 0431_migrate_email_local_part
+Create Date: 2023-11-15 22:27:23.511256
+
+"""
+from alembic import op
+from sqlalchemy import column
+
+revision = "0432_s_add_not_null_check"
+down_revision = "0431_migrate_email_local_part"
+
+
+def upgrade():
+    # acquires access exclusive, but only very briefly as the not_valid stops it doing a full table scan
+    op.create_check_constraint(
+        "ck_services_email_sender_local_part_not_null_check",
+        "services",
+        column("email_sender_local_part").is_not(None),
+        postgresql_not_valid=True,
+    )
+
+
+def downgrade():
+    op.drop_constraint("ck_services_email_sender_local_part_not_null_check", "services")

--- a/migrations/versions/0433_sh_add_not_null_check.py
+++ b/migrations/versions/0433_sh_add_not_null_check.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: 0433_sh_add_not_null_check
+Revises: 0432_s_add_not_null_check
+Create Date: 2023-11-15 22:27:23.511256
+
+"""
+from alembic import op
+from sqlalchemy import column
+
+revision = "0433_sh_add_not_null_check"
+down_revision = "0432_s_add_not_null_check"
+
+
+def upgrade():
+    # acquires access exclusive, but only very briefly as the not_valid stops it doing a full table scan
+    op.create_check_constraint(
+        "ck_services_history_email_sender_local_part_not_null_check",
+        "services_history",
+        column("email_sender_local_part").is_not(None),
+        postgresql_not_valid=True,
+    )
+
+
+def downgrade():
+    op.drop_constraint("ck_services_history_email_sender_local_part_not_null_check", "services_history")

--- a/migrations/versions/0434_validate_not_null_check.py
+++ b/migrations/versions/0434_validate_not_null_check.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0434_validate_not_null_check
+Revises: 0433_sh_add_not_null_check
+Create Date: 2023-11-15 22:27:23.511256
+
+"""
+from alembic import op
+
+revision = "0434_validate_not_null_check"
+down_revision = "0433_sh_add_not_null_check"
+
+
+def upgrade():
+    # These only acquire a SHARE UPDATE EXCLUSIVE lock.
+    op.execute("ALTER TABLE services VALIDATE CONSTRAINT ck_services_email_sender_local_part_not_null_check")
+    op.execute(
+        "ALTER TABLE services_history VALIDATE CONSTRAINT ck_services_history_email_sender_local_part_not_null_check"
+    )
+
+
+def downgrade():
+    pass

--- a/migrations/versions/0435_s_swap_check_for_not_null.py
+++ b/migrations/versions/0435_s_swap_check_for_not_null.py
@@ -1,0 +1,35 @@
+"""
+
+Revision ID: 0435_s_swap_check_for_not_null
+Revises: 0434_validate_not_null_check
+Create Date: 2023-11-15 22:27:23.511256
+
+"""
+from alembic import op
+from sqlalchemy import column
+
+revision = "0435_s_swap_check_for_not_null"
+down_revision = "0434_validate_not_null_check"
+
+
+def upgrade():
+    # quoth the docs:
+
+    # SET NOT NULL may only be applied to a column provided none of the records in the table contain a NULL value
+    # for the column. Ordinarily this is checked during the ALTER TABLE by scanning the entire table; however, if a
+    # valid CHECK constraint is found which proves no NULL can exist, then the table scan is skipped.
+
+    # so now we can add regular nullable constraints without worrying about a lengthy table scan.
+    op.alter_column("services", "email_sender_local_part", nullable=False)
+
+    # now get rid of the old constraint now that it's no longer needed. this is a weird process overall
+    op.drop_constraint("ck_services_email_sender_local_part_not_null_check", "services")
+
+
+def downgrade():
+    op.alter_column("services", "email_sender_local_part", nullable=True)
+
+    # notably this creates _with_ validating constraint otherwise we'll end up with inconsistency
+    op.create_check_constraint(
+        "ck_services_email_sender_local_part_not_null_check", "services", column("email_sender_local_part").is_not(None)
+    )

--- a/migrations/versions/0436_sh_swap_check_for_not_null.py
+++ b/migrations/versions/0436_sh_swap_check_for_not_null.py
@@ -1,0 +1,37 @@
+"""
+
+Revision ID: 0436_sh_swap_check_for_not_null
+Revises: 0435_s_swap_check_for_not_null
+Create Date: 2023-11-15 22:27:23.511256
+
+"""
+from alembic import op
+from sqlalchemy import column
+
+revision = "0436_sh_swap_check_for_not_null"
+down_revision = "0435_s_swap_check_for_not_null"
+
+
+def upgrade():
+    # quoth the docs:
+
+    # SET NOT NULL may only be applied to a column provided none of the records in the table contain a NULL value
+    # for the column. Ordinarily this is checked during the ALTER TABLE by scanning the entire table; however, if a
+    # valid CHECK constraint is found which proves no NULL can exist, then the table scan is skipped.
+
+    # so now we can add regular nullable constraints without worrying about a lengthy table scan.
+    op.alter_column("services_history", "email_sender_local_part", nullable=False)
+
+    # now get rid of the old constraint now that it's no longer needed. this is a weird process overall
+    op.drop_constraint("ck_services_history_email_sender_local_part_not_null_check", "services_history")
+
+
+def downgrade():
+    op.alter_column("services_history", "email_sender_local_part", nullable=True)
+
+    # notably this creates _with_ validating constraint otherwise we'll end up with inconsistency
+    op.create_check_constraint(
+        "ck_services_history_email_sender_local_part_not_null_check",
+        "services_history",
+        column("email_sender_local_part").is_not(None),
+    )


### PR DESCRIPTION
## migrate historical email sender local part data

this is super simple - we already set new values via the sqlalchemy column properties, so all we need to do to bring this column up to date is to migrate old data. I decided to make the services_history column _not null_ and migrate all data over for old columns (so that current code can work with old history columns if that's ever a requirement) even though we didn't always have the concept of a email sender separate to normalised service name

## add not null migrations for email local part

this is a super complex and weird process. I've tried to break it into five (!) separate migrations, partially to keep each migration easy to read and also to keep transactions small and easy to reason about

First, create check constraints that check for not null with the postgresql_not_valid flag[^1]. This creates a check constraint but doesn't apply it retroactively to old rows. We do this across two migrations (432 and 433) so that the locks are acquired on separate tables in separate transactions to avoid the risk of deadlocks.

Then validate that constraint in a separate migration (so that migration can run in a separate transaction while it gets low level locks to validate the constraint).

Then alter the column to have a not null constraint on the column - this doesn't have a "not valid" option in postgres, but from postgres 12 onwards they added a shortcut where if a constraint exists that ensures that no null values will exist on that column, then postgres is smart enough not to scan the table[^2]. Then once that not null is set on the column, we can remove the check constraint that we used to help set it up. Again, do this across migrations 435 and 436 to keep access exclusive locks on their own.

We could just have the check constraint on its own and save a couple of migrations, but the not null on the column is nice for two reasons:

* It means our column can have `nullable=False` on the model which helps as an aide memoire when writing code
* It's more efficient on the postgres side.[^3]

[^1]: https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#postgresql-constraint-options
[^2]: https://www.postgresql.org/docs/16/sql-altertable.html#:~:text=if%20a%20valid%20CHECK%20constraint%20is%20found%20which%20proves%20no%20NULL%20can%20exist%2C%20then%20the%20table%20scan%20is%20skipped
[^3]: https://www.postgresql.org/docs/current/ddl-constraints.html#:~:text=A%20not%2Dnull%20constraint%20is,null%20constraint%20is%20more%20efficient.