### PR TITLE
nightly tasks: don't use a `countdown` greater than `visibility_timeout`

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -135,7 +135,7 @@ def delete_letter_notifications_older_than_retention():
 
 def _delete_notifications_older_than_retention_by_type(
     notification_type,
-    stagger_total_period=timedelta(hours=1),
+    stagger_total_period=timedelta(minutes=5),
 ):
     flexible_data_retention = fetch_service_data_retention_for_all_services_by_notification_type(notification_type)
 

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -590,7 +590,7 @@ def test_delete_notifications_task_calls_task_for_services_with_data_retention_b
     # iterated order in tested code is not necessarily deterministic
     assert sorted(kwargs["countdown"] for method, args, kwargs in mock_subtask.apply_async.mock_calls) == [
         0.0,
-        timedelta(hours=1).seconds / 2,
+        timedelta(minutes=5).seconds / 2,
     ]
 
 
@@ -647,7 +647,7 @@ def test_delete_notifications_task_calls_task_for_services_that_have_sent_notifi
     # iterated order in tested code is not necessarily deterministic
     assert sorted(kwargs["countdown"] for method, args, kwargs in mock_subtask.apply_async.mock_calls) == [
         0.0,
-        timedelta(hours=1).seconds / 2,
+        timedelta(minutes=5).seconds / 2,
     ]
 
 


### PR DESCRIPTION
Fixups for #4207 and  #4210

Celery/kombu's SQS support is imperfect and the [caveats note](https://docs.celeryq.dev/en/v5.4.0/getting-started/backends-and-brokers/sqs.html#caveats) that using a `countdown` greater than the `visibility_timeout` will likely cause duplicate tasks. It looks like this is happening to us (though luckily it hasn't caused drastic ill effects so far).

So reduce the max `countdown` time we're using to less than 5 minutes as we're currently using a 5 minute 10 second `visibility_timeout`.

Going further it may be nice if we found a way to issue a warning if trying to use a task `countdown`/`eta` beyond the `visibility_timeout`, but let's get this fixed in the meantime.