### PR TITLE
Fix v2 api to return consistent error messages when empty strings are passed as phone numbers

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ lxml==4.9.3
 notifications-python-client==8.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.4.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.6.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.4.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.6.1
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
Provides a fix for an edge case was discovered where errors returned from json validation on the v2 API were inconsistent with the old validatio method if an empty string was passed as a phonenumber. The new code returned an INVALID_NUMBER error when it should return a TOO_SHORT error.