### PR TITLE
Set templates/templates_history has_unsubcribe_link boolean to be not null

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1047,7 +1047,7 @@ class TemplateBase(db.Model):
     )
 
     # TODO: migrate this to be nullable=False
-    has_unsubscribe_link = db.Column(db.Boolean, default=False)
+    has_unsubscribe_link = db.Column(db.Boolean, default=False, nullable=False)
 
     @declared_attr
     def service_id(cls):

--- a/app/models.py
+++ b/app/models.py
@@ -1095,8 +1095,11 @@ class TemplateBase(db.Model):
                 "(template_type != 'letter' AND letter_languages IS NULL) OR"
                 " (template_type = 'letter' AND letter_languages IS NOT NULL)"
             ),
-            # if template type is not email, then has_unsubscribe_link MUST be null
-            CheckConstraint("template_type = 'email' OR has_unsubscribe_link IS NULL"),
+            # if template type is not email, then has_unsubscribe_link MUST be false
+            CheckConstraint(
+                "template_type = 'email' OR has_unsubscribe_link IS false",
+                name=f"ck_{cls.__tablename__}_non_email_has_unsubscribe_false",
+            ),
         )
 
     @property

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0455_th_has_unsub_link_not_null
+0458_validate_unsub_constraints

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0447_unsubscribe_requests
+0455_th_has_unsub_link_not_null

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -56,7 +56,13 @@ def run_migrations_offline():
 
     """
     url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url, include_object=include_object)
+    context.configure(
+        url=url,
+        compare_type=True,
+        include_object=include_object,
+        target_metadata=target_metadata,
+        transaction_per_migration=True,
+    )
 
     with context.begin_transaction():
         context.run_migrations()

--- a/migrations/versions/0448_t_has_unsub_link_backfill.py
+++ b/migrations/versions/0448_t_has_unsub_link_backfill.py
@@ -1,0 +1,20 @@
+"""
+Create Date: 2024-06-01 16:34:30.12345
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0448_t_has_unsub_link_backfill"
+down_revision = "0447_unsubscribe_requests"
+
+
+def upgrade():
+    op.execute("UPDATE templates SET has_unsubscribe_link=false WHERE has_unsubscribe_link IS NULL")
+
+
+def downgrade():
+    # non-reversible
+    pass

--- a/migrations/versions/0449_t_has_unsub_link_constraint.py
+++ b/migrations/versions/0449_t_has_unsub_link_constraint.py
@@ -1,0 +1,24 @@
+"""
+Create Date: 2024-06-01 16:35:30.12345
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0449_t_has_unsub_link_constraint"
+down_revision = "0448_t_has_unsub_link_backfill"
+
+
+def upgrade():
+    # acquires access exclusive, but only very briefly as the not_valid stops it doing a full table scan
+    op.create_check_constraint(
+        "ck_templates_has_unsubscribe_link_not_null_check",
+        "templates",
+        sa.column("has_unsubscribe_link").is_not(None),
+        postgresql_not_valid=True,
+    )
+
+
+def downgrade():
+    op.drop_constraint("ck_templates_has_unsubscribe_link_not_null_check", "templates")

--- a/migrations/versions/0450_t_has_unsub_link_validate.py
+++ b/migrations/versions/0450_t_has_unsub_link_validate.py
@@ -1,0 +1,19 @@
+"""
+Create Date: 2024-06-01 16:35:30.12345
+"""
+
+from alembic import op
+
+
+revision = "0450_t_has_unsub_link_validate"
+down_revision = "0449_t_has_unsub_link_constraint"
+
+
+def upgrade():
+    # These only acquire a SHARE UPDATE EXCLUSIVE lock.
+    op.execute("ALTER TABLE templates VALIDATE CONSTRAINT ck_templates_has_unsubscribe_link_not_null_check")
+
+
+def downgrade():
+    # non-reversible
+    pass

--- a/migrations/versions/0451_t_has_unsub_link_not_null.py
+++ b/migrations/versions/0451_t_has_unsub_link_not_null.py
@@ -1,0 +1,33 @@
+"""
+Create Date: 2024-06-01 16:35:30.12345
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0451_t_has_unsub_link_not_null"
+down_revision = "0450_t_has_unsub_link_validate"
+
+
+def upgrade():
+    # quoth the docs:
+
+    # SET NOT NULL may only be applied to a column provided none of the records in the table contain a NULL value
+    # for the column. Ordinarily this is checked during the ALTER TABLE by scanning the entire table; however, if a
+    # valid CHECK constraint is found which proves no NULL can exist, then the table scan is skipped.
+
+    # so now we can add regular nullable constraints without worrying about a lengthy table scan.
+    op.alter_column("templates", "has_unsubscribe_link", nullable=False)
+
+    # now get rid of the old constraint now that it's no longer needed. this is a weird process overall
+    op.drop_constraint("ck_templates_has_unsubscribe_link_not_null_check", "templates")
+
+
+def downgrade():
+    op.alter_column("templates", "has_unsubscribe_link", nullable=True)
+
+    # notably this creates _with_ validating constraint otherwise we'll end up with inconsistency
+    op.create_check_constraint(
+        "ck_templates_has_unsubscribe_link_not_null_check", "templates", sa.column("has_unsubscribe_link").is_not(None)
+    )

