### PR TITLE
Run `check-if-letters-still-pending-virus-check` more often.

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -312,7 +312,7 @@ class Config(object):
             },
             "check-if-letters-still-pending-virus-check": {
                 "task": "check-if-letters-still-pending-virus-check",
-                "schedule": crontab(day_of_week="mon-fri", hour="9,15", minute=0),
+                "schedule": crontab(hour="*", minute=0),
                 "options": {"queue": QueueNames.PERIODIC},
             },
             "check-for-services-with-high-failure-rates-or-sending-to-tv-numbers": {


### PR DESCRIPTION
We've had 154 letters in the past 7 days get caught in pending-virus-check and need kicking off again by this job.

I've made it run every day of the week. If a letter gets stuck in pending virus scan on Friday evening, the user doesn't want to wait until Monday morning for it to get rescanned and then sanitised (so they can be told if it passed validation or not).

I've also set it to run every hour. A user doesn't want to upload at 9am and have to wait until 3pm for it to get kick started again. The task looks back at letters 90 minutes or older that are still pending a virus scan and so this should mean no letter waits more than 2.5 hours to get kicked off after being given to us (90 mins to look back plus up to 1 hour based on at what point it was sent).

These are hopefully small improvements that will move things along quicker generally.