### PR TITLE
Add log line for letters that failed validation due to no fixed abode

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -303,6 +303,12 @@ def process_sanitised_letter(self, sanitise_data):
                 "Processing invalid precompiled pdf with id %s (file %s)", notification_id, filename
             )
 
+            # Log letters that fail with no fixed abode error so we can check for false positives
+            if letter_details["message"] == "no-fixed-abode-address":
+                current_app.logger.info(
+                    "Precomiled PDF with id %s was invalid due to no fixed abode address", notification_id
+                )
+
             _move_invalid_letter_and_update_status(
                 notification=notification,
                 filename=filename,


### PR DESCRIPTION
This adds a log line for precompiled API letters that were sent to addresses which were no fixed abode addresses. This will allow us to look up the address of the notification and check for false positives.

For templated letters sent via the API, we can already see from the logs if any failed validation due to having a no fixed abode address. We won't be able to see the address that was used, but can check which services are sending them.