### PR TITLE
Bump utils to 82.4.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ lxml==4.9.3
 notifications-python-client==8.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.2.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.4.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.2.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.4.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
 ## 82.4.0

* Add support for sending SMS to more international numbers. Sending to Eritrea, Wallis and Futuna, Niue, Kiribati, and Tokelau is now supported.

 ## 82.3.0
* Extends the validation logic for the `PhoneNumber` class to disallow premium rate numbers

Complete changes: https://github.com/alphagov/notifications-utils/compare/82.2.1...82.4.0