### PR TITLE
Remove high volume worker

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -25,8 +25,6 @@ class QueueNames:
     SMS_CALLBACKS = "sms-callbacks"
     ANTIVIRUS = "antivirus-tasks"
     SANITISE_LETTERS = "sanitise-letter-tasks"
-    SAVE_API_EMAIL = "save-api-email-tasks"
-    SAVE_API_SMS = "save-api-sms-tasks"
     BROADCASTS = "broadcast-tasks"
     GOVUK_ALERTS = "govuk-alerts"
 
@@ -49,8 +47,6 @@ class QueueNames:
             QueueNames.LETTERS,
             QueueNames.SES_CALLBACKS,
             QueueNames.SMS_CALLBACKS,
-            QueueNames.SAVE_API_EMAIL,
-            QueueNames.SAVE_API_SMS,
             QueueNames.BROADCASTS,
         ]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,9 +56,6 @@ case "$1" in
   api-worker-service-callbacks)
     exec $COMMON_CMD service-callbacks,service-callbacks-retry
     ;;
-  api-worker-save-api-notifications)
-    exec $COMMON_CMD save-api-email-tasks,save-api-sms-tasks
-    ;;
   celery-beat)
     exec celery -A run_celery.notify_celery beat --loglevel=INFO
     ;;

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -25,8 +25,6 @@ def test_queue_names_all_queues_correct():
         QueueNames.LETTERS,
         QueueNames.SES_CALLBACKS,
         QueueNames.SMS_CALLBACKS,
-        QueueNames.SAVE_API_EMAIL,
-        QueueNames.SAVE_API_SMS,
         QueueNames.BROADCASTS,
     } == set(queues)
 

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -7,7 +7,7 @@ from app.config import QueueNames
 def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()
-    assert len(queues) == 19
+    assert len(queues) == 17
     assert {
         QueueNames.PERIODIC,
         QueueNames.DATABASE,


### PR DESCRIPTION
Here are some reasons I think we should remove it:

1. There’s two queues (save-api-email-tasks and save-api-sms-tasks and a worker (api-worker-save-api-notifications)  that we pay money for
1. Code complexity - this was raised when @BlessedDev tried to update when we save notifications to handle unsubscribe links (which we will need to make sure work for [GOV.UK](http://gov.uk/) Email!), and it’s more nuanced because this json blob is passed on a celery task.
1. We have other services we consider as large such as NHS login, NHS Notify, DWP Prod, that we do not have on this queue and we have been fine
1. I don’t think we’ve ever tested that this actually increased performance of Notify. Our current DB connection usage is pretty low and even at peak times we’re no-where near our hard limit of 5000 concurrent connections.
We return a 200 OK, and give a user a notification ID, but don’t actually create the notification in the database. If something goes wrong (eg the task is lost off the queue/worker) then we won’t have created the notification but will have told the user that we did! that’s really bad.
1. Even if nothing goes wrong, in that period while the task is on the queue, if the service does a GET notification by id request, they’ll receive a 404 not found because the notification won’t be in the DB. This is super weird and confusing.

Deploy process:

- [x] remove services from creds so path isnt used https://github.com/alphagov/notifications-credentials/pull/461
- [x] remove code path https://github.com/alphagov/notifications-api/pull/4124
- [x] terraform delete ecs task, ssm creds. delete from concourse pipeline at the same time? https://github.com/alphagov/notifications-aws/pull/2276
- [x] delete the cred files completely https://github.com/alphagov/notifications-credentials/pull/463
- [ ] clickops remove sqs queues
- [ ] remove worker definition from API <-- YOU ARE HERE
- [ ] figure out what to do with high-volume vs not-high-volume statsd metrics