### PR TITLE
Replace deprecated utcnow

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from datetime import time as dt_time
 
 from botocore.exceptions import ClientError as BotoClientError
@@ -162,7 +162,7 @@ def check_time_to_collate_letters():
     out whether it's running at 17:50 local time: if it is, then letter collation itself will be triggered and all
     letters submitted to Notify before 17:30 local time will be collated and sent over.
     """
-    datetime_local = convert_utc_to_bst(datetime.utcnow())
+    datetime_local = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
 
     if not (dt_time(17, 50) <= datetime_local.time() < dt_time(18, 50)):
         current_app.logger.info("Ignoring collate_letter_pdfs_to_be_sent task outside of expected celery task window")
@@ -430,7 +430,11 @@ def update_letter_pdf_status(reference, status, billable_units, recipient_addres
             raw_address=recipient_address.replace(",", "\n"), allow_international_letters=True
         ).postage
         postage = postage if postage in INTERNATIONAL_POSTAGE_TYPES else None
-    update_dict = {"status": status, "billable_units": billable_units, "updated_at": datetime.utcnow()}
+    update_dict = {
+        "status": status,
+        "billable_units": billable_units,
+        "updated_at": datetime.now(UTC).replace(tzinfo=None),
+    }
     if postage:
         update_dict.update({"postage": postage, "international": True})
     if recipient_address:

--- a/app/celery/process_sms_client_response_tasks.py
+++ b/app/celery/process_sms_client_response_tasks.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 from flask import current_app
 from notifications_utils.template import SMSMessageTemplate
@@ -74,7 +74,7 @@ def _process_for_status(notification_status, client_name, provider_reference, de
     if notification.sent_at:
         statsd_client.timing_with_dates(
             f"callback.{client_name.lower()}.{notification_status}.elapsed-time",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             notification.sent_at,
         )
 

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from botocore.exceptions import ClientError as BotoClientError
 from flask import current_app
@@ -154,7 +154,7 @@ def update_letter_to_sending(notification):
     provider = get_provider_details_by_notification_type(LETTER_TYPE)[0]
 
     notification.status = NOTIFICATION_SENDING
-    notification.sent_at = datetime.utcnow()
+    notification.sent_at = datetime.now(UTC).replace(tzinfo=None)
     notification.sent_by = provider.identifier
 
     notifications_dao.dao_update_notification(notification)

--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -1,6 +1,6 @@
 import json
 import random
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from flask import current_app
 from notifications_utils.s3 import s3upload
@@ -104,7 +104,7 @@ def firetext_callback(notification_id, to):
 
 @notify_celery.task(bind=True, name="create-fake-letter-response-file", max_retries=5, default_retry_delay=300)
 def create_fake_letter_response_file(self, reference):
-    now = datetime.utcnow()
+    now = datetime.now(UTC).replace(tzinfo=None)
     dvla_response_data = f"{reference}|Sent|0|Sorted|{now.date().isoformat()}"
 
     # try and find a filename that hasn't been taken yet - from a random time within the last 30 seconds

--- a/app/commands.py
+++ b/app/commands.py
@@ -5,7 +5,7 @@ import logging
 import os
 import random
 import uuid
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from time import monotonic
 from unittest import mock
 
@@ -164,7 +164,7 @@ def backfill_notification_statuses():
 
     while len(result) > 0:
         db.session.execute(update)
-        print("commit {} updates at {}".format(LIMIT, datetime.utcnow()))
+        print("commit {} updates at {}".format(LIMIT, datetime.now(UTC).replace(tzinfo=None)))
         db.session.commit()
         result = db.session.execute(subq).fetchall()
 
@@ -181,7 +181,7 @@ def update_notification_international_flag():
 
     while len(result) > 0:
         db.session.execute(update)
-        print("commit 250000 updates at {}".format(datetime.utcnow()))
+        print("commit 250000 updates at {}".format(datetime.now(UTC).replace(tzinfo=None)))
         db.session.commit()
         result = db.session.execute(subq).fetchall()
 
@@ -191,7 +191,7 @@ def update_notification_international_flag():
     result_history = db.session.execute(subq_history).fetchall()
     while len(result_history) > 0:
         db.session.execute(update_history)
-        print("commit 250000 updates at {}".format(datetime.utcnow()))
+        print("commit 250000 updates at {}".format(datetime.now(UTC).replace(tzinfo=None)))
         db.session.commit()
         result_history = db.session.execute(subq_history).fetchall()
 
@@ -214,7 +214,7 @@ def fix_notification_statuses_not_in_sync():
 
     while len(result) > 0:
         db.session.execute(update)
-        print("Committed {} updates at {}".format(len(result), datetime.utcnow()))
+        print("Committed {} updates at {}".format(len(result), datetime.now(UTC).replace(tzinfo=None)))
         db.session.commit()
         result = db.session.execute(subq).fetchall()
 
@@ -226,7 +226,7 @@ def fix_notification_statuses_not_in_sync():
 
     while len(result) > 0:
         db.session.execute(update)
-        print("Committed {} updates at {}".format(len(result), datetime.utcnow()))
+        print("Committed {} updates at {}".format(len(result), datetime.now(UTC).replace(tzinfo=None)))
         db.session.commit()
         result = db.session.execute(subq_hist).fetchall()
 
@@ -371,7 +371,7 @@ def populate_notification_postage(start_date):
 
     total_updated = 0
 
-    while start_date < datetime.utcnow():
+    while start_date < datetime.now(UTC).replace(tzinfo=None):
         # process in ten day chunks
         end_date = start_date + timedelta(days=10)
 
@@ -383,9 +383,9 @@ def populate_notification_postage(start_date):
             created_at BETWEEN :start AND :end
             """
 
-        execution_start = datetime.utcnow()
+        execution_start = datetime.now(UTC).replace(tzinfo=None)
 
-        if end_date > datetime.utcnow() - timedelta(days=8):
+        if end_date > datetime.now(UTC).replace(tzinfo=None) - timedelta(days=8):
             print("Updating notifications table as well")
             db.session.execute(sql.format("notifications"), {"start": start_date, "end": end_date})
 
@@ -394,7 +394,7 @@ def populate_notification_postage(start_date):
 
         current_app.logger.info(
             "notification postage took %sms. Migrated %s rows for %s to %s",
-            datetime.utcnow() - execution_start,
+            datetime.now(UTC).replace(tzinfo=None) - execution_start,
             result.rowcount,
             start_date,
             end_date,
@@ -418,7 +418,7 @@ def update_jobs_archived_flag(start_date, end_date):
     total_updated = 0
 
     while process_date < end_date:
-        start_time = datetime.utcnow()
+        start_time = datetime.now(UTC).replace(tzinfo=None)
         sql = """update
                     jobs set archived = true
                 where
@@ -948,7 +948,10 @@ def generate_bulktest_data(user_id):
         for notification_type in ["email", "sms", "letter"]:
             with mock.patch("app.dao.notifications_dao._delete_letters_from_s3"):
                 move_notifications_to_notification_history(
-                    notification_type, service_id, datetime.utcnow() - timedelta(days=7), qry_limit=500_000
+                    notification_type,
+                    service_id,
+                    datetime.now(UTC).replace(tzinfo=None) - timedelta(days=7),
+                    qry_limit=500_000,
                 )
         pprint(f" -> Service {i} done.")
 

--- a/app/complaint/complaint_rest.py
+++ b/app/complaint/complaint_rest.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from flask import Blueprint, jsonify, request
 
@@ -36,7 +36,7 @@ def get_complaint_count():
         validate(request.args, complaint_count_request)
 
     # If start and end date are not set, we are expecting today's stats.
-    today = str(datetime.utcnow().date())
+    today = str(datetime.now(UTC).replace(tzinfo=None).date())
 
     start_date = datetime.strptime(request.args.get("start_date", today), "%Y-%m-%d").date()
     end_date = datetime.strptime(request.args.get("end_date", today), "%Y-%m-%d").date()

--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import func, or_
 
@@ -19,14 +19,14 @@ def save_model_api_key(api_key):
 @version_class(ApiKey)
 def expire_api_key(service_id, api_key_id):
     api_key = ApiKey.query.filter_by(id=api_key_id, service_id=service_id).one()
-    api_key.expiry_date = datetime.utcnow()
+    api_key.expiry_date = datetime.now(UTC).replace(tzinfo=None)
     db.session.add(api_key)
 
 
 def get_model_api_keys(service_id, id=None):
     if id:
         return ApiKey.query.filter_by(id=id, service_id=service_id, expiry_date=None).one()
-    seven_days_ago = datetime.utcnow() - timedelta(days=7)
+    seven_days_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=7)
     return ApiKey.query.filter(
         or_(ApiKey.expiry_date == None, func.date(ApiKey.expiry_date) > seven_days_ago),  # noqa
         ApiKey.service_id == service_id,

--- a/app/dao/daily_sorted_letter_dao.py
+++ b/app/dao/daily_sorted_letter_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy.dialects.postgresql import insert
 
@@ -31,7 +31,7 @@ def dao_create_or_update_daily_sorted_letter(new_daily_sorted_letter):
         set_={
             "unsorted_count": stmt.excluded.unsorted_count,
             "sorted_count": stmt.excluded.sorted_count,
-            "updated_at": datetime.utcnow(),
+            "updated_at": datetime.now(UTC).replace(tzinfo=None),
         },
     )
     db.session.connection().execute(stmt)

--- a/app/dao/date_util.py
+++ b/app/dao/date_util.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, time, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 
 import pytz
 from notifications_utils.timezones import convert_bst_to_utc, convert_utc_to_bst
@@ -27,7 +27,7 @@ def get_financial_year_dates(year):
 
 
 def get_current_financial_year():
-    now = datetime.utcnow()
+    now = datetime.now(UTC).replace(tzinfo=None)
     current_month = int(now.strftime("%-m"))
     current_year = int(now.strftime("%Y"))
     year = current_year if current_month > 3 else current_year - 1

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any, Optional
 
 from flask import current_app
@@ -308,7 +308,7 @@ def fetch_usage_for_service_by_month(service_id, year):
     we also update the table on-the-fly if we need accurate data for this year.
     """
     _, year_end = get_financial_year_dates(year)
-    today = convert_utc_to_bst(datetime.utcnow()).date()
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None)).date()
 
     # if year end date is less than today, we are calculating for data in the past and have no need for deltas.
     if year_end >= today:
@@ -723,7 +723,7 @@ def update_ft_billing(billing_data: list, process_day: date):
         set_={
             "notifications_sent": stmt.excluded.notifications_sent,
             "billable_units": stmt.excluded.billable_units,
-            "updated_at": datetime.utcnow(),
+            "updated_at": datetime.now(UTC).replace(tzinfo=None),
         },
     )
     db.session.connection().execute(stmt)
@@ -830,7 +830,7 @@ def update_ft_billing_letter_despatch(process_day: date):
             constraint="ft_billing_letter_despatch_pkey",
             set_={
                 "notifications_sent": stmt.excluded.notifications_sent,
-                "updated_at": datetime.utcnow(),
+                "updated_at": datetime.now(UTC).replace(tzinfo=None),
             },
         )
         db.session.execute(stmt)
@@ -928,7 +928,7 @@ def fetch_usage_for_organisation(organisation_id, year) -> tuple[Any, Optional[s
     for the current day.
     """
     year_start, year_end = get_financial_year_dates(year)
-    today = convert_utc_to_bst(datetime.utcnow()).date()
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None)).date()
     services = dao_get_organisation_live_services_and_their_free_allowance(organisation_id, year)
     service_with_usage = {}
     # initialise results

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import Date, case, func
 from sqlalchemy.dialects.postgresql import insert
@@ -137,7 +137,7 @@ def fetch_notification_status_for_service_for_day(bst_day, service_id):
 
 def fetch_notification_status_for_service_for_today_and_7_previous_days(service_id, by_template=False, limit_days=7):
     start_date = midnight_n_days_ago(limit_days)
-    now = datetime.utcnow()
+    now = datetime.now(UTC).replace(tzinfo=None)
     stats_for_7_days = db.session.query(
         FactNotificationStatus.notification_type.label("notification_type"),
         FactNotificationStatus.notification_status.label("status"),
@@ -204,8 +204,8 @@ def fetch_notification_status_totals_for_all_services(start_date, end_date):
             FactNotificationStatus.key_type,
         )
     )
-    today = get_london_midnight_in_utc(datetime.utcnow())
-    if start_date <= datetime.utcnow().date() <= end_date:
+    today = get_london_midnight_in_utc(datetime.now(UTC).replace(tzinfo=None))
+    if start_date <= datetime.now(UTC).replace(tzinfo=None).date() <= end_date:
         stats_for_today = (
             db.session.query(
                 Notification.notification_type.cast(db.Text).label("notification_type"),
@@ -285,8 +285,8 @@ def fetch_stats_for_all_services_by_date_range(start_date, end_date, include_fro
     if not include_from_test_key:
         stats = stats.filter(FactNotificationStatus.key_type != KEY_TYPE_TEST)
 
-    if start_date <= datetime.utcnow().date() <= end_date:
-        today = get_london_midnight_in_utc(datetime.utcnow())
+    if start_date <= datetime.now(UTC).replace(tzinfo=None).date() <= end_date:
+        today = get_london_midnight_in_utc(datetime.now(UTC).replace(tzinfo=None))
         subquery = (
             db.session.query(
                 Notification.notification_type.cast(db.Text).label("notification_type"),
@@ -375,8 +375,8 @@ def fetch_monthly_template_usage_for_service(start_date, end_date, service_id):
         )
     )
 
-    if start_date <= datetime.utcnow() <= end_date:
-        today = get_london_midnight_in_utc(datetime.utcnow())
+    if start_date <= datetime.now(UTC).replace(tzinfo=None) <= end_date:
+        today = get_london_midnight_in_utc(datetime.now(UTC).replace(tzinfo=None))
         month = get_london_month_from_utc_column(Notification.created_at)
 
         stats_for_today = (

--- a/app/dao/fact_processing_time_dao.py
+++ b/app/dao/fact_processing_time_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.sql.expression import case
@@ -27,7 +27,7 @@ def insert_update_processing_time(processing_time):
         set_={
             "messages_total": stmt.excluded.messages_total,
             "messages_within_10_secs": stmt.excluded.messages_within_10_secs,
-            "updated_at": datetime.utcnow(),
+            "updated_at": datetime.now(UTC).replace(tzinfo=None),
         },
     )
     db.session.connection().execute(stmt)

--- a/app/dao/invited_org_user_dao.py
+++ b/app/dao/invited_org_user_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from app import db
 from app.models import InvitedOrganisationUser
@@ -24,7 +24,7 @@ def get_invited_org_users_for_organisation(organisation_id):
 def delete_org_invitations_created_more_than_two_days_ago():
     deleted = (
         db.session.query(InvitedOrganisationUser)
-        .filter(InvitedOrganisationUser.created_at <= datetime.utcnow() - timedelta(days=2))
+        .filter(InvitedOrganisationUser.created_at <= datetime.now(UTC).replace(tzinfo=None) - timedelta(days=2))
         .delete()
     )
     db.session.commit()

--- a/app/dao/invited_user_dao.py
+++ b/app/dao/invited_user_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from app import db
 from app.models import InvitedUser
@@ -23,7 +23,9 @@ def get_invited_users_for_service(service_id):
 
 def delete_invitations_created_more_than_two_days_ago():
     deleted = (
-        db.session.query(InvitedUser).filter(InvitedUser.created_at <= datetime.utcnow() - timedelta(days=2)).delete()
+        db.session.query(InvitedUser)
+        .filter(InvitedUser.created_at <= datetime.now(UTC).replace(tzinfo=None) - timedelta(days=2))
+        .delete()
     )
     db.session.commit()
     return deleted

--- a/app/dao/letter_rate_dao.py
+++ b/app/dao/letter_rate_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy import asc, or_
 
@@ -14,10 +14,10 @@ def dao_get_current_letter_rates():
             #
             # So let’s just ignore non-crown for now
             LetterRate.crown.is_(True),
-            LetterRate.start_date <= datetime.utcnow(),
+            LetterRate.start_date <= datetime.now(UTC).replace(tzinfo=None),
             or_(
                 LetterRate.end_date.is_(None),
-                LetterRate.end_date > datetime.utcnow(),
+                LetterRate.end_date > datetime.now(UTC).replace(tzinfo=None),
             ),
         )
         .order_by(

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -4,6 +4,7 @@ from itertools import groupby
 from operator import attrgetter
 
 from botocore.exceptions import ClientError
+from dateutil.relativedelta import relativedelta
 from flask import current_app
 from notifications_utils.international_billing_rates import (
     INTERNATIONAL_BILLING_RATES,
@@ -109,7 +110,11 @@ def dao_get_last_date_template_was_used(template_id, service_id):
     ).scalar():
         last_date = (
             db.session.query(functions.max(FactNotificationStatus.bst_date))
-            .filter(FactNotificationStatus.template_id == template_id, FactNotificationStatus.key_type != KEY_TYPE_TEST)
+            .filter(
+                FactNotificationStatus.template_id == template_id,
+                FactNotificationStatus.key_type != KEY_TYPE_TEST,
+                FactNotificationStatus.bst_date > datetime.now() - relativedelta(years=1),
+            )
             .scalar()
         )
 

--- a/app/dao/returned_letters_dao.py
+++ b/app/dao/returned_letters_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy import desc, func
 from sqlalchemy.dialects.postgresql import insert
@@ -39,10 +39,10 @@ def insert_returned_letters(references):
         stmt = (
             insert(table)
             .values(
-                reported_at=datetime.utcnow().date(),
+                reported_at=datetime.now(UTC).replace(tzinfo=None).date(),
                 service_id=row.service_id,
                 notification_id=row.id,
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(UTC).replace(tzinfo=None),
             )
             .on_conflict_do_nothing(index_elements=[table.c.notification_id])
         )

--- a/app/dao/service_callback_api_dao.py
+++ b/app/dao/service_callback_api_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from app import db
 from app.constants import COMPLAINT_CALLBACK_TYPE, DELIVERY_STATUS_CALLBACK_TYPE
@@ -9,7 +9,7 @@ from app.models import ServiceCallbackApi
 @autocommit
 @version_class(ServiceCallbackApi)
 def save_service_callback_api(service_callback_api):
-    service_callback_api.created_at = datetime.utcnow()
+    service_callback_api.created_at = datetime.now(UTC).replace(tzinfo=None)
     db.session.add(service_callback_api)
 
 
@@ -21,7 +21,7 @@ def reset_service_callback_api(service_callback_api, updated_by_id, url=None, be
     if bearer_token:
         service_callback_api.bearer_token = bearer_token
     service_callback_api.updated_by_id = updated_by_id
-    service_callback_api.updated_at = datetime.utcnow()
+    service_callback_api.updated_at = datetime.now(UTC).replace(tzinfo=None)
 
     db.session.add(service_callback_api)
 

--- a/app/dao/service_data_retention_dao.py
+++ b/app/dao/service_data_retention_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from app import db
 from app.dao.dao_utils import autocommit
@@ -43,7 +43,7 @@ def insert_service_data_retention(service_id, notification_type, days_of_retenti
 def update_service_data_retention(service_data_retention_id, service_id, days_of_retention):
     updated_count = ServiceDataRetention.query.filter(
         ServiceDataRetention.id == service_data_retention_id, ServiceDataRetention.service_id == service_id
-    ).update({"days_of_retention": days_of_retention, "updated_at": datetime.utcnow()})
+    ).update({"days_of_retention": days_of_retention, "updated_at": datetime.now(UTC).replace(tzinfo=None)})
     return updated_count
 
 

--- a/app/dao/service_inbound_api_dao.py
+++ b/app/dao/service_inbound_api_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from app import db
 from app.dao.dao_utils import autocommit, version_class
@@ -8,7 +8,7 @@ from app.models import ServiceInboundApi
 @autocommit
 @version_class(ServiceInboundApi)
 def save_service_inbound_api(service_inbound_api):
-    service_inbound_api.created_at = datetime.utcnow()
+    service_inbound_api.created_at = datetime.now(UTC).replace(tzinfo=None)
     db.session.add(service_inbound_api)
 
 
@@ -20,7 +20,7 @@ def reset_service_inbound_api(service_inbound_api, updated_by_id, url=None, bear
     if bearer_token:
         service_inbound_api.bearer_token = bearer_token
     service_inbound_api.updated_by_id = updated_by_id
-    service_inbound_api.updated_at = datetime.utcnow()
+    service_inbound_api.updated_at = datetime.now(UTC).replace(tzinfo=None)
 
     db.session.add(service_inbound_api)
 

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from flask import current_app
 from sqlalchemy import Float, cast
@@ -239,7 +239,7 @@ def dao_archive_service(service_id):
 
     for api_key in service.api_keys:
         if not api_key.expiry_date:
-            api_key.expiry_date = datetime.utcnow()
+            api_key.expiry_date = datetime.now(UTC).replace(tzinfo=None)
 
 
 def dao_fetch_service_by_id_and_user(service_id, user_id):

--- a/app/dao/sms_rate_dao.py
+++ b/app/dao/sms_rate_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy import desc
 
@@ -6,4 +6,8 @@ from app.models import Rate
 
 
 def dao_get_current_sms_rate():
-    return Rate.query.filter(Rate.valid_from <= datetime.utcnow()).order_by(desc(Rate.valid_from)).first()
+    return (
+        Rate.query.filter(Rate.valid_from <= datetime.now(UTC).replace(tzinfo=None))
+        .order_by(desc(Rate.valid_from))
+        .first()
+    )

--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from flask import current_app
 from sqlalchemy import asc, desc
@@ -38,7 +38,7 @@ def dao_update_template(template):
 @autocommit
 def dao_redact_template(template, user_id):
     template.template_redacted.redact_personalisation = True
-    template.template_redacted.updated_at = datetime.utcnow()
+    template.template_redacted.updated_at = datetime.now(UTC).replace(tzinfo=None)
     template.template_redacted.updated_by_id = user_id
     db.session.add(template.template_redacted)
 

--- a/app/dao/uploads_dao.py
+++ b/app/dao/uploads_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from flask import current_app
 from sqlalchemy import String, and_, desc, func, literal, text
@@ -40,7 +40,7 @@ def _naive_gmt_to_utc(column):
 def dao_get_uploads_by_service_id(service_id, limit_days=None, page=1, page_size=50):
     # Hardcoded filter to exclude cancelled or scheduled jobs
     # for the moment, but we may want to change this method take 'statuses' as a argument in the future
-    today = datetime.utcnow().date()
+    today = datetime.now(UTC).replace(tzinfo=None).date()
     jobs_query_filter = [
         Job.service_id == service_id,
         Job.original_file_name != current_app.config["TEST_MESSAGE_FILENAME"],

--- a/app/dao/webauthn_credential_dao.py
+++ b/app/dao/webauthn_credential_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from app import db
 from app.dao.dao_utils import autocommit
@@ -35,7 +35,7 @@ def dao_update_webauthn_credential_name(webauthn_credential, new_name):
 
 @autocommit
 def dao_update_webauthn_credential_logged_in_at(webauthn_credential):
-    webauthn_credential.logged_in_at = datetime.utcnow()
+    webauthn_credential.logged_in_at = datetime.now(UTC).replace(tzinfo=None)
     db.session.add(webauthn_credential)
     return webauthn_credential
 

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -1,5 +1,5 @@
 import random
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Dict, List
 from urllib import parse
 
@@ -92,7 +92,7 @@ def send_sms_to_provider(notification):
                 if notification.international:
                     statsd_client.incr(f"international-sms.{NOTIFICATION_SENT}.{notification.phone_prefix}")
 
-        delta_seconds = (datetime.utcnow() - created_at).total_seconds()
+        delta_seconds = (datetime.now(UTC).replace(tzinfo=None) - created_at).total_seconds()
         statsd_client.timing("sms.total-time", delta_seconds)
 
         if key_type == KEY_TYPE_TEST:
@@ -158,7 +158,7 @@ def send_email_to_provider(notification):
             )
             notification.reference = reference
             update_notification_to_sending(notification, provider)
-        delta_seconds = (datetime.utcnow() - created_at).total_seconds()
+        delta_seconds = (datetime.now(UTC).replace(tzinfo=None) - created_at).total_seconds()
 
         if key_type == KEY_TYPE_TEST:
             statsd_client.timing("email.test-key.total-time", delta_seconds)
@@ -171,7 +171,7 @@ def send_email_to_provider(notification):
 
 
 def update_notification_to_sending(notification, provider):
-    notification.sent_at = datetime.utcnow()
+    notification.sent_at = datetime.now(UTC).replace(tzinfo=None)
     notification.sent_by = provider.name
     if notification.status not in NOTIFICATION_STATUS_TYPES_COMPLETED:
         notification.status = NOTIFICATION_SENT if notification.international else NOTIFICATION_SENDING

--- a/app/functional_tests/__init__.py
+++ b/app/functional_tests/__init__.py
@@ -1,5 +1,5 @@
-import datetime
 import uuid
+from datetime import UTC, datetime
 
 from flask import Blueprint, request
 
@@ -31,7 +31,7 @@ def create_functional_test_users():
             created = True
             user = User()
             user.id = uuid.uuid4()
-            user.created_at = datetime.datetime.utcnow()
+            user.created_at = datetime.now(UTC).replace(tzinfo=None)
             db.session.add(user)
 
         user.name = user_info["name"]
@@ -40,7 +40,7 @@ def create_functional_test_users():
         user.auth_type = user_info["auth_type"]
         user.password = user_info["password"]
         user.state = user_info["state"]
-        user.email_access_validated_at = datetime.datetime.utcnow()
+        user.email_access_validated_at = datetime.now(UTC).replace(tzinfo=None)
         user.platform_admin = False
 
         permissions = [

--- a/app/history_meta.py
+++ b/app/history_meta.py
@@ -15,8 +15,8 @@ session events.
 
 """
 
-import datetime
 import uuid
+from datetime import UTC, datetime
 
 from sqlalchemy import Column, Integer, Table, util
 from sqlalchemy.ext.declarative import declared_attr
@@ -149,10 +149,10 @@ def create_history(obj, history_cls=None):
 
     if not obj.version:
         obj.version = 1
-        obj.created_at = datetime.datetime.utcnow()
+        obj.created_at = datetime.now(UTC).replace(tzinfo=None)
     else:
         obj.version += 1
-        now = datetime.datetime.utcnow()
+        now = datetime.now(UTC).replace(tzinfo=None)
         obj.updated_at = now
         data["updated_at"] = now
 

--- a/app/letter_attachment/rest.py
+++ b/app/letter_attachment/rest.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import UTC, datetime
 
 from flask import Blueprint, jsonify, request
 
@@ -55,7 +55,7 @@ def archive_letter_attachment(letter_attachment_id):
     if not (template := letter_attachment.template):
         raise InvalidRequest("letter-attachment-already-archived", 400)
     template.letter_attachment = None
-    letter_attachment.archived_at = datetime.datetime.utcnow()
+    letter_attachment.archived_at = datetime.now(UTC).replace(tzinfo=None)
     letter_attachment.archived_by_id = data["archived_by"]
     dao_update_template(template)
 

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -1,7 +1,7 @@
 import io
 import json
 import math
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 
 import boto3
@@ -222,7 +222,7 @@ def letter_print_day(created_at):
     bst_print_datetime = convert_utc_to_bst(created_at) + timedelta(hours=6, minutes=30)
     bst_print_date = bst_print_datetime.date()
 
-    current_bst_date = convert_utc_to_bst(datetime.utcnow()).date()
+    current_bst_date = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None)).date()
 
     if bst_print_date >= current_bst_date:
         return "today"

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,6 @@
-import datetime
 import enum
 import uuid
