### PR TITLE
Update code to use new Zendesk form 

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -219,9 +219,9 @@ def raise_alert_if_letter_notifications_still_sending():
                 subject=f"[{current_app.config['NOTIFY_ENVIRONMENT']}] Letters still sending",
                 email_ccs=current_app.config["DVLA_EMAIL_ADDRESSES"],
                 message=message,
-                ticket_type=NotifySupportTicket.TYPE_INCIDENT,
+                ticket_type=NotifySupportTicket.TYPE_TASK,
                 notify_ticket_type=NotifyTicketType.TECHNICAL,
-                ticket_categories=["notify_letters"],
+                notify_task_type="notify_task_letters_sending",
             )
             zendesk_client.send_ticket_to_zendesk(ticket)
         else:

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -347,9 +347,9 @@ def check_if_letters_still_pending_virus_check():
             ticket = NotifySupportTicket(
                 subject=f"[{current_app.config['NOTIFY_ENVIRONMENT']}] Letters still pending virus check",
                 message=msg,
-                ticket_type=NotifySupportTicket.TYPE_INCIDENT,
+                ticket_type=NotifySupportTicket.TYPE_TASK,
                 notify_ticket_type=NotifyTicketType.TECHNICAL,
-                ticket_categories=["notify_letters"],
+                notify_task_type="notify_task_letters_pending_scan",
             )
             zendesk_client.send_ticket_to_zendesk(ticket)
             current_app.logger.error(
@@ -374,9 +374,9 @@ def check_if_letters_still_in_created():
             ticket = NotifySupportTicket(
                 subject=f"[{current_app.config['NOTIFY_ENVIRONMENT']}] Letters still in 'created' status",
                 message=msg,
-                ticket_type=NotifySupportTicket.TYPE_INCIDENT,
+                ticket_type=NotifySupportTicket.TYPE_TASK,
                 notify_ticket_type=NotifyTicketType.TECHNICAL,
-                ticket_categories=["notify_letters"],
+                notify_task_type="notify_task_letters_created_status",
             )
             zendesk_client.send_ticket_to_zendesk(ticket)
             current_app.logger.error(
@@ -455,8 +455,9 @@ def check_for_services_with_high_failure_rates_or_sending_to_tv_numbers():
             ticket = NotifySupportTicket(
                 subject=f"[{current_app.config['NOTIFY_ENVIRONMENT']}] High failure rates for sms spotted for services",
                 message=message,
-                ticket_type=NotifySupportTicket.TYPE_INCIDENT,
+                ticket_type=NotifySupportTicket.TYPE_TASK,
                 notify_ticket_type=NotifyTicketType.TECHNICAL,
+                notify_task_type="notify_task_high_failure",
             )
             zendesk_client.send_ticket_to_zendesk(ticket)
 
@@ -527,7 +528,7 @@ def zendesk_new_email_branding_report():
             message=message,
             ticket_type=NotifySupportTicket.TYPE_TASK,
             notify_ticket_type=NotifyTicketType.NON_TECHNICAL,
-            ticket_categories=["notify_no_ticket_category"],
+            notify_task_type="notify_task_branding_review",
             message_as_html=True,
         )
         zendesk_client.send_ticket_to_zendesk(ticket)
@@ -557,7 +558,7 @@ def check_for_low_available_inbound_sms_numbers():
         message=message,
         ticket_type=NotifySupportTicket.TYPE_TASK,
         notify_ticket_type=NotifyTicketType.TECHNICAL,
-        ticket_categories=["notify_no_ticket_category"],
+        notify_task_type="notify_task_request_inbound_SMS",
     )
     zendesk_client.send_ticket_to_zendesk(ticket)
 

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ boto3>=1.34.100
 
 notifications-python-client==8.0.1
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@77.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -156,7 +156,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@77.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -201,9 +201,9 @@ def test_create_ticket_if_letter_notifications_still_sending(notify_api, mocker)
             "There are 1 letters in the 'sending' state from Monday 15 January. Resolve using "
             "https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#deal-with-letters-still-in-sending"
         ),
