### PR TITLE
fix bug with setting letter contact block deleting some fields

### DIFF
--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -65,6 +65,10 @@ def dao_update_template_reply_to(template_id, reply_to):
             "process_type": template.process_type,
             "service_letter_contact_id": template.service_letter_contact_id,
             "broadcast_data": template.broadcast_data,
+            "letter_attachment_id": template.letter_attachment_id,
+            "letter_welsh_content": template.letter_welsh_content,
+            "letter_welsh_subject": template.letter_welsh_subject,
+            "letter_languages": template.letter_languages,
         }
     )
     db.session.add(history)

--- a/app/models.py
+++ b/app/models.py
@@ -1022,6 +1022,8 @@ class TemplateBase(db.Model):
 
         super().__init__(**kwargs)
 
+    # WARNING: if we add a new column here, we must add it to templates_dao.py dao_update_template_reply_to
+    # TODO: remove dao_update_template_reply_to and make `dao_update_template` just work
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String(255), nullable=False)
     template_type = db.Column(template_types, nullable=False)


### PR DESCRIPTION
if you update a template to update the sms sender, email reply_to, or letter contact_block, we call a special function
`dao_update_template_reply_to`.

this function has not been kept up to date with changes to the template model, and as a result, when people edited their templates, other bits of data got removed and left the template in an inconsistent state.

the reasons we added this function are complex and to do with nuances of versioning that i haven't fully digested[^1]
this bug has appeared before[^2]

We should fix this function properly in the near future, but for now the priority is to make sure this doesn't reoccur.

[^1]: #1556
[^2]: #2347

we should fix this properly by refactoring update_template