### PR TITLE
Update callback params when sending letters to DVLA

### DIFF
--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -332,7 +332,10 @@ class DVLAClient:
         }
 
         if callback_url:
-            json_payload["callback"] = {"target": callback_url, "retry": {"enabled": True, "maxRetryWindow": 3600}}
+            json_payload["callbackParams"] = {
+                "target": callback_url,
+                "retryParams": {"enabled": True, "maxRetryWindow": 10800},
+            }
 
         # `despatchMethod` should not be added for second class letters
         if postage == FIRST_CLASS:

--- a/tests/app/clients/test_dvla.py
+++ b/tests/app/clients/test_dvla.py
@@ -455,9 +455,9 @@ def test_format_create_print_job_json_adds_callback_key_if_url_provided(dvla_cli
         callback_url="https://www.example.com?token=1234",
     )
 
-    assert formatted_json["callback"] == {
+    assert formatted_json["callbackParams"] == {
         "target": "https://www.example.com?token=1234",
-        "retry": {"enabled": True, "maxRetryWindow": 3600},
+        "retryParams": {"enabled": True, "maxRetryWindow": 10800},
     }
 
 
@@ -571,9 +571,9 @@ def test_send_domestic_letter(dvla_client, dvla_authenticate, rmock):
             {"key": "organisationIdentifier", "value": "org_id"},
             {"key": "serviceIdentifier", "value": "service_id"},
         ],
-        "callback": {
+        "callbackParams": {
             "target": "https://www.example.com?token=1234",
-            "retry": {"enabled": True, "maxRetryWindow": 3600},
+            "retryParams": {"enabled": True, "maxRetryWindow": 10800},
         },
     }
 


### PR DESCRIPTION
This changes the JSON keys to match the new names that the DVLA will use. It also changes the value of the retry window to be the default value for their API.