### PR TITLE
Simplify collate task

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -230,8 +230,8 @@ def send_letters_volume_email_to_dvla(letters_volumes, date):
 
 def send_dvla_letters_via_api(print_run_deadline_local):
     current_app.logger.info("send-dvla-letters-for-day-via-api - starting queuing")
-    for letter in dao_get_letters_to_be_printed(print_run_deadline_local):
-        deliver_letter.apply_async(kwargs={"notification_id": letter.id}, queue=QueueNames.SEND_LETTER)
+    for row in dao_get_letters_to_be_printed(print_run_deadline_local):
+        deliver_letter.apply_async(kwargs={"notification_id": row.id}, queue=QueueNames.SEND_LETTER)
 
     current_app.logger.info("send-dvla-letters-for-day-via-api - finished queuing")
 

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -230,7 +230,9 @@ def send_letters_volume_email_to_dvla(letters_volumes, date):
 
 def send_dvla_letters_via_api(print_run_deadline_local):
     current_app.logger.info("send-dvla-letters-for-day-via-api - starting queuing")
-    for row in dao_get_letters_to_be_printed(print_run_deadline_local):
+    for i, row in enumerate(dao_get_letters_to_be_printed(print_run_deadline_local)):
+        if i % 10000 == 0:
+            current_app.logger.info("triggered tasks for %i letters", i)
         deliver_letter.apply_async(kwargs={"notification_id": row.id}, queue=QueueNames.SEND_LETTER)
 
     current_app.logger.info("send-dvla-letters-for-day-via-api - finished queuing")

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -725,7 +725,7 @@ def notifications_not_yet_sent(should_be_sending_after_seconds, notification_typ
     return notifications
 
 
-def dao_get_letters_to_be_printed(print_run_deadline_local, postage, query_limit=10000):
+def dao_get_letters_to_be_printed(print_run_deadline_local, query_limit=10000):
     """
     Return all letters created before the print run deadline that have not yet been sent. This yields in batches of 10k
     to prevent the query taking too long and eating up too much memory. As each 10k batch is yielded, we'll start
@@ -745,7 +745,6 @@ def dao_get_letters_to_be_printed(print_run_deadline_local, postage, query_limit
             Notification.notification_type == LETTER_TYPE,
             Notification.status == NOTIFICATION_CREATED,
             Notification.key_type == KEY_TYPE_NORMAL,
-            Notification.postage == postage,
             Notification.billable_units > 0,
         )
         .order_by(Notification.service_id, Notification.created_at)

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -740,7 +740,8 @@ def dao_get_letters_to_be_printed(print_run_deadline_local, query_limit=10000):
     https://www.mail-archive.com/sqlalchemy@googlegroups.com/msg12443.html
     """
     notifications = (
-        Notification.query.filter(
+        Notification.query.with_entities(Notification.id)
+        .filter(
             Notification.created_at < convert_bst_to_utc(print_run_deadline_local),
             Notification.notification_type == LETTER_TYPE,
             Notification.status == NOTIFICATION_CREATED,

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -748,7 +748,6 @@ def dao_get_letters_to_be_printed(print_run_deadline_local, query_limit=10000):
             Notification.key_type == KEY_TYPE_NORMAL,
             Notification.billable_units > 0,
         )
-        .order_by(Notification.service_id, Notification.created_at)
         .yield_per(query_limit)
     )
     return notifications

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -746,6 +746,8 @@ def dao_get_letters_to_be_printed(print_run_deadline_local, query_limit=10000):
             Notification.notification_type == LETTER_TYPE,
             Notification.status == NOTIFICATION_CREATED,
             Notification.key_type == KEY_TYPE_NORMAL,
+            # we need billable_units as if a letter is stuck pre-validation, it'll be in state created but won't have a
+            # generated (or sanitised if precompiled) pdf associated with it.
             Notification.billable_units > 0,
         )
         .yield_per(query_limit)

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1539,11 +1539,7 @@ def test_letters_to_be_printed_sort_by_service(notify_db_session):
         create_notification(template=second_template, created_at=datetime(2020, 12, 1, 8, 34)),
     ]
 
-    results = list(
-        dao_get_letters_to_be_printed(
-            print_run_deadline_local=datetime(2020, 12, 1, 17, 30), postage="second", query_limit=4
-        )
-    )
+    results = list(dao_get_letters_to_be_printed(print_run_deadline_local=datetime(2020, 12, 1, 17, 30), query_limit=4))
     assert [x.id for x in results] == [x.id for x in letters_ordered_by_service_then_time]
 
 
@@ -1555,11 +1551,7 @@ def test_letters_to_be_printed_does_not_include_letters_without_billable_units_s
     )
     create_notification(template=sample_letter_template, created_at=datetime(2020, 12, 1, 9, 31), billable_units=0)
 
-    results = list(
-        dao_get_letters_to_be_printed(
-            print_run_deadline_local=datetime(2020, 12, 1, 17, 30), postage="second", query_limit=4
-        )
-    )
+    results = list(dao_get_letters_to_be_printed(print_run_deadline_local=datetime(2020, 12, 1, 17, 30), query_limit=4))
     assert len(results) == 1
     assert results[0].id == included_letter.id
 


### PR DESCRIPTION
Tidy up the task a little bit - there's a bunch of complexity that is left over from when we used to group letters and zip them up

* processing postages separately
* ordering by service and timestamp
* returning entire notification object from the DB rather than just the ID

also added a lil logging and commenting.

ideally i'd like to reduce this to <2 minute runtime so that we don't have to pause deploys in the evening - i dont think this'll get us quite there but it's a nice to have