### PR TITLE
Dockerfile: pre-compile bytecode for app in production image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,7 +51,8 @@ COPY --chown=notify:notify templates templates
 COPY --chown=notify:notify run_celery.py gunicorn_config.py application.py entrypoint.sh ./
 COPY --from=python_build --chown=notify:notify /home/vcap/app/app/version.py app/version.py
 
-RUN chown -R notify:notify /home/vcap/app && \
+RUN python -m compileall . && \
+    chown -R notify:notify /home/vcap/app && \
     chmod +x /home/vcap/app/entrypoint.sh
 
 ENTRYPOINT [ "/home/vcap/app/entrypoint.sh" ]


### PR DESCRIPTION
This should produce a small improvement in startup time, which is useful when scaling up in response to sudden loads.

Bytecode for the libraries in the venv is already generated during pip install.