### PR TITLE
Bump requests to the latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -203,7 +203,7 @@ pyyaml==6.0.1
     # via notifications-utils
 redis==4.5.4
     # via flask-redis
-requests==2.32.0
+requests==2.32.3
     # via
     #   govuk-bank-holidays
     #   notifications-python-client


### PR DESCRIPTION
Versions 2.32.0 and 2.32.1 were yanked and are no longer available from PyPI