### PR TITLE
Use older_than to paginate get_all_notifications_for_service

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -752,6 +752,7 @@ class NotificationsFilterSchema(ma.Schema):
     limit_days = fields.Int(required=False)
     include_jobs = fields.Boolean(required=False)
     include_from_test_key = fields.Boolean(required=False)
+    paginate_by_older_than = fields.Boolean(required=False)
     older_than = fields.UUID(required=False)
     format_for_csv = fields.String()
     to = fields.String()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -157,6 +157,7 @@ from app.user.users_schema import post_set_permissions_schema
 from app.utils import (
     DATE_FORMAT,
     DATETIME_FORMAT_NO_TIMEZONE,
+    get_next_link_for_pagination_by_older_than,
     get_prev_next_pagination_links,
     midnight_n_days_ago,
 )
@@ -440,21 +441,22 @@ def get_all_notifications_for_service(service_id):
             statuses=data.get("status"),
             notification_type=notification_type,
         )
-    page = data["page"] if "page" in data else 1
+
+    paginate_by_older_than = data.get("paginate_by_older_than")
+    older_than = data.get("older_than")
+    page = data.get("page", 1)
+
     page_size = data["page_size"] if "page_size" in data else current_app.config.get("PAGE_SIZE")
     limit_days = data.get("limit_days")
     include_jobs = data.get("include_jobs", True)
     include_from_test_key = data.get("include_from_test_key", False)
     include_one_off = data.get("include_one_off", True)
 
