### PR TITLE
Send inbound sms callback tasks to service-callback queue

### DIFF
--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -75,13 +75,11 @@ def send_inbound_sms_to_service(self, inbound_sms_id, service_id):
     }
 
     _send_data_to_service_callback_api(
-        self, data, inbound_api.url, inbound_api.bearer_token, "send_inbound_sms_to_service", QueueNames.RETRY
+        self, data, inbound_api.url, inbound_api.bearer_token, "send_inbound_sms_to_service"
     )
 
 
-def _send_data_to_service_callback_api(
-    self, data, service_callback_url, token, function_name, retry_queue=QueueNames.CALLBACKS_RETRY
-):
+def _send_data_to_service_callback_api(self, data, service_callback_url, token, function_name):
     object_id = data["notification_id"] if "notification_id" in data else data["id"]
     try:
         response = request(
@@ -109,7 +107,7 @@ def _send_data_to_service_callback_api(
         )
         if not isinstance(e, HTTPError) or e.response.status_code >= 500 or e.response.status_code == 429:
             try:
-                self.retry(queue=retry_queue)
+                self.retry(queue=QueueNames.CALLBACKS_RETRY)
             except self.MaxRetriesExceededError as e:
                 current_app.logger.error(
                     "Retry: %s has retried the max num of times for callback url %s and id: %s",

--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -66,7 +66,7 @@ def receive_mmg_sms():
     )
 
     service_callback_tasks.send_inbound_sms_to_service.apply_async(
-        [str(inbound.id), str(service.id)], queue=QueueNames.NOTIFY
+        [str(inbound.id), str(service.id)], queue=QueueNames.CALLBACKS
     )
 
     current_app.logger.debug(
@@ -105,7 +105,7 @@ def receive_firetext_sms():
     INBOUND_SMS_COUNTER.labels("firetext").inc()
 
     service_callback_tasks.send_inbound_sms_to_service.apply_async(
-        [str(inbound.id), str(service.id)], queue=QueueNames.NOTIFY
+        [str(inbound.id), str(service.id)], queue=QueueNames.CALLBACKS
     )
     current_app.logger.debug(
         "%s received inbound SMS with reference %s from Firetext", service.id, inbound.provider_reference

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -154,7 +154,7 @@ def test_send_inbound_sms_to_service_sends_callback_to_service(notify_api, sampl
 
     send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
     send_callback_mock.assert_called_once_with(
-        mock.ANY, data, "https://some.service.gov.uk/", "something_unique", "send_inbound_sms_to_service", "retry-tasks"
+        mock.ANY, data, "https://some.service.gov.uk/", "something_unique", "send_inbound_sms_to_service"
     )
 
 

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -72,7 +72,7 @@ def test_receive_notification_returns_received_to_mmg(client, mocker, sample_ser
 
     inbound_sms_id = InboundSms.query.all()[0].id
     mocked.assert_called_once_with(
-        [str(inbound_sms_id), str(sample_service_full_permissions.id)], queue="notify-internal-tasks"
+        [str(inbound_sms_id), str(sample_service_full_permissions.id)], queue="service-callbacks"
     )
 
 
@@ -340,7 +340,7 @@ def test_receive_notification_returns_received_to_firetext(notify_db_session, cl
 
     assert result["status"] == "ok"
     inbound_sms_id = InboundSms.query.all()[0].id
-    mocked.assert_called_once_with([str(inbound_sms_id), str(service.id)], queue="notify-internal-tasks")
+    mocked.assert_called_once_with([str(inbound_sms_id), str(service.id)], queue="service-callbacks")
 
 
 def test_receive_notification_from_firetext_persists_message(notify_db_session, client, mocker):
@@ -368,7 +368,7 @@ def test_receive_notification_from_firetext_persists_message(notify_db_session, 
     assert persisted.content == "this is a message"
     assert persisted.provider == "firetext"
     assert persisted.provider_date == datetime(2017, 1, 1, 12, 0, 0, 0)
-    mocked.assert_called_once_with([str(persisted.id), str(service.id)], queue="notify-internal-tasks")
+    mocked.assert_called_once_with([str(persisted.id), str(service.id)], queue="service-callbacks")
 
 
 def test_receive_notification_from_firetext_persists_message_with_normalized_phone(notify_db_session, client, mocker):


### PR DESCRIPTION
The service-callbacks worker now has database access: https://github.com/alphagov/notifications-aws/pull/2284

We can now make the change to put inbound SMS tasks on the service-callbacks queue, with retries on the service-callbacks-retry queue for consistency with other callback tasks.