### PR TITLE
Let `CHECK_PROXY_HEADER` be set with an environment variable

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -579,7 +579,7 @@ class Staging(Config):
     S3_BUCKET_LETTER_SANITISE = "staging-letters-sanitise"
     FROM_NUMBER = "stage"
     API_RATE_LIMIT_ENABLED = True
-    CHECK_PROXY_HEADER = True
+    CHECK_PROXY_HEADER = False if os.environ.get("CHECK_PROXY_HEADER") == "0" else True
     DVLA_API_TLS_CIPHERS = os.environ.get("DVLA_API_TLS_CIPHERS", "must-supply-tls-ciphers")
 
 
@@ -597,7 +597,7 @@ class Production(Config):
     S3_BUCKET_LETTER_SANITISE = "production-letters-sanitise"
     FROM_NUMBER = "GOVUK"
     API_RATE_LIMIT_ENABLED = True
-    CHECK_PROXY_HEADER = True
+    CHECK_PROXY_HEADER = False if os.environ.get("CHECK_PROXY_HEADER") == "0" else True
     SES_STUB_URL = None
 
     CRONITOR_ENABLED = True


### PR DESCRIPTION
This lets `CHECK_PROXY_HEADER` be set with an environment variable in staging and production instead of always being set to `True`. We don't need this value for the ECS apps and were seeing errors when document-download-frontend tried to make authenticated requests to the api since the header was not there.