### PR TITLE
Add link to re-request invite to join service receipt email

### DIFF
--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -136,6 +136,7 @@ def request_invite_to_service(service_id, user_to_invite_id):
     reason_for_request = request_json["reason"]
     invite_link_host = request_json["invite_link_host"]
     accept_invite_request_url = f"{invite_link_host}/services/{service.id}/users/invite/{user_requesting_invite.id}"
+    request_again_url = f"{invite_link_host}/services/{service.id}/join"
 
     if user_requesting_invite.services and service in user_requesting_invite.services:
         raise BadRequestError(400, "user-already-in-service")
@@ -148,6 +149,7 @@ def request_invite_to_service(service_id, user_to_invite_id):
         user_requesting_invite,
         service=service,
         recipients_of_invite_request=recipients_of_invite_request,
+        request_again_url=request_again_url,
     )
 
     return {}, 204
@@ -199,7 +201,13 @@ def send_service_invite_request(
         raise BadRequestError(400, "no-valid-service-managers-ids")
 
 
-def send_receipt_after_sending_request_invite_letter(user_requesting_invite, *, service, recipients_of_invite_request):
+def send_receipt_after_sending_request_invite_letter(
+    user_requesting_invite,
+    *,
+    service,
+    recipients_of_invite_request,
+    request_again_url,
+):
     template_id = current_app.config["RECEIPT_FOR_REQUEST_INVITE_TO_SERVICE_TEMPLATE_ID"]
     template = dao_get_template_by_id(template_id)
     notify_service = Service.query.get(current_app.config["NOTIFY_SERVICE_ID"])
@@ -213,6 +221,7 @@ def send_receipt_after_sending_request_invite_letter(user_requesting_invite, *, 
             "name": user_requesting_invite.name,
             "service name": service.name,
             "service admin names": [user.name for user in recipients_of_invite_request],
+            "request again url": request_again_url,
         },
         notification_type=template.template_type,
         api_key_id=None,

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -220,7 +220,7 @@ def send_receipt_after_sending_request_invite_letter(
         personalisation={
             "name": user_requesting_invite.name,
             "service name": service.name,
-            "service admin names": [user.name for user in recipients_of_invite_request],
+            "service admin names": [f"{user.name} – {user.email_address}" for user in recipients_of_invite_request],
             "request again url": request_again_url,
         },
         notification_type=template.template_type,

--- a/tests/app/service_invite/test_service_invite_rest.py
+++ b/tests/app/service_invite/test_service_invite_rest.py
@@ -326,9 +326,9 @@ def test_request_invite_to_service_email_is_sent_to_valid_service_managers(
     # service manager. Expected behaviour is that notifications will be sent only to the valid service managers.
     mocked = mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
     user_requesting_invite = create_user()
-    service_manager_1 = create_user(name="Manager 1")
-    service_manager_2 = create_user(name="Manager 2")
-    service_manager_3 = create_user(name="Manager 3")
+    service_manager_1 = create_user(name="Manager 1", email_address="manager.1@example.gov.uk")
+    service_manager_2 = create_user(name="Manager 2", email_address="manager.2@example.gov.uk")
+    service_manager_3 = create_user(name="Manager 3", email_address="manager.3@example.gov.uk")
     another_service = create_service(service_name="Another Service")
     service_manager_1.services = [sample_service]
     service_manager_2.services = [sample_service]
@@ -380,9 +380,9 @@ def test_request_invite_to_service_email_is_sent_to_valid_service_managers(
         "name": user_requesting_invite.name,
         "service name": "Sample service",
         "service admin names": [
-            service_manager_1.name,
-            service_manager_2.name,
-            service_manager_3.name,
+            "Manager 1 – manager.1@example.gov.uk",
+            "Manager 2 – manager.2@example.gov.uk",
+            "Manager 3 – manager.3@example.gov.uk",
         ],
         "request again url": f"{invite_link_host}/services/{sample_service.id}/join",
     }

--- a/tests/app/service_invite/test_service_invite_rest.py
+++ b/tests/app/service_invite/test_service_invite_rest.py
@@ -384,6 +384,7 @@ def test_request_invite_to_service_email_is_sent_to_valid_service_managers(
             service_manager_2.name,
             service_manager_3.name,
         ],
+        "request again url": f"{invite_link_host}/services/{sample_service.id}/join",
     }
     assert user_notification.reply_to_text == "notify@gov.uk"
 


### PR DESCRIPTION
If someone isn’t getting a response to their request they could try:
- requesting again
- asking a different team member

This pull request adds a link to the personalisation in the receipt email which will let them do this.

It doesn’t change the text of the email itself since that isn’t version controlled.