### PR TITLE
Updates utils to 84.0.0 to fix a validation bug with the phone_numbers library preventing sending to certain Jersey phone numbers

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ lxml==4.9.3
 notifications-python-client==8.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.6.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.6.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -159,7 +159,7 @@ packaging==23.2
     # via
     #   marshmallow
     #   marshmallow-sqlalchemy
-phonenumbers==8.13.18
+phonenumbers==8.13.45
     # via notifications-utils
 prometheus-client==0.14.1
     # via


### PR DESCRIPTION
t was discovered that a subset of valid Jersey phone numbers were being incorrectly invalidated by the phone_numbers library code due to a bug in the regex phone numbers were being validated against for the Jersey region. The latest version provides a fix