### PR TITLE
`EventletTimeoutMiddleware`: set timeout to 30s, wrap `application.wsgi_app`

### DIFF
--- a/app/status/healthcheck.py
+++ b/app/status/healthcheck.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 from flask import Blueprint, jsonify, request
 
 from app import db, version
@@ -26,6 +28,18 @@ def show_status():
 
 @status.route("/_status/live-service-and-organisation-counts")
 def live_service_and_organisation_counts():
+    return (
+        jsonify(
+            organisations=dao_count_organisations_with_live_services(),
+            services=dao_count_live_services(),
+        ),
+        200,
+    )
+
+
+@status.route("/_status/slow")
+def slow():
+    sleep(45)
     return (
         jsonify(
             organisations=dao_count_organisations_with_live_services(),

--- a/application.py
+++ b/application.py
@@ -13,4 +13,4 @@ application = NotifyApiFlaskApp("app")
 create_app(application)
 
 if using_eventlet:
-    application = EventletTimeoutMiddleware(application, timeout_seconds=60)
+    application.wsgi_app = EventletTimeoutMiddleware(application.wsgi_app, timeout_seconds=30)


### PR DESCRIPTION
30s is what we've decided to set our cloudfront timeouts to.

Wrapping `application.wsgi_app` is more correct than wrapping `application` itself, as it preserves flasky behaviours of the outer `application` object.