### PR TITLE
Bump utils to 74.0.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,6 @@ celery[sqs]==5.2.7
     #   sentry-sdk
 certifi==2023.7.22
     # via
-    #   pyproj
     #   requests
     #   sentry-sdk
 cffi==1.15.1
@@ -113,9 +112,7 @@ geojson==2.5.0
 govuk-bank-holidays==0.11
     # via notifications-utils
 greenlet==1.1.3
-    # via
-    #   eventlet
-    #   sqlalchemy
+    # via eventlet
 gunicorn[eventlet] @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
     # via -r requirements.in
 idna==3.4
@@ -168,9 +165,9 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.0.0
     # via -r requirements.in
-orderedset==2.0.3
+ordered-set==4.1.0
     # via notifications-utils
 packaging==23.2
     # via
@@ -197,8 +194,6 @@ pyjwt==2.5.0
     #   -r requirements.in
     #   notifications-python-client
 pypdf==3.17.0
-    # via notifications-utils
-pyproj==3.4.1
     # via notifications-utils
 pyrsistent==0.18.1
     # via jsonschema
@@ -239,8 +234,6 @@ segno==1.5.2
     # via notifications-utils
 sentry-sdk[celery,flask,sqlalchemy]==1.38.0
     # via -r requirements.in
-shapely==1.8.4
-    # via notifications-utils
 six==1.16.0
     # via
     #   awscli-cwlogs


### PR DESCRIPTION
 ## 74.0.0

Removes Emergency-Alerts-related code

* the `polygons` module has been removed
* `template.BroadcastPreviewTemplate` and `template.BroadcastMessageTemplate` have been removed

 ## 73.2.1

* Fix utils packaging to allow access to subpackages again.

 ## 73.2.0

* Adds a `include_notify_tag` parameter to `LetterPrintTemplate` so that bilingual letters can disable the NOTIFY tag on the English pages of a letter.

 ## 73.1.3

* Add compatibility with Python 3.11 and 3.12

 ## 73.1.2

* Change how utils is packaged to exclude tests.

 ## 73.1.1

(no info)

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/73.1.0...74.0.0