### PR TITLE
Tweak start and end dates of unsubscribe request reports

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2676,6 +2676,27 @@ class UnsubscribeRequestReport(db.Model):
     processed_by_service_at = db.Column(db.DateTime, nullable=True)
     count = db.Column(db.BigInteger, nullable=False)
 
+    def serialize(self):
+        return {
+            "batch_id": str(self.id),
+            "count": self.count,
+            "earliest_timestamp": self.earliest_timestamp.isoformat(),
+            "latest_timestamp": self.latest_timestamp.isoformat(),
+            "processed_by_service_at": self.processed_by_service_at.isoformat(),
+            "is_a_batched_report": True,
+        }
+
+    @staticmethod
+    def serialize_unbatched_requests(self, unbatched_unsubscribe_requests):
+        return {
+            "batch_id": None,
+            "count": len(unbatched_unsubscribe_requests),
+            "earliest_timestamp": unbatched_unsubscribe_requests[-1].created_at.isoformat(),
+            "latest_timestamp": unbatched_unsubscribe_requests[0].created_at.isoformat(),
+            "processed_by_service_at": None,
+            "is_a_batched_report": False,
+        }
+
 
 class UnsubscribeRequest(db.Model):
     __tablename__ = "unsubscribe_request"

--- a/app/models.py
+++ b/app/models.py
@@ -2682,7 +2682,9 @@ class UnsubscribeRequestReport(db.Model):
             "count": self.count,
             "earliest_timestamp": self.earliest_timestamp.isoformat(),
             "latest_timestamp": self.latest_timestamp.isoformat(),
-            "processed_by_service_at": self.processed_by_service_at.isoformat(),
+            "processed_by_service_at": (
+                self.processed_by_service_at.isoformat() if self.processed_by_service_at else None
+            ),
             "is_a_batched_report": True,
         }
 

--- a/app/models.py
+++ b/app/models.py
@@ -2687,7 +2687,7 @@ class UnsubscribeRequestReport(db.Model):
         }
 
     @staticmethod
