### PR TITLE
Adjust values in Redis if letters are cancelled

### DIFF
--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -73,7 +73,7 @@ def cancel_letter_job(service_id, job_id):
     can_we_cancel, errors = can_letter_job_be_cancelled(job)
     if can_we_cancel:
         number_of_cancelled_letters = dao_cancel_letter_job(job)
-        adjust_daily_service_limits_for_cancelled_letters(service_id, number_of_cancelled_letters)
+        adjust_daily_service_limits_for_cancelled_letters(service_id, number_of_cancelled_letters, job.created_at)
         return jsonify(number_of_cancelled_letters), 200
     else:
         return jsonify(message=errors), 400

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -32,6 +32,7 @@ from app.dao.notifications_dao import (
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.templates_dao import dao_get_template_by_id
 from app.errors import InvalidRequest, register_errors
+from app.letters.utils import adjust_daily_service_limits_for_cancelled_letters
 from app.schemas import (
     job_schema,
     notification_with_template_schema,
@@ -71,8 +72,9 @@ def cancel_letter_job(service_id, job_id):
     job = dao_get_job_by_service_id_and_job_id(service_id, job_id)
     can_we_cancel, errors = can_letter_job_be_cancelled(job)
     if can_we_cancel:
-        data = dao_cancel_letter_job(job)
-        return jsonify(data), 200
+        number_of_cancelled_letters = dao_cancel_letter_job(job)
+        adjust_daily_service_limits_for_cancelled_letters(service_id, number_of_cancelled_letters)
+        return jsonify(number_of_cancelled_letters), 200
     else:
         return jsonify(message=errors), 400
 

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -96,7 +96,7 @@ def test_cancel_letter_job_updates_notifications_and_job_to_cancelled(sample_let
     mock_get_job.assert_called_once_with(job.service_id, str(job.id))
     mock_can_letter_job_be_cancelled.assert_called_once_with(job)
     mock_dao_cancel_letter_job.assert_called_once_with(job)
-    mock_update_redis.assert_called_once_with(job.service_id, 1)
+    mock_update_redis.assert_called_once_with(job.service_id, 1, datetime(2019, 6, 13, 13, 0))
 
     assert response == 1
 


### PR DESCRIPTION
We store a Redis key for the total daily notifications sent by a service and for each notification type so that we can ensure that services don't exceed their rate limits. If a large batch of letters is cancelled, we should adjust these values in Redis so that cancelled letters do not count as part of the rate limit.

This adds a function to update the values in Redis for total daily notifications sent and total daily letters sent by service if a letter job is cancelled. This could be added to the endpoint to cancel a single letter, but cancelling individual letters is unlikely to cause a service to falsely appear to go over its limit.

It makes use of a new `decrby` method in the `RedisClient`. It would be possible to just use `set` to re-set the value, however the benefit of using `decrby` is that the TTL stays the same - 1 day after the key was first stored.

**Relies on**
- [x] https://github.com/alphagov/notifications-utils/pull/1086

You'll need to install this locally to test