### PR TITLE
Updated phonenumber validation code to use allow_landline flag

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -149,7 +149,8 @@ def persist_notification(
     )
     if notification_type == SMS_TYPE:
         if service.has_permission(SMS_TO_UK_LANDLINES):
-            phonenumber = PhoneNumber(recipient, allow_international=True)
+            phonenumber = PhoneNumber(recipient)
+            phonenumber.validate(allow_international_number=True, allow_uk_landline=True)
             formatted_recipient = phonenumber.get_normalised_format()
             recipient_info = phonenumber.get_international_phone_info()
         else:

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -143,7 +143,11 @@ def validate_and_format_recipient(send_to, key_type, service, notification_type,
     if notification_type == SMS_TYPE:
         if service.has_permission(SMS_TO_UK_LANDLINES):
             try:
-                phone_number = PhoneNumber(send_to, allow_international=service.has_permission(INTERNATIONAL_SMS_TYPE))
+                phone_number = PhoneNumber(send_to)
+                phone_number.validate(
+                    allow_international_number=service.has_permission(INTERNATIONAL_SMS_TYPE),
+                    allow_uk_landline=service.has_permission(SMS_TO_UK_LANDLINES),
+                )
                 return phone_number.get_normalised_format()
             except InvalidPhoneError as e:
                 if e.code == InvalidPhoneError.Codes.NOT_A_UK_MOBILE:

--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -24,7 +24,11 @@ def validate_schema_phone_number(instance):
 
     if isinstance(instance, str):
         try:
-            PhoneNumber(instance, allow_international=True)
+            number = PhoneNumber(instance)
+            number.validate(
+                allow_international_number=True,
+                allow_uk_landline=True,
+            )
         except InvalidPhoneError as e:
             legacy_message = e.get_legacy_v2_api_error_message()
             raise ValidationError(legacy_message) from None

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ lxml==4.9.3
 notifications-python-client==8.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@85.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@86.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@85.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@86.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test_common.txt
+++ b/requirements_for_test_common.txt
@@ -1,4 +1,4 @@
-# This file is automatically copied from notifications-utils@85.0.0
+# This file is automatically copied from notifications-utils@86.0.0
 
 beautifulsoup4==4.11.1
 pytest==7.2.0


### PR DESCRIPTION
Two changes:

1) Adds permissions (international and landline) as flags to the phonenumbers validation method so that it can be used universally for all validation.

2) Separates out validation from parsing so that an instance of a phonenumber object represents a possible number, and validation is called explicitly to check whether this possible number can be sent to by a service. This makes the class more flexible and improves code readability.