### PR TITLE
Email selected team members when someone asks to join a service

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -184,6 +184,8 @@ class Config(object):
     LETTERS_VOLUME_EMAIL_TEMPLATE_ID = "11fad854-fd38-4a7c-bd17-805fb13dfc12"
     NHS_EMAIL_BRANDING_ID = "a7dc4e56-660b-4db7-8cff-12c37b12b5ea"
     NHS_LETTER_BRANDING_ID = "2cd354bb-6b85-eda3-c0ad-6b613150459f"
+    REQUEST_INVITE_TO_SERVICE_TEMPLATE_ID = "77677459-f862-44ee-96d9-b8cb2323d407"
+    RECEIPT_FOR_REQUEST_INVITE_TO_SERVICE_TEMPLATE_ID = "38bcd263-6ce8-431f-979d-8e637c1f0576"
     # we only need real email in Live environment (production)
     DVLA_EMAIL_ADDRESSES = json.loads(os.environ.get("DVLA_EMAIL_ADDRESSES", "[]"))
 

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -20,6 +20,7 @@ from app.notifications.process_notifications import (
     send_notification_to_queue,
 )
 from app.schemas import invited_user_schema
+from app.v2.errors import BadRequestError
 
 service_invite = Blueprint("service_invite", __name__)
 
@@ -102,20 +103,6 @@ def get_invited_user(invited_user_id):
     return jsonify(data=invited_user_schema.dump(invited_user)), 200
 
 
-@service_invite.route("/service/<uuid:service_id>/invite/request-for/<uuid:user_to_invite_id>", methods=["POST"])
-def request_user_invite(service_id, user_to_invite_id):
-    request_json = request.get_json()
-    get_user_by_id(user_to_invite_id)
-    Service.query.get(current_app.config["NOTIFY_SERVICE_ID"])
-    dao_fetch_service_by_id(service_id)
-    data = {
-        "from_user_ids": request_json[""],
-        "reason": request_json["reason"],
-        "invite_list_host": request_json["oops"],
-    }
-    return jsonify(data=data), 200
-
-
 @service_invite.route("/invite/service/<token>", methods=["GET"])
 @service_invite.route("/invite/service/check/<token>", methods=["GET"])
 def validate_service_invitation_token(token):
@@ -137,3 +124,86 @@ def validate_service_invitation_token(token):
 
     invited_user = get_invited_user_by_id(invited_user_id)
     return jsonify(data=invited_user_schema.dump(invited_user)), 200
