### PR TITLE
Late-assign IDs to objects with history

### DIFF
--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -11,8 +11,6 @@ from app.models import ApiKey
 @autocommit
 @version_class(ApiKey)
 def save_model_api_key(api_key):
-    if not api_key.id:
-        api_key.id = uuid.uuid4()  # must be set now so version history model can use same id
     api_key.secret = uuid.uuid4()
     db.session.add(api_key)
 

--- a/app/dao/service_callback_api_dao.py
+++ b/app/dao/service_callback_api_dao.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from app import create_uuid, db
+from app import db
 from app.constants import COMPLAINT_CALLBACK_TYPE, DELIVERY_STATUS_CALLBACK_TYPE
 from app.dao.dao_utils import autocommit, version_class
 from app.models import ServiceCallbackApi
@@ -9,7 +9,6 @@ from app.models import ServiceCallbackApi
 @autocommit
 @version_class(ServiceCallbackApi)
 def save_service_callback_api(service_callback_api):
-    service_callback_api.id = create_uuid()
     service_callback_api.created_at = datetime.utcnow()
     db.session.add(service_callback_api)
 

--- a/app/dao/service_inbound_api_dao.py
+++ b/app/dao/service_inbound_api_dao.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from app import create_uuid, db
+from app import db
 from app.dao.dao_utils import autocommit, version_class
 from app.models import ServiceInboundApi
 
@@ -8,7 +8,6 @@ from app.models import ServiceInboundApi
 @autocommit
 @version_class(ServiceInboundApi)
 def save_service_inbound_api(service_inbound_api):
-    service_inbound_api.id = create_uuid()
     service_inbound_api.created_at = datetime.utcnow()
     db.session.add(service_inbound_api)
 

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -1,4 +1,3 @@
-import uuid
 from datetime import date, datetime, timedelta
 
 from flask import current_app
@@ -254,7 +253,6 @@ def dao_fetch_service_by_id_and_user(service_id, user_id):
 def dao_create_service(  # noqa: C901
     service,
     user,
-    service_id=None,
     service_permissions=None,
 ):
     if not user:
@@ -269,7 +267,6 @@ def dao_create_service(  # noqa: C901
 
     service.users.append(user)
     permission_dao.add_default_service_permissions_for_user(user, service)
-    service.id = service_id or uuid.uuid4()  # must be set now so version history model can use same id
     service.active = True
 
     for permission in service_permissions:

--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -1,4 +1,3 @@
-import uuid
 from datetime import datetime
 
 from flask import current_app
@@ -14,7 +13,6 @@ from app.models import Template, TemplateHistory, TemplateRedacted
 @autocommit
 @version_class(VersionOptions(Template, history_class=TemplateHistory))
 def dao_create_template(template):
-    template.id = uuid.uuid4()  # must be set now so version history model can use same id
     template.archived = False
 
     redacted_dict = {

--- a/app/history_meta.py
+++ b/app/history_meta.py
@@ -117,6 +117,7 @@ def create_history(obj, history_cls=None):
         if prop.key not in obj_state.dict:
             getattr(obj, prop.key)
 
+        # Ensure the object has an ID before creating the corresponding history object
         if prop.key == "id" and obj.id is None:
             obj.id = uuid.uuid4()
 

--- a/app/history_meta.py
+++ b/app/history_meta.py
@@ -15,6 +15,7 @@ session events.
 
 """
 import datetime
+import uuid
 
 from sqlalchemy import Column, Integer, Table, util
 from sqlalchemy.ext.declarative import declared_attr
@@ -115,6 +116,9 @@ def create_history(obj, history_cls=None):
         # be in the dict.  force it them load no matter what by using getattr().
         if prop.key not in obj_state.dict:
             getattr(obj, prop.key)
+
+        if prop.key == "id" and obj.id is None:
+            obj.id = uuid.uuid4()
 
         # if prop is a normal col just set it on history model
         if isinstance(prop, ColumnProperty):

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -79,7 +79,6 @@ def validate_parent_folder(template_json):
 @template_blueprint.route("", methods=["POST"])
 def create_template(service_id):
     fetched_service = dao_fetch_service_by_id(service_id=service_id)
-    # permissions needs to be placed here otherwise marshmallow will interfere with versioning
     permissions = [p.permission for p in fetched_service.permissions]
     template_json = validate(request.get_json(), post_create_template_schema)
     folder = validate_parent_folder(template_json=template_json)

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -895,6 +895,7 @@ def notify_service(notify_db_session, sample_user):
     service = Service.query.get(current_app.config["NOTIFY_SERVICE_ID"])
     if not service:
         service = Service(
+            id=current_app.config["NOTIFY_SERVICE_ID"],
             name="Notify Service",
             email_message_limit=1000,
             sms_message_limit=1000,
@@ -903,7 +904,7 @@ def notify_service(notify_db_session, sample_user):
             created_by=sample_user,
             prefix_sms=False,
         )
-        dao_create_service(service=service, service_id=current_app.config["NOTIFY_SERVICE_ID"], user=sample_user)
+        dao_create_service(service=service, user=sample_user)
 
         data = {
             "service": service,

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -151,10 +151,11 @@ def create_service(
             billing_reference=billing_reference,
             contact_link=contact_link,
         )
+        if service_id:
+            service.id = service_id
         dao_create_service(
             service,
             service.created_by,
-            service_id,
             service_permissions=service_permissions,
         )
 


### PR DESCRIPTION
Objects that have a corresponding `…History` object must have a value for their `id` property. This is how we know they are versions of the same object, because they have the same value for their primary key.

We assign the value of the `id` property in the DAO layer, for example:

https://github.com/alphagov/notifications-api/blob/492143312cd5ad75775f49c8fd7d3037370115fd/app/dao/templates_dao.py#L17

This is assumed to be the last code that is run before the object is persisted. If we didn’t do this then SQLAlchemy would generate the ID for us at the time we `commit`.

However there is a problem if – earlier in the process – the REST layer creates other objects which have a foreign key relationship to an object which has not been persisted.

What happens in this case is:
1. primary object gets created (without an ID)
2. secondary object gets created, forcing SQLAlchemy to give an ID to the primary object to define the foreign key relationship
3. SQLAlchemy autoflushes and commits the objects
3. primary object is passed to the DAO layer, where it is given a new ID
4. DAO layer re-commits the object, violating a foreign key constraint because the secondary object now refers to an ID which doesn’t exist

The way we have got around this is by triggering unrelated queries on a different object, which seems to prevent step 3 from happening, for example:
https://github.com/alphagov/notifications-api/blob/492143312cd5ad75775f49c8fd7d3037370115fd/app/template/rest.py#L82-L83

If the above lines are moved below this one then the `IntegrityError`s start happening, even though the two bits of code seem unrelated:
https://github.com/alphagov/notifications-api/blob/492143312cd5ad75775f49c8fd7d3037370115fd/app/template/rest.py#L86

***

This pull request moves the assigning of `id`s into the code which creates the history object.

This means that:
- it is done consistently in one place
- it is only done where objects don’t already have a `id`, so we never change an objects `id`

***

A less general purpose proof of concept – which might aid understanding – is shown in e03e5afb3fec75a967451fa1ded03b40f0ecb4af