### PR TITLE
Add config option to set receipt callback urls for firetext and mmg

### DIFF
--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -51,6 +51,7 @@ class FiretextClient(SmsClient):
         self.api_key = self.current_app.config.get("FIRETEXT_API_KEY")
         self.international_api_key = self.current_app.config.get("FIRETEXT_INTERNATIONAL_API_KEY")
         self.url = self.current_app.config.get("FIRETEXT_URL")
+        self.receipt_url = self.current_app.config.get("FIRETEXT_RECEIPT_URL")
 
     @property
     def name(self):
@@ -64,6 +65,9 @@ class FiretextClient(SmsClient):
             "message": content,
             "reference": reference,
         }
+
+        if self.receipt_url:
+            data["receipt"] = self.receipt_url
 
         try:
             response = request("POST", self.url, data=data, timeout=60)

--- a/app/clients/sms/mmg.py
+++ b/app/clients/sms/mmg.py
@@ -82,6 +82,7 @@ class MMGClient(SmsClient):
         super().init_app(*args, **kwargs)
         self.api_key = self.current_app.config.get("MMG_API_KEY")
         self.mmg_url = self.current_app.config.get("MMG_URL")
+        self.receipt_url = self.current_app.config.get("MMG_RECEIPT_URL")
 
     @property
     def name(self):
@@ -89,6 +90,9 @@ class MMGClient(SmsClient):
 
     def try_send_sms(self, to, content, reference, international, sender):
         data = {"reqType": "BULK", "MSISDN": to, "msg": content, "sender": sender, "cid": reference, "multi": True}
+
+        if self.receipt_url:
+            data["delurl"] = self.receipt_url
 
         try:
             response = request(

--- a/app/config.py
+++ b/app/config.py
@@ -98,9 +98,17 @@ class Config(object):
     # MMG API Key
     MMG_API_KEY = os.getenv("MMG_API_KEY")
 
+    # MMG Callback URL for delivery receipts
+    # If this is not set, MMG will send to the URL that they have set up in their system
+    MMG_RECEIPT_URL = os.getenv("MMG_RECEIPT_URL")
+
     # Firetext API Key
     FIRETEXT_API_KEY = os.getenv("FIRETEXT_API_KEY")
     FIRETEXT_INTERNATIONAL_API_KEY = os.getenv("FIRETEXT_INTERNATIONAL_API_KEY", "placeholder")
+
+    # Firetext Callback URL for delivery receipts
+    # If this is not set, Firetext will send to the URL that is set in the Firetext dashboard
+    FIRETEXT_RECEIPT_URL = os.getenv("FIRETEXT_RECEIPT_URL")
 
     # Prefix to identify queues in SQS
     NOTIFICATION_QUEUE_PREFIX = os.getenv("NOTIFICATION_QUEUE_PREFIX")

--- a/tests/app/clients/test_firetext.py
+++ b/tests/app/clients/test_firetext.py
@@ -71,6 +71,21 @@ def test_try_send_sms_calls_firetext_correctly(mocker, mock_firetext_client):
     assert request_args["to"][0] == "447234567890"
     assert request_args["message"][0] == content
     assert request_args["reference"][0] == reference
+    assert "receipt" not in request_args
+
+
+def test_try_send_sms_calls_firetext_correctly_with_receipts(mocker, mock_firetext_client_with_receipts):
+    to = content = reference = "foo"
+    response_dict = {
+        "code": 0,
+    }
+
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post("https://example.com/firetext", json=response_dict, status_code=200)
+        mock_firetext_client_with_receipts.try_send_sms(to, content, reference, False, "bar")
+
+    request_args = parse_qs(request_mock.request_history[0].text)
+    assert request_args["receipt"][0] == "https://www.example.com/notifications/sms/firetext"
 
 
 def test_try_send_sms_calls_firetext_correctly_for_international(mocker, mock_firetext_client):

--- a/tests/app/clients/test_mmg.py
+++ b/tests/app/clients/test_mmg.py
@@ -52,6 +52,18 @@ def test_try_send_sms_successful_returns_mmg_response(notify_api, mocker):
     assert response_json["Reference"] == 12345678
 
 
+def test_try_send_sms_successful_with_custom_receipts(notify_api, mock_mmg_client_with_receipts):
+    to = content = reference = "foo"
+    response_dict = {"Reference": 12345678}
+
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post("https://example.com/mmg", json=response_dict, status_code=200)
+        mock_mmg_client_with_receipts.try_send_sms(to, content, reference, False, "sender")
+
+    request_args = request_mock.request_history[0].json()
+    assert request_args["delurl"] == "https://www.example.com/notifications/sms/mmg"
+
+
 def test_try_send_sms_calls_mmg_correctly(notify_api, mocker):
     to = "+447234567890"
     content = "my message"
@@ -73,6 +85,7 @@ def test_try_send_sms_calls_mmg_correctly(notify_api, mocker):
     assert request_args["sender"] == "testing"
     assert request_args["cid"] == reference
     assert request_args["multi"] is True
+    assert "delurl" not in request_args
 
 
 def test_try_send_sms_raises_if_mmg_rejects(notify_api, mocker):


### PR DESCRIPTION
What
----

Add config option to set receipt callback urls for firetext and mmg.

FIRETEXT_RECEIPT_URL : Set firetext parameter 'receipts' when sending sms messages
MMG_RECEIPT_URL : Set mmg parameter 'devurl' when sending sms messages

These options override account wide callback urls for Firetext and MMG.

Why
----

Having the option to override these settings allows us to share accounts for development environments.

These options are not intended to be used in non-development accounts.