### PR TITLE
Update get service-join-request to include requester and updated_by

### DIFF
--- a/tests/app/dao/test_service_join_requests_dao.py
+++ b/tests/app/dao/test_service_join_requests_dao.py
@@ -103,7 +103,7 @@ def test_get_service_join_request_by_id(client, test_case, notify_db_session):
 
     assert retrieved_request is not None
     assert retrieved_request.id == request.id
-    assert retrieved_request.requester_id == test_case.requester_id
+    assert retrieved_request.requester.id == test_case.requester_id
     assert retrieved_request.service_id == test_case.service_id
     assert len(retrieved_request.contacted_service_users) == test_case.expected_num_contacts
 


### PR DESCRIPTION
We have requirement to display the name of service, requester and status_changed_by. Updated db query to include the user and service and also updated response payload.

https://trello.com/c/pQovKftH/976-create-new-approver-flow-for-request-to-join-a-service