### PR TITLE
Check every field to see if a template has changed 

### DIFF
--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -135,7 +135,7 @@ def update_template(service_id, template_id):
         dao_update_template(fetched_template)
         return jsonify(data=template_schema.dump(fetched_template)), 200
 
-    current_data = dict(template_schema.dump(fetched_template).items())
+    current_data = template_schema.dump(fetched_template)
     updated_template = current_data | data
 
     # Check if there is a change to make.

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -140,7 +140,7 @@ def update_template(service_id, template_id):
     updated_template.update(data)
 
     # Check if there is a change to make.
-    if _template_has_not_changed(current_data, updated_template):
+    if current_data == updated_template:
         return jsonify(data=updated_template), 200
 
     over_limit = _content_count_greater_than_limit(updated_template["content"], fetched_template.template_type)
@@ -218,10 +218,6 @@ def get_template_versions(service_id, template_id):
         dao_get_template_versions(service_id=service_id, template_id=template_id), many=True
     )
     return jsonify(data=data)
-
-
-def _template_has_not_changed(current_data, updated_template):
-    return all(current_data[key] == updated_template[key] for key in updated_template.keys())
 
 
 def redact_template(template, data):

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -221,20 +221,7 @@ def get_template_versions(service_id, template_id):
 
 
 def _template_has_not_changed(current_data, updated_template):
-    return all(
-        current_data[key] == updated_template[key]
-        for key in (
-            "name",
-            "content",
-            "subject",
-            "archived",
-            "process_type",
-            "postage",
-            "letter_welsh_subject",
-            "letter_welsh_content",
-            "letter_languages",
-        )
-    )
+    return all(current_data[key] == updated_template[key] for key in updated_template.keys())
 
 
 def redact_template(template, data):

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -136,8 +136,7 @@ def update_template(service_id, template_id):
         return jsonify(data=template_schema.dump(fetched_template)), 200
 
     current_data = dict(template_schema.dump(fetched_template).items())
-    updated_template = dict(template_schema.dump(fetched_template).items())
-    updated_template.update(data)
+    updated_template = current_data | data
 
     # Check if there is a change to make.
     if current_data == updated_template:


### PR DESCRIPTION
In https://github.com/alphagov/notifications-api/pull/361 we introduced a check to see if a template had changed before saving a new version of it.

That pull request introduced a list of fields to check for changes. This list needed to be maintained and added to over time, otherwise changes to a new field wouldn’t be considered a material change (for example if only `letter_attachment` changed).

Rather than maintaining a custom list of which fields to check for changes, let’s check all of them. This also enables some refactoring, which I’ve split into separate commits.

Things which change a template but don’t create a new version (for example moving it from one folder to another) go through different routes anyway, so I don’t think there’s a concern about accidentally creating spurious versions.