+from datetime import UTC, datetime
 from typing import Union
 
 from flask import current_app, url_for
@@ -95,12 +95,16 @@ class User(db.Model):
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String, nullable=False, unique=False)
     email_address = db.Column(db.String(255), nullable=False, index=True, unique=True)
-    created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=False, default=datetime.now(UTC).replace(tzinfo=None)
+    )
+    updated_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None)
+    )
     _password = db.Column(db.String, index=False, unique=False, nullable=False)
     mobile_number = db.Column(db.String, index=False, unique=False, nullable=True)
     password_changed_at = db.Column(
-        db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow
+        db.DateTime, index=False, unique=False, nullable=False, default=datetime.now(UTC).replace(tzinfo=None)
     )
     logged_in_at = db.Column(db.DateTime, nullable=True)
     failed_login_count = db.Column(db.Integer, nullable=False, default=0)
@@ -109,7 +113,7 @@ class User(db.Model):
     current_session_id = db.Column(UUID(as_uuid=True), nullable=True)
     auth_type = db.Column(db.String, db.ForeignKey("auth_type.name"), nullable=False, default=SMS_AUTH_TYPE)
     email_access_validated_at = db.Column(
-        db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow
+        db.DateTime, index=False, unique=False, nullable=False, default=datetime.now(UTC).replace(tzinfo=None)
     )
     take_part_in_research = db.Column(db.Boolean, nullable=False, default=True)
     receives_new_features_email = db.Column(db.Boolean, nullable=False, default=True)
@@ -249,9 +253,9 @@ class EmailBranding(db.Model):
     brand_type = db.Column(
         db.String(255), db.ForeignKey("branding_type.name"), index=True, nullable=False, default=BRANDING_ORG
     )
-    created_at = db.Column(db.DateTime, nullable=True, default=lambda: datetime.datetime.utcnow())
+    created_at = db.Column(db.DateTime, nullable=True, default=lambda: datetime.now(UTC).replace(tzinfo=None))
     created_by = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=lambda: datetime.datetime.utcnow())
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=lambda: datetime.now(UTC).replace(tzinfo=None))
     updated_by = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
 
     active = db.Column(db.Boolean, nullable=False, default=True)
@@ -297,9 +301,9 @@ class LetterBranding(db.Model):
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String(255), unique=True, nullable=False)
     filename = db.Column(db.String(255), unique=True, nullable=False)
-    created_at = db.Column(db.DateTime, nullable=True, default=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=True, default=datetime.now(UTC).replace(tzinfo=None))
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
     updated_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
 
     def serialize(self):
@@ -345,7 +349,7 @@ class OrganisationPermission(db.Model):
     __tablename__ = "organisation_permissions"
     id = db.Column(UUID(as_uuid=True), primary_key=True, nullable=False, default=uuid.uuid4)
 
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
     organisation = db.relationship("Organisation", backref="permissions")
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), nullable=False)
     permission = db.Column(
@@ -360,7 +364,9 @@ class OrganisationUserPermissions(db.Model):
     __tablename__ = "organisation_user_permissions"
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
+    created_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=False, default=datetime.now(UTC).replace(tzinfo=None)
+    )
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), index=True)
     organisation = db.relationship("Organisation")
 
@@ -381,8 +387,8 @@ class Organisation(db.Model):
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=False)
     name = db.Column(db.String(255), nullable=False, unique=True, index=True)
     active = db.Column(db.Boolean, nullable=False, default=True)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
     agreement_signed = db.Column(db.Boolean, nullable=True)
     agreement_signed_at = db.Column(db.DateTime, nullable=True)
     agreement_signed_by_id = db.Column(
@@ -524,8 +530,12 @@ class Service(db.Model, Versioned):
     _custom_email_sender_name = db.Column("custom_email_sender_name", db.String(255), nullable=True)
     _email_sender_local_part = db.Column("email_sender_local_part", db.String(255), nullable=False)
 
-    created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=False, default=datetime.now(UTC).replace(tzinfo=None)
+    )
+    updated_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None)
+    )
     active = db.Column(db.Boolean, index=False, unique=False, nullable=False, default=True)
     letter_message_limit = db.Column(db.BigInteger, index=False, unique=False, nullable=False, default=999_999_999)
     sms_message_limit = db.Column(db.BigInteger, index=False, unique=False, nullable=False, default=999_999_999)
@@ -697,8 +707,8 @@ class AnnualBilling(db.Model):
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), unique=False, index=True, nullable=False)
     financial_year_start = db.Column(db.Integer, nullable=False, default=True, unique=False)
     free_sms_fragment_limit = db.Column(db.Integer, nullable=False, index=False, unique=False)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
     UniqueConstraint("financial_year_start", "service_id", name="ix_annual_billing_service_id")
     service = db.relationship(Service, backref=db.backref("annual_billing", uselist=True))
 
@@ -736,8 +746,8 @@ class InboundNumber(db.Model):
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), unique=True, index=True, nullable=True)
     service = db.relationship(Service, backref=db.backref("inbound_number", uselist=False))
     active = db.Column(db.Boolean, index=False, unique=False, nullable=False, default=True)
-    created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow, nullable=False)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=datetime.now(UTC).replace(tzinfo=None), nullable=False)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
 
     def serialize(self):
         def serialize_service():
@@ -767,8 +777,8 @@ class ServiceSmsSender(db.Model):
         UUID(as_uuid=True), db.ForeignKey("inbound_numbers.id"), unique=True, index=True, nullable=True
     )
     inbound_number = db.relationship(InboundNumber, backref=db.backref("inbound_number", uselist=False))
-    created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow, nullable=False)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=datetime.now(UTC).replace(tzinfo=None), nullable=False)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
 
     def get_reply_to_text(self):
         return try_validate_and_format_phone_number(self.sms_sender)
@@ -795,7 +805,7 @@ class ServicePermission(db.Model):
     permission = db.Column(
         db.String(255), db.ForeignKey("service_permission_types.name"), index=True, primary_key=True, nullable=False
     )
-    created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.now(UTC).replace(tzinfo=None), nullable=False)
 
     service_permission_types = db.relationship(Service, backref=db.backref("permissions", cascade="all, delete-orphan"))
 
@@ -811,7 +821,7 @@ class ServiceGuestList(db.Model):
     service = db.relationship("Service", backref="guest_list")
     recipient_type = db.Column(guest_list_recipient_types, nullable=False)
     recipient = db.Column(db.String(255), nullable=False)
-    created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=datetime.now(UTC).replace(tzinfo=None))
 
     @classmethod
     def from_string(cls, service_id, recipient_type, recipient):
@@ -844,7 +854,7 @@ class ServiceInboundApi(db.Model, Versioned):
     service = db.relationship("Service", backref="inbound_api")
     url = db.Column(db.String(), nullable=False)
     _bearer_token = db.Column("bearer_token", db.String(), nullable=False)
-    created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.now(UTC).replace(tzinfo=None), nullable=False)
     updated_at = db.Column(db.DateTime, nullable=True)
     updated_by = db.relationship("User")
     updated_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=False)
@@ -879,7 +889,7 @@ class ServiceCallbackApi(db.Model, Versioned):
     url = db.Column(db.String(), nullable=False)
     callback_type = db.Column(db.String(), db.ForeignKey("service_callback_type.name"), nullable=True)
     _bearer_token = db.Column("bearer_token", db.String(), nullable=False)
-    created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.now(UTC).replace(tzinfo=None), nullable=False)
     updated_at = db.Column(db.DateTime, nullable=True)
     updated_by = db.relationship("User")
     updated_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=False)
@@ -924,8 +934,12 @@ class ApiKey(db.Model, Versioned):
     service = db.relationship("Service", backref="api_keys")
     key_type = db.Column(db.String(255), db.ForeignKey("key_types.name"), nullable=False)
     expiry_date = db.Column(db.DateTime)
-    created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=False, default=datetime.now(UTC).replace(tzinfo=None)
+    )
+    updated_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None)
+    )
     created_by = db.relationship("User")
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=False)
 
@@ -1027,8 +1041,8 @@ class TemplateBase(db.Model):
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String(255), nullable=False)
     template_type = db.Column(template_types, nullable=False)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
+    updated_at = db.Column(db.DateTime, onupdate=datetime.now(UTC).replace(tzinfo=None))
     content = db.Column(db.Text, nullable=False)
     archived = db.Column(db.Boolean, nullable=False, default=False)
     hidden = db.Column(db.Boolean, nullable=False, default=False)
@@ -1217,7 +1231,7 @@ class TemplateRedacted(db.Model):
 
     template_id = db.Column(UUID(as_uuid=True), db.ForeignKey("templates.id"), primary_key=True, nullable=False)
     redact_personalisation = db.Column(db.Boolean, nullable=False, default=False)
-    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
     updated_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=False, index=True)
     updated_by = db.relationship("User")
 
@@ -1254,7 +1268,7 @@ class ProviderDetails(db.Model):
     notification_type = db.Column(notification_types, nullable=False)
     active = db.Column(db.Boolean, default=False, nullable=False)
     version = db.Column(db.Integer, default=1, nullable=False)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=True)
     created_by = db.relationship("User")
     supports_international = db.Column(db.Boolean, nullable=False, default=False)
@@ -1270,7 +1284,7 @@ class ProviderDetailsHistory(db.Model):
     notification_type = db.Column(notification_types, nullable=False)
     active = db.Column(db.Boolean, nullable=False)
     version = db.Column(db.Integer, primary_key=True, nullable=False)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=True)
     created_by = db.relationship("User")
     supports_international = db.Column(db.Boolean, nullable=False, default=False)
@@ -1301,8 +1315,12 @@ class Job(db.Model):
     template_id = db.Column(UUID(as_uuid=True), db.ForeignKey("templates.id"), index=True, unique=False)
     template = db.relationship("Template", backref=db.backref("jobs", lazy="dynamic"))
     template_version = db.Column(db.Integer, nullable=False)
-    created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=False, default=datetime.now(UTC).replace(tzinfo=None)
+    )
+    updated_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None)
+    )
     notification_count = db.Column(db.Integer, nullable=False)
     notifications_sent = db.Column(db.Integer, nullable=False, default=0)
     notifications_delivered = db.Column(db.Integer, nullable=False, default=0)
@@ -1332,7 +1350,9 @@ class VerifyCode(db.Model):
     )
     expiry_datetime = db.Column(db.DateTime, nullable=False)
     code_used = db.Column(db.Boolean, default=False)
-    created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
+    created_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=False, default=datetime.now(UTC).replace(tzinfo=None)
+    )
 
     @property
     def code(self):
@@ -1412,7 +1432,9 @@ class Notification(db.Model):
     created_at = db.Column(db.DateTime, index=True, unique=False, nullable=False)
     sent_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
     sent_by = db.Column(db.String, nullable=True)
-    updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.datetime.utcnow)
+    updated_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None)
+    )
     status = db.Column(
         "notification_status",
         db.Text,
@@ -1658,7 +1680,9 @@ class NotificationHistory(db.Model):
     created_at = db.Column(db.DateTime, unique=False, nullable=False)
     sent_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
     sent_by = db.Column(db.String, nullable=True)
-    updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.datetime.utcnow)
+    updated_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None)
+    )
     status = db.Column(
         "notification_status",
         db.Text,
@@ -1732,7 +1756,9 @@ class InvitedUser(db.Model):
     from_user = db.relationship("User")
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), index=True, unique=False)
     service = db.relationship("Service")
-    created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
+    created_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=False, default=datetime.now(UTC).replace(tzinfo=None)
+    )
     status = db.Column(
         db.Enum(*INVITED_USER_STATUS_TYPES, name="invited_users_status_types"), nullable=False, default=INVITE_PENDING
     )
@@ -1757,7 +1783,7 @@ class InvitedOrganisationUser(db.Model):
     organisation = db.relationship("Organisation")
 
     permissions = db.Column(db.String, nullable=False)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
 
     status = db.Column(db.String, db.ForeignKey("invite_status_type.name"), nullable=False, default=INVITE_PENDING)
 
@@ -1785,7 +1811,9 @@ class Permission(db.Model):
     permission = db.Column(
         db.Enum(*PERMISSION_LIST, name="permission_types"), index=False, unique=False, nullable=False
     )
-    created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
+    created_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=False, default=datetime.now(UTC).replace(tzinfo=None)
+    )
 
     __table_args__ = (UniqueConstraint("service_id", "user_id", "permission", name="uix_service_user_permission"),)
 
@@ -1795,7 +1823,9 @@ class Event(db.Model):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     event_type = db.Column(db.String(255), nullable=False)
-    created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
+    created_at = db.Column(
+        db.DateTime, index=False, unique=False, nullable=False, default=datetime.now(UTC).replace(tzinfo=None)
+    )
     data = db.Column(JSON, nullable=False)
 
 
