### PR TITLE
Add process unsubscribe request report endpoint

### DIFF
--- a/app/dao/unsubscribe_request_dao.py
+++ b/app/dao/unsubscribe_request_dao.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from sqlalchemy import desc, func
 
 from app import db
@@ -57,6 +59,10 @@ def get_unsubscribe_request_reports_dao(service_id):
     )
 
 
+def get_unsubscribe_request_report_by_id_dao(batch_id):
+    return UnsubscribeRequestReport.query.filter_by(id=batch_id).one_or_none()
+
+
 def get_unbatched_unsubscribe_requests_dao(service_id):
     return (
         UnsubscribeRequest.query.filter_by(service_id=service_id, unsubscribe_request_report_id=None)
@@ -68,3 +74,9 @@ def get_unbatched_unsubscribe_requests_dao(service_id):
 @autocommit
 def create_unsubscribe_request_reports_dao(unsubscribe_request_report):
     db.session.add(unsubscribe_request_report)
+
+
+@autocommit
+def update_unsubscribe_request_report_processed_by_date_dao(report):
+    report.processed_by_service_at = datetime.utcnow()
+    db.session.add(report)

--- a/app/dao/unsubscribe_request_dao.py
+++ b/app/dao/unsubscribe_request_dao.py
@@ -77,6 +77,6 @@ def create_unsubscribe_request_reports_dao(unsubscribe_request_report):
 
 
 @autocommit
-def update_unsubscribe_request_report_processed_by_date_dao(report):
-    report.processed_by_service_at = datetime.utcnow()
+def update_unsubscribe_request_report_processed_by_date_dao(report, report_has_been_processed):
+    report.processed_by_service_at = datetime.utcnow() if report_has_been_processed else None
     db.session.add(report)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1106,6 +1106,19 @@ def get_unsubscribe_requests_statistics(service_id):
     return jsonify(data), 200
 
 
+@service_blueprint.route("/<uuid:service_id>/process-unsubscribe-request-report/<uuid:batch_id>", methods=["POST"])
+def process_unsubscribe_request_report(service_id, batch_id):
+    """
+    This endpoint processes unsubscribe_request_reports by updating the processed_by_service_at
+    field
+    """
+    report = get_unsubscribe_request_reports_by_id_dao(batch_id)
+    report.processed_by_service_at = datetime.utcnow()
+    update_unsubscribe_request_report_dao(report)
+
+    return "", 204
+
+
 @service_blueprint.route("/<uuid:service_id>/contact-list", methods=["GET"])
 def get_contact_list(service_id):
     contact_lists = dao_get_contact_lists(service_id)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1114,9 +1114,15 @@ def process_unsubscribe_request_report(service_id, batch_id):
     This endpoint processes unsubscribe_request_reports by updating the processed_by_service_at
     field
     """
-    report = get_unsubscribe_request_report_by_id_dao(batch_id)
-    if report:
-        update_unsubscribe_request_report_processed_by_date_dao(report)
+    if data := request.get_json():
+        report_has_been_processed = data["report_has_been_processed"]
+    else:
+        raise InvalidRequest(
+            message={"marked_as_completed": "missing data for required field"},
+            status_code=400,
+        )
+    if report := get_unsubscribe_request_report_by_id_dao(batch_id):
+        update_unsubscribe_request_report_processed_by_date_dao(report, report_has_been_processed)
     else:
         raise InvalidRequest(
             message={"batch_id": f"No UnsubscribeRequestReport found for id:{batch_id}"},

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -100,7 +100,9 @@ from app.dao.services_dao import (
 from app.dao.templates_dao import dao_get_template_by_id
 from app.dao.unsubscribe_request_dao import (
     get_latest_unsubscribe_request_date_dao,
+    get_unsubscribe_request_report_by_id_dao,
     get_unsubscribe_requests_statistics_dao,
+    update_unsubscribe_request_report_processed_by_date_dao,
 )
 from app.dao.users_dao import get_user_by_id
 from app.errors import InvalidRequest, register_errors
@@ -1112,9 +1114,14 @@ def process_unsubscribe_request_report(service_id, batch_id):
     This endpoint processes unsubscribe_request_reports by updating the processed_by_service_at
     field
     """
-    report = get_unsubscribe_request_reports_by_id_dao(batch_id)
-    report.processed_by_service_at = datetime.utcnow()
-    update_unsubscribe_request_report_dao(report)
+    report = get_unsubscribe_request_report_by_id_dao(batch_id)
+    if report:
+        update_unsubscribe_request_report_processed_by_date_dao(report)
+    else:
+        raise InvalidRequest(
+            message={"batch_id": f"No UnsubscribeRequestReport found for id:{batch_id}"},
+            status_code=400,
+        )
 
     return "", 204
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3687,16 +3687,29 @@ def test_process_unsubscribe_request_report(admin_request, sample_service):
         service_id=sample_service.id,
     )
     create_unsubscribe_request_reports_dao(unsubscribe_request_report)
-    admin_request.post("service.process_unsubscribe_request_report",
-                       service_id=sample_service.id,
-                       batch_id=unsubscribe_request_report.id,
-                       _expected_status=204,
-                       _data=None,
-                       )
-    updated_unsubscribe_request_report = UnsubscribeRequestReport.query.filter_by(id=unsubscribe_request_report.id)\
-        .one()
+    admin_request.post(
+        "service.process_unsubscribe_request_report",
+        service_id=sample_service.id,
+        batch_id=unsubscribe_request_report.id,
+        _expected_status=204,
+        _data=None,
+    )
+    updated_unsubscribe_request_report = UnsubscribeRequestReport.query.filter_by(
+        id=unsubscribe_request_report.id
+    ).one()
     assert updated_unsubscribe_request_report.id == unsubscribe_request_report.id
     assert updated_unsubscribe_request_report.processed_by_service_at == datetime.utcnow()
+
+
+def test_process_unsubscribe_request_report_raises_error_for_invalid_batch_id(admin_request, sample_service):
+    random_batch_id = "258de158-07d3-457b-8eec-3e0e3bdab3bf"
+    admin_request.post(
+        "service.process_unsubscribe_request_report",
+        service_id=sample_service.id,
+        batch_id=random_batch_id,
+        _expected_status=400,
+        _data=None,
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds a `process_unsubscribe_request_report` endpoint which supports the work done in [this](https://github.com/alphagov/notifications-admin/pull/5152) PR to facilitate a user being able to mark an `unsubscribe_request_report` as completed by updating the `processed_by_service_at` value of an `unsubscribe_request_report` as described in [this](https://trello.com/c/5hJS5Oia/54-let-users-mark-email-unsubscribe-requests-as-completed) card.