### PR TITLE
Add automated email to send out new user survey

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -183,6 +183,7 @@ class Config:
     NHS_LETTER_BRANDING_ID = "2cd354bb-6b85-eda3-c0ad-6b613150459f"
     REQUEST_INVITE_TO_SERVICE_TEMPLATE_ID = "77677459-f862-44ee-96d9-b8cb2323d407"
     RECEIPT_FOR_REQUEST_INVITE_TO_SERVICE_TEMPLATE_ID = "38bcd263-6ce8-431f-979d-8e637c1f0576"
+    USER_RESEARCH_EMAIL_FOR_NEW_USERS_TEMPLATE_ID = "55bcb671-4924-46c5-a00d-1a9d48458008"
     # we only need real email in Live environment (production)
     DVLA_EMAIL_ADDRESSES = json.loads(os.environ.get("DVLA_EMAIL_ADDRESSES", "[]"))
 
@@ -353,6 +354,11 @@ class Config:
                 "task": "weekly-dwp-report",
                 "schedule": crontab(hour=9, minute=0, day_of_week="mon"),
                 "options": {"queue": QueueNames.REPORTING},
+            },
+            "weekly-user-research-email": {
+                "task": "weekly-user-research-email",
+                "schedule": crontab(hour=10, minute=0, day_of_week="wed"),
+                "options": {"queue": QueueNames.PERIODIC},
             },
             # first tuesday of every month
             "change-dvla-api-key": {

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from random import SystemRandom
 
 from flask import current_app
@@ -192,3 +192,16 @@ def user_can_be_archived(user):
             return False
 
     return True
+
+
+def get_users_for_research(start_date: date, end_date: date) -> list[User]:
+    """
+    Returns active users who have consented to take part in user research and who
+    were created on or after the start but before the end date.
+    """
+    return User.query.filter(
+        User.state == "active",
+        User.take_part_in_research == True,  # noqa
+        User.created_at >= start_date,
+        User.created_at < end_date,
+    ).all()

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0460_letter_rates_july_2024
+0461_user_research_email

--- a/migrations/versions/0461_user_research_email.py
+++ b/migrations/versions/0461_user_research_email.py
@@ -1,0 +1,95 @@
+"""
+Create Date: 2024-08-20 18:50:23.266628
+"""
+
+import textwrap
+from alembic import op
+from flask import current_app
+
+
+revision = "0461_user_research_email"
+down_revision = "0460_letter_rates_july_2024"
+
+
+template_id = "55bcb671-4924-46c5-a00d-1a9d48458008"
+template_content = textwrap.dedent(
+    """
+Hi ((name))
+# How easy was it to start using GOV.UK Notify?
+
+Please take 30 seconds to let us know:
+
+https://surveys.publishing.service.gov.uk/s/notify-getting-started/
+
+If you want to, you can tell us more about your experiences so far – from creating an account to setting up your first service.
+
+We’ll read every piece of feedback we get, and your insights will help us to make GOV.UK Notify better for everyone.
+
+Kind regards
+GOV.UK Notify
+
+---
+
+If you do not want to take part in user research, you can [unsubscribe from these emails](https://www.notifications.service.gov.uk/user-profile/take-part-in-user-research).    """
+)
+
+
+def upgrade():
+    for table_name in ("templates", "templates_history"):
+        op.execute(
+            f"""
+            INSERT INTO {table_name} (
+                id,
+                name,
+                template_type,
+                created_at,
+                subject,
+                content,
+                archived,
+                service_id,
+                created_by_id,
+                version,
+                process_type,
+                hidden,
+                has_unsubscribe_link
+            )
+            VALUES (
+                '{template_id}',
+                'New user survey',
+                'email',
+                current_timestamp,
+                'How easy was it to start using GOV.UK Notify?',
+                '{template_content}',
+                false,
+                '{current_app.config["NOTIFY_SERVICE_ID"]}',
+                '{current_app.config["NOTIFY_USER_ID"]}',
+                1,
+                'normal',
+                false,
+                false
+            )
+            ON CONFLICT DO NOTHING
+            """
+        )
+
+    op.execute(
+        f"""
+        INSERT INTO template_redacted
+        (
+            template_id,
+            redact_personalisation,
+            updated_at,
+            updated_by_id
+        ) VALUES (
+            '{template_id}',
+            false,
+            current_timestamp,
+            '{current_app.config["NOTIFY_USER_ID"]}'
+        )
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+
+def downgrade():
+    pass

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -928,6 +928,40 @@ def organisation_reject_go_live_request_template(notify_service):
     )
 
 
+@pytest.fixture(scope="function")
+def user_research_email_for_new_users_template(notify_service):
+    template_content = textwrap.dedent(
+        """\
+        Hi ((name))
+        # How easy was it to start using GOV.UK Notify?
+
+        Please take 30 seconds to let us know:
+
+        https://surveys.publishing.service.gov.uk/s/notify-getting-started/
+
+        If you want to, you can tell us more about your experiences so far – from creating an account to setting up your first service.
+
+        We’ll read every piece of feedback we get, and your insights will help us to make GOV.UK Notify better for everyone.
+
+        Kind regards
+        GOV.UK Notify
+
+        ---
+
+        If you do not want to take part in user research, you can [unsubscribe from these emails](https://www.notifications.service.gov.uk/user-profile/take-part-in-user-research).
+        """  # noqa
+    )
+
+    return create_custom_template(
+        service=notify_service,
+        user=notify_service.users[0],
+        template_config_name="USER_RESEARCH_EMAIL_FOR_NEW_USERS_TEMPLATE_ID",
+        content=template_content,
+        subject="How easy was it to start using GOV.UK Notify?",
+        template_type="email",
+    )
+
+
 @pytest.fixture
 def notify_service(notify_db_session, sample_user):
     service = Service.query.get(current_app.config["NOTIFY_SERVICE_ID"])


### PR DESCRIPTION
https://trello.com/c/RyvaiUpK/890-automate-email-to-send-out-new-user-survey

We want to send out a survey to users roughly 2 weeks after signing up to Notify. This adds a migration to create the template, and a scheduled task to send the email.

To give examples of which users will be receiving the email:
- The task run on Wednesday 14 August will get users created between Monday 29th July and Sunday 4th August inclusive
- The task run on Wednesday 21st August will get users created between Monday 5th August and Sunday 11th August inclusive
- The task run on Wednesday 28th will get users created between Monday 12 August and Sunday 18th August inclusive.