### PR TITLE
Fix sqla warnings

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1719,6 +1719,7 @@ class NotificationLetterDespatch(db.Model):
         "NotificationAllTimeView",
         primaryjoin="NotificationLetterDespatch.notification_id == foreign(NotificationAllTimeView.id)",
         uselist=False,
+        viewonly=True,
     )
 
 
@@ -2584,6 +2585,7 @@ class UnsubscribeRequest(db.Model):
         "NotificationAllTimeView",
         primaryjoin="UnsubscribeRequest.notification_id == foreign(NotificationAllTimeView.id)",
         uselist=False,
+        viewonly=True,
     )
 
     # this is denormalised but might still be useful to have as a separate column?

--- a/app/models.py
+++ b/app/models.py
@@ -2601,6 +2601,7 @@ class UnsubscribeRequest(db.Model):
         foreign_keys=[template_id],
         primaryjoin="Template.id == UnsubscribeRequest.template_id",
         backref=db.backref("unsubscribe_requests"),
+        viewonly=True,
     )
 
     email_address = db.Column(db.Text, nullable=False)


### PR DESCRIPTION
Fix a couple of warnings you could observe when running `flask db heads` to run alembic

-------------

[set NotificationAllTimeView relationships viewonly](https://github.com/alphagov/notifications-api/commit/4122625a4a8438575433053257abf7c5a986d435) 

NotificationAllTimeView is a view (quelle surprise). You can't edit a view rather than the underlying table.

Sqlalchemy doesn't have a way to mark a model as a view, so there's nothing stopping you writing `NotificationAllTimeView(id=..., ...)`. This would error when sqlalchemy tried to execute the sql.

However, as sqlaclhemy doesn't know this it's printing out lots of warnings about UnsubscribeRequest.notification conflicting with NotificationLetterDespatch.notification. We can solve these warnings by marking the relationships to the NotificationAllTimeView as viewonly.

For an explanation on why this is an issue more generally, see the following commit.

----------------

[Set UnsubscribeRequest.template to viewonly](https://github.com/alphagov/notifications-api/commit/7ccfe07ad9534bcf22c7fe9af44e1572aca89e38) 

Without this, sqlalchemy prints warnings about a conflict between `UnsubscribeRequest.template` and `UnsubscribeRequest.template_history` (and also `TemplateHistory.unsubscribe_requests`, the backref for the second of those relationships).

The conflict occurs if you create a sqlalchemy ORM object by specifying relationships rather than columns, and relying on sqlalchemy to set the column values themselves. Imagine the following situation:

```python
my_template = Template(id=1234, version=1)
other_template_history = TemplateHistory(id=4567, version=2)
ur = UnsubscribeRequest(
    template=some_template,
    template_history=other_template_history
)

assert ur.template_id == my_template.id
assert ur.template_id == other_template_history.id
```

This behaviour is undefined by sqlalchemy and it'll randomly pick one of those to set on the db object.

The solution to this is to set the `template` relationship as viewonly. This means you cannot write `UnsubscribeRequest(template=some_template)` at all - this is useful as the relationship between an unsubscribe request and a template spans _all_ versions of that template ("lets see all historical unsubscribe requests across all versions of this template") so with that code snippet we wouldn't know what `template_version` to set on the UnsubscribeRequest object.

When creating an UnsubscribeRequest, we should be creating it from a notification, which has a link to a specific TemplateHistory object.
