### PR TITLE
Add API key name to notifications serialisation for CSV

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -268,8 +268,11 @@ def get_notifications_for_service(
 
     query = Notification.query.filter(*filters)
     query = _filter_query(query, filter_dict)
+
     if personalisation:
         query = query.options(joinedload("template"))
+
+    query = query.options(joinedload("api_key"))
 
     return query.order_by(desc(Notification.created_at)).paginate(
         page=page,

--- a/app/models.py
+++ b/app/models.py
@@ -1576,6 +1576,7 @@ class Notification(db.Model):
             "created_at": created_at_in_bst.strftime("%Y-%m-%d %H:%M:%S"),
             "created_by_name": self.get_created_by_name(),
             "created_by_email_address": self.get_created_by_email_address(),
+            "api_key_name": self.api_key.name if self.api_key else None,
         }
 
         return serialized

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -874,6 +874,7 @@ def test_get_all_notifications_for_job_returns_csv_format(admin_request, sample_
         "row_number",
         "recipient",
         "client_reference",
+        "api_key_name",
     }
 
 


### PR DESCRIPTION
So we can put that field in the report our users download.