### PR TITLE
move FROM_NUMBER override from root Config to Development

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -374,8 +374,6 @@ class Config(object):
     if os.getenv("CELERYD_PREFETCH_MULTIPLIER"):
         CELERY["worker_prefetch_multiplier"] = os.getenv("CELERYD_PREFETCH_MULTIPLIER")
 
-    FROM_NUMBER = "development"
-
     STATSD_HOST = os.getenv("STATSD_HOST")
     STATSD_PORT = 8125
     STATSD_ENABLED = bool(STATSD_HOST)
@@ -504,6 +502,8 @@ class Development(Config):
     CBC_PROXY_ENABLED = False
 
     REGISTER_FUNCTIONAL_TESTING_BLUEPRINT = True
+
+    FROM_NUMBER = "development"
 
 
 class Test(Development):


### PR DESCRIPTION
We already had a manually set FROM_NUMBER of `development`, but when we updated the root config to be environment-agnostic[^1] we missed this. As such, when FROM_NUMBER isn't set manually in the environment (which it isn't on dev envs), we'd error because it'd default to None rather than to `development`.

Move this declaration to the `Development` config where it fits anyway

[^1]: https://github.com/alphagov/notifications-api/pull/4078