### PR TITLE
paas manifest: handle notify-delivery-worker-ecs-fixup app

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -57,6 +57,19 @@
       'production': 1
     },
   },
+  'notify-delivery-worker-ecs-fixup': {
+    'disk_quota': '10G',
+    'memory': '4G',
+    'additional_env_vars': {
+      'NOTIFICATION_QUEUE_PREFIX': NOTIFICATION_QUEUE_PREFIX + '-ecs',
+      'CELERYD_PREFETCH_MULTIPLIER': 1,
+    },
+    'instances': {
+      'preview': 0,
+      'staging': 0,
+      'production': 0
+    },
+  },
   'notify-delivery-worker-jobs': {'memory': '2G'},
   'notify-delivery-worker-research': {'disk_quota': '10G'},
   'notify-delivery-worker-sender': {'disk_quota': '4G', 'memory': '4G'},

--- a/scripts/paas_app_wrapper.sh
+++ b/scripts/paas_app_wrapper.sh
@@ -4,6 +4,10 @@ case $NOTIFY_APP_NAME in
     unset GUNICORN_CMD_ARGS
     exec scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py application
     ;;
+  delivery-worker-ecs-fixup)
+    exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \
+    -Q broadcast-tasks,create-letters-pdf-tasks,database-tasks,job-tasks,letter-tasks,notify-internal-tasks,periodic-tasks,reporting-tasks,research-mode-tasks,retry-tasks,save-api-email-tasks,save-api-sms-tasks,send-email-tasks,send-letter-tasks,send-sms-tasks,service-callbacks,service-callbacks-retry,ses-callbacks,sms-callbacks 2> /dev/null
+    ;;
   delivery-worker-retry-tasks)
     exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 \
     -Q retry-tasks 2> /dev/null


### PR DESCRIPTION
This is the "combined app" approach to https://trello.com/c/TSJ74HqV/533-create-a-deployment-in-paas-of-the-workers-that-is-scaled-down-to-0-which-has-the-queue-prefix-for-ecs-production-instead-of-paa