### PR TITLE
Switch to using an exec in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,76 +17,76 @@ COMMON_CMD="$WORKER_CMD -Q"
 
 if [ "$1" == "worker" ]
 then
-  $WORKER_CMD
+  exec $WORKER_CMD
 
 elif [ "$1" == "api" ]
 then
-  gunicorn -c /home/vcap/app/gunicorn_config.py application
+  exec gunicorn -c /home/vcap/app/gunicorn_config.py application
 
 elif [ "$1" == "api-local" ]
 then
-  flask run --host 0.0.0.0 --port $PORT
+  exec flask run --host 0.0.0.0 --port $PORT
 
 elif [ "$1" == "migration" ]
 then
-  flask db upgrade
+  exec flask db upgrade
 
 elif [ "$1" == "api-worker-retry-tasks" ]
 then
-  $COMMON_CMD retry-tasks
+  exec $COMMON_CMD retry-tasks
 
 elif [ "$1" == "api-worker-letters" ]
 then
-  $COMMON_CMD create-letters-pdf-tasks,letter-tasks
+  exec $COMMON_CMD create-letters-pdf-tasks,letter-tasks
 
 elif [ "$1" == "api-worker-jobs" ]
 then
-  $COMMON_CMD database-tasks,job-tasks
+  exec $COMMON_CMD database-tasks,job-tasks
 
 elif [ "$1" == "api-worker-research" ]
 then
-  $COMMON_CMD research-mode-tasks
+  exec $COMMON_CMD research-mode-tasks
 
 elif [ "$1" == "api-worker-sender" ]
 then
-  $COMMON_CMD send-sms-tasks,send-email-tasks
+  exec $COMMON_CMD send-sms-tasks,send-email-tasks
 
 elif [ "$1" == "api-worker-sender-letters" ]
 then
-  $COMMON_CMD send-letter-tasks
+  exec $COMMON_CMD send-letter-tasks
 
 elif [ "$1" == "api-worker-periodic" ]
 then
-  $COMMON_CMD periodic-tasks
+  exec $COMMON_CMD periodic-tasks
 
 elif [ "$1" == "api-worker-reporting" ]
 then
-  $COMMON_CMD reporting-tasks
+  exec $COMMON_CMD reporting-tasks
 
 # Only consume the notify-internal-tasks queue on this app so that Notify messages are processed as a priority
 elif [ "$1" == "api-worker-internal" ]
 then
-  $COMMON_CMD notify-internal-tasks
+  exec $COMMON_CMD notify-internal-tasks
 
 elif [ "$1" == "api-worker-broadcasts" ]
 then
-  $COMMON_CMD broadcast-tasks
+  exec $COMMON_CMD broadcast-tasks
 
 elif [ "$1" == "api-worker-receipts" ]
 then
-  $COMMON_CMD ses-callbacks,sms-callbacks
+  exec $COMMON_CMD ses-callbacks,sms-callbacks
 
 elif [ "$1" == "api-worker-service-callbacks" ]
 then
-  $COMMON_CMD service-callbacks,service-callbacks-retry
+  exec $COMMON_CMD service-callbacks,service-callbacks-retry
 
 elif [ "$1" == "api-worker-save-api-notifications" ]
 then
-  $COMMON_CMD save-api-email-tasks,save-api-sms-tasks
+  exec $COMMON_CMD save-api-email-tasks,save-api-sms-tasks
 
 elif [ "$1" == "celery-beat" ]
 then
-  celery -A run_celery.notify_celery beat --loglevel=INFO
+  exec celery -A run_celery.notify_celery beat --loglevel=INFO
 
 else
   echo -e "'\033[31m'FATAL: missing argument'\033[0m'" && exit 1


### PR DESCRIPTION
What
----

Switch to using an exec in entrypoint.sh

The exec will replace the the entrypoint pid (usually 1) with the main gunicorn or flask one.

Why
----

Following guidance [from aws](https://aws.amazon.com/blogs/containers/graceful-shutdowns-with-ecs/) we should use exec to prevent the shell script middleman from consuming SIGTERM signals and not passing them to child processes.
