### PR TITLE
Remove 9 biggest remaining unused indexes

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -107,7 +107,7 @@ class User(db.Model):
     state = db.Column(db.String, nullable=False, default="pending")
     platform_admin = db.Column(db.Boolean, nullable=False, default=False)
     current_session_id = db.Column(UUID(as_uuid=True), nullable=True)
-    auth_type = db.Column(db.String, db.ForeignKey("auth_type.name"), index=True, nullable=False, default=SMS_AUTH_TYPE)
+    auth_type = db.Column(db.String, db.ForeignKey("auth_type.name"), nullable=False, default=SMS_AUTH_TYPE)
     email_access_validated_at = db.Column(
         db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow
     )
@@ -922,7 +922,7 @@ class ApiKey(db.Model, Versioned):
     _secret = db.Column("secret", db.String(255), unique=True, nullable=False)
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), index=True, nullable=False)
     service = db.relationship("Service", backref="api_keys")
-    key_type = db.Column(db.String(255), db.ForeignKey("key_types.name"), index=True, nullable=False)
+    key_type = db.Column(db.String(255), db.ForeignKey("key_types.name"), nullable=False)
     expiry_date = db.Column(db.DateTime)
     created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.datetime.utcnow)

--- a/app/models.py
+++ b/app/models.py
@@ -93,7 +93,7 @@ class User(db.Model):
     __tablename__ = "users"
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    name = db.Column(db.String, nullable=False, index=True, unique=False)
+    name = db.Column(db.String, nullable=False, unique=False)
     email_address = db.Column(db.String(255), nullable=False, index=True, unique=True)
     created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.datetime.utcnow)
@@ -1857,7 +1857,7 @@ class InboundSms(db.Model):
 class InboundSmsHistory(db.Model):
     __tablename__ = "inbound_sms_history"
     id = db.Column(UUID(as_uuid=True), primary_key=True)
-    created_at = db.Column(db.DateTime, index=True, unique=False, nullable=False)
+    created_at = db.Column(db.DateTime, unique=False, nullable=False)
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), index=True, unique=False)
     service = db.relationship("Service")
     notify_number = db.Column(db.String, nullable=False)
@@ -1949,7 +1949,7 @@ class DailySortedLetter(db.Model):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     billing_day = db.Column(db.Date, nullable=False, index=True)
-    file_name = db.Column(db.String, nullable=True, index=True)
+    file_name = db.Column(db.String, nullable=True)
     unsorted_count = db.Column(db.Integer, nullable=False, default=0)
     sorted_count = db.Column(db.Integer, nullable=False, default=0)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0445_drop_unused_indexes_1
+0446_drop_unused_indexes_2

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0444_user_features_email_column
+0445_drop_unused_indexes_1

