### PR TITLE
feat: join service requests

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -340,3 +340,14 @@ class CacheKeys:
 
 # Admin API error codes
 QR_CODE_TOO_LONG = "qr-code-too-long"
+
+# Service Join Request statuses
+JOIN_REQUEST_PENDING = "pending"
+JOIN_REQUEST_APPROVED = "approved"
+JOIN_REQUEST_REJECTED = "rejected"
+
+REQUEST_STATUS_VALUES = [
+    JOIN_REQUEST_APPROVED,
+    JOIN_REQUEST_REJECTED,
+    JOIN_REQUEST_PENDING,
+]

--- a/app/dao/service_join_requests_dao.py
+++ b/app/dao/service_join_requests_dao.py
@@ -1,0 +1,29 @@
+from uuid import UUID
+
+from app import db
+from app.dao.dao_utils import autocommit
+from app.models import ServiceJoinRequest, User
+
+
+@autocommit
+def dao_create_service_join_request(
+    requester_id: UUID, service_id: UUID, contacted_user_ids: list[UUID]
+) -> ServiceJoinRequest:
+    new_request = ServiceJoinRequest(
+        requester_id=requester_id,
+        service_id=service_id,
+    )
+
+    contacted_users = User.query.filter(User.id.in_(contacted_user_ids)).all()
+    new_request.contacted_service_users.extend(contacted_users)
+
+    db.session.add(new_request)
+    return new_request
+
+
+def dao_get_service_join_request_by_id(request_id: UUID) -> ServiceJoinRequest | None:
+    return (
+        ServiceJoinRequest.query.filter_by(id=request_id)
+        .options(db.joinedload("contacted_service_users"))
+        .one_or_none()
+    )

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,7 @@
 import datetime
 import enum
 import uuid
+from dataclasses import dataclass
 
 from flask import current_app, url_for
 from notifications_utils.insensitive_dict import InsensitiveDict
@@ -44,6 +45,7 @@ from app.constants import (
     GUEST_LIST_RECIPIENT_TYPE,
     INVITE_PENDING,
     INVITED_USER_STATUS_TYPES,
+    JOIN_REQUEST_PENDING,
     LETTER_TYPE,
     MOBILE_TYPE,
     NORMAL,
@@ -62,6 +64,7 @@ from app.constants import (
     ORGANISATION_PERMISSION_TYPES,
     PERMISSION_LIST,
     PRECOMPILED_TEMPLATE_NAME,
+    REQUEST_STATUS_VALUES,
     SMS_AUTH_TYPE,
     SMS_TYPE,
     TEMPLATE_TYPES,
@@ -2815,3 +2818,63 @@ class ProtectedSenderId(db.Model):
     __tablename__ = "protected_sender_ids"
 
     sender_id = db.Column(db.String, primary_key=True, nullable=False)
+
+
+@dataclass
+class SerializedServiceJoinRequest:
+    service_join_request_id: str
+    requester_id: str
+    service_id: str
+    created_at: str
+    status: str
+    status_changed_at: str | None
+    status_changed_by_id: str | None
+    reason: str | None
+    contacted_service_users: list[str]
+
+
+contacted_users = db.Table(
+    "contacted_users",
+    db.Model.metadata,
+    db.Column(
+        "service_join_request_id", UUID(as_uuid=True), db.ForeignKey("service_join_requests.id"), primary_key=True
+    ),
+    db.Column("user_id", UUID(as_uuid=True), db.ForeignKey("users.id"), primary_key=True),
+)
+
+
+class ServiceJoinRequest(db.Model):
+    __tablename__ = "service_join_requests"
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    requester_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=False)
+    service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), nullable=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow())
+    status = db.Column(
+        db.Enum(*REQUEST_STATUS_VALUES, name="request_status"), nullable=False, default=JOIN_REQUEST_PENDING
+    )
+    status_changed_at = db.Column(db.DateTime, nullable=True)
+    status_changed_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
+    reason = db.Column(db.Text, nullable=True)
+
+    requester = db.relationship("User", foreign_keys=[requester_id])
+    status_changed_by = db.relationship("User", foreign_keys=[status_changed_by_id])
+
+    # Use lazy="joined" to load the contacted_service_users relationship with a SQL JOIN
+    # This is a nice option as we expect to load this relationship frequently when querying ServiceJoinRequest
+    contacted_service_users = db.relationship(
+        "User", secondary=contacted_users, backref="service_join_requests", lazy="joined"
+    )
+
+    def serialize(self) -> SerializedServiceJoinRequest:
+        return SerializedServiceJoinRequest(
+            service_join_request_id=get_uuid_string_or_none(self.id),
+            requester_id=get_uuid_string_or_none(self.requester_id),
+            service_id=get_uuid_string_or_none(self.service_id),
+            created_at=get_dt_string_or_none(self.created_at),
+            status=self.status,
+            status_changed_at=get_dt_string_or_none(self.status_changed_at),
+            status_changed_by_id=get_uuid_string_or_none(self.status_changed_by_id),
+            reason=self.reason,
+            contacted_service_users=[get_uuid_string_or_none(user.id) for user in self.contacted_service_users],
+        )

