### PR TITLE
models: add `pg_trgm` indexes for `Notification`'s `normalised_to` & `client_reference` fields

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1466,6 +1466,22 @@ class Notification(db.Model):
             "notification_type = 'email' OR unsubscribe_link is null",
             name="ck_unsubscribe_link_is_null_if_notification_not_an_email",
         ),
+        Index(
+            "ix_notifications_normalised_to_trgm",
+            "normalised_to",
+            postgresql_using="gin",
+            postgresql_ops={
+                "normalised_to": "gin_trgm_ops",
+            },
+        ),
+        Index(
+            "ix_notifications_client_reference_trgm",
+            "client_reference",
+            postgresql_using="gin",
+            postgresql_ops={
+                "client_reference": "gin_trgm_ops",
+            },
+        ),
     )
 
     @property

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0467_svc_join_approved_tmp
+0468_add_notifications_trgm_normto_cref_idxs

--- a/migrations/versions/0468_add_notifications_trgm_normto_cref_idxs.py
+++ b/migrations/versions/0468_add_notifications_trgm_normto_cref_idxs.py
@@ -1,0 +1,51 @@
+"""
+Create Date: 2024-10-29 13:00:22.856730
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0468"
+down_revision = "0467_svc_join_approved_tmp"
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        op.create_index(
+            "ix_notifications_client_reference_trgm",
+            "notifications",
+            ["client_reference"],
+            unique=False,
+            postgresql_using="gin",
+            postgresql_ops={"client_reference": "gin_trgm_ops"},
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            "ix_notifications_normalised_to_trgm",
+            "notifications",
+            ["normalised_to"],
+            unique=False,
+            postgresql_using="gin",
+            postgresql_ops={"normalised_to": "gin_trgm_ops"},
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade():
+    op.drop_index(
+        "ix_notifications_normalised_to_trgm",
+        table_name="notifications",
+        postgresql_using="gin",
+        postgresql_ops={"normalised_to": "gin_trgm_ops"},
+        postgresql_concurrently=True,
+    )
+    op.drop_index(
+        "ix_notifications_client_reference_trgm",
+        table_name="notifications",
+        postgresql_using="gin",
+        postgresql_ops={"client_reference": "gin_trgm_ops"},
+        postgresql_concurrently=True,
+    )
+    # not reversing CREATE EXTENSION as it may have been present already


### PR DESCRIPTION
https://trello.com/c/sHzruWY5/929-add-pgtrgm-index

These fields are searched by `dao_get_notifications_by_recipient_or_reference` with `LIKE`/`ILIKE` operators, which are unable to use a btree index as the search terms aren't left-anchored. A `pg_trgm` index can be used by these queries to massively reduce the number of rows that need to be scanned.

Using a GIN index as, despite the documentation suggesting it have slightly faster insertion performance than GiST (which is probably more critical to us), most peoples' real world experiences seem to favour GIN by a significant margin for all operations.

One poster even claims they've *never* managed to get GiST to outperform GIN for `pg_trgm` in any scenario.

Migration adds it with a `CREATE INDEX CONCURRENTLY` command to avoid locking tables.