+
+
+@service_invite.route("/service/<service_id>/invite/request-for/<user_to_invite_id>", methods=["POST"])
+def request_user_invite(service_id, user_to_invite_id):
+    request_json = request.get_json()
+
+    user_requesting_invite = get_user_by_id(user_to_invite_id)
+    recipients_of_invite_request_ids = request_json["from_user_ids"]
+    [get_user_by_id(recipient_id) for recipient_id in recipients_of_invite_request_ids]
+    service = dao_fetch_service_by_id(service_id)
+    request_json["reason"]
+    request_json["invite_link_host"]
+    if user_requesting_invite.services and service in user_requesting_invite.services:
+        message = f"You are already a member of {service.name}"
+        raise BadRequestError(message=message)
+
+    # Send the user's service invite request to the service managers listed
+    # send_service_invite_request(recipients_of_invite_request,
+    # service, reason_for_request, invite_link_host)
+
+    # Send a receipt email to the user that requested the invite
+    # send_receipt_after_sending_request_invite_letter(user_requesting_invite.name, service)
+
+    return {}, 204
+
+
+def send_service_invite_request(
+    recipients_of_invite_request,
+    service,
+    reason_for_request,
+    invite_link_host,
+):
+    # TODO REQUEST_INVITE_TO_SERVICE_TEMPLATE needs to be created
+    template_id = current_app.config["REQUEST_INVITE_TO_SERVICE_TEMPLATE_ID"]
+    template = dao_get_template_by_id(template_id)
+    notify_service = Service.query.get(current_app.config["NOTIFY_SERVICE_ID"])
+    for recipient in recipients_of_invite_request:
+        if service.name in recipient.services:
+            saved_notification = persist_notification(
+                template_id=template.id,
+                template_version=template.version,
+                # TODO change recipient to actual email address of service managers when the testing phase completes
+                recipient="notify-join-service-request@digital.cabinet-office.gov.uk",
+                service=notify_service,
+                # TODO flesh out personalisation
+                personalisation={
+                    "service_name": service.name,
+                    "service_manager_name": recipient.name,
+                    "reason_for_request": reason_for_request,
+                    "invite_link_host": invite_link_host,
+                },
+                notification_type=template.template_type,
+                api_key_id=None,
+                key_type=KEY_TYPE_NORMAL,
+                reply_to_text=notify_service.get_default_reply_to_email_address(),
+            )
+            send_notification_to_queue(saved_notification, queue=QueueNames.NOTIFY)
+
+        else:
+            message = f"Can’t create notification - {recipient.name} is not part of the {service.name}"
+            raise BadRequestError(message=message)
+
+
+def send_receipt_after_sending_request_invite_letter(user_requesting_invite, service):
+    # TODO RECEIPT_FOR_REQUEST_INVITE_TO_SERVICE_TEMPLATE needs to be created
+    template_id = current_app.config["RECEIPT_FOR_REQUEST_INVITE_TO_SERVICE_TEMPLATE_ID"]
+    template = dao_get_template_by_id(template_id)
+    notify_service = Service.query.get(current_app.config["NOTIFY_SERVICE_ID"])
+
+    saved_notification = persist_notification(
+        template_id=template.id,
+        template_version=template.version,
+        # TODO change recipient to actual email address of service managers when the testing phase completes
+        recipient="notify-join-service-request@digital.cabinet-office.gov.uk",
+        service=notify_service,
+        # TODO flesh out personalisation
+        personalisation={"service_name": service, "user_requesting_invite_name": user_requesting_invite},
+        notification_type=template.template_type,
+        api_key_id=None,
+        key_type=KEY_TYPE_NORMAL,
+        reply_to_text=notify_service.get_default_reply_to_email_address(),
+    )
+    send_notification_to_queue(saved_notification, queue=QueueNames.NOTIFY)

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -10,7 +10,9 @@ from app.dao.invited_user_dao import (
     get_invited_users_for_service,
     save_invited_user,
 )
