### PR TITLE
Count all unsubscribe requests from last 7 days on dashboard

### DIFF
--- a/app/dao/unsubscribe_request_dao.py
+++ b/app/dao/unsubscribe_request_dao.py
@@ -1,4 +1,4 @@
-from sqlalchemy import desc, func, or_
+from sqlalchemy import desc, func
 
 from app import db
 from app.dao.dao_utils import autocommit
@@ -17,26 +17,17 @@ def get_unsubscribe_request_by_notification_id_dao(notification_id):
 
 def get_unsubscribe_requests_statistics_dao(service_id):
     """
-    This method returns statistics for only unprocessed unsubscribe requests received
+    This method returns statistics for only unsubscribe requests received
     in the last 7 days
     """
     return (
         db.session.query(
-            func.count(UnsubscribeRequest.service_id).label("unprocessed_unsubscribe_requests_count"),
+            func.count(UnsubscribeRequest.service_id).label("unsubscribe_requests_count"),
             UnsubscribeRequest.service_id.label("service_id"),
             func.max(UnsubscribeRequest.created_at).label("datetime_of_latest_unsubscribe_request"),
         )
         .select_from(UnsubscribeRequest)
-        .join(
-            UnsubscribeRequestReport,
-            UnsubscribeRequestReport.id == UnsubscribeRequest.unsubscribe_request_report_id,
-            isouter=True,
-        )
         .filter(
-            or_(
-                UnsubscribeRequest.unsubscribe_request_report_id.is_(None),
-                UnsubscribeRequestReport.processed_by_service_at.is_(None),
-            ),
             UnsubscribeRequest.service_id == service_id,
             UnsubscribeRequest.created_at >= midnight_n_days_ago(7),
         )

--- a/app/dao/unsubscribe_request_dao.py
+++ b/app/dao/unsubscribe_request_dao.py
@@ -37,7 +37,7 @@ def get_unsubscribe_requests_statistics_dao(service_id):
                 UnsubscribeRequest.unsubscribe_request_report_id.is_(None),
                 UnsubscribeRequestReport.processed_by_service_at.is_(None),
             ),
-            service_id == service_id,
+            UnsubscribeRequest.service_id == service_id,
             UnsubscribeRequest.created_at >= midnight_n_days_ago(7),
         )
         .group_by(UnsubscribeRequest.service_id)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1094,12 +1094,12 @@ def get_unsubscribe_requests_statistics(service_id):
     data = {}
     if unsubscribe_statistics := get_unsubscribe_requests_statistics_dao(service_id):
         data = {
-            "unprocessed_unsubscribe_requests_count": unsubscribe_statistics.unprocessed_unsubscribe_requests_count,
+            "unsubscribe_requests_count": unsubscribe_statistics.unprocessed_unsubscribe_requests_count,
             "datetime_of_latest_unsubscribe_request": unsubscribe_statistics.datetime_of_latest_unsubscribe_request,
         }
     elif latest_unsubscribe_request := get_latest_unsubscribe_request_date_dao(service_id):
         data = {
-            "unprocessed_unsubscribe_requests_count": 0,
+            "unsubscribe_requests_count": 0,
             "datetime_of_latest_unsubscribe_request": latest_unsubscribe_request.datetime_of_latest_unsubscribe_request,
         }
 

--- a/tests/app/dao/test_unsubscribe_request_dao.py
+++ b/tests/app/dao/test_unsubscribe_request_dao.py
@@ -91,6 +91,19 @@ def test_get_unsubscribe_requests_statistics_dao(sample_service):
         }
     )
 
