### PR TITLE
remove unnecessary db lines

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -107,14 +107,10 @@ RUN mkdir -p app
 COPY --from=python_build --chown=notify:notify /opt/venv /opt/venv
 
 # Install dev/test requirements
-COPY --chown=notify:notify Makefile requirements.txt requirements_for_test.txt ./
 COPY --from=python_build --chown=notify:notify /home/vcap/app/app/version.py app/version.py
 COPY --chown=notify:notify . .
 
-ENV PORT=6011
-ENV FLASK_APP=application.py
-ENV NOTIFY_ENVIRONMENT='test'
-ENV SQLALCHEMY_DATABASE_URI=postgresql://postgres:postgres@localhost/notification_api
+ENV SQLALCHEMY_DATABASE_URI=postgresql://postgres:postgres@localhost/
 
 RUN pip3 install -r requirements_for_test.txt
 
@@ -150,5 +146,4 @@ RUN \
 
 RUN \
     service postgresql start \
-    && su - postgres -c "psql -c \"alter user postgres with password 'postgres';\"" \
-    && su - postgres -c "psql -c \"create database notification_api;\""
+    && su - postgres -c "psql -c \"alter user postgres with password 'postgres';\""


### PR DESCRIPTION
* we don't need to copy across the makefile as we copy everything on the next line
* we dont need the port/flask_app/etc as they're defined in pytest.ini
* we don't need the notifciation_api db in the sqlalchemy URI as the tests don't use that
* we don't need to create the notification_api db either