### PR TITLE
feat: update service join request

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2824,7 +2824,7 @@ class ProtectedSenderId(db.Model):
 
 @dataclass
 class SerializedServiceJoinRequest:
-    service_join_request_id: str
+    id: str
     service_id: str
     created_at: str
     status: str
@@ -2872,7 +2872,7 @@ class ServiceJoinRequest(db.Model):
 
     def serialize(self) -> SerializedServiceJoinRequest:
         return SerializedServiceJoinRequest(
-            service_join_request_id=get_uuid_string_or_none(self.id),
+            id=get_uuid_string_or_none(self.id),
             service_id=get_uuid_string_or_none(self.service_id),
             created_at=get_dt_string_or_none(self.created_at),
             status=self.status,

--- a/app/schema_validation/service_join_request.py
+++ b/app/schema_validation/service_join_request.py
@@ -10,3 +10,38 @@ service_join_request_schema = {
     "required": ["requester_id", "contacted_user_ids"],
     "additionalProperties": False,
 }
+
+service_join_request_update_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Schema for updating a service join request",
+    "type": "object",
+    "properties": {
+        "permissions": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": [
+                    "manage_users",
+                    "manage_templates",
+                    "manage_settings",
+                    "send_texts",
+                    "send_emails",
+                    "send_letters",
+                    "manage_api_keys",
+                    "view_activity",
+                ],
+            },
+            "description": "List of permissions being granted or modified",
+        },
+        "status_changed_by_id": {"type": "string", "format": "uuid"},
+        "status": {
+            "type": "string",
+            "enum": ["pending", "approved", "rejected", "cancelled"],
+            "description": "The new status of the join request",
+        },
+        "reason": {"type": ["string", "null"], "description": "Optional reason for the status change"},
+    },
+    "required": ["status_changed_by_id", "status"],
+    "additionalProperties": False,
+    "minProperties": 2,
+}

--- a/tests/app/dao/test_service_join_requests_dao.py
+++ b/tests/app/dao/test_service_join_requests_dao.py
@@ -3,8 +3,12 @@ from uuid import uuid4
 
 import pytest
 
-from app.constants import SERVICE_JOIN_REQUEST_PENDING
-from app.dao.service_join_requests_dao import dao_create_service_join_request, dao_get_service_join_request_by_id
+from app.constants import SERVICE_JOIN_REQUEST_APPROVED, SERVICE_JOIN_REQUEST_PENDING, SERVICE_JOIN_REQUEST_REJECTED
+from app.dao.service_join_requests_dao import (
+    dao_create_service_join_request,
+    dao_get_service_join_request_by_id,
+    dao_update_service_join_request,
+)
 from tests.app.db import create_service, create_user
 
 
@@ -116,3 +120,56 @@ def test_get_service_join_request_by_id_not_found(notify_db_session):
     retrieved_request = dao_get_service_join_request_by_id(non_existent_id)
 
     assert retrieved_request is None
+
+
+@pytest.mark.parametrize(
+    "updated_status,reason",
+    [
+        (SERVICE_JOIN_REQUEST_APPROVED, None),
+        (SERVICE_JOIN_REQUEST_REJECTED, "Rejected due to incomplete information"),
+    ],
+    ids=["Approved", "Rejected with reason"],
+)
+def test_dao_update_service_join_request(client, notify_db_session, updated_status, reason):
+    requester_id = uuid4()
+    service_id = uuid4()
+    user_1 = uuid4()
+    user_2 = uuid4()
+
+    setup_service_join_request_test_data(service_id, requester_id, [user_1, user_2])
+
+    request = dao_create_service_join_request(
+        requester_id=requester_id,
+        service_id=service_id,
+        contacted_user_ids=[user_1, user_2],
+    )
+
+    updated_request = dao_update_service_join_request(
+        request_id=request.id,
+        status=updated_status,
+        status_changed_by_id=user_1,
+        reason=reason,
+    )
+
+    assert updated_request.status == updated_status
+    assert updated_request.status_changed_by_id == user_1
+    assert updated_request.reason == reason
+    assert len(updated_request.contacted_service_users) == 2
+
+
+def test_dao_update_service_join_request_no_request_found(client, notify_db_session):
+    requester_id = uuid4()
+    request_id = uuid4()
+    service_id = uuid4()
+    user_1 = uuid4()
+
+    setup_service_join_request_test_data(service_id, requester_id, [user_1])
+
+    updated_request = dao_update_service_join_request(
+        request_id=request_id,
+        status=SERVICE_JOIN_REQUEST_REJECTED,
+        status_changed_by_id=user_1,
+        reason=None,
+    )
+
+    assert updated_request is None


### PR DESCRIPTION
### Summary
This PR introduces a new endpoint that allows updating the status of a service join request. The endpoint also handles assigning permissions to users when the request is approved.

### Endpoint:
POST /update-service-join-request-status/<uuid:request_id>

### Changes:
**Service Join Request Status Update:**

- Accepts a request to update the status of a service join request (pending, approved, rejected).
- Handles validation of the input payload using service_join_request_update_schema.
- If the service join request is not found, returns a 404 response.

**Add user to service:**

- When the status is set to approved, it adds the user to a service and sets the permission
- This is applied by dao_add_user_to_service

**Send approved email**
- If the user request is approved, an email is sent to the user 
- This is handled by send_service_join_request_decision_email

**Cancel Pending requests for the same service by the same user**
- Pending service join requests are cancelled for a user when one of their requests is approved, ensuring the system reflects the most up-to-date request. 
- The cancellation is service-specific, meaning only requests for the same service as the approved request will be canceled. Any requests the user has for other services remain unaffected

### Ticket
[Update the request status when request to join service approved/rejected](https://trello.com/c/7jW26Z4s/969-update-the-request-status-when-request-to-join-service-approved-rejected)