### PR TITLE
send_one_off_notification: don't eager-load users on initial load of service

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -197,8 +197,11 @@ def dao_fetch_live_services_data():
     return results
 
 
-def dao_fetch_service_by_id(service_id, only_active=False):
-    query = Service.query.filter_by(id=service_id).options(joinedload("users"))
+def dao_fetch_service_by_id(service_id, only_active=False, with_users=True):
+    query = Service.query.filter_by(id=service_id)
+
+    if with_users:
+        query = query.options(joinedload("users"))
 
     if only_active:
         query = query.filter(Service.active)

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -56,7 +56,7 @@ def _get_reference_from_personalisation(personalisation):
 
 
 def send_one_off_notification(service_id, post_data):
-    service = dao_fetch_service_by_id(service_id)
+    service = dao_fetch_service_by_id(service_id, with_users=False)
     template = dao_get_template_by_id_and_service_id(template_id=post_data["template_id"], service_id=service_id)
 
     personalisation = post_data.get("personalisation", None)


### PR DESCRIPTION
https://trello.com/c/fZVZvLHh/691-fix-the-5xx-errors-on-notification-check-admin-app-route

A `Service`'s `users` aren't needed until the recipient is validated, at which point `service_allowed_to_send_to` does a re-fetch of the service anyway. So whether or not performing an eager load of all users is the most efficient way of performing this check, there's no need to do it twice.

This is likely what was causing some requests to fail on ECS (though the exact mechanism is unclear) - but all services for which this view caused a segfault had a ridiculous number of users (>500) which could have been causing memory issues for the process.

I put together a version of this that used `raiseload` in place of `joinedload` and it passed the tests (which I'm fairly confident exercise this code). So that suggests that the `users` aren't accessed before the re-fetch.