@@ -1824,7 +1854,7 @@ class InboundSms(db.Model):
     __tablename__ = "inbound_sms"
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), index=True, nullable=False)
     service = db.relationship("Service", backref="inbound_sms")
 
@@ -1897,8 +1927,8 @@ class ServiceEmailReplyTo(db.Model):
     email_address = db.Column(db.Text, nullable=False, index=False, unique=False)
     is_default = db.Column(db.Boolean, nullable=False, default=True)
     archived = db.Column(db.Boolean, nullable=False, default=False)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
 
     def serialize(self):
         return {
@@ -1923,8 +1953,8 @@ class ServiceLetterContact(db.Model):
     contact_block = db.Column(db.Text, nullable=False, index=False, unique=False)
     is_default = db.Column(db.Boolean, nullable=False, default=True)
     archived = db.Column(db.Boolean, nullable=False, default=False)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
 
     def serialize(self):
         return {
@@ -1952,7 +1982,7 @@ class DailySortedLetter(db.Model):
     file_name = db.Column(db.String, nullable=True)
     unsorted_count = db.Column(db.Integer, nullable=False, default=0)
     sorted_count = db.Column(db.Integer, nullable=False, default=0)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
 
     __table_args__ = (UniqueConstraint("file_name", "billing_day", name="uix_file_name_billing_day"),)
 
@@ -1972,8 +2002,8 @@ class FactBillingLetterDespatch(db.Model):
     rate = db.Column(db.Numeric(), nullable=False, primary_key=True)
     billable_units = db.Column(db.Integer(), nullable=True, primary_key=True)
     notifications_sent = db.Column(db.Integer(), nullable=True)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
 
 
 class FactBilling(db.Model):
@@ -1990,8 +2020,8 @@ class FactBilling(db.Model):
     postage = db.Column(db.String, nullable=False, primary_key=True)
     billable_units = db.Column(db.Integer(), nullable=True)
     notifications_sent = db.Column(db.Integer(), nullable=True)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
 
 
 class FactNotificationStatus(db.Model):
@@ -2010,8 +2040,8 @@ class FactNotificationStatus(db.Model):
     key_type = db.Column(db.Text, primary_key=True, nullable=False)
     notification_status = db.Column(db.Text, primary_key=True, nullable=False)
     notification_count = db.Column(db.Integer(), nullable=False)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
 
 
 class FactProcessingTime(db.Model):
@@ -2020,8 +2050,8 @@ class FactProcessingTime(db.Model):
     bst_date = db.Column(db.Date, index=True, primary_key=True, nullable=False)
     messages_total = db.Column(db.Integer(), nullable=False)
     messages_within_10_secs = db.Column(db.Integer(), nullable=False)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
 
 
 class Complaint(db.Model):
@@ -2034,7 +2064,7 @@ class Complaint(db.Model):
     ses_feedback_id = db.Column(db.Text, nullable=True)
     complaint_type = db.Column(db.Text, nullable=True)
     complaint_date = db.Column(db.DateTime, nullable=True)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
 
     def serialize(self):
         return {
@@ -2059,8 +2089,8 @@ class ServiceDataRetention(db.Model):
     )
     notification_type = db.Column(notification_types, nullable=False)
     days_of_retention = db.Column(db.Integer, nullable=False)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
 
     __table_args__ = (UniqueConstraint("service_id", "notification_type", name="uix_service_data_retention"),)
 
@@ -2085,7 +2115,7 @@ class ReturnedLetter(db.Model):
     service = db.relationship(Service, backref=db.backref("returned_letters"))
     notification_id = db.Column(UUID(as_uuid=True), unique=True, nullable=False)
     created_at = db.Column(db.DateTime, nullable=False)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
 
 
 class ServiceContactList(db.Model):
@@ -2100,12 +2130,12 @@ class ServiceContactList(db.Model):
     created_by = db.relationship("User")
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=True)
     created_at = db.Column(db.DateTime, nullable=False)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
     archived = db.Column(db.Boolean, nullable=False, default=False)
 
     @property
     def job_count(self):
-        today = datetime.datetime.utcnow().date()
+        today = datetime.now(UTC).replace(tzinfo=None).date()
         return (
             Job.query.filter(
                 Job.contact_list_id == self.id,
@@ -2214,10 +2244,10 @@ class BroadcastMessage(db.Model):
     finishes_at = db.Column(db.DateTime, nullable=True)  # isn't updated if user cancels
 
     # these times correspond to when
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
     approved_at = db.Column(db.DateTime, nullable=True)
     cancelled_at = db.Column(db.DateTime, nullable=True)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
 
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
     approved_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
@@ -2305,7 +2335,7 @@ class BroadcastEvent(db.Model):
     broadcast_message = db.relationship("BroadcastMessage", backref="events")
 
     # this is used for <sent> in the cap xml
-    sent_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    sent_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
 
     # msgType. alert, cancel, or update. (other options in the spec are "ack" and "error")
     message_type = db.Column(db.String, nullable=False)
@@ -2406,8 +2436,8 @@ class BroadcastProviderMessage(db.Model):
 
     status = db.Column(db.String)
 
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
 
     UniqueConstraint(broadcast_event_id, provider)
 
@@ -2447,8 +2477,8 @@ class ServiceBroadcastSettings(db.Model):
     service = db.relationship(Service, backref=db.backref("service_broadcast_settings", uselist=False))
     channel = db.Column(db.String(255), db.ForeignKey("broadcast_channel_types.name"), nullable=False)
     provider = db.Column(db.String, db.ForeignKey("broadcast_provider_types.name"), nullable=False)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
 
 
 class BroadcastChannelTypes(db.Model):
@@ -2488,7 +2518,7 @@ class ServiceBroadcastProviderRestriction(db.Model):
 
     provider = db.Column(db.String, nullable=False)
 
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
 
 
 class WebauthnCredential(db.Model):
@@ -2511,8 +2541,8 @@ class WebauthnCredential(db.Model):
     # base64 encoded CBOR. used for auditing. https://www.w3.org/TR/webauthn-2/#authenticatorattestationresponse
     registration_response = db.Column(db.String, nullable=False)
 
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.now(UTC).replace(tzinfo=None))
 
     logged_in_at = db.Column(db.DateTime, nullable=True)
 
@@ -2533,7 +2563,7 @@ class LetterAttachment(db.Model):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, nullable=False, default=uuid.uuid4)
 
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now(UTC).replace(tzinfo=None))
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=False)
     archived_at = db.Column(db.DateTime, nullable=True)
     archived_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 from flask import current_app
 from gds_metrics import Histogram
@@ -115,7 +115,7 @@ def persist_notification(
     document_download_count=None,
     updated_at=None,
 ):
