### PR TITLE
Fix reference to ‘unprocessed’ unsubscribe requests

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1094,7 +1094,7 @@ def get_unsubscribe_requests_statistics(service_id):
     data = {}
     if unsubscribe_statistics := get_unsubscribe_requests_statistics_dao(service_id):
         data = {
-            "unsubscribe_requests_count": unsubscribe_statistics.unprocessed_unsubscribe_requests_count,
+            "unsubscribe_requests_count": unsubscribe_statistics.unsubscribe_requests_count,
             "datetime_of_latest_unsubscribe_request": unsubscribe_statistics.datetime_of_latest_unsubscribe_request,
         }
     elif latest_unsubscribe_request := get_latest_unsubscribe_request_date_dao(service_id):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3645,13 +3645,13 @@ def test_get_unsubscribe_request_reports_summary(admin_request, sample_service, 
 def test_get_unsubscribe_requests_statistics(admin_request, sample_service, mocker):
     MockUnsubscribeRequest = namedtuple(
         "MockUnsubscribeRequest",
-        ["unprocessed_unsubscribe_requests_count", "service_id", "datetime_of_latest_unsubscribe_request"],
+        ["unsubscribe_requests_count", "service_id", "datetime_of_latest_unsubscribe_request"],
     )
     test_data = MockUnsubscribeRequest(0, "2fed1b45-66e1-4682-a389-85d0d50a916f", "Thu, 18 Jul 2024 15:32:28 GMT")
 
     mocker.patch("app.service.rest.get_unsubscribe_requests_statistics_dao", return_value=test_data)
     response = admin_request.get("service.get_unsubscribe_requests_statistics", service_id=sample_service.id)
-    assert response["unsubscribe_requests_count"] == test_data.unprocessed_unsubscribe_requests_count
+    assert response["unsubscribe_requests_count"] == test_data.unsubscribe_requests_count
     assert response["datetime_of_latest_unsubscribe_request"] == test_data.datetime_of_latest_unsubscribe_request
 
 


### PR DESCRIPTION
We changed the query and renamed this column, but missed changing the reference here.