### PR TITLE
Pin requests due to bug with connecting to DVLA

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -16,6 +16,8 @@ itsdangerous==2.1.2
 jsonschema[format]==4.16.0
 marshmallow-sqlalchemy==0.28.1
 marshmallow==3.18.0
+# Requests pinned to 2.32.2 until https://github.com/psf/requests/issues/6730 is fixed. Once so, we can remove this pin
+requests==2.32.2
 psycopg2-binary==2.9.6
 PyJWT==2.5.0
 SQLAlchemy==1.4.41

--- a/requirements.txt
+++ b/requirements.txt
@@ -203,8 +203,9 @@ pyyaml==6.0.1
     # via notifications-utils
 redis==4.5.4
     # via flask-redis
-requests==2.32.3
+requests==2.32.2
     # via
+    #   -r requirements.in
     #   govuk-bank-holidays
     #   notifications-python-client
     #   notifications-utils


### PR DESCRIPTION
We updated requests in https://github.com/alphagov/notifications-api/pull/4108 but we saw errors in production connecting to DVLA as per https://github.com/psf/requests/issues/6730.

It looks like moving back to 2.32.2 should be unaffected, at least according to the github issue above.

Once a new version is released that fixes it, we can drop this pin. If it doesn't get fixed we could look at an alternative approach like https://github.com/alphagov/notifications-api/pull/4113