### PR TITLE
manually create and delete enum in existing alembic migration

### DIFF
--- a/migrations/versions/0464_create_svc_join_requests.py
+++ b/migrations/versions/0464_create_svc_join_requests.py
@@ -5,8 +5,11 @@ from sqlalchemy.dialects import postgresql
 revision = "0464_create_svc_join_requests"
 down_revision = "0463_backfill_created_at"
 
+request_status_enum = sa.Enum("pending", "approved", "rejected", name="request_status")
+
 
 def upgrade():
+    request_status_enum.create(op.get_bind())
     op.create_table(
         "service_join_requests",
         sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, default=sa.text("uuid_generate_v4()")),
@@ -15,7 +18,7 @@ def upgrade():
         sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
         sa.Column(
             "status",
-            sa.Enum("pending", "approved", "rejected", name="request_status"),
+            request_status_enum,
             nullable=False,
             server_default="pending",
         ),
@@ -41,3 +44,5 @@ def downgrade():
     op.drop_table("contacted_users")
 
     op.drop_table("service_join_requests")
+
+    request_status_enum.drop(op.get_bind(), checkfirst=False)

--- a/migrations/versions/0464_create_svc_join_requests.py
+++ b/migrations/versions/0464_create_svc_join_requests.py
@@ -5,7 +5,8 @@ from sqlalchemy.dialects import postgresql
 revision = "0464_create_svc_join_requests"
 down_revision = "0463_backfill_created_at"
 
-request_status_enum = sa.Enum("pending", "approved", "rejected", name="request_status")
+values = ["pending", "approved", "rejected"]
+request_status_enum = sa.Enum(*values, name="request_status")
 
 
 def upgrade():
@@ -18,7 +19,13 @@ def upgrade():
         sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
         sa.Column(
             "status",
-            request_status_enum,
+            postgresql.ENUM(
+                *values,
+                name="request_status",
+                create_type=False,
+                checkfirst=True,
+                inherit_schema=True,
+            ),
             nullable=False,
             server_default="pending",
         ),


### PR DESCRIPTION
there's a bug/design flaw in alembic where if you autogenerate a migration script, it'll create the enum implicitly, but won't include it in the downgrade. This is due to complex reasons that I kinda glazed over.[^1][^2]

With this migration, if you run downgrade and then upgrade again it fails due to the enum not being dropped by the downgrade, and thus already existing for the upgrade.

Lets drop the enum manually in the downgrade script. create the enum manually (not because we need to, but just to give a bit of clarity as to what's going on behind the scenes)

[^1]: https://github.com/sqlalchemy/alembic/issues/89
[^2]: https://github.com/sqlalchemy/alembic/issues/868#issuecomment-867914756