### PR TITLE
Add new sms rate and allowances into the database

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0439_intl_letters_jan_24
+0440_new_sms_allowance_n_rate

--- a/migrations/versions/0440_new_sms_allowance_n_rate.py
+++ b/migrations/versions/0440_new_sms_allowance_n_rate.py
@@ -1,0 +1,45 @@
+"""
+
+Revision ID: 0440_new_sms_allowance_n_rate
+Revises: 0439_intl_letters_jan_24
+Create Date: 2023-03-06 11:32:20.588364
+
+"""
+
+import uuid
+
+from alembic import op
+
+
+revision = "0440_new_sms_allowance_n_rate"
+down_revision = "0439_intl_letters_jan_24"
+
+new_allowances = {
+    "central": 30000,
+    "nhs_central": 30000,
+    "local": 10000,
+    "nhs_local": 10000,
+    "emergency_service": 10000,
+    "school_or_college": 5000,
+    "other": 5000,
+    "nhs_gp": 0,
+}
+
+
+def upgrade():
+    op.execute(
+        "INSERT INTO rates(id, valid_from, rate, notification_type) "
+        f"VALUES('{uuid.uuid4()}', '2024-03-31 23:00:00', 0.0227, 'sms')"
+    )
+
+    for org_type, allowance in new_allowances.items():
+        op.execute(
+            "INSERT INTO default_annual_allowance(id, valid_from_financial_year_start, organisation_type, allowance, notification_type) "
+            f"VALUES('{uuid.uuid4()}', 2024, '{org_type}', {allowance}, 'sms')"
+        )
+
+
+def downgrade():
+    op.execute(f"DELETE FROM rates WHERE valid_from = '2024-03-31 23:00:00' AND notification_type = 'sms'")
+
+    op.execute("DELETE FROM default_annual_allowance WHERE valid_from_financial_year_start = 2024")


### PR DESCRIPTION
through a migration.

New sms rate: 2.27p

New allowances:

- 30,000 free text messages for `central`, `nhs_central`
- 10,000 free text messages for `local`, `nhs_local`, `emergency_service`
- 5,000 free text messages for `school_or_college`, `other`
- 0 free text messages for `nhs_gp`

My local db after migration:
<img width="1049" alt="Screenshot 2024-03-20 at 16 50 24" src="https://github.com/alphagov/notifications-api/assets/20957548/7933c02e-4222-42de-8e88-a7eb63db1c29">
