### PR TITLE
Move to using SES v2 API

### DIFF
--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -65,17 +65,14 @@ class AwsSesClient(EmailClient):
     def name(self):
         return "ses"
 
-    def send_email(self, source, to_addresses, subject, body, html_body="", reply_to_address=None):
+    def send_email(self, source, to_addresses, subject, *, body, html_body, reply_to_address=None):
         try:
             if isinstance(to_addresses, str):
                 to_addresses = [to_addresses]
 
             reply_to_addresses = [reply_to_address] if reply_to_address else []
 
-            body = {"Text": {"Data": body}}
-
-            if html_body:
-                body.update({"Html": {"Data": html_body}})
+            body = {"Text": {"Data": body}, "Html": {"Data": html_body}}
 
             start_time = monotonic()
             response = self._client.send_email(

--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -1,4 +1,5 @@
 from time import monotonic
+from typing import Optional
 
 import boto3
 import botocore
@@ -65,20 +66,26 @@ class AwsSesClient(EmailClient):
     def name(self):
         return "ses"
 
-    def send_email(self, source, to_addresses, subject, *, body, html_body, reply_to_address=None):
+    def send_email(
+        self,
+        *,
+        from_address: str,
+        to_address: str,
+        subject: str,
+        body: str,
+        html_body: str,
+        reply_to_address: Optional[str] = None,
+    ) -> str:
         try:
-            if isinstance(to_addresses, str):
-                to_addresses = [to_addresses]
-
             reply_to_addresses = [reply_to_address] if reply_to_address else []
 
             body = {"Text": {"Data": body}, "Html": {"Data": html_body}}
 
             start_time = monotonic()
             response = self._client.send_email(
-                Source=source,
+                Source=from_address,
                 Destination={
-                    "ToAddresses": [punycode_encode_email(addr) for addr in to_addresses],
+                    "ToAddresses": [punycode_encode_email(to_address)],
                     "CcAddresses": [],
                     "BccAddresses": [],
                 },

--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -58,7 +58,7 @@ class AwsSesClient(EmailClient):
     """
 
     def init_app(self, region, statsd_client, *args, **kwargs):
-        self._client = boto3.client("ses", region_name=region)
+        self._client = boto3.client("sesv2", region_name=region)
         super(AwsSesClient, self).__init__(*args, **kwargs)
         self.statsd_client = statsd_client
 
@@ -85,17 +85,17 @@ class AwsSesClient(EmailClient):
 
         try:
             response = self._client.send_email(
-                Source=from_address,
+                FromEmailAddress=from_address,
                 Destination={
                     "ToAddresses": to_addresses,
                     "CcAddresses": [],
                     "BccAddresses": [],
                 },
-                Message={
-                    "Subject": {
-                        "Data": subject,
+                Content={
+                    "Simple": {
+                        "Subject": {"Data": subject},
+                        "Body": body,
                     },
-                    "Body": body,
                 },
                 ReplyToAddresses=reply_to_addresses,
             )

--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -74,7 +74,7 @@ class AwsSesClient(EmailClient):
         subject: str,
         body: str,
         html_body: str,
-        reply_to_address: Optional[str] = None,
+        reply_to_address: Optional[str],
     ) -> str:
         try:
             reply_to_addresses = [reply_to_address] if reply_to_address else []

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -134,9 +134,9 @@ def send_email_to_provider(notification):
             )
 
             reference = provider.send_email(
-                from_address,
-                notification.normalised_to,
-                plain_text_email.subject,
+                from_address=from_address,
+                to_address=notification.normalised_to,
+                subject=plain_text_email.subject,
                 body=str(plain_text_email),
                 html_body=str(html_email),
                 reply_to_address=notification.reply_to_text,

--- a/tests/app/clients/test_aws_ses.py
+++ b/tests/app/clients/test_aws_ses.py
@@ -80,7 +80,12 @@ def test_send_email_handles_punycode_to_address(notify_api, mocker):
 
     with notify_api.app_context():
         aws_ses_client.send_email(
-            from_address=Mock(), to_address="føøøø@bååååår.com", subject=Mock(), body=Mock(), html_body=Mock()
+            from_address=Mock(),
+            to_address="føøøø@bååååår.com",
+            subject=Mock(),
+            body=Mock(),
+            html_body=Mock(),
+            reply_to_address=None,
         )
 
     boto_mock.send_email.assert_called_once_with(
@@ -107,6 +112,7 @@ def test_send_email_raises_invalid_parameter_value_error_as_EmailClientNonRetrya
             subject=Mock(),
             body=Mock(),
             html_body=Mock(),
+            reply_to_address=None,
         )
 
     assert "some error message from amazon" in str(excinfo.value)
@@ -120,7 +126,12 @@ def test_send_email_raises_send_rate_throttling_as_AwsSesClientThrottlingSendRat
 
     with pytest.raises(AwsSesClientThrottlingSendRateException):
         aws_ses_client.send_email(
-            from_address=Mock(), to_address="foo@bar.com", subject=Mock(), body=Mock(), html_body=Mock()
+            from_address=Mock(),
+            to_address="foo@bar.com",
+            subject=Mock(),
+            body=Mock(),
+            html_body=Mock(),
+            reply_to_address=None,
         )
 
 
@@ -132,7 +143,12 @@ def test_send_email_does_not_raise_AwsSesClientThrottlingSendRateException_if_no
 
     with pytest.raises(AwsSesClientException):
         aws_ses_client.send_email(
-            from_address=Mock(), to_address="foo@bar.com", subject=Mock(), body=Mock(), html_body=Mock()
+            from_address=Mock(),
+            to_address="foo@bar.com",
+            subject=Mock(),
+            body=Mock(),
+            html_body=Mock(),
+            reply_to_address=None,
         )
 
 
@@ -147,7 +163,12 @@ def test_send_email_raises_other_errs_as_AwsSesClientException(mocker):
 
     with pytest.raises(AwsSesClientException) as excinfo:
         aws_ses_client.send_email(
-            from_address=Mock(), to_address="foo@bar.com", subject=Mock(), body=Mock(), html_body=Mock()
+            from_address=Mock(),
+            to_address="foo@bar.com",
+            subject=Mock(),
+            body=Mock(),
+            html_body=Mock(),
+            reply_to_address=None,
         )
 
     assert "some error message from amazon" in str(excinfo.value)

--- a/tests/app/clients/test_aws_ses.py
+++ b/tests/app/clients/test_aws_ses.py
@@ -61,8 +61,8 @@ def test_send_email_handles_reply_to_address(notify_api, mocker, reply_to_addres
 
     with notify_api.app_context():
         aws_ses_client.send_email(
-            source=Mock(),
-            to_addresses="to@address.com",
+            from_address=Mock(),
+            to_address="to@address.com",
             subject=Mock(),
             body=Mock(),
             html_body=Mock(),
@@ -80,7 +80,7 @@ def test_send_email_handles_punycode_to_address(notify_api, mocker):
 
     with notify_api.app_context():
         aws_ses_client.send_email(
-            Mock(), to_addresses="føøøø@bååååår.com", subject=Mock(), body=Mock(), html_body=Mock()
+            from_address=Mock(), to_address="føøøø@bååååår.com", subject=Mock(), body=Mock(), html_body=Mock()
         )
 
     boto_mock.send_email.assert_called_once_with(
@@ -102,8 +102,8 @@ def test_send_email_raises_invalid_parameter_value_error_as_EmailClientNonRetrya
 
     with pytest.raises(EmailClientNonRetryableException) as excinfo:
         aws_ses_client.send_email(
-            source=Mock(),
-            to_addresses="definitely@invalid_email.com",
+            from_address=Mock(),
+            to_address="definitely@invalid_email.com",
             subject=Mock(),
             body=Mock(),
             html_body=Mock(),
@@ -120,7 +120,7 @@ def test_send_email_raises_send_rate_throttling_as_AwsSesClientThrottlingSendRat
 
     with pytest.raises(AwsSesClientThrottlingSendRateException):
         aws_ses_client.send_email(
-            source=Mock(), to_addresses="foo@bar.com", subject=Mock(), body=Mock(), html_body=Mock()
+            from_address=Mock(), to_address="foo@bar.com", subject=Mock(), body=Mock(), html_body=Mock()
         )
 
 
@@ -132,7 +132,7 @@ def test_send_email_does_not_raise_AwsSesClientThrottlingSendRateException_if_no
 
     with pytest.raises(AwsSesClientException):
         aws_ses_client.send_email(
-            source=Mock(), to_addresses="foo@bar.com", subject=Mock(), body=Mock(), html_body=Mock()
+            from_address=Mock(), to_address="foo@bar.com", subject=Mock(), body=Mock(), html_body=Mock()
         )
 
 
@@ -147,7 +147,7 @@ def test_send_email_raises_other_errs_as_AwsSesClientException(mocker):
 
     with pytest.raises(AwsSesClientException) as excinfo:
         aws_ses_client.send_email(
-            source=Mock(), to_addresses="foo@bar.com", subject=Mock(), body=Mock(), html_body=Mock()
+            from_address=Mock(), to_address="foo@bar.com", subject=Mock(), body=Mock(), html_body=Mock()
         )
 
     assert "some error message from amazon" in str(excinfo.value)

--- a/tests/app/clients/test_aws_ses.py
+++ b/tests/app/clients/test_aws_ses.py
@@ -70,7 +70,7 @@ def test_send_email_handles_reply_to_address(notify_api, mocker, reply_to_addres
         )
 
     boto_mock.send_email.assert_called_once_with(
-        Source=ANY, Destination=ANY, Message=ANY, ReplyToAddresses=expected_value
+        FromEmailAddress=ANY, Destination=ANY, Content=ANY, ReplyToAddresses=expected_value
     )
 
 
@@ -89,9 +89,9 @@ def test_send_email_handles_punycode_to_address(notify_api, mocker):
         )
 
     boto_mock.send_email.assert_called_once_with(
-        Source=ANY,
+        FromEmailAddress=ANY,
         Destination={"ToAddresses": ["føøøø@xn--br-yiaaaaa.com"], "CcAddresses": [], "BccAddresses": []},
-        Message=ANY,
+        Content=ANY,
         ReplyToAddresses=ANY,
     )
 

--- a/tests/app/clients/test_aws_ses.py
+++ b/tests/app/clients/test_aws_ses.py
@@ -61,7 +61,12 @@ def test_send_email_handles_reply_to_address(notify_api, mocker, reply_to_addres
 
     with notify_api.app_context():
         aws_ses_client.send_email(
-            source=Mock(), to_addresses="to@address.com", subject=Mock(), body=Mock(), reply_to_address=reply_to_address
+            source=Mock(),
+            to_addresses="to@address.com",
+            subject=Mock(),
+            body=Mock(),
+            html_body=Mock(),
+            reply_to_address=reply_to_address,
         )
 
     boto_mock.send_email.assert_called_once_with(
@@ -74,7 +79,9 @@ def test_send_email_handles_punycode_to_address(notify_api, mocker):
     mocker.patch.object(aws_ses_client, "statsd_client", create=True)
 
     with notify_api.app_context():
-        aws_ses_client.send_email(Mock(), to_addresses="føøøø@bååååår.com", subject=Mock(), body=Mock())
+        aws_ses_client.send_email(
+            Mock(), to_addresses="føøøø@bååååår.com", subject=Mock(), body=Mock(), html_body=Mock()
+        )
 
     boto_mock.send_email.assert_called_once_with(
         Source=ANY,
@@ -95,7 +102,11 @@ def test_send_email_raises_invalid_parameter_value_error_as_EmailClientNonRetrya
 
     with pytest.raises(EmailClientNonRetryableException) as excinfo:
         aws_ses_client.send_email(
-            source=Mock(), to_addresses="definitely@invalid_email.com", subject=Mock(), body=Mock()
+            source=Mock(),
+            to_addresses="definitely@invalid_email.com",
+            subject=Mock(),
+            body=Mock(),
+            html_body=Mock(),
         )
 
     assert "some error message from amazon" in str(excinfo.value)
@@ -108,7 +119,9 @@ def test_send_email_raises_send_rate_throttling_as_AwsSesClientThrottlingSendRat
     boto_mock.send_email.side_effect = botocore.exceptions.ClientError(error_response, "opname")
 
     with pytest.raises(AwsSesClientThrottlingSendRateException):
-        aws_ses_client.send_email(source=Mock(), to_addresses="foo@bar.com", subject=Mock(), body=Mock())
+        aws_ses_client.send_email(
+            source=Mock(), to_addresses="foo@bar.com", subject=Mock(), body=Mock(), html_body=Mock()
+        )
 
 
 def test_send_email_does_not_raise_AwsSesClientThrottlingSendRateException_if_non_send_rate_throttling(mocker):
@@ -118,7 +131,9 @@ def test_send_email_does_not_raise_AwsSesClientThrottlingSendRateException_if_no
     boto_mock.send_email.side_effect = botocore.exceptions.ClientError(error_response, "opname")
 
     with pytest.raises(AwsSesClientException):
-        aws_ses_client.send_email(source=Mock(), to_addresses="foo@bar.com", subject=Mock(), body=Mock())
+        aws_ses_client.send_email(
+            source=Mock(), to_addresses="foo@bar.com", subject=Mock(), body=Mock(), html_body=Mock()
+        )
 
 
 def test_send_email_raises_other_errs_as_AwsSesClientException(mocker):
@@ -131,6 +146,8 @@ def test_send_email_raises_other_errs_as_AwsSesClientException(mocker):
     mocker.patch.object(aws_ses_client, "statsd_client", create=True)
 
     with pytest.raises(AwsSesClientException) as excinfo:
-        aws_ses_client.send_email(source=Mock(), to_addresses="foo@bar.com", subject=Mock(), body=Mock())
+        aws_ses_client.send_email(
+            source=Mock(), to_addresses="foo@bar.com", subject=Mock(), body=Mock(), html_body=Mock()
+        )
 
     assert "some error message from amazon" in str(excinfo.value)

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -159,9 +159,9 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
     send_to_providers.send_email_to_provider(db_notification)
 
     app.aws_ses_client.send_email.assert_called_once_with(
-        '"Sample service" <sample.service@test.notify.com>',
-        "jo.smith@example.com",
-        "Jo <em>some HTML</em>",
+        from_address='"Sample service" <sample.service@test.notify.com>',
+        to_address="jo.smith@example.com",
+        subject="Jo <em>some HTML</em>",
         body="Hello Jo\nThis is an email from GOV.\u200bUK with <em>some HTML</em>\n",
         html_body=ANY,
         reply_to_address=None,
@@ -378,7 +378,7 @@ def test_send_email_should_use_service_reply_to_email(sample_service, sample_ema
     )
 
     app.aws_ses_client.send_email.assert_called_once_with(
-        ANY, ANY, ANY, body=ANY, html_body=ANY, reply_to_address="foo@bar.com"
+        from_address=ANY, to_address=ANY, subject=ANY, body=ANY, html_body=ANY, reply_to_address="foo@bar.com"
     )
 
 
@@ -394,7 +394,7 @@ def test_send_email_works_with_and_without_email_branding(request, service_fixtu
     )
 
     app.aws_ses_client.send_email.assert_called_once_with(
-        ANY, ANY, ANY, body=ANY, html_body=ANY, reply_to_address="foo@bar.com"
+        from_address=ANY, to_address=ANY, subject=ANY, body=ANY, html_body=ANY, reply_to_address="foo@bar.com"
     )
 
 
@@ -677,7 +677,7 @@ def test_send_email_to_provider_uses_reply_to_from_notification(sample_email_tem
     )
 
     app.aws_ses_client.send_email.assert_called_once_with(
-        ANY, ANY, ANY, body=ANY, html_body=ANY, reply_to_address="test@test.com"
+        from_address=ANY, to_address=ANY, subject=ANY, body=ANY, html_body=ANY, reply_to_address="test@test.com"
     )
 
 
@@ -688,9 +688,9 @@ def test_send_email_to_provider_uses_custom_email_sender_name_if_set(sample_emai
     send_to_providers.send_email_to_provider(sample_email_notification)
 
     app.aws_ses_client.send_email.assert_called_once_with(
-        '"Custom Sender Name" <custom.sender.name@test.notify.com>',
-        ANY,
-        ANY,
+        from_address='"Custom Sender Name" <custom.sender.name@test.notify.com>',
+        to_address=ANY,
+        subject=ANY,
         body=ANY,
         html_body=ANY,
         reply_to_address=ANY,
@@ -718,7 +718,12 @@ def test_send_email_to_provider_should_user_normalised_to(mocker, client, sample
 
     send_to_providers.send_email_to_provider(notification)
     send_mock.assert_called_once_with(
-        ANY, notification.normalised_to, ANY, body=ANY, html_body=ANY, reply_to_address=notification.reply_to_text
+        from_address=ANY,
+        to_address=notification.normalised_to,
+        subject=ANY,
+        body=ANY,
+        html_body=ANY,
+        reply_to_address=notification.reply_to_text,
     )
 
 
@@ -776,7 +781,12 @@ def test_send_email_to_provider_should_return_template_if_found_in_redis(mocker,
     assert mock_get_template.called is False
     assert mock_get_service.called is False
     send_mock.assert_called_once_with(
-        ANY, notification.normalised_to, ANY, body=ANY, html_body=ANY, reply_to_address=notification.reply_to_text
+        from_address=ANY,
+        to_address=notification.normalised_to,
+        subject=ANY,
+        body=ANY,
+        html_body=ANY,
+        reply_to_address=notification.reply_to_text,
     )
 
 


### PR DESCRIPTION
This is probably worth a separate pull request to anything around custom headers, as it makes a big change - using SESv2 (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sesv2.html), which has a new format.

Also do some refactoring to make it clearer what is being passed in and around this function