### PR TITLE
Allow creating letters with bilingual fields

### DIFF
--- a/app/template/template_schemas.py
+++ b/app/template/template_schemas.py
@@ -1,45 +1,8 @@
 from app.constants import TEMPLATE_PROCESS_TYPE, TEMPLATE_TYPES, LetterLanguageOptions
 from app.schema_validation.definitions import nullable_uuid, uuid
 
-post_create_template_schema = {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "description": "POST create new template",
-    "type": "object",
-    "title": "payload for POST /service/<uuid:service_id>/template",
+letter_languages_subschema = {
     "properties": {
-        "name": {"type": "string"},
-        "template_type": {"enum": TEMPLATE_TYPES},
-        "service": uuid,
-        "process_type": {"enum": TEMPLATE_PROCESS_TYPE},
-        "content": {"type": "string"},
-        "subject": {"type": "string"},
-        "created_by": uuid,
-        "parent_folder_id": uuid,
-        "postage": {"type": "string", "format": "postage"},
-    },
-    "if": {"properties": {"template_type": {"enum": ["email", "letter"]}}},
-    "then": {"required": ["subject"]},
-    "required": ["name", "template_type", "content", "service", "created_by"],
-}
-
-post_update_template_schema = {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "description": "POST update existing template",
-    "type": "object",
-    "title": "payload for POST /service/<uuid:service_id>/template/<uuid:template_id>",
-    "properties": {
-        "id": uuid,
-        "name": {"type": "string"},
-        "template_type": {"enum": TEMPLATE_TYPES},
-        "service": uuid,
-        "process_type": {"enum": TEMPLATE_PROCESS_TYPE},
-        "content": {"type": "string"},
-        "subject": {"type": "string"},
-        "postage": {"type": "string", "format": "postage"},
-        "reply_to": nullable_uuid,
-        "created_by": uuid,
-        "archived": {"type": "boolean"},
-        "current_user": uuid,
         "letter_languages": {"type": "string", "enum": [i.value for i in LetterLanguageOptions]},
     },
     # read as: "if `letter_languages` is present
@@ -84,4 +47,52 @@ post_update_template_schema = {
             },
         ]
     },
+}
+
+post_create_template_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "POST create new template",
+    "type": "object",
+    "title": "payload for POST /service/<uuid:service_id>/template",
+    "properties": {
+        "name": {"type": "string"},
+        "template_type": {"enum": TEMPLATE_TYPES},
+        "service": uuid,
+        "process_type": {"enum": TEMPLATE_PROCESS_TYPE},
+        "content": {"type": "string"},
+        "subject": {"type": "string"},
+        "created_by": uuid,
+        "parent_folder_id": uuid,
+        "postage": {"type": "string", "format": "postage"},
+    },
+    "allOf": [
+        {
+            "if": {"properties": {"template_type": {"enum": ["email", "letter"]}}},
+            "then": {"required": ["subject"]},
+            "required": ["name", "template_type", "content", "service", "created_by"],
+        },
+        letter_languages_subschema,
+    ],
+}
+
+post_update_template_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "POST update existing template",
+    "type": "object",
+    "title": "payload for POST /service/<uuid:service_id>/template/<uuid:template_id>",
+    "properties": {
+        "id": uuid,
+        "name": {"type": "string"},
+        "template_type": {"enum": TEMPLATE_TYPES},
+        "service": uuid,
+        "process_type": {"enum": TEMPLATE_PROCESS_TYPE},
+        "content": {"type": "string"},
+        "subject": {"type": "string"},
+        "postage": {"type": "string", "format": "postage"},
+        "reply_to": nullable_uuid,
+        "created_by": uuid,
+        "archived": {"type": "boolean"},
+        "current_user": uuid,
+    },
+    "allOf": [letter_languages_subschema],
 }

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -927,6 +927,33 @@ def test_create_a_template_with_reply_to(admin_request, sample_user):
     assert th.service_letter_contact_id == letter_contact.id
 
 
+def test_create_template_bilingual_letter(admin_request, sample_service_full_permissions, sample_user):
+    letter_contact = create_letter_contact(sample_service_full_permissions, "Edinburgh, ED1 1AA")
+    json_resp = admin_request.post(
+        "template.create_template",
+        service_id=sample_service_full_permissions.id,
+        _data={
+            "name": "my template",
+            "template_type": "letter",
+            "subject": "subject",
+            "content": "content",
+            "postage": "second",
+            "service": str(sample_service_full_permissions.id),
+            "created_by": str(sample_user.id),
+            "reply_to": str(letter_contact.id),
+            "letter_languages": "welsh_then_english",
+            "letter_welsh_subject": "welsh subject",
+            "letter_welsh_content": "welsh body",
+        },
+        _expected_status=201,
+    )
+
+    t = Template.query.get(json_resp["data"]["id"])
+    assert t.letter_languages == "welsh_then_english"
+    assert t.letter_welsh_subject == "welsh subject"
+    assert t.letter_welsh_content == "welsh body"
+
+
 def test_create_a_template_with_foreign_service_reply_to(admin_request, sample_user):
     service = create_service(service_permissions=["letter"])
     service2 = create_service(service_name="test service", service_permissions=["letter"])


### PR DESCRIPTION
When we added support for bilingual letters, we didn't allow creating them (via the admin API) from scratch. You would need to create a basic letter template, then POST an update with bilingual fields.

In order to allow efficient copying of templates, let's make it possible to create a letter template with bilingual fields in a single request.