### PR TITLE
add unsubscribe link to save_api_email_or_sms

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -305,6 +305,7 @@ def save_api_email_or_sms(self, encoded_notification):
             reply_to_text=notification["reply_to_text"],
             status=notification["status"],
             document_download_count=notification["document_download_count"],
+            unsubscribe_link=notification["unsubscribe_link"],
         )
 
         q = QueueNames.SEND_EMAIL if notification["notification_type"] == EMAIL_TYPE else QueueNames.SEND_SMS


### PR DESCRIPTION
This PR fixes a bug that was noticed by a user as described in [this](https://trello.com/c/VRzsixUp/59-add-unsubscribelink-to-saveapiemailorsms) card, by adding `unsubscribe_link` to the persisted notification in `save_api_email_or_sms`.

I have added an assertion to `test_save_api_email_or_sms` to test that a provided `unsubscribe_link` is set on the notification.
