### PR TITLE
Make DVLA callback API update `NotificationLetterDespatch`

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -889,3 +889,25 @@ def dao_record_letter_despatched_on(reference: str, despatched_on: datetime.date
     )
 
     db.session.execute(stmt)
+
+
+@autocommit
+def dao_record_letter_despatched_on_by_id(
+    notification_id: str,
+    despatched_on: datetime.date,
+    cost_threshold: LetterCostThreshold,
+):
+    stmt = (
+        insert(NotificationLetterDespatch)
+        .values(
+            notification_id=notification_id,
+            despatched_on=despatched_on,
+            cost_threshold=cost_threshold,
+        )
+        .on_conflict_do_update(
+            index_elements=["notification_id"],
+            set_={"despatched_on": despatched_on, "cost_threshold": cost_threshold.value},
+        )
+    )
+
+    db.session.execute(stmt)

--- a/app/notifications/notifications_letter_callback.py
+++ b/app/notifications/notifications_letter_callback.py
@@ -1,9 +1,11 @@
+import datetime
 import json
 from dataclasses import dataclass
 from functools import wraps
 
 from flask import Blueprint, current_app, jsonify, request
 from itsdangerous import BadSignature
+from notifications_utils.timezones import convert_utc_to_bst
 
 from app import signing
 from app.celery.process_letter_client_response_tasks import process_letter_callback_data
@@ -13,6 +15,7 @@ from app.celery.tasks import (
 )
 from app.config import QueueNames
 from app.errors import InvalidRequest
+from app.models import LetterCostThreshold
 from app.notifications.utils import autoconfirm_subscription
 from app.schema_validation import validate
 from app.v2.errors import register_errors
@@ -181,6 +184,8 @@ def check_token_matches_payload(notification_id, request_id):
 class LetterUpdate:
     page_count: str
     status: str
+    cost_threshold: LetterCostThreshold
+    despatch_date: str
 
 
 def extract_properties_from_request(request_data) -> LetterUpdate:
@@ -190,4 +195,31 @@ def extract_properties_from_request(request_data) -> LetterUpdate:
     page_count = next(item["value"] for item in despatch_properties if item["key"] == "totalSheets")
     status = request_data["data"]["jobStatus"]
 
-    return LetterUpdate(page_count=page_count, status=status)
+    mailing_product = next(item["value"] for item in despatch_properties if item["key"] == "mailingProduct")
+    postage = next(item["value"] for item in despatch_properties if item["key"] == "postageClass")
+    cost_threshold = _get_cost_threshold(mailing_product, postage)
+
+    despatch_datetime = next(item["value"] for item in despatch_properties if item["key"] == "Print Date")
+    despatch_date = _get_despatch_date(despatch_datetime)
+
+    return LetterUpdate(
+        page_count=page_count,
+        status=status,
+        cost_threshold=cost_threshold,
+        despatch_date=despatch_date,
+    )
+
+
+def _get_cost_threshold(mailing_product: str, postage: str) -> LetterCostThreshold:
+    if mailing_product == "MM" and postage == "2ND":
+        return LetterCostThreshold("sorted")
+
+    return LetterCostThreshold("unsorted")
+
+
+def _get_despatch_date(despatch_datetime: str) -> datetime.date:
+    """
+    Converts a string which has the format of 2024-08-01T09:15:14.456Z to a local time date
+    """
+    utc_datetime = datetime.datetime.strptime(despatch_datetime, "%Y-%m-%dT%H:%M:%S.%fZ")
+    return convert_utc_to_bst(utc_datetime).date()

--- a/app/notifications/notifications_letter_callback.py
+++ b/app/notifications/notifications_letter_callback.py
@@ -160,7 +160,7 @@ def process_letter_callback():
         queue=QueueNames.NOTIFY,
     )
 
-    return jsonify(result="success"), 200
+    return {}, 204
 
 
 def parse_token(token):

--- a/app/notifications/notifications_letter_callback.py
+++ b/app/notifications/notifications_letter_callback.py
@@ -154,6 +154,8 @@ def process_letter_callback():
             "notification_id": notification_id,
             "page_count": letter_update.page_count,
             "status": letter_update.status,
+            "cost_threshold": letter_update.cost_threshold,
+            "despatch_date": letter_update.despatch_date,
         },
         queue=QueueNames.NOTIFY,
     )

--- a/tests/app/notifications/test_notifications_letter_callbacks.py
+++ b/tests/app/notifications/test_notifications_letter_callbacks.py
@@ -293,7 +293,7 @@ def test_process_letter_callback_calls_process_letter_callback_data_task(
     data = mock_dvla_callback_data()
     data["data"]["jobStatus"] = status
 
-    client.post(
+    response = client.post(
         url_for(
             "notifications_letter_callback.process_letter_callback",
             token=signing.encode("cfce9e7b-1534-4c07-a66d-3cf9172f7640"),
@@ -311,6 +311,8 @@ def test_process_letter_callback_calls_process_letter_callback_data_task(
             "despatch_date": datetime.date(2024, 8, 1),
         },
     )
+
+    assert response.status_code == 204
 
 
 @pytest.mark.parametrize("token", [None, "invalid-token"])

--- a/tests/app/notifications/test_notifications_letter_callbacks.py
+++ b/tests/app/notifications/test_notifications_letter_callbacks.py
@@ -354,7 +354,7 @@ def test_extract_properties_from_request(mock_dvla_callback_data):
 
     data = mock_dvla_callback_data(overrides)
 
-    page_count, status = extract_properties_from_request(data)
+    letter_update = extract_properties_from_request(data)
 
-    assert page_count == "10"
-    assert status == "REJECTED"
+    assert letter_update.page_count == "10"
+    assert letter_update.status == "REJECTED"

--- a/tests/app/notifications/test_notifications_letter_callbacks.py
+++ b/tests/app/notifications/test_notifications_letter_callbacks.py
@@ -6,6 +6,7 @@ from itsdangerous import BadSignature
 
 from app import signing
 from app.errors import InvalidRequest
+from app.models import LetterCostThreshold
 from app.notifications.notifications_letter_callback import (
     _get_cost_threshold,
     _get_despatch_date,
@@ -306,6 +307,8 @@ def test_process_letter_callback_calls_process_letter_callback_data_task(
             "notification_id": "cfce9e7b-1534-4c07-a66d-3cf9172f7640",
             "page_count": "5",
             "status": status,
+            "cost_threshold": LetterCostThreshold.unsorted,
+            "despatch_date": datetime.date(2024, 8, 1),
         },
     )
 


### PR DESCRIPTION
https://trello.com/c/rpy5t1Dh/887-make-dvla-callback-api-update-notificationletterdespatch

For each letter notification, we store in the `notifications_letter_despatch` table the notification ID, the despatchDate (ie: the date when it was printed, which is the date that DVLA will bill us for in their invoice), and the costThreshold which is one of sorted or unsorted - these refer to two different pricing models that DVLA apply based on volumes of letters that we send.

Best reviewed commit by commit, but change now ensures that we write to the `notifications_letter_despatch` table when we get a letter callback from the DVLA.

Still to do: We need to think more about error handling and what happens if the `process_letter_callback_data` task fails part way through - what do we do about retries, how do we identify which tasks failed etc. I think that can be split out into a separate story.