### PR TITLE
Delete cache when processing new unsubscribe request

### DIFF
--- a/app/one_click_unsubscribe/rest.py
+++ b/app/one_click_unsubscribe/rest.py
@@ -2,6 +2,7 @@ from flask import Blueprint, current_app, jsonify
 from itsdangerous import BadData
 from notifications_utils.url_safe_token import check_token
 
+from app import redis_store
 from app.dao.notification_history_dao import get_notification_history_by_id
 from app.dao.notifications_dao import get_notification_by_id
 from app.dao.unsubscribe_request_dao import create_unsubscribe_request_dao
@@ -38,6 +39,7 @@ def one_click_unsubscribe(notification_id, token):
         raise InvalidRequest(errors, status_code=404)
 
     create_unsubscribe_request_dao(unsubscribe_data)
+    redis_store.delete(f"service-{unsubscribe_data['service_id']}-unsubscribe-request-statistics")
 
     current_app.logger.debug("Received unsubscribe request for notification_id: %s", notification_id)
 


### PR DESCRIPTION
We want to cache a summary of unsubscribe requests for each service to make the dashboard load quickly.

We need to invalidate this cache whenever:
1. a new requst comes in
2. some requests are marked as completed
3. some old requests are cleaned up according to our data retention policy

This commit does 1., as a start