### PR TITLE
Add column to User table to show if user receives features email

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -112,6 +112,7 @@ class User(db.Model):
         db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow
     )
     take_part_in_research = db.Column(db.Boolean, nullable=False, default=True)
+    receives_new_features_email = db.Column(db.Boolean, nullable=False, default=True)
 
     # either email auth or a mobile number must be provided
     __table_args__ = (CheckConstraint("auth_type in ('email_auth', 'webauthn_auth') or mobile_number is not null"),)
@@ -193,6 +194,7 @@ class User(db.Model):
             "can_use_webauthn": self.can_use_webauthn,
             "state": self.state,
             "take_part_in_research": self.take_part_in_research,
+            "receives_new_features_email": self.receives_new_features_email,
         }
 
     def serialize_for_users_list(self):

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0443_drop_ix_letter_cost
+0444_user_features_email_column

--- a/migrations/versions/0444_user_features_email_column.py
+++ b/migrations/versions/0444_user_features_email_column.py
@@ -1,0 +1,20 @@
+"""
+Create Date: 2024-05-13 13:53:11.227939
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0444_user_features_email_column"
+down_revision = "0443_drop_ix_letter_cost"
+
+
+def upgrade():
+    op.add_column(
+        "users", sa.Column("receives_new_features_email", sa.Boolean(), nullable=False, server_default=sa.true())
+    )
+
+
+def downgrade():
+    op.drop_column("users", "receives_new_features_email")


### PR DESCRIPTION
This adds the `receives_new_features_email` column to the users table so that we can store whether or not people want to receive emails about new features in the database. It has a default of true, but we will need to manually update the data before using it since we have a list of people who have opted out.

While this migration will require an access exclusive lock, it does pass the Squawk linting and it is running it on a small table.