### PR TITLE
Update get service-join-request to include requester and updated_by

### DIFF
--- a/app/dao/service_join_requests_dao.py
+++ b/app/dao/service_join_requests_dao.py
@@ -24,6 +24,6 @@ def dao_create_service_join_request(
 def dao_get_service_join_request_by_id(request_id: UUID) -> ServiceJoinRequest | None:
     return (
         ServiceJoinRequest.query.filter_by(id=request_id)
-        .options(db.joinedload("contacted_service_users"))
+        .options(db.joinedload("contacted_service_users"), db.joinedload("requester.services"))
         .one_or_none()
     )

--- a/app/models.py
+++ b/app/models.py
@@ -2825,14 +2825,15 @@ class ProtectedSenderId(db.Model):
 @dataclass
 class SerializedServiceJoinRequest:
     service_join_request_id: str
-    requester_id: str
     service_id: str
     created_at: str
     status: str
     status_changed_at: str | None
-    status_changed_by_id: str | None
     reason: str | None
     contacted_service_users: list[str]
+    status_changed_by: User
+    requester: User
+    requested_service: Service
 
 
 contacted_users = db.Table(
@@ -2861,6 +2862,7 @@ class ServiceJoinRequest(db.Model):
 
     requester = db.relationship("User", foreign_keys=[requester_id])
     status_changed_by = db.relationship("User", foreign_keys=[status_changed_by_id])
+    requested_service = db.relationship("Service", foreign_keys=[service_id])
 
     # Use lazy="joined" to load the contacted_service_users relationship with a SQL JOIN
     # This is a nice option as we expect to load this relationship frequently when querying ServiceJoinRequest
@@ -2871,12 +2873,26 @@ class ServiceJoinRequest(db.Model):
     def serialize(self) -> SerializedServiceJoinRequest:
         return SerializedServiceJoinRequest(
             service_join_request_id=get_uuid_string_or_none(self.id),
-            requester_id=get_uuid_string_or_none(self.requester_id),
             service_id=get_uuid_string_or_none(self.service_id),
             created_at=get_dt_string_or_none(self.created_at),
             status=self.status,
+            status_changed_by=(
+                {
+                    "id": self.status_changed_by.id,
+                    "name": self.status_changed_by.name,
+                }
+                if self.status_changed_by
+                else None
+            ),
+            requester={
+                "id": self.requester.id,
+                "name": self.requester.name,
+                "belongs_to_service": [service.id for service in self.requester.services],
+            },
+            requested_service={
+                "id": self.requested_service.id,
+            },
             status_changed_at=get_dt_string_or_none(self.status_changed_at),
-            status_changed_by_id=get_uuid_string_or_none(self.status_changed_by_id),
             reason=self.reason,
             contacted_service_users=[get_uuid_string_or_none(user.id) for user in self.contacted_service_users],
         )

--- a/tests/app/dao/test_service_join_requests_dao.py
+++ b/tests/app/dao/test_service_join_requests_dao.py
@@ -103,7 +103,7 @@ def test_get_service_join_request_by_id(client, test_case, notify_db_session):
 
     assert retrieved_request is not None
     assert retrieved_request.id == request.id
-    assert retrieved_request.requester_id == test_case.requester_id
+    assert retrieved_request.requester.id == test_case.requester_id
     assert retrieved_request.service_id == test_case.service_id
     assert len(retrieved_request.contacted_service_users) == test_case.expected_num_contacts
 


### PR DESCRIPTION
We have requirement to display the name of service, requester and status_changed_by. Updated db query to include the user and service and also updated response payload.
https://trello.com/c/pQovKftH/976-create-new-approver-flow-for-request-to-join-a-service