### PR TITLE
remove use of `NOTIFY_RUNTIME_PLATFORM` & `NOTIFY_LOG_PATH` flask config parameters

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -118,7 +118,6 @@ class Config(object):
     DEBUG = False
     NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH")
 
-    NOTIFY_RUNTIME_PLATFORM = os.getenv("NOTIFY_RUNTIME_PLATFORM", "ecs")
     NOTIFY_REQUEST_LOG_LEVEL = os.getenv("NOTIFY_REQUEST_LOG_LEVEL", "INFO")
 
     # Cronitor

--- a/app/config.py
+++ b/app/config.py
@@ -116,7 +116,6 @@ class Config(object):
 
     # Logging
     DEBUG = False
-    NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH")
 
     NOTIFY_REQUEST_LOG_LEVEL = os.getenv("NOTIFY_REQUEST_LOG_LEVEL", "INFO")
 
@@ -476,7 +475,6 @@ class Development(Config):
     MMG_INBOUND_SMS_USERNAME = ["username"]
 
     NOTIFY_ENVIRONMENT = "development"
-    NOTIFY_LOG_PATH = "application.log"
     NOTIFY_EMAIL_DOMAIN = "notify.tools"
 
     SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI", "postgresql://localhost/notification_api")

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ lxml==4.9.3
 
 notifications-python-client==8.0.1
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -154,7 +154,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
https://trello.com/c/kuPbusFR/724-check-if-we-should-and-then-remove-notifyruntimeplatform-functionality

~Depends on https://github.com/alphagov/notifications-utils/pull/1109 (though actually doesn't technically require it)~