### PR TITLE
entrypoint.sh: set `CONCURRENCY` of 12 for `api-worker-sender`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-#Cater for specific concurrency level
-if [ "$1" == "api-worker-periodic" ] || [ "$1" == "api-worker-broadcasts" ]
-then
+# Cater for specific concurrency level
+if [ "$1" == "api-worker-periodic" ] || [ "$1" == "api-worker-broadcasts" ] ; then
   CONCURRENCY=2
-elif [ "$1" == "api-worker-sender-letters" ]
-then
+elif [ "$1" == "api-worker-sender-letters" ] ; then
+  CONCURRENCY=3
+elif [ "$1" == "api-worker-sender-letters" ] ; then
   CONCURRENCY=3
 else
   CONCURRENCY=4

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,8 @@ elif [ "$1" == "api-worker-sender-letters" ] ; then
   CONCURRENCY=3
 elif [ "$1" == "api-worker-sender-letters" ] ; then
   CONCURRENCY=3
+elif [ "$1" == "api-worker-sender" ] ; then
+  CONCURRENCY=12
 else
   CONCURRENCY=4
 fi


### PR DESCRIPTION
https://trello.com/c/o5DyzyFT/740-investigate-performance-of-messages-sent-within-10-seconds

They don't use much memory and spend most their time waiting for responses from calls to providers. These instances rarely even hit 20% memory usage at the moment.

With the CPU autoscaling trigger kept as it is, we should still autoscale to a similar number of instances for a given load, but cases of immediate demand, this should make the existing instances able to take on more load until the new instances have started.