### PR TITLE
control timeout configuration using config/env vars

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -474,6 +474,10 @@ def setup_sqlalchemy_events(app):  # noqa: C901
             # with our own constructed one
 
             cursor.execute(
+                "SET statement_timeout = %s",
+                (current_app.config["DATABASE_STATEMENT_TIMEOUT_MS"],),
+            )
+            cursor.execute(
                 "SET application_name = %s",
                 (current_app.config["NOTIFY_APP_NAME"],),
             )

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -444,7 +444,7 @@ def create_random_identifier():
     return "".join(random.choice(string.ascii_uppercase + string.digits) for _ in range(16))
 
 
-def setup_sqlalchemy_events(app):
+def setup_sqlalchemy_events(app):  # noqa: C901
     TOTAL_DB_CONNECTIONS = Gauge(
         "db_connection_total_connected",
         "How many db connections are currently held (potentially idle) by the server",
@@ -469,19 +469,22 @@ def setup_sqlalchemy_events(app):
             # connection first opened with db
             TOTAL_DB_CONNECTIONS.inc()
 
-            # by default disable parallel query because it allows large analytic-style
-            # queries to consume more resources than smaller transactional queries
-            # typically will, and if anything we want to prioritize the small
-            # transactional queries. this can be re-enabled on a case-by-case basis by
-            # executing SET LOCAL max_parallel_workers_per_gather = ... before the
-            # intended query.
-            #
-            # because this is only done once at connection-creation time, there's a small
-            # danger that SET max_par... (instead of SET LOCAL max_par...) will be used
-            # by the application somewhere, which would persist across checkouts.
-            # however, (re-)setting this on every checkout would likely add a database
-            # round-trip of latency to every request.
-            dbapi_connection.cursor().execute("SET max_parallel_workers_per_gather = 0")
+            cursor = dbapi_connection.cursor()
+
+            if current_app.config["DATABASE_DEFAULT_DISABLE_PARALLEL_QUERY"]:
+                # by default disable parallel query because it allows large analytic-style
+                # queries to consume more resources than smaller transactional queries
+                # typically will, and if anything we want to prioritize the small
+                # transactional queries. this can be re-enabled on a case-by-case basis by
+                # executing SET LOCAL max_parallel_workers_per_gather = ... before the
+                # intended query.
+                #
+                # because this is only done once at connection-creation time, there's a small
+                # danger that SET max_par... (instead of SET LOCAL max_par...) will be used
+                # by the application somewhere, which would persist across checkouts.
+                # however, (re-)setting this on every checkout would likely add a database
+                # round-trip of latency to every request.
+                cursor.execute("SET max_parallel_workers_per_gather = 0")
 
         @event.listens_for(db.engine, "close")
         def close(dbapi_connection, connection_record):

--- a/app/config.py
+++ b/app/config.py
@@ -138,11 +138,15 @@ class Config:
     AWS_REGION = "eu-west-1"
     INVITATION_EXPIRATION_DAYS = 2
     NOTIFY_APP_NAME = "api"
+
     SQLALCHEMY_ENGINE_OPTIONS = {
         "pool_size": int(os.environ.get("SQLALCHEMY_POOL_SIZE", 5)),
         "pool_timeout": 30,
         "pool_recycle": 300,
         "connect_args": {
+            # statement_timeout is overridden in setup_sqlalchemy_events, but not all our
+            # invocations heed those event hooks (e.g. alembic migrations), so this is set
+            # as a fallback
             "options": "-c statement_timeout=1200000",
         },
     }
@@ -153,6 +157,8 @@ class Config:
         )
         == "1"
     )
+    DATABASE_STATEMENT_TIMEOUT_MS = int(os.getenv("DATABASE_STATEMENT_TIMEOUT_MS", 1_200_000))
+
     PAGE_SIZE = 50
     API_PAGE_SIZE = 250
     TEST_MESSAGE_FILENAME = "Test message"

--- a/app/config.py
+++ b/app/config.py
@@ -146,6 +146,13 @@ class Config:
             "options": "-c statement_timeout=1200000",
         },
     }
+    DATABASE_DEFAULT_DISABLE_PARALLEL_QUERY = (
+        os.getenv(
+            "DATABASE_DEFAULT_DISABLE_PARALLEL_QUERY",
+            "1",
+        )
+        == "1"
+    )
     PAGE_SIZE = 50
     API_PAGE_SIZE = 250
     TEST_MESSAGE_FILENAME = "Test message"

--- a/application.py
+++ b/application.py
@@ -1,4 +1,6 @@
 ##!/usr/bin/env python
+import os
+
 from app.performance import init_performance_monitoring
 
 init_performance_monitoring()
@@ -13,4 +15,7 @@ application = NotifyApiFlaskApp("app")
 create_app(application)
 
 if using_eventlet:
-    application = EventletTimeoutMiddleware(application, timeout_seconds=60)
+    application.wsgi_app = EventletTimeoutMiddleware(
+        application.wsgi_app,
+        timeout_seconds=int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30)),
+    )

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -11,3 +11,4 @@ worker_class = "eventlet"
 worker_connections = 256
 statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
 keepalive = 90
+timeout = int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30))  # though has little effect with eventlet worker_class


### PR DESCRIPTION
Doing a few things here to make some of the database tweaks we do and timeouts we set more consistent and controllable via environment variables (which will become useful when we e.g. want to use different `statement_timeout` values for different daemons.

Replacement for  #4218

See commits for individual detail..

Successfully tested on dev-a https://concourse.notify.tools/teams/dev-a/pipelines/deploy-notify/jobs/test/builds/52