-    notification_created_at = created_at or datetime.utcnow()
+    notification_created_at = created_at or datetime.now(UTC).replace(tzinfo=None)
     if not notification_id:
         notification_id = uuid.uuid4()
     notification = Notification(

--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from urllib.parse import unquote
 
 import iso8601
@@ -127,7 +127,7 @@ def format_mmg_datetime(date):
         parsed_datetime = iso8601.parse_date(orig_date).replace(tzinfo=None)
         return parsed_datetime
     except iso8601.ParseError:
-        return datetime.utcnow()
+        return datetime.now(UTC).replace(tzinfo=None)
 
 
 def create_inbound_sms_object(service, content, from_number, provider_ref, date_received, provider_name):

--- a/app/performance_dashboard/rest.py
+++ b/app/performance_dashboard/rest.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from flask import Blueprint, jsonify, request
 
@@ -29,7 +29,7 @@ def get_performance_dashboard():
         validate(request.args, performance_dashboard_request)
 
     # If start and end date are not set, we are expecting today's stats.
-    today = str(datetime.utcnow().date())
+    today = str(datetime.now(UTC).replace(tzinfo=None).date())
 
     start_date = datetime.strptime(request.args.get("start_date", today), "%Y-%m-%d").date()
     end_date = datetime.strptime(request.args.get("end_date", today), "%Y-%m-%d").date()

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from flask import Blueprint, jsonify, request
 
@@ -34,7 +34,7 @@ def get_platform_stats():
         validate(request.args, platform_stats_request)
 
     # If start and end date are not set, we are expecting today's stats.
-    today = str(datetime.utcnow().date())
+    today = str(datetime.now(UTC).replace(tzinfo=None).date())
 
     start_date = datetime.strptime(request.args.get("start_date", today), "%Y-%m-%d").date()
     end_date = datetime.strptime(request.args.get("end_date", today), "%Y-%m-%d").date()

--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -1,6 +1,6 @@
 import json
 import re
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 from iso8601 import ParseError, iso8601
@@ -54,9 +54,9 @@ def validate_schema_date_with_hour(instance):
     if isinstance(instance, str):
         try:
             dt = iso8601.parse_date(instance).replace(tzinfo=None)
-            if dt < datetime.utcnow():
+            if dt < datetime.now(UTC).replace(tzinfo=None):
                 raise ValidationError("datetime can not be in the past")
-            if dt > datetime.utcnow() + timedelta(hours=24):
+            if dt > datetime.now(UTC).replace(tzinfo=None) + timedelta(hours=24):
                 raise ValidationError("datetime can only be 24 hours in the future")
         except ParseError as e:
             raise ValidationError(

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 from dateutil.parser import parse
@@ -544,10 +544,10 @@ class JobSchema(BaseSchema):
 
     @validates("scheduled_for")
     def validate_scheduled_for(self, value):
-        if value < datetime.utcnow():
+        if value < datetime.now(UTC).replace(tzinfo=None):
             raise ValidationError("Date cannot be in the past")
 
-        if value > datetime.utcnow() + timedelta(days=7):
+        if value > datetime.now(UTC).replace(tzinfo=None) + timedelta(days=7):
             raise ValidationError("Date cannot be more than 7 days in the future")
 
     class Meta(BaseSchema.Meta):

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1,5 +1,5 @@
 import itertools
-from datetime import datetime
+from datetime import UTC, datetime
 
 from flask import Blueprint, current_app, jsonify, request
 from notifications_utils.letter_timings import (
@@ -183,7 +183,7 @@ def get_services():
     include_from_test_key = request.args.get("include_from_test_key", "True") != "False"
 
     # If start and end date are not set, we are expecting today's stats.
-    today = str(datetime.utcnow().date())
+    today = str(datetime.now(UTC).replace(tzinfo=None).date())
 
     start_date = datetime.strptime(request.args.get("start_date", today), "%Y-%m-%d").date()
     end_date = datetime.strptime(request.args.get("end_date", today), "%Y-%m-%d").date()
@@ -599,7 +599,7 @@ def get_monthly_notification_stats(service_id):
     stats = fetch_notification_status_for_service_by_month(start_date, end_date, service_id)
     statistics.add_monthly_notification_status_stats(data, stats)
 
-    now = datetime.utcnow()
+    now = datetime.now(UTC).replace(tzinfo=None)
     if end_date > now:
         todays_deltas = fetch_notification_status_for_service_for_day(convert_utc_to_bst(now), service_id=service_id)
         statistics.add_monthly_notification_status_stats(data, todays_deltas)
@@ -625,7 +625,7 @@ def get_service_statistics(service_id, today_only, limit_days=7):
 
 
 def get_detailed_services(start_date, end_date, only_active=False, include_from_test_key=True):
-    if start_date == datetime.utcnow().date():
+    if start_date == datetime.now(UTC).replace(tzinfo=None).date():
         stats = dao_fetch_todays_stats_for_all_services(
             include_from_test_key=include_from_test_key, only_active=only_active
         )
@@ -1094,7 +1094,7 @@ def delete_contact_list_by_id(service_id, contact_list_id):
 def create_contact_list(service_id):
     service_contact_list = validate(request.get_json(), create_service_contact_list_schema)
     service_contact_list["created_by_id"] = service_contact_list.pop("created_by")
-    service_contact_list["created_at"] = datetime.utcnow()
+    service_contact_list["created_at"] = datetime.now(UTC).replace(tzinfo=None)
     service_contact_list["service_id"] = str(service_id)
     list_to_save = ServiceContactList(**service_contact_list)
 

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 from urllib.parse import urlencode
 
 from flask import Blueprint, abort, current_app, jsonify, request
@@ -218,7 +218,7 @@ def verify_user_code(user_id):
         increment_failed_login_count(user_to_verify)
         raise InvalidRequest("Code not found", status_code=404)
 
-    expired = datetime.utcnow() > code.expiry_datetime
+    expired = datetime.now(UTC).replace(tzinfo=None) > code.expiry_datetime
     used = code.code_used
     if expired or used:
         # sms and email
@@ -227,9 +227,9 @@ def verify_user_code(user_id):
         raise InvalidRequest("Code has expired", status_code=400)
 
     user_to_verify.current_session_id = str(uuid.uuid4())
-    user_to_verify.logged_in_at = datetime.utcnow()
+    user_to_verify.logged_in_at = datetime.now(UTC).replace(tzinfo=None)
     if data["code_type"] == "email":
-        user_to_verify.email_access_validated_at = datetime.utcnow()
+        user_to_verify.email_access_validated_at = datetime.now(UTC).replace(tzinfo=None)
     user_to_verify.failed_login_count = 0
     save_model_user(user_to_verify)
 
@@ -260,7 +260,7 @@ def complete_login_after_webauthn_authentication_attempt(user_id):
 
     if successful:
         user.current_session_id = str(uuid.uuid4())
-        user.logged_in_at = datetime.utcnow()
+        user.logged_in_at = datetime.now(UTC).replace(tzinfo=None)
         user.failed_login_count = 0
         save_model_user(user)
 
@@ -560,7 +560,7 @@ def get_organisations_and_services_for_user(user_id):
 
 
 def _create_reset_password_url(email, next_redirect, base_url=None):
-    data = json.dumps({"email": email, "created_at": str(datetime.utcnow())})
+    data = json.dumps({"email": email, "created_at": str(datetime.now(UTC).replace(tzinfo=None))})
     static_url_part = "/new-password/"
     full_url = url_with_token(data, static_url_part, current_app.config, base_url=base_url)
     if next_redirect:

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Optional
 
 import pytz
@@ -113,7 +113,7 @@ def midnight_n_days_ago(number_of_days):
     """
     Returns midnight a number of days ago. Takes care of daylight savings etc.
     """
-    return get_london_midnight_in_utc(datetime.utcnow() - timedelta(days=number_of_days))
+    return get_london_midnight_in_utc(datetime.now(UTC).replace(tzinfo=None) - timedelta(days=number_of_days))
 
 
 def escape_special_characters(string):
@@ -134,7 +134,7 @@ def email_address_is_nhs(email_address):
 
 
 def get_archived_db_column_value(column):
-    date = datetime.utcnow().strftime("%Y-%m-%d")
+    date = datetime.now(UTC).replace(tzinfo=None).strftime("%Y-%m-%d")
     return f"_archived_{date}_{column}"
 
 

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -1,7 +1,7 @@
 import base64
 import functools
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 import botocore
 from flask import abort, current_app, jsonify, request
@@ -297,7 +297,7 @@ def save_email_or_sms_to_queue(
         "unsubscribe_link": unsubscribe_link,
         "document_download_count": document_download_count,
         "status": NOTIFICATION_CREATED,
-        "created_at": datetime.utcnow().strftime(DATETIME_FORMAT),
+        "created_at": datetime.now(UTC).replace(tzinfo=None).strftime(DATETIME_FORMAT),
     }
     encoded = signing.encode(data)
 
@@ -387,7 +387,7 @@ def process_letter_notification(
         # mark test letter as delivered and do not create a fake response later
         else:
             status = NOTIFICATION_DELIVERED
-            updated_at = datetime.utcnow()
+            updated_at = datetime.now(UTC).replace(tzinfo=None)
 
     queue = QueueNames.CREATE_LETTERS_PDF if not test_key else QueueNames.RESEARCH_MODE
 

--- a/migrations/versions/0025_notify_service_data.py
+++ b/migrations/versions/0025_notify_service_data.py
@@ -9,7 +9,7 @@ Create Date: 2016-06-01 14:17:01.963181
 import uuid
 
 # revision identifiers, used by Alembic.
-from datetime import datetime
+from datetime import UTC, datetime
 
 from alembic import op
 
@@ -29,18 +29,18 @@ def upgrade():
     user_insert = """INSERT INTO users (id, name, email_address, created_at, failed_login_count, _password, mobile_number, state, platform_admin)
                      VALUES ('{}', 'Notify service user', 'notify-service-user@digital.cabinet-office', '{}', 0,'{}', '+441234123412', 'active', False)
                   """
-    op.execute(user_insert.format(user_id, datetime.utcnow(), password))
+    op.execute(user_insert.format(user_id, datetime.now(UTC).replace(tzinfo=None), password))
     service_history_insert = """INSERT INTO services_history (id, name, created_at, active, message_limit, restricted, research_mode, email_from, created_by_id, reply_to_email_address, version)
                         VALUES ('{}', 'Notify service', '{}', True, 1000, False, False, 'notify@digital.cabinet-office.gov.uk',
                         '{}', 'notify@digital.cabinet-office.gov.uk', 1)
 
                      """
-    op.execute(service_history_insert.format(service_id, datetime.utcnow(), user_id))
+    op.execute(service_history_insert.format(service_id, datetime.now(UTC).replace(tzinfo=None), user_id))
     service_insert = """INSERT INTO services (id, name, created_at, active, message_limit, restricted, research_mode, email_from, created_by_id, reply_to_email_address, version)
                         VALUES ('{}', 'Notify service', '{}', True, 1000, False, False, 'notify@digital.cabinet-office.gov.uk',
                         '{}', 'notify@digital.cabinet-office.gov.uk', 1)
                     """
-    op.execute(service_insert.format(service_id, datetime.utcnow(), user_id))
+    op.execute(service_insert.format(service_id, datetime.now(UTC).replace(tzinfo=None), user_id))
     user_to_service_insert = """INSERT INTO user_to_service (user_id, service_id) VALUES ('{}', '{}')"""
     op.execute(user_to_service_insert.format(user_id, service_id))
 
@@ -61,7 +61,7 @@ def upgrade():
             uuid.uuid4(),
             "Notify email verification code",
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             email_verification_content,
             service_id,
             "Confirm GOV.UK Notify registration",
@@ -73,7 +73,7 @@ def upgrade():
             "ece42649-22a8-4d06-b87f-d52d5d3f0a27",
             "Notify email verification code",
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             email_verification_content,
             service_id,
             "Confirm GOV.UK Notify registration",
@@ -92,7 +92,7 @@ def upgrade():
             "4f46df42-f795-4cc4-83bb-65ca312f49cc",
             "Notify invitation email",
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             invitation_content,
             service_id,
             invitation_subject,
@@ -104,7 +104,7 @@ def upgrade():
             "4f46df42-f795-4cc4-83bb-65ca312f49cc",
             "Notify invitation email",
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             invitation_content,
             service_id,
             invitation_subject,
@@ -118,7 +118,7 @@ def upgrade():
             "36fb0730-6259-4da1-8a80-c8de22ad4246",
             "Notify SMS verify code",
             "sms",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             sms_code_content,
             service_id,
             None,
@@ -131,7 +131,7 @@ def upgrade():
             "36fb0730-6259-4da1-8a80-c8de22ad4246",
             "Notify SMS verify code",
             "sms",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             sms_code_content,
             service_id,
             None,
@@ -153,7 +153,7 @@ def upgrade():
             "474e9242-823b-4f99-813d-ed392e7f1201",
             "Notify password reset email",
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             password_reset_content,
             service_id,
             "Reset your GOV.UK Notify password",
@@ -165,7 +165,7 @@ def upgrade():
             "474e9242-823b-4f99-813d-ed392e7f1201",
             "Notify password reset email",
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             password_reset_content,
             service_id,
             "Reset your GOV.UK Notify password",

--- a/migrations/versions/0027_update_provider_rates.py
+++ b/migrations/versions/0027_update_provider_rates.py
@@ -11,7 +11,7 @@ revision = "0027_update_provider_rates"
 down_revision = "0026_rename_notify_service"
 
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 import sqlalchemy as sa
 from alembic import op
@@ -24,13 +24,13 @@ def upgrade():
         (
             "INSERT INTO provider_rates (id, valid_from, rate, provider_id) VALUES ('{}', '{}', 1.8, "
             "(SELECT id FROM provider_details WHERE identifier = 'mmg'))"
-        ).format(uuid.uuid4(), datetime.utcnow())
+        ).format(uuid.uuid4(), datetime.now(UTC).replace(tzinfo=None))
     )
     op.execute(
         (
             "INSERT INTO provider_rates (id, valid_from, rate, provider_id) VALUES ('{}', '{}', 2.5, "
             "(SELECT id FROM provider_details WHERE identifier = 'firetext'))"
-        ).format(uuid.uuid4(), datetime.utcnow())
+        ).format(uuid.uuid4(), datetime.now(UTC).replace(tzinfo=None))
     )
     ### end Alembic commands ###
 

--- a/migrations/versions/0028_fix_reg_template_history.py
+++ b/migrations/versions/0028_fix_reg_template_history.py
@@ -7,7 +7,7 @@ Create Date: 2016-06-13 11:04:15.888017
 """
 
 # revision identifiers, used by Alembic.
-from datetime import datetime
+from datetime import UTC, datetime
 
 revision = "0028_fix_reg_template_history"
 down_revision = "0027_update_provider_rates"
@@ -36,7 +36,7 @@ def upgrade():
             "ece42649-22a8-4d06-b87f-d52d5d3f0a27",
             "Notify email verification code",
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             email_verification_content,
             service_id,
             "Confirm GOV.UK Notify registration",

--- a/migrations/versions/0041_email_template_.py
+++ b/migrations/versions/0041_email_template_.py
@@ -7,7 +7,7 @@ Create Date: 2016-07-07 16:02:06.241769
 """
 
 # revision identifiers, used by Alembic.
-from datetime import datetime
+from datetime import UTC, datetime
 
 revision = "0041_email_template"
 down_revision = "0040_adjust_mmg_provider_rate"
@@ -43,7 +43,7 @@ If you didn’t try to register for a GOV.UK Notify account recently, please let
             "0880fbb1-a0c6-46f0-9a8e-36c986381ceb",
             "Your GOV.UK Notify account",
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             content,
             service_id,
             "Your GOV.UK Notify account",
@@ -55,7 +55,7 @@ If you didn’t try to register for a GOV.UK Notify account recently, please let
             "0880fbb1-a0c6-46f0-9a8e-36c986381ceb",
             "Your GOV.UK Notify account",
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             content,
             service_id,
             "Your GOV.UK Notify account",
@@ -71,7 +71,7 @@ If you didn’t try to register for a GOV.UK Notify account recently, please let
 #         INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
 #         VALUES ('0880fbb1-a0c6-46f0-9a8e-36c986381ceb', '{}', '{}', '{}')
 #         ;
-#     """.format(False, datetime.utcnow(), user_id)
+#     """.format(False, datetime.now(UTC).replace(tzinfo=None), user_id)
 # )
 
 

--- a/migrations/versions/0057_change_email_template.py
+++ b/migrations/versions/0057_change_email_template.py
@@ -7,7 +7,7 @@ Create Date: 2016-10-11 09:24:45.669018
 """
 
 # revision identifiers, used by Alembic.
-from datetime import datetime
+from datetime import UTC, datetime
 
 from alembic import op
 
@@ -37,12 +37,26 @@ def upgrade():
     template_name = "Confirm new email address"
     op.execute(
         template_history_insert.format(
-            template_id, template_name, "email", datetime.utcnow(), template_content, service_id, template_name, user_id
+            template_id,
+            template_name,
+            "email",
+            datetime.now(UTC).replace(tzinfo=None),
+            template_content,
+            service_id,
+            template_name,
+            user_id,
         )
     )
     op.execute(
         template_insert.format(
-            template_id, template_name, "email", datetime.utcnow(), template_content, service_id, template_name, user_id
+            template_id,
+            template_name,
+            "email",
+            datetime.now(UTC).replace(tzinfo=None),
+            template_content,
+            service_id,
+            template_name,
+            user_id,
         )
     )
 
@@ -54,7 +68,7 @@ def upgrade():
 #         INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
 #         VALUES ('{}', '{}', '{}', '{}')
 #         ;
-#     """.format(template_id, False, datetime.utcnow(), user_id)
+#     """.format(template_id, False, datetime.now(UTC).replace(tzinfo=None), user_id)
 # )
 
 

--- a/migrations/versions/0066_add_dvla_provider.py
+++ b/migrations/versions/0066_add_dvla_provider.py
@@ -7,7 +7,7 @@ Create Date: 2017-03-02 10:32:28.984947
 """
 
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 revision = "0066_add_dvla_provider"
 down_revision = "0065_users_current_session_id"
@@ -29,7 +29,7 @@ def upgrade():
     )
     op.execute(
         "INSERT INTO provider_rates (id, valid_from, rate, provider_id) VALUES ('{}', '{}', 1.0, '{}')".format(
-            uuid.uuid4(), datetime.utcnow(), provider_id
+            uuid.uuid4(), datetime.now(UTC).replace(tzinfo=None), provider_id
         )
     )
 

--- a/migrations/versions/0082_add_golive_template.py
+++ b/migrations/versions/0082_add_golive_template.py
@@ -7,7 +7,7 @@ Create Date: 2017-05-10 16:06:04.070874
 """
 
 # revision identifiers, used by Alembic.
-from datetime import datetime
+from datetime import UTC, datetime
 
 import sqlalchemy as sa
 from alembic import op
@@ -89,7 +89,7 @@ GOV.UK Notify team
             template_id,
             template_name,
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             template_content,
             current_app.config["NOTIFY_SERVICE_ID"],
             template_subject,
@@ -103,7 +103,7 @@ GOV.UK Notify team
             template_id,
             template_name,
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             template_content,
             current_app.config["NOTIFY_SERVICE_ID"],
             template_subject,
@@ -120,7 +120,7 @@ GOV.UK Notify team
 #         INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
 #         VALUES ('{}', '{}', '{}', '{}')
 #         ;
-#     """.format(template_id, False, datetime.utcnow(), current_app.config['NOTIFY_USER_ID'])
+#     """.format(template_id, False, datetime.now(UTC).replace(tzinfo=None), current_app.config['NOTIFY_USER_ID'])
 # )
 
 

--- a/migrations/versions/0117_international_sms_notify.py
+++ b/migrations/versions/0117_international_sms_notify.py
@@ -10,7 +10,7 @@ Create Date: 2017-08-29 14:09:41.042061
 revision = "0117_international_sms_notify"
 down_revision = "0116_another_letter_org"
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from alembic import op
 
@@ -23,7 +23,7 @@ def upgrade():
         INSERT INTO service_permissions VALUES
         ('{}', 'international_sms', '{}')
     """.format(
-            NOTIFY_SERVICE_ID, datetime.utcnow()
+            NOTIFY_SERVICE_ID, datetime.now(UTC).replace(tzinfo=None)
         )
     )
 

--- a/migrations/versions/0134_add_email_2fa_template_.py
+++ b/migrations/versions/0134_add_email_2fa_template_.py
@@ -6,7 +6,7 @@ Create Date: 2017-11-03 13:52:59.715203
 
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from alembic import op
 from flask import current_app
@@ -44,7 +44,7 @@ def upgrade():
             template_id,
             template_name,
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             template_content,
             current_app.config["NOTIFY_SERVICE_ID"],
             template_subject,
@@ -58,7 +58,7 @@ def upgrade():
             template_id,
             template_name,
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             template_content,
             current_app.config["NOTIFY_SERVICE_ID"],
             template_subject,
@@ -75,7 +75,7 @@ def upgrade():
 #         INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
 #         VALUES ('{}', '{}', '{}', '{}')
 #         ;
-#     """.format(template_id, False, datetime.utcnow(), current_app.config['NOTIFY_USER_ID'])
+#     """.format(template_id, False, datetime.now(UTC).replace(tzinfo=None), current_app.config['NOTIFY_USER_ID'])
 # )
 
 

--- a/migrations/versions/0139_migrate_sms_allowance_data.py
+++ b/migrations/versions/0139_migrate_sms_allowance_data.py
@@ -7,7 +7,7 @@ Create Date: 2017-11-10 21:42:59.715203
 """
 
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 from alembic import op
 
@@ -38,7 +38,7 @@ def upgrade():
          FROM services WHERE id NOT IN
         (select service_id from annual_billing)
     """.format(
-        current_year, default_limit, datetime.utcnow(), datetime.utcnow()
+        current_year, default_limit, datetime.now(UTC).replace(tzinfo=None), datetime.now(UTC).replace(tzinfo=None)
     )
     op.execute(insert_row_if_not_exist)
 

--- a/migrations/versions/0171_add_org_invite_template.py
+++ b/migrations/versions/0171_add_org_invite_template.py
@@ -6,7 +6,7 @@ Create Date: 2018-02-16 14:16:43.618062
 
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from alembic import op
 from flask import current_app
@@ -51,7 +51,7 @@ def upgrade():
             template_id,
             template_name,
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             template_content,
             current_app.config["NOTIFY_SERVICE_ID"],
             template_subject,
@@ -65,7 +65,7 @@ def upgrade():
             template_id,
             template_name,
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             template_content,
             current_app.config["NOTIFY_SERVICE_ID"],
             template_subject,
@@ -81,7 +81,7 @@ def upgrade():
     #         INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
     #         VALUES ('{}', '{}', '{}', '{}')
     #         ;
-    #     """.format(template_id, False, datetime.utcnow(), current_app.config['NOTIFY_USER_ID'])
+    #     """.format(template_id, False, datetime.now(UTC).replace(tzinfo=None), current_app.config['NOTIFY_USER_ID'])
     # )
 
     # clean up constraints on org_to_service - service_id-org_id constraint is redundant

--- a/migrations/versions/0265_add_confirm_edit_templates.py
+++ b/migrations/versions/0265_add_confirm_edit_templates.py
@@ -6,7 +6,7 @@ Create Date: 2019-02-26 15:16:53.268135
 
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from alembic import op
 from flask import current_app
@@ -55,7 +55,7 @@ def upgrade():
             email_template_id,
             email_template_name,
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             email_template_content,
             current_app.config["NOTIFY_SERVICE_ID"],
             email_template_subject,
@@ -69,7 +69,7 @@ def upgrade():
             email_template_id,
             email_template_name,
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             email_template_content,
             current_app.config["NOTIFY_SERVICE_ID"],
             email_template_subject,
@@ -87,7 +87,7 @@ def upgrade():
             mobile_template_id,
             mobile_template_name,
             "sms",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             mobile_template_content,
             current_app.config["NOTIFY_SERVICE_ID"],
             None,
@@ -101,7 +101,7 @@ def upgrade():
             mobile_template_id,
             mobile_template_name,
             "sms",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             mobile_template_content,
             current_app.config["NOTIFY_SERVICE_ID"],
             None,
@@ -118,7 +118,7 @@ def upgrade():
 #         INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
 #         VALUES ('{}', '{}', '{}', '{}')
 #         ;
-#     """.format(email_template_id, False, datetime.utcnow(), current_app.config['NOTIFY_USER_ID'])
+#     """.format(email_template_id, False, datetime.now(UTC).replace(tzinfo=None), current_app.config['NOTIFY_USER_ID'])
 # )
 
 # op.execute(
@@ -126,7 +126,7 @@ def upgrade():
 #         INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
 #         VALUES ('{}', '{}', '{}', '{}')
 #         ;
-#     """.format(mobile_template_id, False, datetime.utcnow(), current_app.config['NOTIFY_USER_ID'])
+#     """.format(mobile_template_id, False, datetime.now(UTC).replace(tzinfo=None), current_app.config['NOTIFY_USER_ID'])
 # )
 
 

--- a/migrations/versions/0294_add_verify_reply_to_.py
+++ b/migrations/versions/0294_add_verify_reply_to_.py
@@ -6,7 +6,7 @@ Create Date: 2019-05-22 16:58:52.929661
 
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from alembic import op
 from flask import current_app
@@ -55,7 +55,7 @@ def upgrade():
             email_template_id,
             email_template_name,
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             email_template_content,
             current_app.config["NOTIFY_SERVICE_ID"],
             email_template_subject,
@@ -69,7 +69,7 @@ def upgrade():
             email_template_id,
             email_template_name,
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             email_template_content,
             current_app.config["NOTIFY_SERVICE_ID"],
             email_template_subject,
@@ -86,7 +86,7 @@ def upgrade():
 #         INSERT INTO template_redacted (template_id, redact_personalisation, updated_at, updated_by_id)
 #         VALUES ('{}', '{}', '{}', '{}')
 #         ;
-#     """.format(email_template_id, False, datetime.utcnow(), current_app.config['NOTIFY_USER_ID'])
+#     """.format(email_template_id, False, datetime.now(UTC).replace(tzinfo=None), current_app.config['NOTIFY_USER_ID'])
 # )
 
 

--- a/migrations/versions/0330_broadcast_invite_email.py
+++ b/migrations/versions/0330_broadcast_invite_email.py
@@ -7,7 +7,7 @@ Create Date: 2020-09-15 14:17:01.963181
 """
 
 # revision identifiers, used by Alembic.
-from datetime import datetime
+from datetime import UTC, datetime
 
 from alembic import op
 
@@ -50,7 +50,7 @@ def upgrade():
             "templates_history",
             template_id,
             broadcast_invitation_template_name,
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             broadcast_invitation_content,
             service_id,
             broadcast_invitation_subject,
@@ -63,7 +63,7 @@ def upgrade():
             "templates",
             template_id,
             broadcast_invitation_template_name,
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             broadcast_invitation_content,
             service_id,
             broadcast_invitation_subject,

--- a/migrations/versions/0347_add_dvla_volumes_template.py
+++ b/migrations/versions/0347_add_dvla_volumes_template.py
@@ -7,7 +7,7 @@ Create Date: 2021-02-15 15:36:34.654275
 """
 
 import os
-from datetime import datetime
+from datetime import UTC, datetime
 
 from alembic import op
 from flask import current_app
@@ -54,7 +54,7 @@ def upgrade():
             email_template_id,
             email_template_name,
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             email_template_content,
             current_app.config["NOTIFY_SERVICE_ID"],
             email_template_subject,
@@ -68,7 +68,7 @@ def upgrade():
             email_template_id,
             email_template_name,
             "email",
-            datetime.utcnow(),
+            datetime.now(UTC).replace(tzinfo=None),
             email_template_content,
             current_app.config["NOTIFY_SERVICE_ID"],
             email_template_subject,

--- a/migrations/versions/0416_add_org_user_perms.py
+++ b/migrations/versions/0416_add_org_user_perms.py
@@ -7,7 +7,7 @@ Create Date: 2023-06-19 12:43:09.194732
 """
 
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 from alembic import op
 import sqlalchemy as sa
@@ -34,7 +34,7 @@ def upgrade():
                 "VALUES (:id, :created_at, :user_id, :organisation_id, :permission)"
             ),
             id=uuid.uuid4(),
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(UTC).replace(tzinfo=None),
             organisation_id=organisation_id,
             user_id=user_id,
             permission="can_make_services_live",

--- a/tests/app/aws/test_s3.py
+++ b/tests/app/aws/test_s3.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 import pytz
@@ -12,7 +12,7 @@ def single_s3_object_stub(key="foo", last_modified=None):
     return {
         "ETag": '"d41d8cd98f00b204e9800998ecf8427e"',
         "Key": key,
-        "LastModified": last_modified or datetime.utcnow(),
+        "LastModified": last_modified or datetime.now(UTC).replace(tzinfo=None),
     }
 
 

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from unittest.mock import ANY, call
 
 import pytest
@@ -65,7 +65,7 @@ def test_will_remove_csv_files_for_jobs_older_than_seven_days(notify_db_session,
     """
     mocker.patch("app.celery.nightly_tasks.s3.remove_job_from_s3")
 
-    seven_days_ago = datetime.utcnow() - timedelta(days=7)
+    seven_days_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=7)
     just_under_seven_days = seven_days_ago + timedelta(seconds=1)
     eight_days_ago = seven_days_ago - timedelta(days=1)
     nine_days_ago = eight_days_ago - timedelta(days=1)
@@ -104,9 +104,9 @@ def test_will_remove_csv_files_for_jobs_older_than_retention_period(notify_db_se
     sms_template_service_2 = create_template(service=service_2)
     email_template_service_2 = create_template(service=service_2, template_type="email")
 
-    four_days_ago = datetime.utcnow() - timedelta(days=4)
-    eight_days_ago = datetime.utcnow() - timedelta(days=8)
-    thirty_one_days_ago = datetime.utcnow() - timedelta(days=31)
+    four_days_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=4)
+    eight_days_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=8)
+    thirty_one_days_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=31)
 
     job1_to_delete = create_job(sms_template_service_1, created_at=four_days_ago)
     job2_to_delete = create_job(email_template_service_1, created_at=eight_days_ago)
@@ -138,7 +138,7 @@ def test_remove_csv_files_filters_by_type(mocker, sample_service):
     letter_template = create_template(service=sample_service, template_type=LETTER_TYPE)
     sms_template = create_template(service=sample_service, template_type=SMS_TYPE)
 
-    eight_days_ago = datetime.utcnow() - timedelta(days=8)
+    eight_days_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=8)
 
     job_to_delete = create_job(template=letter_template, created_at=eight_days_ago)
     create_job(template=sms_template, created_at=eight_days_ago)
@@ -169,7 +169,7 @@ def test_delete_letter_notifications_older_than_retention_calls_child_task(notif
 
 
 def test_should_not_update_status_of_letter_notifications(client, sample_letter_template):
-    created_at = datetime.utcnow() - timedelta(days=5)
+    created_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=5)
     not1 = create_notification(template=sample_letter_template, status="sending", created_at=created_at)
     not2 = create_notification(template=sample_letter_template, status="created", created_at=created_at)
 
@@ -248,7 +248,7 @@ def test_dont_create_ticket_if_letter_notifications_not_still_sending(notify_api
 def test_get_letter_notifications_still_sending_when_they_shouldnt_finds_no_letters_if_sent_a_day_ago(
     sample_letter_template,
 ):
-    today = datetime.utcnow()
+    today = datetime.now(UTC).replace(tzinfo=None)
     one_day_ago = today - timedelta(days=1)
     create_notification(template=sample_letter_template, status="sending", sent_at=one_day_ago)
 
@@ -347,7 +347,7 @@ def test_letter_raise_alert_if_no_ack_file_for_zip_does_not_raise_when_files_mat
     letter_raise_alert_if_no_ack_file_for_zip()
 
     yesterday = datetime.now(tz=pytz.utc) - timedelta(days=1)  # Datatime format on AWS
-    subfoldername = datetime.utcnow().strftime("%Y-%m-%d") + "/zips_sent"
+    subfoldername = datetime.now(UTC).replace(tzinfo=None).strftime("%Y-%m-%d") + "/zips_sent"
     assert mock_file_list.call_count == 2
     assert mock_file_list.call_args_list == [
         call(bucket_name=current_app.config["S3_BUCKET_LETTERS_PDF"], subfolder=subfoldername, suffix=".TXT"),

--- a/tests/app/celery/test_process_sms_client_response_tasks.py
+++ b/tests/app/celery/test_process_sms_client_response_tasks.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from freezegun import freeze_time
@@ -121,13 +121,13 @@ def test_process_sms_client_response_records_statsd_metrics(sample_notification,
     mocker.patch("app.statsd_client.timing_with_dates")
 
     sample_notification.status = "sending"
-    sample_notification.sent_at = datetime.utcnow()
+    sample_notification.sent_at = datetime.now(UTC).replace(tzinfo=None)
 
     process_sms_client_response("0", str(sample_notification.id), "Firetext")
 
     statsd_client.incr.assert_any_call("callback.firetext.delivered")
     statsd_client.timing_with_dates.assert_any_call(
-        "callback.firetext.delivered.elapsed-time", datetime.utcnow(), sample_notification.sent_at
+        "callback.firetext.delivered.elapsed-time", datetime.now(UTC).replace(tzinfo=None), sample_notification.sent_at
     )
 
 

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 import boto3
 import pytest
@@ -218,8 +218,8 @@ def test_update_letter_to_sending(sample_letter_template):
     update_letter_to_sending(letter)
 
     assert letter.status == NOTIFICATION_SENDING
-    assert letter.sent_at == datetime.utcnow()
-    assert letter.updated_at == datetime.utcnow()
+    assert letter.sent_at == datetime.now(UTC).replace(tzinfo=None)
+    assert letter.updated_at == datetime.now(UTC).replace(tzinfo=None)
     assert letter.sent_by == "dvla"
 
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -1,6 +1,6 @@
 import uuid
 from collections import namedtuple
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest import mock
 from unittest.mock import ANY, call
 
@@ -85,7 +85,7 @@ def test_should_call_delete_invotations_on_delete_invitations_task(notify_db_ses
 def test_should_update_scheduled_jobs_and_put_on_queue(mocker, sample_template):
     mocked = mocker.patch("app.celery.tasks.process_job.apply_async")
 
-    one_minute_in_the_past = datetime.utcnow() - timedelta(minutes=1)
+    one_minute_in_the_past = datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=1)
     job = create_job(sample_template, job_status="scheduled", scheduled_for=one_minute_in_the_past)
 
     run_scheduled_jobs()
@@ -98,9 +98,9 @@ def test_should_update_scheduled_jobs_and_put_on_queue(mocker, sample_template):
 def test_should_update_all_scheduled_jobs_and_put_on_queue(sample_template, mocker):
     mocked = mocker.patch("app.celery.tasks.process_job.apply_async")
 
-    one_minute_in_the_past = datetime.utcnow() - timedelta(minutes=1)
-    ten_minutes_in_the_past = datetime.utcnow() - timedelta(minutes=10)
-    twenty_minutes_in_the_past = datetime.utcnow() - timedelta(minutes=20)
+    one_minute_in_the_past = datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=1)
+    ten_minutes_in_the_past = datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=10)
+    twenty_minutes_in_the_past = datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=20)
     job_1 = create_job(sample_template, job_status="scheduled", scheduled_for=one_minute_in_the_past)
     job_2 = create_job(sample_template, job_status="scheduled", scheduled_for=ten_minutes_in_the_past)
     job_3 = create_job(sample_template, job_status="scheduled", scheduled_for=twenty_minutes_in_the_past)
