### PR TITLE
Bump utils to 74.9.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.9.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.9.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -163,7 +163,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.9.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.9.1
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
To stop logging sensitive information.

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/74.9.0...74.9.1