--- a/migrations/versions/0452_th_has_unsub_link_backfill.py
+++ b/migrations/versions/0452_th_has_unsub_link_backfill.py
@@ -1,0 +1,18 @@
+"""
+Create Date: 2024-06-01 16:34:30.12345
+"""
+
+from alembic import op
+
+
+revision = "0452_th_has_unsub_link_backfill"
+down_revision = "0451_t_has_unsub_link_not_null"
+
+
+def upgrade():
+    op.execute("UPDATE templates_history SET has_unsubscribe_link=false WHERE has_unsubscribe_link IS NULL")
+
+
+def downgrade():
+    # non-reversible
+    pass

--- a/migrations/versions/0453_th_has_unsub_link_constrain.py
+++ b/migrations/versions/0453_th_has_unsub_link_constrain.py
@@ -1,0 +1,24 @@
+"""
+Create Date: 2024-06-01 16:35:30.12345
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0453_th_has_unsub_link_constrain"
+down_revision = "0452_th_has_unsub_link_backfill"
+
+
+def upgrade():
+    # acquires access exclusive, but only very briefly as the not_valid stops it doing a full table scan
+    op.create_check_constraint(
+        "ck_templates_history_has_unsubscribe_link_not_null_check",
+        "templates_history",
+        sa.column("has_unsubscribe_link").is_not(None),
+        postgresql_not_valid=True,
+    )
+
+
+def downgrade():
+    op.drop_constraint("ck_templates_history_has_unsubscribe_link_not_null_check", "templates_history")

--- a/migrations/versions/0454_th_has_unsub_link_validate.py
+++ b/migrations/versions/0454_th_has_unsub_link_validate.py
@@ -1,0 +1,21 @@
+"""
+Create Date: 2024-06-01 16:35:30.12345
+"""
+
+from alembic import op
+
+
+revision = "0454_th_has_unsub_link_validate"
+down_revision = "0453_th_has_unsub_link_constrain"
+
+
+def upgrade():
+    # These only acquire a SHARE UPDATE EXCLUSIVE lock.
+    op.execute(
+        "ALTER TABLE templates_history VALIDATE CONSTRAINT ck_templates_history_has_unsubscribe_link_not_null_check"
+    )
+
+
+def downgrade():
+    # non-reversible
+    pass

--- a/migrations/versions/0455_th_has_unsub_link_not_null.py
+++ b/migrations/versions/0455_th_has_unsub_link_not_null.py
@@ -1,0 +1,35 @@
+"""
+Create Date: 2024-06-01 16:35:30.12345
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0455_th_has_unsub_link_not_null"
+down_revision = "0454_th_has_unsub_link_validate"
+
+
+def upgrade():
+    # quoth the docs:
+
+    # SET NOT NULL may only be applied to a column provided none of the records in the table contain a NULL value
+    # for the column. Ordinarily this is checked during the ALTER TABLE by scanning the entire table; however, if a
+    # valid CHECK constraint is found which proves no NULL can exist, then the table scan is skipped.
+
+    # so now we can add regular nullable constraints without worrying about a lengthy table scan.
+    op.alter_column("templates_history", "has_unsubscribe_link", nullable=False)
+
+    # now get rid of the old constraint now that it's no longer needed. this is a weird process overall
+    op.drop_constraint("ck_templates_history_has_unsubscribe_link_not_null_check", "templates_history")
+
+
+def downgrade():
+    op.alter_column("templates_history", "has_unsubscribe_link", nullable=True)
+
+    # notably this creates _with_ validating constraint otherwise we'll end up with inconsistency
+    op.create_check_constraint(
+        "ck_templates_history_has_unsubscribe_link_not_null_check",
+        "templates_history",
+        sa.column("has_unsubscribe_link").is_not(None),
+    )

