### PR TITLE
Send unsubscribe header

### DIFF
--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -1,5 +1,5 @@
 from time import monotonic
-from typing import Optional
+from typing import Dict, List, Optional
 
 import boto3
 import botocore
@@ -75,6 +75,7 @@ class AwsSesClient(EmailClient):
         body: str,
         html_body: str,
         reply_to_address: Optional[str],
+        headers: List[Dict[str, str]],
     ) -> str:
         reply_to_addresses = [punycode_encode_email(reply_to_address)] if reply_to_address else []
         to_addresses = [punycode_encode_email(to_address)]
@@ -95,6 +96,7 @@ class AwsSesClient(EmailClient):
                     "Simple": {
                         "Subject": {"Data": subject},
                         "Body": body,
+                        "Headers": headers,
                     },
                 },
                 ReplyToAddresses=reply_to_addresses,

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -1,5 +1,6 @@
 import random
 from datetime import datetime, timedelta
+from typing import Dict, List
 from urllib import parse
 
 from cachetools import TTLCache, cached
@@ -33,6 +34,7 @@ from app.dao.provider_details_dao import (
     get_provider_details_by_notification_type,
 )
 from app.exceptions import NotificationTechnicalFailureException
+from app.models import Notification
 from app.serialised_models import SerialisedService, SerialisedTemplate
 
 
@@ -103,6 +105,18 @@ def send_sms_to_provider(notification):
                 statsd_client.timing("sms.live-key.not-high-volume.total-time", delta_seconds)
 
 
+def _get_email_headers(notification: Notification) -> List[Dict[str, str]]:
+    headers = []
+
+    if notification.unsubscribe_link:
+        headers += [
+            {"List-Unsubscribe": f"<{notification.unsubscribe_link}>"},
+            {"List-Unsubscribe-Post": "List-Unsubscribe=One-Click"},
+        ]
+
+    return headers
+
+
 def send_email_to_provider(notification):
     service = SerialisedService.from_id(notification.service_id)
 
@@ -140,6 +154,7 @@ def send_email_to_provider(notification):
                 body=str(plain_text_email),
                 html_body=str(html_email),
                 reply_to_address=notification.reply_to_text,
+                headers=_get_email_headers(notification),
             )
             notification.reference = reference
             update_notification_to_sending(notification, provider)

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -110,8 +110,8 @@ def _get_email_headers(notification: Notification) -> List[Dict[str, str]]:
 
     if notification.unsubscribe_link:
         headers += [
-            {"List-Unsubscribe": f"<{notification.unsubscribe_link}>"},
-            {"List-Unsubscribe-Post": "List-Unsubscribe=One-Click"},
+            {"Name": "List-Unsubscribe", "Value": f"<{notification.unsubscribe_link}>"},
+            {"Name": "List-Unsubscribe-Post", "Value": "List-Unsubscribe=One-Click"},
         ]
 
     return headers

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@
 # with package version changes made in requirements.in
 
 cffi==1.15.1
-celery[sqs]==5.2.7
+celery[sqs]==5.4.0
 Flask-Bcrypt==1.0.1
 flask-marshmallow==0.14.0
 Flask-Migrate==3.1.0
@@ -22,6 +22,9 @@ SQLAlchemy==1.4.41
 cachetools==5.2.0
 beautifulsoup4==4.11.1
 lxml==4.9.3
+
+# TODO: remove from here once boto3 dependencies are updated in utils
+boto3>=1.34.100
 
 notifications-python-client==8.0.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,18 +18,20 @@ bcrypt==4.0.0
     # via flask-bcrypt
 beautifulsoup4==4.11.1
     # via -r requirements.in
-billiard==3.6.4.0
+billiard==4.2.0
     # via celery
 blinker==1.6.2
     # via
     #   flask
     #   gds-metrics
     #   sentry-sdk
-boto3==1.28.5
+boto3==1.34.100
     # via
+    #   -r requirements.in
+    #   celery
     #   kombu
     #   notifications-utils
-botocore==1.31.5
+botocore==1.34.100
     # via
     #   boto3
     #   s3transfer
@@ -37,7 +39,7 @@ cachetools==5.2.0
     # via
     #   -r requirements.in
     #   notifications-utils
-celery[sqs]==5.2.7
+celery[sqs]==5.4.0
     # via
     #   -r requirements.in
     #   sentry-sdk
