### PR TITLE
Make dao_get_last_date_template_was_used only search within last year

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -4,6 +4,7 @@ from itertools import groupby
 from operator import attrgetter
 
 from botocore.exceptions import ClientError
+from dateutil.relativedelta import relativedelta
 from flask import current_app
 from notifications_utils.international_billing_rates import (
     INTERNATIONAL_BILLING_RATES,
@@ -109,7 +110,11 @@ def dao_get_last_date_template_was_used(template_id, service_id):
     ).scalar():
         last_date = (
             db.session.query(functions.max(FactNotificationStatus.bst_date))
-            .filter(FactNotificationStatus.template_id == template_id, FactNotificationStatus.key_type != KEY_TYPE_TEST)
+            .filter(
+                FactNotificationStatus.template_id == template_id,
+                FactNotificationStatus.key_type != KEY_TYPE_TEST,
+                FactNotificationStatus.bst_date > datetime.now() - relativedelta(years=1),
+            )
             .scalar()
         )
 

--- a/tests/app/dao/notification_dao/test_notification_dao_template_usage.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_template_usage.py
@@ -1,11 +1,11 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from app.dao.notifications_dao import dao_get_last_date_template_was_used
 from tests.app.db import create_ft_notification_status, create_notification
 
 
 def test_dao_get_last_date_template_was_used_returns_bst_date_from_stats_table(sample_template):
-    last_status_date = (datetime.utcnow() - timedelta(days=2)).date()
+    last_status_date = (datetime.now(UTC) - timedelta(days=2)).date()
     create_ft_notification_status(bst_date=last_status_date, template=sample_template)
 
     last_used_date = dao_get_last_date_template_was_used(
@@ -14,11 +14,21 @@ def test_dao_get_last_date_template_was_used_returns_bst_date_from_stats_table(s
     assert last_used_date == last_status_date
 
 
+def test_dao_get_last_date_template_was_used_only_searches_within_one_year(sample_template):
+    last_status_date = (datetime.now(UTC) - timedelta(days=400)).date()
+    create_ft_notification_status(bst_date=last_status_date, template=sample_template)
+
+    last_used_date = dao_get_last_date_template_was_used(
+        template_id=sample_template.id, service_id=sample_template.service_id
+    )
+    assert last_used_date is None
+
+
 def test_dao_get_last_date_template_was_used_returns_created_at_from_notifications(sample_template):
-    last_notification_date = datetime.utcnow() - timedelta(hours=2)
+    last_notification_date = datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2)
     create_notification(template=sample_template, created_at=last_notification_date)
 
-    last_status_date = (datetime.utcnow() - timedelta(days=2)).date()
+    last_status_date = (datetime.now(UTC).replace(tzinfo=None) - timedelta(days=2)).date()
     create_ft_notification_status(bst_date=last_status_date, template=sample_template)
     last_used_date = dao_get_last_date_template_was_used(
         template_id=sample_template.id, service_id=sample_template.service_id


### PR DESCRIPTION
To reduce time it takes to run the query and prevent delete_template page from timing out.

The query to check when template was last used would often time out (Sentry has record of 10 000 errors this caused - and it's a manual process to delete a template, so it's a lot of users seeing error page :< ).

One measure to prevent that is for us to only search within last year - that should be good enough for the user to be warned if they are deleting a well-used template by mistake.

Should go out after this PR: https://github.com/alphagov/notifications-admin/pull/5101


Story ticket: https://trello.com/c/RyEMRpQw/719-find-out-why-template-last-use-query-is-slow-and-fails