### PR TITLE
fix(utils): change archived field nomanclature from date to datetime

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -134,8 +134,8 @@ def email_address_is_nhs(email_address):
 
 
 def get_archived_db_column_value(column):
-    date = datetime.utcnow().strftime("%Y-%m-%d")
-    return f"_archived_{date}_{column}"
+    date_time = datetime.utcnow().strftime("%Y-%m-%d-%H:%M:%S")
+    return f"_archived_{date_time}_{column}"
 
 
 def get_dt_string_or_none(val):

--- a/tests/app/dao/test_organisation_dao.py
+++ b/tests/app/dao/test_organisation_dao.py
@@ -326,7 +326,7 @@ def test_update_organisation_updates_services_with_new_crown_type(sample_service
     assert not Service.query.get(sample_service.id).crown
 
 
-@freeze_time("2022-05-17 11:09")
+@freeze_time("2022-05-17 11:09:16")
 def test_dao_archive_organisation(sample_organisation, fake_uuid):
     email_branding = create_email_branding(id=fake_uuid)
     letter_branding = create_letter_branding()
@@ -346,7 +346,7 @@ def test_dao_archive_organisation(sample_organisation, fake_uuid):
     assert not sample_organisation.letter_branding
     assert not sample_organisation.domains
     assert sample_organisation.active is False
-    assert sample_organisation.name == f"_archived_2022-05-17_{org_name}"
+    assert sample_organisation.name == f"_archived_2022-05-17-11:09:16_{org_name}"
 
 
 def test_add_service_to_organisation(sample_service, sample_organisation):

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -237,7 +237,7 @@ def test_dao_archive_user(sample_user, sample_organisation, fake_uuid):
     assert sample_user.organisations == []
     assert sample_user.auth_type == EMAIL_AUTH_TYPE
     assert sample_user.name == "Archived user"
-    assert sample_user.email_address == f"_archived_2018-07-07_{sample_user.id}@test.notify.com"
+    assert sample_user.email_address == f"_archived_2018-07-07-12:00:00_{sample_user.id}@test.notify.com"
     assert sample_user.mobile_number is None
     assert sample_user.current_session_id == uuid.UUID("00000000-0000-0000-0000-000000000000")
     assert sample_user.state == "inactive"

--- a/tests/app/email_branding/test_rest.py
+++ b/tests/app/email_branding/test_rest.py
@@ -472,7 +472,7 @@ def test_archive_email_branding_removes_branding_from_org_pools(admin_request, n
     assert len(dao_get_email_branding_pool_for_organisation(org_2.id)) == 1
 
 
-@freeze_time("2023-01-13")
+@freeze_time("2023-01-13 11:09:16")
 def test_archive_email_branding_archives_branding_and_changes_its_name(admin_request, notify_db_session):
     email_branding_1 = create_email_branding(name="branding 1")
 
@@ -484,4 +484,4 @@ def test_archive_email_branding_archives_branding_and_changes_its_name(admin_req
     )
 
     assert email_branding_1.active is False
-    assert email_branding_1.name == "_archived_2023-01-13_branding 1"
+    assert email_branding_1.name == "_archived_2023-01-13-11:09:16_branding 1"

--- a/tests/app/service/test_archived_service.py
+++ b/tests/app/service/test_archived_service.py
@@ -56,8 +56,8 @@ def test_deactivating_service_changes_name_and_email(client, sample_service):
 
     archived_service = dao_fetch_service_by_id(sample_service.id)
 
-    assert archived_service.name == "_archived_2018-07-07_Sample service"
-    assert archived_service.email_sender_local_part == "archived20180707sample.service"
+    assert archived_service.name == "_archived_2018-07-07-12:00:00_Sample service"
+    assert archived_service.email_sender_local_part == "archived20180707120000sample.service"
 
 
 def test_deactivating_service_revokes_api_keys(archived_service):


### PR DESCRIPTION
## PR Summary
- by archiving service fields with a date suffix, this means that if we archive more than one service with the same name in one day, we get a constraint error
- here, this is being change to datetime to avoid the issue

### Related Tasks
[Change archive name format from date to datetime](https://trello.com/c/xAjLBYtE/794-change-archive-name-format-from-date-to-datetime)