### PR TITLE
Speed up 'last used' query by only checking table when needed

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -104,13 +104,18 @@ def dao_get_last_date_template_was_used(template_id, service_id):
         if last_date_from_notifications:
             return last_date_from_notifications
 
-    last_date = (
-        db.session.query(functions.max(FactNotificationStatus.bst_date))
-        .filter(FactNotificationStatus.template_id == template_id, FactNotificationStatus.key_type != KEY_TYPE_TEST)
-        .scalar()
-    )
+    if db.session.query(
+        FactNotificationStatus.query.filter(FactNotificationStatus.template_id == template_id).exists()
+    ).scalar():
+        last_date = (
+            db.session.query(functions.max(FactNotificationStatus.bst_date))
+            .filter(FactNotificationStatus.template_id == template_id, FactNotificationStatus.key_type != KEY_TYPE_TEST)
+            .scalar()
+        )
 
-    return last_date
+        return last_date
+
+    return None
 
 
 @autocommit


### PR DESCRIPTION
Only check FactNotificationStatus table for last used date if there are any notifications at all for that template in that table.

Ticket: https://trello.com/c/RyEMRpQw/719-find-out-why-template-last-use-query-is-slow-and-fails

Possible other solutions: we could only search through data from last 6 months or last year. Then we would have to change current warning text: "This template has never been used." to something like: "This template has not been used within last 6 months."

Here is the screenshot with the warning text for context:
![Screenshot 2024-05-17 at 17 39 22](https://github.com/alphagov/notifications-api/assets/20957548/bb7328b4-cc54-40af-8962-28dd5b69c3ac)

I think changing the text would make it a bit more confusing - do we mean the template was used before last 6 months, or that we just don't know (that second interpretation would be more true).

So I vote for just making this little change for now and keeping an eye on if the problem with slow query keeps happening. Then we could either try the above solution, or maybe fiddle with a custom index for this query if we think that would be useful? `fact_notification_status` table is only updated periodically, so maybe an extra index on it, on `bst_date` and `template_id` columns, could be a good fit?