### PR TITLE
rename migration file to just 0468.py

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0468_add_notifications_trgm_normto_cref_idxs
+0468

--- a/migrations/versions/0468.py
+++ b/migrations/versions/0468.py
@@ -6,6 +6,7 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
+# was meant to be 0468_add_notifications_trgm_normto_cref_idxs but accidentally committed as this
 revision = "0468"
 down_revision = "0467_svc_join_approved_tmp"
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -6,7 +6,7 @@ def test_migration_files_start_with_numeric_id():
     """Make sure that all of the migration files start with a 4-character integer"""
     migrations = sorted(glob.glob("migrations/versions/*.py"))
 
-    migration_versions = [pathlib.Path(migration).name.split("_")[0] for migration in migrations]
+    migration_versions = [pathlib.Path(migration).stem.split("_")[0] for migration in migrations]
 
     assert all(
         migration_version.isdigit() and len(migration_version) == 4 for migration_version in migration_versions
@@ -15,8 +15,19 @@ def test_migration_files_start_with_numeric_id():
 
 def test_current_alembic_head():
     migrations = sorted(glob.glob("migrations/versions/*.py"))
-
-    head_migration_id = pathlib.Path(migrations[-1]).name.split(".")[0]
+    head_migration_filename = pathlib.Path(migrations[-1]).stem
 
     with open("migrations/.current-alembic-head") as current_alembic_head:
-        assert current_alembic_head.read() == f"{head_migration_id}\n"
+        assert current_alembic_head.read() == f"{head_migration_filename}\n"
+
+
+def test_revision_matches_filename(notify_db_session):
+    migrations = sorted(glob.glob("migrations/versions/*.py"))
+    head_migration_filename = pathlib.Path(migrations[-1]).stem
+    head_migration_id = head_migration_filename.split(".")[0]
+
+    results = notify_db_session.execute("select version_num from alembic_version").fetchall()
+    assert len(results) == 1
+    assert (
+        results[0].version_num == head_migration_id
+    ), 'alembic head filename {head_migration_filename} does not match "revision" {results[0].version}'


### PR DESCRIPTION
unfortunately we accidentally merged a PR with a migration that just had "0468" as the reference, rather than a name with a description. This has been deployed through to production now, so rather than updating the alembic_version field in the database, we should just change the filename and the .current-alembic-head file so we (and our unit tests and migration CI checks) don't get confused about which file is the most recent migration head