### PR TITLE
Clean up old unsubscribe requests

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -43,8 +43,8 @@ from app.dao.service_data_retention_dao import (
     fetch_service_data_retention_for_all_services_by_notification_type,
 )
 from app.dao.unsubscribe_request_dao import (
+    dao_archive_batched_unsubscribe_requests,
     dao_archive_old_unsubscribe_requests,
-    dao_archive_processed_unsubscribe_requests,
     get_service_ids_with_unsubscribe_requests,
 )
 from app.models import FactProcessingTime, Notification
@@ -77,14 +77,14 @@ def _remove_csv_files(job_types):
 @notify_celery.task(name="archive_unsubscribe_requests")
 def archive_unsubscribe_requests():
     for service_id in get_service_ids_with_unsubscribe_requests():
-        archive_processed_unsubscribe_requests.apply_async(queue=QueueNames.REPORTING, args=[service_id])
+        archive_batched_unsubscribe_requests.apply_async(queue=QueueNames.REPORTING, args=[service_id])
         archive_old_unsubscribe_requests.apply_async(queue=QueueNames.REPORTING, args=[service_id])
 
 
-@notify_celery.task(name="archive_processed_unsubscribe_requests")
-def archive_processed_unsubscribe_requests(service_id):
+@notify_celery.task(name="archive_batched_unsubscribe_requests")
+def archive_batched_unsubscribe_requests(service_id):
     start = datetime.now(UTC)
