### PR TITLE
Use internal api route when checking if migrations should run

### DIFF
--- a/scripts/check_if_new_migration.py
+++ b/scripts/check_if_new_migration.py
@@ -15,7 +15,7 @@ def get_latest_db_migration_to_apply():
 
 
 def get_current_db_version():
-    api_status_url = "{}/_status".format(os.getenv("API_HOST_NAME"))
+    api_status_url = "{}/_status".format(os.getenv("API_HOST_NAME_INTERNAL"))
 
     try:
         response = requests.get(api_status_url)


### PR DESCRIPTION
We prefer to use internal routes where possible, and it makes no difference to use the internal vs external route when checking if migrations should run.