### PR TITLE
config: set `NOTIFY_RUNTIME_PLATFORM` and `NOTIFY_REQUEST_LOG_LEVEL`

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -118,6 +118,9 @@ class Config(object):
     DEBUG = False
     NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH")
 
+    NOTIFY_RUNTIME_PLATFORM = os.getenv("NOTIFY_RUNTIME_PLATFORM", "paas")
+    NOTIFY_REQUEST_LOG_LEVEL = os.getenv("NOTIFY_REQUEST_LOG_LEVEL", "INFO")
+
     # Cronitor
     CRONITOR_ENABLED = False
     CRONITOR_KEYS = json.loads(os.environ.get("CRONITOR_KEYS", "{}"))


### PR DESCRIPTION
For some reason this was never set for this app, so on PaaS the app just has an empty value.

This configuration should continue to produce `app.request` post-request log messages on PaaS.