### PR TITLE
use email_sender_local_part to send messages

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -126,9 +126,8 @@ def send_email_to_provider(notification):
             update_notification_to_sending(notification, provider)
             send_email_response(notification.reference, notification.to)
         else:
-            # TODO: replace this with email_sender_local_part once field is populated in db
             from_address = (
-                f'"{service.name}" <{service.normalised_service_name}@{current_app.config["NOTIFY_EMAIL_DOMAIN"]}>'
+                f'"{service.name}" <{service.email_sender_local_part}@{current_app.config["NOTIFY_EMAIL_DOMAIN"]}>'
             )
 
             reference = provider.send_email(

--- a/app/models.py
+++ b/app/models.py
@@ -633,9 +633,6 @@ class Service(db.Model, Versioned):
         # validate json with marshmallow
         fields = data.copy()
 
-        # TODO: remove this line once admin stops passing through normalised_service_name:
-        fields.pop("normalised_service_name", None)
-
         fields["created_by_id"] = fields.pop("created_by")
 
         return cls(**fields)

--- a/app/models.py
+++ b/app/models.py
@@ -534,8 +534,7 @@ class Service(db.Model, Versioned):
             self._email_sender_local_part = self._normalised_service_name
 
     _custom_email_sender_name = db.Column("custom_email_sender_name", db.String(255), nullable=True)
-    # TODO: once data is migrated this should be not nullable
-    _email_sender_local_part = db.Column("email_sender_local_part", db.String(255), nullable=True)
+    _email_sender_local_part = db.Column("email_sender_local_part", db.String(255), nullable=False)
 
     @hybrid_property  # a hybrid_property enables us to still use it in queries
     def custom_email_sender_name(self):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,4 +1,3 @@
-import string
 from datetime import datetime, timedelta
 from uuid import UUID
 
@@ -303,13 +302,6 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
         if len(set(permissions)) != len(permissions):
             duplicates = list(set([x for x in permissions if permissions.count(x) > 1]))
             raise ValidationError("Duplicate Service Permission: {}".format(duplicates))
-
-    @validates("normalised_service_name")
-    def validate_normalised_service_name(self, value):
-        if not all(char in string.ascii_lowercase + string.digits + "." for char in value):
-            raise ValidationError(
-                "Unacceptable characters: `normalised_service_name` may only contain letters, numbers and full stops."
-            )
 
     @pre_load()
     def format_for_data_model(self, in_data, **kwargs):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -226,8 +226,6 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
     allowed_broadcast_provider = fields.Method(dump_only=True, serialize="_get_allowed_broadcast_provider")
     broadcast_channel = fields.Method(dump_only=True, serialize="_get_broadcast_channel")
     name = fields.String(required=True)
-    # this can only be set via name
-    normalised_service_name = fields.String(dump_only=True)
     custom_email_sender_name = fields.String(allow_none=True)
     # this can only be set via custom_email_sender_name or name
     email_sender_local_part = fields.String(dump_only=True)
@@ -324,7 +322,6 @@ class DetailedServiceSchema(BaseSchema):
     created_at = FlexibleDateTime()
     updated_at = FlexibleDateTime()
     name = fields.String()
-    normalised_service_name = fields.String()
     custom_email_sender_name = fields.String(required=False)
     email_sender_local_part = fields.String()
 
@@ -350,7 +347,6 @@ class DetailedServiceSchema(BaseSchema):
             "inbound_sms",
             "jobs",
             "letter_message_limit",
-            "normalised_service_name",
             "permissions",
             "rate_limit",
             "reply_to_email_addresses",
@@ -785,7 +781,6 @@ class ServiceHistorySchema(ma.Schema):
     sms_message_limit = fields.Integer()
     letter_message_limit = fields.Integer()
     restricted = fields.Boolean()
-    normalised_service_name = fields.String()
     custom_email_sender_name = fields.String()
     email_sender_local_part = fields.String()
     created_by_id = fields.UUID()

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -78,10 +78,10 @@ class SerialisedService(SerialisedModel):
         "name",
         "active",
         "contact_link",
+        # TODO: do we still need this?
         "normalised_service_name",
-        # TODO: add these fields when data migrated. check how these interact with hybrid properties on model.
-        # "custom_email_sender_name",
-        # "email_sender_local_part",
+        "custom_email_sender_name",
+        "email_sender_local_part",
         "email_message_limit",
         "letter_message_limit",
         "sms_message_limit",

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -78,8 +78,6 @@ class SerialisedService(SerialisedModel):
         "name",
         "active",
         "contact_link",
-        # TODO: do we still need this?
-        "normalised_service_name",
         "custom_email_sender_name",
         "email_sender_local_part",
         "email_message_limit",

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -490,8 +490,7 @@ def create_response_for_post_notification(
         create_resp_partial = functools.partial(
             create_post_email_response_from_notification,
             subject=template_with_content.subject,
-            # TODO: replace this with email_sender_local_part once field is populated in db
-            email_from=f"{authenticated_service.normalised_service_name}@{current_app.config['NOTIFY_EMAIL_DOMAIN']}",
+            email_from=f"{authenticated_service.email_sender_local_part}@{current_app.config['NOTIFY_EMAIL_DOMAIN']}",
         )
     elif notification_type == LETTER_TYPE:
         create_resp_partial = functools.partial(

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -96,7 +96,7 @@ def service_factory(sample_user):
                     service,
                     template_name="Template Name",
                     template_type=template_type,
-                    subject=service.normalised_service_name,
+                    subject=service.email_sender_local_part,
                 )
             else:
                 create_template(

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -105,7 +105,7 @@ def test_create_service(notify_db_session):
     service_db = Service.query.one()
     assert service_db.name == "service name"
     assert service_db.id == service.id
-    assert service_db.normalised_service_name == "service.name"
+    assert service_db.email_sender_local_part == "service.name"
     assert service_db.prefix_sms is True
     assert service.active is True
     assert user in service_db.users

--- a/tests/app/service/test_archived_service.py
+++ b/tests/app/service/test_archived_service.py
@@ -57,7 +57,7 @@ def test_deactivating_service_changes_name_and_email(client, sample_service):
     archived_service = dao_fetch_service_by_id(sample_service.id)
 
     assert archived_service.name == "_archived_2018-07-07_Sample service"
-    assert archived_service.normalised_service_name == "archived20180707sample.service"
+    assert archived_service.email_sender_local_part == "archived20180707sample.service"
 
 
 def test_deactivating_service_revokes_api_keys(archived_service):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -399,8 +399,6 @@ def test_create_service(
         "letter_message_limit": 1000,
         "restricted": False,
         "active": False,
-        # TODO: remove this line after admin stops sending back normalised_service_name
-        "normalised_service_name": "ignore me",
         "created_by": str(sample_user.id),
     }
 
@@ -687,8 +685,6 @@ def test_update_service(client, notify_db_session, sample_service, has_active_go
 
     data = {
         "name": "updated service name",
-        # TODO: remove this line after admin stops sending back normalised_service_name
-        "normalised_service_name": "ignore me",
         "created_by": str(sample_service.created_by.id),
         "email_branding": str(brand.id),
         "organisation_type": "school_or_college",

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -263,7 +263,6 @@ def test_get_service_by_id(admin_request, sample_service):
         "letter_branding",
         "letter_message_limit",
         "name",
-        "normalised_service_name",
         "notes",
         "organisation",
         "organisation_type",
@@ -406,7 +405,7 @@ def test_create_service(
 
     assert json_resp["data"]["id"]
     assert json_resp["data"]["name"] == "created service"
-    assert json_resp["data"]["normalised_service_name"] == "created.service"
+    assert json_resp["data"]["email_sender_local_part"] == "created.service"
     assert json_resp["data"]["letter_branding"] is None
     assert json_resp["data"]["count_as_live"] is expected_count_as_live
 
@@ -701,7 +700,7 @@ def test_update_service(client, notify_db_session, sample_service, has_active_go
     result = resp.json
     assert resp.status_code == 200
     assert result["data"]["name"] == "updated service name"
-    assert result["data"]["normalised_service_name"] == "updated.service.name"
+    assert result["data"]["email_sender_local_part"] == "updated.service.name"
     assert result["data"]["email_branding"] == str(brand.id)
     assert result["data"]["organisation_type"] == "school_or_college"
     assert result["data"]["has_active_go_live_request"] == has_active_go_live_request
@@ -1139,7 +1138,6 @@ def test_default_permissions_are_added_for_user_service(notify_api, notify_db_se
             assert resp.status_code == 201
             assert json_resp["data"]["id"]
             assert json_resp["data"]["name"] == "created service"
-            assert json_resp["data"]["normalised_service_name"] == "created.service"
 
             auth_header_fetch = create_admin_authorization_header()
 

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -502,7 +502,7 @@ def test_post_email_notification_returns_201(
     assert resp_json["content"]["body"] == sample_email_template_with_placeholders.content.replace("((name))", "Bob")
     assert resp_json["content"]["subject"] == sample_email_template_with_placeholders.subject.replace("((name))", "Bob")
     assert resp_json["content"]["from_email"] == "{}@{}".format(
-        sample_email_template_with_placeholders.service.normalised_service_name,
+        sample_email_template_with_placeholders.service.email_sender_local_part,
         current_app.config["NOTIFY_EMAIL_DOMAIN"],
     )
     assert "v2/notifications/{}".format(notification.id) in resp_json["uri"]


### PR DESCRIPTION
also clean up todos of removing normalised_service_name - it's no longer in the admin app so is safe to not expect in json