### PR TITLE
v2 api errors, other blueprint errors: add handler for `EventletTimeout` returning 504

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -1,6 +1,7 @@
 from flask import current_app, json, jsonify
 from jsonschema import ValidationError as JsonSchemaValidationError
 from marshmallow import ValidationError
+from notifications_utils.eventlet import EventletTimeout
 from notifications_utils.recipient_validation.errors import InvalidRecipientError
 from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
@@ -96,6 +97,11 @@ def register_errors(blueprint):  # noqa: C901
     def no_result_found(e):
         current_app.logger.info(e)
         return jsonify(result="error", message="No result found"), 404
+
+    @blueprint.errorhandler(EventletTimeout)
+    def eventlet_timeout(error):
+        current_app.logger.exception(error)
+        return jsonify(result="error", message="Timeout serving request"), 504
 
     # this must be defined after all other error handlers since it catches the generic Exception object
     @blueprint.app_errorhandler(500)


### PR DESCRIPTION
Turns out handlers added in #4209 aren't enough - several blueprints register their own handlers on `Exception` which has higher priority than our `EventletTimeout` app-level handlers.

Someone with some knowledge/opinion about the v2 api and how it's supposed to behave should weigh in on this, because I just made it mostly mimic the general `Internal server error` handler.

_Are there any more places I need to install this handler...?_