### PR TITLE
Enable download of unsubscribe request reports

### DIFF
--- a/app/dao/unsubscribe_request_dao.py
+++ b/app/dao/unsubscribe_request_dao.py
@@ -63,7 +63,7 @@ def get_unsubscribe_request_report_by_id_dao(batch_id):
     return UnsubscribeRequestReport.query.filter_by(id=batch_id).one_or_none()
 
 
-def get_unsubscribe_request_report_for_download_dao(service_id, batch_id):
+def get_unsubscribe_requests_data_for_download_dao(service_id, batch_id):
     results = []
     for table in [Notification, NotificationHistory]:
         query = (
@@ -85,7 +85,6 @@ def get_unsubscribe_request_report_for_download_dao(service_id, batch_id):
             .order_by(desc(Template.name), desc(Job.original_file_name), desc(table.sent_at))
         )
         results = results + query.all()
-    results = sorted(results, key=lambda i: i.created_at, reverse=True)
     return results
 
 

--- a/app/dao/unsubscribe_request_dao.py
+++ b/app/dao/unsubscribe_request_dao.py
@@ -110,15 +110,12 @@ def update_unsubscribe_request_report_processed_by_date_dao(report, report_has_b
 @autocommit
 def assign_unbatched_unsubscribe_requests_to_report_dao(report_id, service_id, earliest_timestamp, latest_timestamp):
     """
-    This method retrieves all the un-batched unsubscribe requests received before or on
-    the report's latest_timestamp and sets their unsubscribe_request_report_id to the report_i
+    This method updates the unsubscribe_request_report_id of all un-batched unsubscribe requests that fall
+    within the earliest_timestamp and latest_timestamp values to report_id
     """
-    unbatched_unsubscribe_requests = UnsubscribeRequest.query.filter(
+    UnsubscribeRequest.query.filter(
         UnsubscribeRequest.unsubscribe_request_report_id.is_(None),
         UnsubscribeRequest.service_id == service_id,
         UnsubscribeRequest.created_at >= earliest_timestamp,
         UnsubscribeRequest.created_at <= latest_timestamp,
-    ).all()
-    for unsubscribe_request in unbatched_unsubscribe_requests:
-        unsubscribe_request.unsubscribe_request_report_id = report_id
-        db.session.add(unsubscribe_request)
+    ).update({"unsubscribe_request_report_id": report_id})

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -109,7 +109,7 @@ from app.dao.unsubscribe_request_dao import (
     create_unsubscribe_request_reports_dao,
     get_latest_unsubscribe_request_date_dao,
     get_unsubscribe_request_reports_by_id_dao,
-    get_unsubscribe_requests_statistics_dao,
+    get_unsubscribe_requests_statistics_dao, get_unsubscribe_requests_data_for_download_dao,
 )
 from app.dao.users_dao import get_user_by_id
 from app.errors import InvalidRequest, register_errors
@@ -1181,18 +1181,16 @@ def get_unsubscribe_request_report_for_download(service_id, batch_id):
             "batch_id": report.id,
             "earliest_timestamp": report.earliest_timestamp,
             "latest_timestamp": report.latest_timestamp,
-            "unsubscribe_requests": sorted(
+            "unsubscribe_requests":
                 [
                     {
                         "email_address": unsubscribe_request.email_address,
-                        "template_name": unsubscribe_request.template.name,
-                        "template_sent_at": unsubscribe_request.notification.sent_at,
+                        "template_name": unsubscribe_request.template_name,
+                        "original_file_name": unsubscribe_request.original_file_name,
+                        "template_sent_at": unsubscribe_request.template_sent_at,
                     }
-                    for get_unsubscribe_request_report_for_download_dao(unsubscribe_request.id) in report.unsubscribe_requests
+                    for unsubscribe_request in get_unsubscribe_requests_data_for_download_dao(service_id, report.id)
                 ],
-                key=lambda row: row["template_sent_at"],
-                reverse=True,
-            ),
         }
         return jsonify(data), 200
     else:

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -100,16 +100,13 @@ from app.dao.services_dao import (
 )
 from app.dao.templates_dao import dao_get_template_by_id
 from app.dao.unsubscribe_request_dao import (
-    get_latest_unsubscribe_request_date_dao,
-    get_unsubscribe_request_report_by_id_dao,
-    get_unsubscribe_requests_statistics_dao,
-    update_unsubscribe_request_report_processed_by_date_dao,
-    get_unsubscribe_requests_statistics_dao, create_unsubscribe_request_reports_dao,
     assign_unbatched_unsubscribe_requests_to_report_dao,
     create_unsubscribe_request_reports_dao,
     get_latest_unsubscribe_request_date_dao,
-    get_unsubscribe_request_reports_by_id_dao,
-    get_unsubscribe_requests_statistics_dao, get_unsubscribe_requests_data_for_download_dao,
+    get_unsubscribe_request_report_by_id_dao,
+    get_unsubscribe_requests_data_for_download_dao,
+    get_unsubscribe_requests_statistics_dao,
+    update_unsubscribe_request_report_processed_by_date_dao,
 )
 from app.dao.users_dao import get_user_by_id
 from app.errors import InvalidRequest, register_errors
