### PR TITLE
Stop checking proxy header before requests

### DIFF
--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -14,7 +14,6 @@ from notifications_python_client.errors import (
     TokenExpiredError,
     TokenIssuerError,
 )
-from notifications_utils import request_helper
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.serialised_models import SerialisedService
@@ -68,7 +67,6 @@ def requires_internal_auth(expected_client_id):
     if expected_client_id not in current_app.config.get("INTERNAL_CLIENT_API_KEYS"):
         raise TypeError("Unknown client_id for internal auth")
 
-    request_helper.check_proxy_header_before_request()
     auth_token = _get_auth_token(request)
     client_id = _get_token_issuer(auth_token)
 
@@ -85,8 +83,6 @@ def requires_internal_auth(expected_client_id):
 
 
 def requires_auth():
-    request_helper.check_proxy_header_before_request()
-
     auth_token = _get_auth_token(request)
     issuer = _get_token_issuer(auth_token)  # ie the `iss` claim which should be a service ID
 

--- a/app/config.py
+++ b/app/config.py
@@ -149,8 +149,6 @@ class Config(object):
     MAX_VERIFY_CODE_COUNT = 5
     MAX_FAILED_LOGIN_COUNT = 10
 
-    CHECK_PROXY_HEADER = False
-
     # these should always add up to 100%
     SMS_PROVIDER_RESTING_POINTS = {"mmg": 51, "firetext": 49}
 
@@ -399,8 +397,6 @@ class Config(object):
     MMG_INBOUND_SMS_AUTH = json.loads(os.environ.get("MMG_INBOUND_SMS_AUTH", "[]"))
     MMG_INBOUND_SMS_USERNAME = json.loads(os.environ.get("MMG_INBOUND_SMS_USERNAME", "[]"))
     LOW_INBOUND_SMS_NUMBER_THRESHOLD = 50
-    ROUTE_SECRET_KEY_1 = os.environ.get("ROUTE_SECRET_KEY_1", "")
-    ROUTE_SECRET_KEY_2 = os.environ.get("ROUTE_SECRET_KEY_2", "")
 
     HIGH_VOLUME_SERVICE = json.loads(os.environ.get("HIGH_VOLUME_SERVICE", "[]"))
 
@@ -552,7 +548,6 @@ class Preview(Config):
     S3_BUCKET_LETTER_SANITISE = "preview-letters-sanitise"
     FROM_NUMBER = "preview"
     API_RATE_LIMIT_ENABLED = True
-    CHECK_PROXY_HEADER = False
     DVLA_API_TLS_CIPHERS = os.environ.get("DVLA_API_TLS_CIPHERS", "must-supply-tls-ciphers")
 
 
@@ -570,7 +565,6 @@ class Staging(Config):
     S3_BUCKET_LETTER_SANITISE = "staging-letters-sanitise"
     FROM_NUMBER = "stage"
     API_RATE_LIMIT_ENABLED = True
-    CHECK_PROXY_HEADER = False if os.environ.get("CHECK_PROXY_HEADER") == "0" else True
     DVLA_API_TLS_CIPHERS = os.environ.get("DVLA_API_TLS_CIPHERS", "must-supply-tls-ciphers")
 
 
@@ -588,7 +582,6 @@ class Production(Config):
     S3_BUCKET_LETTER_SANITISE = "production-letters-sanitise"
     FROM_NUMBER = "GOVUK"
     API_RATE_LIMIT_ENABLED = True
-    CHECK_PROXY_HEADER = False if os.environ.get("CHECK_PROXY_HEADER") == "0" else True
     SES_STUB_URL = None
 
     CRONITOR_ENABLED = True

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -312,18 +312,6 @@ def test_requires_auth_should_cache_service_and_api_key_lookups(mocker, client, 
     mock_get_service.assert_called_once()
 
 
-def test_requires_internal_auth_checks_proxy_key(
-    client,
-    mocker,
-    internal_jwt_token,
-):
-    proxy_check_mock = mocker.patch("app.authentication.auth.request_helper.check_proxy_header_before_request")
-
-    request.headers = {"Authorization": "Bearer {}".format(internal_jwt_token)}
-    requires_my_internal_app_auth()
-    proxy_check_mock.assert_called_once()
-
-
 def test_requires_internal_auth_errors_for_unknown_app(client):
     with pytest.raises(TypeError) as exc:
         requires_internal_auth("another-app")


### PR DESCRIPTION
https://trello.com/c/wZF8EJLW/706-see-if-we-should-remove-the-checkproxyheader-code-from-our-apps-and-remove-it

This removes the check for the proxy header that was used to stop people accessing the apps via CloudFront when deployed on the PaaS. We can also get rid of the environment variables that were used for the check.