### PR TITLE
Bump utils to 74.12.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.9.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.12.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -163,7 +163,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.9.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.12.1
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -302,7 +302,7 @@ def test_should_send_sms_with_downgraded_content(notify_db_session, mocker):
     # ó isn't in GSM, but it is in the welsh alphabet so will still be sent
     msg = "a é ī o u 🍇 foo\tbar\u200bbaz((misc))…"
     placeholder = "∆∆∆abc"
-    gsm_message = "?ódz Housing Service: a é i o u ? foo barbaz???abc..."
+    gsm_message = "Lódz Housing Service: a é i o u ? foo barbaz???abc..."
     service = create_service(service_name="Łódź Housing Service")
     template = create_template(service, content=msg)
     db_notification = create_notification(template=template, personalisation={"misc": placeholder})


### PR DESCRIPTION
 ## 74.12.0

* Remove celery.* structured logging for now. It can return when we have more certainty over what values it will log or can rule out that it is ever given sensitive values.

 ## 74.11.0

* Add option to ignore list of web paths from request logging. Defaults to /_status and /metrics.
* Add new fields to web request log messages (user_agent, host, path)

 ## 74.9.1
***

Complete changes: https://github.com/alphagov/notifications-utils/compare/74.9.1...74.12.0