### PR TITLE
Serialize `service_id` in unsubscribe request reports

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2722,6 +2722,7 @@ class UnsubscribeRequestReport(db.Model):
             ),
             "is_a_batched_report": True,
             "will_be_archived_at": self.will_be_archived_at.strftime(DATETIME_FORMAT),
+            "service_id": str(self.service_id),
         }
 
     @staticmethod
@@ -2737,6 +2738,7 @@ class UnsubscribeRequestReport(db.Model):
             "will_be_archived_at": get_london_midnight_in_utc(
                 unbatched_unsubscribe_requests[-1].created_at + datetime.timedelta(days=90)
             ).strftime(DATETIME_FORMAT),
+            "service_id": unbatched_unsubscribe_requests[0].service_id,
         }
 
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3563,6 +3563,7 @@ def test_get_unsubscribe_request_report_summary_for_initial_unsubscribe_requests
             "processed_by_service_at": None,
             "is_a_batched_report": False,
             "will_be_archived_at": "2024-09-26T23:00:00.000000Z",
+            "service_id": str(sample_service.id),
         }
     ]
 
@@ -3607,6 +3608,7 @@ def test_get_unsubscribe_request_reports_summary(admin_request, sample_service, 
             ),
             "is_a_batched_report": True,
             "will_be_archived_at": report.will_be_archived_at.strftime(DATETIME_FORMAT),
+            "service_id": str(sample_service.id),
         }
         for report in [unsubscribe_request_report_2, unsubscribe_request_report_1]
     ]
@@ -3619,6 +3621,7 @@ def test_get_unsubscribe_request_reports_summary(admin_request, sample_service, 
         "processed_by_service_at": None,
         "is_a_batched_report": False,
         "will_be_archived_at": "2024-09-26T23:00:00.000000Z",
+        "service_id": str(sample_service.id),
     }
 
     expected_reports_summary = [


### PR DESCRIPTION
This is kind of a convention we follow. It makes it easier to code in the admin app’s model layer when objects are aware of which service they belong to, without having to get this info from the view layer.