### PR TITLE
Backfill `created_at` dates for unsubscribe request reports

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2698,6 +2698,7 @@ class UnsubscribeRequestReport(db.Model):
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), nullable=False)
     service = db.relationship(Service, backref=db.backref("unsubscribe_request_reports"))
 
+    created_at = db.Column(db.DateTime, nullable=True, default=datetime.datetime.utcnow)
     earliest_timestamp = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     latest_timestamp = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     processed_by_service_at = db.Column(db.DateTime, nullable=True)
@@ -2707,6 +2708,7 @@ class UnsubscribeRequestReport(db.Model):
         return {
             "batch_id": str(self.id),
             "count": self.count,
+            "created_at": self.created_at.strftime(DATETIME_FORMAT),
             "earliest_timestamp": self.earliest_timestamp.strftime(DATETIME_FORMAT),
             "latest_timestamp": self.latest_timestamp.strftime(DATETIME_FORMAT),
             "processed_by_service_at": (
@@ -2720,6 +2722,7 @@ class UnsubscribeRequestReport(db.Model):
         return {
             "batch_id": None,
             "count": len(unbatched_unsubscribe_requests),
+            "created_at": None,
             "earliest_timestamp": unbatched_unsubscribe_requests[-1].created_at.strftime(DATETIME_FORMAT),
             "latest_timestamp": unbatched_unsubscribe_requests[0].created_at.strftime(DATETIME_FORMAT),
             "processed_by_service_at": None,

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0462_unsubscribe_created_at
+0463_backfill_created_at

--- a/migrations/versions/0463_backfill_created_at.py
+++ b/migrations/versions/0463_backfill_created_at.py
@@ -1,0 +1,47 @@
+"""
+Create Date: 2024-07-02 08:51:23.266628
+"""
+
+from alembic import op
+from sqlalchemy import DateTime
+
+
+revision = "0463_backfill_created_at"
+down_revision = "0462_unsubscribe_created_at"
+
+
+DAY_ZERO = "2024-05-29"  # The day before we added the table
+
+
+def upgrade():
+    op.execute(f"""
+        UPDATE
+            unsubscribe_request_report
+        SET
+            created_at = '{DAY_ZERO}'
+        WHERE
+            created_at is NULL
+    """)
+    op.alter_column(
+        "unsubscribe_request_report",
+        "created_at",
+        existing_type=DateTime(),
+        nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "unsubscribe_request_report",
+        "created_at",
+        existing_type=DateTime(),
+        nullable=True,
+    )
+    op.execute(f"""
+        UPDATE
+            unsubscribe_request_report
+        SET
+            created_at = NULL
+        WHERE
+            created_at <= '{DAY_ZERO}'
+    """)

--- a/migrations/versions/0463_backfill_created_at.py
+++ b/migrations/versions/0463_backfill_created_at.py
@@ -14,14 +14,16 @@ DAY_ZERO = "2024-05-29"  # The day before we added the table
 
 
 def upgrade():
-    op.execute(f"""
+    op.execute(
+        f"""
         UPDATE
             unsubscribe_request_report
         SET
             created_at = '{DAY_ZERO}'
         WHERE
             created_at is NULL
-    """)
+    """
+    )
     op.alter_column(
         "unsubscribe_request_report",
         "created_at",
@@ -37,11 +39,13 @@ def downgrade():
         existing_type=DateTime(),
         nullable=True,
     )
-    op.execute(f"""
+    op.execute(
+        f"""
         UPDATE
             unsubscribe_request_report
         SET
             created_at = NULL
         WHERE
             created_at <= '{DAY_ZERO}'
-    """)
+    """
+    )

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3557,6 +3557,7 @@ def test_get_unsubscribe_request_report_summary_for_initial_unsubscribe_requests
         {
             "batch_id": None,
             "count": 2,
+            "created_at": None,
             "earliest_timestamp": "2024-06-29T12:00:00.000000Z",
             "latest_timestamp": "2024-06-30T12:00:00.000000Z",
             "processed_by_service_at": None,
@@ -3597,6 +3598,7 @@ def test_get_unsubscribe_request_reports_summary(admin_request, sample_service, 
         {
             "batch_id": str(report.id),
             "count": report.count,
+            "created_at": report.created_at.strftime(DATETIME_FORMAT),
             "earliest_timestamp": report.earliest_timestamp.strftime(DATETIME_FORMAT),
             "latest_timestamp": report.latest_timestamp.strftime(DATETIME_FORMAT),
             "processed_by_service_at": (
@@ -3609,6 +3611,7 @@ def test_get_unsubscribe_request_reports_summary(admin_request, sample_service, 
     expected_unbatched_unsubscribe_request_summary = {
         "batch_id": None,
         "count": 2,
+        "created_at": None,
         "earliest_timestamp": "2024-06-29T12:00:00.000000Z",
         "latest_timestamp": "2024-06-30T12:00:00.000000Z",
         "processed_by_service_at": None,
@@ -3621,16 +3624,7 @@ def test_get_unsubscribe_request_reports_summary(admin_request, sample_service, 
 
     response = admin_request.get("service.get_unsubscribe_request_reports_summary", service_id=sample_service.id)
 
-    for index, summary in enumerate(response):
-        assert summary["batch_id"] == expected_reports_summary[index]["batch_id"]
-        assert summary["count"] == expected_reports_summary[index]["count"]
-        assert summary["earliest_timestamp"] == expected_reports_summary[index]["earliest_timestamp"]
-        assert summary["latest_timestamp"] == expected_reports_summary[index]["latest_timestamp"]
-        assert summary["is_a_batched_report"] == expected_reports_summary[index]["is_a_batched_report"]
-
-    assert response[0]["processed_by_service_at"] == expected_reports_summary[0]["processed_by_service_at"]
-    assert response[1]["processed_by_service_at"] == expected_reports_summary[1]["processed_by_service_at"]
-    assert response[2]["processed_by_service_at"] == expected_reports_summary[2]["processed_by_service_at"]
+    assert response == expected_reports_summary
 
 
 def test_get_unsubscribe_requests_statistics(admin_request, sample_service, mocker):


### PR DESCRIPTION
So that the codebase doesn’t have to deal with null values in this column we need to make sure every row has a value. The value chosen is the date when the table was first created. So it’s impossible for any reports to have this as their real `created_at` date.

Secondly we can modify the table to make the column non-nullable.

Now that we know the column will always have a value, we can start returning it in the serialised response.