### PR TITLE
Add `created_at` column to unsubscribe request reports

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0461_user_research_email
+0462_unsubscribe_created_at

--- a/migrations/versions/0462_unsubscribe_created_at.py
+++ b/migrations/versions/0462_unsubscribe_created_at.py
@@ -1,0 +1,18 @@
+"""
+Create Date: 2024-07-02 08:50:23.266628
+"""
+
+from alembic import op
+from sqlalchemy import Column, DateTime
+
+
+revision = "0462_unsubscribe_created_at"
+down_revision = "0461_user_research_email"
+
+
+def upgrade():
+    op.add_column("unsubscribe_request_report", Column("created_at", DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("unsubscribe_request_report", "created_at")


### PR DESCRIPTION
So we can perform actions a certain nuber of days after a report is first downloaded, we need to know when it was first downloaded. This is also the same time it gets created. Therefore we can use the pattern of a `created_at` column.

Need to deploy this as a migration first before adding the column to the model.