-    def serialize_unbatched_requests(self, unbatched_unsubscribe_requests):
+    def serialize_unbatched_requests(unbatched_unsubscribe_requests):
         return {
             "batch_id": None,
             "count": len(unbatched_unsubscribe_requests),

--- a/app/one_click_unsubscribe/rest.py
+++ b/app/one_click_unsubscribe/rest.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from flask import Blueprint, current_app, jsonify
 from itsdangerous import BadData
 from notifications_utils.url_safe_token import check_token
@@ -74,14 +72,8 @@ def create_unsubscribe_request_reports_summary(service_id):
         batched_unsubscribe_reports_summary = batched_unsubscribe_reports_summary
     # Check for unsubscribe requests and create a summary for them
     if unbatched_unsubscribe_requests := get_unbatched_unsubscribe_requests_dao(service_id):
-        if batched_unsubscribe_reports_summary:
-            earliest_timestamp = batched_unsubscribe_reports_summary[0]["latest_timestamp"]
-        else:
-
-            earliest_timestamp = unbatched_unsubscribe_requests[0].created_at
-
         unbatched_unsubscribe_report_summary.append(
-            _create_unbatched_unsubscribe_request_report_summary(unbatched_unsubscribe_requests, earliest_timestamp)
+            _create_unbatched_unsubscribe_request_report_summary(unbatched_unsubscribe_requests)
         )
     reports_summary = unbatched_unsubscribe_report_summary + batched_unsubscribe_reports_summary
 
@@ -94,9 +86,9 @@ def _create_batched_unsubscribe_request_reports_summary(unsubscribe_request_repo
         report_summary = {
             "batch_id": str(report.id),
             "count": report.count,
-            "earliest_timestamp": report.earliest_timestamp,
-            "latest_timestamp": report.latest_timestamp,
-            "processed_by_service_at": report.processed_by_service_at,
+            "earliest_timestamp": report.earliest_timestamp.isoformat(),
+            "latest_timestamp": report.latest_timestamp.isoformat(),
+            "processed_by_service_at": report.processed_by_service_at.isoformat(),
             "is_a_batched_report": True,
         }
         report_summaries.append(report_summary)
@@ -110,8 +102,8 @@ def _create_unbatched_unsubscribe_request_report_summary(
     report_summary = {
         "batch_id": None,
         "count": count,
-        "earliest_timestamp": earliest_timestamp,
-        "latest_timestamp": datetime.utcnow(),
+        "earliest_timestamp": unbatched_unsubscribe_requests[-1].created_at.isoformat(),
+        "latest_timestamp": unbatched_unsubscribe_requests[0].created_at.isoformat(),
         "processed_by_service_at": None,
         "is_a_batched_report": False,
     }

--- a/app/one_click_unsubscribe/rest.py
+++ b/app/one_click_unsubscribe/rest.py
@@ -11,6 +11,7 @@ from app.dao.unsubscribe_request_dao import (
     get_unsubscribe_request_reports_dao,
 )
 from app.errors import InvalidRequest, register_errors
+from app.models import UnsubscribeRequestReport
 
 one_click_unsubscribe_blueprint = Blueprint("one_click_unsubscribe", __name__)
 
@@ -81,30 +82,8 @@ def create_unsubscribe_request_reports_summary(service_id):
 
 
 def _create_batched_unsubscribe_request_reports_summary(unsubscribe_request_reports: list) -> list:
-    report_summaries = []
-    for report in unsubscribe_request_reports:
-        report_summary = {
-            "batch_id": str(report.id),
-            "count": report.count,
-            "earliest_timestamp": report.earliest_timestamp.isoformat(),
-            "latest_timestamp": report.latest_timestamp.isoformat(),
-            "processed_by_service_at": report.processed_by_service_at.isoformat(),
-            "is_a_batched_report": True,
-        }
-        report_summaries.append(report_summary)
-    return report_summaries
+    return [report.serialize() for report in unsubscribe_request_reports]
 
 
-def _create_unbatched_unsubscribe_request_report_summary(
-    unbatched_unsubscribe_requests: list, earliest_timestamp: str = None
-) -> dict:
-    count = len(unbatched_unsubscribe_requests)
-    report_summary = {
-        "batch_id": None,
-        "count": count,
-        "earliest_timestamp": unbatched_unsubscribe_requests[-1].created_at.isoformat(),
-        "latest_timestamp": unbatched_unsubscribe_requests[0].created_at.isoformat(),
-        "processed_by_service_at": None,
-        "is_a_batched_report": False,
-    }
-    return report_summary
+def _create_unbatched_unsubscribe_request_report_summary(unbatched_unsubscribe_requests: list) -> dict:
+    return UnsubscribeRequestReport.serialize_unbatched_requests(unbatched_unsubscribe_requests)

--- a/app/one_click_unsubscribe/rest.py
+++ b/app/one_click_unsubscribe/rest.py
@@ -62,28 +62,11 @@ def get_unsubscribe_request_data(notification, email_address):
 
 
 def create_unsubscribe_request_reports_summary(service_id):
-    reports_summary = []
-    batched_unsubscribe_reports_summary = []
-    unbatched_unsubscribe_report_summary = []
-    # Check for existing unsubscribe reports and create their summaries
-    if unsubscribe_request_reports := get_unsubscribe_request_reports_dao(service_id):
-        batched_unsubscribe_reports_summary = _create_batched_unsubscribe_request_reports_summary(
-            unsubscribe_request_reports,
-        )
-        batched_unsubscribe_reports_summary = batched_unsubscribe_reports_summary
-    # Check for unsubscribe requests and create a summary for them
+    unsubscribe_request_reports = [report.serialize() for report in get_unsubscribe_request_reports_dao(service_id)]
+
     if unbatched_unsubscribe_requests := get_unbatched_unsubscribe_requests_dao(service_id):
-        unbatched_unsubscribe_report_summary.append(
-            _create_unbatched_unsubscribe_request_report_summary(unbatched_unsubscribe_requests)
-        )
-    reports_summary = unbatched_unsubscribe_report_summary + batched_unsubscribe_reports_summary
+        return [
+            UnsubscribeRequestReport.serialize_unbatched_requests(unbatched_unsubscribe_requests)
+        ] + unsubscribe_request_reports
 
-    return reports_summary
-
-
-def _create_batched_unsubscribe_request_reports_summary(unsubscribe_request_reports: list) -> list:
-    return [report.serialize() for report in unsubscribe_request_reports]
-
-
-def _create_unbatched_unsubscribe_request_report_summary(unbatched_unsubscribe_requests: list) -> dict:
-    return UnsubscribeRequestReport.serialize_unbatched_requests(unbatched_unsubscribe_requests)
+    return unsubscribe_request_reports

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1084,8 +1084,7 @@ def get_unsubscribe_request_reports_summary(service_id):
     return: reports_summary = []
 
     """
-    reports_summary = create_unsubscribe_request_reports_summary(service_id)
-    return jsonify(reports_summary)
+    return jsonify(create_unsubscribe_request_reports_summary(service_id))
 
 
 @service_blueprint.route("/<uuid:service_id>/unsubscribe-request-statistics", methods=["GET"])

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1075,12 +1075,9 @@ def get_unsubscribe_request_reports_summary(service_id):
     This returns report summaries for both batched and un-batched unsubscribe requests.
 
     In the case of un-batched unsubscribe requests:
-    is_a_batched_result has a value of False.
-    The latest earliest_timestamp value is the date the user views the summary
-    The earliest_timestamp value is either:
-        i. the latest_timestamp of the last existing unsubscribe_request_report
-        or
-        ii. the date of the earliest unsubscribe request in the report.
+    - is_a_batched_result has a value of False.
+    - the latest_timestamp value is the date of the newest unsubscribe request in the report
+    - the earliest_timestamp value is the date of the oldest unsubscribe request in the report
 
     parameter: uuid service_id
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3583,7 +3583,7 @@ def test_get_unsubscribe_request_reports_summary(admin_request, sample_service, 
         count=141,
         earliest_timestamp=datetime.utcnow() + timedelta(days=-8),
         latest_timestamp=datetime.utcnow() + timedelta(days=-7),
-        processed_by_service_at=datetime.utcnow() + timedelta(days=-6),
+        processed_by_service_at=None,
         service_id=sample_service.id,
     )
     create_unsubscribe_request_reports_dao(unsubscribe_request_report_1)
@@ -3604,7 +3604,9 @@ def test_get_unsubscribe_request_reports_summary(admin_request, sample_service, 
             "count": report.count,
             "earliest_timestamp": report.earliest_timestamp.isoformat(),
             "latest_timestamp": report.latest_timestamp.isoformat(),
-            "processed_by_service_at": report.processed_by_service_at.isoformat(),
+            "processed_by_service_at": (
+                report.processed_by_service_at.isoformat() if report.processed_by_service_at else None
+            ),
             "is_a_batched_report": True,
         }
         for report in [unsubscribe_request_report_2, unsubscribe_request_report_1]


### PR DESCRIPTION
Originally we thought it would be nice and clean to extend the end dates of the reports so there were no gaps between them.

On second thought I think this will be confusing where the latest report claims to run up to the current time. In this case:
- the report, when downloaded might not even contain requests from today so it could look like requests are missing from the report
- the report might claim to have requests up until now, but if any new ones come in between the user clicking on the page and generating the report then they wouldn’t be included

In could also be confusing when a report is cleaned up by data retention. Adjacent reports would then appear to expand to fill the gap, even though they gain no new requests.