### PR TITLE
use `EventletTimeoutMiddleware` if using eventlet

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -27,6 +27,7 @@ from notifications_utils.clients.redis.redis_client import RedisClient
 from notifications_utils.clients.signing.signing_client import Signing
 from notifications_utils.clients.statsd.statsd_client import StatsdClient
 from notifications_utils.clients.zendesk.zendesk_client import ZendeskClient
+from notifications_utils.eventlet import EventletTimeout
 from notifications_utils.local_vars import LazyLocalGetter
 from sqlalchemy import event
 from werkzeug.exceptions import HTTPException as WerkzeugHTTPException
@@ -419,6 +420,11 @@ def init_app(app):
         msg = getattr(error, "message", str(error))
         code = getattr(error, "code", 500)
         return jsonify(result="error", message=msg), code
+
+    @app.errorhandler(EventletTimeout)
+    def eventlet_timeout(error):
+        app.logger.exception(error)
+        return jsonify(result="error", message="Timeout serving request"), 504
 
     @app.errorhandler(WerkzeugHTTPException)
     def werkzeug_exception(e):

--- a/application.py
+++ b/application.py
@@ -6,6 +6,11 @@ init_performance_monitoring()
 from app import create_app  # noqa
 from app.notify_api_flask_app import NotifyApiFlaskApp  # noqa
 
+from notifications_utils.eventlet import EventletTimeoutMiddleware, using_eventlet  # noqa
+
 application = NotifyApiFlaskApp("app")
 
 create_app(application)
+
+if using_eventlet:
+    application = EventletTimeoutMiddleware(application, timeout_seconds=60)

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ lxml==4.9.3
 notifications-python-client==8.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@86.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@86.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@86.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@86.1.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
See https://github.com/alphagov/notifications-utils/pull/1157

~This successfully raises an exception after 30s, which is what we previously expected our gunicorn timeouts to be set to everywhere (and is what they're set to on our non-eventlet gunicorn apps - template-preview-web & antivirus-web). Perhaps we should be setting it to 60s though - what our cloudfront and ALBs supposedly use - because this will cause the same visible behaviour as we currently get.~

:point_up: Changed my mind - switched this to 60s for the reasons suggested above.

I can demonstrate this working on dev-a to anyone interested.

Note that even though it will stop this app processing a request after N seconds, that doesn't mean this cancellation will necessarily be propagated to whatever this app is waiting on (database, another http api..). That sort of thing would require more plumbing.

_It would be useful if a developer would check this doesn't break their local development workflow before I merge this_. It should have no effect for them because most development modes don't use eventlet by default.