### PR TITLE
Revert "Use internal api route when checking if migrations should run"

### DIFF
--- a/scripts/check_if_new_migration.py
+++ b/scripts/check_if_new_migration.py
@@ -15,7 +15,7 @@ def get_latest_db_migration_to_apply():
 
 
 def get_current_db_version():
-    api_status_url = "{}/_status".format(os.getenv("API_HOST_NAME_INTERNAL"))
+    api_status_url = "{}/_status".format(os.getenv("API_HOST_NAME"))
 
     try:
         response = requests.get(api_status_url)


### PR DESCRIPTION
Reverts alphagov/notifications-api#3973

We don't have access to the `API_HOST_NAME_INTERNAL` environment variable because it gets set in the manifest and this script is run before the app is deployed. We'll need to make sure it is available first by adding it to the credentials repo before this change can be made.