@@ -261,8 +261,8 @@ def test_check_job_status_task_calls_process_incomplete_jobs(mocker, sample_temp
     job = create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     create_notification(template=sample_template, job=job)
@@ -278,9 +278,9 @@ def test_check_job_status_task_calls_process_incomplete_jobs_when_scheduled_job_
     job = create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
+        scheduled_for=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     check_job_status()
@@ -293,8 +293,8 @@ def test_check_job_status_task_calls_process_incomplete_jobs_for_pending_schedul
     job = create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
+        scheduled_for=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_PENDING,
     )
 
@@ -311,7 +311,7 @@ def test_check_job_status_task_does_not_call_process_incomplete_jobs_for_non_sch
     create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(hours=2),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
         job_status=JOB_STATUS_PENDING,
     )
     check_job_status()
@@ -324,17 +324,17 @@ def test_check_job_status_task_calls_process_incomplete_jobs_for_multiple_jobs(m
     job = create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
+        scheduled_for=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     job_2 = create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
+        scheduled_for=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     check_job_status()
@@ -347,23 +347,23 @@ def test_check_job_status_task_only_sends_old_tasks(mocker, sample_template):
     job = create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
+        scheduled_for=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=29),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=29),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(minutes=50),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=29),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=50),
+        scheduled_for=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=29),
         job_status=JOB_STATUS_PENDING,
     )
     check_job_status()
@@ -377,16 +377,16 @@ def test_check_job_status_task_sets_jobs_to_error(mocker, sample_template):
     job = create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
+        scheduled_for=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     job_2 = create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=29),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=29),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     check_job_status()
@@ -406,20 +406,28 @@ def test_replay_created_notifications(notify_db_session, sample_service, mocker)
     older_than = (60 * 60) + (60 * 15)  # 1 hour 15 minutes
     # notifications expected to be resent
     old_sms = create_notification(
-        template=sms_template, created_at=datetime.utcnow() - timedelta(seconds=older_than), status="created"
+        template=sms_template,
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=older_than),
+        status="created",
     )
     old_email = create_notification(
-        template=email_template, created_at=datetime.utcnow() - timedelta(seconds=older_than), status="created"
+        template=email_template,
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=older_than),
+        status="created",
     )
     # notifications that are not to be resent
     create_notification(
-        template=sms_template, created_at=datetime.utcnow() - timedelta(seconds=older_than), status="sending"
+        template=sms_template,
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=older_than),
+        status="sending",
     )
     create_notification(
-        template=email_template, created_at=datetime.utcnow() - timedelta(seconds=older_than), status="delivered"
+        template=email_template,
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=older_than),
+        status="delivered",
     )
-    create_notification(template=sms_template, created_at=datetime.utcnow(), status="created")
-    create_notification(template=email_template, created_at=datetime.utcnow(), status="created")
+    create_notification(template=sms_template, created_at=datetime.now(UTC).replace(tzinfo=None), status="created")
+    create_notification(template=email_template, created_at=datetime.now(UTC).replace(tzinfo=None), status="created")
 
     replay_created_notifications()
     email_delivery_queue.assert_called_once_with([str(old_email.id)], queue="send-email-tasks")
@@ -431,17 +439,25 @@ def test_replay_created_notifications_get_pdf_for_templated_letter_tasks_for_let
 ):
     mock_task = mocker.patch("app.celery.scheduled_tasks.get_pdf_for_templated_letter.apply_async")
     create_notification(
-        template=sample_letter_template, billable_units=0, created_at=datetime.utcnow() - timedelta(hours=4)
+        template=sample_letter_template,
+        billable_units=0,
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=4),
     )
 
     create_notification(
-        template=sample_letter_template, billable_units=0, created_at=datetime.utcnow() - timedelta(minutes=20)
+        template=sample_letter_template,
+        billable_units=0,
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=20),
     )
     notification_1 = create_notification(
-        template=sample_letter_template, billable_units=0, created_at=datetime.utcnow() - timedelta(hours=1, minutes=20)
+        template=sample_letter_template,
+        billable_units=0,
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=1, minutes=20),
     )
     notification_2 = create_notification(
-        template=sample_letter_template, billable_units=0, created_at=datetime.utcnow() - timedelta(hours=5)
+        template=sample_letter_template,
+        billable_units=0,
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=5),
     )
 
     replay_created_notifications()
@@ -457,16 +473,16 @@ def test_check_job_status_task_does_not_raise_error(sample_template):
     create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
+        scheduled_for=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_FINISHED,
     )
     create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_FINISHED,
     )
 
@@ -482,13 +498,13 @@ def test_check_if_letters_still_pending_virus_check_restarts_scan_for_stuck_lett
     create_notification(
         template=sample_letter_template,
         status=NOTIFICATION_PENDING_VIRUS_CHECK,
-        created_at=datetime.utcnow() - timedelta(seconds=601),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=601),
         reference="one",
     )
     create_notification(
         template=sample_letter_template,
         status=NOTIFICATION_PENDING_VIRUS_CHECK,
-        created_at=datetime.utcnow() - timedelta(seconds=599),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=599),
         reference="still has time to send",
     )
     expected_filename = "NOTIFY.ONE.D.2.C.20190530134959.PDF"
@@ -519,25 +535,25 @@ def test_check_if_letters_still_pending_virus_check_raises_zendesk_if_files_cant
     create_notification(
         template=sample_letter_template,
         status=NOTIFICATION_PENDING_VIRUS_CHECK,
-        created_at=datetime.utcnow() - timedelta(seconds=600),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=600),
         reference="ignore as still has time",
     )
     create_notification(
         template=sample_letter_template,
         status=NOTIFICATION_DELIVERED,
-        created_at=datetime.utcnow() - timedelta(seconds=1000),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=1000),
         reference="ignore as status in delivered",
     )
     notification_1 = create_notification(
         template=sample_letter_template,
         status=NOTIFICATION_PENDING_VIRUS_CHECK,
-        created_at=datetime.utcnow() - timedelta(seconds=601),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=601),
         reference="one",
     )
     notification_2 = create_notification(
         template=sample_letter_template,
         status=NOTIFICATION_PENDING_VIRUS_CHECK,
-        created_at=datetime.utcnow() - timedelta(seconds=1000),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=1000),
         reference="two",
     )
 
@@ -664,7 +680,7 @@ def test_check_for_missing_rows_in_completed_jobs_ignores_old_and_new_jobs(
         template=sample_email_template,
         notification_count=5,
         job_status=JOB_STATUS_FINISHED,
-        processing_finished=datetime.utcnow() - offset,
+        processing_finished=datetime.now(UTC).replace(tzinfo=None) - offset,
     )
     for i in range(0, 4):
         create_notification(job=job, job_row_number=i)
@@ -686,7 +702,7 @@ def test_check_for_missing_rows_in_completed_jobs(mocker, sample_email_template)
         template=sample_email_template,
         notification_count=5,
         job_status=JOB_STATUS_FINISHED,
-        processing_finished=datetime.utcnow() - timedelta(minutes=20),
+        processing_finished=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=20),
     )
     for i in range(0, 4):
         create_notification(job=job, job_row_number=i)
@@ -709,7 +725,7 @@ def test_check_for_missing_rows_in_completed_jobs_calls_save_email(mocker, sampl
         template=sample_email_template,
         notification_count=5,
         job_status=JOB_STATUS_FINISHED,
-        processing_finished=datetime.utcnow() - timedelta(minutes=20),
+        processing_finished=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=20),
     )
     for i in range(0, 4):
         create_notification(job=job, job_row_number=i)
@@ -737,7 +753,7 @@ def test_check_for_missing_rows_in_completed_jobs_uses_sender_id(mocker, sample_
         template=sample_email_template,
         notification_count=5,
         job_status=JOB_STATUS_FINISHED,
-        processing_finished=datetime.utcnow() - timedelta(minutes=20),
+        processing_finished=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=20),
     )
     for i in range(0, 4):
         create_notification(job=job, job_row_number=i)
@@ -815,7 +831,9 @@ def test_check_for_services_with_high_failure_rates_or_sending_to_tv_numbers(
 
 
 def test_delete_old_records_from_events_table(notify_db_session):
-    old_datetime, recent_datetime = datetime.utcnow() - timedelta(weeks=78), datetime.utcnow() - timedelta(weeks=50)
+    old_datetime, recent_datetime = datetime.now(UTC).replace(tzinfo=None) - timedelta(weeks=78), datetime.now(
+        UTC
+    ).replace(tzinfo=None) - timedelta(weeks=50)
     old_event = Event(event_type="test_event", created_at=old_datetime, data={})
     recent_event = Event(event_type="test_event", created_at=recent_datetime, data={})
 

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 import requests_mock
@@ -72,7 +72,7 @@ def test_send_complaint_to_service_posts_https_request_to_service_with_encoded_d
             "complaint_id": str(complaint.id),
             "reference": notification.client_reference,
             "to": notification.to,
-            "complaint_date": datetime.utcnow().strftime(DATETIME_FORMAT),
+            "complaint_date": datetime.now(UTC).replace(tzinfo=None).strftime(DATETIME_FORMAT),
         }
 
         assert request_mock.call_count == 1

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock, call
 
 import pytest
