### PR TITLE
Return local times in unsubscribe request report

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -20,7 +20,6 @@ from notifications_utils.template import (
     PlainTextEmailTemplate,
     SMSMessageTemplate,
 )
-from notifications_utils.timezones import convert_utc_to_bst
 from sqlalchemy import (
     CheckConstraint,
     Index,
@@ -79,6 +78,7 @@ from app.utils import (
     get_london_midnight_in_utc,
     get_uuid_string_or_none,
     url_with_token,
+    utc_string_to_bst_string,
 )
 
 
@@ -1582,7 +1582,6 @@ class Notification(db.Model):
             return None
 
     def serialize_for_csv(self):
-        created_at_in_bst = convert_utc_to_bst(self.created_at)
         serialized = {
             "id": self.id,
             "row_number": "" if self.job_row_number is None else self.job_row_number + 1,
@@ -1592,7 +1591,7 @@ class Notification(db.Model):
             "template_type": self.template.template_type,
             "job_name": self.job.original_file_name if self.job else "",
             "status": self.formatted_status,
-            "created_at": created_at_in_bst.strftime("%Y-%m-%d %H:%M:%S"),
+            "created_at": utc_string_to_bst_string(self.created_at),
             "created_by_name": self.get_created_by_name(),
             "created_by_email_address": self.get_created_by_email_address(),
             "api_key_name": self.api_key.name if self.api_key else None,

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -161,6 +161,7 @@ from app.utils import (
     get_next_link_for_pagination_by_older_than,
     get_prev_next_pagination_links,
     midnight_n_days_ago,
+    utc_string_to_bst_string,
 )
 
 service_blueprint = Blueprint("service", __name__)
@@ -1218,8 +1219,10 @@ def get_unsubscribe_request_report_for_download(service_id, batch_id):
                     "email_address": unsubscribe_request.email_address,
                     "template_name": unsubscribe_request.template_name,
                     "original_file_name": unsubscribe_request.original_file_name,
-                    "template_sent_at": unsubscribe_request.template_sent_at,
-                    "unsubscribe_request_received_at": unsubscribe_request.unsubscribe_request_received_at,
+                    "template_sent_at": utc_string_to_bst_string(unsubscribe_request.template_sent_at),
+                    "unsubscribe_request_received_at": utc_string_to_bst_string(
+                        unsubscribe_request.unsubscribe_request_received_at
+                    ),
                 }
                 for unsubscribe_request in get_unsubscribe_requests_data_for_download_dao(service_id, report.id)
             ],

--- a/app/utils.py
+++ b/app/utils.py
@@ -8,7 +8,7 @@ from notifications_utils.template import (
     LetterPrintTemplate,
     SMSMessageTemplate,
 )
-from notifications_utils.timezones import convert_bst_to_utc
+from notifications_utils.timezones import convert_bst_to_utc, utc_string_to_aware_gmt_datetime
 from notifications_utils.url_safe_token import generate_token
 from sqlalchemy import func
 
@@ -168,3 +168,7 @@ def get_ft_billing_data_for_today_updated_at() -> str | None:
         return updated_at_utc_isoformat.decode()
 
     return None
+
+
+def utc_string_to_bst_string(utc_string):
+    return utc_string_to_aware_gmt_datetime(utc_string).strftime("%Y-%m-%d %H:%M:%S")

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3802,16 +3802,36 @@ def test_get_unsubscribe_request_report_for_download(admin_request, sample_servi
     assert response["batch_id"] == unsubscribe_request_report.id
     assert response["earliest_timestamp"] == unsubscribe_request_report.earliest_timestamp
     assert response["latest_timestamp"] == unsubscribe_request_report.latest_timestamp
-
-    for i, row in enumerate(unsubscribe_request_report.unsubscribe_requests):
-        assert response["unsubscribe_requests"][i]["email_address"] == row.email_address
-        assert response["unsubscribe_requests"][i]["template_name"] == row.template_name
-        assert response["unsubscribe_requests"][i]["original_file_name"] == row.original_file_name
-        assert response["unsubscribe_requests"][i]["template_sent_at"] == row.template_sent_at
-        assert (
-            response["unsubscribe_requests"][i]["unsubscribe_request_received_at"]
-            == row.unsubscribe_request_received_at
-        )
+    assert response["unsubscribe_requests"] == [
+        {
+            "email_address": "foo@bar.com",
+            "original_file_name": "contact list",
+            "template_name": "email Template Name",
+            "template_sent_at": "2024-07-23 14:30:00",
+            "unsubscribe_request_received_at": "2024-07-25 14:30:00",
+        },
+        {
+            "email_address": "fizz@bar.com",
+            "original_file_name": "contact list",
+            "template_name": "email Template Name",
+            "template_sent_at": "2024-07-21 12:04:00",
+            "unsubscribe_request_received_at": "2024-07-23 12:04:00",
+        },
+        {
+            "email_address": "fizzbuzz@bar.com",
+            "original_file_name": None,
+            "template_name": "Another Service",
+            "template_sent_at": "2024-07-20 00:45:00",
+            "unsubscribe_request_received_at": "2024-07-22 00:45:00",
+        },
+        {
+            "email_address": "buzz@bar.com",
+            "original_file_name": "another contact list",
+            "template_name": "Another Service",
+            "template_sent_at": "2024-07-17 10:42:00",
+            "unsubscribe_request_received_at": "2024-07-19 10:42:00",
+        },
+    ]
 
 
 def test_get_unsubscribe_request_report_for_download_400_error(admin_request, sample_service):


### PR DESCRIPTION
We don’t want people who download spreadsheets having to wonder about what UTC time is.

Originally I thought it would be better for the admin app to do this conversion, but:
- it would be a more fiddly change
- this follows the pattern set by the notifications reports, which return data from the API to the admin app with the UTC/GMT/BST conversion already done: https://github.com/alphagov/notifications-api/blob/526f1ed4d6748e8f83fa72dc119792dee39680e5/app/models.py#L1584-L1599

I’ve also rewritten the test assertion to be hard coded because this makes it harder for bugs to hide.

***

https://trello.com/c/fD9FsfWc/92-fix-times-in-unsubscribe-request-reports