@@ -1169,28 +1166,27 @@ def create_unsubscribe_request_report(service_id):
         )
     else:
         raise InvalidRequest(
-            message="summary data needed to create an unsubscribe request report is missing",
+            message={"summary_data": "summary data needed to create an unsubscribe request report is missing"},
             status_code=400,
         )
 
 
 @service_blueprint.route("/<uuid:service_id>/unsubscribe-request-report/<uuid:batch_id>", methods=["GET"])
 def get_unsubscribe_request_report_for_download(service_id, batch_id):
-    if report := get_unsubscribe_request_reports_by_id_dao(batch_id):
+    if report := get_unsubscribe_request_report_by_id_dao(batch_id):
         data = {
             "batch_id": report.id,
             "earliest_timestamp": report.earliest_timestamp,
             "latest_timestamp": report.latest_timestamp,
-            "unsubscribe_requests":
-                [
-                    {
-                        "email_address": unsubscribe_request.email_address,
-                        "template_name": unsubscribe_request.template_name,
-                        "original_file_name": unsubscribe_request.original_file_name,
-                        "template_sent_at": unsubscribe_request.template_sent_at,
-                    }
-                    for unsubscribe_request in get_unsubscribe_requests_data_for_download_dao(service_id, report.id)
-                ],
+            "unsubscribe_requests": [
+                {
+                    "email_address": unsubscribe_request.email_address,
+                    "template_name": unsubscribe_request.template_name,
+                    "original_file_name": unsubscribe_request.original_file_name,
+                    "template_sent_at": unsubscribe_request.template_sent_at,
+                }
+                for unsubscribe_request in get_unsubscribe_requests_data_for_download_dao(service_id, report.id)
+            ],
         }
         return jsonify(data), 200
     else:

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1169,6 +1169,31 @@ def create_unsubscribe_request_report(service_id):
         )
 
 
+@service_blueprint.route("/<uuid:service_id>/unsubscribe-request-report/<uuid:batch_id>", methods=["GET"])
+def get_unsubscribe_request_report_for_download(service_id, batch_id):
+    report = get_unsubscribe_request_reports_by_id_dao(batch_id)
+    data = {
+        "batch_id": report.id,
+        "earliest_timestamp": report.earliest_timestamp,
+        "latest_timestamp": report.latest_timestamp,
+        "unsubscribe_requests": sorted(
+            [
+                {
+                    "email_address": unsubscribe_request.email_address,
+                    "template_name": unsubscribe_request.template.name,
+                    "sent_at": unsubscribe_request.notification.sent_at,
+                }
+                for unsubscribe_request in report.unsubscribe_requests
+            ],
+            key=lambda row: row["sent_at"],
+            reverse=True,
+        ),
+    }
+    return jsonify(data), 200
+
+
+
+
 @service_blueprint.route("/<uuid:service_id>/contact-list", methods=["GET"])
 def get_contact_list(service_id):
     contact_lists = dao_get_contact_lists(service_id)

--- a/tests/app/dao/test_unsubscribe_request_dao.py
+++ b/tests/app/dao/test_unsubscribe_request_dao.py
@@ -1,10 +1,11 @@
 from app.constants import EMAIL_TYPE
 from app.dao.unsubscribe_request_dao import (
+    assign_unbatched_unsubscribe_requests_to_report_dao,
     create_unsubscribe_request_dao,
     create_unsubscribe_request_reports_dao,
     get_latest_unsubscribe_request_date_dao,
     get_unsubscribe_request_by_notification_id_dao,
-    get_unsubscribe_requests_statistics_dao, assign_unbatched_unsubscribe_requests_to_report_dao,
+    get_unsubscribe_requests_statistics_dao,
 )
 from app.models import UnsubscribeRequest, UnsubscribeRequestReport
 from app.one_click_unsubscribe.rest import get_unsubscribe_request_data

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3854,8 +3854,7 @@ def test_get_unsubscribe_request_report_for_download(admin_request, sample_servi
     )
     unsubscribe_requests = sorted(
         UnsubscribeRequest.query.filter_by(service_id=sample_service.id).all(),
-        key=lambda row: row.notification.sent_at,
-        reverse=True,
+        key=lambda row: row.template.name, reverse=True,
     )
     date_format = "%a, %d %b %Y %H:%M:%S"
     assert response["batch_id"] == str(unsubscribe_request_report.id)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3769,7 +3769,15 @@ def test_create_unsubscribe_request_report(sample_service, admin_request, mocker
     mock_assign_unbatched_requests.assert_called_once_with(
         report_id=created_unsubscribe_request_report.id,
         service_id=created_unsubscribe_request_report.service_id,
+        earliest_timestamp=created_unsubscribe_request_report.earliest_timestamp,
         latest_timestamp=created_unsubscribe_request_report.latest_timestamp,
+    )
+
+
+def test_create_unsubscribe_request_report_raises_error_for_no_summary_data(sample_service, admin_request, mocker):
+    response = admin_request.post(
+        "service.create_unsubscribe_request_report", service_id=sample_service.id, _data=None,
+        _expected_status=400
     )
 
 


### PR DESCRIPTION
This PR adds the endpoints to support downloading an `unsubscribe-request-report` as described in [this](https://trello.com/c/BeZGTW0E/53-let-users-download-email-unsubscribe-requests) card.