### PR TITLE
Create new celery mock and fix some tests

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -549,7 +549,7 @@ class Test(Development):
     # but the database name is set in the _notify_db fixture
     SQLALCHEMY_RECORD_QUERIES = True
 
-    CELERY = {**Config.CELERY, "broker_url": "you-forgot-to-mock-celery-in-your-tests://"}
+    CELERY = {**Config.CELERY, "broker_url": "you-forgot-to-mock-celery-in-your-tests://", "broker_transport": None}
 
     ANTIVIRUS_ENABLED = True
 

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -10,6 +10,7 @@ from app.celery.research_mode_tasks import (
     ses_notification_callback,
     ses_soft_bounce_callback,
 )
+from app.celery.service_callback_tasks import send_complaint_to_service
 from app.dao.notifications_dao import get_notification_by_id
 from app.models import Complaint, Notification
 from app.notifications.notifications_ses_callback import (
@@ -195,8 +196,8 @@ def test_ses_callback_should_set_status_to_permanent_failure(
     assert hasattr(bounce_record, "bounce_message")
 
 
-def test_ses_callback_should_send_on_complaint_to_user_callback_api(sample_email_template, mocker):
-    send_mock = mocker.patch("app.celery.service_callback_tasks.send_complaint_to_service.apply_async")
+def test_ses_callback_should_send_on_complaint_to_user_callback_api(sample_email_template, mock_celery_task):
+    send_mock = mock_celery_task(send_complaint_to_service)
     create_service_callback_api(
         service=sample_email_template.service, url="https://original_url.com", callback_type="complaint"
     )

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -18,6 +18,8 @@ from notifications_utils.clients.zendesk.zendesk_client import (
 from redis.exceptions import LockError
 
 from app.celery import scheduled_tasks
+from app.celery.letters_pdf_tasks import get_pdf_for_templated_letter
+from app.celery.provider_tasks import deliver_email, deliver_sms
 from app.celery.scheduled_tasks import (
     _check_slow_text_message_delivery_reports_and_raise_error_if_needed,
     change_dvla_api_key,
@@ -41,6 +43,7 @@ from app.celery.scheduled_tasks import (
     weekly_user_research_email,
     zendesk_new_email_branding_report,
 )
+from app.celery.tasks import process_incomplete_jobs, process_job, save_email
 from app.clients.letter.dvla import (
     DvlaNonRetryableException,
     DvlaThrottlingException,
@@ -83,8 +86,8 @@ def test_should_call_delete_invotations_on_delete_invitations_task(notify_db_ses
     assert scheduled_tasks.delete_invitations_created_more_than_two_days_ago.call_count == 1
 
 
-def test_should_update_scheduled_jobs_and_put_on_queue(mocker, sample_template):
-    mocked = mocker.patch("app.celery.tasks.process_job.apply_async")
+def test_should_update_scheduled_jobs_and_put_on_queue(mock_celery_task, sample_template):
+    mocked = mock_celery_task(process_job)
 
     one_minute_in_the_past = datetime.utcnow() - timedelta(minutes=1)
     job = create_job(sample_template, job_status="scheduled", scheduled_for=one_minute_in_the_past)
@@ -96,8 +99,8 @@ def test_should_update_scheduled_jobs_and_put_on_queue(mocker, sample_template):
     mocked.assert_called_with([str(job.id)], queue="job-tasks")
 
 
-def test_should_update_all_scheduled_jobs_and_put_on_queue(sample_template, mocker):
-    mocked = mocker.patch("app.celery.tasks.process_job.apply_async")
+def test_should_update_all_scheduled_jobs_and_put_on_queue(sample_template, mock_celery_task):
+    mocked = mock_celery_task(process_job)
 
     one_minute_in_the_past = datetime.utcnow() - timedelta(minutes=1)
     ten_minutes_in_the_past = datetime.utcnow() - timedelta(minutes=10)
@@ -257,8 +260,8 @@ def test_check_slow_text_message_delivery_reports_and_raise_error_if_needed(
             assert mock_incr.call_args_list == [mocker.call("slow-sms-delivery:number-of-times-over-threshold")]
 
 
-def test_check_job_status_task_calls_process_incomplete_jobs(mocker, sample_template):
-    mock_celery = mocker.patch("app.celery.tasks.process_incomplete_jobs.apply_async")
+def test_check_job_status_task_calls_process_incomplete_jobs(mock_celery_task, sample_template):
+    mock_celery = mock_celery_task(process_incomplete_jobs)
     job = create_job(
         template=sample_template,
         notification_count=3,
@@ -273,9 +276,9 @@ def test_check_job_status_task_calls_process_incomplete_jobs(mocker, sample_temp
 
 
 def test_check_job_status_task_calls_process_incomplete_jobs_when_scheduled_job_is_not_complete(
-    mocker, sample_template
+    mock_celery_task, sample_template
 ):
-    mock_celery = mocker.patch("app.celery.tasks.process_incomplete_jobs.apply_async")
+    mock_celery = mock_celery_task(process_incomplete_jobs)
     job = create_job(
         template=sample_template,
         notification_count=3,
@@ -289,8 +292,10 @@ def test_check_job_status_task_calls_process_incomplete_jobs_when_scheduled_job_
     mock_celery.assert_called_once_with([[str(job.id)]], queue=QueueNames.JOBS)
 
 
-def test_check_job_status_task_calls_process_incomplete_jobs_for_pending_scheduled_jobs(mocker, sample_template):
-    mock_celery = mocker.patch("app.celery.tasks.process_incomplete_jobs.apply_async")
+def test_check_job_status_task_calls_process_incomplete_jobs_for_pending_scheduled_jobs(
+    mock_celery_task, sample_template
+):
+    mock_celery = mock_celery_task(process_incomplete_jobs)
     job = create_job(
         template=sample_template,
         notification_count=3,
@@ -305,10 +310,10 @@ def test_check_job_status_task_calls_process_incomplete_jobs_for_pending_schedul
 
 
 def test_check_job_status_task_does_not_call_process_incomplete_jobs_for_non_scheduled_pending_jobs(
-    mocker,
+    mock_celery_task,
     sample_template,
 ):
-    mock_celery = mocker.patch("app.celery.tasks.process_incomplete_jobs.apply_async")
+    mock_celery = mock_celery_task(process_incomplete_jobs)
     create_job(
         template=sample_template,
         notification_count=3,
@@ -320,8 +325,8 @@ def test_check_job_status_task_does_not_call_process_incomplete_jobs_for_non_sch
     assert not mock_celery.called
 
 
-def test_check_job_status_task_calls_process_incomplete_jobs_for_multiple_jobs(mocker, sample_template):
-    mock_celery = mocker.patch("app.celery.tasks.process_incomplete_jobs.apply_async")
+def test_check_job_status_task_calls_process_incomplete_jobs_for_multiple_jobs(mock_celery_task, sample_template):
+    mock_celery = mock_celery_task(process_incomplete_jobs)
     job = create_job(
         template=sample_template,
         notification_count=3,
@@ -343,8 +348,8 @@ def test_check_job_status_task_calls_process_incomplete_jobs_for_multiple_jobs(m
     mock_celery.assert_called_once_with([[str(job.id), str(job_2.id)]], queue=QueueNames.JOBS)
 
 
-def test_check_job_status_task_only_sends_old_tasks(mocker, sample_template):
-    mock_celery = mocker.patch("app.celery.tasks.process_incomplete_jobs.apply_async")
+def test_check_job_status_task_only_sends_old_tasks(mock_celery_task, sample_template):
+    mock_celery = mock_celery_task(process_incomplete_jobs)
     job = create_job(
         template=sample_template,
         notification_count=3,
@@ -373,8 +378,8 @@ def test_check_job_status_task_only_sends_old_tasks(mocker, sample_template):
     mock_celery.assert_called_once_with([[str(job.id)]], queue=QueueNames.JOBS)
 
 
-def test_check_job_status_task_sets_jobs_to_error(mocker, sample_template):
-    mock_celery = mocker.patch("app.celery.tasks.process_incomplete_jobs.apply_async")
+def test_check_job_status_task_sets_jobs_to_error(mock_celery_task, sample_template):
+    mock_celery = mock_celery_task(process_incomplete_jobs)
     job = create_job(
         template=sample_template,
         notification_count=3,
@@ -398,9 +403,9 @@ def test_check_job_status_task_sets_jobs_to_error(mocker, sample_template):
     assert job_2.job_status == JOB_STATUS_IN_PROGRESS
 
 
-def test_replay_created_notifications(notify_db_session, sample_service, mocker):
-    email_delivery_queue = mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
-    sms_delivery_queue = mocker.patch("app.celery.provider_tasks.deliver_sms.apply_async")
+def test_replay_created_notifications(sample_service, mock_celery_task):
+    email_delivery_queue = mock_celery_task(deliver_email)
+    sms_delivery_queue = mock_celery_task(deliver_sms)
 
     sms_template = create_template(service=sample_service, template_type="sms")
     email_template = create_template(service=sample_service, template_type="email")
@@ -428,9 +433,9 @@ def test_replay_created_notifications(notify_db_session, sample_service, mocker)
 
 
 def test_replay_created_notifications_get_pdf_for_templated_letter_tasks_for_letters_not_ready_to_send(
-    sample_letter_template, mocker
+    sample_letter_template, mock_celery_task
 ):
-    mock_task = mocker.patch("app.celery.scheduled_tasks.get_pdf_for_templated_letter.apply_async")
+    mock_task = mock_celery_task(get_pdf_for_templated_letter)
     create_notification(
         template=sample_letter_template, billable_units=0, created_at=datetime.utcnow() - timedelta(hours=4)
     )
@@ -697,12 +702,12 @@ def test_check_for_missing_rows_in_completed_jobs(mocker, sample_email_template)
     process_row.assert_called_once_with(mock.ANY, mock.ANY, job, job.service, sender_id=None)
 
 
-def test_check_for_missing_rows_in_completed_jobs_calls_save_email(mocker, sample_email_template):
+def test_check_for_missing_rows_in_completed_jobs_calls_save_email(mocker, mock_celery_task, sample_email_template):
     mocker.patch(
         "app.celery.tasks.s3.get_job_and_metadata_from_s3",
         return_value=(load_example_csv("multiple_email"), {"sender_id": None}),
     )
-    save_email_task = mocker.patch("app.celery.tasks.save_email.apply_async")
+    save_email_task = mock_celery_task(save_email)
     mocker.patch("app.signing.encode", return_value="something_encoded")
     mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1,5 +1,6 @@
 import collections.abc
 import copy
+import inspect
 import json
 import textwrap
 import uuid
@@ -1269,7 +1270,41 @@ def mock_dvla_callback_data():
 @pytest.fixture
 def mock_celery_task(mocker):
 
-    def celery_mocker(celery_task: celery.local.PromiseProxy) -> MagicMock:
+    def celery_mocker(celery_task: celery.local.PromiseProxy, assert_types=True) -> MagicMock:
+
+        def _assert_types_match(
+            args: tuple | list | None = None,
+            kwargs: dict | None = None,
+        ):
+            """
+            Checks all the args/kwargs provided match type hints if necessary by using the inspect module to introspect
+            the params and extract annotations. Handles partial args and kwargs, parameters without type hints, etc
+            """
+            args = args or []
+            kwargs = kwargs or {}
+            # get an iterator so we can loop through args in step with inspect
+            args = iter(args)
+
+            # try and check types are correct
+            for parameter_signature in inspect.signature(celery_task).parameters.values():
+                # skip if there's no type hint
+                if parameter_signature.annotation == inspect._empty:
+                    continue
+
+                # try and match with a provided arg - if there are no more args, then we must be calling with a kwarg
+                # instead. if there's no kwarg, then we're just falling back on a provided default
+                try:
+                    param_value = next(args)
+                except StopIteration:
+                    if parameter_signature.name in kwargs:
+                        param_value = kwargs[parameter_signature.name]
+                    else:
+                        # skip this param if we're not calling it as an arg or a kwarg - must be relying on a default
+                        # (the `celery_task.__header__` call would have failed if we needed to supply something)
+                        continue
+
+                assert isinstance(param_value, parameter_signature.annotation)
+
         def check_apply_async(
             args: tuple | list | None = None,
             kwargs: dict | None = None,
@@ -1279,6 +1314,10 @@ def mock_celery_task(mocker):
             assert queue in QueueNames.all_queues()
             # this'll raise an exception if the args/kwargs don't match the function definition
             celery_task.__header__(*(args or ()), **(kwargs or {}))
+
+            if assert_types:
+                _assert_types_match(args, kwargs)
+
             # make sure the values are all json serializable
 
             dumps(args, serializer="json")

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -11,6 +11,7 @@ import pytest
 import pytz
 import requests_mock
 from flask import current_app, url_for
+from kombu.serialization import dumps
 from sqlalchemy.orm.session import make_transient
 
 from app import db
@@ -1279,8 +1280,9 @@ def mock_celery_task(mocker):
             # this'll raise an exception if the args/kwargs don't match the function definition
             celery_task.__header__(*(args or ()), **(kwargs or {}))
             # make sure the values are all json serializable
-            json.dumps(args)
-            json.dumps(kwargs)
+
+            dumps(args, serializer="json")
+            dumps(kwargs, serializer="json")
 
         mock_apply_async = MagicMock(side_effect=check_apply_async)
 

--- a/tests/app/notifications/test_notifications_sms_callbacks.py
+++ b/tests/app/notifications/test_notifications_sms_callbacks.py
@@ -1,5 +1,6 @@
 from flask import json
 
+from app.celery.process_sms_client_response_tasks import process_sms_client_response
 from app.notifications.notifications_sms_callback import validate_callback_data
 
 
@@ -49,8 +50,8 @@ def test_firetext_callback_should_return_400_if_no_status(client):
     assert json_resp["message"] == ["Firetext callback failed: status missing"]
 
 
-def test_firetext_callback_should_return_200_and_call_task_with_valid_data(client, mocker):
-    mock_celery = mocker.patch("app.notifications.notifications_sms_callback.process_sms_client_response.apply_async")
+def test_firetext_callback_should_return_200_and_call_task_with_valid_data(client, mock_celery_task):
+    mock_celery = mock_celery_task(process_sms_client_response)
 
     data = "mobile=441234123123&status=0&time=2016-03-10 14:17:00&reference=notification_id"
     response = firetext_post(client, data)
@@ -64,8 +65,8 @@ def test_firetext_callback_should_return_200_and_call_task_with_valid_data(clien
     )
 
 
-def test_firetext_callback_including_a_code_should_return_200_and_call_task_with_valid_data(client, mocker):
-    mock_celery = mocker.patch("app.notifications.notifications_sms_callback.process_sms_client_response.apply_async")
+def test_firetext_callback_including_a_code_should_return_200_and_call_task_with_valid_data(client, mock_celery_task):
+    mock_celery = mock_celery_task(process_sms_client_response)
 
     data = "mobile=441234123123&status=1&code=101&time=2016-03-10 14:17:00&reference=notification_id"
     response = firetext_post(client, data)
@@ -115,8 +116,8 @@ def test_process_mmg_response_returns_400_for_malformed_data(client):
     assert "{} callback failed: {} missing".format("MMG", "CID") in json_data["message"]
 
 
-def test_mmg_callback_should_return_200_and_call_task_with_valid_data(client, mocker):
-    mock_celery = mocker.patch("app.notifications.notifications_sms_callback.process_sms_client_response.apply_async")
+def test_mmg_callback_should_return_200_and_call_task_with_valid_data(client, mock_celery_task):
+    mock_celery = mock_celery_task(process_sms_client_response)
     data = json.dumps(
         {
             "reference": "mmg_reference",

--- a/tests/app/v2/notifications/test_notification_schemas.py
+++ b/tests/app/v2/notifications/test_notification_schemas.py
@@ -262,7 +262,7 @@ def test_post_email_schema_invalid_email_address(email_address, err_msg):
     ],
 )
 def test_post_email_schema_invalid_unsubscribe_link(unsubscribe_link, err_msg):
-    j_son = valid_post_email_json_with_optionals
+    j_son = valid_post_email_json_with_optionals.copy()
     j_son["one_click_unsubscribe_url"] = unsubscribe_link
     with pytest.raises(ValidationError) as e:
         validate(j_son, post_email_request_schema)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def create_test_db(database_uri):
         postgres_db.dispose()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", autouse=True)
 def _notify_db(notify_api, worker_id):
     """
     Manages the connection to the database. Generally this shouldn't be used, instead you should use the


### PR DESCRIPTION
I was getting frustrated that we had some unit tests that were saying

```
@celery.task
def some_task(arg1, arg2):
  pass

def foo():
  some_task.apply_async(args=[1, 2, 3], queue='some-queue-name')

def test_foo(mocker)
  mock_task = mocker.patch('some_task.apply_async')
  mock_task.assert_called_with(args=[1, 2, 3], queue=ANY)
```

There's a bug here - This code'll never work as `some_task` has two arguments but we're trying to call it with three args!

So, I wrote a `mock_celery_task` fixture that does some clever bits. It will:

* make sure your args and kwargs match up with the underlying task definition
* make sure your arguments are json serializable (so that they could be sent to SQS)
* make sure your args and kwargs match the type hints in the task definition (if there are any)

----

This isn't perfect. Notable things I've found so far:

As it tries to json serialize all your inputs, if you have a Mock you're passing around it'll throw an error. I think this is okay, and maybe we just move away from throwing mocks about and move towards the actual values we expect things to return etc