### PR TITLE
Add an endpoint to get current letter rates

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -146,7 +146,7 @@ def register_blueprint(application):
     from app.letter_branding.letter_branding_rest import (
         letter_branding_blueprint,
     )
-    from app.letters.rest import letter_job
+    from app.letters.rest import letter_job, letter_rates_blueprint
     from app.notifications.notifications_letter_callback import (
         letter_callback_blueprint,
     )
@@ -240,6 +240,9 @@ def register_blueprint(application):
 
     letter_job.before_request(requires_admin_auth)
     application.register_blueprint(letter_job)
+
+    letter_rates_blueprint.before_request(requires_admin_auth)
+    application.register_blueprint(letter_rates_blueprint)
 
     letter_callback_blueprint.before_request(requires_no_auth)
     application.register_blueprint(letter_callback_blueprint)

--- a/app/dao/letter_rate_dao.py
+++ b/app/dao/letter_rate_dao.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+from sqlalchemy import asc, or_
+
+from app.models import LetterRate
+
+
+def dao_get_current_letter_rates():
+    return (
+        LetterRate.query.filter(
+            # We have rows for crown and non-crown but
+            # - they should always be the same
+            # - we don’t show them separately anywhere
+            #
+            # So let’s just ignore non-crown for now
+            LetterRate.crown.is_(True),
+            LetterRate.start_date <= datetime.utcnow(),
+            or_(
+                LetterRate.end_date.is_(None),
+                LetterRate.end_date > datetime.utcnow(),
+            ),
+        )
+        .order_by(
+            asc(LetterRate.sheet_count),
+            asc(LetterRate.rate),
+            asc(LetterRate.post_class),
+        )
+        .all()
+    )

--- a/app/models.py
+++ b/app/models.py
@@ -1861,6 +1861,14 @@ class LetterRate(db.Model):
     crown = db.Column(db.Boolean, nullable=False)
     post_class = db.Column(db.String, nullable=False)
 
+    def serialize(self):
+        return {
+            "sheet_count": self.sheet_count,
+            "start_date": self.start_date.isoformat(),
+            "rate": self.rate,
+            "post_class": self.post_class,
+        }
+
 
 class ServiceEmailReplyTo(db.Model):
     __tablename__ = "service_email_reply_to"

--- a/tests/app/letters/test_rates.py
+++ b/tests/app/letters/test_rates.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timedelta
+
+from freezegun import freeze_time
+
+from tests.app.db import create_letter_rate
+
+
+@freeze_time("2024-01-02T12:00:00")
+def test_letter_rates(admin_request, notify_db_session):
+    now = datetime.utcnow()
+    tomorrow = datetime.utcnow() + timedelta(days=1)
+    yesterday = datetime.utcnow() - timedelta(days=1)
+
+    # Should be returned
+    create_letter_rate(start_date=now, rate=0.66, post_class="first", sheet_count=1)
+    create_letter_rate(start_date=now, rate=0.33, post_class="second", sheet_count=2)
+    create_letter_rate(start_date=yesterday, end_date=tomorrow, rate=0.84, post_class="europe", sheet_count=3)
+    create_letter_rate(start_date=yesterday, end_date=tomorrow, rate=0.84, post_class="rest-of-world", sheet_count=4)
+
+    # Expired (should not be returned)
+    create_letter_rate(start_date=yesterday, end_date=now)
+
+    # Future (should not be returned)
+    create_letter_rate(start_date=tomorrow)
+    create_letter_rate(start_date=tomorrow, end_date=tomorrow + timedelta(days=1))
+
+    # Non crown (should not be returned)
+    create_letter_rate(start_date=now, crown=False)
+
+    json_response = admin_request.get("letter_rates.get_letter_rates")
+
+    assert json_response == [
+        {"post_class": "first", "rate": "0.66", "sheet_count": 1, "start_date": "2024-01-02T12:00:00"},
+        {"post_class": "second", "rate": "0.33", "sheet_count": 2, "start_date": "2024-01-02T12:00:00"},
+        {"post_class": "europe", "rate": "0.84", "sheet_count": 3, "start_date": "2024-01-01T12:00:00"},
+        {"post_class": "rest-of-world", "rate": "0.84", "sheet_count": 4, "start_date": "2024-01-01T12:00:00"},
+    ]


### PR DESCRIPTION
This means we don’t have to keep them in two places (database and admin app) and means the rates displayed on the frontend will update automatically as soon as new ones come into effect.

I’ve chosen a format which will work well with https://github.com/alphagov/notifications-admin/pull/4960