### PR TITLE
Add unsubscribe link

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1438,6 +1438,15 @@ class Notification(db.Model):
 
     postage = db.Column(db.String, nullable=True)
 
+    unsubscribe_link = db.Column(db.String, nullable=True)
+
+    # unsubscribe_link value should be null for letters and sms
+    CheckConstraint(
+        "(notification_type != 'email' AND unsubscribe_link IS NULL) "
+        "OR (notification_type = 'email' AND unsubscribe_link IS NULL) "
+        "OR (notification_type = 'email' AND unsubscribe_link IS NOT NULL)"
+    )
+
     __table_args__ = (
         db.ForeignKeyConstraint(
             ["template_id", "template_version"],

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -113,6 +113,7 @@ def persist_notification(
     postage=None,
     document_download_count=None,
     updated_at=None,
+    unsubscribe_link=None,
 ):
     notification_created_at = created_at or datetime.utcnow()
     if not notification_id:
@@ -138,6 +139,7 @@ def persist_notification(
         billable_units=billable_units,
         document_download_count=document_download_count,
         updated_at=updated_at,
+        unsubscribe_link=unsubscribe_link,
     )
 
     if notification_type == SMS_TYPE:

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -1,3 +1,4 @@
+import validators
 from flask import current_app
 from gds_metrics.metrics import Histogram
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
@@ -289,3 +290,12 @@ def check_template_can_contain_documents(template_type, personalisation):
 
 def remap_phone_number_validation_messages(error_message):
     return PHONE_NUMBER_VALIDATION_ERROR_MAP.get(error_message, error_message)
+
+
+def validate_unsubscribe_link(url):
+    if not url:
+        return None
+    if validators.url(url):
+        return url
+    else:
+        raise ValidationError(message="The unsubscribe_link provided is an invalid url")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -635,6 +635,7 @@ class NotificationWithTemplateSchema(BaseSchema):
     created_at = FlexibleDateTime()
     updated_at = FlexibleDateTime()
     sent_at = FlexibleDateTime()
+    unsubscribe_link = fields.String()
 
     @pre_dump
     def add_api_key_name(self, in_data, **kwargs):

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -4,7 +4,7 @@ from app.constants import (
     NOTIFICATION_STATUS_TYPES,
     NOTIFICATION_TYPES,
 )
-from app.schema_validation.definitions import personalisation, uuid
+from app.schema_validation.definitions import https_url, personalisation, uuid
 
 template = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -202,6 +202,7 @@ post_email_request = {
         "personalisation": personalisation,
         "scheduled_for": {"type": ["string", "null"], "format": "datetime_within_next_day"},
         "email_reply_to_id": uuid,
+        "unsubscribe_link": https_url,
     },
     "required": ["email_address", "template_id"],
     "additionalProperties": False,

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0440_new_sms_allowance_n_rate
+0441_add_unsubscribe_link

--- a/migrations/versions/0441_add_unsubscribe_link.py
+++ b/migrations/versions/0441_add_unsubscribe_link.py
@@ -1,0 +1,31 @@
+"""
+
+Revision ID: 0441_add_unsubscribe_link
+Revises: 0440_new_sms_allowance_n_rate
+Create Date: 2024-03-25 14:38:54.618674
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0441_add_unsubscribe_link"
+down_revision = "0440_new_sms_allowance_n_rate"
+
+
+def upgrade():
+    op.add_column("notifications", sa.Column("unsubscribe_link", sa.String(), nullable=True))
+    op.create_check_constraint(
+        "ck_unsubscribe_link_is_null_for_letters_and_sms",
+        "notifications",
+        """
+        notification_type != 'email' AND unsubscribe_link IS NULL OR
+        notification_type = 'email' AND unsubscribe_link IS NULL OR
+        notification_type = 'email' AND unsubscribe_link IS NOT NULL
+
+        """,
+    )
+
+
+def downgrade():
+    op.drop_column("notifications", "unsubscribe_link")

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -33,6 +33,7 @@ from app.notifications.validators import (
     validate_address,
     validate_and_format_recipient,
     validate_template,
+    validate_unsubscribe_link,
 )
 from app.serialised_models import (
     SerialisedAPIKeyCollection,
@@ -700,3 +701,27 @@ def test_validate_address_international_bfpo_error(notify_db_session):
         validate_address(service, data)
 
     assert e.value.message == "The last line of a BFPO address must not be a country."
+
+
+@pytest.mark.parametrize(
+    "url, expected_result",
+    [
+        (None, None),
+        ("https://unsubscribelink.com/unsubscribe", "https://unsubscribelink.com/unsubscribe"),
+    ],
+)
+def test_validate_unsubscribe_link(url, expected_result):
+    assert validate_unsubscribe_link(url) == expected_result
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "www.https:/unsubscribelink.com",
+        "https:/unsubscribelink.com/unsubscribe",
+    ],
+)
+def test_test_validate_unsubscribe_link_raises_exception_for_invalid_url(url):
+    with pytest.raises(ValidationError) as e:
+        validate_unsubscribe_link(url)
+    assert e.value.message == "The unsubscribe_link provided is an invalid url"

--- a/tests/app/v2/notifications/test_notification_schemas.py
+++ b/tests/app/v2/notifications/test_notification_schemas.py
@@ -213,12 +213,22 @@ valid_post_email_json_with_optionals = {
     "template_id": str(uuid.uuid4()),
     "reference": "reference from caller",
     "personalisation": {"key": "value"},
+    "unsubscribe_link": "https://unsubscribelink.com/unsubscribe",
 }
 
 
 @pytest.mark.parametrize("input", [valid_post_email_json, valid_post_email_json_with_optionals])
 def test_post_email_schema_is_valid(input):
     assert validate(input, post_email_request_schema) == input
+
+
+def test_post_email_schema_invalid_unsubscribe_link():
+    input = valid_post_email_json_with_optionals
+    input["unsubscribe_link"] = "www.unsubscribe_link.com/unsubscribe"
+    with pytest.raises(ValidationError) as e:
+        validate(input, post_email_request_schema)
+    errors = json.loads(str(e.value)).get("errors")
+    assert {"error": "ValidationError", "message": "unsubscribe_link is not a valid https url"} in errors
 
 
 def test_post_email_schema_bad_uuid_and_missing_email_address():


### PR DESCRIPTION
This adds an `unsubscribe_link` field to our email notifications as described in [this](https://github.com/alphagov/notifications-python-client/pull/241) card