### PR TITLE
Add unsubscribe link to body of emails

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -125,15 +125,21 @@ def send_email_to_provider(notification):
             template_id=notification.template_id, service_id=service.id, version=notification.template_version
         )
 
+        unsubscribe_link_for_body = notification.get_unsubscribe_link_for_body(
+            template_has_unsubscribe_link=template.has_unsubscribe_link
+        )
+
         html_email = HTMLEmailTemplate(
             template.__dict__,
             values=notification.personalisation,
+            unsubscribe_link=unsubscribe_link_for_body,
             **get_html_email_options(service),
         )
 
         plain_text_email = PlainTextEmailTemplate(
             template.__dict__,
             values=notification.personalisation,
+            unsubscribe_link=unsubscribe_link_for_body,
         )
         created_at = notification.created_at
         key_type = notification.key_type

--- a/app/models.py
+++ b/app/models.py
@@ -1751,15 +1751,22 @@ class Notification(db.Model):
 
         return letter_rate
 
+    def _generate_unsubscribe_link(self, base_url):
+        return url_with_token(
+            self.to,
+            url=f"/unsubscribe/{str(self.id)}/",
+            base_url=base_url,
+        )
+
     def get_unsubscribe_link_for_headers(self, *, template_has_unsubscribe_link):
         if self.unsubscribe_link:
             return self.unsubscribe_link
         if template_has_unsubscribe_link:
-            return url_with_token(
-                self.to,
-                url=f"/unsubscribe/{str(self.id)}/",
-                base_url=current_app.config["API_HOST_NAME"],
-            )
+            return self._generate_unsubscribe_link(current_app.config["API_HOST_NAME"])
+
+    def get_unsubscribe_link_for_body(self, *, template_has_unsubscribe_link):
+        if template_has_unsubscribe_link:
+            return self._generate_unsubscribe_link(current_app.config["ADMIN_BASE_URL"])
 
 
 class NotificationHistory(db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -1759,12 +1759,19 @@ class Notification(db.Model):
         )
 
     def get_unsubscribe_link_for_headers(self, *, template_has_unsubscribe_link):
+        """
+        Generates a URL on the API domain, which accepts a POST request from an email client
+        """
         if self.unsubscribe_link:
             return self.unsubscribe_link
         if template_has_unsubscribe_link:
             return self._generate_unsubscribe_link(current_app.config["API_HOST_NAME"])
 
     def get_unsubscribe_link_for_body(self, *, template_has_unsubscribe_link):
+        """
+        Generates a URL on the admin domain, which serves a page telling the user they
+        have been unsubscribed
+        """
         if template_has_unsubscribe_link:
             return self._generate_unsubscribe_link(current_app.config["ADMIN_BASE_URL"])
 

--- a/app/models.py
+++ b/app/models.py
@@ -77,6 +77,7 @@ from app.utils import (
     DATETIME_FORMAT_NO_TIMEZONE,
     get_dt_string_or_none,
     get_uuid_string_or_none,
+    url_with_token,
 )
 
 
@@ -1622,7 +1623,9 @@ class Notification(db.Model):
             "completed_at": self.completed_at(),
             "scheduled_for": None,
             "postage": self.postage,
-            "one_click_unsubscribe_url": self.unsubscribe_link,
+            "one_click_unsubscribe_url": self.get_unsubscribe_link_for_headers(
+                template_has_unsubscribe_link=self.template.has_unsubscribe_link
+            ),
         }
 
         if self.notification_type == LETTER_TYPE:
@@ -1747,6 +1750,16 @@ class Notification(db.Model):
         )
 
         return letter_rate
+
+    def get_unsubscribe_link_for_headers(self, *, template_has_unsubscribe_link):
+        if self.unsubscribe_link:
+            return self.unsubscribe_link
+        if template_has_unsubscribe_link:
+            return url_with_token(
+                self.to,
+                url=f"/unsubscribe/{str(self.id)}/",
+                base_url=current_app.config["API_HOST_NAME"],
+            )
 
 
 class NotificationHistory(db.Model):

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -36,7 +36,6 @@ from app.dao.notifications_dao import (
     dao_delete_notifications_by_id,
 )
 from app.models import Notification
