### PR TITLE
Bumping utils for crown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -110,9 +110,7 @@ gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6
 govuk-bank-holidays==0.11
     # via notifications-utils
 greenlet==3.0.3
-    # via
-    #   eventlet
-    #   sqlalchemy
+    # via eventlet
 gunicorn[eventlet] @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
     # via -r requirements.in
 idna==3.4


### PR DESCRIPTION
**74.12.1**

email template: use the new crown and associated styling
**74.12.0**
Remove celery.* structured logging for now. It can return when we have more certainty over what values it will log or can rule out that it is ever given sensitive values.
**74.11.0**
Add option to ignore list of web paths from request logging. Defaults to /_status and /metrics.
Add new fields to web request log messages (user_agent, host, path)
**74.9.1**