### PR TITLE
When getting rate from Redis cache, cast it to float

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1710,7 +1710,7 @@ class Notification(db.Model):
         created_at_date = self.created_at.date()
 
         if rate := redis_store.get(f"sms-rate-for-{created_at_date}"):
-            return rate
+            return float(rate)
 
         from app.dao.sms_rate_dao import dao_get_sms_rate_for_timestamp
 
@@ -1729,7 +1729,7 @@ class Notification(db.Model):
         if rate := redis_store.get(
             f"letter-rate-for-date-{created_at_date}-sheets-{self.billable_units}-postage-{self.postage}"
         ):
-            return rate
+            return float(rate)
 
         from app.dao.letter_rate_dao import dao_get_letter_rates_for_timestamp
 


### PR DESCRIPTION
Even though we send the rate as a float to Redis, redis then gives it back to us as a byte-string.

We did not take it into consideration when building the test data, and it broke our deploy sadly.

So now we update the unit tests mocks to behave more realistically, and we cast the rates we are getting back from redis to float to fix the issue.