+from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.templates_dao import dao_get_template_by_id
+from app.dao.users_dao import get_user_by_id
 from app.errors import InvalidRequest, register_errors
 from app.models import Service
 from app.notifications.process_notifications import (
@@ -98,6 +100,20 @@ def invited_user_url(invited_user_id, invite_link_host=None):
 def get_invited_user(invited_user_id):
     invited_user = get_invited_user_by_id(invited_user_id)
     return jsonify(data=invited_user_schema.dump(invited_user)), 200
+
+
+@service_invite.route("/service/<uuid:service_id>/invite/request-for/<uuid:user_to_invite_id>", methods=["POST"])
+def request_user_invite(service_id, user_to_invite_id):
+    request_json = request.get_json()
+    get_user_by_id(user_to_invite_id)
+    Service.query.get(current_app.config["NOTIFY_SERVICE_ID"])
+    dao_fetch_service_by_id(service_id)
+    data = {
+        "from_user_ids": request_json[""],
+        "reason": request_json["reason"],
+        "invite_list_host": request_json["oops"],
+    }
+    return jsonify(data=data), 200
 
 
 @service_invite.route("/invite/service/<token>", methods=["GET"])

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0437_min_numeric_scl_aux_tbls
+0438_request_invite_to_a_service_templates.py

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0438_request_invite_to_a_service_templates.py
+0438_request_invite_templates

--- a/migrations/versions/0438_request_invite_templates.py
+++ b/migrations/versions/0438_request_invite_templates.py
@@ -1,6 +1,6 @@
 """
 
-Revision ID: 0438_request_invite_to_a_service_templates
+Revision ID: 0438_request_invite_templates
 Revises: 0437_min_numeric_scl_aux_tbls
 Create Date: 2023-12-11 16:21:05.947886
 
@@ -10,7 +10,7 @@ from alembic import op
 from flask import current_app
 
 
-revision = "0438_request_invite_to_a_service_templates"
+revision = "0438_request_invite_templates"
 down_revision = "0437_min_numeric_scl_aux_tbls"
 
 
@@ -21,7 +21,7 @@ request_invite_to_a_service_template_content = textwrap.dedent(
 
 ((requester_name)) would like to join the ‘((service_name))’ team on GOV.UK Notify.
 
-((reason_given??They gave the following reason for wanting to join:))
+((reason??They gave the following reason for wanting to join:))
 
 ((reason))
 

--- a/migrations/versions/0438_request_invite_templates.py
+++ b/migrations/versions/0438_request_invite_templates.py
@@ -17,11 +17,11 @@ down_revision = "0437_min_numeric_scl_aux_tbls"
 request_invite_to_a_service_template_id = "77677459-f862-44ee-96d9-b8cb2323d407"
 request_invite_to_a_service_template_content = textwrap.dedent(
     """\
-    Hi ((name))
+Hi ((name))
 
 ((requester_name)) would like to join the ‘((service_name))’ team on GOV.UK Notify.
 
-((reason??They gave the following reason for wanting to join:))
+((reason_given??They gave the following reason for wanting to join:))
 
 ((reason))
 

--- a/migrations/versions/0438_request_invite_to_a_service_templates.py
+++ b/migrations/versions/0438_request_invite_to_a_service_templates.py
@@ -1,0 +1,167 @@
+"""
+
+Revision ID: 0438_request_invite_to_a_service_templates
+Revises: 0437_min_numeric_scl_aux_tbls
+Create Date: 2023-12-11 16:21:05.947886
+
+"""
+import textwrap
+from alembic import op
+from flask import current_app
+
+
+revision = "0438_request_invite_to_a_service_templates"
+down_revision = "0437_min_numeric_scl_aux_tbls"
+
+
+request_invite_to_a_service_template_id = "77677459-f862-44ee-96d9-b8cb2323d407"
+request_invite_to_a_service_template_content = textwrap.dedent(
+    """\
+    Hi ((name))
+
+((requester_name)) would like to join the ‘((service_name))’ team on GOV.UK Notify.
+
+((reason_given??They gave the following reason for wanting to join:))
+
+((reason))
+
+Use this link to invite ((requester_name)) to join the team:
+
+((url))
+
+If you have any questions, you can email ((requester_name)) at ((requester_email))
+
+Thanks
+
+GOV.​UK Notify team
+https://www.gov.uk/notify
+    """
+)
+
+
+receipt_for_request_invite_to_a_service_template_id = "38bcd263-6ce8-431f-979d-8e637c1f0576"
+receipt_for_request_invite_to_a_service_template_content = textwrap.dedent(
+    """\
+    Hi ((name))
+
+    …
+
+    Thanks
+
+    GOV.​UK Notify team
+    https://www.gov.uk/notify
+
+    """
+)
+
+
+def upgrade():
+    for table_name in ("templates", "templates_history"):
+        op.execute(
+            f"""
+            INSERT INTO {table_name} (
+                id,
+                name,
+                template_type,
+                created_at,
+                subject,
+                content,
+                archived,
+                service_id,
+                created_by_id,
+                version,
+                process_type,
+                hidden
+            )
+            VALUES (
+                '{request_invite_to_a_service_template_id}',
+                'Request invite to a service',
+                'email',
+                current_timestamp,
+                '((requester_name)) wants to join your GOV.UK Notify service',
+                '{request_invite_to_a_service_template_content}',
+                false,
+                '{current_app.config["NOTIFY_SERVICE_ID"]}',
+                '{current_app.config["NOTIFY_USER_ID"]}',
+                1,
+                'normal',
+                false
+            )
+            ON CONFLICT DO NOTHING
+            """
+        )
+
+    op.execute(
+        f"""
+        INSERT INTO template_redacted
+        (
+            template_id,
+            redact_personalisation,
+            updated_at,
+            updated_by_id
+        ) VALUES (
+            '{request_invite_to_a_service_template_id}',
+            false,
+            current_timestamp,
+            '{current_app.config["NOTIFY_USER_ID"]}'
+        )
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+    for table_name in ("templates", "templates_history"):
+        op.execute(
+            f"""
+            INSERT INTO {table_name} (
+                id,
+                name,
+                template_type,
+                created_at,
+                subject,
+                content,
+                archived,
+                service_id,
+                created_by_id,
+                version,
+                process_type,
+                hidden
+            )
+            VALUES (
+                '{receipt_for_request_invite_to_a_service_template_id}',
+                'Receipt email after requesting service invite',
+                'email',
+                current_timestamp,
+                '',
+                '{receipt_for_request_invite_to_a_service_template_content}',
+                false,
+                '{current_app.config["NOTIFY_SERVICE_ID"]}',
+                '{current_app.config["NOTIFY_USER_ID"]}',
+                1,
+                'normal',
+                false
+            )
+            ON CONFLICT DO NOTHING
+            """
+        )
+
+    op.execute(
+        f"""
+        INSERT INTO template_redacted
+        (
+            template_id,
+            redact_personalisation,
+            updated_at,
+            updated_by_id
+        ) VALUES (
+            '{receipt_for_request_invite_to_a_service_template_id}',
+            false,
+            current_timestamp,
+            '{current_app.config["NOTIFY_USER_ID"]}'
+        )
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+
+def downgrade():
+    pass

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -702,6 +702,30 @@ def org_invite_email_template(notify_service):
 
 
 @pytest.fixture(scope="function")
+def request_invite_email_template(notify_service):
+    return create_custom_template(
+        service=notify_service,
+        user=notify_service.users[0],
+        template_config_name="REQUEST_INVITE_TO_SERVICE_TEMPLATE_ID",
+        content="((user_name)) ((organisation_name)) ((url))",
+        subject="((requester_name)) wants to join your GOV.UK Notify service",
+        template_type="email",
+    )
+
+
+@pytest.fixture(scope="function")
+def receipt_for_request_invite_email_template(notify_service):
+    return create_custom_template(
+        service=notify_service,
+        user=notify_service.users[0],
+        template_config_name="RECEIPT_FOR_REQUEST_INVITE_TO_SERVICE_TEMPLATE_ID",
+        content="((name)) ((requester_name)) ((service_name)) ((reason)) ((url)) ((requester_email))",
+        subject="",
+        template_type="email",
+    )
+
+
+@pytest.fixture(scope="function")
 def password_reset_email_template(notify_service):
     return create_custom_template(
         service=notify_service,

--- a/tests/app/service_invite/test_service_invite_rest.py
+++ b/tests/app/service_invite/test_service_invite_rest.py
@@ -339,7 +339,7 @@ def test_get_invited_user_404s_if_invite_doesnt_exist(admin_request, sample_invi
     assert json_resp["result"] == "error"
 
 
-def test_request_user_invite_is_sent_to_valid_service_managers(
+def test_request_invite_to_service_email_is_sent_to_valid_service_managers(
     admin_request,
     notify_service,
     sample_service,
@@ -371,7 +371,7 @@ def test_request_user_invite_is_sent_to_valid_service_managers(
         invite_link_host=invite_link_host,
     )
     admin_request.post(
-        "service_invite.request_user_invite",
+        "service_invite.request_invite_to_service",
         service_id=sample_service.id,
         user_to_invite_id=user_requesting_invite.id,
         _data=data,
@@ -404,7 +404,9 @@ def test_request_user_invite_is_sent_to_valid_service_managers(
     assert notification[-1].personalisation["name"] == user_requesting_invite.name
 
 
-def test_invite_request_is_not_sent_if_requester_is_already_part_of_service(admin_request, sample_service):
+def test_request_invite_to_service_email_is_not_sent_if_requester_is_already_part_of_service(
+    admin_request, sample_service
+):
     user_requesting_invite = create_user()
     user_requesting_invite.services = [sample_service]
     service_manager_1 = create_user()
@@ -418,17 +420,16 @@ def test_invite_request_is_not_sent_if_requester_is_already_part_of_service(admi
         invite_link_host=invite_link_host,
     )
 
-    json_resp = admin_request.post(
-        "service_invite.request_user_invite",
+    admin_request.post(
+        "service_invite.request_invite_to_service",
         service_id=sample_service.id,
         user_to_invite_id=user_requesting_invite.id,
         _data=data,
         _expected_status=400,
     )
-    assert json_resp["message"] == "user-already-in-service"
 
 
-def test_exception_is_raised_if_no_invite_request_is_sent(
+def test_exception_is_raised_if_no_request_invite_to_service_email_is_sent(
     admin_request,
     notify_service,
     sample_service,
@@ -449,11 +450,10 @@ def test_exception_is_raised_if_no_invite_request_is_sent(
         invite_link_host=invite_link_host,
     )
 
-    json_resp = admin_request.post(
-        "service_invite.request_user_invite",
+    admin_request.post(
+        "service_invite.request_invite_to_service",
         service_id=sample_service.id,
         user_to_invite_id=user_requesting_invite.id,
         _data=data,
         _expected_status=400,
     )
-    assert json_resp["message"] == "no-valid-service-managers"

--- a/tests/app/service_invite/test_service_invite_rest.py
+++ b/tests/app/service_invite/test_service_invite_rest.py
@@ -9,7 +9,7 @@ from notifications_utils.url_safe_token import generate_token
 from app.constants import EMAIL_AUTH_TYPE, SMS_AUTH_TYPE
 from app.models import Notification
 from tests import create_admin_authorization_header
-from tests.app.db import create_invited_user
+from tests.app.db import create_invited_user, create_user
 
 
 @pytest.mark.parametrize(
@@ -337,3 +337,17 @@ def test_get_invited_user(admin_request, sample_invited_user):
 def test_get_invited_user_404s_if_invite_doesnt_exist(admin_request, sample_invited_user, fake_uuid):
     json_resp = admin_request.get("service_invite.get_invited_user", invited_user_id=fake_uuid, _expected_status=404)
     assert json_resp["result"] == "error"
+
+
+def test_request_user_invite(admin_request, sample_service):
+    data = dict(from_user_ids=[], reason="oops", invite_list_host="oops")
+    user_to_invite = create_user()
+    json_resp = admin_request.post(
+        "service_invite.request_user_invite",
+        service_id=sample_service.id,
+        user_to_invite_id=user_to_invite.id,
+        _data=data,
+        _expected_status=200,
+    )
+
+    assert json_resp["reason"] == data["reason"]

--- a/tests/app/service_invite/test_service_invite_rest.py
+++ b/tests/app/service_invite/test_service_invite_rest.py
@@ -425,7 +425,7 @@ def test_invite_request_is_not_sent_if_requester_is_already_part_of_service(admi
         _data=data,
         _expected_status=400,
     )
-    assert json_resp["message"] == "You are already a member of Sample service"
+    assert json_resp["message"] == "user-already-in-service"
 
 
 def test_exception_is_raised_if_no_invite_request_is_sent(
@@ -435,7 +435,6 @@ def test_exception_is_raised_if_no_invite_request_is_sent(
     request_invite_email_template,
     receipt_for_request_invite_email_template,
 ):
-    # We want to test that an exception is raised if all service managers listed are invalid
     user_requesting_invite = create_user()
     service_manager = create_user()
     another_service = create_service(service_name="Another Service")
@@ -457,7 +456,4 @@ def test_exception_is_raised_if_no_invite_request_is_sent(
         _data=data,
         _expected_status=400,
     )
-    assert (
-        json_resp["message"]
-        == f"Can’t create notification as the service manager listed is not part of the {sample_service.name}"
-    )
+    assert json_resp["message"] == "no-valid-service-managers"


### PR DESCRIPTION
This PR adds the endpoint to support the work being done in this [PR](https://github.com/alphagov/notifications-admin/pull/4912), as described in [this](https://trello.com/c/rYMOdCYZ/578-email-selected-team-members-when-someone-asks-to-join-a-service) card.

An alteration has been made to the expected JSON content, `from_user_ids ` has now been replaced with `service_managers_ids` which is a better description.
Also the new endpoint will only return a status code.

Also for now all request invite emails are being sent to `notify-join-service-request@digital.cabinet-office.gov.uk` as prescribed in the ticket, instead of service managers.