### PR TITLE
add script that tests downgrade scripts for new migrations

### DIFF
--- a/scripts/test_sql_migration_downgrade.sh
+++ b/scripts/test_sql_migration_downgrade.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+BOLDGREEN="\033[1;32m"
+ENDCOLOR="\033[0m"
+
+export FLASK_APP=application.py
+export NOTIFY_ENVIRONMENT="development"
+
+# what is the database currently pointing at on main?
+CURRENT_VERSION=$(curl -s https://raw.githubusercontent.com/alphagov/notifications-api/main/migrations/.current-alembic-head)
+
+# what is the most recent version? note this depends on us only ever having one head
+NEWEST_VERSION=$(flask db heads | tail -n 1 | cut -d " " -f 1)
+
+if [[ "${CURRENT_VERSION}" == "${NEWEST_VERSION}" ]]; then
+    echo "No migrations to check"
+    exit 0;
+fi
+
+
+# delete any existing test DB
+psql -c "drop database migration_test" || true
+psql -c "create database migration_test"
+
+echo -e "${BOLDGREEN}======== running upgrade (logs hidden) ========${ENDCOLOR}"
+
+SQLALCHEMY_DATABASE_URI="postgresql://localhost/migration_test" flask db upgrade > /dev/null 2>&1
+
+# make sure downgrade can run succesfully
+echo -e "${BOLDGREEN}============== running downgrade ==============${ENDCOLOR}"
+SQLALCHEMY_DATABASE_URI="postgresql://localhost/migration_test" flask db downgrade $CURRENT_VERSION
+
+# make sure downgrade has left everything okay
+echo -e "${BOLDGREEN}============ running upgrade again ============${ENDCOLOR}"
+SQLALCHEMY_DATABASE_URI="postgresql://localhost/migration_test" flask db upgrade
+
+psql -c "drop database migration_test"
+
+echo -e "${BOLDGREEN}=================== success ===================${ENDCOLOR}"


### PR DESCRIPTION
if this script finds new migration files, it will

* create a blank DB
* upgrade to the latest head (ie: all new migration files)
* downgrade to the current main to make sure the downgrade scripts run
* upgrade again to make sure the downgrade scripts left things in a sensible state
* fail if there were any sql errors etc

as this just runs the whole branch's diff, this _doesn't_ cover cases where an individual downgrade script is bad, but all when combined with the other downgrade scripts in that branch it works out ok (imagine if you have two versions in a PR, but the downgrade for both alembic versions only happens in the function for one of them).

But i think this is okay as a first step

next steps:

- [ ] create a new task in the PR concourse job
  - fail concourse 
- [ ] maybe make a lil jinja template to format the output into a nice github comment?