@@ -515,7 +515,7 @@ def test_should_send_template_to_correct_sms_task_and_persist(
     assert persisted_notification.template_id == sample_template_with_placeholders.id
     assert persisted_notification.template_version == sample_template_with_placeholders.version
     assert persisted_notification.status == "created"
-    assert persisted_notification.created_at <= datetime.utcnow()
+    assert persisted_notification.created_at <= datetime.now(UTC).replace(tzinfo=None)
     assert not persisted_notification.sent_at
     assert not persisted_notification.sent_by
     assert not persisted_notification.job_id
@@ -547,7 +547,7 @@ def test_should_save_sms_if_restricted_service_and_valid_number(notify_db_sessio
     assert persisted_notification.template_id == template.id
     assert persisted_notification.template_version == template.version
     assert persisted_notification.status == "created"
-    assert persisted_notification.created_at <= datetime.utcnow()
+    assert persisted_notification.created_at <= datetime.now(UTC).replace(tzinfo=None)
     assert not persisted_notification.sent_at
     assert not persisted_notification.sent_by
     assert not persisted_notification.job_id
@@ -634,7 +634,7 @@ def test_should_save_sms_template_to_and_persist_with_job_id(sample_job, mocker)
     mocker.patch("app.celery.provider_tasks.deliver_sms.apply_async")
 
     notification_id = uuid.uuid4()
-    now = datetime.utcnow()
+    now = datetime.now(UTC).replace(tzinfo=None)
     save_sms(
         sample_job.service.id,
         notification_id,
@@ -740,7 +740,7 @@ def test_save_email_should_use_template_version_from_job_not_latest(sample_email
     dao_update_template(sample_email_template)
     t = dao_get_template_by_id(sample_email_template.id)
     assert t.version > version_on_notification
-    now = datetime.utcnow()
+    now = datetime.now(UTC).replace(tzinfo=None)
     save_email(
         sample_email_template.service_id,
         uuid.uuid4(),
@@ -766,7 +766,7 @@ def test_should_use_email_template_subject_placeholders(sample_email_template_wi
     mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
 
     notification_id = uuid.uuid4()
-    now = datetime.utcnow()
+    now = datetime.now(UTC).replace(tzinfo=None)
     save_email(
         sample_email_template_with_placeholders.service_id,
         notification_id,
@@ -833,7 +833,7 @@ def test_should_use_email_template_and_persist_without_personalisation(sample_em
 
     notification_id = uuid.uuid4()
 
-    now = datetime.utcnow()
+    now = datetime.now(UTC).replace(tzinfo=None)
     save_email(
         sample_email_template.service_id,
         notification_id,
@@ -986,7 +986,7 @@ def test_save_letter_saves_letter_to_database(
         client_reference=client_reference,
     )
     notification_id = uuid.uuid4()
-    created_at = datetime.utcnow()
+    created_at = datetime.now(UTC).replace(tzinfo=None)
 
     save_letter(
         job.service_id,
@@ -1096,7 +1096,7 @@ def test_save_letter_saves_letter_to_database_right_reply_to(mocker, notify_db_s
         template=job.template, to="Foo", personalisation=personalisation, job_id=job.id, row_number=1
     )
     notification_id = uuid.uuid4()
-    created_at = datetime.utcnow()
+    created_at = datetime.now(UTC).replace(tzinfo=None)
 
     save_letter(
         job.service_id,
@@ -1426,9 +1426,9 @@ def test_process_incomplete_job_sms(mocker, sample_template):
     job = create_job(
         template=sample_template,
         notification_count=10,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
+        scheduled_for=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_ERROR,
     )
 
@@ -1456,9 +1456,9 @@ def test_process_incomplete_job_with_notifications_all_sent(mocker, sample_templ
     job = create_job(
         template=sample_template,
         notification_count=10,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
+        scheduled_for=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_ERROR,
     )
 
@@ -1494,9 +1494,9 @@ def test_process_incomplete_jobs_sms(mocker, sample_template):
     job = create_job(
         template=sample_template,
         notification_count=10,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
+        scheduled_for=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_ERROR,
     )
     create_notification(sample_template, job, 0)
@@ -1508,9 +1508,9 @@ def test_process_incomplete_jobs_sms(mocker, sample_template):
     job2 = create_job(
         template=sample_template,
         notification_count=10,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
+        scheduled_for=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_ERROR,
     )
 
@@ -1545,9 +1545,9 @@ def test_process_incomplete_jobs_no_notifications_added(mocker, sample_template)
     job = create_job(
         template=sample_template,
         notification_count=10,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
+        scheduled_for=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_ERROR,
     )
 
@@ -1598,9 +1598,9 @@ def test_process_incomplete_job_email(mocker, sample_email_template):
     job = create_job(
         template=sample_email_template,
         notification_count=10,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
+        scheduled_for=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_ERROR,
     )
 
@@ -1628,9 +1628,9 @@ def test_process_incomplete_job_letter(mocker, sample_letter_template):
     job = create_job(
         template=sample_letter_template,
         notification_count=10,
-        created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-        processing_started=datetime.utcnow() - timedelta(minutes=31),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2),
+        scheduled_for=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
         job_status=JOB_STATUS_ERROR,
     )
 
@@ -1649,19 +1649,23 @@ def test_process_incomplete_jobs_sets_status_to_in_progress_and_resets_processin
     mock_process_incomplete_job = mocker.patch("app.celery.tasks.process_incomplete_job")
 
     job1 = create_job(
-        sample_template, processing_started=datetime.utcnow() - timedelta(minutes=30), job_status=JOB_STATUS_ERROR
+        sample_template,
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=30),
+        job_status=JOB_STATUS_ERROR,
     )
     job2 = create_job(
-        sample_template, processing_started=datetime.utcnow() - timedelta(minutes=31), job_status=JOB_STATUS_ERROR
+        sample_template,
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=31),
+        job_status=JOB_STATUS_ERROR,
     )
 
     process_incomplete_jobs([str(job1.id), str(job2.id)])
 
     assert job1.job_status == JOB_STATUS_IN_PROGRESS
-    assert job1.processing_started == datetime.utcnow()
+    assert job1.processing_started == datetime.now(UTC).replace(tzinfo=None)
 
     assert job2.job_status == JOB_STATUS_IN_PROGRESS
-    assert job2.processing_started == datetime.utcnow()
+    assert job2.processing_started == datetime.now(UTC).replace(tzinfo=None)
 
     assert mock_process_incomplete_job.mock_calls == [call(str(job1.id)), call(str(job2.id))]
 
@@ -1723,7 +1727,7 @@ def test_save_api_email_or_sms(mocker, sample_service, notification_type):
         "reply_to_text": None,
         "document_download_count": 0,
         "status": NOTIFICATION_CREATED,
-        "created_at": datetime.utcnow().strftime(DATETIME_FORMAT),
+        "created_at": datetime.now(UTC).replace(tzinfo=None).strftime(DATETIME_FORMAT),
     }
 
     if notification_type == EMAIL_TYPE:
@@ -1771,7 +1775,7 @@ def test_save_api_email_dont_retry_if_notification_already_exists(sample_service
         "reply_to_text": "our.email@gov.uk",
         "document_download_count": 0,
         "status": NOTIFICATION_CREATED,
-        "created_at": datetime.utcnow().strftime(DATETIME_FORMAT),
+        "created_at": datetime.now(UTC).replace(tzinfo=None).strftime(DATETIME_FORMAT),
     }
 
     if notification_type == EMAIL_TYPE:
@@ -1905,7 +1909,7 @@ def test_save_api_tasks_use_cache(
                 "reply_to_text": "our.email@gov.uk",
                 "document_download_count": 0,
                 "status": NOTIFICATION_CREATED,
-                "created_at": datetime.utcnow().strftime(DATETIME_FORMAT),
+                "created_at": datetime.now(UTC).replace(tzinfo=None).strftime(DATETIME_FORMAT),
             }
         )
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1,7 +1,7 @@
 import json
 import textwrap
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 import pytz
@@ -307,7 +307,7 @@ def sample_job(notify_db_session):
         "template_version": template.version,
         "original_file_name": "some.csv",
         "notification_count": 1,
-        "created_at": datetime.utcnow(),
+        "created_at": datetime.now(UTC).replace(tzinfo=None),
         "created_by": service.created_by,
         "job_status": "pending",
         "scheduled_for": None,
@@ -334,7 +334,7 @@ def sample_scheduled_job(sample_template_with_placeholders):
     return create_job(
         sample_template_with_placeholders,
         job_status="scheduled",
-        scheduled_for=(datetime.utcnow() + timedelta(minutes=60)).isoformat(),
+        scheduled_for=(datetime.now(UTC).replace(tzinfo=None) + timedelta(minutes=60)).isoformat(),
     )
 
 
@@ -349,7 +349,7 @@ def sample_letter_job(sample_letter_template):
         "template_version": sample_letter_template.version,
         "original_file_name": "some.csv",
         "notification_count": 1,
-        "created_at": datetime.utcnow(),
+        "created_at": datetime.now(UTC).replace(tzinfo=None),
         "created_by": service.created_by,
     }
     job = Job(**data)
@@ -380,7 +380,7 @@ def sample_notification_with_job(notify_db_session):
 
 @pytest.fixture(scope="function")
 def sample_notification(notify_db_session):
-    created_at = datetime.utcnow()
+    created_at = datetime.now(UTC).replace(tzinfo=None)
     service = create_service(check_if_service_exists=True)
     template = create_template(service=service)
 
@@ -440,7 +440,7 @@ def sample_letter_notification(sample_letter_template):
 
 @pytest.fixture(scope="function")
 def sample_email_notification(notify_db_session):
-    created_at = datetime.utcnow()
+    created_at = datetime.now(UTC).replace(tzinfo=None)
     service = create_service(check_if_service_exists=True)
     template = create_template(service, template_type=EMAIL_TYPE)
     job = create_job(template)
@@ -475,8 +475,8 @@ def sample_email_notification(notify_db_session):
 
 @pytest.fixture(scope="function")
 def sample_notification_history(notify_db_session, sample_template):
-    created_at = datetime.utcnow()
-    sent_at = datetime.utcnow()
+    created_at = datetime.now(UTC).replace(tzinfo=None)
+    sent_at = datetime.now(UTC).replace(tzinfo=None)
     notification_type = sample_template.template_type
     api_key = create_api_key(sample_template.service, key_type=KEY_TYPE_NORMAL)
 

--- a/tests/app/dao/notification_dao/test_notification_dao_template_usage.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_template_usage.py
@@ -5,7 +5,7 @@ from tests.app.db import create_ft_notification_status, create_notification
 
 
 def test_dao_get_last_date_template_was_used_returns_bst_date_from_stats_table(sample_template):
-    last_status_date = (datetime.now(UTC) - timedelta(days=2)).date()
+    last_status_date = (datetime.now(UTC).replace(tzinfo=None) - timedelta(days=2)).date()
     create_ft_notification_status(bst_date=last_status_date, template=sample_template)
 
     last_used_date = dao_get_last_date_template_was_used(
@@ -15,7 +15,7 @@ def test_dao_get_last_date_template_was_used_returns_bst_date_from_stats_table(s
 
 
 def test_dao_get_last_date_template_was_used_only_searches_within_one_year(sample_template):
-    last_status_date = (datetime.now(UTC) - timedelta(days=400)).date()
+    last_status_date = (datetime.now(UTC).replace(tzinfo=None) - timedelta(days=400)).date()
     create_ft_notification_status(bst_date=last_status_date, template=sample_template)
 
     last_used_date = dao_get_last_date_template_was_used(
@@ -25,10 +25,10 @@ def test_dao_get_last_date_template_was_used_only_searches_within_one_year(sampl
 
 
 def test_dao_get_last_date_template_was_used_returns_created_at_from_notifications(sample_template):
-    last_notification_date = datetime.now(UTC) - timedelta(hours=2)
+    last_notification_date = datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2)
     create_notification(template=sample_template, created_at=last_notification_date)
 
-    last_status_date = (datetime.now(UTC) - timedelta(days=2)).date()
+    last_status_date = (datetime.now(UTC).replace(tzinfo=None) - timedelta(days=2)).date()
     create_ft_notification_status(bst_date=last_status_date, template=sample_template)
     last_used_date = dao_get_last_date_template_was_used(
         template_id=sample_template.id, service_id=sample_template.service_id

--- a/tests/app/dao/notification_dao/test_notification_dao_template_usage.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_template_usage.py
@@ -1,11 +1,11 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from app.dao.notifications_dao import dao_get_last_date_template_was_used
 from tests.app.db import create_ft_notification_status, create_notification
 
 
 def test_dao_get_last_date_template_was_used_returns_bst_date_from_stats_table(sample_template):
-    last_status_date = (datetime.utcnow() - timedelta(days=2)).date()
+    last_status_date = (datetime.now(UTC) - timedelta(days=2)).date()
     create_ft_notification_status(bst_date=last_status_date, template=sample_template)
 
     last_used_date = dao_get_last_date_template_was_used(
@@ -14,11 +14,21 @@ def test_dao_get_last_date_template_was_used_returns_bst_date_from_stats_table(s
     assert last_used_date == last_status_date
 
 
+def test_dao_get_last_date_template_was_used_only_searches_within_one_year(sample_template):
+    last_status_date = (datetime.now(UTC) - timedelta(days=400)).date()
+    create_ft_notification_status(bst_date=last_status_date, template=sample_template)
+
+    last_used_date = dao_get_last_date_template_was_used(
+        template_id=sample_template.id, service_id=sample_template.service_id
+    )
+    assert last_used_date is None
+
+
 def test_dao_get_last_date_template_was_used_returns_created_at_from_notifications(sample_template):
-    last_notification_date = datetime.utcnow() - timedelta(hours=2)
+    last_notification_date = datetime.now(UTC) - timedelta(hours=2)
     create_notification(template=sample_template, created_at=last_notification_date)
 
-    last_status_date = (datetime.utcnow() - timedelta(days=2)).date()
+    last_status_date = (datetime.now(UTC) - timedelta(days=2)).date()
     create_ft_notification_status(bst_date=last_status_date, template=sample_template)
     last_used_date = dao_get_last_date_template_was_used(
         template_id=sample_template.id, service_id=sample_template.service_id

--- a/tests/app/dao/test_api_key_dao.py
+++ b/tests/app/dao/test_api_key_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -41,7 +41,7 @@ def test_expire_api_key_should_update_the_api_key_and_create_history_record(noti
     expire_api_key(service_id=sample_api_key.service_id, api_key_id=sample_api_key.id)
     all_api_keys = get_model_api_keys(service_id=sample_api_key.service_id)
     assert len(all_api_keys) == 1
-    assert all_api_keys[0].expiry_date <= datetime.utcnow()
+    assert all_api_keys[0].expiry_date <= datetime.now(UTC).replace(tzinfo=None)
     assert all_api_keys[0].secret == sample_api_key.secret
     assert all_api_keys[0].id == sample_api_key.id
     assert all_api_keys[0].service_id == sample_api_key.service_id
@@ -99,7 +99,7 @@ def test_save_api_key_can_create_key_with_same_name_if_other_is_expired(sample_s
             "name": "normal api key",
             "created_by": sample_service.created_by,
             "key_type": KEY_TYPE_NORMAL,
-            "expiry_date": datetime.utcnow(),
+            "expiry_date": datetime.now(UTC).replace(tzinfo=None),
         }
     )
     save_model_api_key(expired_api_key)
@@ -143,7 +143,7 @@ def test_should_not_return_revoked_api_keys_older_than_7_days(sample_service, da
             "name": sample_service.name,
             "created_by": sample_service.created_by,
             "key_type": KEY_TYPE_NORMAL,
-            "expiry_date": datetime.utcnow() - timedelta(days=days_old),
+            "expiry_date": datetime.now(UTC).replace(tzinfo=None) - timedelta(days=days_old),
         }
     )
     save_model_api_key(expired_api_key)

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 
 import pytest
@@ -101,7 +101,7 @@ def test_fetch_billing_data_for_today_includes_data_with_the_right_key_type(noti
     for key_type in ["normal", "test", "team"]:
         create_notification(template=template, status="delivered", key_type=key_type)
 
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(today.date())
     assert len(results) == 1
     assert results[0].notifications_sent == 2
@@ -116,7 +116,7 @@ def test_fetch_billing_data_for_day_only_calls_query_for_permission_type(notify_
     create_notification(template=email_template, status="delivered")
     create_notification(template=sms_template, status="delivered")
     create_notification(template=letter_template, status="delivered")
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(process_day=today.date(), check_permissions=True)
     assert len(results) == 1
 
@@ -130,7 +130,7 @@ def test_fetch_billing_data_for_day_only_calls_query_for_all_channels(notify_db_
     create_notification(template=email_template, status="delivered")
     create_notification(template=sms_template, status="delivered")
     create_notification(template=letter_template, status="delivered")
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(process_day=today.date(), check_permissions=False)
     assert len(results) == 3
 
@@ -159,7 +159,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_template_and_notification_type
     create_notification(template=email_template, status="delivered")
     create_notification(template=sms_template, status="delivered")
 
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(today.date())
     assert len(results) == 2
     assert results[0].notifications_sent == 1
@@ -174,7 +174,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_service(notify_db_session):
     create_notification(template=email_template, status="delivered")
     create_notification(template=sms_template, status="delivered")
 
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(today.date())
     assert len(results) == 2
     assert results[0].notifications_sent == 1
@@ -187,7 +187,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_provider(notify_db_session):
     create_notification(template=template, status="delivered", sent_by="mmg")
     create_notification(template=template, status="delivered", sent_by="firetext")
 
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(today.date())
     assert len(results) == 2
     assert results[0].notifications_sent == 1
@@ -200,7 +200,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_rate_mulitplier(notify_db_sess
     create_notification(template=template, status="delivered", rate_multiplier=1)
     create_notification(template=template, status="delivered", rate_multiplier=2)
 
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(today.date())
     assert len(results) == 2
     assert results[0].notifications_sent == 1
@@ -216,7 +216,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_international(notify_db_sessio
     create_notification(template=letter_template, status="delivered", international=True)
     create_notification(template=letter_template, status="delivered", international=False)
 
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(today.date())
     assert len(results) == 4
     assert all(result.notifications_sent == 1 for result in results)
@@ -234,7 +234,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_notification_type(notify_db_se
     create_notification(template=email_template, status="delivered")
     create_notification(template=letter_template, status="delivered")
 
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(today.date())
     assert len(results) == 3
     notification_types = [x.notification_type for x in results]
@@ -252,7 +252,7 @@ def test_fetch_billing_data_for_day_groups_by_postage(notify_db_session):
     create_notification(template=letter_template, status="delivered", postage="rest-of-world")
     create_notification(template=email_template, status="delivered")
 
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(today.date())
     assert len(results) == 5
 
@@ -266,7 +266,7 @@ def test_fetch_billing_data_for_day_groups_by_sent_by(notify_db_session):
     create_notification(template=letter_template, status="delivered", postage="second", sent_by=None)
     create_notification(template=email_template, status="delivered")
 
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(today.date())
     assert len(results) == 2
 
@@ -280,7 +280,7 @@ def test_fetch_billing_data_for_day_groups_by_page_count(notify_db_session):
     create_notification(template=letter_template, status="delivered", postage="second", billable_units=2)
     create_notification(template=email_template, status="delivered")
 
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(today.date())
     assert len(results) == 3
 
@@ -292,7 +292,7 @@ def test_fetch_billing_data_for_day_sets_postage_for_emails_and_sms_to_none(noti
     create_notification(template=sms_template, status="delivered")
     create_notification(template=email_template, status="delivered")
 
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(today.date())
     assert len(results) == 2
     assert results[0].postage == "none"
@@ -300,7 +300,7 @@ def test_fetch_billing_data_for_day_sets_postage_for_emails_and_sms_to_none(noti
 
 
 def test_fetch_billing_data_for_day_returns_empty_list(notify_db_session):
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(today.date())
     assert results == []
 
@@ -311,7 +311,7 @@ def test_fetch_billing_data_for_day_uses_correct_table(notify_db_session):
     sms_template = create_template(service=service, template_type="sms")
     email_template = create_template(service=service, template_type="email")
 
-    five_days_ago = datetime.utcnow() - timedelta(days=5)
+    five_days_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=5)
     create_notification(template=sms_template, status="delivered", created_at=five_days_ago)
     create_notification_history(template=email_template, status="delivered", created_at=five_days_ago)
 
@@ -331,7 +331,7 @@ def test_fetch_billing_data_for_day_returns_list_for_given_service(notify_db_ses
     create_notification(template=template, status="delivered")
     create_notification(template=template_2, status="delivered")
 
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(process_day=today.date(), service_ids=[service.id])
     assert len(results) == 1
     assert results[0].service_id == service.id
@@ -346,7 +346,7 @@ def test_fetch_billing_data_for_day_bills_correctly_for_status(notify_db_session
         create_notification(template=sms_template, status=status)
         create_notification(template=email_template, status=status)
         create_notification(template=letter_template, status=status)
-    today = convert_utc_to_bst(datetime.utcnow())
+    today = convert_utc_to_bst(datetime.now(UTC).replace(tzinfo=None))
     results = fetch_billing_data_for_day(process_day=today.date(), service_ids=[service.id])
 
     sms_results = [x for x in results if x.notification_type == "sms"]
@@ -359,13 +359,13 @@ def test_fetch_billing_data_for_day_bills_correctly_for_status(notify_db_session
 
 
 def test_get_rates_for_billing(notify_db_session):
-    create_rate(start_date=datetime.utcnow(), value=12, notification_type="email")
-    create_rate(start_date=datetime.utcnow(), value=22, notification_type="sms")
-    create_rate(start_date=datetime.utcnow(), value=33, notification_type="email")
-    create_letter_rate(start_date=datetime.utcnow(), rate=0.66, post_class="first")
-    create_letter_rate(start_date=datetime.utcnow(), rate=0.33, post_class="second")
-    create_letter_rate(start_date=datetime.utcnow(), rate=0.84, post_class="europe")
-    create_letter_rate(start_date=datetime.utcnow(), rate=0.84, post_class="rest-of-world")
+    create_rate(start_date=datetime.now(UTC).replace(tzinfo=None), value=12, notification_type="email")
+    create_rate(start_date=datetime.now(UTC).replace(tzinfo=None), value=22, notification_type="sms")
+    create_rate(start_date=datetime.now(UTC).replace(tzinfo=None), value=33, notification_type="email")
+    create_letter_rate(start_date=datetime.now(UTC).replace(tzinfo=None), rate=0.66, post_class="first")
+    create_letter_rate(start_date=datetime.now(UTC).replace(tzinfo=None), rate=0.33, post_class="second")
+    create_letter_rate(start_date=datetime.now(UTC).replace(tzinfo=None), rate=0.84, post_class="europe")
+    create_letter_rate(start_date=datetime.now(UTC).replace(tzinfo=None), rate=0.84, post_class="rest-of-world")
     non_letter_rates, letter_rates = get_rates_for_billing()
 
     assert len(non_letter_rates) == 3
@@ -435,7 +435,7 @@ def test_get_rate_for_letters_when_page_count_is_zero(notify_db_session):
         notification_type="letter",
         crown=True,
         letter_page_count=0,
-        date=datetime.utcnow(),
+        date=datetime.now(UTC).replace(tzinfo=None),
     )
     assert letter_rate == 0
 
@@ -531,7 +531,9 @@ def test_fetch_usage_for_service_by_month_populates_ft_billing_for_today(notify_
     service = create_service()
     template = create_template(service=service, template_type="sms")
 
-    create_rate(start_date=datetime.utcnow() - timedelta(days=1), value=0.158, notification_type="sms")
+    create_rate(
+        start_date=datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1), value=0.158, notification_type="sms"
+    )
     create_annual_billing(service_id=service.id, free_sms_fragment_limit=1000, financial_year_start=2018)
 
     for i in range(1, 32):

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from unittest import mock
 from uuid import UUID
 
@@ -367,8 +367,8 @@ def test_fetch_monthly_template_usage_for_service(sample_service):
     create_ft_notification_status(bst_date=date(2018, 1, 1), service=sample_service, template=template_one, count=4)
 
     create_ft_notification_status(bst_date=date(2018, 3, 1), service=sample_service, template=template_three, count=5)
-    create_notification(template=template_three, created_at=datetime.utcnow() - timedelta(days=1))
-    create_notification(template=template_three, created_at=datetime.utcnow())
+    create_notification(template=template_three, created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1))
+    create_notification(template=template_three, created_at=datetime.now(UTC).replace(tzinfo=None))
     results = fetch_monthly_template_usage_for_service(datetime(2017, 4, 1), datetime(2018, 3, 31), sample_service.id)
 
     assert len(results) == 4
@@ -420,7 +420,7 @@ def test_fetch_monthly_template_usage_for_service_does_join_to_notifications_if_
     create_ft_notification_status(
         bst_date=date(2018, 3, 1), service=template_one.service, template=template_one, count=3
     )
-    create_notification(template=template_one, created_at=datetime.utcnow())
+    create_notification(template=template_one, created_at=datetime.now(UTC).replace(tzinfo=None))
     results = fetch_monthly_template_usage_for_service(
         datetime(2018, 1, 1), datetime(2018, 2, 20), template_one.service_id
     )
@@ -452,7 +452,7 @@ def test_fetch_monthly_template_usage_for_service_does_not_include_cancelled_sta
         notification_status="cancelled",
         count=15,
     )
-    create_notification(template=sample_template, created_at=datetime.utcnow(), status="cancelled")
+    create_notification(template=sample_template, created_at=datetime.now(UTC).replace(tzinfo=None), status="cancelled")
     results = fetch_monthly_template_usage_for_service(
         datetime(2018, 1, 1), datetime(2018, 3, 31), sample_template.service_id
     )
@@ -472,7 +472,7 @@ def test_fetch_monthly_template_usage_for_service_does_not_include_test_notifica
     )
     create_notification(
         template=sample_template,
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(UTC).replace(tzinfo=None),
         status="delivered",
         key_type="test",
     )
@@ -617,7 +617,7 @@ def test_get_total_notifications_for_date_range(sample_service):
     "created_at_utc,process_day,expected_count",
     [
         # Clocks change on the 27th of March 2022, so the query needs to look at the
-        # time range 00:00 - 23:00 (UTC) thereafter.
+        # time range 00:00 - 23:00 (UTC).replace(tzinfo=None) thereafter.
         ("2022-03-27T00:30", date(2022, 3, 27), 1),  # 27/03 00:30 GMT
         ("2022-03-27T22:30", date(2022, 3, 27), 1),  # 27/03 23:30 BST
         ("2022-03-27T23:30", date(2022, 3, 27), 0),  # 28/03 00:30 BST

--- a/tests/app/dao/test_invited_user_dao.py
+++ b/tests/app/dao/test_invited_user_dao.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy.orm.exc import NoResultFound
@@ -136,7 +136,7 @@ def make_invitation(user, service, age=None, email_address="test@test.com"):
         from_user=user,
         service=service,
         status="pending",
-        created_at=datetime.utcnow() - (age or timedelta(hours=0)),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - (age or timedelta(hours=0)),
         permissions="manage_settings",
         folder_permissions=[str(uuid.uuid4())],
     )

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from functools import partial
 
 import pytest
@@ -198,8 +198,8 @@ def test_update_job(sample_job):
 
 
 def test_set_scheduled_jobs_to_pending_gets_all_jobs_in_scheduled_state_before_now(sample_template):
-    one_minute_ago = datetime.utcnow() - timedelta(minutes=1)
-    one_hour_ago = datetime.utcnow() - timedelta(minutes=60)
+    one_minute_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=1)
+    one_hour_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=60)
     job_new = create_job(sample_template, scheduled_for=one_minute_ago, job_status="scheduled")
     job_old = create_job(sample_template, scheduled_for=one_hour_ago, job_status="scheduled")
     jobs = dao_set_scheduled_jobs_to_pending()
@@ -209,7 +209,7 @@ def test_set_scheduled_jobs_to_pending_gets_all_jobs_in_scheduled_state_before_n
 
 
 def test_set_scheduled_jobs_to_pending_gets_ignores_jobs_not_scheduled(sample_template, sample_job):
-    one_minute_ago = datetime.utcnow() - timedelta(minutes=1)
+    one_minute_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=1)
     job_scheduled = create_job(sample_template, scheduled_for=one_minute_ago, job_status="scheduled")
     jobs = dao_set_scheduled_jobs_to_pending()
     assert len(jobs) == 1
@@ -222,8 +222,8 @@ def test_set_scheduled_jobs_to_pending_gets_ignores_jobs_scheduled_in_the_future
 
 
 def test_set_scheduled_jobs_to_pending_updates_rows(sample_template):
-    one_minute_ago = datetime.utcnow() - timedelta(minutes=1)
-    one_hour_ago = datetime.utcnow() - timedelta(minutes=60)
+    one_minute_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=1)
+    one_hour_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=60)
     create_job(sample_template, scheduled_for=one_minute_ago, job_status="scheduled")
     create_job(sample_template, scheduled_for=one_hour_ago, job_status="scheduled")
     jobs = dao_set_scheduled_jobs_to_pending()
@@ -248,7 +248,7 @@ def test_should_get_jobs_seven_days_old(sample_template):
     """
     Jobs older than seven days are deleted, but only two day's worth (two-day window)
     """
-    seven_days_ago = datetime.utcnow() - timedelta(days=7)
+    seven_days_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=7)
     within_seven_days = seven_days_ago + timedelta(seconds=1)
 
     eight_days_ago = seven_days_ago - timedelta(days=1)
@@ -313,7 +313,7 @@ def test_get_jobs_for_service_doesnt_return_test_messages(
 
 @freeze_time("2016-10-31 10:00:00")
 def test_should_get_jobs_seven_days_old_filters_type(sample_service):
-    eight_days_ago = datetime.utcnow() - timedelta(days=8)
+    eight_days_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=8)
     letter_template = create_template(sample_service, template_type=LETTER_TYPE)
     sms_template = create_template(sample_service, template_type=SMS_TYPE)
     email_template = create_template(sample_service, template_type=EMAIL_TYPE)
@@ -330,8 +330,8 @@ def test_should_get_jobs_seven_days_old_filters_type(sample_service):
 
 @freeze_time("2016-10-31 10:00:00")
 def test_should_get_jobs_seven_days_old_by_scheduled_for_date(sample_service):
-    six_days_ago = datetime.utcnow() - timedelta(days=6)
-    eight_days_ago = datetime.utcnow() - timedelta(days=8)
+    six_days_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=6)
+    eight_days_ago = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=8)
     letter_template = create_template(sample_service, template_type=LETTER_TYPE)
 
     create_job(letter_template, created_at=eight_days_ago)
@@ -450,7 +450,7 @@ def test_find_jobs_with_missing_rows(sample_email_template):
         template=sample_email_template,
         notification_count=3,
         job_status=JOB_STATUS_FINISHED,
-        processing_finished=datetime.utcnow() - timedelta(minutes=20),
+        processing_finished=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=20),
     )
     for i in range(0, 3):
         create_notification(job=healthy_job, job_row_number=i)
@@ -458,7 +458,7 @@ def test_find_jobs_with_missing_rows(sample_email_template):
         template=sample_email_template,
         notification_count=5,
         job_status=JOB_STATUS_FINISHED,
-        processing_finished=datetime.utcnow() - timedelta(minutes=20),
+        processing_finished=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=20),
     )
     for i in range(0, 4):
         create_notification(job=job_with_missing_rows, job_row_number=i)
@@ -476,7 +476,7 @@ def test_find_jobs_with_missing_rows_returns_nothing_for_a_job_completed_less_th
         template=sample_email_template,
         notification_count=5,
         job_status=JOB_STATUS_FINISHED,
-        processing_finished=datetime.utcnow() - timedelta(minutes=9),
+        processing_finished=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=9),
     )
     for i in range(0, 4):
         create_notification(job=job, job_row_number=i)
@@ -491,7 +491,7 @@ def test_find_jobs_with_missing_rows_returns_nothing_for_a_job_completed_more_th
         template=sample_email_template,
         notification_count=5,
         job_status=JOB_STATUS_FINISHED,
-        processing_finished=datetime.utcnow() - timedelta(days=1),
+        processing_finished=datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1),
     )
     for i in range(0, 4):
         create_notification(job=job, job_row_number=i)
@@ -507,7 +507,7 @@ def test_find_jobs_with_missing_rows_doesnt_return_jobs_that_are_not_finished(sa
         template=sample_email_template,
         notification_count=5,
         job_status=status,
-        processing_finished=datetime.utcnow() - timedelta(minutes=11),
+        processing_finished=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=11),
     )
     for i in range(0, 4):
         create_notification(job=job, job_row_number=i)
@@ -522,7 +522,7 @@ def test_find_missing_row_for_job(sample_email_template):
         template=sample_email_template,
         notification_count=5,
         job_status=JOB_STATUS_FINISHED,
-        processing_finished=datetime.utcnow() - timedelta(minutes=11),
+        processing_finished=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=11),
     )
     create_notification(job=job, job_row_number=0)
     create_notification(job=job, job_row_number=1)
