### PR TITLE
Set reply to address on join service request as user making the request

### DIFF
--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -179,7 +179,7 @@ def send_service_invite_request(
                 notification_type=template.template_type,
                 api_key_id=None,
                 key_type=KEY_TYPE_NORMAL,
-                reply_to_text=notify_service.get_default_reply_to_email_address(),
+                reply_to_text=user_requesting_invite.email_address,
             )
             send_notification_to_queue(saved_notification, queue=QueueNames.NOTIFY)
             number_of_notifications_generated += 1

--- a/tests/app/service_invite/test_service_invite_rest.py
+++ b/tests/app/service_invite/test_service_invite_rest.py
@@ -373,6 +373,7 @@ def test_request_invite_to_service_email_is_sent_to_valid_service_managers(
         manager_notification.personalisation["url"]
         == f"{invite_link_host}/services/{sample_service.id}/users/invite/{user_requesting_invite.id}"
     )
+    assert manager_notification.reply_to_text == user_requesting_invite.email_address
 
     # Receipt for request invite notification
     assert user_notification.personalisation == {
@@ -384,6 +385,7 @@ def test_request_invite_to_service_email_is_sent_to_valid_service_managers(
             service_manager_3.name,
         ],
     }
+    assert user_notification.reply_to_text == "notify@gov.uk"
 
 
 def test_request_invite_to_service_email_is_not_sent_if_requester_is_already_part_of_service(


### PR DESCRIPTION
When a user requests to join a service, the person responding to that request might want to follow up with the user.

By making the reply-to address the email address of the user making the request they can do this just by hitting reply.

We will also add content to the email later telling them they can do this.

It also means that if the email bounces then that message goes back to the user who made the request, not us.