### PR TITLE
Fix check to see if migrations should run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,24 +109,6 @@ clean:
 
 ## DEPLOYMENT
 
-.PHONY: preview
-preview: ## Set environment to preview
-	$(eval export DEPLOY_ENV=preview)
-	$(eval export DNS_NAME="notify.works")
-	@true
-
-.PHONY: staging
-staging: ## Set environment to staging
-	$(eval export DEPLOY_ENV=staging)
-	$(eval export DNS_NAME="staging-notify.works")
-	@true
-
-.PHONY: production
-production: ## Set environment to production
-	$(eval export DEPLOY_ENV=production)
-	$(eval export DNS_NAME="notifications.service.gov.uk")
-	@true
-
 .PHONY: check-if-migrations-to-run
 check-if-migrations-to-run:
 	@echo $(shell python3 scripts/check_if_new_migration.py)

--- a/Makefile
+++ b/Makefile
@@ -129,4 +129,4 @@ production: ## Set environment to production
 
 .PHONY: check-if-migrations-to-run
 check-if-migrations-to-run:
-	@echo $(shell API_HOST_NAME=https://api.${DNS_NAME} python3 scripts/check_if_new_migration.py)
+	@echo $(shell python3 scripts/check_if_new_migration.py)


### PR DESCRIPTION
`API_HOST_NAME` is set to the full URL in the Concourse pipelines, so it is already in a format like `https://api.notify.works`. By setting it to `API_HOST_NAME=https://api.${DNS_NAME}` we were ending up with it being set to `https://api./_status`, and the check to see if migrations should run was always returning true.