### PR TITLE
Don't use pipedream API token in FT fixtures

### DIFF
--- a/app/functional_tests_fixtures/__init__.py
+++ b/app/functional_tests_fixtures/__init__.py
@@ -469,6 +469,6 @@ def _create_service_inbound_api(service_id, user_id):
             service_id=service_id, url="https://5c6b93352e82dab5d82d02e5178c2d57.m.pipedream.net", updated_by_id=user_id
         )
 
-    inbound_api.bearer_token = os.environ["REQUEST_BIN_API_TOKEN"]
+    inbound_api.bearer_token = "1234567890"
 
     save_service_inbound_api(inbound_api)


### PR DESCRIPTION
The token isn't actually needed here, we just need to provide _some_ value because the field is required and the minimum length is 10 characters.

The value 1234567890 is already used in preview (where it's hardcoded in the database)