--- a/migrations/versions/0445_drop_unused_indexes_1.py
+++ b/migrations/versions/0445_drop_unused_indexes_1.py
@@ -1,0 +1,91 @@
+"""
+
+Revision ID: 0445_drop_unused_indexes_1
+Revises: 0444_user_features_email_column
+Create Date: 2024-05-14 11:35:58.545277
+
+"""
+
+from alembic import op
+
+
+revision = "0445_drop_unused_indexes_1"
+down_revision = "0444_user_features_email_column"
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        # 1
+        op.drop_index(
+            "ix_inbound_sms_history_created_at",
+            table_name="inbound_sms_history",
+            postgresql_concurrently=True,
+        )
+        # 2
+        op.drop_index(
+            "ix_users_name",
+            table_name="users",
+            postgresql_concurrently=True,
+        )
+        # 3
+        op.drop_index(
+            "ix_services_history_created_by_id",
+            table_name="services_history",
+            postgresql_concurrently=True,
+        )
+        # 4
+        op.drop_index(
+            "ix_services_history_organisation_id",
+            table_name="services_history",
+            postgresql_concurrently=True,
+        )
+        # 5
+        op.drop_index(
+            "ix_daily_sorted_letter_file_name",
+            table_name="daily_sorted_letter",
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        # 1
+        op.create_index(
+            "ix_inbound_sms_history_created_at",
+            "inbound_sms_history",
+            ["created_at"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+        # 2
+        op.create_index(
+            "ix_users_name",
+            "users",
+            ["name"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+        # 3
+        op.create_index(
+            "ix_services_history_created_by_id",
+            "services_history",
+            ["created_by_id"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+        # 4
+        op.create_index(
+            "ix_services_history_organisation_id",
+            "services_history",
+            ["organisation_id"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+        # 5
+        op.create_index(
+            "ix_daily_sorted_letter_file_name",
+            "daily_sorted_letter",
+            ["file_name"],
+            unique=False,
+            postgresql_concurrently=True,
+        )

--- a/migrations/versions/0445_drop_unused_indexes_1.py
+++ b/migrations/versions/0445_drop_unused_indexes_1.py
@@ -29,13 +29,13 @@ def upgrade():
         )
         # 3
         op.drop_index(
-            "ix_services_history_created_by_id",
+            "ix_services_history_created_by_id",  # can't remove index from model as this is based on services table
             table_name="services_history",
             postgresql_concurrently=True,
         )
         # 4
         op.drop_index(
-            "ix_services_history_organisation_id",
+            "ix_services_history_organisation_id",  # can't remove index from model as this is based on services table
             table_name="services_history",
             postgresql_concurrently=True,
         )

--- a/migrations/versions/0446_drop_unused_indexes_2.py
+++ b/migrations/versions/0446_drop_unused_indexes_2.py
@@ -1,0 +1,77 @@
+"""
+
+Revision ID: 0446_drop_unused_indexes_2
+Revises: 0445_drop_unused_indexes_1
+Create Date: 2023-09-17 15:17:58.545277
+
+"""
+
+from alembic import op
+
+
+revision = "0446_drop_unused_indexes_2"
+down_revision = "0445_drop_unused_indexes_1"
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        # 6
+        op.drop_index(
+            "ix_users_auth_type",
+            table_name="users",
+            postgresql_concurrently=True,
+        )
+        # 7
+        op.drop_index(
+            "ix_api_keys_history_created_by_id",
+            table_name="api_keys_history",
+            postgresql_concurrently=True,
+        )
+        # 8
+        op.drop_index(
+            "ix_api_keys_history_key_type",
+            table_name="api_keys_history",
+            postgresql_concurrently=True,
+        )
+        # 9
+        op.drop_index(
+            "ix_api_keys_key_type",
+            table_name="api_keys",
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        # 6
+        op.create_index(
+            "ix_users_auth_type",
+            "users",
+            ["auth_type"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+        # 7
+        op.create_index(
+            "ix_api_keys_history_created_by_id",
+            "api_keys_history",
+            ["created_by_id"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+        # 8
+        op.create_index(
+            "ix_api_keys_history_key_type",
+            "api_keys_history",
+            ["key_type"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+        # 9
+        op.create_index(
+            "ix_api_keys_key_type",
+            "api_keys",
+            ["key_type"],
+            unique=False,
+            postgresql_concurrently=True,
+        )

--- a/migrations/versions/0446_drop_unused_indexes_2.py
+++ b/migrations/versions/0446_drop_unused_indexes_2.py
@@ -23,7 +23,7 @@ def upgrade():
         )
         # 7
         op.drop_index(
-            "ix_api_keys_history_created_by_id",
+            "ix_api_keys_history_created_by_id",  # can't remove index from model as this is based on api_keys table
             table_name="api_keys_history",
             postgresql_concurrently=True,
         )


### PR DESCRIPTION
I divided them into two migration files for better readability.

Info on droping many indexes at once concurrently: https://dba.stackexchange.com/questions/319720/multiple-drop-index-concurrently-running-on-the-same-table-in-postgres

Here is the list of all unused indexes: https://docs.google.com/spreadsheets/d/1Eqfze5WTXM4LDIFDqPcfQ_7axnaodC0zzOz5eFmCU-U/edit?usp=sharing

Why it's good to remove unused indexes: https://www.cybertec-postgresql.com/en/get-rid-of-your-unused-indexes/