-    count_deleted = dao_archive_processed_unsubscribe_requests(service_id)
+    count_deleted = dao_archive_batched_unsubscribe_requests(service_id)
     log_archive_unsubscribe_requests(start, service_id, count_deleted)
 
 

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from flask import current_app
 from notifications_utils.clients.zendesk.zendesk_client import (
@@ -42,6 +42,11 @@ from app.dao.notifications_dao import (
 from app.dao.service_data_retention_dao import (
     fetch_service_data_retention_for_all_services_by_notification_type,
 )
+from app.dao.unsubscribe_request_dao import (
+    dao_archive_old_unsubscribe_requests,
+    dao_archive_processed_unsubscribe_requests,
+    get_service_ids_with_unsubscribe_requests,
+)
 from app.models import FactProcessingTime, Notification
 from app.notifications.notifications_ses_callback import (
     check_and_queue_callback_task,
@@ -67,6 +72,39 @@ def _remove_csv_files(job_types):
         s3.remove_job_from_s3(job.service_id, job.id)
         dao_archive_job(job)
         current_app.logger.info("Job ID %s has been removed from s3.", job.id)
+
+
+@notify_celery.task(name="archive_unsubscribe_requests")
+def archive_unsubscribe_requests():
+    for service_id in get_service_ids_with_unsubscribe_requests():
+        archive_processed_unsubscribe_requests.apply_async(queue=QueueNames.REPORTING, args=[service_id])
+        archive_old_unsubscribe_requests.apply_async(queue=QueueNames.REPORTING, args=[service_id])
+
+
+@notify_celery.task(name="archive_processed_unsubscribe_requests")
+def archive_processed_unsubscribe_requests(service_id):
+    start = datetime.now(UTC)
+    count_deleted = dao_archive_processed_unsubscribe_requests(service_id)
+    log_archive_unsubscribe_requests(start, service_id, count_deleted)
+
+
+@notify_celery.task(name="archive_old_unsubscribe_requests")
+def archive_old_unsubscribe_requests(service_id):
+    start = datetime.now(UTC)
+    count_deleted = dao_archive_old_unsubscribe_requests(service_id)
+    log_archive_unsubscribe_requests(start, service_id, count_deleted)
+
+
+def log_archive_unsubscribe_requests(start, service_id, count_deleted):
+    current_app.logger.info(
+        "%(task)s service: %(service_id)s, count deleted: %(count_deleted)s, duration: %(duration)s seconds",
+        {
+            "task": notify_celery.current_task.name,
+            "service_id": service_id,
+            "count_deleted": count_deleted,
+            "duration": (datetime.now(UTC) - start).seconds,
+        },
+    )
 
 
 @notify_celery.task(name="delete-notifications-older-than-retention")

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -74,21 +74,21 @@ def _remove_csv_files(job_types):
         current_app.logger.info("Job ID %s has been removed from s3.", job.id)
 
 
-@notify_celery.task(name="archive_unsubscribe_requests")
+@notify_celery.task(name="archive-unsubscribe-requests")
 def archive_unsubscribe_requests():
     for service_id in get_service_ids_with_unsubscribe_requests():
         archive_batched_unsubscribe_requests.apply_async(queue=QueueNames.REPORTING, args=[service_id])
         archive_old_unsubscribe_requests.apply_async(queue=QueueNames.REPORTING, args=[service_id])
 
 
-@notify_celery.task(name="archive_batched_unsubscribe_requests")
+@notify_celery.task(name="archive-batched-unsubscribe-requests")
 def archive_batched_unsubscribe_requests(service_id):
     start = datetime.now(UTC)
     count_deleted = dao_archive_batched_unsubscribe_requests(service_id)
     log_archive_unsubscribe_requests(start, service_id, count_deleted)
 
 
-@notify_celery.task(name="archive_old_unsubscribe_requests")
+@notify_celery.task(name="archive-old-unsubscribe-requests")
 def archive_old_unsubscribe_requests(service_id):
     start = datetime.now(UTC)
     count_deleted = dao_archive_old_unsubscribe_requests(service_id)

--- a/app/config.py
+++ b/app/config.py
@@ -264,6 +264,11 @@ class Config:
                 "schedule": crontab(hour=0, minute=5),
                 "options": {"queue": QueueNames.PERIODIC},
             },
+            "archive-unsubscribe-requests": {
+                "task": "archive-unsubscribe-requests",
+                "schedule": crontab(hour=0, minute=5),
+                "options": {"queue": QueueNames.REPORTING},
+            },
             "create-nightly-billing": {
                 "task": "create-nightly-billing",
                 "schedule": crontab(hour=0, minute=15),

--- a/app/dao/unsubscribe_request_dao.py
+++ b/app/dao/unsubscribe_request_dao.py
@@ -152,6 +152,7 @@ def dao_archive_old_unsubscribe_requests(service_id):
         UnsubscribeRequest.query.filter(
             UnsubscribeRequest.created_at < midnight_n_days_ago(90),
             UnsubscribeRequest.service_id == service_id,
+            UnsubscribeRequest.unsubscribe_request_report_id.is_(None),
         )
     )
 

--- a/app/dao/unsubscribe_request_dao.py
+++ b/app/dao/unsubscribe_request_dao.py
@@ -135,13 +135,13 @@ def get_service_ids_with_unsubscribe_requests():
     return {row.service_id for row in UnsubscribeRequest.query.distinct()}
 
 
-def dao_archive_processed_unsubscribe_requests(service_id):
+def dao_archive_batched_unsubscribe_requests(service_id):
     return archive_unsubscribe_requests_from_query(
         UnsubscribeRequest.query.join(
             UnsubscribeRequestReport,
             UnsubscribeRequest.unsubscribe_request_report_id == UnsubscribeRequestReport.id,
         ).filter(
-            UnsubscribeRequestReport.processed_by_service_at < midnight_n_days_ago(7),
+            UnsubscribeRequestReport.created_at < midnight_n_days_ago(7),
             UnsubscribeRequest.service_id == service_id,
         )
     )

--- a/app/models.py
+++ b/app/models.py
@@ -76,6 +76,7 @@ from app.utils import (
     DATETIME_FORMAT,
     DATETIME_FORMAT_NO_TIMEZONE,
     get_dt_string_or_none,
+    get_london_midnight_in_utc,
     get_uuid_string_or_none,
     url_with_token,
 )
@@ -2704,6 +2705,10 @@ class UnsubscribeRequestReport(db.Model):
     processed_by_service_at = db.Column(db.DateTime, nullable=True)
     count = db.Column(db.BigInteger, nullable=False)
 
+    @property
+    def will_be_archived_at(self):
+        return get_london_midnight_in_utc(self.created_at + datetime.timedelta(days=7))
+
     def serialize(self):
         return {
             "batch_id": str(self.id),
@@ -2715,6 +2720,7 @@ class UnsubscribeRequestReport(db.Model):
                 self.processed_by_service_at.strftime(DATETIME_FORMAT) if self.processed_by_service_at else None
             ),
             "is_a_batched_report": True,
+            "will_be_archived_at": self.will_be_archived_at.strftime(DATETIME_FORMAT),
         }
 
     @staticmethod
@@ -2727,6 +2733,9 @@ class UnsubscribeRequestReport(db.Model):
             "latest_timestamp": unbatched_unsubscribe_requests[0].created_at.strftime(DATETIME_FORMAT),
             "processed_by_service_at": None,
             "is_a_batched_report": False,
+            "will_be_archived_at": get_london_midnight_in_utc(
+                unbatched_unsubscribe_requests[-1].created_at + datetime.timedelta(days=90)
+            ).strftime(DATETIME_FORMAT),
         }
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -2780,6 +2780,11 @@ class UnsubscribeRequest(db.Model):
         Index("ix_unsubscribe_request_unsubscribe_request_report_id", "unsubscribe_request_report_id"),
     )
 