@@ -539,7 +539,7 @@ def test_find_missing_row_for_job_more_than_one_missing_row(sample_email_templat
         template=sample_email_template,
         notification_count=5,
         job_status=JOB_STATUS_FINISHED,
-        processing_finished=datetime.utcnow() - timedelta(minutes=11),
+        processing_finished=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=11),
     )
     create_notification(job=job, job_row_number=0)
     create_notification(job=job, job_row_number=1)
@@ -556,7 +556,7 @@ def test_find_missing_row_for_job_return_none_when_row_isnt_missing(sample_email
         template=sample_email_template,
         notification_count=5,
         job_status=JOB_STATUS_FINISHED,
-        processing_finished=datetime.utcnow() - timedelta(minutes=11),
+        processing_finished=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=11),
     )
     for i in range(0, 5):
         create_notification(job=job, job_row_number=i)

--- a/tests/app/dao/test_organisation_dao.py
+++ b/tests/app/dao/test_organisation_dao.py
@@ -1,5 +1,5 @@
-import datetime
 import uuid
+from datetime import UTC, datetime
 
 import pytest
 from flask import current_app
@@ -78,7 +78,7 @@ def test_update_organisation(notify_db_session):
         "crown": True,
         "organisation_type": "local",
         "agreement_signed": True,
-        "agreement_signed_at": datetime.datetime.utcnow(),
+        "agreement_signed_at": datetime.now(UTC).replace(tzinfo=None),
         "agreement_signed_by_id": user.id,
         "agreement_signed_version": 999.99,
         "letter_branding_id": letter_branding.id,

--- a/tests/app/dao/test_provider_details_dao.py
+++ b/tests/app/dao/test_provider_details_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from freezegun import freeze_time
@@ -142,7 +142,7 @@ def test_adjust_provider_priority_sets_priority(
 
     _adjust_provider_priority(mmg_provider, 50)
 
-    assert mmg_provider.updated_at == datetime.utcnow()
+    assert mmg_provider.updated_at == datetime.now(UTC).replace(tzinfo=None)
     assert mmg_provider.created_by.id == notify_user.id
     assert mmg_provider.priority == 50
 

--- a/tests/app/dao/test_returned_letters_dao.py
+++ b/tests/app/dao/test_returned_letters_dao.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from freezegun import freeze_time
 
@@ -145,7 +145,7 @@ def test_fetch_most_recent_returned_letter_for_service(sample_service):
 
 
 def test_get_returned_letter_summary(sample_service):
-    now = datetime.utcnow()
+    now = datetime.now(UTC).replace(tzinfo=None)
     create_returned_letter(sample_service, reported_at=now)
     create_returned_letter(sample_service, reported_at=now)
 
@@ -158,8 +158,8 @@ def test_get_returned_letter_summary(sample_service):
 
 
 def test_get_returned_letter_summary_orders_by_reported_at(sample_service):
-    now = datetime.utcnow()
-    last_month = datetime.utcnow() - timedelta(days=30)
+    now = datetime.now(UTC).replace(tzinfo=None)
+    last_month = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=30)
     create_returned_letter(sample_service, reported_at=now)
     create_returned_letter(sample_service, reported_at=now)
     create_returned_letter(sample_service, reported_at=now)
