### PR TITLE
Make service callback sending consistent

### DIFF
--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -120,7 +120,7 @@ def _send_data_to_service_callback_api(
             try:
                 self.retry(queue=retry_queue)
             except self.MaxRetriesExceededError as e:
-                current_app.logger.warning(
+                current_app.logger.error(
                     "Retry: %s has retried the max num of times for callback url %s and id: %s",
                     function_name,
                     service_callback_url,

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -5,6 +5,8 @@ from requests import HTTPError, RequestException, request
 
 from app import notify_celery, signing
 from app.config import QueueNames
+from app.dao.inbound_sms_dao import dao_get_inbound_sms_by_id
+from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
 from app.utils import DATETIME_FORMAT
 
 
@@ -53,6 +55,71 @@ def send_complaint_to_service(self, complaint_data):
         complaint["service_callback_api_bearer_token"],
         "send_complaint_to_service",
     )
+
+
+@notify_celery.task(bind=True, name="send-inbound-sms", max_retries=5, default_retry_delay=300)
+def send_inbound_sms_to_service(self, inbound_sms_id, service_id):
+    inbound_api = get_service_inbound_api_for_service(service_id=service_id)
+    if not inbound_api:
+        # No API data has been set for this service
+        return
+
+    inbound_sms = dao_get_inbound_sms_by_id(service_id=service_id, inbound_id=inbound_sms_id)
+    data = {
+        "id": str(inbound_sms.id),
+        # TODO: should we be validating and formatting the phone number here?
+        "source_number": inbound_sms.user_number,
+        "destination_number": inbound_sms.notify_number,
+        "message": inbound_sms.content,
+        "date_received": inbound_sms.provider_date.strftime(DATETIME_FORMAT),
+    }
+
+    try:
+        response = request(
+            method="POST",
+            url=inbound_api.url,
+            data=json.dumps(data),
+            headers={"Content-Type": "application/json", "Authorization": "Bearer {}".format(inbound_api.bearer_token)},
+            timeout=60,
+        )
+        current_app.logger.debug(
+            "send_inbound_sms_to_service sending %s to %s, response %s",
+            inbound_sms_id,
+            inbound_api.url,
+            response.status_code,
+        )
+        response.raise_for_status()
+    except RequestException as e:
+        current_app.logger.warning(
+            "send_inbound_sms_to_service failed for service_id: %s for inbound_sms_id: %s and url: %s. exception: %s",
+            service_id,
+            inbound_sms_id,
+            inbound_api.url,
+            e,
+        )
+        if not isinstance(e, HTTPError) or e.response.status_code >= 500:
+            try:
+                self.retry(queue=QueueNames.RETRY)
+            except self.MaxRetriesExceededError:
+                current_app.logger.error(
+                    (
+                        "Retry: send_inbound_sms_to_service has retried the max number of times "
+                        "for service: %s and inbound_sms %s"
+                    ),
+                    service_id,
+                    inbound_sms_id,
+                )
+        else:
+            current_app.logger.warning(
+                (
+                    "send_inbound_sms_to_service is not being retried for service_id: %s "
+                    "for inbound_sms id: %s and url: %s. exception: %s"
+                ),
+                service_id,
+                inbound_sms_id,
+                inbound_api.url,
+                e,
+            )
 
 
 def _send_data_to_service_callback_api(self, data, service_callback_url, token, function_name):

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -75,14 +75,21 @@ def send_inbound_sms_to_service(self, inbound_sms_id, service_id):
     }
 
     _send_data_to_service_callback_api(
-        self, data, inbound_api.url, inbound_api.bearer_token, "send_inbound_sms_to_service", QueueNames.RETRY
+        self,
+        data,
+        inbound_api.url,
+        inbound_api.bearer_token,
+        "send_inbound_sms_to_service",
+        QueueNames.RETRY,
+        service_id,
     )
 
 
 def _send_data_to_service_callback_api(
-    self, data, service_callback_url, token, function_name, retry_queue=QueueNames.CALLBACKS_RETRY
+    self, data, service_callback_url, token, function_name, retry_queue=QueueNames.CALLBACKS_RETRY, service_id=None
 ):
     object_id = data["notification_id"] if "notification_id" in data else data["id"]
+    service_id = str(service_id) if service_id else "no-service-id"
     try:
         response = request(
             method="POST",
@@ -97,6 +104,7 @@ def _send_data_to_service_callback_api(
             object_id,
             service_callback_url,
             response.status_code,
+            extra={"service_id": service_id},
         )
         response.raise_for_status()
     except RequestException as e:
@@ -106,6 +114,7 @@ def _send_data_to_service_callback_api(
             object_id,
             service_callback_url,
             e,
+            extra={"service_id": service_id},
         )
         if not isinstance(e, HTTPError) or e.response.status_code >= 500 or e.response.status_code == 429:
             try:
@@ -116,6 +125,7 @@ def _send_data_to_service_callback_api(
                     function_name,
                     service_callback_url,
                     object_id,
+                    extra={"service_id": service_id},
                 )
         else:
             current_app.logger.warning(
@@ -124,6 +134,7 @@ def _send_data_to_service_callback_api(
                 object_id,
                 service_callback_url,
                 e,
+                extra={"service_id": service_id},
             )
 
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1,4 +1,3 @@
-import json
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
@@ -8,7 +7,6 @@ from notifications_utils.insensitive_dict import InsensitiveDict
 from notifications_utils.postal_address import PostalAddress
 from notifications_utils.recipients import RecipientCSV
 from notifications_utils.timezones import convert_utc_to_bst
-from requests import HTTPError, RequestException, request
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from app import create_random_identifier, create_uuid, notify_celery, signing
@@ -33,7 +31,6 @@ from app.constants import (
 from app.dao.daily_sorted_letter_dao import (
     dao_create_or_update_daily_sorted_letter,
 )
-from app.dao.inbound_sms_dao import dao_get_inbound_sms_by_id
 from app.dao.jobs_dao import dao_get_job_by_id, dao_update_job
 from app.dao.notifications_dao import (
     dao_get_last_notification_added_for_job_id,
@@ -44,7 +41,6 @@ from app.dao.notifications_dao import (
 )
 from app.dao.returned_letters_dao import insert_returned_letters
 from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_id
-from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
 from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id
 from app.dao.templates_dao import dao_get_template_by_id
 from app.exceptions import DVLAException
@@ -53,7 +49,6 @@ from app.notifications.process_notifications import persist_notification
 from app.notifications.validators import check_service_over_daily_message_limit
 from app.serialised_models import SerialisedService, SerialisedTemplate
 from app.service.utils import service_allowed_to_send_to
-from app.utils import DATETIME_FORMAT
 from app.v2.errors import TooManyRequestsError
 
 
@@ -525,71 +520,6 @@ def check_billable_units(notification_update):
             notification.billable_units,
             notification_update.page_count,
         )
-
-
-@notify_celery.task(bind=True, name="send-inbound-sms", max_retries=5, default_retry_delay=300)
-def send_inbound_sms_to_service(self, inbound_sms_id, service_id):
-    inbound_api = get_service_inbound_api_for_service(service_id=service_id)
-    if not inbound_api:
-        # No API data has been set for this service
-        return
-
-    inbound_sms = dao_get_inbound_sms_by_id(service_id=service_id, inbound_id=inbound_sms_id)
-    data = {
-        "id": str(inbound_sms.id),
-        # TODO: should we be validating and formatting the phone number here?
-        "source_number": inbound_sms.user_number,
-        "destination_number": inbound_sms.notify_number,
-        "message": inbound_sms.content,
-        "date_received": inbound_sms.provider_date.strftime(DATETIME_FORMAT),
-    }
-
-    try:
-        response = request(
-            method="POST",
-            url=inbound_api.url,
-            data=json.dumps(data),
-            headers={"Content-Type": "application/json", "Authorization": "Bearer {}".format(inbound_api.bearer_token)},
-            timeout=60,
-        )
-        current_app.logger.debug(
-            "send_inbound_sms_to_service sending %s to %s, response %s",
-            inbound_sms_id,
-            inbound_api.url,
-            response.status_code,
-        )
-        response.raise_for_status()
-    except RequestException as e:
-        current_app.logger.warning(
-            "send_inbound_sms_to_service failed for service_id: %s for inbound_sms_id: %s and url: %s. exception: %s",
-            service_id,
-            inbound_sms_id,
-            inbound_api.url,
-            e,
-        )
-        if not isinstance(e, HTTPError) or e.response.status_code >= 500:
-            try:
-                self.retry(queue=QueueNames.RETRY)
-            except self.MaxRetriesExceededError:
-                current_app.logger.error(
-                    (
-                        "Retry: send_inbound_sms_to_service has retried the max number of times "
-                        "for service: %s and inbound_sms %s"
-                    ),
-                    service_id,
-                    inbound_sms_id,
-                )
-        else:
-            current_app.logger.warning(
-                (
-                    "send_inbound_sms_to_service is not being retried for service_id: %s "
-                    "for inbound_sms id: %s and url: %s. exception: %s"
-                ),
-                service_id,
-                inbound_sms_id,
-                inbound_api.url,
-                e,
-            )
 
 
 @notify_celery.task(name="process-incomplete-jobs")

--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -6,7 +6,7 @@ from flask import Blueprint, abort, current_app, jsonify, request
 from gds_metrics.metrics import Counter
 from notifications_utils.recipients import try_validate_and_format_phone_number
 
-from app.celery import tasks
+from app.celery import service_callback_tasks
 from app.config import QueueNames
 from app.constants import INBOUND_SMS_TYPE
 from app.dao.inbound_sms_dao import dao_create_inbound_sms
@@ -65,7 +65,9 @@ def receive_mmg_sms():
         provider_name="mmg",
     )
 
-    tasks.send_inbound_sms_to_service.apply_async([str(inbound.id), str(service.id)], queue=QueueNames.NOTIFY)
+    service_callback_tasks.send_inbound_sms_to_service.apply_async(
+        [str(inbound.id), str(service.id)], queue=QueueNames.NOTIFY
+    )
 
     current_app.logger.debug(
         "%s received inbound SMS with reference %s from MMG", service.id, inbound.provider_reference
@@ -102,7 +104,9 @@ def receive_firetext_sms():
 
     INBOUND_SMS_COUNTER.labels("firetext").inc()
 
-    tasks.send_inbound_sms_to_service.apply_async([str(inbound.id), str(service.id)], queue=QueueNames.NOTIFY)
+    service_callback_tasks.send_inbound_sms_to_service.apply_async(
+        [str(inbound.id), str(service.id)], queue=QueueNames.NOTIFY
+    )
     current_app.logger.debug(
         "%s received inbound SMS with reference %s from Firetext", service.id, inbound.provider_reference
     )

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 from datetime import datetime
+from unittest import mock
 
 import pytest
 import requests_mock
@@ -10,6 +11,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from app import signing
 from app.celery.service_callback_tasks import (
+    _send_data_to_service_callback_api,
     send_complaint_to_service,
     send_delivery_status_to_service,
     send_inbound_sms_to_service,
@@ -24,122 +26,6 @@ from tests.app.db import (
     create_service_inbound_api,
     create_template,
 )
-
-
-@pytest.mark.parametrize("notification_type", ["email", "sms"])
-def test_send_delivery_status_to_service_post_https_request_to_service_with_encoded_data(
-    notify_db_session, notification_type
-):
-    callback_api, template = _set_up_test_data(notification_type, "delivery_status")
-    datestr = datetime(2017, 6, 20)
-
-    notification = create_notification(
-        template=template, created_at=datestr, updated_at=datestr, sent_at=datestr, status="sent"
-    )
-    encoded_status_update = _set_up_data_for_status_update(callback_api, notification)
-    with requests_mock.Mocker() as request_mock:
-        request_mock.post(callback_api.url, json={}, status_code=200)
-        send_delivery_status_to_service(notification.id, encoded_status_update=encoded_status_update)
-
-    mock_data = {
-        "id": str(notification.id),
-        "reference": notification.client_reference,
-        "to": notification.to,
-        "status": notification.status,
-        "created_at": datestr.strftime(DATETIME_FORMAT),
-        "completed_at": datestr.strftime(DATETIME_FORMAT),
-        "sent_at": datestr.strftime(DATETIME_FORMAT),
-        "notification_type": notification_type,
-        "template_id": str(template.id),
-        "template_version": 1,
-    }
-
-    assert request_mock.call_count == 1
-    assert request_mock.request_history[0].url == callback_api.url
-    assert request_mock.request_history[0].method == "POST"
-    assert request_mock.request_history[0].text == json.dumps(mock_data)
-    assert request_mock.request_history[0].headers["Content-type"] == "application/json"
-    assert request_mock.request_history[0].headers["Authorization"] == "Bearer {}".format(callback_api.bearer_token)
-
-
-def test_send_complaint_to_service_posts_https_request_to_service_with_encoded_data(notify_db_session):
-    with freeze_time("2001-01-01T12:00:00"):
-        callback_api, template = _set_up_test_data("email", "complaint")
-
-        notification = create_notification(template=template)
-        complaint = create_complaint(service=template.service, notification=notification)
-        complaint_data = _set_up_data_for_complaint(callback_api, complaint, notification)
-        with requests_mock.Mocker() as request_mock:
-            request_mock.post(callback_api.url, json={}, status_code=200)
-            send_complaint_to_service(complaint_data)
-
-        mock_data = {
-            "notification_id": str(notification.id),
-            "complaint_id": str(complaint.id),
-            "reference": notification.client_reference,
-            "to": notification.to,
-            "complaint_date": datetime.utcnow().strftime(DATETIME_FORMAT),
-        }
-
-        assert request_mock.call_count == 1
-        assert request_mock.request_history[0].url == callback_api.url
-        assert request_mock.request_history[0].method == "POST"
-        assert request_mock.request_history[0].text == json.dumps(mock_data)
-        assert request_mock.request_history[0].headers["Content-type"] == "application/json"
-        assert request_mock.request_history[0].headers["Authorization"] == "Bearer {}".format(callback_api.bearer_token)
-
-
-@pytest.mark.parametrize("notification_type", ["email", "sms"])
-@pytest.mark.parametrize("status_code", [429, 500, 503])
-def test__send_data_to_service_callback_api_retries_if_request_returns_error_code_with_encoded_data(
-    notify_db_session, mocker, notification_type, status_code
-):
-    callback_api, template = _set_up_test_data(notification_type, "delivery_status")
-    datestr = datetime(2017, 6, 20)
-    notification = create_notification(
-        template=template, created_at=datestr, updated_at=datestr, sent_at=datestr, status="sent"
-    )
-    encoded_data = _set_up_data_for_status_update(callback_api, notification)
-    mocked = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.retry")
-    with requests_mock.Mocker() as request_mock:
-        request_mock.post(callback_api.url, json={}, status_code=status_code)
-        send_delivery_status_to_service(notification.id, encoded_status_update=encoded_data)
-
-    assert mocked.call_count == 1
-    assert mocked.call_args[1]["queue"] == "service-callbacks-retry"
-
-
-@pytest.mark.parametrize("notification_type", ["email", "sms"])
-def test__send_data_to_service_callback_api_does_not_retry_if_request_returns_404_with_encoded_data(
-    notify_db_session, mocker, notification_type
-):
-    callback_api, template = _set_up_test_data(notification_type, "delivery_status")
-    datestr = datetime(2017, 6, 20)
-    notification = create_notification(
-        template=template, created_at=datestr, updated_at=datestr, sent_at=datestr, status="sent"
-    )
-    encoded_data = _set_up_data_for_status_update(callback_api, notification)
-    mocked = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.retry")
-    with requests_mock.Mocker() as request_mock:
-        request_mock.post(callback_api.url, json={}, status_code=404)
-        send_delivery_status_to_service(notification.id, encoded_status_update=encoded_data)
-
-    assert mocked.call_count == 0
-
-
-def test_send_delivery_status_to_service_succeeds_if_sent_at_is_none(notify_db_session, mocker):
-    callback_api, template = _set_up_test_data("email", "delivery_status")
-    datestr = datetime(2017, 6, 20)
-    notification = create_notification(
-        template=template, created_at=datestr, updated_at=datestr, sent_at=None, status="technical-failure"
-    )
-    encoded_data = _set_up_data_for_status_update(callback_api, notification)
-    mocked = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.retry")
-    with requests_mock.Mocker() as request_mock:
-        request_mock.post(callback_api.url, json={}, status_code=404)
-        send_delivery_status_to_service(notification.id, encoded_status_update=encoded_data)
-
-    assert mocked.call_count == 0
 
 
 def _set_up_test_data(notification_type, callback_type):
@@ -189,8 +75,64 @@ def _set_up_data_for_complaint(callback_api, complaint, notification):
     return obscured_status_update
 
 
-def test_send_inbound_sms_to_service_post_https_request_to_service(notify_api, sample_service):
-    inbound_api = create_service_inbound_api(
+@pytest.mark.parametrize("notification_type", ["email", "sms"])
+def test_send_delivery_status_to_service_sends_callback_to_service(notify_db_session, notification_type, mocker):
+    callback_api, template = _set_up_test_data(notification_type, "delivery_status")
+    datestr = datetime(2017, 6, 20)
+
+    notification = create_notification(
+        template=template, created_at=datestr, updated_at=datestr, sent_at=datestr, status="sent"
+    )
+    encoded_status_update = _set_up_data_for_status_update(callback_api, notification)
+
+    send_callback_mock = mocker.patch("app.celery.service_callback_tasks._send_data_to_service_callback_api")
+
+    send_delivery_status_to_service(notification.id, encoded_status_update=encoded_status_update)
+
+    expected_data = {
+        "id": str(notification.id),
+        "reference": notification.client_reference,
+        "to": notification.to,
+        "status": notification.status,
+        "created_at": datestr.strftime(DATETIME_FORMAT),
+        "completed_at": datestr.strftime(DATETIME_FORMAT),
+        "sent_at": datestr.strftime(DATETIME_FORMAT),
+        "notification_type": notification_type,
+        "template_id": str(template.id),
+        "template_version": 1,
+    }
+
+    send_callback_mock.assert_called_once_with(
+        mock.ANY, expected_data, callback_api.url, callback_api.bearer_token, "send_delivery_status_to_service"
+    )
+
+
+def test_send_complaint_to_service_sends_callback_to_service(notify_db_session, mocker):
+    with freeze_time("2001-01-01T12:00:00"):
+        callback_api, template = _set_up_test_data("email", "complaint")
+
+        notification = create_notification(template=template)
+        complaint = create_complaint(service=template.service, notification=notification)
+        complaint_data = _set_up_data_for_complaint(callback_api, complaint, notification)
+        send_callback_mock = mocker.patch("app.celery.service_callback_tasks._send_data_to_service_callback_api")
+
+        send_complaint_to_service(complaint_data)
+
+        expected_data = {
+            "notification_id": str(notification.id),
+            "complaint_id": str(complaint.id),
+            "reference": notification.client_reference,
+            "to": notification.to,
+            "complaint_date": datetime.utcnow().strftime(DATETIME_FORMAT),
+        }
+
+        send_callback_mock.assert_called_once_with(
+            mock.ANY, expected_data, callback_api.url, callback_api.bearer_token, "send_complaint_to_service"
+        )
+
+
+def test_send_inbound_sms_to_service_sends_callback_to_service(notify_api, sample_service, mocker):
+    create_service_inbound_api(
         service=sample_service, url="https://some.service.gov.uk/", bearer_token="something_unique"
     )
     inbound_sms = create_inbound_sms(
@@ -208,28 +150,27 @@ def test_send_inbound_sms_to_service_post_https_request_to_service(notify_api, s
         "date_received": inbound_sms.provider_date.strftime(DATETIME_FORMAT),
     }
 
-    with requests_mock.Mocker() as request_mock:
-        request_mock.post(inbound_api.url, json={}, status_code=200)
-        send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
-    assert request_mock.call_count == 1
-    assert request_mock.request_history[0].url == inbound_api.url
-    assert request_mock.request_history[0].method == "POST"
-    assert request_mock.request_history[0].text == json.dumps(data)
-    assert request_mock.request_history[0].headers["Content-type"] == "application/json"
-    assert request_mock.request_history[0].headers["Authorization"] == "Bearer {}".format(inbound_api.bearer_token)
+    send_callback_mock = mocker.patch("app.celery.service_callback_tasks._send_data_to_service_callback_api")
+
+    send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
+    send_callback_mock.assert_called_once_with(
+        mock.ANY, data, "https://some.service.gov.uk/", "something_unique", "send_inbound_sms_to_service", "retry-tasks"
+    )
 
 
-def test_send_inbound_sms_to_service_does_not_send_request_when_inbound_sms_does_not_exist(notify_api, sample_service):
-    inbound_api = create_service_inbound_api(service=sample_service)
-    with requests_mock.Mocker() as request_mock:
-        request_mock.post(inbound_api.url, json={}, status_code=200)
-        with pytest.raises(SQLAlchemyError):
-            send_inbound_sms_to_service(inbound_sms_id=uuid.uuid4(), service_id=sample_service.id)
+def test_send_inbound_sms_to_service_does_not_send_callback_when_inbound_sms_does_not_exist(
+    notify_api, sample_service, mocker
+):
+    create_service_inbound_api(service=sample_service)
+    send_callback_mock = mocker.patch("app.celery.service_callback_tasks._send_data_to_service_callback_api")
 
-    assert request_mock.call_count == 0
+    with pytest.raises(SQLAlchemyError):
+        send_inbound_sms_to_service(inbound_sms_id=uuid.uuid4(), service_id=sample_service.id)
+
+    assert send_callback_mock.call_count == 0
 
 
-def test_send_inbound_sms_to_service_does_not_sent_request_when_inbound_api_does_not_exist(
+def test_send_inbound_sms_to_service_does_not_sent_callback_when_inbound_api_does_not_exist(
     notify_api, sample_service, mocker
 ):
     inbound_sms = create_inbound_sms(
@@ -239,69 +180,80 @@ def test_send_inbound_sms_to_service_does_not_sent_request_when_inbound_api_does
         provider_date=datetime(2017, 6, 20),
         content="Here is some content",
     )
-    mocked = mocker.patch("requests.request")
+    send_callback_mock = mocker.patch("app.celery.service_callback_tasks._send_data_to_service_callback_api")
     send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
 
-    assert mocked.call_count == 0
+    assert send_callback_mock.call_count == 0
 
 
-def test_send_inbound_sms_to_service_retries_if_request_returns_500(notify_api, sample_service, mocker):
-    inbound_api = create_service_inbound_api(
-        service=sample_service, url="https://some.service.gov.uk/", bearer_token="something_unique"
-    )
-    inbound_sms = create_inbound_sms(
-        service=sample_service,
-        notify_number="0751421",
-        user_number="447700900111",
-        provider_date=datetime(2017, 6, 20),
-        content="Here is some content",
-    )
+def test__send_data_to_service_callback_api_posts_https_request_to_service(notify_db_session, mocker):
+    data = {"id": "hello"}
+    callback_url = "https://www.example.com/callback"
+    celery_task_mock = mock.MagicMock()
 
-    mocked = mocker.patch("app.celery.service_callback_tasks.send_inbound_sms_to_service.retry")
     with requests_mock.Mocker() as request_mock:
-        request_mock.post(inbound_api.url, json={}, status_code=500)
-        send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
+        request_mock.post(callback_url, json={}, status_code=200)
+        _send_data_to_service_callback_api(celery_task_mock, data, callback_url, "my-token", "my_function_name")
 
-    assert mocked.call_count == 1
-    assert mocked.call_args[1]["queue"] == "retry-tasks"
+    assert request_mock.call_count == 1
+    assert request_mock.request_history[0].url == callback_url
+    assert request_mock.request_history[0].method == "POST"
+    assert request_mock.request_history[0].text == json.dumps(data)
+    assert request_mock.request_history[0].headers["Content-type"] == "application/json"
+    assert request_mock.request_history[0].headers["Authorization"] == "Bearer {}".format("my-token")
+
+    celery_task_mock.retry.assert_not_called()
 
 
-def test_send_inbound_sms_to_service_retries_if_request_throws_unknown(notify_api, sample_service, mocker):
-    create_service_inbound_api(
-        service=sample_service, url="https://some.service.gov.uk/", bearer_token="something_unique"
-    )
-    inbound_sms = create_inbound_sms(
-        service=sample_service,
-        notify_number="0751421",
-        user_number="447700900111",
-        provider_date=datetime(2017, 6, 20),
-        content="Here is some content",
-    )
+@pytest.mark.parametrize("status_code", [429, 500, 503])
+def test__send_data_to_service_callback_api_retries_if_request_returns_retryable_status_code(
+    notify_db_session, mocker, status_code
+):
+    data = {"id": "hello"}
+    callback_url = "https://www.example.com/callback"
 
-    mocked = mocker.patch("app.celery.service_callback_tasks.send_inbound_sms_to_service.retry")
+    celery_task_mock = mock.MagicMock()
+
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post(callback_url, json={}, status_code=status_code)
+        _send_data_to_service_callback_api(celery_task_mock, data, callback_url, "my-token", "my_function_name")
+
+    celery_task_mock.retry.assert_called_once_with(queue="service-callbacks-retry")
+
+
+def test__send_data_to_service_callback_api_retries_if_request_raises_unknown_exception(notify_db_session, mocker):
+    data = {"id": "hello"}
+    callback_url = "https://www.example.com/callback"
+
+    celery_task_mock = mock.MagicMock()
+
     mocker.patch("app.celery.service_callback_tasks.request", side_effect=RequestException())
 
-    send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
+    _send_data_to_service_callback_api(celery_task_mock, data, callback_url, "my-token", "my_function_name")
 
-    assert mocked.call_count == 1
-    assert mocked.call_args[1]["queue"] == "retry-tasks"
+    celery_task_mock.retry.assert_called_once_with(queue="service-callbacks-retry")
 
 
-def test_send_inbound_sms_to_service_does_not_retries_if_request_returns_404(notify_api, sample_service, mocker):
-    inbound_api = create_service_inbound_api(
-        service=sample_service, url="https://some.service.gov.uk/", bearer_token="something_unique"
-    )
-    inbound_sms = create_inbound_sms(
-        service=sample_service,
-        notify_number="0751421",
-        user_number="447700900111",
-        provider_date=datetime(2017, 6, 20),
-        content="Here is some content",
-    )
+@pytest.mark.parametrize("status_code", [403, 404])
+def test__send_data_to_service_callback_api_doesnt_retry_if_non_retry_status_code(
+    notify_db_session, mocker, status_code
+):
+    data = {"id": "hello"}
+    callback_url = "https://www.example.com/callback"
 
-    mocked = mocker.patch("app.celery.service_callback_tasks.send_inbound_sms_to_service.retry")
+    celery_task_mock = mock.MagicMock()
+
     with requests_mock.Mocker() as request_mock:
-        request_mock.post(inbound_api.url, json={}, status_code=404)
-        send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
+        request_mock.post(callback_url, json={}, status_code=status_code)
+        _send_data_to_service_callback_api(celery_task_mock, data, callback_url, "my-token", "my_function_name")
 
-    assert mocked.call_count == 0
+    celery_task_mock.retry.assert_not_called()
+
+
+@pytest.mark.parametrize("data", [{"id": "hello"}, {"notification_id": "hello"}])
+def test__send_data_to_service_callback_api_handles_data_with_notification_id_or_id(notify_db_session, mocker, data):
+    callback_url = "https://www.example.com/callback"
+
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post(callback_url, json={}, status_code=200)
+        _send_data_to_service_callback_api(mock.MagicMock(), data, callback_url, "my-token", "my_function_name")

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -154,7 +154,13 @@ def test_send_inbound_sms_to_service_sends_callback_to_service(notify_api, sampl
 
     send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
     send_callback_mock.assert_called_once_with(
-        mock.ANY, data, "https://some.service.gov.uk/", "something_unique", "send_inbound_sms_to_service", "retry-tasks"
+        mock.ANY,
+        data,
+        "https://some.service.gov.uk/",
+        "something_unique",
+        "send_inbound_sms_to_service",
+        "retry-tasks",
+        sample_service.id,
     )
 
 
@@ -257,3 +263,14 @@ def test__send_data_to_service_callback_api_handles_data_with_notification_id_or
     with requests_mock.Mocker() as request_mock:
         request_mock.post(callback_url, json={}, status_code=200)
         _send_data_to_service_callback_api(mock.MagicMock(), data, callback_url, "my-token", "my_function_name")
+
+
+@pytest.mark.parametrize("service_id", ["string-service-id", uuid.uuid4()])
+def test__send_data_to_service_callback_api_handles_service_id(notify_db_session, mocker, service_id):
+    callback_url = "https://www.example.com/callback"
+
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post(callback_url, json={}, status_code=200)
+        _send_data_to_service_callback_api(
+            mock.MagicMock(), {"id": "hello"}, callback_url, "my-token", "my_function_name", service_id=service_id
+        )

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1,10 +1,8 @@
-import json
 import uuid
 from datetime import datetime, timedelta
 from unittest.mock import Mock, call
 
 import pytest
-import requests_mock
 from celery.exceptions import Retry
 from freezegun import freeze_time
 from notifications_utils.recipients import Row
@@ -13,7 +11,6 @@ from notifications_utils.template import (
     PlainTextEmailTemplate,
     SMSMessageTemplate,
 )
-from requests import RequestException
 from sqlalchemy.exc import SQLAlchemyError
 
 from app import signing
@@ -31,7 +28,6 @@ from app.celery.tasks import (
     save_email,
     save_letter,
     save_sms,
-    send_inbound_sms_to_service,
 )
 from app.config import QueueNames
 from app.constants import (
@@ -52,14 +48,12 @@ from app.v2.errors import TooManyRequestsError
 from tests.app import load_example_csv
 from tests.app.db import (
     create_api_key,
-    create_inbound_sms,
     create_job,
     create_letter_contact,
     create_notification,
     create_notification_history,
     create_reply_to_email,
     create_service,
-    create_service_inbound_api,
     create_service_with_defined_sms_sender,
     create_template,
     create_user,
@@ -1296,124 +1290,6 @@ def test_get_letter_template_instance(mocker, sample_job):
         "postcode",
         "address line 7",
     ]
-
-
-def test_send_inbound_sms_to_service_post_https_request_to_service(notify_api, sample_service):
-    inbound_api = create_service_inbound_api(
-        service=sample_service, url="https://some.service.gov.uk/", bearer_token="something_unique"
-    )
-    inbound_sms = create_inbound_sms(
-        service=sample_service,
-        notify_number="0751421",
-        user_number="447700900111",
-        provider_date=datetime(2017, 6, 20),
-        content="Here is some content",
-    )
-    data = {
-        "id": str(inbound_sms.id),
-        "source_number": inbound_sms.user_number,
-        "destination_number": inbound_sms.notify_number,
-        "message": inbound_sms.content,
-        "date_received": inbound_sms.provider_date.strftime(DATETIME_FORMAT),
-    }
-
-    with requests_mock.Mocker() as request_mock:
-        request_mock.post(inbound_api.url, json={}, status_code=200)
-        send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
-    assert request_mock.call_count == 1
-    assert request_mock.request_history[0].url == inbound_api.url
-    assert request_mock.request_history[0].method == "POST"
-    assert request_mock.request_history[0].text == json.dumps(data)
-    assert request_mock.request_history[0].headers["Content-type"] == "application/json"
-    assert request_mock.request_history[0].headers["Authorization"] == "Bearer {}".format(inbound_api.bearer_token)
-
-
-def test_send_inbound_sms_to_service_does_not_send_request_when_inbound_sms_does_not_exist(notify_api, sample_service):
-    inbound_api = create_service_inbound_api(service=sample_service)
-    with requests_mock.Mocker() as request_mock:
-        request_mock.post(inbound_api.url, json={}, status_code=200)
-        with pytest.raises(SQLAlchemyError):
-            send_inbound_sms_to_service(inbound_sms_id=uuid.uuid4(), service_id=sample_service.id)
-
-    assert request_mock.call_count == 0
-
-
-def test_send_inbound_sms_to_service_does_not_sent_request_when_inbound_api_does_not_exist(
-    notify_api, sample_service, mocker
-):
-    inbound_sms = create_inbound_sms(
-        service=sample_service,
-        notify_number="0751421",
-        user_number="447700900111",
-        provider_date=datetime(2017, 6, 20),
-        content="Here is some content",
-    )
-    mocked = mocker.patch("requests.request")
-    send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
-
-    assert mocked.call_count == 0
-
-
-def test_send_inbound_sms_to_service_retries_if_request_returns_500(notify_api, sample_service, mocker):
-    inbound_api = create_service_inbound_api(
-        service=sample_service, url="https://some.service.gov.uk/", bearer_token="something_unique"
-    )
-    inbound_sms = create_inbound_sms(
-        service=sample_service,
-        notify_number="0751421",
-        user_number="447700900111",
-        provider_date=datetime(2017, 6, 20),
-        content="Here is some content",
-    )
-
-    mocked = mocker.patch("app.celery.tasks.send_inbound_sms_to_service.retry")
-    with requests_mock.Mocker() as request_mock:
-        request_mock.post(inbound_api.url, json={}, status_code=500)
-        send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
-
-    assert mocked.call_count == 1
-    assert mocked.call_args[1]["queue"] == "retry-tasks"
-
-
-def test_send_inbound_sms_to_service_retries_if_request_throws_unknown(notify_api, sample_service, mocker):
-    create_service_inbound_api(
-        service=sample_service, url="https://some.service.gov.uk/", bearer_token="something_unique"
-    )
-    inbound_sms = create_inbound_sms(
-        service=sample_service,
-        notify_number="0751421",
-        user_number="447700900111",
-        provider_date=datetime(2017, 6, 20),
-        content="Here is some content",
-    )
-
-    mocked = mocker.patch("app.celery.tasks.send_inbound_sms_to_service.retry")
-    mocker.patch("app.celery.tasks.request", side_effect=RequestException())
-
-    send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
-
-    assert mocked.call_count == 1
-    assert mocked.call_args[1]["queue"] == "retry-tasks"
-
-
-def test_send_inbound_sms_to_service_does_not_retries_if_request_returns_404(notify_api, sample_service, mocker):
-    inbound_api = create_service_inbound_api(
-        service=sample_service, url="https://some.service.gov.uk/", bearer_token="something_unique"
-    )
-    inbound_sms = create_inbound_sms(
-        service=sample_service,
-        notify_number="0751421",
-        user_number="447700900111",
-        provider_date=datetime(2017, 6, 20),
-        content="Here is some content",
-    )
-
-    mocked = mocker.patch("app.celery.tasks.send_inbound_sms_to_service.retry")
-    with requests_mock.Mocker() as request_mock:
-        request_mock.post(inbound_api.url, json={}, status_code=404)
-        send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
-
-    assert mocked.call_count == 0
 
 
 def test_process_incomplete_job_sms(mocker, sample_template):

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -48,7 +48,9 @@ def mmg_post(client, data, auth=True, password="testkey"):
 
 
 def test_receive_notification_returns_received_to_mmg(client, mocker, sample_service_full_permissions):
-    mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
+    mocked = mocker.patch(
+        "app.notifications.receive_notifications.service_callback_tasks.send_inbound_sms_to_service.apply_async"
+    )
     prom_counter_labels_mock = mocker.patch("app.notifications.receive_notifications.INBOUND_SMS_COUNTER.labels")
     data = {
         "ID": "1234",
@@ -84,7 +86,9 @@ def test_receive_notification_returns_received_to_mmg(client, mocker, sample_ser
 def test_receive_notification_from_mmg_without_permissions_does_not_persist(
     client, mocker, notify_db_session, permissions
 ):
-    mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
+    mocked = mocker.patch(
+        "app.notifications.receive_notifications.service_callback_tasks.send_inbound_sms_to_service.apply_async"
+    )
     create_service_with_inbound_number(inbound_number="07111111111", service_permissions=permissions)
     data = {
         "ID": "1234",
@@ -116,7 +120,7 @@ def test_receive_notification_from_firetext_without_permissions_does_not_persist
     service = create_service_with_inbound_number(inbound_number="07111111111", service_permissions=permissions)
     mocker.patch("app.notifications.receive_notifications.dao_fetch_service_by_inbound_number", return_value=service)
     mocked_send_inbound_sms = mocker.patch(
-        "app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async"
+        "app.notifications.receive_notifications.service_callback_tasks.send_inbound_sms_to_service.apply_async"
     )
     mocker.patch("app.notifications.receive_notifications.has_inbound_sms_permissions", return_value=False)
 
@@ -137,7 +141,7 @@ def test_receive_notification_without_permissions_does_not_create_inbound_even_w
     inbound_number = create_inbound_number("1", service_id=sample_service.id, active=True)
 
     mocked_send_inbound_sms = mocker.patch(
-        "app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async"
+        "app.notifications.receive_notifications.service_callback_tasks.send_inbound_sms_to_service.apply_async"
     )
     mocked_has_permissions = mocker.patch(
         "app.notifications.receive_notifications.has_inbound_sms_permissions", return_value=False
@@ -315,7 +319,9 @@ def test_receive_notification_error_if_not_single_matching_service(client, notif
 
 
 def test_receive_notification_returns_received_to_firetext(notify_db_session, client, mocker):
-    mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
+    mocked = mocker.patch(
+        "app.notifications.receive_notifications.service_callback_tasks.send_inbound_sms_to_service.apply_async"
+    )
     prom_counter_labels_mock = mocker.patch("app.notifications.receive_notifications.INBOUND_SMS_COUNTER.labels")
 
     service = create_service_with_inbound_number(
@@ -338,7 +344,9 @@ def test_receive_notification_returns_received_to_firetext(notify_db_session, cl
 
 
 def test_receive_notification_from_firetext_persists_message(notify_db_session, client, mocker):
-    mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
+    mocked = mocker.patch(
+        "app.notifications.receive_notifications.service_callback_tasks.send_inbound_sms_to_service.apply_async"
+    )
     mocker.patch("app.notifications.receive_notifications.INBOUND_SMS_COUNTER")
 
     service = create_service_with_inbound_number(
@@ -364,7 +372,9 @@ def test_receive_notification_from_firetext_persists_message(notify_db_session, 
 
 
 def test_receive_notification_from_firetext_persists_message_with_normalized_phone(notify_db_session, client, mocker):
-    mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
+    mocker.patch(
+        "app.notifications.receive_notifications.service_callback_tasks.send_inbound_sms_to_service.apply_async"
+    )
     mocker.patch("app.notifications.receive_notifications.INBOUND_SMS_COUNTER")
 
     create_service_with_inbound_number(
@@ -385,7 +395,9 @@ def test_receive_notification_from_firetext_persists_message_with_normalized_pho
 
 
 def test_returns_ok_to_firetext_if_mismatched_sms_sender(notify_db_session, client, mocker):
-    mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
+    mocked = mocker.patch(
+        "app.notifications.receive_notifications.service_callback_tasks.send_inbound_sms_to_service.apply_async"
+    )
     mocker.patch("app.notifications.receive_notifications.INBOUND_SMS_COUNTER")
 
     create_service_with_inbound_number(
@@ -431,7 +443,9 @@ def test_strip_leading_country_code(number, expected):
     ],
 )
 def test_firetext_inbound_sms_auth(notify_db_session, notify_api, client, mocker, auth, keys, status_code):
-    mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
+    mocker.patch(
+        "app.notifications.receive_notifications.service_callback_tasks.send_inbound_sms_to_service.apply_async"
+    )
 
     create_service_with_inbound_number(
         service_name="b", inbound_number="07111111111", service_permissions=[EMAIL_TYPE, SMS_TYPE, INBOUND_SMS_TYPE]
@@ -458,7 +472,9 @@ def test_firetext_inbound_sms_auth(notify_db_session, notify_api, client, mocker
     ],
 )
 def test_mmg_inbound_sms_auth(notify_db_session, notify_api, client, mocker, auth, keys, status_code):
-    mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
+    mocker.patch(
+        "app.notifications.receive_notifications.service_callback_tasks.send_inbound_sms_to_service.apply_async"
+    )
 
     create_service_with_inbound_number(
         service_name="b", inbound_number="07111111111", service_permissions=[EMAIL_TYPE, SMS_TYPE, INBOUND_SMS_TYPE]


### PR DESCRIPTION
Best reviewed commit by commit.

See https://trello.com/c/KQ6vP4EK/770-incident-action-review-if-we-can-make-inbound-sms-callbacks-more-similar-to-how-we-do-delivery-notification-callbacks for context

Very open to critique on my test coverage here please