--- a/app/schema_validation/service_join_request.py
+++ b/app/schema_validation/service_join_request.py
@@ -1,0 +1,12 @@
+service_join_request_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Schema for creating a service join request",
+    "type": "object",
+    "properties": {
+        "requester_id": {"type": "string", "format": "uuid"},
+        "contacted_user_ids": {"type": "array", "minItems": 1, "items": {"type": "string", "format": "uuid"}},
+        "reason": {"type": ["string", "null"], "description": "Optional reason for the request"},
+    },
+    "required": ["requester_id", "contacted_user_ids"],
+    "additionalProperties": False,
+}

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0463_backfill_created_at
+0464_create_svc_join_requests

--- a/migrations/versions/0464_create_svc_join_requests.py
+++ b/migrations/versions/0464_create_svc_join_requests.py
@@ -1,0 +1,43 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0464_create_svc_join_requests"
+down_revision = "0463_backfill_created_at"
+
+
+def upgrade():
+    op.create_table(
+        "service_join_requests",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, default=sa.text("uuid_generate_v4()")),
+        sa.Column("requester_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("service_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("services.id"), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column(
+            "status",
+            sa.Enum("pending", "approved", "rejected", name="request_status"),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("status_changed_at", sa.DateTime(), nullable=True),
+        sa.Column("status_changed_by_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=True),
+        sa.Column("reason", sa.Text, nullable=True),
+    )
+
+    op.create_table(
+        "contacted_users",
+        sa.Column(
+            "service_join_request_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("service_join_requests.id"),
+            primary_key=True,
+        ),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), primary_key=True),
+    )
+
+
+def downgrade():
+    # Drop the contacted_users table first due to foreign key dependency
+    op.drop_table("contacted_users")
+
+    op.drop_table("service_join_requests")

--- a/requirements_for_test_common.txt
+++ b/requirements_for_test_common.txt
@@ -1,4 +1,4 @@
-# This file is automatically copied from notifications-utils@82.4.0
+# This file is automatically copied from notifications-utils@84.0.0
 
 beautifulsoup4==4.11.1
 pytest==7.2.0