-    # count_pages is not being used for whether to count the number of pages, but instead as a flag
-    # for whether to show pagination links
-    count_pages = data.get("count_pages", True)
-
-    pagination = notifications_dao.get_notifications_for_service(
+    current_notifications_batch = notifications_dao.get_notifications_for_service(
         service_id,
         filter_dict=data,
-        page=page,
+        older_than=older_than if paginate_by_older_than else None,
+        page=page if not paginate_by_older_than else 1,
         page_size=page_size,
         count_pages=False,
         limit_days=limit_days,
@@ -467,40 +469,53 @@ def get_all_notifications_for_service(service_id):
     kwargs["service_id"] = service_id
 
     if data.get("format_for_csv"):
-        notifications = [notification.serialize_for_csv() for notification in pagination.items]
+        notifications = [notification.serialize_for_csv() for notification in current_notifications_batch.items]
     else:
-        notifications = notification_with_template_schema.dump(pagination.items, many=True)
+        notifications = notification_with_template_schema.dump(current_notifications_batch.items, many=True)
 
-    # We try and get the next page of results to work out if we need provide a pagination link to the next page
-    # in our response if it exists. Note, this could be done instead by changing `count_pages` in the previous
-    # call to be True which will enable us to use Flask-Sqlalchemy to tell if there is a next page of results but
-    # this way is much more performant for services with many results (unlike Flask SqlAlchemy, this approach
-    # doesn't do an additional query to count all the results of which there could be millions but instead only
-    # asks for a single extra page of results).
-    next_page_of_pagination = notifications_dao.get_notifications_for_service(
-        service_id,
-        filter_dict=data,
-        page=page + 1,
-        page_size=page_size,
-        count_pages=False,
-        limit_days=limit_days,
-        include_jobs=include_jobs,
-        include_from_test_key=include_from_test_key,
-        include_one_off=include_one_off,
-        error_out=False,  # False so that if there are no results, it doesn't end in aborting with a 404
-    )
+    # if we paginate by older_than, then we don't need to get the next batch, as we use it to get data for a CSV report
+    # only for now - once we use it for views where we are actually showing a next page link, we might need it?
+    # Or we could keep track how many notifications we have left to pull insteead.
+    if not paginate_by_older_than:
+        # We try and get the next page of results to work out if we need provide a pagination link to the next page
+        # in our response if it exists. Note, this could be done instead by changing `count_pages` in the previous
+        # call to be True which will enable us to use Flask-Sqlalchemy to tell if there is a next page of results but
+        # this way is much more performant for services with many results (unlike Flask SqlAlchemy, this approach
+        # doesn't do an additional query to count all the results of which there could be millions but instead only
+        # asks for a single extra page of results).
+        next_notifications_batch = notifications_dao.get_notifications_for_service(
+            service_id,
+            filter_dict=data,
+            page=page + 1,
+            page_size=page_size,
+            count_pages=False,
+            limit_days=limit_days,
+            include_jobs=include_jobs,
+            include_from_test_key=include_from_test_key,
+            include_one_off=include_one_off,
+            error_out=False,  # False so that if there are no results, it doesn't end in aborting with a 404
+        )
+
+    # count_pages is not being used for whether to count the number of pages, but instead as a flag
+    # for whether to show pagination links
+    count_pages = data.get("count_pages", True)
+
+    links = {}
+    if count_pages and not paginate_by_older_than:
+        links = get_prev_next_pagination_links(
+            page, len(next_notifications_batch.items), ".get_all_notifications_for_service", **kwargs
+        )
+    elif paginate_by_older_than:
+        # for first iteration, we don't care about 'previous' link, as CSV report doesn't utilise that.
+        links = get_next_link_for_pagination_by_older_than(
+            current_notifications_batch.items, ".get_all_notifications_for_service", **kwargs
+        )
 
     return (
         jsonify(
             notifications=notifications,
             page_size=page_size,
-            links=(
-                get_prev_next_pagination_links(
-                    page, len(next_page_of_pagination.items), ".get_all_notifications_for_service", **kwargs
-                )
-                if count_pages
-                else {}
-            ),
+            links=links,
         ),
         200,
     )

--- a/app/utils.py
+++ b/app/utils.py
@@ -40,6 +40,8 @@ def pagination_links(pagination, endpoint, **kwargs):
     return links
 
 
+# Not sure those links ever get utilised beyond checking if they exist - changing the mocks to nonsense in admin
+# didn't break any tests, and admin does its own page counting - so maybe a bit redundant code here?
 def get_prev_next_pagination_links(current_page, next_page_exists, endpoint, **kwargs):
     if "page" in kwargs:
         kwargs.pop("page", None)
@@ -48,6 +50,16 @@ def get_prev_next_pagination_links(current_page, next_page_exists, endpoint, **k
         links["prev"] = url_for(endpoint, page=current_page - 1, **kwargs)
     if next_page_exists:
         links["next"] = url_for(endpoint, page=current_page + 1, **kwargs)
+    return links
+
+
+def get_next_link_for_pagination_by_older_than(current_notifications_batch, endpoint, **kwargs):
+    links = {}
+
+    if len(current_notifications_batch):
+        kwargs["older_than"] = current_notifications_batch[-1].id
+        links["next"] = url_for(endpoint, **kwargs)
+
     return links
 
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1783,23 +1783,31 @@ def test_get_notifications_for_service_pagination_links(
     sample_template,
     sample_user,
 ):
-    for _ in range(101):
+    for _ in range(11):
         create_notification(sample_template, to_field="+447700900855", normalised_to="447700900855")
 
-    resp = admin_request.get("service.get_all_notifications_for_service", service_id=sample_template.service_id)
+    page_size = 5
 
-    assert "prev" not in resp["links"]
-    assert "?page=2" in resp["links"]["next"]
+    page_1_response = admin_request.get(
+        "service.get_all_notifications_for_service", service_id=sample_template.service_id, page_size=page_size
+    )
 
-    resp = admin_request.get("service.get_all_notifications_for_service", service_id=sample_template.service_id, page=2)
+    assert "prev" not in page_1_response["links"]
+    assert "?page=2" in page_1_response["links"]["next"]
 
-    assert "?page=1" in resp["links"]["prev"]
-    assert "?page=3" in resp["links"]["next"]
+    page_2_response = admin_request.get(
+        "service.get_all_notifications_for_service", service_id=sample_template.service_id, page=2, page_size=page_size
+    )
 
-    resp = admin_request.get("service.get_all_notifications_for_service", service_id=sample_template.service_id, page=3)
+    assert "?page=1" in page_2_response["links"]["prev"]
+    assert "?page=3" in page_2_response["links"]["next"]
 
-    assert "?page=2" in resp["links"]["prev"]
-    assert "next" not in resp["links"]
+    page_3_response = admin_request.get(
+        "service.get_all_notifications_for_service", service_id=sample_template.service_id, page=3, page_size=page_size
+    )
+
+    assert "?page=2" in page_3_response["links"]["prev"]
+    assert "next" not in page_3_response["links"]
 
 
 def test_get_notifications_for_service_with_paginate_by_older_than(


### PR DESCRIPTION
Paginating by page numbers made us use offset, which makes large queries quite expensive: https://use-the-index-luke.com/no-offset

This caused issues for notifications CSV reports that services can download. If a service has sent many notifications, the report will be very big - even above 1,000,000 rows.

To prevent it, for this use case we will use older_than parameter to paginate instead - that is - we get our notifications sorted by created_at date. So if we set older_than parameter to the id of the oldest notification in a current page/batch, we know where to start our next batch without using the inefficient offset mechanism.

For now, for other use cases, this query will still use offset
- this is to get the improvement out quickly where it's needed and prevent future incidents.

After immediate danger has passed, we should look at other places where this query is used, and see if we can move them over to using older_than, too.


Note: this code could probably use a refactor in another PR - after we get the functional changes out to reduce danger of incidents.

===========

This PR needs to go in first, with admin after: https://github.com/alphagov/notifications-admin/pull/5178