### PR TITLE
Add `templates` directory to docker prod build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,6 +47,7 @@ ENV PATH="/opt/venv/bin:${PATH}"
 
 COPY --chown=notify:notify app app
 COPY --chown=notify:notify migrations migrations
+COPY --chown=notify:notify templates templates
 COPY --chown=notify:notify run_celery.py gunicorn_config.py application.py entrypoint.sh ./
 COPY --from=python_build --chown=notify:notify /home/vcap/app/app/version.py app/version.py
 


### PR DESCRIPTION
This was missing but is relied upon in production. We saw this for the first time when it was run in ECS last night.
https://govuk-notify-gds.sentry.io/issues/5018435002/?alert_rule_id=14332219&alert_timestamp=1709080207374&alert_type=email&environment=production&notification_uuid=8193ee42-da5f-4053-8ec8-c8daa327e3d1&project=4504949325824000&referrer=alert_email

I wonder if there is a more defensive way to write our dockerfile so that we don't run into similar problems in the future if someone added a new folder (and didn't realise/forgot to add it to the dockerfile) but I haven't pondered it for long and so no immediate good ideas.