### PR TITLE
Return `created_at` field for users

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -181,6 +181,7 @@ class User(db.Model):
             "id": self.id,
             "name": self.name,
             "email_address": self.email_address,
+            "created_at": self.created_at.strftime(DATETIME_FORMAT),
             "auth_type": self.auth_type,
             "current_session_id": self.current_session_id,
             "failed_login_count": self.failed_login_count,

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -20,6 +20,7 @@ from app.dao.service_user_dao import (
     dao_update_service_user,
 )
 from app.models import Notification, OrganisationUserPermissions, Permission, User
+from app.utils import DATETIME_FORMAT
 from tests import create_admin_authorization_header, create_service_authorization_header
 from tests.app.db import (
     create_organisation,
@@ -41,11 +42,12 @@ def test_get_user(admin_request, sample_service, sample_organisation):
     expected_permissions = default_service_permissions
     fetched = json_resp["data"]
 
-    assert len(fetched) == 19
+    assert len(fetched) == 20
 
     assert fetched["id"] == str(sample_user.id)
     assert fetched["name"] == sample_user.name
     assert fetched["email_address"] == sample_user.email_address
+    assert fetched["created_at"] == sample_user.created_at.strftime(DATETIME_FORMAT)
     assert fetched["auth_type"] == SMS_AUTH_TYPE
     assert fetched["current_session_id"] is None
     assert fetched["failed_login_count"] == 0


### PR DESCRIPTION
We want to be able to use the date that a user was created in admin (for adding as a field to Zendesk tickets), so this change adds it to the user fields that get returned.