### PR TITLE
`SmsClient`: take over `requests_session` construction, configure tcp keepalive

### DIFF
--- a/app/clients/sms/__init__.py
+++ b/app/clients/sms/__init__.py
@@ -1,4 +1,9 @@
+import platform
+import socket
 from time import monotonic
+
+import requests
+from urllib3.connection import HTTPConnection
 
 from app.clients import Client, ClientException
 
@@ -24,6 +29,20 @@ class SmsClient(Client):
         super().__init__()
         self.current_app = current_app
         self.statsd_client = statsd_client
+
+        self.requests_session = requests.Session()
+        if platform.system() == "Linux":  # these are linux-specific socket options enabling tcp keepalive
+            for adapter in self.requests_session.adapters.values():
+                adapter.poolmanager.connection_pool_kw = {
+                    "socket_options": HTTPConnection.default_socket_options
+                    + [
+                        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+                        (socket.SOL_TCP, socket.TCP_KEEPIDLE, 4),
+                        (socket.SOL_TCP, socket.TCP_KEEPINTVL, 2),
+                        (socket.SOL_TCP, socket.TCP_KEEPCNT, 8),
+                    ],
+                    **adapter.poolmanager.connection_pool_kw,
+                }
 
     def record_outcome(self, success):
         if success:

--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -56,7 +56,6 @@ class FiretextClient(SmsClient):
         self.international_api_key = self.current_app.config.get("FIRETEXT_INTERNATIONAL_API_KEY")
         self.url = self.current_app.config.get("FIRETEXT_URL")
         self.receipt_url = self.current_app.config.get("FIRETEXT_RECEIPT_URL")
-        self.requests_session = requests.Session()
 
     def try_send_sms(self, to, content, reference, international, sender):
         data = {

--- a/app/clients/sms/mmg.py
+++ b/app/clients/sms/mmg.py
@@ -87,7 +87,6 @@ class MMGClient(SmsClient):
         self.api_key = self.current_app.config.get("MMG_API_KEY")
         self.mmg_url = self.current_app.config.get("MMG_URL")
         self.receipt_url = self.current_app.config.get("MMG_RECEIPT_URL")
-        self.requests_session = requests.Session()
 
     def try_send_sms(self, to, content, reference, international, sender):
         data = {"reqType": "BULK", "MSISDN": to, "msg": content, "sender": sender, "cid": reference, "multi": True}


### PR DESCRIPTION
These are quite aggressive tcp keepalive options, but the http keepalives we're dealing with are on quite a short timescale anyway.

This is extremely hard to test via unit tests, but it has "passed" dev-a.