### PR TITLE
Add https validation for unsusbscribe links

### DIFF
--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -4,7 +4,7 @@ from app.constants import (
     NOTIFICATION_STATUS_TYPES,
     NOTIFICATION_TYPES,
 )
-from app.schema_validation.definitions import personalisation, uuid
+from app.schema_validation.definitions import https_url, personalisation, uuid
 
 template = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -202,7 +202,7 @@ post_email_request = {
         "personalisation": personalisation,
         "scheduled_for": {"type": ["string", "null"], "format": "datetime_within_next_day"},
         "email_reply_to_id": uuid,
-        "unsubscribe_link": {"type": "string", "format": "uri"},
+        "unsubscribe_link": https_url,
     },
     "required": ["email_address", "template_id"],
     "additionalProperties": False,

--- a/tests/app/v2/notifications/test_notification_schemas.py
+++ b/tests/app/v2/notifications/test_notification_schemas.py
@@ -248,6 +248,24 @@ def test_post_email_schema_invalid_email_address(email_address, err_msg):
     assert {"error": "ValidationError", "message": err_msg} == errors[0]
 
 
+@pytest.mark.parametrize(
+    "unsubscribe_link, err_msg",
+    [
+        ("http://www.unsubscribe-me-please.com", "unsubscribe_link is not a valid https url"),
+        ("www.unsubscribe-me-please.com", "unsubscribe_link is not a valid https url"),
+    ],
+)
+def test_post_email_schema_invalid_unsubscribe_link(unsubscribe_link, err_msg):
+    j_son = valid_post_email_json_with_optionals
+    j_son["unsubscribe_link"] = unsubscribe_link
+    with pytest.raises(ValidationError) as e:
+        validate(j_son, post_email_request_schema)
+
+    errors = json.loads(str(e.value)).get("errors")
+    assert len(errors) == 1
+    assert {"error": "ValidationError", "message": err_msg} == errors[0]
+
+
 def valid_email_response():
     return {
         "id": str(uuid.uuid4()),


### PR DESCRIPTION
 This is to enforce https urls for unsubscribe links posted to the post_notification endpoint.