--- a/tests/app/dao/test_service_join_requests_dao.py
+++ b/tests/app/dao/test_service_join_requests_dao.py
@@ -1,0 +1,118 @@
+from collections import namedtuple
+from uuid import uuid4
+
+import pytest
+
+from app.constants import JOIN_REQUEST_PENDING
+from app.dao.service_join_requests_dao import dao_create_service_join_request, dao_get_service_join_request_by_id
+from tests.app.db import create_service, create_user
+
+
+def setup_service_join_request_test_data(service_id: uuid4(), requester_id: uuid4(), contacted_user_ids: list[uuid4()]):
+    """Helper function to create service, requester, and contacted users."""
+    create_service(service_id=service_id, service_name=f"Service Requester Wants To Join {service_id}")
+    create_user(id=requester_id, name="Requester User")
+
+    users = []
+    for user_id in contacted_user_ids:
+        user = create_user(id=user_id, name=f"User Within Existing Service {user_id}")
+        users.append(user)
+
+    return users
+
+
+ServiceJoinRequestTestCase = namedtuple(
+    "TestCase", ["requester_id", "service_id", "contacted_user_ids", "expected_num_contacts"]
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ServiceJoinRequestTestCase(
+            requester_id=uuid4(),
+            service_id=uuid4(),
+            contacted_user_ids=[uuid4(), uuid4()],
+            expected_num_contacts=2,
+        ),
+        ServiceJoinRequestTestCase(
+            requester_id=uuid4(),
+            service_id=uuid4(),
+            contacted_user_ids=[uuid4()],
+            expected_num_contacts=1,
+        ),
+    ],
+    ids=["two_contacts", "one_contact"],
+)
+def test_dao_create_service_join_request(client, test_case, notify_db_session):
+    users = setup_service_join_request_test_data(
+        test_case.service_id, test_case.requester_id, test_case.contacted_user_ids
+    )
+
+    request = dao_create_service_join_request(
+        requester_id=test_case.requester_id,
+        service_id=test_case.service_id,
+        contacted_user_ids=test_case.contacted_user_ids,
+    )
+
+    assert request.requester_id == test_case.requester_id
+    assert request.service_id == test_case.service_id
+    assert len(request.contacted_service_users) == test_case.expected_num_contacts
+    assert request.status == JOIN_REQUEST_PENDING
+
+    for user in users:
+        assert user in request.contacted_service_users
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ServiceJoinRequestTestCase(
+            requester_id=uuid4(),
+            service_id=uuid4(),
+            contacted_user_ids=[],
+            expected_num_contacts=0,
+        ),
+        ServiceJoinRequestTestCase(
+            requester_id=uuid4(),
+            service_id=uuid4(),
+            contacted_user_ids=[uuid4(), uuid4()],
+            expected_num_contacts=2,
+        ),
+        ServiceJoinRequestTestCase(
+            requester_id=uuid4(),
+            service_id=uuid4(),
+            contacted_user_ids=[uuid4()],
+            expected_num_contacts=1,
+        ),
+    ],
+    ids=["no_contacts", "two_contacts", "one_contact"],
+)
+def test_get_service_join_request_by_id(client, test_case, notify_db_session):
+    users = setup_service_join_request_test_data(
+        test_case.service_id, test_case.requester_id, test_case.contacted_user_ids
+    )
+
+    request = dao_create_service_join_request(
+        requester_id=test_case.requester_id,
+        service_id=test_case.service_id,
+        contacted_user_ids=test_case.contacted_user_ids,
+    )
+
+    retrieved_request = dao_get_service_join_request_by_id(request.id)
+
+    assert retrieved_request is not None
+    assert retrieved_request.id == request.id
+    assert retrieved_request.requester_id == test_case.requester_id
+    assert retrieved_request.service_id == test_case.service_id
+    assert len(retrieved_request.contacted_service_users) == test_case.expected_num_contacts
+
+    for user in users:
+        assert user in retrieved_request.contacted_service_users
+
+
+def test_get_service_join_request_by_id_not_found(notify_db_session):
+    non_existent_id = uuid4()
+    retrieved_request = dao_get_service_join_request_by_id(non_existent_id)
+
+    assert retrieved_request is None


### PR DESCRIPTION
## Summary 
As part of the new flow for Service Join Request, we want to start storing the data for join requests on our DB

**DAO**
Defined `ServiceJoinRequest` for interacting with DB data models.py

Methods available:
- dao_create_service_join_request
- dao_get_service_join_request_by_id

**SERVICE (rest)**
Defined`ServiceJoinRequestSchema` for data validation schemas.py

Methods available:
- dao_create_service_join_request
- dao_get_service_join_request


### Ticket
[Update "join a service" flow to persist data
](https://trello.com/c/iI2xFQq9/907-update-join-a-service-flow-to-persist-data)