### PR TITLE
Turn off celery beat running in prod PaaS

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -54,7 +54,7 @@
     'instances': {
       'preview': 0,
       'staging': 0,
-      'production': 1
+      'production': 0
     },
   },
   'notify-delivery-worker-ecs-fixup': {


### PR DESCRIPTION
As per plan:
https://docs.google.com/document/d/1YlyzUrsxT3wyS2PoT9RzWO651yXRcLXBt3KyzAv7rGs/edit#heading=h.x0lgwjmc38xw