### PR TITLE
Remove `service_has permission` function

### DIFF
--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -13,7 +13,6 @@ from app.notifications.process_notifications import (
 from app.notifications.validators import (
     check_if_service_can_send_to_number,
     check_rate_limiting,
-    service_has_permission,
     validate_template,
 )
 from app.schemas import (
@@ -89,7 +88,7 @@ def send_notification(notification_type):
     )
 
     _service_allowed_to_send_to(notification_form, authenticated_service)
-    if not service_has_permission(notification_type, authenticated_service.permissions):
+    if not authenticated_service.has_permission(notification_type):
         raise InvalidRequest(
             {"service": ["Cannot send {}".format(get_public_notify_type_text(notification_type, plural=True))]},
             status_code=400,

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -117,12 +117,8 @@ def service_can_send_to_recipient(send_to, key_type, service, allow_guest_list_r
         raise BadRequestError(message=message)
 
 
-def service_has_permission(notify_type, permissions):
-    return notify_type in permissions
-
-
 def check_service_has_permission(notify_type, permissions):
-    if not service_has_permission(notify_type, permissions):
+    if not notify_type in permissions:
         raise BadRequestError(
             message="Service is not allowed to send {}".format(get_public_notify_type_text(notify_type, plural=True))
         )

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -117,10 +117,10 @@ def service_can_send_to_recipient(send_to, key_type, service, allow_guest_list_r
         raise BadRequestError(message=message)
 
 
-def check_service_has_permission(notify_type, permissions):
-    if not notify_type in permissions:
+def check_service_has_permission(service, permission):
+    if not service.has_permission(permission):
         raise BadRequestError(
-            message="Service is not allowed to send {}".format(get_public_notify_type_text(notify_type, plural=True))
+            message="Service is not allowed to send {}".format(get_public_notify_type_text(permission, plural=True))
         )
 
 

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -113,6 +113,9 @@ class SerialisedService(SerialisedModel):
     def high_volume(self):
         return self.id in current_app.config["HIGH_VOLUME_SERVICE"]
 
+    def has_permission(self, permission):
+        return permission in self.permissions
+
 
 class SerialisedAPIKey(SerialisedModel):
     ALLOWED_PROPERTIES = {

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -130,7 +130,7 @@ def get_reply_to_text(notification_type, sender_id, service, template):
 def send_pdf_letter_notification(service_id, post_data):
     service = dao_fetch_service_by_id(service_id)
 
-    check_service_has_permission(LETTER_TYPE, [p.permission for p in service.permissions])
+    check_service_has_permission(service, LETTER_TYPE)
     check_service_over_daily_message_limit(service, KEY_TYPE_NORMAL, notification_type=LETTER_TYPE)
     validate_created_by(service, post_data["created_by"])
     validate_and_format_recipient(

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -91,8 +91,7 @@ def post_precompiled_letter_notification():
 
     form = validate(request_json, post_precompiled_letter_request)
 
-    # Check permission to send letters
-    check_service_has_permission(LETTER_TYPE, authenticated_service.permissions)
+    check_service_has_permission(authenticated_service, LETTER_TYPE)
 
     check_rate_limiting(authenticated_service, api_user, notification_type=LETTER_TYPE)
 
@@ -129,7 +128,7 @@ def post_notification(notification_type):
         else:
             abort(404)
 
-    check_service_has_permission(notification_type, authenticated_service.permissions)
+    check_service_has_permission(authenticated_service, notification_type)
 
     check_rate_limiting(authenticated_service, api_user, notification_type=notification_type)
 


### PR DESCRIPTION
Using the method on the service model itself is less verbose.

Some detail of specific changes in individual commits.