### PR TITLE
Simplify how we update contact blocks on letter templates

### DIFF
--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -37,39 +37,9 @@ def dao_update_template(template):
 
 @autocommit
 def dao_update_template_reply_to(template_id, reply_to):
-    Template.query.filter_by(id=template_id).update(
-        {
-            "service_letter_contact_id": reply_to,
-            "updated_at": datetime.utcnow(),
-            "version": Template.version + 1,
-        }
-    )
     template = Template.query.filter_by(id=template_id).one()
-
-    history = TemplateHistory(
-        **{
-            "id": template.id,
-            "name": template.name,
-            "template_type": template.template_type,
-            "created_at": template.created_at,
-            "updated_at": template.updated_at,
-            "content": template.content,
-            "service_id": template.service_id,
-            "subject": template.subject,
-            "postage": template.postage,
-            "created_by_id": template.created_by_id,
-            "version": template.version,
-            "archived": template.archived,
-            "process_type": template.process_type,
-            "service_letter_contact_id": template.service_letter_contact_id,
-            "broadcast_data": template.broadcast_data,
-            "letter_attachment_id": template.letter_attachment_id,
-            "letter_welsh_content": template.letter_welsh_content,
-            "letter_welsh_subject": template.letter_welsh_subject,
-            "letter_languages": template.letter_languages,
-        }
-    )
-    db.session.add(history)
+    template.service_letter_contact_id = reply_to
+    dao_update_template(template)
     return template
 
 

--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -36,14 +36,6 @@ def dao_update_template(template):
 
 
 @autocommit
-def dao_update_template_reply_to(template_id, reply_to):
-    template = Template.query.filter_by(id=template_id).one()
-    template.service_letter_contact_id = reply_to
-    dao_update_template(template)
-    return template
-
-
-@autocommit
 def dao_redact_template(template, user_id):
     template.template_redacted.redact_personalisation = True
     template.template_redacted.updated_at = datetime.utcnow()

--- a/app/models.py
+++ b/app/models.py
@@ -1022,7 +1022,6 @@ class TemplateBase(db.Model):
 
         super().__init__(**kwargs)
 
-    # WARNING: if we add a new column here, we must add it to templates_dao.py dao_update_template_reply_to
     # TODO: remove dao_update_template_reply_to and make `dao_update_template` just work
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String(255), nullable=False)

--- a/app/models.py
+++ b/app/models.py
@@ -1022,7 +1022,6 @@ class TemplateBase(db.Model):
 
         super().__init__(**kwargs)
 
-    # TODO: remove dao_update_template_reply_to and make `dao_update_template` just work
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String(255), nullable=False)
     template_type = db.Column(template_types, nullable=False)

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -28,7 +28,6 @@ from app.dao.templates_dao import (
     dao_get_template_versions,
     dao_redact_template,
     dao_update_template,
-    dao_update_template_reply_to,
     get_precompiled_letter_template,
 )
 from app.errors import InvalidRequest, register_errors
@@ -132,8 +131,9 @@ def update_template(service_id, template_id):
 
     if "reply_to" in data:
         check_service_letter_contact_id(service_id, data.get("reply_to"), fetched_template.template_type)
-        updated = dao_update_template_reply_to(template_id=template_id, reply_to=data.get("reply_to"))
-        return jsonify(data=template_schema.dump(updated)), 200
+        fetched_template.service_letter_contact_id = data.get("reply_to")
+        dao_update_template(fetched_template)
+        return jsonify(data=template_schema.dump(fetched_template)), 200
 
     current_data = dict(template_schema.dump(fetched_template).items())
     updated_template = dict(template_schema.dump(fetched_template).items())

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -34,7 +34,7 @@ from app.dao.templates_dao import (
 from app.errors import InvalidRequest, register_errors
 from app.letters.utils import get_letter_pdf_and_metadata
 from app.models import Template
-from app.notifications.validators import check_reply_to
+from app.notifications.validators import check_service_letter_contact_id
 from app.schema_validation import validate
 from app.schemas import (
     template_history_schema,
@@ -104,7 +104,7 @@ def create_template(service_id):
     ):
         raise InvalidRequest({"content": [QR_CODE_TOO_LONG]}, status_code=400)
 
-    check_reply_to(service_id, new_template.reply_to, new_template.template_type)
+    check_service_letter_contact_id(service_id, new_template.reply_to, new_template.template_type)
 
     dao_create_template(new_template)
 
@@ -131,7 +131,7 @@ def update_template(service_id, template_id):
         return redact_template(fetched_template, data)
 
     if "reply_to" in data:
-        check_reply_to(service_id, data.get("reply_to"), fetched_template.template_type)
+        check_service_letter_contact_id(service_id, data.get("reply_to"), fetched_template.template_type)
         updated = dao_update_template_reply_to(template_id=template_id, reply_to=data.get("reply_to"))
         return jsonify(data=template_schema.dump(updated)), 200
 

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -11,7 +11,6 @@ from app.dao.templates_dao import (
     dao_get_template_versions,
     dao_redact_template,
     dao_update_template,
-    dao_update_template_reply_to,
 )
 from app.models import Template, TemplateHistory, TemplateRedacted
 from tests.app.db import create_letter_contact, create_template
@@ -110,7 +109,8 @@ def test_dao_update_template_reply_to_none_to_some(sample_service, sample_user):
     assert created.reply_to is None
     assert created.service_letter_contact_id is None
 
-    dao_update_template_reply_to(template_id=template.id, reply_to=letter_contact.id)
+    created.service_letter_contact_id = letter_contact.id
+    dao_update_template(created)
 
     updated = Template.query.get(template.id)
     assert updated.reply_to == letter_contact.id
@@ -138,7 +138,8 @@ def test_dao_update_template_reply_to_some_to_some(sample_service, sample_user):
     template = Template(**data)
     dao_create_template(template)
     created = Template.query.get(template.id)
-    dao_update_template_reply_to(template_id=created.id, reply_to=letter_contact_2.id)
+    created.service_letter_contact_id = letter_contact_2.id
+    dao_update_template(created)
     updated = Template.query.get(template.id)
     assert updated.reply_to == letter_contact_2.id
     assert updated.version == 2
@@ -163,7 +164,10 @@ def test_dao_update_template_reply_to_some_to_none(sample_service, sample_user):
     template = Template(**data)
     dao_create_template(template)
     created = Template.query.get(template.id)
-    dao_update_template_reply_to(template_id=created.id, reply_to=None)
+
+    created.service_letter_contact_id = None
+    dao_update_template(created)
+
     updated = Template.query.get(template.id)
     assert updated.reply_to is None
     assert updated.version == 2


### PR DESCRIPTION
See individual commits.

The aim of this is to get rid of the separate method with its hand-crafted `dict` of properties, and prevent a re-occurrence of bugs like https://github.com/alphagov/notifications-api/pull/4032

I would have liked to go further and re-use the same code path as other updates but was defeated by schema weirdness (something to do with `reply_to`, `service_letter_contact_block` and `service_letter_contact_block_id` being sort of the same things but sort of different).