### PR TITLE
API clients: make thread-local, allowing use of persistent requests sessions

### DIFF
--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -1,16 +1,26 @@
 import json
 import random
+from contextvars import ContextVar
 from datetime import datetime, timedelta
 
+import requests
 from flask import current_app
+from notifications_utils.local_vars import LazyLocalGetter
 from notifications_utils.s3 import s3upload
-from requests import HTTPError, request
+from werkzeug.local import LocalProxy
 
 from app import notify_celery
 from app.aws.s3 import file_exists
 from app.celery.process_ses_receipts_tasks import process_ses_results
 from app.config import QueueNames
 from app.constants import SMS_TYPE
+
+_requests_session_context_var: ContextVar[requests.Session] = ContextVar("research_mode_requests_session")
+get_requests_session: LazyLocalGetter[requests.Session] = LazyLocalGetter(
+    _requests_session_context_var,
+    lambda: requests.Session(),
+)
+requests_session = LocalProxy(get_requests_session)
 
 temp_fail = "7700900003"
 perm_fail = "7700900002"
@@ -53,9 +63,9 @@ def make_request(notification_type, provider, data, headers):
     api_call = f"{current_app.config['API_HOST_NAME_INTERNAL']}/notifications/{notification_type}/{provider}"
 
     try:
-        response = request("POST", api_call, headers=headers, data=data, timeout=60)
+        response = requests_session.request("POST", api_call, headers=headers, data=data, timeout=60)
         response.raise_for_status()
-    except HTTPError as e:
+    except requests.HTTPError as e:
         current_app.logger.error("API POST request on %s failed with status %s", api_call, e.response.status_code)
         raise e
     finally:

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -1,13 +1,23 @@
 import json
+from contextvars import ContextVar
 
+import requests
 from flask import current_app
-from requests import HTTPError, RequestException, request
+from notifications_utils.local_vars import LazyLocalGetter
+from werkzeug.local import LocalProxy
 
 from app import notify_celery, signing
 from app.config import QueueNames
 from app.dao.inbound_sms_dao import dao_get_inbound_sms_by_id
 from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
 from app.utils import DATETIME_FORMAT
+
+_requests_session_context_var: ContextVar[requests.Session] = ContextVar("service_callback_requests_session")
+get_requests_session: LazyLocalGetter[requests.Session] = LazyLocalGetter(
+    _requests_session_context_var,
+    lambda: requests.Session(),
+)
+requests_session = LocalProxy(get_requests_session)
 
 
 @notify_celery.task(bind=True, name="send-delivery-status", max_retries=5, default_retry_delay=300)
@@ -82,7 +92,7 @@ def send_inbound_sms_to_service(self, inbound_sms_id, service_id):
 def _send_data_to_service_callback_api(self, data, service_callback_url, token, function_name):
     object_id = data["notification_id"] if "notification_id" in data else data["id"]
     try:
