### PR TITLE
Drop unused index on letter despatch cost threshold

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0442_add_new_service_permission
+0443_drop_ix_letter_cost

--- a/migrations/versions/0443_drop_ix_letter_cost.py
+++ b/migrations/versions/0443_drop_ix_letter_cost.py
@@ -1,0 +1,33 @@
+"""
+
+Revision ID: 0443_drop_ix_letter_cost
+Revises: 0442_add_new_service_permission
+Create Date: 2023-09-17 15:17:58.545277
+
+"""
+
+from alembic import op
+
+
+revision = "0443_drop_ix_letter_cost"
+down_revision = "0442_add_new_service_permission"
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_notifications_letter_despatch_cost_threshold",
+            table_name="notifications_letter_despatch",
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_notifications_letter_despatch_cost_threshold",
+            "notifications_letter_despatch",
+            ["cost_threshold"],
+            unique=False,
+            postgresql_concurrently=True,
+        )


### PR DESCRIPTION
We did an audit of indexes in our database and found that some of them have not been used at all.

Here is the list of all unused insexes: https://docs.google.com/spreadsheets/d/1Eqfze5WTXM4LDIFDqPcfQ_7axnaodC0zzOz5eFmCU-U/edit?usp=sharing (look at 2nd tab)

In this PR I am removing one of those indexes, just to cautiously dip a toe. If that goes well, we will remove all the rest of them.

More context about decision to remove unused indexes is explained in this blog post: https://www.cybertec-postgresql.com/en/get-rid-of-your-unused-indexes/