### PR TITLE
Only return unsubscribe reports with requests

### DIFF
--- a/app/dao/unsubscribe_request_dao.py
+++ b/app/dao/unsubscribe_request_dao.py
@@ -53,9 +53,10 @@ def get_latest_unsubscribe_request_date_dao(service_id):
 
 def get_unsubscribe_request_reports_dao(service_id):
     return (
-        UnsubscribeRequestReport.query.filter_by(service_id=service_id)
+        UnsubscribeRequestReport.query.filter(UnsubscribeRequestReport.service_id == service_id)
+        .join(UnsubscribeRequest, UnsubscribeRequest.unsubscribe_request_report_id == UnsubscribeRequestReport.id)
         .order_by(desc(UnsubscribeRequestReport.latest_timestamp))
-        .all()
+        .distinct()
     )
 
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3638,6 +3638,9 @@ def test_get_unsubscribe_request_reports_summary(admin_request, sample_service, 
         service_id=sample_service.id,
     )
     create_unsubscribe_request_reports_dao(unsubscribe_request_report_1)
+    create_unsubscribe_request_dao(
+        unbatched_request_2_data | {"unsubscribe_request_report_id": unsubscribe_request_report_1.id}
+    )
 
     unsubscribe_request_report_2 = UnsubscribeRequestReport(
         id=uuid.uuid4(),
@@ -3648,6 +3651,9 @@ def test_get_unsubscribe_request_reports_summary(admin_request, sample_service, 
         service_id=sample_service.id,
     )
     create_unsubscribe_request_reports_dao(unsubscribe_request_report_2)
+    create_unsubscribe_request_dao(
+        unbatched_request_2_data | {"unsubscribe_request_report_id": unsubscribe_request_report_2.id}
+    )
 
     expected_batched_unsubscribe_request_reports_summary = [
         {


### PR DESCRIPTION
When we start to delete old unsubscribe requests we will leave behind the reports to which they were joined.

We don’t want to delete these reports completely, since it’s useful for us to keep a record of what happened when, and how many requests there were. We do a similar thing for `Job` objects, where they stay in the database for all time.

However it’s not useful to show these old reports on the dashboard, because if a user clicks through to them they won’t be able to access the underlying requests.

So this pull request modifies the function which returns the list of reports to the admin app, excluding those which no longer have any requests attached to them.