@@ -184,7 +184,7 @@ def test_fetch_returned_letters_from_notifications_and_notification_history(samp
         template=sample_letter_template,
         client_reference="letter_1",
         status=NOTIFICATION_RETURNED_LETTER,
-        created_at=datetime.utcnow() - timedelta(days=1),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1),
     )
     returned_letter_1 = create_returned_letter(
         service=sample_letter_template.service, reported_at=today, notification_id=letter_1.id
@@ -193,7 +193,7 @@ def test_fetch_returned_letters_from_notifications_and_notification_history(samp
         template=sample_letter_template,
         client_reference="letter_2",
         status=NOTIFICATION_RETURNED_LETTER,
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(UTC).replace(tzinfo=None),
     )
     returned_letter_2 = create_returned_letter(
         service=sample_letter_template.service, reported_at=today, notification_id=letter_2.id
@@ -248,7 +248,7 @@ def test_fetch_returned_letters_with_jobs(sample_letter_job):
         status=NOTIFICATION_RETURNED_LETTER,
         job=sample_letter_job,
         job_row_number=20,
-        created_at=datetime.utcnow() - timedelta(minutes=1),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=1),
     )
     returned_letter_1 = create_returned_letter(
         service=sample_letter_job.service, reported_at=today, notification_id=letter_1.id
@@ -280,7 +280,7 @@ def test_fetch_returned_letters_with_create_by_user(sample_letter_template):
         template=sample_letter_template,
         client_reference="letter_1",
         status=NOTIFICATION_RETURNED_LETTER,
-        created_at=datetime.utcnow() - timedelta(minutes=1),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=1),
         created_by_id=sample_letter_template.service.users[0].id,
     )
     returned_letter_1 = create_returned_letter(

--- a/tests/app/dao/test_service_data_retention_dao.py
+++ b/tests/app/dao/test_service_data_retention_dao.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -72,7 +72,7 @@ def test_insert_service_data_retention(sample_service):
     assert results[0].service_id == sample_service.id
     assert results[0].notification_type == "email"
     assert results[0].days_of_retention == 3
-    assert results[0].created_at.date() == datetime.utcnow().date()
+    assert results[0].created_at.date() == datetime.now(UTC).replace(tzinfo=None).date()
 
 
 def test_insert_service_data_retention_throws_unique_constraint(sample_service):
@@ -95,8 +95,8 @@ def test_update_service_data_retention(sample_service):
     assert results[0].service_id == sample_service.id
     assert results[0].notification_type == "sms"
     assert results[0].days_of_retention == 5
-    assert results[0].created_at.date() == datetime.utcnow().date()
-    assert results[0].updated_at.date() == datetime.utcnow().date()
+    assert results[0].created_at.date() == datetime.now(UTC).replace(tzinfo=None).date()
+    assert results[0].updated_at.date() == datetime.now(UTC).replace(tzinfo=None).date()
 
 
 def test_update_service_data_retention_does_not_update_if_row_does_not_exist(sample_service):

--- a/tests/app/dao/test_service_email_reply_to_dao.py
+++ b/tests/app/dao/test_service_email_reply_to_dao.py
@@ -26,8 +26,8 @@ def test_dao_get_reply_to_by_service_id(notify_db_session):
 
     assert len(results) == 3
     assert default_reply_to == results[0]
-    assert another_reply_to == results[1]
-    assert second_reply_to == results[2]
+    assert second_reply_to == results[1]
+    assert another_reply_to == results[2]
 
 
 def test_dao_get_reply_to_by_service_id_does_not_return_archived_reply_tos(notify_db_session):

--- a/tests/app/dao/test_service_letter_contact_dao.py
+++ b/tests/app/dao/test_service_letter_contact_dao.py
@@ -24,8 +24,8 @@ def test_dao_get_letter_contacts_by_service_id(notify_db_session):
 
     assert len(results) == 3
     assert default_letter_contact == results[0]
-    assert third_letter_contact == results[1]
-    assert second_letter_contact == results[2]
+    assert second_letter_contact == results[1]
+    assert third_letter_contact == results[2]
 
 
 def test_dao_get_letter_contacts_by_service_id_does_not_return_archived_contacts(notify_db_session):

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest import mock
 
 import pytest
@@ -1212,8 +1212,8 @@ def test_dao_find_services_sending_to_tv_numbers(notify_db_session, fake_uuid):
         create_notification(template_2, normalised_to=normal_number, status="delivered")
         create_notification(template_2, normalised_to=normal_number_resembling_tv_number, status="delivered")
 
-    start_date = datetime.utcnow() - timedelta(days=1)
-    end_date = datetime.utcnow()
+    start_date = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
+    end_date = datetime.now(UTC).replace(tzinfo=None)
 
     result = dao_find_services_sending_to_tv_numbers(start_date, end_date, threshold=4)
     assert len(result) == 1
@@ -1246,8 +1246,8 @@ def test_dao_find_services_with_high_failure_rates(notify_db_session, fake_uuid)
         create_notification(template_2, status="permanent-failure", key_type="test")  # test key type is excluded
     create_notification(template_2, status="permanent-failure")  # below threshold is excluded
 
-    start_date = datetime.utcnow() - timedelta(days=1)
-    end_date = datetime.utcnow()
+    start_date = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
+    end_date = datetime.now(UTC).replace(tzinfo=None)
 
     result = dao_find_services_with_high_failure_rates(start_date, end_date, threshold=3)
     # assert len(result) == 3

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from freezegun import freeze_time
@@ -55,7 +55,7 @@ def test_create_user(notify_db_session, phone_number):
     assert user_query.email_address == email
     assert user_query.id == user.id
     assert user_query.mobile_number == phone_number
-    assert user_query.email_access_validated_at == datetime.utcnow()
+    assert user_query.email_access_validated_at == datetime.now(UTC).replace(tzinfo=None)
     assert not user_query.platform_admin
 
 
@@ -134,8 +134,8 @@ def make_verify_code(user, age=None, expiry_age=None, code="12335", code_used=Fa
     verify_code = VerifyCode(
         code_type="sms",
         _code=code,
-        created_at=datetime.utcnow() - (age or timedelta(hours=0)),
-        expiry_datetime=datetime.utcnow() - (expiry_age or timedelta(0)),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - (age or timedelta(hours=0)),
+        expiry_datetime=datetime.now(UTC).replace(tzinfo=None) - (expiry_age or timedelta(0)),
         user=user,
         code_used=code_used,
     )
@@ -156,16 +156,16 @@ def test_update_user_attribute(client, sample_user, user_attribute, user_value):
 
 @freeze_time("2020-01-24T12:00:00")
 def test_update_user_password(notify_api, notify_db_session, sample_user):
-    sample_user.password_changed_at = datetime.utcnow() - timedelta(days=1)
+    sample_user.password_changed_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
     password = "newpassword"
     assert not sample_user.check_password(password)
     update_user_password(sample_user, password)
     assert sample_user.check_password(password)
-    assert sample_user.password_changed_at == datetime.utcnow()
+    assert sample_user.password_changed_at == datetime.now(UTC).replace(tzinfo=None)
 
 
 def test_count_user_verify_codes(sample_user):
-    with freeze_time(datetime.utcnow() + timedelta(hours=1)):
+    with freeze_time(datetime.now(UTC).replace(tzinfo=None) + timedelta(hours=1)):
         make_verify_code(sample_user, code_used=True)
         make_verify_code(sample_user, expiry_age=timedelta(hours=2))
         [make_verify_code(sample_user) for i in range(5)]

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -1,6 +1,6 @@
 import random
 import uuid
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 import pytest
 
@@ -264,14 +264,14 @@ def create_notification(
         template = job.template
 
     if created_at is None:
-        created_at = datetime.utcnow()
+        created_at = datetime.now(UTC).replace(tzinfo=None)
 
     if to_field is None:
         to_field = "+447700900855" if template.template_type == SMS_TYPE else "test@example.com"
 
     if status not in ("created", "validation-failed", "virus-scan-failed", "pending-virus-check"):
-        sent_at = sent_at or datetime.utcnow()
-        updated_at = updated_at or datetime.utcnow()
+        sent_at = sent_at or datetime.now(UTC).replace(tzinfo=None)
+        updated_at = updated_at or datetime.now(UTC).replace(tzinfo=None)
 
     if not one_off and (job is None and api_key is None):
         # we did not specify in test - lets create it
@@ -347,11 +347,11 @@ def create_notification_history(
         template = job.template
 
     if created_at is None:
-        created_at = datetime.utcnow()
+        created_at = datetime.now(UTC).replace(tzinfo=None)
 
     if status != "created":
-        sent_at = sent_at or datetime.utcnow()
-        updated_at = updated_at or datetime.utcnow()
+        sent_at = sent_at or datetime.now(UTC).replace(tzinfo=None)
+        updated_at = updated_at or datetime.now(UTC).replace(tzinfo=None)
 
     if template.template_type == "letter" and postage is None:
         postage = "second"
@@ -410,7 +410,7 @@ def create_job(
         "template_version": template.version,
         "original_file_name": original_file_name,
         "notification_count": notification_count,
-        "created_at": created_at or datetime.utcnow(),
+        "created_at": created_at or datetime.now(UTC).replace(tzinfo=None),
         "created_by": template.created_by,
         "job_status": job_status,
         "scheduled_for": scheduled_for,
@@ -452,10 +452,10 @@ def create_inbound_sms(
 
     inbound = InboundSms(
         service=service,
-        created_at=created_at or datetime.utcnow(),
+        created_at=created_at or datetime.now(UTC).replace(tzinfo=None),
         notify_number=service.get_inbound_number(),
         user_number=user_number,
-        provider_date=provider_date or datetime.utcnow(),
+        provider_date=provider_date or datetime.now(UTC).replace(tzinfo=None),
         provider_reference=provider_reference or "foo",
         content=content,
         provider=provider,
@@ -773,7 +773,7 @@ def create_complaint(service=None, notification=None, created_at=None):
         service_id=service.id,
         ses_feedback_id=str(uuid.uuid4()),
         complaint_type="abuse",
-        complaint_date=datetime.utcnow(),
+        complaint_date=datetime.now(UTC).replace(tzinfo=None),
         created_at=created_at if created_at else datetime.now(),
     )
     db.session.add(complaint)
@@ -1121,9 +1121,9 @@ def create_returned_letter(service=None, reported_at=None, notification_id=None)
         service = create_service(service_name="a - with sms and letter")
     returned_letter = ReturnedLetter(
         service_id=service.id,
-        reported_at=reported_at or datetime.utcnow(),
+        reported_at=reported_at or datetime.now(UTC).replace(tzinfo=None),
         notification_id=notification_id or uuid.uuid4(),
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(UTC).replace(tzinfo=None),
     )
 
     db.session.add(returned_letter)
@@ -1148,7 +1148,7 @@ def create_service_contact_list(
         row_count=row_count,
         template_type=template_type,
         created_by_id=created_by_id or service.users[0].id,
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(UTC).replace(tzinfo=None),
         archived=archived,
     )
     db.session.add(contact_list)
@@ -1216,13 +1216,13 @@ def create_broadcast_event(
     b_e = BroadcastEvent(
         service=broadcast_message.service,
         broadcast_message=broadcast_message,
-        sent_at=sent_at or datetime.utcnow(),
+        sent_at=sent_at or datetime.now(UTC).replace(tzinfo=None),
         message_type=message_type,
         transmitted_content=transmitted_content or {"body": "this is an emergency broadcast message"},
         transmitted_areas=transmitted_areas or broadcast_message.areas,
         transmitted_sender=transmitted_sender or "www.notifications.service.gov.uk",
         transmitted_starts_at=transmitted_starts_at,
-        transmitted_finishes_at=transmitted_finishes_at or datetime.utcnow() + timedelta(hours=24),
+        transmitted_finishes_at=transmitted_finishes_at or datetime.now(UTC).replace(tzinfo=None) + timedelta(hours=24),
     )
     db.session.add(b_e)
     db.session.commit()

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from collections import namedtuple
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import ANY
 
 import pytest
@@ -138,7 +138,7 @@ def test_should_send_personalised_template_to_correct_sms_provider_and_persist(s
     notification = Notification.query.filter_by(id=db_notification.id).one()
 
     assert notification.status == "sending"
-    assert notification.sent_at <= datetime.utcnow()
+    assert notification.sent_at <= datetime.now(UTC).replace(tzinfo=None)
     assert notification.sent_by == "mmg"
     assert notification.billable_units == 1
     assert notification.personalisation == {"name": "Jo"}
@@ -173,7 +173,7 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
 
     notification = Notification.query.filter_by(id=db_notification.id).one()
     assert notification.status == "sending"
-    assert notification.sent_at <= datetime.utcnow()
+    assert notification.sent_at <= datetime.now(UTC).replace(tzinfo=None)
     assert notification.sent_by == "ses"
     assert notification.personalisation == {"name": "Jo"}
 
@@ -270,7 +270,7 @@ def test_should_call_send_sms_response_task_if_test_api_key(
     assert persisted_notification.to == sample_notification.to
     assert persisted_notification.template_id == sample_notification.template_id
     assert persisted_notification.status == "sending"
-    assert persisted_notification.sent_at <= datetime.utcnow()
+    assert persisted_notification.sent_at <= datetime.now(UTC).replace(tzinfo=None)
     assert persisted_notification.sent_by == "mmg"
     assert not persisted_notification.personalisation
 
@@ -351,8 +351,8 @@ def test_send_email_to_provider_should_call_response_task_if_test_key(sample_ser
     assert persisted_notification.to == "john@smith.com"
     assert persisted_notification.template_id == sample_email_template.id
     assert persisted_notification.status == "sending"
-    assert persisted_notification.sent_at <= datetime.utcnow()
-    assert persisted_notification.created_at <= datetime.utcnow()
+    assert persisted_notification.sent_at <= datetime.now(UTC).replace(tzinfo=None)
+    assert persisted_notification.created_at <= datetime.now(UTC).replace(tzinfo=None)
     assert persisted_notification.sent_by == "ses"
     assert persisted_notification.reference == str(reference)
     assert persisted_notification.billable_units == 0

--- a/tests/app/email_branding/test_rest.py
+++ b/tests/app/email_branding/test_rest.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from freezegun import freeze_time
@@ -105,7 +105,7 @@ def test_post_create_email_branding(admin_request, notify_db_session):
 
     email_branding = EmailBranding.query.filter(EmailBranding.name == data["name"]).one()
     assert email_branding.created_by is None
-    assert email_branding.created_at == datetime.utcnow()
+    assert email_branding.created_at == datetime.now(UTC).replace(tzinfo=None)
 
 
 @freeze_time()
@@ -127,7 +127,7 @@ def test_post_create_email_branding_with_created_fields(admin_request, notify_db
 
     email_branding = EmailBranding.query.filter(EmailBranding.name == data["name"]).one()
     assert str(email_branding.created_by) == data["created_by"]
-    assert email_branding.created_at == datetime.utcnow()
+    assert email_branding.created_at == datetime.now(UTC).replace(tzinfo=None)
     assert email_branding.text is None
 
 

--- a/tests/app/inbound_sms/test_rest.py
+++ b/tests/app/inbound_sms/test_rest.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from freezegun import freeze_time
@@ -176,7 +176,7 @@ def test_get_most_recent_inbound_sms_for_service(
 def test_get_most_recent_inbound_sms_for_service_respects_data_retention(admin_request, sample_service):
     create_service_data_retention(sample_service, "sms", 5)
     for i in range(10):
-        created = datetime.utcnow() - timedelta(days=i)
+        created = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=i)
         create_inbound_sms(sample_service, user_number="44770090000{}".format(i), created_at=created)
 
     response = admin_request.get("inbound_sms.get_most_recent_inbound_sms_for_service", service_id=sample_service.id)
@@ -209,7 +209,7 @@ def test_get_most_recent_inbound_sms_for_service_respects_data_retention_if_olde
 def test_get_inbound_sms_for_service_respects_data_retention(admin_request, sample_service):
     create_service_data_retention(sample_service, "sms", 5)
     for i in range(10):
-        created = datetime.utcnow() - timedelta(days=i)
+        created = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=i)
         create_inbound_sms(sample_service, user_number="44770090000{}".format(i), created_at=created)
 
     response = admin_request.get("inbound_sms.get_most_recent_inbound_sms_for_service", service_id=sample_service.id)

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from unittest.mock import ANY
 
 import pytest
@@ -197,7 +197,7 @@ def test_create_unscheduled_job_with_sender_id_in_metadata(client, sample_templa
 
 @freeze_time("2016-01-01 12:00:00.000000")
 def test_create_scheduled_job(client, sample_template, mocker, fake_uuid):
-    scheduled_date = (datetime.utcnow() + timedelta(hours=95, minutes=59)).isoformat()
+    scheduled_date = (datetime.now(UTC).replace(tzinfo=None) + timedelta(hours=95, minutes=59)).isoformat()
     mocker.patch("app.celery.tasks.process_job.apply_async")
     mocker.patch(
         "app.job.rest.get_job_metadata_from_s3",
@@ -354,7 +354,7 @@ def test_create_job_returns_403_if_letter_template_type_and_service_in_trial(
 
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_should_not_create_scheduled_job_more_then_7_days_in_the_future(client, sample_template, mocker, fake_uuid):
-    scheduled_date = (datetime.utcnow() + timedelta(days=7, minutes=1)).isoformat()
+    scheduled_date = (datetime.now(UTC).replace(tzinfo=None) + timedelta(days=7, minutes=1)).isoformat()
     mocker.patch("app.celery.tasks.process_job.apply_async")
     mocker.patch(
         "app.job.rest.get_job_metadata_from_s3",
@@ -387,7 +387,7 @@ def test_should_not_create_scheduled_job_more_then_7_days_in_the_future(client, 
 
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_should_not_create_scheduled_job_in_the_past(client, sample_template, mocker, fake_uuid):
-    scheduled_date = (datetime.utcnow() - timedelta(minutes=1)).isoformat()
+    scheduled_date = (datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=1)).isoformat()
     mocker.patch("app.celery.tasks.process_job.apply_async")
     mocker.patch(
         "app.job.rest.get_job_metadata_from_s3",
@@ -661,7 +661,10 @@ def test_get_job_by_id_should_return_summed_statistics(admin_request, sample_job
 
 def test_get_job_by_id_with_stats_for_old_job_where_notifications_have_been_purged(admin_request, sample_template):
     old_job = create_job(
-        sample_template, notification_count=10, created_at=datetime.utcnow() - timedelta(days=9), job_status="finished"
+        sample_template,
+        notification_count=10,
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(days=9),
+        job_status="finished",
     )
 
     def __create_ft_status(job, status, count):
@@ -757,8 +760,8 @@ def test_get_jobs_by_contact_list(admin_request, sample_template):
 
 
 def test_get_jobs_should_return_statistics(admin_request, sample_template):
-    now = datetime.utcnow()
-    earlier = datetime.utcnow() - timedelta(days=1)
+    now = datetime.now(UTC).replace(tzinfo=None)
+    earlier = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
     job_1 = create_job(sample_template, processing_started=earlier)
     job_2 = create_job(sample_template, processing_started=now)
     create_notification(job=job_1, status="created")
@@ -778,8 +781,8 @@ def test_get_jobs_should_return_statistics(admin_request, sample_template):
 
 
 def test_get_jobs_should_return_no_stats_if_no_rows_in_notifications(admin_request, sample_template):
-    now = datetime.utcnow()
-    earlier = datetime.utcnow() - timedelta(days=1)
+    now = datetime.now(UTC).replace(tzinfo=None)
+    earlier = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
     job_1 = create_job(sample_template, created_at=earlier)
     job_2 = create_job(sample_template, created_at=now)
 

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import call
 
 import boto3
@@ -41,8 +41,8 @@ def _sample_precompiled_letter_notification(sample_letter_notification):
     sample_letter_notification.template.name = PRECOMPILED_TEMPLATE_NAME
     sample_letter_notification.reference = "foo"
     with freeze_time(FROZEN_DATE_TIME):
-        sample_letter_notification.created_at = datetime.utcnow()
-        sample_letter_notification.updated_at = datetime.utcnow()
+        sample_letter_notification.created_at = datetime.now(UTC).replace(tzinfo=None)
+        sample_letter_notification.updated_at = datetime.now(UTC).replace(tzinfo=None)
     return sample_letter_notification
 
 
@@ -214,7 +214,7 @@ def test_get_letter_pdf_gets_pdf_from_correct_bucket(
         sample_precompiled_letter_notification_using_test_key.key_type = KEY_TYPE_NORMAL
 
     bucket_name = current_app.config[bucket_config_name]
-    filename = datetime.utcnow().strftime(filename_format)
+    filename = datetime.now(UTC).replace(tzinfo=None).strftime(filename_format)
     conn = boto3.resource("s3", region_name="eu-west-1")
     conn.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": "eu-west-1"})
     s3 = boto3.client("s3", region_name="eu-west-1")
@@ -352,7 +352,10 @@ def test_move_sanitised_letter_to_live_pdf_bucket(notify_api, mocker):
     s3.put_object(Bucket=source_bucket_name, Key=filename, Body=b"pdf_content")
 
     move_sanitised_letter_to_test_or_live_pdf_bucket(
-        filename=filename, is_test_letter=False, created_at=datetime.utcnow(), new_filename=filename
+        filename=filename,
+        is_test_letter=False,
+        created_at=datetime.now(UTC).replace(tzinfo=None),
+        new_filename=filename,
     )
 
     assert not [x for x in source_bucket.objects.all()]
@@ -377,7 +380,7 @@ def test_move_sanitised_letter_to_test_pdf_bucket(notify_api, mocker):
     s3.put_object(Bucket=source_bucket_name, Key=filename, Body=b"pdf_content")
 
     move_sanitised_letter_to_test_or_live_pdf_bucket(
-        filename=filename, is_test_letter=True, created_at=datetime.utcnow(), new_filename=filename
+        filename=filename, is_test_letter=True, created_at=datetime.now(UTC).replace(tzinfo=None), new_filename=filename
     )
 
     assert not [x for x in source_bucket.objects.all()]

--- a/tests/app/letters/test_rates.py
+++ b/tests/app/letters/test_rates.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from freezegun import freeze_time
 
@@ -7,9 +7,9 @@ from tests.app.db import create_letter_rate
 
 @freeze_time("2024-01-02T12:00:00")
 def test_letter_rates(admin_request, notify_db_session):
-    now = datetime.utcnow()
-    tomorrow = datetime.utcnow() + timedelta(days=1)
-    yesterday = datetime.utcnow() - timedelta(days=1)
+    now = datetime.now(UTC).replace(tzinfo=None)
+    tomorrow = datetime.now(UTC).replace(tzinfo=None) + timedelta(days=1)
+    yesterday = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
 
     # Should be returned
     create_letter_rate(start_date=now, rate=0.66, post_class="first", sheet_count=1)

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -1,5 +1,5 @@
 import base64
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from flask import json
@@ -234,7 +234,7 @@ def test_format_mmg_datetime(provider_date, expected_output):
 
 @freeze_time("2020-05-14 14:30:00")
 def test_format_mmg_datetime_returns_now_if_cannot_parse_date():
-    assert format_mmg_datetime("13-05-2020 08%3A37%3A43") == datetime.utcnow()
+    assert format_mmg_datetime("13-05-2020 08%3A37%3A43") == datetime.now(UTC).replace(tzinfo=None)
 
 
 def test_create_inbound_mmg_sms_object(sample_service_full_permissions):

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -1,6 +1,6 @@
 import random
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import ANY
 
 import pytest
@@ -857,7 +857,11 @@ def test_get_organisation_services_usage(admin_request, notify_db_session, mocke
     dao_add_service_to_organisation(service=service, organisation_id=org.id)
     create_annual_billing(service_id=service.id, free_sms_fragment_limit=10, financial_year_start=2019)
     create_ft_billing(
-        bst_date=datetime.utcnow().date(), template=template, billable_unit=19, rate=0.060, notifications_sent=19
+        bst_date=datetime.now(UTC).replace(tzinfo=None).date(),
+        template=template,
+        billable_unit=19,
+        rate=0.060,
+        notifications_sent=19,
     )
     mocker.patch(
         "app.dao.fact_billing_dao.get_ft_billing_data_for_today_updated_at", return_value="2019-06-01T12:00:00+00:00"
@@ -892,7 +896,7 @@ def test_get_organisation_services_usage_limit_queries_executed(admin_request, n
         create_annual_billing(service_id=service.id, free_sms_fragment_limit=10, financial_year_start=2019)
         for num_billing_days in range(random.randint(10, 25)):
             create_ft_billing(
-                bst_date=datetime.utcnow().date() - timedelta(days=num_billing_days),
+                bst_date=datetime.now(UTC).replace(tzinfo=None).date() - timedelta(days=num_billing_days),
                 template=template,
                 billable_unit=num_billing_days + 1,
                 rate=0.060,
@@ -920,7 +924,11 @@ def test_get_organisation_services_usage_sort_active_first(admin_request, notify
     dao_add_service_to_organisation(service=archived_service, organisation_id=org.id)
     create_annual_billing(service_id=service.id, free_sms_fragment_limit=10, financial_year_start=2019)
     create_ft_billing(
-        bst_date=datetime.utcnow().date(), template=template, billable_unit=19, rate=0.060, notifications_sent=19
+        bst_date=datetime.now(UTC).replace(tzinfo=None).date(),
+        template=template,
+        billable_unit=19,
+        rate=0.060,
+        notifications_sent=19,
     )
     response = admin_request.get(
         "organisation.get_organisation_services_usage", organisation_id=org.id, **{"year": 2019}

--- a/tests/app/service/test_service_contact_list_rest.py
+++ b/tests/app/service/test_service_contact_list_rest.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from freezegun import freeze_time
@@ -93,7 +93,7 @@ def test_get_contact_list_counts_jobs(
         create_job(
             template=sample_template,
             contact_list_id=contact_list_2.id,
-            created_at=datetime.utcnow() - timedelta(days=i),
+            created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(days=i),
         )
 
     response = admin_request.get("service.get_contact_list", service_id=contact_list_1.service_id)

--- a/tests/app/service/test_statistics_rest.py
+++ b/tests/app/service/test_statistics_rest.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 
 import pytest
 from freezegun import freeze_time
@@ -24,7 +24,7 @@ from tests.app.db import (
 @freeze_time("2017-11-11 02:00")
 def test_get_template_usage_by_month_returns_correct_data(admin_request, sample_template):
     create_ft_notification_status(bst_date=date(2017, 4, 2), template=sample_template, count=3)
-    create_notification(sample_template, created_at=datetime.utcnow())
+    create_notification(sample_template, created_at=datetime.now(UTC).replace(tzinfo=None))
 
     resp_json = admin_request.get(
         "service.get_monthly_template_usage", service_id=sample_template.service_id, year=2017
@@ -55,7 +55,7 @@ def test_get_template_usage_by_month_returns_two_templates(admin_request, sample
     )
     create_ft_notification_status(bst_date=datetime(2017, 4, 1), template=template_one, count=1)
     create_ft_notification_status(bst_date=datetime(2017, 4, 1), template=sample_template, count=3)
-    create_notification(sample_template, created_at=datetime.utcnow())
+    create_notification(sample_template, created_at=datetime.now(UTC).replace(tzinfo=None))
 
     resp_json = admin_request.get(
         "service.get_monthly_template_usage", service_id=sample_template.service_id, year=2017

--- a/tests/app/sms/test_rates.py
+++ b/tests/app/sms/test_rates.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from freezegun import freeze_time
 
@@ -7,9 +7,9 @@ from tests.app.db import create_rate
 
 @freeze_time("2024-01-02T12:00:00")
 def test_sms_rate(admin_request, notify_db_session):
-    now = datetime.utcnow()
-    tomorrow = datetime.utcnow() + timedelta(days=1)
-    yesterday = datetime.utcnow() - timedelta(days=1)
+    now = datetime.now(UTC).replace(tzinfo=None)
+    tomorrow = datetime.now(UTC).replace(tzinfo=None) + timedelta(days=1)
+    yesterday = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
 
     # Older (should not be returned)
     create_rate(start_date=yesterday, value=1.23, notification_type="sms")

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -3,7 +3,7 @@ import json
 import random
 import string
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import botocore
 import pytest
@@ -1282,7 +1282,7 @@ def test_preview_letter_template_by_id_valid_file_type(
     mock_onwards_request_headers,
     file_type,
 ):
-    sample_letter_notification.created_at = datetime.utcnow()
+    sample_letter_notification.created_at = datetime.now(UTC).replace(tzinfo=None)
     with set_config_values(
         notify_api,
         {
@@ -1334,7 +1334,7 @@ def test_preview_letter_template_by_id_shows_template_version_used_by_notificati
     mock_onwards_request_headers,
     admin_request,
 ):
-    sample_letter_notification.created_at = datetime.utcnow()
+    sample_letter_notification.created_at = datetime.now(UTC).replace(tzinfo=None)
     assert sample_letter_notification.template_version == 1
 
     # Create a new template history to check that our preview doesn't use the newest version

--- a/tests/app/template_statistics/test_rest.py
+++ b/tests/app/template_statistics/test_rest.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock
 
 import pytest
@@ -111,9 +111,9 @@ def test_get_template_statistics_for_service_by_day_returns_empty_list_if_no_tem
 
 
 def test_get_last_used_datetime_for_template(admin_request, sample_template):
-    date_from_notification = datetime.utcnow() - timedelta(hours=2)
+    date_from_notification = datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2)
     create_notification(template=sample_template, created_at=date_from_notification)
-    date_from_ft_status = (datetime.utcnow() - timedelta(days=2)).date()
+    date_from_ft_status = (datetime.now(UTC).replace(tzinfo=None) - timedelta(days=2)).date()
     create_ft_notification_status(bst_date=date_from_ft_status, template=sample_template)
 
     json_resp = admin_request.get(

--- a/tests/app/upload/test_rest.py
+++ b/tests/app/upload/test_rest.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from freezegun import freeze_time
 
@@ -45,22 +45,22 @@ def test_get_uploads(admin_request, sample_template):
         letter_template,
         sample_template.service,
         status="delivered",
-        created_at=datetime.utcnow() - timedelta(minutes=4),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=4),
     )
     upload_2 = create_job(
         template=sample_template,
-        processing_started=datetime.utcnow() - timedelta(minutes=3),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=3),
         job_status=JOB_STATUS_FINISHED,
     )
     create_uploaded_letter(
         letter_template,
         sample_template.service,
         status="delivered",
-        created_at=datetime.utcnow() - timedelta(minutes=2),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=2),
     )
     upload_4 = create_job(
         template=sample_template,
-        processing_started=datetime.utcnow() - timedelta(minutes=1),
+        processing_started=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=1),
         job_status=JOB_STATUS_FINISHED,
     )
     upload_5 = create_job(
@@ -105,8 +105,8 @@ def test_get_uploads(admin_request, sample_template):
 
 
 def test_get_uploads_should_return_statistics(admin_request, sample_template):
-    now = datetime.utcnow()
-    earlier = datetime.utcnow() - timedelta(days=1)
+    now = datetime.now(UTC).replace(tzinfo=None)
+    earlier = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
     job_1 = create_job(template=sample_template, job_status="pending")
     job_2 = create_job(sample_template, processing_started=earlier)
     for _ in range(3):
@@ -118,7 +118,10 @@ def test_get_uploads_should_return_statistics(admin_request, sample_template):
 
     letter_template = create_precompiled_template(sample_template.service)
     create_uploaded_letter(
-        letter_template, sample_template.service, status="delivered", created_at=datetime.utcnow() - timedelta(days=3)
+        letter_template,
+        sample_template.service,
+        status="delivered",
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(days=3),
     )
 
     resp_json = admin_request.get("upload.get_uploads_by_service", service_id=sample_template.service_id)["data"]
@@ -204,13 +207,13 @@ def test_get_uploaded_letters_by_print_date(admin_request, sample_template):
         letter_template,
         sample_template.service,
         status="delivered",
-        created_at=datetime.utcnow() - timedelta(minutes=1),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=1),
     )
     letter_2 = create_uploaded_letter(
         letter_template,
         sample_template.service,
         status="delivered",
-        created_at=datetime.utcnow() - timedelta(minutes=2),
+        created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=2),
     )
 
     service_id = sample_template.service.id
@@ -240,7 +243,7 @@ def test_get_uploaded_letters_by_print_date_paginates(admin_request, sample_temp
             letter_template,
             sample_template.service,
             status="delivered",
-            created_at=datetime.utcnow() - timedelta(minutes=1),
+            created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=1),
         )
 
     service_id = sample_template.service.id


### PR DESCRIPTION
`datetime.datetime.utcnow()` gets deprecated in Python 3.12 - we can still use Python 3.11 for a long while (it's end of life in 2027), but I thought it might be interesting to have a think how we will deal with it.

In the changes below, I changed to new, accepted syntax, while keeping the naive dates. As you can see, the syntax becomes a bit clunky.

Whereas it would probably be better to switch to timezone-aware dates. This would reduce scope for confusion - we would always know which timezone the date is in.

Main questions we'd have to answer to switch to timezone-aware datetimes is how to correctly use SQLAlchemy to save timezone-aware dates in our Postgres db.

Converting between timezone-aware and naive datetimes each time we write or read from database sounds much more clunky.

Some sources about the deprecation:
Discussion: https://discuss.python.org/t/deprecating-utcnow-and-utcfromtimestamp/26221
Blog post: https://blog.miguelgrinberg.com/post/it-s-time-for-a-change-datetime-utcnow-is-now-deprecated