### PR TITLE
docker entrypoint: send celery worker stderr to /dev/null

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ COMMON_CMD="$WORKER_CMD -Q"
 
 if [ "$1" == "worker" ]
 then
-  exec $WORKER_CMD
+  exec $WORKER_CMD 2> /dev/null
 
 elif [ "$1" == "api" ]
 then
@@ -33,60 +33,60 @@ then
 
 elif [ "$1" == "api-worker-retry-tasks" ]
 then
-  exec $COMMON_CMD retry-tasks
+  exec $COMMON_CMD retry-tasks 2> /dev/null
 
 elif [ "$1" == "api-worker-letters" ]
 then
-  exec $COMMON_CMD create-letters-pdf-tasks,letter-tasks
+  exec $COMMON_CMD create-letters-pdf-tasks,letter-tasks 2> /dev/null
 
 elif [ "$1" == "api-worker-jobs" ]
 then
-  exec $COMMON_CMD database-tasks,job-tasks
+  exec $COMMON_CMD database-tasks,job-tasks 2> /dev/null
 
 elif [ "$1" == "api-worker-research" ]
 then
-  exec $COMMON_CMD research-mode-tasks
+  exec $COMMON_CMD research-mode-tasks 2> /dev/null
 
 elif [ "$1" == "api-worker-sender" ]
 then
-  exec $COMMON_CMD send-sms-tasks,send-email-tasks
+  exec $COMMON_CMD send-sms-tasks,send-email-tasks 2> /dev/null
 
 elif [ "$1" == "api-worker-sender-letters" ]
 then
-  exec $COMMON_CMD send-letter-tasks
+  exec $COMMON_CMD send-letter-tasks 2> /dev/null
 
 elif [ "$1" == "api-worker-periodic" ]
 then
-  exec $COMMON_CMD periodic-tasks
+  exec $COMMON_CMD periodic-tasks 2> /dev/null
 
 elif [ "$1" == "api-worker-reporting" ]
 then
-  exec $COMMON_CMD reporting-tasks
+  exec $COMMON_CMD reporting-tasks 2> /dev/null
 
 # Only consume the notify-internal-tasks queue on this app so that Notify messages are processed as a priority
 elif [ "$1" == "api-worker-internal" ]
 then
-  exec $COMMON_CMD notify-internal-tasks
+  exec $COMMON_CMD notify-internal-tasks 2> /dev/null
 
 elif [ "$1" == "api-worker-broadcasts" ]
 then
-  exec $COMMON_CMD broadcast-tasks
+  exec $COMMON_CMD broadcast-tasks 2> /dev/null
 
 elif [ "$1" == "api-worker-receipts" ]
 then
-  exec $COMMON_CMD ses-callbacks,sms-callbacks
+  exec $COMMON_CMD ses-callbacks,sms-callbacks 2> /dev/null
 
 elif [ "$1" == "api-worker-service-callbacks" ]
 then
-  exec $COMMON_CMD service-callbacks,service-callbacks-retry
+  exec $COMMON_CMD service-callbacks,service-callbacks-retry 2> /dev/null
 
 elif [ "$1" == "api-worker-save-api-notifications" ]
 then
-  exec $COMMON_CMD save-api-email-tasks,save-api-sms-tasks
+  exec $COMMON_CMD save-api-email-tasks,save-api-sms-tasks 2> /dev/null
 
 elif [ "$1" == "celery-beat" ]
 then
-  exec celery -A run_celery.notify_celery beat --loglevel=INFO
+  exec celery -A run_celery.notify_celery beat --loglevel=INFO 2> /dev/null
 
 else
   echo -e "'\033[31m'FATAL: missing argument'\033[0m'" && exit 1


### PR DESCRIPTION
Celery sets up its own (unstructured) logging handler outputting to stderr, and we can't be certain it won't try to emit potentially sensitive values.

We already discard stderr for celery workers on PaaS, but for some reason never have on ECS.