### PR TITLE
Fix preview of letter notification for bilingual letters

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -604,6 +604,9 @@ class NotificationWithTemplateSchema(BaseSchema):
             "is_precompiled_letter",
             "letter_attachment",
             "reply_to_text",
+            "letter_languages",
+            "letter_welsh_subject",
+            "letter_welsh_content",
         ],
         dump_only=True,
     )

--- a/tests/app/test_schemas.py
+++ b/tests/app/test_schemas.py
@@ -38,10 +38,22 @@ def test_notification_schema_adds_api_key_name(sample_notification):
     assert data["key_name"] == "Test key"
 
 
+def test_notification_schema_includes_templates_bilingual_related_fields(sample_letter_notification):
+    from app.schemas import notification_with_template_schema
+
+    sample_letter_notification.template.letter_languages = "welsh_then_english"
+    sample_letter_notification.template.letter_welsh_subject = "Bore da"
+    sample_letter_notification.template.letter_welsh_content = "Cymraeg da"
+
+    data = notification_with_template_schema.dump(sample_letter_notification)
+    assert data["template"]["letter_languages"] == "welsh_then_english"
+    assert data["template"]["letter_welsh_subject"] == "Bore da"
+    assert data["template"]["letter_welsh_content"] == "Cymraeg da"
+
+
 @pytest.mark.parametrize(
     "schema_name",
     [
-        "notification_with_template_schema",
         "notification_schema",
         "notification_with_template_schema",
         "notification_with_personalisation_schema",


### PR DESCRIPTION
The template serialisation in notification schema didn't have the language related fields in it, so Welsh pages were not rendering on the notification preview page.