### PR TITLE
paas manifest: use correct `NOTIFICATION_QUEUE_PREFIX` for prod ecs queues

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -61,7 +61,7 @@
     'disk_quota': '10G',
     'memory': '4G',
     'additional_env_vars': {
-      'NOTIFICATION_QUEUE_PREFIX': NOTIFICATION_QUEUE_PREFIX + '-ecs',
+      'NOTIFICATION_QUEUE_PREFIX': ('production-' if environment == 'production' else (NOTIFICATION_QUEUE_PREFIX + '-ecs')),
       'CELERYD_PREFETCH_MULTIPLIER': 1,
     },
     'instances': {


### PR DESCRIPTION
when creating `-ecs-fixup` apps

https://trello.com/c/TSJ74HqV/533-create-a-deployment-in-paas-of-the-workers-that-is-scaled-down-to-0-which-has-the-queue-prefix-for-ecs-production-instead-of-paa

Inconsistent naming schemes keep life interesting I suppose.