+    def serialize_for_history(self):
+        return {
+            column.key: getattr(self, column.key) for column in self.__table__.columns if column.key != "email_address"
+        }
+
 
 class UnsubscribeRequestHistory(db.Model):
     __tablename__ = "unsubscribe_request_history"
@@ -2793,7 +2798,6 @@ class UnsubscribeRequestHistory(db.Model):
     template_id = db.Column(UUID(as_uuid=True), nullable=False)
     template_version = db.Column(db.Integer, nullable=False)
     created_at = db.Column(db.DateTime, nullable=False)
-    processed_at = db.Column(db.DateTime)
     unsubscribe_request_report_id = db.Column(UUID(as_uuid=True), index=True, nullable=True)
 
 

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -219,11 +219,13 @@ def test_archive_old_unsubscribe_requests(sample_service):
     service_with_no_old_requests = create_service(service_name="No old requests")
 
     for service, created_days_ago, report_id in (
+        # Should not be deleted by this task
         (service_with_no_old_requests, 1, None),
         (sample_service, 90, unsubscribe_request_report.id),
         (sample_service, 90, None),
         (another_service, 90, None),
         (sample_service, 91, unsubscribe_request_report.id),
+        # Should be deleted by this task
         (sample_service, 91, None),
         (another_service, 91, None),
     ):
@@ -237,8 +239,8 @@ def test_archive_old_unsubscribe_requests(sample_service):
     created_unsubscribe_request_history_objects = UnsubscribeRequestHistory.query.all()
     remaining_unsubscribe_requests = UnsubscribeRequest.query.all()
     UnsubscribeRequestReport.query.all()
-    assert len(created_unsubscribe_request_history_objects) == 3
-    assert len(remaining_unsubscribe_requests) == 4
+    assert len(created_unsubscribe_request_history_objects) == 2
+    assert len(remaining_unsubscribe_requests) == 5
 
 
 def test_delete_sms_notifications_older_than_retention_calls_child_task(notify_api, mocker):

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -1326,6 +1326,7 @@ def create_unsubscribe_request_report(
     earliest_timestamp,
     latest_timestamp,
     processed_by_service_at=None,
+    created_at=None,
 ):
     report = UnsubscribeRequestReport(
         id=uuid.uuid4(),
@@ -1334,6 +1335,7 @@ def create_unsubscribe_request_report(
         latest_timestamp=latest_timestamp,
         service_id=service.id,
         processed_by_service_at=processed_by_service_at,
+        created_at=created_at,
     )
     create_unsubscribe_request_reports_dao(report)
     return report

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3562,6 +3562,7 @@ def test_get_unsubscribe_request_report_summary_for_initial_unsubscribe_requests
             "latest_timestamp": "2024-06-30T12:00:00.000000Z",
             "processed_by_service_at": None,
             "is_a_batched_report": False,
+            "will_be_archived_at": "2024-09-26T23:00:00.000000Z",
         }
     ]
 
@@ -3605,6 +3606,7 @@ def test_get_unsubscribe_request_reports_summary(admin_request, sample_service, 
                 report.processed_by_service_at.strftime(DATETIME_FORMAT) if report.processed_by_service_at else None
             ),
             "is_a_batched_report": True,
+            "will_be_archived_at": report.will_be_archived_at.strftime(DATETIME_FORMAT),
         }
         for report in [unsubscribe_request_report_2, unsubscribe_request_report_1]
     ]
@@ -3616,6 +3618,7 @@ def test_get_unsubscribe_request_reports_summary(admin_request, sample_service, 
         "latest_timestamp": "2024-06-30T12:00:00.000000Z",
         "processed_by_service_at": None,
         "is_a_batched_report": False,
+        "will_be_archived_at": "2024-09-26T23:00:00.000000Z",
     }
 
     expected_reports_summary = [


### PR DESCRIPTION
This PR adds celery tasks to cleanup unsubscribe requests that are beyond the data retention period of 7 days for processed requests and 90 days for unprocessed requests.
This [card ](https://trello.com/c/X2Y9Zn26/84-clean-up-old-email-unsubscribe-requests-after-7-days-or-3-months)has more details.