### PR TITLE
Return id for serialize_for_csv - so that admin app can determine older_than arg

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1582,6 +1582,7 @@ class Notification(db.Model):
     def serialize_for_csv(self):
         created_at_in_bst = convert_utc_to_bst(self.created_at)
         serialized = {
+            "id": self.id,
             "row_number": "" if self.job_row_number is None else self.job_row_number + 1,
             "recipient": self.to,
             "client_reference": self.client_reference or "",

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -868,6 +868,7 @@ def test_get_all_notifications_for_job_returns_csv_format(admin_request, sample_
 
     assert len(resp["notifications"]) == 1
     assert set(resp["notifications"][0].keys()) == {
+        "id",
         "created_at",
         "created_by_name",
         "created_by_email_address",


### PR DESCRIPTION
Related to, and needs to go in before this admin PR: https://github.com/alphagov/notifications-api/pull/4175