### PR TITLE
Delete nightly letters fixes

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -36,6 +36,7 @@ from app.dao.notification_history_dao import (
 from app.dao.notifications_dao import (
     dao_get_notifications_processing_time_stats,
     dao_timeout_notifications,
+    delete_test_notifications,
     get_service_ids_with_notifications_before,
     move_notifications_to_notification_history,
 )
@@ -213,6 +214,10 @@ def delete_notifications_for_service_and_type(service_id, notification_type, dat
             args=(service_id, notification_type, datetime_to_delete_before),
             queue=QueueNames.REPORTING,
         )
+    else:
+        # now we've deleted all the real notifications, clean up the test notifications - this doesnt have a limit so
+        # is only run once per service/day/type
+        delete_test_notifications(notification_type, service_id, datetime_to_delete_before)
 
 
 @notify_celery.task(name="timeout-sending-notifications")

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -207,6 +207,12 @@ def delete_notifications_for_service_and_type(service_id, notification_type, dat
                 "duration": (end - start).seconds,
             },
         )
+        # if some things were deleted, there could be more! lets queue up a new task with the same params
+        # if there was nothing deleted, we've got no more work to do
+        delete_notifications_for_service_and_type.apply_async(
+            args=(service_id, notification_type, datetime_to_delete_before),
+            queue=QueueNames.REPORTING,
+        )
 
 
 @notify_celery.task(name="timeout-sending-notifications")

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -398,21 +398,18 @@ def insert_notification_history_delete_notifications(
 def move_notifications_to_notification_history(
     notification_type, service_id, timestamp_to_delete_backwards_from, qry_limit=50000
 ):
-    deleted = 0
     if notification_type == LETTER_TYPE:
         # reduced query limit so we don't run into issues trying to loop through 50k letters in python deleting from s3
         qry_limit = 5_000
 
         _delete_letters_from_s3(notification_type, service_id, timestamp_to_delete_backwards_from, qry_limit)
-    delete_count_per_call = 1
-    while delete_count_per_call > 0:
-        delete_count_per_call = insert_notification_history_delete_notifications(
-            notification_type=notification_type,
-            service_id=service_id,
-            timestamp_to_delete_backwards_from=timestamp_to_delete_backwards_from,
-            qry_limit=qry_limit,
-        )
-        deleted += delete_count_per_call
+
+    deleted = insert_notification_history_delete_notifications(
+        notification_type=notification_type,
+        service_id=service_id,
+        timestamp_to_delete_backwards_from=timestamp_to_delete_backwards_from,
+        qry_limit=qry_limit,
+    )
 
     # Deleting test Notifications, test notifications are not persisted to NotificationHistory
     Notification.query.filter(

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -400,6 +400,9 @@ def move_notifications_to_notification_history(
 ):
     deleted = 0
     if notification_type == LETTER_TYPE:
+        # reduced query limit so we don't run into issues trying to loop through 50k letters in python deleting from s3
+        qry_limit = 5_000
+
         _delete_letters_from_s3(notification_type, service_id, timestamp_to_delete_backwards_from, qry_limit)
     delete_count_per_call = 1
     while delete_count_per_call > 0:

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -352,6 +352,7 @@ def insert_notification_history_delete_notifications(
           AND notification_type = :notification_type
           AND created_at < :timestamp_to_delete_backwards_from
           AND key_type in ('normal', 'team')
+        ORDER BY created_at
         limit :qry_limit
         """
     select_into_temp_table_for_letters = f"""
@@ -363,6 +364,7 @@ def insert_notification_history_delete_notifications(
           AND created_at < :timestamp_to_delete_backwards_from
           AND notification_status NOT IN ('pending-virus-check', 'created', 'sending')
           AND key_type in ('normal', 'team')
+        ORDER BY created_at
         limit :qry_limit
         """
     # Insert into NotificationHistory if the row already exists do nothing.
@@ -400,7 +402,8 @@ def move_notifications_to_notification_history(
 ):
     if notification_type == LETTER_TYPE:
         # reduced query limit so we don't run into issues trying to loop through 50k letters in python deleting from s3
-        qry_limit = 5_000
+        # use `min` so we can reduce query limit artificially during unit tests
+        qry_limit = min(qry_limit, 5_000)
 
         _delete_letters_from_s3(notification_type, service_id, timestamp_to_delete_backwards_from, qry_limit)
 
@@ -436,6 +439,7 @@ def _delete_letters_from_s3(notification_type, service_id, date_to_delete_from, 
             # them from it
             Notification.status.in_(NOTIFICATION_STATUS_TYPES_COMPLETED),
         )
+        .order_by(Notification.created_at)
         .limit(query_limit)
         .all()
     )

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -404,13 +404,15 @@ def move_notifications_to_notification_history(
 
         _delete_letters_from_s3(notification_type, service_id, timestamp_to_delete_backwards_from, qry_limit)
 
-    deleted = insert_notification_history_delete_notifications(
+    return insert_notification_history_delete_notifications(
         notification_type=notification_type,
         service_id=service_id,
         timestamp_to_delete_backwards_from=timestamp_to_delete_backwards_from,
         qry_limit=qry_limit,
     )
 
+
+def delete_test_notifications(notification_type, service_id, timestamp_to_delete_backwards_from):
     # Deleting test Notifications, test notifications are not persisted to NotificationHistory
     Notification.query.filter(
         Notification.notification_type == notification_type,
@@ -418,9 +420,8 @@ def move_notifications_to_notification_history(
         Notification.created_at < timestamp_to_delete_backwards_from,
         Notification.key_type == KEY_TYPE_TEST,
     ).delete(synchronize_session=False)
-    db.session.commit()
 
-    return deleted
+    db.session.commit()
 
 
 def _delete_letters_from_s3(notification_type, service_id, date_to_delete_from, query_limit):

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime, timedelta
-from unittest.mock import ANY, call
+from unittest.mock import ANY, Mock, call
+from uuid import UUID
 
 import pytest
 from flask import current_app
@@ -18,6 +19,7 @@ from app.celery.nightly_tasks import (
     delete_email_notifications_older_than_retention,
     delete_inbound_sms,
     delete_letter_notifications_older_than_retention,
+    delete_notifications_for_service_and_type,
     delete_sms_notifications_older_than_retention,
     delete_unneeded_notification_history_by_hour,
     delete_unneeded_notification_history_for_specific_hour,
@@ -661,3 +663,37 @@ def test_delete_unneeded_notification_history_by_hour(mocker):
     assert mock_subtask.apply_async.call_args_list[-1] == call(
         [datetime(2022, 12, 31, 23, 0, 0), datetime(2023, 1, 1, 0, 0, 0)], queue=ANY
     )
+
+
+def test_delete_notifications_for_service_and_type_queues_up_second_task_if_things_deleted(mocker):
+    mock_move = mocker.patch("app.celery.nightly_tasks.move_notifications_to_notification_history", return_value=1)
+    mock_task_call = mocker.patch("app.celery.nightly_tasks.delete_notifications_for_service_and_type.apply_async")
+    mock_delete_tests = mocker.patch("app.celery.nightly_tasks.delete_test_notifications")
+    service_id = Mock(spec=UUID)
+    notification_type = Mock(spec=str)
+    datetime_to_delete_before = Mock(spec=datetime)
+
+    delete_notifications_for_service_and_type(service_id, notification_type, datetime_to_delete_before)
+
+    mock_move.assert_called_once_with(notification_type, service_id, datetime_to_delete_before)
+    # the next task is queued up with the exact same args
+    mock_task_call.assert_called_once_with(
+        args=(service_id, notification_type, datetime_to_delete_before), queue="reporting-tasks"
+    )
+    assert not mock_delete_tests.called
+
+
+def test_delete_notifications_for_service_and_type_removes_test_notifications_if_no_normal_ones_deleted(mocker):
+    mock_move = mocker.patch("app.celery.nightly_tasks.move_notifications_to_notification_history", return_value=0)
+    mock_task_call = mocker.patch("app.celery.nightly_tasks.delete_notifications_for_service_and_type.apply_async")
+    mock_delete_tests = mocker.patch("app.celery.nightly_tasks.delete_test_notifications")
+    service_id = Mock(spec=UUID)
+    notification_type = Mock(spec=str)
+    datetime_to_delete_before = Mock(spec=datetime)
+
+    delete_notifications_for_service_and_type(service_id, notification_type, datetime_to_delete_before)
+
+    mock_move.assert_called_once_with(notification_type, service_id, datetime_to_delete_before)
+    # the next task is not queued up
+    assert not mock_task_call.called
+    mock_delete_tests.assert_called_once_with(notification_type, service_id, datetime_to_delete_before)

--- a/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
@@ -83,7 +83,7 @@ def test_move_notifications_does_nothing_if_notification_history_row_already_exi
         status="delivered",
     )
 
-    move_notifications_to_notification_history("email", sample_email_template.service_id, datetime.utcnow(), 1)
+    move_notifications_to_notification_history("email", sample_email_template.service_id, datetime.utcnow())
 
     assert Notification.query.count() == 0
     history = NotificationHistory.query.all()

--- a/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
@@ -9,6 +9,7 @@ from moto import mock_aws
 from app.constants import KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST
 from app.dao.notifications_dao import (
     FIELDS_TO_TRANSFER_TO_NOTIFICATION_HISTORY,
+    delete_test_notifications,
     insert_notification_history_delete_notifications,
     move_notifications_to_notification_history,
 )
@@ -222,7 +223,7 @@ def test_move_notifications_only_moves_for_given_service(notify_db_session):
     assert Notification.query.one().service_id == other_service.id
 
 
-def test_move_notifications_just_deletes_test_key_notifications(sample_template):
+def test_move_notifications_doesnt_touch_test_notifications(sample_template):
     delete_time = datetime(2020, 6, 1, 12)
     one_second_before = delete_time - timedelta(seconds=1)
     create_notification(template=sample_template, created_at=one_second_before, key_type=KEY_TYPE_NORMAL)
@@ -233,9 +234,41 @@ def test_move_notifications_just_deletes_test_key_notifications(sample_template)
 
     assert result == 2
 
-    assert Notification.query.count() == 0
+    assert Notification.query.count() == 1
+    assert Notification.query.filter(Notification.key_type == KEY_TYPE_TEST).count() == 1
+
     assert NotificationHistory.query.count() == 2
     assert NotificationHistory.query.filter(NotificationHistory.key_type == KEY_TYPE_TEST).count() == 0
+
+
+def test_delete_test_notifications(sample_template, sample_email_template):
+    delete_time = datetime(2020, 6, 1, 12)
+    one_second_before = delete_time - timedelta(seconds=1)
+    one_second_after = delete_time + timedelta(seconds=1)
+
+    other_service = create_service(service_name="other")
+    other_template = create_template(other_service)
+
+    # to be deleted
+    expected_deleted = create_notification(
+        template=sample_template, created_at=one_second_before, key_type=KEY_TYPE_TEST
+    )
+    expected_deleted_id = expected_deleted.id
+
+    # wrong keytype
+    create_notification(template=sample_template, created_at=one_second_before, key_type=KEY_TYPE_NORMAL)
+    create_notification(template=sample_template, created_at=one_second_before, key_type=KEY_TYPE_TEAM)
+    # wrong service
+    create_notification(template=other_template, created_at=one_second_before, key_type=KEY_TYPE_TEST)
+    # wrong notification type
+    create_notification(template=sample_email_template, created_at=one_second_before, key_type=KEY_TYPE_TEST)
+    # too recent
+    create_notification(template=sample_template, created_at=one_second_after, key_type=KEY_TYPE_TEST)
+
+    delete_test_notifications("sms", sample_template.service_id, delete_time)
+
+    assert Notification.query.count() == 5
+    assert Notification.query.get(expected_deleted_id) is None
 
 
 @freeze_time("2020-03-20 14:00")

--- a/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
@@ -1,4 +1,3 @@
-import uuid
 from datetime import datetime, timedelta
 
 import boto3
@@ -184,24 +183,6 @@ def test_move_notifications_only_moves_notifications_older_than_provided_timesta
 
     assert Notification.query.one().id == new_notification.id
     assert NotificationHistory.query.one().id == old_notification_id
-
-
-def test_move_notifications_keeps_calling_until_no_more_to_delete_and_then_returns_total_deleted(
-    notify_db_session, mocker
-):
-    mock_insert = mocker.patch(
-        "app.dao.notifications_dao.insert_notification_history_delete_notifications", side_effect=[5, 5, 1, 0]
-    )
-    service_id = uuid.uuid4()
-    timestamp = datetime(2021, 1, 1)
-
-    result = move_notifications_to_notification_history("sms", service_id, timestamp, qry_limit=5)
-    assert result == 11
-
-    mock_insert.assert_called_with(
-        notification_type="sms", service_id=service_id, timestamp_to_delete_backwards_from=timestamp, qry_limit=5
-    )
-    assert mock_insert.call_count == 4
 
 
 def test_move_notifications_only_moves_for_given_notification_type(sample_service):


### PR DESCRIPTION
Best reviewed commit-by-commit

The commits:

#### reduce query limit for deleting leters nightly 223f270e68611f4fb7e0e51fc344512750a6edb6

we're concerned that we can't delete 50,000 letters from s3, and move their notifications, within the two minute time during celery shutdown between a worker being told gracefully and firmly (SIGTERM and SIGKILL).

reduce the limit to 5k for letters only, since they have to fetch all the notifications into python to look at s3

#### trigger multiple tasks to delete large amounts rather than looping ce5c5e2015d03d16e32e79e87eb34742ccf80b42

this has the advantage that if the worker executing the task downscales, then we won't lose work - instead, we'll just queue up a new task to be executed by another worker.

#### only delete test notifications once c2e4fc2f7c2f4a06b3410bcf65fe35e6a9049679

after the refactor to multiple tasks we would have ended up deleting test notifications every single time we hit the query limit.

now we just do it when the move task returns 0 - ie all the real notifications have already been processed by earlier tasks

#### ensure we delete the same files from s3 as we do from the database 25ee022308b71299d12c6982426f6081a0d7fb8e

we were not ordering our queries previously - this meant that when we fetched 5000 letters to delete from s3, and then later in the task fetched 5000 letters to move from notifications to notification_history, we wouldn't be guaranteed the same 5000. With all the thrashing of the db as we're deleting across every service all at once, it's hard to reason about what postgres may or may not cache.

if these two queries returned different things, we'd end up in a state where we may delete things from the database before we've deleted them from s3 - but without them in the notifications table we've got no way of being able to find them in s3! There's a 90 day aws lifecycle policy preventing anything from sticking around for _too_ long but still it's not great practice.

order both by created_at (asc) to ensure we always delete the oldest first. this also means if the task fails the oldest things are gone, which seems like a sensible way to do it.