### PR TITLE
paas manifest: handle -ecs-fixup suffixed apps

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -82,7 +82,22 @@
   'notify-delivery-worker-save-api-notifications': {'disk_quota': '4G'},
 } -%}
 
-{%- set app = app_vars[CF_APP] -%}
+{# extremely awkward syntax here because jinja has no inline way to merge dictionaries %}
+{%- set app = app_vars[CF_APP] if CF_APP in app_vars else app_vars[CF_APP.removesuffix('-ecs-fixup')] -%}
+{%- if CF_APP not in app_vars -%}
+  {%- set _ = app.update({
+    'instances': {
+      'preview': 0,
+      'staging': 0,
+      'production': 0
+    },
+  }) -%}
+  {%- set _ = app.setdefault('additional_env_vars', {}) -%}
+  {%- set _ = app['additional_env_vars'].update({
+    'NOTIFICATION_QUEUE_PREFIX': NOTIFICATION_QUEUE_PREFIX + '-ecs',
+  }) -%}
+{%- endif -%}
+
 {%- set instance_count = app.get('instances', {}).get(environment) -%}
 
 ---

--- a/scripts/paas_app_wrapper.sh
+++ b/scripts/paas_app_wrapper.sh
@@ -1,60 +1,63 @@
 #!/bin/bash
+
+shopt -s extglob
+
 case $NOTIFY_APP_NAME in
   api)
     unset GUNICORN_CMD_ARGS
     exec scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py application
     ;;
-  delivery-worker-retry-tasks)
+  delivery-worker-retry-tasks?(-ecs-fixup))
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \
     -Q retry-tasks 2> /dev/null
     ;;
-  delivery-worker-letters)
+  delivery-worker-letters?(-ecs-fixup))
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \
     -Q create-letters-pdf-tasks,letter-tasks 2> /dev/null
     ;;
-  delivery-worker-jobs)
+  delivery-worker-jobs?(-ecs-fixup))
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \
     -Q database-tasks,job-tasks 2> /dev/null
     ;;
-  delivery-worker-research)
+  delivery-worker-research?(-ecs-fixup))
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \
     -Q research-mode-tasks 2> /dev/null
     ;;
-  delivery-worker-sender)
+  delivery-worker-sender?(-ecs-fixup))
     exec scripts/run_multi_worker_app_paas.sh celery multi start 3 -c 4 -A run_celery.notify_celery --loglevel=INFO \
     --logfile=/dev/null --pidfile=/tmp/celery%N.pid -Q send-sms-tasks,send-email-tasks
     ;;
-  delivery-worker-sender-letters)
+  delivery-worker-sender-letters?(-ecs-fixup))
     # at the default of 2 instances with 4 concurrent workers, we hit DVLA's 50rps rate limit 
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=3 \
     -Q send-letter-tasks 2> /dev/null
     ;;
-  delivery-worker-periodic)
+  delivery-worker-periodic?(-ecs-fixup))
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=2 \
     -Q periodic-tasks 2> /dev/null
     ;;
-  delivery-worker-reporting)
+  delivery-worker-reporting?(-ecs-fixup))
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \
     -Q reporting-tasks 2> /dev/null
     ;;
   # Only consume the notify-internal-tasks queue on this app so that Notify messages are processed as a priority
-  delivery-worker-internal)
+  delivery-worker-internal?(-ecs-fixup))
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \
     -Q notify-internal-tasks 2> /dev/null
     ;;
-  delivery-worker-broadcasts)
+  delivery-worker-broadcasts?(-ecs-fixup))
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=2 \
     -Q broadcast-tasks 2> /dev/null
     ;;
-  delivery-worker-receipts)
+  delivery-worker-receipts?(-ecs-fixup))
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \
     -Q ses-callbacks,sms-callbacks 2> /dev/null
     ;;
-  delivery-worker-service-callbacks)
+  delivery-worker-service-callbacks?(-ecs-fixup))
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \
     -Q service-callbacks,service-callbacks-retry 2> /dev/null
     ;;
-  delivery-worker-save-api-notifications)
+  delivery-worker-save-api-notifications?(-ecs-fixup))
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \
     -Q save-api-email-tasks,save-api-sms-tasks 2> /dev/null
     ;;


### PR DESCRIPTION
This is one possible implementation for https://trello.com/c/TSJ74HqV/533-create-a-deployment-in-paas-of-the-workers-that-is-scaled-down-to-0-which-has-the-queue-prefix-for-ecs-production-instead-of-paa - the approach that creates copies of each app listening on the ECS queue.

Not tested yet (how?).