@@ -131,7 +133,7 @@ jsonpointer==2.3
     # via jsonschema
 jsonschema[format]==4.16.0
     # via -r requirements.in
-kombu[sqs]==5.2.4
+kombu[sqs]==5.3.7
     # via celery
 lxml==4.9.3
     # via -r requirements.in
@@ -175,7 +177,9 @@ psycopg2-binary==2.9.6
 pycparser==2.21
     # via cffi
 pycurl==7.44.1
-    # via kombu
+    # via
+    #   celery
+    #   kombu
 pyjwt==2.5.0
     # via
     #   -r requirements.in
@@ -188,12 +192,11 @@ python-dateutil==2.8.2
     # via
     #   arrow
     #   botocore
+    #   celery
 python-json-logger==2.0.4
     # via notifications-utils
 pytz==2022.4
-    # via
-    #   celery
-    #   notifications-utils
+    # via notifications-utils
 pyyaml==6.0.1
     # via notifications-utils
 redis==4.5.4
@@ -207,7 +210,7 @@ rfc3339-validator==0.1.4
     # via jsonschema
 rfc3987==1.3.8
     # via jsonschema
-s3transfer==0.6.0
+s3transfer==0.10.1
     # via boto3
 segno==1.5.2
     # via notifications-utils
@@ -232,15 +235,18 @@ sqlalchemy==1.4.41
     #   sentry-sdk
 statsd==3.3.0
     # via notifications-utils
+tzdata==2024.1
+    # via celery
 uri-template==1.2.0
     # via jsonschema
 urllib3==1.26.18
     # via
     #   botocore
+    #   celery
     #   kombu
     #   requests
     #   sentry-sdk
-vine==5.0.0
+vine==5.1.0
     # via
     #   amqp
     #   celery

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -257,6 +257,7 @@ def create_notification(
     created_by_id=None,
     postage=None,
     document_download_count=None,
+    unsubscribe_link=None,
 ):
     assert job or template
     if job:
@@ -312,6 +313,7 @@ def create_notification(
         "created_by_id": created_by_id,
         "postage": postage,
         "document_download_count": document_download_count,
+        "unsubscribe_link": unsubscribe_link,
     }
     notification = Notification(**data)
     dao_create_notification(notification)

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -849,8 +849,8 @@ def test_send_email_to_provider_sends_unsubscribe_link(sample_email_template, mo
     db_notification = create_notification(template=sample_email_template, unsubscribe_link="https://example.com")
 
     expected_headers = [
-        {"List-Unsubscribe": "<https://example.com>"},
-        {"List-Unsubscribe-Post": "List-Unsubscribe=One-Click"},
+        {"Name": "List-Unsubscribe", "Value": "<https://example.com>"},
+        {"Name": "List-Unsubscribe-Post", "Value": "List-Unsubscribe=One-Click"},
     ]
 
     send_to_providers.send_email_to_provider(


### PR DESCRIPTION
Requires the following to be merged (split into two PRs to keep PRs focused, and risk lower)

- [ ] #4079 

-----------

[bump boto3 (and celery) to bring in latest ses API](https://github.com/alphagov/notifications-api/commit/3bc9a759ca44f4e9e93c6acd98681fbcf94fdeac) 

we need to bump boto3 to bring in the changes to the sesv2 API to add
support for custom headers.

I went through the boto3 changelogs with a fine toothcomb - nothing
there is particularly alarming. Here's a filtered list of just the lines
i think will affect our apps. Note that we only use boto3 for
interacting with things programatically, so while there may have been
changes to, eg, boto3's ecs API, since we don't interact with ECS from
our apps we don't need to worry about that. See the filtered list[^1].

Notably there were some changes to the boto3 sqs protocol, and celery
needed to be bumped to support that - see the kombu PR[^2] if you're
interested in learning more.

[^1]: https://gist.github.com/leohemsted/0572ad15c57fdbaef8b9697cc6e5eaa4
[^2]: https://github.com/celery/kombu/pull/1807
-------
[send unsubscribe headers](https://github.com/alphagov/notifications-api/commit/5909d048f842c2267709b11bcf5be4fbb30480bc) 

send unsubscribe links and one-click directive in line with the RFC[^3]
make a list that we can add further headers to in the future if we want
to

[^3]: https://www.rfcreader.com/#rfc8058_line278