### PR TITLE
Start split of get_all_notifications_for_service()

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -445,6 +445,7 @@ def get_all_notifications_for_service_for_csv(service_id):
         include_jobs=include_jobs,
         include_from_test_key=include_from_test_key,
         include_one_off=include_one_off,
+        error_out=False,
     )
 
     kwargs = request.args.to_dict()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -431,9 +431,6 @@ def get_all_notifications_for_service_for_csv(service_id):
     older_than = data.get("older_than")
     page_size = data["page_size"] if "page_size" in data else current_app.config.get("PAGE_SIZE")
     limit_days = data.get("limit_days")
-    include_jobs = data.get("include_jobs", True)
-    include_from_test_key = data.get("include_from_test_key", False)
-    include_one_off = data.get("include_one_off", True)
 
     current_notifications_batch = notifications_dao.get_notifications_for_service(
         service_id,
@@ -442,10 +439,10 @@ def get_all_notifications_for_service_for_csv(service_id):
         page_size=page_size,
         count_pages=False,
         limit_days=limit_days,
-        include_jobs=include_jobs,
-        include_from_test_key=include_from_test_key,
-        include_one_off=include_one_off,
         error_out=False,
+        include_jobs=True,
+        include_from_test_key=False,
+        include_one_off=True,
     )
 
     kwargs = request.args.to_dict()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -425,6 +425,43 @@ def get_service_history(service_id):
     return jsonify(data=data)
 
 
+@service_blueprint.route("/<uuid:service_id>/notifications/csv", methods=["GET", "POST"])
+def get_all_notifications_for_service_for_csv(service_id):
+    data = notifications_filter_schema.load(request.args)
+
+    older_than = data.get("older_than")
+    page_size = data["page_size"] if "page_size" in data else current_app.config.get("PAGE_SIZE")
+    limit_days = data.get("limit_days")
+    include_jobs = data.get("include_jobs", True)
+    include_from_test_key = data.get("include_from_test_key", False)
+    include_one_off = data.get("include_one_off", True)
+
+    current_notifications_batch = notifications_dao.get_notifications_for_service(
+        service_id,
+        filter_dict=data,
+        older_than=older_than,
+        page_size=page_size,
+        count_pages=False,
+        limit_days=limit_days,
+        include_jobs=include_jobs,
+        include_from_test_key=include_from_test_key,
+        include_one_off=include_one_off,
+    )
+
+    kwargs = request.args.to_dict()
+    kwargs["service_id"] = service_id
+
+    notifications = [notification.serialize_for_csv() for notification in current_notifications_batch.items]
+
+    return (
+        jsonify(
+            notifications=notifications,
+            page_size=page_size,
+        ),
+        200,
+    )
+
+
 @service_blueprint.route("/<uuid:service_id>/notifications", methods=["GET", "POST"])
 def get_all_notifications_for_service(service_id):
     if request.method == "GET":

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -158,7 +158,6 @@ from app.user.users_schema import post_set_permissions_schema
 from app.utils import (
     DATE_FORMAT,
     DATETIME_FORMAT_NO_TIMEZONE,
-    get_next_link_for_pagination_by_older_than,
     get_prev_next_pagination_links,
     midnight_n_days_ago,
 )
@@ -542,11 +541,6 @@ def get_all_notifications_for_service(service_id):
     if count_pages and not paginate_by_older_than:
         links = get_prev_next_pagination_links(
             page, len(next_notifications_batch.items), ".get_all_notifications_for_service", **kwargs
-        )
-    elif paginate_by_older_than:
-        # for first iteration, we don't care about 'previous' link, as CSV report doesn't utilise that.
-        links = get_next_link_for_pagination_by_older_than(
-            current_notifications_batch.items, ".get_all_notifications_for_service", **kwargs
         )
 
     return (

--- a/app/utils.py
+++ b/app/utils.py
@@ -47,19 +47,9 @@ def get_prev_next_pagination_links(current_page, next_page_exists, endpoint, **k
         kwargs.pop("page", None)
     links = {}
     if current_page > 1:
-        links["prev"] = url_for(endpoint, page=current_page - 1, **kwargs)
+        links["prev"] = True
     if next_page_exists:
-        links["next"] = url_for(endpoint, page=current_page + 1, **kwargs)
-    return links
-
-
-def get_next_link_for_pagination_by_older_than(current_notifications_batch, endpoint, **kwargs):
-    links = {}
-
-    if len(current_notifications_batch):
-        kwargs["older_than"] = current_notifications_batch[-1].id
-        links["next"] = url_for(endpoint, **kwargs)
-
+        links["next"] = True
     return links
 
 


### PR DESCRIPTION
Start splitting of get_all_notifications_for_service() into two endpoints:
- one that returns notifications batches for SCV reports
- one that returns notifications batches to show on the page

Why is this - having one endpoint with so many options and flags is confusing. So to simplify - we split it into two leaner endpoints.

In this commit we split out the new endpoint, but the old one stays as is. Once admin app knows to use the new endpoint for CSVs, we will make the old endpoint leaner, too.

Needs to go in before https://github.com/alphagov/notifications-admin/pull/5212