### PR TITLE
Remove no-argument form of `get_user_by_id`

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -100,10 +100,8 @@ def count_user_verify_codes(user):
     return query.count()
 
 
-def get_user_by_id(user_id=None):
-    if user_id:
-        return User.query.filter_by(id=user_id).one()
-    return User.query.filter_by().all()
+def get_user_by_id(user_id):
+    return User.query.filter_by(id=user_id).one()
 
 
 def get_user_by_email(email):

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -431,8 +431,7 @@ def send_already_registered_email(user_id):
 
 
 @user_blueprint.route("/<uuid:user_id>", methods=["GET"])
-@user_blueprint.route("", methods=["GET"])
-def get_user(user_id=None):
+def get_user(user_id):
     users = get_user_by_id(user_id=user_id)
     result = [x.serialize() for x in users] if isinstance(users, list) else users.serialize()
     return jsonify(data=result)

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -60,14 +60,6 @@ def test_create_user(notify_db_session, phone_number):
     assert not user_query.platform_admin
 
 
-def test_get_all_users(notify_db_session):
-    create_user(email="1@test.com")
-    create_user(email="2@test.com")
-
-    assert User.query.count() == 2
-    assert len(get_user_by_id()) == 2
-
-
 def test_get_user(notify_db_session):
     email = "1@test.com"
     user = create_user(email=email)

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -30,25 +30,6 @@ from tests.app.db import (
 )
 
 
-def test_get_user_list(admin_request, sample_service):
-    """
-    Tests GET endpoint '/' to retrieve entire user list.
-    """
-    json_resp = admin_request.get("user.get_user")
-
-    # it may have the notify user in the DB still :weary:
-    assert len(json_resp["data"]) >= 1
-    sample_user = sample_service.users[0]
-    expected_permissions = default_service_permissions
-    fetched = next(x for x in json_resp["data"] if x["id"] == str(sample_user.id))
-
-    assert sample_user.name == fetched["name"]
-    assert sample_user.mobile_number == fetched["mobile_number"]
-    assert sample_user.email_address == fetched["email_address"]
-    assert sample_user.state == fetched["state"]
-    assert sorted(expected_permissions) == sorted(fetched["permissions"][str(sample_service.id)])
-
-
 def test_get_user(admin_request, sample_service, sample_organisation):
     """
     Tests GET endpoint '/<user_id>' to retrieve a single user.


### PR DESCRIPTION
This function isn’t called without an ID anywhere.

It was introduced without explanation in January 2016 (a327702ad011db87e2e26a6281177adfdb9d8185)

It wouldn’t be very useful now because we have tens of thousands of users.