### PR TITLE
Send bilingual letter content to template-preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,15 @@ drop-test-dbs:
 	@dropdb test_notification_api_master --if-exists
 	@echo "Done."
 
+.PHONY: drop-test-dbs-in-docker
+drop-test-dbs-in-docker:
+	@echo "Dropping test DBs in docker."
+	@for number in $$(seq 0 $$(python -c 'import os; print(os.cpu_count() - 1)')); do \
+	    PGUSER=notify PGPASSWORD=notify PGHOST=0.0.0.0 PGPORT=5433 dropdb test_notification_api_gw$${number} --if-exists; \
+	done
+	@PGUSER=notify PGPASSWORD=notify PGHOST=0.0.0.0 PGPORT=5433 dropdb test_notification_api_master --if-exists
+	@echo "Done."
+
 .PHONY: test
 test: ## Run tests
 	ruff check .

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -76,8 +76,11 @@ def get_pdf_for_templated_letter(self, notification_id):
             "letter_contact_block": notification.reply_to_text,
             "template": {
                 "service": str(notification.service_id),
+                "letter_languages": notification.template.letter_languages,
                 "subject": notification.template.subject,
                 "content": notification.template.content,
+                "letter_welsh_subject": notification.template.letter_welsh_subject,
+                "letter_welsh_content": notification.template.letter_welsh_content,
                 "template_type": notification.template.template_type,
                 "letter_attachment": letter_attachment_json,
             },

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -84,8 +84,11 @@ def test_get_pdf_for_templated_letter_happy_path(mocker, sample_letter_notificat
         "letter_contact_block": sample_letter_notification.reply_to_text,
         "template": {
             "service": str(sample_letter_notification.service_id),
+            "letter_languages": sample_letter_notification.template.letter_languages,
             "subject": sample_letter_notification.template.subject,
             "content": sample_letter_notification.template.content,
+            "letter_welsh_subject": sample_letter_notification.template.letter_welsh_subject,
+            "letter_welsh_content": sample_letter_notification.template.letter_welsh_content,
             "template_type": sample_letter_notification.template.template_type,
             "letter_attachment": None,
         },


### PR DESCRIPTION
When we are generating letters via celery in preparation for printing via DVLA, we need to send across Welsh content (if any is present), so that Welsh pages can be generated.