### PR TITLE
forward onwards request headers to other notify apps

### DIFF
--- a/app/clients/document_download.py
+++ b/app/clients/document_download.py
@@ -1,7 +1,8 @@
 from typing import Optional
 
 import requests
-from flask import current_app
+from flask import current_app, request
+from flask.ctx import has_request_context
 
 
 class DocumentDownloadError(Exception):
@@ -59,11 +60,13 @@ class DocumentDownloadClient:
             if filename:
                 data["filename"] = filename
 
+            headers = {"Authorization": "Bearer {}".format(self.auth_token)}
+            if has_request_context() and hasattr(request, "get_onwards_request_headers"):
+                headers.update(request.get_onwards_request_headers())
+
             response = requests.post(
                 self._get_upload_url(service_id),
-                headers={
-                    "Authorization": "Bearer {}".format(self.auth_token),
-                },
+                headers=headers,
                 json=data,
             )
 

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.5.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.6.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -163,7 +163,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.5.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.6.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/tests/app/clients/test_document_download.py
+++ b/tests/app/clients/test_document_download.py
@@ -36,13 +36,14 @@ def test_get_upload_url_for_simulated_email(document_download):
     )
 
 
-def test_upload_document(document_download):
+def test_upload_document(document_download, mock_onwards_request_headers):
     with requests_mock.Mocker() as request_mock:
         request_mock.post(
             "https://document-download-internal/services/service-id/documents",
             json={"document": {"url": "https://document-download/services/service-id/documents/uploaded-url"}},
             request_headers={
                 "Authorization": "Bearer test-key",
+                "some-onwards": "request-headers",
             },
             status_code=201,
         )
@@ -53,13 +54,18 @@ def test_upload_document(document_download):
 
 
 @pytest.mark.parametrize("confirmation_email", [None, "dev@test.notify"])
-def test_upload_document_confirm_email(document_download, confirmation_email):
+def test_upload_document_confirm_email(
+    document_download,
+    mock_onwards_request_headers,
+    confirmation_email,
+):
     with requests_mock.Mocker() as request_mock:
         request_mock.post(
             "https://document-download-internal/services/service-id/documents",
             json={"document": {"url": "https://document-download/services/service-id/documents/uploaded-url"}},
             request_headers={
                 "Authorization": "Bearer test-key",
+                "some-onwards": "request-headers",
             },
             status_code=201,
         )
@@ -77,12 +83,19 @@ def test_upload_document_confirm_email(document_download, confirmation_email):
 
 
 @pytest.mark.parametrize("retention_period", [None, "1 week", "5 weeks"])
-def test_upload_document_retention_period(document_download, retention_period):
+def test_upload_document_retention_period(
+    document_download,
+    mock_onwards_request_headers,
+    retention_period,
+):
     with requests_mock.Mocker() as request_mock:
         request_mock.post(
             "https://document-download-internal/services/service-id/documents",
             json={"document": {"url": "https://document-download/services/service-id/documents/uploaded-url"}},
-            request_headers={"Authorization": "Bearer test-key"},
+            request_headers={
+                "Authorization": "Bearer test-key",
+                "some-onwards": "request-headers",
+            },
             status_code=201,
         )
 
@@ -98,7 +111,7 @@ def test_upload_document_retention_period(document_download, retention_period):
         assert "retention_period" not in request_json
 
 
