### PR TITLE
Bump utils to 78.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ boto3>=1.34.100
 
 notifications-python-client==8.0.1
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -156,7 +156,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.1.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
 ## 78.1.0

* Restrict postcodes to valid UK postcode zones

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/78.0.0...78.1.0