-        response = request(
+        response = requests_session.request(
             method="POST",
             url=service_callback_url,
             data=json.dumps(data),
@@ -97,7 +107,7 @@ def _send_data_to_service_callback_api(self, data, service_callback_url, token, 
             response.status_code,
         )
         response.raise_for_status()
-    except RequestException as e:
+    except requests.RequestException as e:
         current_app.logger.warning(
             "%s request failed for id: %s and url: %s. exception: %s",
             function_name,
@@ -105,7 +115,7 @@ def _send_data_to_service_callback_api(self, data, service_callback_url, token, 
             service_callback_url,
             e,
         )
-        if not isinstance(e, HTTPError) or e.response.status_code >= 500 or e.response.status_code == 429:
+        if not isinstance(e, requests.HTTPError) or e.response.status_code >= 500 or e.response.status_code == 429:
             try:
                 self.retry(queue=QueueNames.CALLBACKS_RETRY)
             except self.MaxRetriesExceededError as e:

--- a/app/clients/document_download.py
+++ b/app/clients/document_download.py
@@ -20,6 +20,7 @@ class DocumentDownloadClient:
         self.api_host_external = app.config["DOCUMENT_DOWNLOAD_API_HOST"]
         self.api_host_internal = app.config["DOCUMENT_DOWNLOAD_API_HOST_INTERNAL"]
         self.auth_token = app.config["DOCUMENT_DOWNLOAD_API_KEY"]
+        self.requests_session = requests.Session()
 
     def get_upload_url_for_simulated_email(self, service_id):
         """
@@ -62,7 +63,7 @@ class DocumentDownloadClient:
             if has_request_context() and hasattr(request, "get_onwards_request_headers"):
                 headers.update(request.get_onwards_request_headers())
 
-            response = requests.post(
+            response = self.requests_session.post(
                 self._get_upload_url(service_id),
                 headers=headers,
                 json=data,

--- a/app/clients/document_download.py
+++ b/app/clients/document_download.py
@@ -16,7 +16,7 @@ class DocumentDownloadError(Exception):
 
 
 class DocumentDownloadClient:
-    def init_app(self, app):
+    def __init__(self, app):
         self.api_host_external = app.config["DOCUMENT_DOWNLOAD_API_HOST"]
         self.api_host_internal = app.config["DOCUMENT_DOWNLOAD_API_HOST_INTERNAL"]
         self.auth_token = app.config["DOCUMENT_DOWNLOAD_API_KEY"]

--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -56,9 +56,9 @@ class AwsSesClient(EmailClient):
     Amazon SES email client.
     """
 
-    def init_app(self, region, statsd_client, *args, **kwargs):
+    def __init__(self, region, statsd_client):
+        super().__init__()
         self._client = boto3.client("sesv2", region_name=region)
-        super().__init__(*args, **kwargs)
         self.statsd_client = statsd_client
 
     @property

--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -54,6 +54,8 @@ class AwsSesClientThrottlingSendRateException(AwsSesClientException):
 class AwsSesClient(EmailClient):
     """
     Amazon SES email client.
+
+    This class is not thread-safe
     """
 
     def __init__(self, region, statsd_client):

--- a/app/clients/email/aws_ses_stub.py
+++ b/app/clients/email/aws_ses_stub.py
@@ -12,7 +12,8 @@ class AwsSesStubClientException(EmailClientException):
 
 
 class AwsSesStubClient(EmailClient):
-    def init_app(self, region, statsd_client, stub_url):
+    def __init__(self, region, statsd_client, stub_url):
+        super().__init__()
         self.statsd_client = statsd_client
         self.url = stub_url
 

--- a/app/clients/email/aws_ses_stub.py
+++ b/app/clients/email/aws_ses_stub.py
@@ -1,8 +1,8 @@
 import json
 from time import monotonic
 
+import requests
 from flask import current_app
-from requests import request
 
 from app.clients.email import EmailClient, EmailClientException
 
@@ -12,10 +12,17 @@ class AwsSesStubClientException(EmailClientException):
 
 
 class AwsSesStubClient(EmailClient):
+    """
+    Amazon SES "stub" email client for sending emails to a testing stub.
+
+    This class is not thread-safe.
+    """
+
     def __init__(self, region, statsd_client, stub_url):
         super().__init__()
         self.statsd_client = statsd_client
         self.url = stub_url
+        self.requests_session = requests.Session()
 
     @property
     def name(self):
@@ -24,7 +31,7 @@ class AwsSesStubClient(EmailClient):
     def send_email(self, source, to_addresses, subject, body, html_body="", reply_to_address=None):
         try:
             start_time = monotonic()
-            response = request("POST", self.url, data={"id": "dummy-data"}, timeout=60)
+            response = self.session.request("POST", self.url, data={"id": "dummy-data"}, timeout=60)
             response.raise_for_status()
             response_json = json.loads(response.text)
 

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -110,6 +110,8 @@ class _SpecifiedCiphersAdapter(HTTPAdapter):
 class DVLAClient:
     """
     DVLA HTTP API letter client.
+
+    This class is not thread-safe.
     """
 
     statsd_client = None

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -117,7 +117,7 @@ class DVLAClient:
     _jwt_token = None
     _jwt_expires_at = None
 
-    def init_app(self, application, *, statsd_client):
+    def __init__(self, application, *, statsd_client):
         self.base_url = application.config["DVLA_API_BASE_URL"]
         self.ciphers = application.config["DVLA_API_TLS_CIPHERS"]
         ssm_client = boto3.client("ssm", region_name=application.config["AWS_REGION"])

--- a/app/clients/sms/__init__.py
+++ b/app/clients/sms/__init__.py
@@ -20,7 +20,8 @@ class SmsClient(Client):
     Base Sms client for sending smss.
     """
 
-    def init_app(self, current_app, statsd_client):
+    def __init__(self, current_app, statsd_client):
+        super().__init__()
         self.current_app = current_app
         self.statsd_client = statsd_client
 

--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -46,8 +46,8 @@ class FiretextClient(SmsClient):
     FireText sms client.
     """
 
-    def init_app(self, *args, **kwargs):
-        super().init_app(*args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.api_key = self.current_app.config.get("FIRETEXT_API_KEY")
         self.international_api_key = self.current_app.config.get("FIRETEXT_INTERNATIONAL_API_KEY")
         self.url = self.current_app.config.get("FIRETEXT_URL")

--- a/app/clients/sms/mmg.py
+++ b/app/clients/sms/mmg.py
@@ -78,8 +78,8 @@ class MMGClient(SmsClient):
     MMG sms client
     """
 
-    def init_app(self, *args, **kwargs):
-        super().init_app(*args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.api_key = self.current_app.config.get("MMG_API_KEY")
         self.mmg_url = self.current_app.config.get("MMG_URL")
         self.receipt_url = self.current_app.config.get("MMG_RECEIPT_URL")

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -1,5 +1,6 @@
 import random
 from datetime import datetime, timedelta
+from threading import RLock
 from urllib import parse
 
 from cachetools import TTLCache, cached
@@ -181,9 +182,10 @@ def update_notification_to_sending(notification, provider):
 
 
 provider_cache = TTLCache(maxsize=8, ttl=10)
+provider_cache_lock = RLock()
 
 
-@cached(cache=provider_cache)
+@cached(cache=provider_cache, lock=provider_cache_lock)
 def provider_to_use(notification_type, international=False):
     active_providers = [
         p for p in get_provider_details_by_notification_type(notification_type, international) if p.active

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ lxml==4.9.3
 notifications-python-client==8.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.4.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.6.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.4.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.6.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/tests/app/celery/test_research_mode_tasks.py
+++ b/tests/app/celery/test_research_mode_tasks.py
@@ -2,12 +2,12 @@ import uuid
 from unittest.mock import ANY, call
 
 import pytest
+import requests
 import requests_mock
 from flask import current_app, json
 from freezegun import freeze_time
 
 from app.celery.research_mode_tasks import (
-    HTTPError,
     create_fake_letter_response_file,
     firetext_callback,
     mmg_callback,
@@ -37,7 +37,7 @@ def test_callback_logs_on_api_call_failure(notify_api, rmock, caplog):
     endpoint = "http://localhost:6011/notifications/sms/mmg"
     rmock.request("POST", endpoint, json={"error": "something went wrong"}, status_code=500)
 
-    with pytest.raises(HTTPError), caplog.at_level("ERROR"):
+    with pytest.raises(requests.HTTPError), caplog.at_level("ERROR"):
         send_sms_response("mmg", "1234", "07700900001")
 
     assert rmock.called

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -227,7 +227,7 @@ def test__send_data_to_service_callback_api_retries_if_request_raises_unknown_ex
 
     celery_task_mock = mock.MagicMock()
 
-    mocker.patch("app.celery.service_callback_tasks.request", side_effect=RequestException())
+    mocker.patch("app.celery.service_callback_tasks.requests_session.request", side_effect=RequestException())
 
     _send_data_to_service_callback_api(celery_task_mock, data, callback_url, "my-token", "my_function_name")
 

--- a/tests/app/clients/test_document_download.py
+++ b/tests/app/clients/test_document_download.py
@@ -10,7 +10,6 @@ from app.clients.document_download import (
 
 @pytest.fixture(scope="function")
 def document_download(client, mocker):
-    client = DocumentDownloadClient()
     current_app = mocker.Mock(
         config={
             "DOCUMENT_DOWNLOAD_API_HOST": "https://document-download",
@@ -18,7 +17,7 @@ def document_download(client, mocker):
             "DOCUMENT_DOWNLOAD_API_KEY": "test-key",
         },
     )
-    client.init_app(current_app)
+    client = DocumentDownloadClient(current_app)
     return client
 
 

--- a/tests/app/clients/test_dvla.py
+++ b/tests/app/clients/test_dvla.py
@@ -55,8 +55,7 @@ def ssm():
 
 @pytest.fixture
 def dvla_client(notify_api, client, ssm):
-    dvla_client = DVLAClient()
-    dvla_client.init_app(notify_api, statsd_client=Mock())
+    dvla_client = DVLAClient(notify_api, statsd_client=Mock())
     yield dvla_client
 
 
@@ -941,8 +940,7 @@ class TestDVLAApiClientRestrictedCiphers:
             method="GET",
         ).respond_with_data("OK")
 
-        dvla_client = DVLAClient()
-        dvla_client.init_app(
+        dvla_client = DVLAClient(
             fake_app,
             statsd_client=mocker.Mock(),
         )
@@ -956,11 +954,9 @@ class TestDVLAApiClientRestrictedCiphers:
         assert response.text == "OK"
 
     def test_invalid_ciphers(self, mocker, server_base_url, fake_app):
-        dvla_client = DVLAClient()
-
         with pytest.raises(ssl.SSLError) as e:
             fake_app.config["DVLA_API_TLS_CIPHERS"] = "not-a-valid-cipher"
-            dvla_client.init_app(fake_app, statsd_client=mocker.Mock())
+            DVLAClient(fake_app, statsd_client=mocker.Mock())
 
         assert "No cipher can be selected." in e.value.args
 
@@ -976,8 +972,7 @@ class TestDVLAApiClientRestrictedCiphers:
         fake_app,
     ):
         fake_app.config["DVLA_API_TLS_CIPHERS"] = ":".join(cipherlist.allowlist)
-        dvla_client = DVLAClient()
-        dvla_client.init_app(
+        dvla_client = DVLAClient(
             fake_app,
             statsd_client=mocker.Mock(),
         )
@@ -1007,8 +1002,7 @@ class TestDVLAApiClientRestrictedCiphers:
         fake_app,
     ):
         fake_app.config["DVLA_API_TLS_CIPHERS"] = ":".join(cipherlist.blocklist)
-        dvla_client = DVLAClient()
-        dvla_client.init_app(
+        dvla_client = DVLAClient(
             fake_app,
             statsd_client=mocker.Mock(),
         )

--- a/tests/app/clients/test_sms.py
+++ b/tests/app/clients/test_sms.py
@@ -11,8 +11,7 @@ def fake_client(notify_api):
         def name(self):
             return "fake"
 
-    fake_client = FakeSmsClient()
-    fake_client.init_app(notify_api, statsd_client)
+    fake_client = FakeSmsClient(notify_api, statsd_client)
     return fake_client
 
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -570,10 +570,8 @@ def create_mock_firetext_config(mocker, additional_config=None):
 
 
 def create_mock_firetext_client(mocker, mock_config):
-    client = FiretextClient()
     statsd_client = mocker.Mock()
-    client.init_app(mock_config, statsd_client)
-    return client
+    return FiretextClient(mock_config, statsd_client)
 
 
 @pytest.fixture(scope="function")
@@ -591,7 +589,6 @@ def mock_firetext_client_with_receipts(mocker):
 
 @pytest.fixture(scope="function")
 def mock_mmg_client_with_receipts(mocker):
-    client = MMGClient()
     statsd_client = mocker.Mock()
     current_app = mocker.Mock(
         config={
@@ -600,8 +597,7 @@ def mock_mmg_client_with_receipts(mocker):
             "MMG_RECEIPT_URL": "https://www.example.com/notifications/sms/mmg",
         }
     )
-    client.init_app(current_app, statsd_client)
-    return client
+    return MMGClient(current_app, statsd_client)
 
 
 @pytest.fixture(scope="function")

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -614,9 +614,9 @@ def test_post_email_notification_returns_201(
             {"doc": {"file": "YSxiLGMKMSwyLDMK", "filename": "file.csv"}},
             201,
             None,
-            False,
-            None,
-            None,
+            True,
+            True,
+            "26 weeks",
             "file.csv",
         ),
         (
@@ -685,8 +685,8 @@ def test_post_email_notification_validates_personalisation_send_a_file_values(
     if expect_error_message:
         assert expect_error_message in response["errors"][0]["message"]
 
-    if expect_upload:
-        assert document_download_upload_document_mock.call_args_list == [
+    assert document_download_upload_document_mock.call_args_list == (
+        [
             mocker.call(
                 str(template.service_id),
                 "YSxiLGMKMSwyLDMK",
@@ -696,6 +696,9 @@ def test_post_email_notification_validates_personalisation_send_a_file_values(
                 filename=expected_filename,
             )
         ]
+        if expect_upload
+        else []
+    )
 
 
 @pytest.mark.parametrize(
@@ -1228,6 +1231,7 @@ def test_post_notification_without_document_upload_permission(api_client_request
     api_client_request.post(
         service.id, "v2_notifications.post_notification", notification_type="email", _data=data, _expected_status=400
     )
+    assert document_download_upload_document_mock.call_args_list == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
https://trello.com/c/ORGrd1jn/498-upgrade-docker-images-for-our-ecs-apps-to-debian-bookworm

Individual commit messages contain more details - note caveat about service callback session reuse.

The use of requests sessions should reduce CPU usage resulting from continual re-parsing of the CA bundle, which in turn should allow us to upgrade to OpenSSL 3.x with little trouble.

Ran the FTs against this on dev-a with `merged_api_workers` disabled: https://concourse.notify.tools/teams/dev-a/pipelines/deploy-notify/jobs/deploy/builds/144
