### PR TITLE
Count team members in an organisation’s services

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -650,6 +650,9 @@ class Service(db.Model, Versioned):
             "name": self.name,
             "active": self.active,
             "restricted": self.restricted,
+            "count_of_users_with_manage_service_permission": len(
+                [user for user in self.users if "manage_settings" in user.get_permissions(self.id)]
+            ),
         }
 
     def get_available_broadcast_providers(self):


### PR DESCRIPTION
The way we show the count of service users when listing all the services in an organisation is very inefficient<sup>1</sup>. It requires an API call per service. This is very slow for organisations that have hundreds of services.

This pull request adds the count to the JSON response for listing an organisation’s services instead.

***

1. https://github.com/alphagov/notifications-admin/blob/aa3bcad54c789b5bf6744d4a8d827c4fe7c23cfd/app/templates/views/choose-service-to-join.html#L40