### PR TITLE
Rename `unsubscribe_link` to `one_click_unsubscribe_url`

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1614,7 +1614,7 @@ class Notification(db.Model):
             "completed_at": self.completed_at(),
             "scheduled_for": None,
             "postage": self.postage,
-            "unsubscribe_link": self.unsubscribe_link,
+            "one_click_unsubscribe_url": self.unsubscribe_link,
         }
 
         if self.notification_type == LETTER_TYPE:

--- a/app/v2/notifications/create_response.py
+++ b/app/v2/notifications/create_response.py
@@ -27,7 +27,7 @@ def create_post_email_response_from_notification(
         "from_email": email_from,
         "body": content,
         "subject": subject,
-        "unsubscribe_link": unsubscribe_link,
+        "one_click_unsubscribe_url": unsubscribe_link,
     }
     return response
 

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -202,7 +202,7 @@ post_email_request = {
         "personalisation": personalisation,
         "scheduled_for": {"type": ["string", "null"], "format": "datetime_within_next_day"},
         "email_reply_to_id": uuid,
-        "unsubscribe_link": https_url,
+        "one_click_unsubscribe_url": https_url,
     },
     "required": ["email_address", "template_id"],
     "additionalProperties": False,

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -160,7 +160,7 @@ def post_notification(notification_type):
             template_process_type=template.process_type,
             service=authenticated_service,
             reply_to_text=reply_to,
-            unsubscribe_link=form.get("unsubscribe_link", None),
+            unsubscribe_link=form.get("one_click_unsubscribe_url", None),
         )
 
     return jsonify(notification), 201

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -58,7 +58,7 @@ def test_get_notification_by_id_returns_200(api_client_request, billable_units, 
         "completed_at": sample_notification.completed_at(),
         "scheduled_for": None,
         "postage": None,
-        "unsubscribe_link": None,
+        "one_click_unsubscribe_url": None,
     }
 
     assert json_response == expected_response
@@ -106,7 +106,7 @@ def test_get_notification_by_id_with_placeholders_returns_200(
         "completed_at": sample_notification.completed_at(),
         "scheduled_for": None,
         "postage": None,
-        "unsubscribe_link": None,
+        "one_click_unsubscribe_url": None,
     }
 
     assert json_response == expected_response

--- a/tests/app/v2/notifications/test_notification_schemas.py
+++ b/tests/app/v2/notifications/test_notification_schemas.py
@@ -251,13 +251,13 @@ def test_post_email_schema_invalid_email_address(email_address, err_msg):
 @pytest.mark.parametrize(
     "unsubscribe_link, err_msg",
     [
-        ("http://www.unsubscribe-me-please.com", "unsubscribe_link is not a valid https url"),
-        ("www.unsubscribe-me-please.com", "unsubscribe_link is not a valid https url"),
+        ("http://www.unsubscribe-me-please.com", "one_click_unsubscribe_url is not a valid https url"),
+        ("www.unsubscribe-me-please.com", "one_click_unsubscribe_url is not a valid https url"),
     ],
 )
 def test_post_email_schema_invalid_unsubscribe_link(unsubscribe_link, err_msg):
     j_son = valid_post_email_json_with_optionals
-    j_son["unsubscribe_link"] = unsubscribe_link
+    j_son["one_click_unsubscribe_url"] = unsubscribe_link
     with pytest.raises(ValidationError) as e:
         validate(j_son, post_email_request_schema)
 

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1032,7 +1032,7 @@ def test_post_email_notification_with_unsubscribe_link_returns_201(api_client_re
     data = {
         "email_address": sample_email_template.service.users[0].email_address,
         "template_id": sample_email_template.id,
-        "unsubscribe_link": unsubscribe_link,
+        "one_click_unsubscribe_url": unsubscribe_link,
     }
 
     response_json = api_client_request.post(
@@ -1046,7 +1046,7 @@ def test_post_email_notification_with_unsubscribe_link_returns_201(api_client_re
     notification = Notification.query.first()
     assert response_json["id"] == str(notification.id)
 
-    assert notification.unsubscribe_link == unsubscribe_link == response_json["content"]["unsubscribe_link"]
+    assert notification.unsubscribe_link == unsubscribe_link == response_json["content"]["one_click_unsubscribe_url"]
     assert mocked.called
 
 


### PR DESCRIPTION
This is:
- more correct (it’s a URL designed for machine consumption, not a link in a web page)
- less likely to be confused with the manual unsubscribe links we talk about in our guidance<sup>1</sup>

This will mean a bit of work to rename the parameter in all the clients, but easier to do it now than after we’ve released them (when it would be a breaking change)

***

Internally we retain `unsubscribe_link`. We will make it consistent later, in order to avoid any need for updates to the `notifications` table (which would require locks, multiple migrations, etc).

***

1. https://www.notifications.service.gov.uk/using-notify/unsubscribe-links or
   snapshotted at https://github.com/alphagov/notifications-admin/blob/20fd4424d613d256e02284cc7c523392c18e8b8c/app/templates/views/guidance/using-notify/unsubscribe-links.html