### PR TITLE
nightly notification deletion: stagger sub-task invocations over 1h

### DIFF
--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -544,6 +544,7 @@ def test_delete_notifications_task_calls_task_for_services_with_data_retention_o
             # three days of retention, its morn of 5th, so we want to keep all messages from 4th, 3rd and 2nd.
             "datetime_to_delete_before": datetime(2021, 6, 1, 23, 0),
         },
+        countdown=0.0,
     )
 
 
@@ -571,6 +572,7 @@ def test_delete_notifications_task_calls_task_for_services_with_data_retention_b
                     "notification_type": "sms",
                     "datetime_to_delete_before": datetime(2021, 3, 22, 0, 0),
                 },
+                countdown=0.0,
             ),
             call(
                 queue=ANY,
@@ -579,6 +581,7 @@ def test_delete_notifications_task_calls_task_for_services_with_data_retention_b
                     "notification_type": "sms",
                     "datetime_to_delete_before": datetime(2021, 4, 1, 23, 0),
                 },
+                countdown=timedelta(hours=1).seconds / 2,
             ),
         ],
     )
@@ -621,6 +624,7 @@ def test_delete_notifications_task_calls_task_for_services_that_have_sent_notifi
                     "notification_type": "sms",
                     "datetime_to_delete_before": datetime(2021, 3, 27, 0, 0),
                 },
+                countdown=timedelta(hours=1).seconds / 2,
             ),
             call(
                 queue=ANY,
@@ -629,6 +633,7 @@ def test_delete_notifications_task_calls_task_for_services_that_have_sent_notifi
                     "notification_type": "sms",
                     "datetime_to_delete_before": datetime(2021, 3, 27, 0, 0),
                 },
+                countdown=0.0,
             ),
         ],
     )


### PR DESCRIPTION
To hopefully avoid saturating database iops when thousands of these tasks are requested simultaneously.

Using a `stagger_total_period` instead of an individual step size to avoid a huge number of sub-tasks being spread over an excessively long time. Making this configurable should allow us to trigger ad-hoc invocations with different periods.

~Untested :muscle:~