### PR TITLE
remove high volume queues

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -399,8 +399,6 @@ class Config:
     MMG_INBOUND_SMS_USERNAME = json.loads(os.environ.get("MMG_INBOUND_SMS_USERNAME", "[]"))
     LOW_INBOUND_SMS_NUMBER_THRESHOLD = 50
 
-    HIGH_VOLUME_SERVICE = json.loads(os.environ.get("HIGH_VOLUME_SERVICE", "[]"))
-
     TEMPLATE_PREVIEW_API_HOST = os.environ.get("TEMPLATE_PREVIEW_API_HOST", "http://localhost:6013")
     TEMPLATE_PREVIEW_API_KEY = os.environ.get("TEMPLATE_PREVIEW_API_KEY", "my-secret-key")
 
@@ -512,13 +510,6 @@ class Test(Development):
     FROM_NUMBER = "testing"
     NOTIFY_ENVIRONMENT = "test"
     TESTING = True
-
-    HIGH_VOLUME_SERVICE = [
-        "941b6f9a-50d7-4742-8d50-f365ca74bf27",
-        "63f95b86-2d19-4497-b8b2-ccf25457df4e",
-        "7e5950cb-9954-41f5-8376-962b8c8555cf",
-        "10d1b9c9-0072-4fa9-ae1c-595e333841da",
-    ]
 
     S3_BUCKET_CSV_UPLOAD = "test-notifications-csv-upload"
     S3_BUCKET_CONTACT_LIST = "test-contact-list"

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -98,10 +98,6 @@ def send_sms_to_provider(notification):
             statsd_client.timing("sms.test-key.total-time", delta_seconds)
         else:
             statsd_client.timing("sms.live-key.total-time", delta_seconds)
-            if service.high_volume:
-                statsd_client.timing("sms.live-key.high-volume.total-time", delta_seconds)
-            else:
-                statsd_client.timing("sms.live-key.not-high-volume.total-time", delta_seconds)
 
 
 def _get_email_headers(notification: Notification) -> list[dict[str, str]]:
@@ -163,10 +159,6 @@ def send_email_to_provider(notification):
             statsd_client.timing("email.test-key.total-time", delta_seconds)
         else:
             statsd_client.timing("email.live-key.total-time", delta_seconds)
-            if service.high_volume:
-                statsd_client.timing("email.live-key.high-volume.total-time", delta_seconds)
-            else:
-                statsd_client.timing("email.live-key.not-high-volume.total-time", delta_seconds)
 
 
 def update_notification_to_sending(notification, provider):

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -3,7 +3,6 @@ from functools import partial
 from threading import RLock
 
 import cachetools
-from flask import current_app
 from notifications_utils.clients.redis import RequestCache
 from notifications_utils.serialised_model import (
     SerialisedModel,
@@ -108,10 +107,6 @@ class SerialisedService(SerialisedModel):
     @cached_property
     def api_keys(self):
         return SerialisedAPIKeyCollection.from_service_id(self.id)
-
-    @property
-    def high_volume(self):
-        return self.id in current_app.config["HIGH_VOLUME_SERVICE"]
 
     def has_permission(self, permission):
         return permission in self.permissions


### PR DESCRIPTION
we have no high volume services defined in our creds at all so we can simply remove the entire codebase without worrying about deprecation orders of task definitions


Here are some reasons I think we should remove it:

1. There’s two queues (save-api-email-tasks and save-api-sms-tasks and a worker (api-worker-save-api-notifications)  that we pay money for
1. Code complexity - this was raised when @BlessedDev tried to update when we save notifications to handle unsubscribe links (which we will need to make sure work for [GOV.UK](http://gov.uk/) Email!), and it’s more nuanced because this json blob is passed on a celery task.
1. We have other services we consider as large such as NHS login, NHS Notify, DWP Prod, that we do not have on this queue and we have been fine
1. I don’t think we’ve ever tested that this actually increased performance of Notify. Our current DB connection usage is pretty low and even at peak times we’re no-where near our hard limit of 5000 concurrent connections.
1. We return a 200 OK, and give a user a notification ID, but don’t actually create the notification in the database. If something goes wrong (eg the task is lost off the queue/worker) then we won’t have created the notification but will have told the user that we did! that’s really bad.
1. Even if nothing goes wrong, in that period while the task is on the queue, if the service does a GET notification by id request, they’ll receive a 404 not found because the notification won’t be in the DB. This is super weird and confusing.


Deploy process:

- [x] remove services from creds so path isnt used https://github.com/alphagov/notifications-credentials/pull/461
- [ ] remove code path <-- YOU ARE HERE
- [ ] terraform delete ecs task, ssm creds. delete from concourse pipeline at the same time? https://github.com/alphagov/notifications-aws/pull/2276
- [ ] delete the cred files completely https://github.com/alphagov/notifications-credentials/pull/463
- [ ] clickops remove sqs queues
- [ ] remove worker definition from API https://github.com/alphagov/notifications-api/pull/4115
- [ ] figure out what to do with high-volume vs not-high-volume statsd metrics