### PR TITLE
Bump utils to 74.4.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.4.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -165,7 +165,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.4.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
 ## 74.4.0

* Reverts the 'single session' change from 74.1.0, which may be causing us some connection errors.

 ## 74.3.0

* Add `decrby` method to the RedisClient

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/74.2.0...74.4.0