-from app.utils import url_with_token
 from app.v2.errors import BadRequestError, QrCodeTooLongError
 
 REDIS_GET_AND_INCR_DAILY_LIMIT_DURATION_SECONDS = Histogram(
@@ -124,11 +123,6 @@ def persist_notification(
     notification_created_at = created_at or datetime.utcnow()
     if not notification_id:
         notification_id = uuid.uuid4()
-
-    if template_has_unsubscribe_link and not unsubscribe_link:
-        base_url = current_app.config["API_HOST_NAME"]
-        url = f"/unsubscribe/{str(notification_id)}/"
-        unsubscribe_link = url_with_token(recipient, url=url, base_url=base_url)
 
     notification = Notification(
         id=notification_id,

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ lxml==4.9.3
 notifications-python-client==8.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.2.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.2.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from collections import namedtuple
 from datetime import datetime, timedelta
-from unittest.mock import ANY
+from unittest.mock import ANY, call
 
 import pytest
 from flask import current_app
@@ -843,10 +843,25 @@ def test_get_html_email_options_add_email_branding_from_service(sample_service):
     }
 
 
-def test_send_email_to_provider_sends_unsubscribe_link(sample_email_template, mocker):
+@pytest.mark.parametrize(
+    "template_has_unsubscribe_link",
+    (
+        # If the notification has an unsubscribe link it shouldn’t matter what the
+        # setting on the template is
+        True,
+        False,
+    ),
+)
+def test_send_email_to_provider_sends_unsubscribe_link(sample_service, mocker, template_has_unsubscribe_link):
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
 
-    db_notification = create_notification(template=sample_email_template, unsubscribe_link="https://example.com")
+    template = create_template(
+        service=sample_service,
+        template_type="email",
+        has_unsubscribe_link=template_has_unsubscribe_link,
+    )
+
+    db_notification = create_notification(template=template, unsubscribe_link="https://example.com")
 
     expected_headers = [
         {"Name": "List-Unsubscribe", "Value": "<https://example.com>"},
@@ -858,3 +873,31 @@ def test_send_email_to_provider_sends_unsubscribe_link(sample_email_template, mo
     )
     app.aws_ses_client.send_email.assert_called_once()
     assert app.aws_ses_client.send_email.call_args[1]["headers"] == expected_headers
+
+
+def test_send_email_to_provider_sends_unsubscribe_link_if_template_is_unsubscribable(sample_service, mocker):
+    mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mock_url_with_token = mocker.patch(
+        "app.models.url_with_token",
+        return_value="https://api.notify.example.com",
+    )
+
+    template = create_template(
+        service=sample_service,
+        template_type="email",
+        has_unsubscribe_link=True,
+    )
+
+    db_notification = create_notification(template=template)
+
+    send_to_providers.send_email_to_provider(db_notification)
+    app.aws_ses_client.send_email.assert_called_once()
+
+    assert mock_url_with_token.call_args_list == [
+        call("test@example.com", url=f"/unsubscribe/{db_notification.id}/", base_url="http://localhost:6011"),
+    ]
+
+    assert app.aws_ses_client.send_email.call_args[1]["headers"] == [
+        {"Name": "List-Unsubscribe", "Value": "<https://api.notify.example.com>"},
+        {"Name": "List-Unsubscribe-Post", "Value": "List-Unsubscribe=One-Click"},
+    ]

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -635,6 +635,7 @@ def test_persist_notification_when_template_has_unsubscribe_link_is_false(
     "unsubscribe_link, expected_unsubscribe_link",
     [
         ("https://please-unsubscribe-me.com/unsubscribe", "https://please-unsubscribe-me.com/unsubscribe"),
+        # We don’t persist template-level unsubscribe links – they are generated at time of sending
         (None, None),
     ],
 )

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -612,11 +612,6 @@ def test_persist_notification_when_template_has_unsubscribe_link_is_false(
     sample_job.service = template.service
     recipient = "foo@bar.com"
 
-    mocker.patch(
-        "app.notifications.process_notifications.url_with_token",
-        return_value="https://notify-generated-super-unsubscribe-link.com/unsubscribe",
-    )
-
     persist_notification(
         notification_id=uuid.uuid4(),
         template_id=sample_job.template.id,
@@ -640,7 +635,7 @@ def test_persist_notification_when_template_has_unsubscribe_link_is_false(
     "unsubscribe_link, expected_unsubscribe_link",
     [
         ("https://please-unsubscribe-me.com/unsubscribe", "https://please-unsubscribe-me.com/unsubscribe"),
-        (None, "https://notify-generated-super-unsubscribe-link.com/unsubscribe"),
+        (None, None),
     ],
 )
 def test_persist_notification_when_template_has_unsubscribe_link_is_true(
@@ -660,11 +655,6 @@ def test_persist_notification_when_template_has_unsubscribe_link_is_true(
     job = create_job(template=template)
 
     recipient = "foo@bar.com"
-
-    mocker.patch(
-        "app.notifications.process_notifications.url_with_token",
-        return_value="https://notify-generated-super-unsubscribe-link.com/unsubscribe",
-    )
 
     persist_notification(
         notification_id=uuid.uuid4(),


### PR DESCRIPTION
Best reviewed commit-by-commit.

# Generate unsubscribe link at time of sending

When  a user has provided us an unsubscribe link through an API call we need to store it. But where we are generating the link we don’t need to store it, because we already store all the information needed to generate it.

By not storing it we make it easy to differentiate which notifications have user-supplied unsubscribe links and which have ones which we are generating.

# Add unsubscribe link to body of emails

We have started sending list-unsubscribe headers if a user marks a template as unsubscribeable, for teams who aren’t using the API.

However we are already telling these teams to add unsubscribe links to the body of their emails.

This means:

- there are two different ways to add unsubscribe links
- users will have to manage requests to unsubscribe coming from two different places

This will be confusing, and make it harder for us to write good guidance that users will be able to follow, and harder to explain what the ‘let users unsubscribe from these emails’ checkbox does.

If we have a confusing product proposition and users cant follow our guidance then we risk our spam score rising.

This commit adds a way to generate a separate unsubscribe link which we can add to the footer of every email (using the argument added in https://github.com/alphagov/notifications-utils/pull/1136)

We can then report unsubscribes back to the team in the same way, no matter if the recipient has clicked the button in their email client or the link at the end of the email.

***

If the user has checked the checkbox then we will always show the link in the body of the email (this feels like the most predictable behaviour). If they have also passed in a one-click URL for the headers then we will respect that too.

The only combination which isn’t possible is using Notify’s generated URL for one-click, and your own in the body of the email. This feels like the most unlikely combination.

***

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/1136