-        ticket_type="incident",
+        ticket_type="task",
         notify_ticket_type=NotifyTicketType.TECHNICAL,
-        ticket_categories=["notify_letters"],
+        notify_task_type="notify_task_letters_sending",
     )
     mock_send_ticket_to_zendesk.assert_called_once()
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -557,9 +557,9 @@ def test_check_if_letters_still_pending_virus_check_raises_zendesk_if_files_cant
         ANY,
         subject="[test] Letters still pending virus check",
         message=ANY,
-        ticket_type="incident",
+        ticket_type="task",
         notify_ticket_type=NotifyTicketType.TECHNICAL,
-        ticket_categories=["notify_letters"],
+        notify_task_type="notify_task_letters_pending_scan",
     )
     assert "2 precompiled letters have been pending-virus-check" in mock_create_ticket.call_args.kwargs["message"]
     assert f"{(str(notification_1.id), notification_1.reference)}" in mock_create_ticket.call_args.kwargs["message"]
@@ -596,9 +596,9 @@ def test_check_if_letters_still_in_created_during_bst(mocker, sample_letter_temp
             "https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#deal-with-letters-still-in-created."
         ),
         subject="[test] Letters still in 'created' status",
-        ticket_type="incident",
+        ticket_type="task",
         notify_ticket_type=NotifyTicketType.TECHNICAL,
-        ticket_categories=["notify_letters"],
+        notify_task_type="notify_task_letters_created_status",
     )
     mock_send_ticket_to_zendesk.assert_called_once()
 
@@ -632,9 +632,9 @@ def test_check_if_letters_still_in_created_during_utc(mocker, sample_letter_temp
             "https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#deal-with-letters-still-in-created."
         ),
         subject="[test] Letters still in 'created' status",
-        ticket_type="incident",
+        ticket_type="task",
         notify_ticket_type=NotifyTicketType.TECHNICAL,
-        ticket_categories=["notify_letters"],
+        notify_task_type="notify_task_letters_created_status",
     )
     mock_send_ticket_to_zendesk.assert_called_once()
 
@@ -808,8 +808,9 @@ def test_check_for_services_with_high_failure_rates_or_sending_to_tv_numbers(
         ANY,
         message=expected_message + zendesk_actions,
         subject="[test] High failure rates for sms spotted for services",
-        ticket_type="incident",
+        ticket_type="task",
         notify_ticket_type=NotifyTicketType.TECHNICAL,
+        notify_task_type="notify_task_high_failure",
     )
     mock_send_ticket_to_zendesk.assert_called_once()
 
@@ -865,12 +866,12 @@ def test_zendesk_new_email_branding_report(notify_db_session, mocker, notify_use
             },
             "group_id": 360000036529,
             "organization_id": 21891972,
-            "ticket_form_id": 1900000284794,
+            "ticket_form_id": 14226867890588,
             "priority": "normal",
             "tags": ["govuk_notify_support"],
             "type": "task",
             "custom_fields": [
-                {"id": "360022836500", "value": ["notify_no_ticket_category"]},
+                {"id": "14229641690396", "value": "notify_task_branding_review"},
                 {"id": "360022943959", "value": None},
                 {"id": "360022943979", "value": None},
                 {"id": "1900000745014", "value": None},
@@ -1052,7 +1053,7 @@ def test_check_for_low_available_inbound_sms_numbers_logs_zendesk_ticket_if_too_
             ),
             ticket_type=mock_ticket.TYPE_TASK,
             notify_ticket_type=NotifyTicketType.TECHNICAL,
-            ticket_categories=["notify_no_ticket_category"],
+            notify_task_type="notify_task_request_inbound_SMS",
         )
     ]
     assert mock_send_ticket.call_args_list == [mocker.call(mock_ticket.return_value)]


### PR DESCRIPTION
Every ticket type is now a "task" and should have the `notify_task_type`
drop down menu populated instead of the `ticket_categories` dropdown,
which has been removed.

Needs https://github.com/alphagov/notifications-utils/pull/1121 to be merged first