### PR TITLE
Bump sentry-sdk to 1.38.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -237,7 +237,7 @@ s3transfer==0.6.0
     #   boto3
 segno==1.5.2
     # via notifications-utils
-sentry-sdk[celery,flask,sqlalchemy]==1.35.0
+sentry-sdk[celery,flask,sqlalchemy]==1.38.0
     # via -r requirements.in
 shapely==1.8.4
     # via notifications-utils


### PR DESCRIPTION
In another attempt to fix their cron monitoring. Sentry support has indicated that the fix should be in this release.