### PR TITLE
run the letter still pending virus scan check every ten minutes

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -337,7 +337,7 @@ def check_if_letters_still_pending_virus_check():
     if len(letters) > 0:
         letter_ids = [(str(letter.id), letter.reference) for letter in letters]
 
-        msg = f"""{len(letters)} precompiled letters have been pending-virus-check for over 90 minutes.
+        msg = f"""{len(letters)} precompiled letters have been pending-virus-check for over 10 minutes
             We couldn't find them in the scan bucket. We'll need to find out where the files are and kick them off
             again or move them to technical failure.
 

--- a/app/config.py
+++ b/app/config.py
@@ -312,7 +312,7 @@ class Config(object):
             },
             "check-if-letters-still-pending-virus-check": {
                 "task": "check-if-letters-still-pending-virus-check",
-                "schedule": crontab(hour="*", minute=0),
+                "schedule": crontab(minute="*/10"),
                 "options": {"queue": QueueNames.PERIODIC},
             },
             "check-for-services-with-high-failure-rates-or-sending-to-tv-numbers": {

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -788,11 +788,11 @@ def letters_missing_from_sending_bucket(seconds_to_subtract):
 
 
 def dao_precompiled_letters_still_pending_virus_check():
-    ninety_minutes_ago = datetime.utcnow() - timedelta(seconds=5400)
+    ten_minutes_ago = datetime.utcnow() - timedelta(seconds=600)
 
     notifications = (
         Notification.query.filter(
-            Notification.created_at < ninety_minutes_ago, Notification.status == NOTIFICATION_PENDING_VIRUS_CHECK
+            Notification.created_at < ten_minutes_ago, Notification.status == NOTIFICATION_PENDING_VIRUS_CHECK
         )
         .order_by(Notification.created_at)
         .all()

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -481,10 +481,16 @@ def test_check_if_letters_still_pending_virus_check_restarts_scan_for_stuck_lett
     create_notification(
         template=sample_letter_template,
         status=NOTIFICATION_PENDING_VIRUS_CHECK,
-        created_at=datetime.utcnow() - timedelta(seconds=5401),
+        created_at=datetime.utcnow() - timedelta(seconds=601),
         reference="one",
     )
-    expected_filename = "NOTIFY.ONE.D.2.C.20190530122959.PDF"
+    create_notification(
+        template=sample_letter_template,
+        status=NOTIFICATION_PENDING_VIRUS_CHECK,
+        created_at=datetime.utcnow() - timedelta(seconds=599),
+        reference="still has time to send",
+    )
+    expected_filename = "NOTIFY.ONE.D.2.C.20190530134959.PDF"
 
     check_if_letters_still_pending_virus_check()
 
@@ -512,23 +518,25 @@ def test_check_if_letters_still_pending_virus_check_raises_zendesk_if_files_cant
     create_notification(
         template=sample_letter_template,
         status=NOTIFICATION_PENDING_VIRUS_CHECK,
-        created_at=datetime.utcnow() - timedelta(seconds=5400),
+        created_at=datetime.utcnow() - timedelta(seconds=600),
+        reference="ignore as still has time",
     )
     create_notification(
         template=sample_letter_template,
         status=NOTIFICATION_DELIVERED,
-        created_at=datetime.utcnow() - timedelta(seconds=6000),
+        created_at=datetime.utcnow() - timedelta(seconds=1000),
+        reference="ignore as status in delivered",
     )
     notification_1 = create_notification(
         template=sample_letter_template,
         status=NOTIFICATION_PENDING_VIRUS_CHECK,
-        created_at=datetime.utcnow() - timedelta(seconds=5401),
+        created_at=datetime.utcnow() - timedelta(seconds=601),
         reference="one",
     )
     notification_2 = create_notification(
         template=sample_letter_template,
         status=NOTIFICATION_PENDING_VIRUS_CHECK,
-        created_at=datetime.utcnow() - timedelta(seconds=70000),
+        created_at=datetime.utcnow() - timedelta(seconds=1000),
         reference="two",
     )
 
@@ -537,8 +545,8 @@ def test_check_if_letters_still_pending_virus_check_raises_zendesk_if_files_cant
     assert mock_file_exists.call_count == 2
     mock_file_exists.assert_has_calls(
         [
-            call("test-letters-scan", "NOTIFY.ONE.D.2.C.20190530122959.PDF"),
-            call("test-letters-scan", "NOTIFY.TWO.D.2.C.20190529183320.PDF"),
+            call("test-letters-scan", "NOTIFY.ONE.D.2.C.20190530134959.PDF"),
+            call("test-letters-scan", "NOTIFY.TWO.D.2.C.20190530134320.PDF"),
         ],
         any_order=True,
     )


### PR DESCRIPTION
currently we run every hour, and wait for a letter to be stuck for 90 minutes before we kick it off again.

We don't think this is necessary, and is causing issues where, for example, a letter passed virus scan and was sent to template preview for sanitising at 4:30pm. the template preview task crashed, and we didn't pick up the letter to scan/sanitise it again until 7pm, causing it to miss the cutoff.

it isn't the end of the world if a letter is processed/scanned twice as this should be relatively idempotent, so we can just check every ten minutes if something has been stuck for ten minutes