### PR TITLE
Add unsubscribe request received at column to reports

### DIFF
--- a/app/dao/unsubscribe_request_dao.py
+++ b/app/dao/unsubscribe_request_dao.py
@@ -74,7 +74,7 @@ def get_unsubscribe_requests_data_for_download_dao(service_id, batch_id):
                 table.template_id,
                 func.coalesce(Job.original_file_name, "N/A").label("original_file_name"),
                 table.sent_at.label("template_sent_at"),
-                UnsubscribeRequest.created_at.label("unsubscribe_request_received_at")
+                UnsubscribeRequest.created_at.label("unsubscribe_request_received_at"),
             )
             .outerjoin(Job, table.job_id == Job.id)
             .filter(

--- a/app/dao/unsubscribe_request_dao.py
+++ b/app/dao/unsubscribe_request_dao.py
@@ -74,6 +74,7 @@ def get_unsubscribe_requests_data_for_download_dao(service_id, batch_id):
                 table.template_id,
                 func.coalesce(Job.original_file_name, "N/A").label("original_file_name"),
                 table.sent_at.label("template_sent_at"),
+                UnsubscribeRequest.created_at.label("unsubscribe_request_received_at")
             )
             .outerjoin(Job, table.job_id == Job.id)
             .filter(

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1204,6 +1204,7 @@ def get_unsubscribe_request_report_for_download(service_id, batch_id):
                     "template_name": unsubscribe_request.template_name,
                     "original_file_name": unsubscribe_request.original_file_name,
                     "template_sent_at": unsubscribe_request.template_sent_at,
+                    "unsubscribe_request_received_at": unsubscribe_request.unsubscribe_request_received_at
                 }
                 for unsubscribe_request in get_unsubscribe_requests_data_for_download_dao(service_id, report.id)
             ],

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1204,7 +1204,7 @@ def get_unsubscribe_request_report_for_download(service_id, batch_id):
                     "template_name": unsubscribe_request.template_name,
                     "original_file_name": unsubscribe_request.original_file_name,
                     "template_sent_at": unsubscribe_request.template_sent_at,
-                    "unsubscribe_request_received_at": unsubscribe_request.unsubscribe_request_received_at
+                    "unsubscribe_request_received_at": unsubscribe_request.unsubscribe_request_received_at,
                 }
                 for unsubscribe_request in get_unsubscribe_requests_data_for_download_dao(service_id, report.id)
             ],

--- a/tests/app/dao/test_unsubscribe_request_dao.py
+++ b/tests/app/dao/test_unsubscribe_request_dao.py
@@ -1,3 +1,5 @@
+from sqlalchemy import desc
+
 from app.constants import EMAIL_TYPE
 from app.dao.unsubscribe_request_dao import (
     assign_unbatched_unsubscribe_requests_to_report_dao,
@@ -370,23 +372,28 @@ def test_get_unsubscribe_request_data_for_download_dao(sample_service):
     )
 
     result = get_unsubscribe_requests_data_for_download_dao(sample_service.id, unsubscribe_request_report.id)
+    created_unsubscribe_requests = UnsubscribeRequest.query.order_by(desc(UnsubscribeRequest.created_at)).all()
 
     assert result[0].email_address == notification_1.to
     assert result[0].template_name == notification_1.template.name
     assert result[0].original_file_name == notification_1.job.original_file_name
     assert result[0].template_sent_at == notification_1.sent_at
+    assert result[0].unsubscribe_request_received_at == created_unsubscribe_requests[0].created_at
     assert result[1].email_address == notification_2.to
     assert result[1].template_name == notification_2.template.name
     assert result[1].original_file_name == notification_2.job.original_file_name
     assert result[1].template_sent_at == notification_2.sent_at
+    assert result[1].unsubscribe_request_received_at == created_unsubscribe_requests[1].created_at
     assert result[2].email_address == notification_4.to
     assert result[2].template_name == notification_4.template.name
     assert result[2].original_file_name == "N/A"
     assert result[2].template_sent_at == notification_4.sent_at
