### PR TITLE
Add missing `db.session.commit()` when archiving unsubscribe requests

### DIFF
--- a/app/dao/unsubscribe_request_dao.py
+++ b/app/dao/unsubscribe_request_dao.py
@@ -168,4 +168,6 @@ def archive_unsubscribe_requests_from_query(query):
         UnsubscribeRequest.__table__.delete().where(UnsubscribeRequest.id.in_({row["id"] for row in rows}))
     )
 
+    db.session.commit()
+
     return delete_result.rowcount


### PR DESCRIPTION
Maybe this is why the task says it’s run successfully but hasn’t done anything?