### PR TITLE
Delete Redis cache after archiving unsubscribe requests

### DIFF
--- a/app/dao/unsubscribe_request_dao.py
+++ b/app/dao/unsubscribe_request_dao.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from sqlalchemy import desc, func
 
-from app import db
+from app import db, redis_store
 from app.dao.dao_utils import autocommit
 from app.models import (
     Job,
@@ -169,5 +169,8 @@ def archive_unsubscribe_requests_from_query(query):
     )
 
     db.session.commit()
+
+    redis_store.delete(f"service-{rows[0]['service_id']}-unsubscribe-request-statistics")
+    redis_store.delete(f"service-{rows[0]['service_id']}-unsubscribe-request-reports-summary")
 
     return delete_result.rowcount


### PR DESCRIPTION
If we don’t do this the numbers on the dashboard and in the reports won’t update.

Unfortunately we need to do this twice per service, since we can’t guarantee execution order of the two Celery tasks.