-def test_should_raise_400s_as_DocumentDownloadErrors(document_download):
+def test_should_raise_400s_as_DocumentDownloadErrors(document_download, mock_onwards_request_headers):
     with pytest.raises(DocumentDownloadError) as excinfo, requests_mock.Mocker() as request_mock:
         request_mock.post(
             "https://document-download-internal/services/service-id/documents",
@@ -112,7 +125,7 @@ def test_should_raise_400s_as_DocumentDownloadErrors(document_download):
     assert excinfo.value.status_code == 400
 
 
-def test_should_raise_non_400_statuses_as_exceptions(document_download):
+def test_should_raise_non_400_statuses_as_exceptions(document_download, mock_onwards_request_headers):
     with pytest.raises(Exception) as excinfo, requests_mock.Mocker() as request_mock:
         request_mock.post(
             "https://document-download-internal/services/service-id/documents",
@@ -126,7 +139,10 @@ def test_should_raise_non_400_statuses_as_exceptions(document_download):
     assert str(excinfo.value) == 'Unhandled document download error: {"error": "Auth Error Of Some Kind"}'
 
 
-def test_should_raise_exceptions_without_http_response_bodies_as_exceptions(document_download):
+def test_should_raise_exceptions_without_http_response_bodies_as_exceptions(
+    document_download,
+    mock_onwards_request_headers,
+):
     with pytest.raises(Exception) as excinfo, requests_mock.Mocker() as request_mock:
         request_mock.post(
             "https://document-download-internal/services/service-id/documents", exc=requests.exceptions.ConnectTimeout

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1110,5 +1110,12 @@ def api_client_request(client, notify_user):
     return ApiClientRequest
 
 
+@pytest.fixture(scope="function")
+def mock_onwards_request_headers(mocker):
+    mock_gorh = mocker.patch("notifications_utils.request_helper.NotifyRequest.get_onwards_request_headers")
+    mock_gorh.return_value = {"some-onwards": "request-headers"}
+    return mock_gorh
+
+
 def datetime_in_past(days=0, seconds=0):
     return datetime.now(tz=pytz.utc) - timedelta(days=days, seconds=seconds)

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1253,6 +1253,7 @@ def test_preview_letter_template_by_id_valid_file_type(
     notify_api,
     sample_letter_notification,
     admin_request,
+    mock_onwards_request_headers,
     file_type,
 ):
     sample_letter_notification.created_at = datetime.utcnow()
@@ -1269,7 +1270,10 @@ def test_preview_letter_template_by_id_valid_file_type(
             mock_post = request_mock.post(
                 "http://localhost/notifications-template-preview/preview.{}".format(file_type),
                 content=content,
-                headers={"X-pdf-page-count": "1"},
+                headers={
+                    "X-pdf-page-count": "1",
+                    "some-onwards": "request-headers",
+                },
                 status_code=200,
             )
 
@@ -1298,7 +1302,11 @@ def test_preview_letter_template_by_id_valid_file_type(
 
 @freeze_time("2012-12-12")
 def test_preview_letter_template_by_id_shows_template_version_used_by_notification(
-    notify_api, sample_letter_notification, sample_letter_template, admin_request
+    notify_api,
+    sample_letter_notification,
+    sample_letter_template,
+    mock_onwards_request_headers,
+    admin_request,
 ):
     sample_letter_notification.created_at = datetime.utcnow()
     assert sample_letter_notification.template_version == 1
@@ -1323,7 +1331,10 @@ def test_preview_letter_template_by_id_shows_template_version_used_by_notificati
             mock_post = request_mock.post(
                 "http://localhost/notifications-template-preview/preview.png",
                 content=content,
-                headers={"X-pdf-page-count": "1"},
+                headers={
+                    "X-pdf-page-count": "1",
+                    "some-onwards": "request-headers",
+                },
                 status_code=200,
             )
 
@@ -1340,7 +1351,11 @@ def test_preview_letter_template_by_id_shows_template_version_used_by_notificati
 
 
 def test_preview_letter_template_by_id_template_preview_500(
-    notify_api, client, admin_request, sample_letter_notification
+    notify_api,
+    client,
+    admin_request,
+    sample_letter_notification,
+    mock_onwards_request_headers,
 ):
     with set_config_values(
         notify_api,
@@ -1357,7 +1372,10 @@ def test_preview_letter_template_by_id_template_preview_500(
             mock_post = request_mock.post(
                 "http://localhost/notifications-template-preview/preview.pdf",
                 content=content,
-                headers={"X-pdf-page-count": "1"},
+                headers={
+                    "X-pdf-page-count": "1",
+                    "some-onwards": "request-headers",
+                },
                 status_code=404,
             )
 
@@ -1475,6 +1493,7 @@ def test_preview_letter_template_precompiled_for_png_shows_overlay_on_pages_with
     admin_request,
     sample_service,
     mocker,
+    mock_onwards_request_headers,
     requested_page,
     message,
     expected_post_url,
@@ -1511,7 +1530,10 @@ def test_preview_letter_template_precompiled_for_png_shows_overlay_on_pages_with
             mock_post = request_mock.post(
                 "http://localhost/notifications-template-preview/{}".format(expected_post_url),
                 content=expected_returned_content,
-                headers={"X-pdf-page-count": "4"},
+                headers={
+                    "X-pdf-page-count": "4",
+                    "some-onwards": "request-headers",
+                },
                 status_code=200,
             )
 
@@ -1543,6 +1565,7 @@ def test_preview_letter_template_precompiled_for_pdf_shows_overlay_on_all_pages_
     admin_request,
     sample_service,
     mocker,
+    mock_onwards_request_headers,
     invalid_pages,
 ):
     template = create_template(
@@ -1577,7 +1600,10 @@ def test_preview_letter_template_precompiled_for_pdf_shows_overlay_on_all_pages_
             mock_post = request_mock.post(
                 "http://localhost/notifications-template-preview/precompiled/overlay.pdf",
                 content=expected_returned_content,
-                headers={"X-pdf-page-count": "4"},
+                headers={
+                    "X-pdf-page-count": "4",
+                    "some-onwards": "request-headers",
+                },
                 status_code=200,
             )
 
@@ -1646,7 +1672,12 @@ def test_preview_letter_template_precompiled_png_file_type_hide_notify_tag_only_
 
 
 def test_preview_letter_template_precompiled_png_template_preview_500_error(
-    notify_api, client, admin_request, sample_service, mocker
+    notify_api,
+    client,
+    admin_request,
+    sample_service,
+    mocker,
+    mock_onwards_request_headers,
 ):
     template = create_template(
         sample_service,
@@ -1679,7 +1710,10 @@ def test_preview_letter_template_precompiled_png_template_preview_500_error(
             mock_post = request_mock.post(
                 "http://localhost/notifications-template-preview/precompiled-preview.png",
                 content=png_content,
-                headers={"X-pdf-page-count": "1"},
+                headers={
+                    "X-pdf-page-count": "1",
+                    "some-onwards": "request-headers",
+                },
                 status_code=500,
             )
 
@@ -1696,7 +1730,12 @@ def test_preview_letter_template_precompiled_png_template_preview_500_error(
 
 
 def test_preview_letter_template_precompiled_png_template_preview_400_error(
-    notify_api, client, admin_request, sample_service, mocker
+    notify_api,
+    client,
+    admin_request,
+    sample_service,
+    mocker,
+    mock_onwards_request_headers,
 ):
     template = create_template(
         sample_service,
@@ -1729,7 +1768,10 @@ def test_preview_letter_template_precompiled_png_template_preview_400_error(
             mock_post = request_mock.post(
                 "http://localhost/notifications-template-preview/precompiled-preview.png",
                 content=png_content,
-                headers={"X-pdf-page-count": "1"},
+                headers={
+                    "X-pdf-page-count": "1",
+                    "some-onwards": "request-headers",
+                },
                 status_code=404,
             )
 
@@ -1746,7 +1788,12 @@ def test_preview_letter_template_precompiled_png_template_preview_400_error(
 
 
 def test_preview_letter_template_precompiled_png_template_preview_pdf_error(
-    notify_api, client, admin_request, sample_service, mocker
+    notify_api,
+    client,
+    admin_request,
+    sample_service,
+    mocker,
+    mock_onwards_request_headers,
 ):
     template = create_template(
         sample_service,
@@ -1780,7 +1827,10 @@ def test_preview_letter_template_precompiled_png_template_preview_pdf_error(
             request_mock.post(
                 "http://localhost/notifications-template-preview/precompiled-preview.png",
                 content=png_content,
-                headers={"X-pdf-page-count": "1"},
+                headers={
+                    "X-pdf-page-count": "1",
+                    "some-onwards": "request-headers",
+                },
                 status_code=404,
             )
 


### PR DESCRIPTION
https://trello.com/c/n4FmWuff/585-annotate-logs-with-cloudfront-http-request-ids

Two obvious other apps the API calls out to - document-download-api and template-preview. One has a pseudo-client, t'other just makes ad-hoc `requests` calls.

If the API makes requests to any _other_ (internal) apps I can't see where gets the related configuration from.

Also bump notifications-utils to get more logging of tracing-related values.