### PR TITLE
Fix postage validation in schemas

### DIFF
--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -40,6 +40,20 @@ def validate_schema_email_address(instance):
 
 @format_checker.checks("postage", raises=ValidationError)
 def validate_schema_postage(instance):
+    """
+    For validating postage on templates and user requests, where postage can only be `first` or `second`
+    """
+    if isinstance(instance, str):
+        if instance not in ["first", "second"]:
+            raise ValidationError("invalid. It must be either first or second.")
+    return True
+
+
+@format_checker.checks("postage_including_international", raises=ValidationError)
+def validate_schema_postage_including_international(instance):
+    """
+    For validating postage sent by admin when sending a precompiled letter, where postage can include international
+    """
     if isinstance(instance, str):
         if instance not in ["first", "second", "europe", "rest-of-world"]:
             raise ValidationError("invalid. It must be first, second, europe or rest-of-world.")

--- a/app/service/send_pdf_letter_schema.py
+++ b/app/service/send_pdf_letter_schema.py
@@ -4,7 +4,7 @@ send_pdf_letter_request = {
     "type": "object",
     "title": "Send an uploaded pdf letter",
     "properties": {
-        "postage": {"type": "string", "format": "postage"},
+        "postage": {"type": "string", "format": "postage_including_international"},
         "filename": {"type": "string"},
         "created_by": {"type": "string"},
         "file_id": {"type": "string"},

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1003,7 +1003,7 @@ def test_create_a_template_with_foreign_service_reply_to(admin_request, sample_u
             [
                 {
                     "error": "ValidationError",
-                    "message": "postage invalid. It must be first, second, europe or rest-of-world.",
+                    "message": "postage invalid. It must be either first or second.",
                 },
             ],
         ),

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -668,13 +668,13 @@ def test_post_precompiled_letter_notification_if_s3_upload_fails_notification_is
     assert Notification.query.count() == 0
 
 
-def test_post_letter_notification_throws_error_for_invalid_postage(api_client_request, mocker):
+def test_post_letter_notification_throws_error_for_invalid_postage(api_client_request):
     sample_service = create_service(service_permissions=["letter"])
-    data = {"reference": "letter-reference", "content": "bGV0dGVyLWNvbnRlbnQ=", "postage": "space unicorn"}
+    data = {"reference": "letter-reference", "content": "bGV0dGVyLWNvbnRlbnQ=", "postage": "europe"}
     resp_json = api_client_request.post(
         sample_service.id, "v2_notifications.post_precompiled_letter_notification", _data=data, _expected_status=400
     )
-    assert resp_json["errors"][0]["message"] == "postage invalid. It must be first, second, europe or rest-of-world."
+    assert resp_json["errors"][0]["message"] == "postage invalid. It must be either first or second."
 
     assert not Notification.query.first()
 


### PR DESCRIPTION
The postage validator allowed the value to be "first", "second", "europe" or "rest-of-world", however when sending a letter using the API or setting the postage on a template you should not be able to use the international postage options.

We use the postage validator in a number of places and there is one of those that _does_ need to allow international postage - when the admin app sends a precompiled letter it can use the international postage types. This splits the postage validator into two - one for the UK types of postage (used in most places) and one for the admin app to use (used in one place).