### PR TITLE
Improve alembic error output

### DIFF
--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -11,7 +11,7 @@
 
 # Logging configuration
 [loggers]
-keys = root,sqlalchemy,alembic
+keys = root,sqlalchemy,alembic,flask_migrate
 
 [handlers]
 keys = console
@@ -28,6 +28,11 @@ qualname =
 level = INFO
 handlers = console
 qualname = sqlalchemy.engine
+
+[logger_flask_migrate]
+level = INFO
+handlers = console
+qualname = flask_migrate
 
 [logger_alembic]
 level = INFO

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,6 +108,7 @@ def _notify_db(notify_api, worker_id):
             "SQLALCHEMY_DATABASE_URI": current_app.config["SQLALCHEMY_DATABASE_URI"],
             "FLASK_APP": "application:application",
         },
+        check=True,
     )
 
     # now db is initialised, run cleanup on it to remove any artifacts from migrations (such as the notify service and


### PR DESCRIPTION
Without these, a migration failure (particularly during the unit tests) is a puzzling thing to encounter with little information to go on.

More detail in commit messages.