### PR TITLE
Bump utils to 76.0.2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ lxml==4.9.3
 
 notifications-python-client==8.0.1
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.2
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,11 +101,11 @@ gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6
 govuk-bank-holidays==0.11
     # via notifications-utils
 greenlet==3.0.3
-    # via
-    #   eventlet
-    #   sqlalchemy
+    # via eventlet
 gunicorn[eventlet] @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   notifications-utils
 idna==3.4
     # via
     #   jsonschema
@@ -154,7 +154,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.2
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
 ## 76.0.2

* linting changes

 ## 76.0.1

* Reject Gibraltar’s postcode (`GX11 1AA`) when validating postal addresses

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/76.0.0...76.0.2