### PR TITLE
Add validation for letters sent to "no fixed abode" addresses

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -265,6 +265,8 @@ def validate_address(service, letter_data):
         raise ValidationError(
             message="Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / , < >"
         )
+    if address.has_no_fixed_abode_address:
+        raise ValidationError(message="Must be a real address")
     if address.international:
         return address.postage
     else:

--- a/requirements.in
+++ b/requirements.in
@@ -23,7 +23,7 @@ lxml==4.9.3
 
 notifications-python-client==8.0.1
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@81.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@81.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -209,6 +209,16 @@ def test_post_letter_notification_international_sets_rest_of_world(api_client_re
             },
             "Last line of address must be a real UK postcode or another country",
         ),
+        (
+            [LETTER_TYPE],
+            {
+                "address_line_1": "No fixed abode",
+                "address_line_2": "Buckingham Palace",
+                "postcode": "SW1A 1AA",
+                "name": "Unknown",
+            },
+            "Must be a real address",
+        ),
     ),
 )
 def test_post_letter_notification_throws_error_for_bad_address(


### PR DESCRIPTION
This brings in the new `has_no_fixed_abode_address ` method added to the `PostalAddress` to validate that letters are sent to real addresses.