+    assert result[2].unsubscribe_request_received_at == created_unsubscribe_requests[3].created_at
     assert result[3].email_address == notification_3.to
     assert result[3].template_name == notification_3.template.name
     assert result[3].original_file_name == notification_3.job.original_file_name
     assert result[3].template_sent_at == notification_3.sent_at
+    assert result[3].unsubscribe_request_received_at == created_unsubscribe_requests[2].created_at
 
 
 def test_get_unsubscribe_request_data_for_download_dao_invalid_batch_id(sample_service):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3781,18 +3781,21 @@ def test_get_unsubscribe_request_report_for_download(admin_request, sample_servi
         "UnsubscribeRequestReport", ["id", "earliest_timestamp", "latest_timestamp", "unsubscribe_requests"]
     )
     UnsubscribeRequest = namedtuple(
-        "UnsubscribeRequest", ["email_address", "template_name", "original_file_name", "template_sent_at"]
+        "UnsubscribeRequest",
+        ["email_address", "template_name", "original_file_name", "template_sent_at", "unsubscribe_request_received_at"],
     )
 
     unsubscribe_request_1 = UnsubscribeRequest(
-        "foo@bar.com", "email Template Name", "contact list", "2024-07-23 13:30:00"
+        "foo@bar.com", "email Template Name", "contact list", "2024-07-23 13:30:00", "2024-07-25 13:30:00"
     )
     unsubscribe_request_2 = UnsubscribeRequest(
-        "fizz@bar.com", "email Template Name", "contact list", "2024-07-21 11:04:00"
+        "fizz@bar.com", "email Template Name", "contact list", "2024-07-21 11:04:00", "2024-07-23 11:04:00"
     )
-    unsubscribe_request_3 = UnsubscribeRequest("fizzbuzz@bar.com", "Another Service", None, "2024-07-19 23:45:00")
+    unsubscribe_request_3 = UnsubscribeRequest(
+        "fizzbuzz@bar.com", "Another Service", None, "2024-07-19 23:45:00", "2024-07-21 23:45:00"
+    )
     unsubscribe_request_4 = UnsubscribeRequest(
-        "buzz@bar.com", "Another Service", "another contact list", "2024-07-17 09:42:00"
+        "buzz@bar.com", "Another Service", "another contact list", "2024-07-17 09:42:00", "2024-07-19 09:42:00"
     )
     unsubscribe_request_report = UnsubscribeRequestReport(
         "e6c02a98-8e64-4ab3-b176-271274517c21",

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3820,6 +3820,8 @@ def test_get_unsubscribe_request_report_for_download(admin_request, sample_servi
         assert response["unsubscribe_requests"][i]["template_name"] == row.template_name
         assert response["unsubscribe_requests"][i]["original_file_name"] == row.original_file_name
         assert response["unsubscribe_requests"][i]["template_sent_at"] == row.template_sent_at
+        assert response["unsubscribe_requests"][i]["unsubscribe_request_received_at"] == \
+               row.unsubscribe_request_received_at
 
 
 def test_get_unsubscribe_request_report_for_download_400_error(admin_request, sample_service):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3820,8 +3820,10 @@ def test_get_unsubscribe_request_report_for_download(admin_request, sample_servi
         assert response["unsubscribe_requests"][i]["template_name"] == row.template_name
         assert response["unsubscribe_requests"][i]["original_file_name"] == row.original_file_name
         assert response["unsubscribe_requests"][i]["template_sent_at"] == row.template_sent_at
-        assert response["unsubscribe_requests"][i]["unsubscribe_request_received_at"] == \
-               row.unsubscribe_request_received_at
+        assert (
+            response["unsubscribe_requests"][i]["unsubscribe_request_received_at"]
+            == row.unsubscribe_request_received_at
+        )
 
 
 def test_get_unsubscribe_request_report_for_download_400_error(admin_request, sample_service):


### PR DESCRIPTION
This PR adds an `unsubscribe_request_received_at` column to unsubscribe request reports as described [here](https://trello.com/c/mkDkkHgX/85-update-unsubscribe-request-report-to-include-when-unsubscribe-request-was-received)