### PR TITLE
Log successful delivery for emails

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -60,6 +60,11 @@ def process_ses_results(self, response):
                 notification.id,
                 extra=dict(bounce_message=json.dumps(bounce_message)),
             )
+        else:
+            current_app.logger.info(
+                "SES successful delivery for notification ID %s",
+                notification.id,
+            )
 
         if notification.status not in [NOTIFICATION_SENDING, NOTIFICATION_PENDING]:
             notifications_dao._duplicate_update_warning(notification=notification, status=notification_status)


### PR DESCRIPTION
So that when investigating, we are reassured that we got the delivered receipt for the email.

This makes logs for emails more consistent with logs for sms.

Consider: this means we will produce more logs.