### PR TITLE
Put reason for request to join service in a callout

### DIFF
--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -173,7 +173,7 @@ def send_service_invite_request(
                     "requester_email": user_requesting_invite.email_address,
                     "service_name": service.name,
                     "reason_given": "yes" if reason_for_request else "no",
-                    "reason": reason_for_request,
+                    "reason": "\n".join(f"^ {line}" for line in reason_for_request.splitlines()),
                     "url": accept_invite_request_url,
                 },
                 notification_type=template.template_type,


### PR DESCRIPTION
This helps differentiate the text we put in the email from the text that the user makes the request has entered.

Looks like this:

<img width="702" alt="image" src="https://github.com/alphagov/notifications-api/assets/355079/9e242089-6ed9-4605-9481-a5a3b9ff40e5">
