### PR TITLE
Bump utils to 85.0.0

### DIFF
--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
+from datetime import datetime
 from functools import partial
 from threading import RLock
+from typing import Any
 
 import cachetools
 from notifications_utils.clients.redis import RequestCache
@@ -36,18 +38,16 @@ def ignore_first_argument_cache_key(cls, *args, **kwargs):
 
 
 class SerialisedTemplate(SerialisedModel):
-    ALLOWED_PROPERTIES = {
-        "archived",
-        "content",
-        "id",
-        "postage",
-        "process_type",
-        "reply_to_text",
-        "subject",
-        "template_type",
-        "version",
-        "has_unsubscribe_link",
-    }
+    archived: bool
+    content: str
+    id: Any
+    postage: str
+    process_type: str
+    reply_to_text: str
+    subject: str
+    template_type: str
+    version: int
+    has_unsubscribe_link: bool
 
     @classmethod
     @memory_cache
@@ -73,22 +73,20 @@ class SerialisedTemplate(SerialisedModel):
 
 
 class SerialisedService(SerialisedModel):
-    ALLOWED_PROPERTIES = {
-        "id",
-        "name",
-        "active",
-        "contact_link",
-        "custom_email_sender_name",
-        "email_sender_local_part",
-        "email_message_limit",
-        "letter_message_limit",
-        "sms_message_limit",
-        "permissions",
-        "rate_limit",
-        "restricted",
-        "prefix_sms",
-        "email_branding",
-    }
+    id: Any
+    name: str
+    active: bool
+    contact_link: str
+    custom_email_sender_name: str
+    email_sender_local_part: str
+    email_message_limit: int
+    letter_message_limit: int
+    sms_message_limit: int
+    permissions: Any
+    rate_limit: int
+    restricted: bool
+    prefix_sms: bool
+    email_branding: Any
 
     @classmethod
     @memory_cache
@@ -114,12 +112,10 @@ class SerialisedService(SerialisedModel):
 
 
 class SerialisedAPIKey(SerialisedModel):
-    ALLOWED_PROPERTIES = {
-        "id",
-        "secret",
-        "expiry_date",
-        "key_type",
-    }
+    id: Any
+    secret: str
+    expiry_date: datetime
+    key_type: str
 
 
 class SerialisedAPIKeyCollection(SerialisedModelCollection):
@@ -129,7 +125,7 @@ class SerialisedAPIKeyCollection(SerialisedModelCollection):
     @memory_cache
     def from_service_id(cls, service_id):
         keys = [
-            {k: getattr(key, k) for k in SerialisedAPIKey.ALLOWED_PROPERTIES} for key in get_model_api_keys(service_id)
+            {k: getattr(key, k) for k in SerialisedAPIKey.__annotations__} for key in get_model_api_keys(service_id)
         ]
         db.session.commit()
         return cls(keys)

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ lxml==4.9.3
 notifications-python-client==8.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@85.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@85.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test_common.txt
+++ b/requirements_for_test_common.txt
@@ -1,4 +1,4 @@
-# This file is automatically copied from notifications-utils@84.0.0
+# This file is automatically copied from notifications-utils@85.0.0
 
 beautifulsoup4==4.11.1
 pytest==7.2.0

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -876,6 +876,7 @@ def test_zendesk_new_email_branding_report(notify_db_session, mocker, notify_use
                 {"id": "360022943959", "value": None},
                 {"id": "360022943979", "value": None},
                 {"id": "1900000745014", "value": None},
+                {"id": "15925693889308", "value": None},
                 {"id": "1900000744994", "value": "notify_ticket_type_non_technical"},
             ],
         }


### PR DESCRIPTION
 ## 85.0.0

* Removes `SerialisedModel.ALLOWED_PROPERTIES` in favour of annotations syntax

 ## 84.3.0

* Reverts 84.1.0

 ## 84.2.0

* The Zendesk client takes a new optional argument, `user_created_at` which populates a new field on the Notify Zendesk form if provided.

 ## 84.1.1

* Remove GIR 0AA from valid postcodes

 ## 84.1.0

* Bump versions of common test dependencies (run `make bootstrap` to copy these into your app)

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/84.0.0...85.0.0