### PR TITLE
Bump notifications-utils to 84.2.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ lxml==4.9.3
 notifications-python-client==8.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.2.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.2.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 -r requirements_for_test_common.txt
 
-flaky==3.7.0
+flaky==3.8.1
 moto==5.0.11
 pytest-httpserver==1.0.8
 trustme==0.9.0

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -876,6 +876,7 @@ def test_zendesk_new_email_branding_report(notify_db_session, mocker, notify_use
                 {"id": "360022943959", "value": None},
                 {"id": "360022943979", "value": None},
                 {"id": "1900000745014", "value": None},
+                {"id": "15925693889308", "value": None},
                 {"id": "1900000744994", "value": "notify_ticket_type_non_technical"},
             ],
         }


### PR DESCRIPTION
This mostly brings in lots of updated test dependencies:

84.2.0
The Zendesk client takes a new optional argument, user_created_at which populates a new field on the Notify Zendesk form if provided.

84.1.1
Remove GIR 0AA from valid postcodes

84.1.0
Bump versions of common test dependencies (run make bootstrap to copy these into your app)

We also need to bump flaky and a test for the tests to pass.