### PR TITLE
 Include User Permissions in find-users-by-email API Response

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -209,6 +209,7 @@ class User(db.Model):
             "name": self.name,
             "email_address": self.email_address,
             "mobile_number": self.mobile_number,
+            "permissions": self.get_permissions(),
         }
 
 


### PR DESCRIPTION
- Updated the `find_users_by_email` endpoint to return associated service-specific permissions for each user.
- Modified the `User.serialize_for_users_list()` method to include user permissions in the response.
- Added test coverage to verify that user permissions are returned correctly when searching users by email.