+    notification_5 = create_notification(template=template_2)
+    # This request should not be counted because it’s more than 7 days ago
+    create_unsubscribe_request_dao(
+        {
+            "notification_id": notification_5.id,
+            "template_id": notification_5.template_id,
+            "template_version": notification_5.template_version,
+            "service_id": notification_5.service_id,
+            "email_address": notification_5.to,
+            "created_at": midnight_n_days_ago(8),
+        }
+    )
+
     other_service_template = create_template(
         create_service(service_name="Other service"),
         template_type=EMAIL_TYPE,
@@ -137,11 +150,11 @@ def test_get_unsubscribe_requests_statistics_dao(sample_service):
 
     result = get_unsubscribe_requests_statistics_dao(sample_service.id)
     expected_result = {
-        "unprocessed_unsubscribe_requests_count": 3,
+        "unsubscribe_requests_count": 4,
         "datetime_of_latest_unsubscribe_request": unsubscribe_requests[0].created_at,
     }
 
-    assert result.unprocessed_unsubscribe_requests_count == expected_result["unprocessed_unsubscribe_requests_count"]
+    assert result.unsubscribe_requests_count == expected_result["unsubscribe_requests_count"]
     assert result.datetime_of_latest_unsubscribe_request == expected_result["datetime_of_latest_unsubscribe_request"]
 
 
@@ -184,11 +197,11 @@ def test_get_unsubscribe_requests_statistics_dao_adheres_to_7_days_limit(sample_
     unsubscribe_requests = UnsubscribeRequest.query.order_by(UnsubscribeRequest.created_at.desc()).all()
     result = get_unsubscribe_requests_statistics_dao(sample_service.id)
     expected_result = {
-        "unprocessed_unsubscribe_requests_count": 1,
+        "unsubscribe_requests_count": 1,
         "datetime_of_latest_unsubscribe_request": unsubscribe_requests[0].created_at,
     }
 
-    assert result.unprocessed_unsubscribe_requests_count == expected_result["unprocessed_unsubscribe_requests_count"]
+    assert result.unsubscribe_requests_count == expected_result["unsubscribe_requests_count"]
     assert result.datetime_of_latest_unsubscribe_request == expected_result["datetime_of_latest_unsubscribe_request"]
 
 

--- a/tests/app/dao/test_unsubscribe_request_dao.py
+++ b/tests/app/dao/test_unsubscribe_request_dao.py
@@ -25,14 +25,7 @@ def test_create_unsubscribe_request_dao(sample_email_notification):
 
 
 def test_get_unsubscribe_requests_statistics_dao(sample_service):
-    """
-    This test creates 2 un-batched unprocessed unsubscribe requests, 1 batched  unprocessed unsubscribe request
-    and 1 batched processed unsubscribe requests.
 
-     The test cases covered are
-     i.The batched unprocessed unsubscribe request is included in the count_of_pending_unsubscribe_requests
-     ii.The right datetime_of_latest_unsubscribe_request is returned.
-    """
     # Create 2 un-batched unsubscribe requests
     template_1 = create_template(
         sample_service,

--- a/tests/app/dao/test_unsubscribe_request_dao.py
+++ b/tests/app/dao/test_unsubscribe_request_dao.py
@@ -9,7 +9,7 @@ from app.dao.unsubscribe_request_dao import (
 from app.models import UnsubscribeRequest, UnsubscribeRequestReport
 from app.one_click_unsubscribe.rest import get_unsubscribe_request_data
 from app.utils import midnight_n_days_ago
-from tests.app.db import create_notification, create_template
+from tests.app.db import create_notification, create_service, create_template
 
 
 def test_create_unsubscribe_request_dao(sample_email_notification):
@@ -88,6 +88,23 @@ def test_get_unsubscribe_requests_statistics_dao(sample_service):
             "service_id": notification_4.service_id,
             "email_address": notification_4.to,
             "created_at": midnight_n_days_ago(6),
+        }
+    )
+
+    other_service_template = create_template(
+        create_service(service_name="Other service"),
+        template_type=EMAIL_TYPE,
+    )
+    notification_6 = create_notification(template=other_service_template)
+    # This request should not be counted because it’s from a different service
+    create_unsubscribe_request_dao(
+        {
+            "notification_id": notification_6.id,
+            "template_id": notification_6.template_id,
+            "template_version": notification_6.template_version,
+            "service_id": notification_6.service_id,
+            "email_address": notification_6.to,
+            "created_at": midnight_n_days_ago(1),
         }
     )
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3649,7 +3649,7 @@ def test_get_unsubscribe_requests_statistics(admin_request, sample_service, mock
 
     mocker.patch("app.service.rest.get_unsubscribe_requests_statistics_dao", return_value=test_data)
     response = admin_request.get("service.get_unsubscribe_requests_statistics", service_id=sample_service.id)
-    assert response["unprocessed_unsubscribe_requests_count"] == test_data.unprocessed_unsubscribe_requests_count
+    assert response["unsubscribe_requests_count"] == test_data.unprocessed_unsubscribe_requests_count
     assert response["datetime_of_latest_unsubscribe_request"] == test_data.datetime_of_latest_unsubscribe_request
 
 
@@ -3658,14 +3658,14 @@ def test_get_unsubscribe_requests_statistics_for_unsubscribe_requests_older_than
 ):
     MockUnsubscribeRequest = namedtuple(
         "MockUnsubscribeRequest",
-        ["unprocessed_unsubscribe_requests_count", "service_id", "datetime_of_latest_unsubscribe_request"],
+        ["unsubscribe_requests_count", "service_id", "datetime_of_latest_unsubscribe_request"],
     )
     test_data = MockUnsubscribeRequest(0, "2fed1b45-66e1-4682-a389-85d0d50a916f", "Thu, 18 Jul 2024 15:32:28 GMT")
 
     mocker.patch("app.service.rest.get_unsubscribe_requests_statistics_dao", return_value=None)
     mocker.patch("app.service.rest.get_latest_unsubscribe_request_date_dao", return_value=test_data)
     response = admin_request.get("service.get_unsubscribe_requests_statistics", service_id=sample_service.id)
-    assert response["unprocessed_unsubscribe_requests_count"] == 0
+    assert response["unsubscribe_requests_count"] == 0
     assert response["datetime_of_latest_unsubscribe_request"] == test_data.datetime_of_latest_unsubscribe_request
 
 


### PR DESCRIPTION
The dashboard says:
> ## In the last 7 days
>
> **1,234** email unsubscribe requests
> Latest report 3 weeks ago

At the moment the 1,234 number will go down when requests are marked as completed. This doesn’t feel right, because those requests have still been received in the last 7 days.

This pull request changes the query to count all requests from the last 7 days, whether or not they have been marked as completed.

This is consistent with received text messages and returned letters (although we don’t have a similar concept of marking these are completed at the moment).