### PR TITLE
Revert "FiretextClient: use persistent requests session"

### DIFF
--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-import requests
+from requests import RequestException, request
 
 from app.clients.sms import SmsClient, SmsClientResponseException
 
@@ -44,8 +44,6 @@ def get_message_status_and_reason_from_firetext_code(detailed_status_code):
 class FiretextClient(SmsClient):
     """
     FireText sms client.
-
-    This class is not thread-safe.
     """
 
     name = "firetext"
@@ -56,7 +54,6 @@ class FiretextClient(SmsClient):
         self.international_api_key = self.current_app.config.get("FIRETEXT_INTERNATIONAL_API_KEY")
         self.url = self.current_app.config.get("FIRETEXT_URL")
         self.receipt_url = self.current_app.config.get("FIRETEXT_RECEIPT_URL")
-        self.requests_session = requests.Session()
 
     def try_send_sms(self, to, content, reference, international, sender):
         data = {
@@ -71,7 +68,7 @@ class FiretextClient(SmsClient):
             data["receipt"] = self.receipt_url
 
         try:
-            response = self.requests_session.request("POST", self.url, data=data, timeout=60)
+            response = request("POST", self.url, data=data, timeout=60)
             response.raise_for_status()
             try:
                 json.loads(response.text)
@@ -79,7 +76,7 @@ class FiretextClient(SmsClient):
                     raise ValueError("Expected 'code' to be '0'")
             except (ValueError, AttributeError) as e:
                 raise SmsClientResponseException("Invalid response JSON") from e
-        except requests.RequestException as e:
+        except RequestException as e:
             raise SmsClientResponseException("Request failed") from e
 
         return response


### PR DESCRIPTION
Temporarily revert `FiretextClient`'s use of persistent sessions (from #4179) to try and narrow down an issue.