--- a/migrations/versions/0456_t_unsub_constraint.py
+++ b/migrations/versions/0456_t_unsub_constraint.py
@@ -1,0 +1,22 @@
+"""
+Create Date: 2024-06-07 10:37:51.851999
+"""
+
+from alembic import op
+
+revision = "0456_t_unsub_constraint"
+down_revision = "0455_th_has_unsub_link_not_null"
+
+
+def upgrade():
+    # acquires access exclusive, but only very briefly as the not_valid stops it doing a full table scan
+    op.create_check_constraint(
+        "ck_templates_non_email_has_unsubscribe_false",
+        "templates",
+        "template_type = 'email' OR has_unsubscribe_link IS false",
+        postgresql_not_valid=True,
+    )
+
+
+def downgrade():
+    op.drop_constraint("ck_templates_non_email_has_unsubscribe_false", "templates")

--- a/migrations/versions/0457_th_unsub_constraint.py
+++ b/migrations/versions/0457_th_unsub_constraint.py
@@ -1,0 +1,22 @@
+"""
+Create Date: 2024-06-07 10:37:51.851999
+"""
+
+from alembic import op
+
+revision = "0457_th_unsub_constraint"
+down_revision = "0456_t_unsub_constraint"
+
+
+def upgrade():
+    # acquires access exclusive, but only very briefly as the not_valid stops it doing a full table scan
+    op.create_check_constraint(
+        "ck_templates_history_non_email_has_unsubscribe_false",
+        "templates_history",
+        "template_type = 'email' OR has_unsubscribe_link IS false",
+        postgresql_not_valid=True,
+    )
+
+
+def downgrade():
+    op.drop_constraint("ck_templates_history_non_email_has_unsubscribe_false", "templates_history")

--- a/migrations/versions/0458_validate_unsub_constraints.py
+++ b/migrations/versions/0458_validate_unsub_constraints.py
@@ -1,0 +1,18 @@
+"""
+Create Date: 2024-06-07 10:37:51.851999
+"""
+
+from alembic import op
+
+revision = "0458_validate_unsub_constraints"
+down_revision = "0457_th_unsub_constraint"
+
+
+def upgrade():
+    # These only acquire a SHARE UPDATE EXCLUSIVE lock.
+    op.execute("ALTER TABLE templates VALIDATE CONSTRAINT ck_templates_non_email_has_unsubscribe_false")
+    op.execute("ALTER TABLE templates_history VALIDATE CONSTRAINT ck_templates_history_non_email_has_unsubscribe_false")
+
+
+def downgrade():
+    pass

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -39,10 +39,10 @@ def test_create_template(sample_service, sample_user, template_type, subject):
     template = Template(**data)
     dao_create_template(template)
 
-    assert Template.query.count() == 1
-    assert len(dao_get_all_templates_for_service(sample_service.id)) == 1
-    assert dao_get_all_templates_for_service(sample_service.id)[0].name == "Sample Template"
-    assert dao_get_all_templates_for_service(sample_service.id)[0].process_type == "normal"
+    template = Template.query.one()
+    assert template.name == "Sample Template"
+    assert template.process_type == "normal"
+    assert template.has_unsubscribe_link is False
 
 
 def test_create_template_creates_redact_entry(sample_service):


### PR DESCRIPTION
I heard you like migrations. so I made eight of them.

this follows the same four step plan as we did in migrations 0431-0435.

See https://github.com/alphagov/notifications-api/pull/3954 for more details

(I also tweaked alembic to make squawk check against the same alembic config as when we actually run against real envs)