### PR TITLE
in task, expect values deserialised from json

### DIFF
--- a/app/celery/process_letter_client_response_tasks.py
+++ b/app/celery/process_letter_client_response_tasks.py
@@ -20,11 +20,10 @@ from app.models import LetterCostThreshold
 
 @notify_celery.task(bind=True, name="process-letter-callback")
 def process_letter_callback_data(
-    self, notification_id: str, page_count: int, dvla_status: str, cost_threshold: str, despatch_date: str
+    self, notification_id: str, page_count: int, dvla_status: str, cost_threshold: str, despatch_date: date
 ):
     notification_id = uuid.UUID(notification_id)
     cost_threshold = LetterCostThreshold(cost_threshold)
-    despatch_date = date.fromisoformat(despatch_date)
 
     notification = dao_get_notification_or_history_by_id(notification_id)
 

--- a/app/celery/process_letter_client_response_tasks.py
+++ b/app/celery/process_letter_client_response_tasks.py
@@ -20,9 +20,8 @@ from app.models import LetterCostThreshold
 
 @notify_celery.task(bind=True, name="process-letter-callback")
 def process_letter_callback_data(
-    self, notification_id: str, page_count: int, dvla_status: str, cost_threshold: str, despatch_date: date
+    self, notification_id: uuid.UUID, page_count: int, dvla_status: str, cost_threshold: str, despatch_date: date
 ):
-    notification_id = uuid.UUID(notification_id)
     cost_threshold = LetterCostThreshold(cost_threshold)
 
     notification = dao_get_notification_or_history_by_id(notification_id)

--- a/app/celery/process_letter_client_response_tasks.py
+++ b/app/celery/process_letter_client_response_tasks.py
@@ -1,3 +1,6 @@
+import uuid
+from datetime import date
+
 from flask import current_app
 
 from app import notify_celery
@@ -12,10 +15,17 @@ from app.dao.notifications_dao import (
     dao_update_notification,
 )
 from app.exceptions import NotificationTechnicalFailureException
+from app.models import LetterCostThreshold
 
 
 @notify_celery.task(bind=True, name="process-letter-callback")
-def process_letter_callback_data(self, notification_id, page_count, dvla_status, cost_threshold, despatch_date):
+def process_letter_callback_data(
+    self, notification_id: str, page_count: int, dvla_status: str, cost_threshold: str, despatch_date: str
+):
+    notification_id = uuid.UUID(notification_id)
+    cost_threshold = LetterCostThreshold(cost_threshold)
+    despatch_date = date.fromisoformat(despatch_date)
+
     notification = dao_get_notification_or_history_by_id(notification_id)
 
     validate_billable_units(notification, page_count)

--- a/app/config.py
+++ b/app/config.py
@@ -23,6 +23,7 @@ class QueueNames:
     LETTERS = "letter-tasks"
     SES_CALLBACKS = "ses-callbacks"
     SMS_CALLBACKS = "sms-callbacks"
+    LETTER_CALLBACKS = "letter-callbacks"
     ANTIVIRUS = "antivirus-tasks"
     SANITISE_LETTERS = "sanitise-letter-tasks"
     BROADCASTS = "broadcast-tasks"
@@ -47,6 +48,7 @@ class QueueNames:
             QueueNames.LETTERS,
             QueueNames.SES_CALLBACKS,
             QueueNames.SMS_CALLBACKS,
+            QueueNames.LETTER_CALLBACKS,
             QueueNames.BROADCASTS,
         ]
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -1,3 +1,4 @@
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from itertools import groupby
@@ -898,7 +899,7 @@ def dao_record_letter_despatched_on(reference: str, despatched_on: datetime.date
 
 @autocommit
 def dao_record_letter_despatched_on_by_id(
-    notification_id: str,
+    notification_id: uuid.UUID,
     despatched_on: datetime.date,
     cost_threshold: LetterCostThreshold,
 ):

--- a/app/notifications/notifications_letter_callback.py
+++ b/app/notifications/notifications_letter_callback.py
@@ -162,7 +162,7 @@ def process_letter_callback():
             "cost_threshold": letter_update.cost_threshold,
             "despatch_date": letter_update.despatch_date,
         },
-        queue=QueueNames.NOTIFY,
+        queue=QueueNames.LETTER_CALLBACKS,
     )
 
     return {}, 204

--- a/app/notifications/notifications_letter_callback.py
+++ b/app/notifications/notifications_letter_callback.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import uuid
 from dataclasses import dataclass
 
 from flask import Blueprint, current_app, jsonify, request
@@ -156,7 +157,7 @@ def process_letter_callback():
 
     process_letter_callback_data.apply_async(
         kwargs={
-            "notification_id": notification_id,
+            "notification_id": uuid.UUID(notification_id),
             "page_count": letter_update.page_count,
             "dvla_status": letter_update.status,
             "cost_threshold": letter_update.cost_threshold,

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,7 +54,7 @@ case "$1" in
     exec $COMMON_CMD broadcast-tasks
     ;;
   api-worker-receipts)
-    exec $COMMON_CMD ses-callbacks,sms-callbacks
+    exec $COMMON_CMD ses-callbacks,sms-callbacks,letter-callbacks
     ;;
   api-worker-service-callbacks)
     exec $COMMON_CMD service-callbacks,service-callbacks-retry

--- a/tests/app/celery/test_process_letter_client_response_tasks.py
+++ b/tests/app/celery/test_process_letter_client_response_tasks.py
@@ -41,7 +41,7 @@ def test_process_letter_callback_data_validate_billable_units(mocker, sample_let
         1,
         DVLA_NOTIFICATION_DISPATCHED,
         str(LetterCostThreshold.unsorted),
-        date(2024, 8, 10).isoformat(),
+        date(2024, 8, 10),
     )
 
     mock_validate_billable_units.assert_called_once_with(sample_letter_notification, 1)
@@ -55,7 +55,7 @@ def test_process_letter_callback_data_dao_update_notification_despatched_status(
         1,
         DVLA_NOTIFICATION_DISPATCHED,
         str(LetterCostThreshold.unsorted),
-        date(2024, 7, 9).isoformat(),
+        date(2024, 7, 9),
     )
 
     assert sample_letter_notification.status == NOTIFICATION_DELIVERED
@@ -81,7 +81,7 @@ def test_process_letter_callback_data_dao_update_notification_rejected_status(sa
             1,
             DVLA_NOTIFICATION_REJECTED,
             str(LetterCostThreshold.sorted),
-            date(2024, 7, 8).isoformat(),
+            date(2024, 7, 8),
         )
 
     assert sample_letter_notification.status == NOTIFICATION_TECHNICAL_FAILURE
@@ -105,7 +105,7 @@ def test_process_letter_callback_data_dao_update_notification_despatched_status_
         1,
         DVLA_NOTIFICATION_DISPATCHED,
         str(LetterCostThreshold.sorted),
-        date(2024, 7, 10).isoformat(),
+        date(2024, 7, 10),
     )
 
     assert notification.status == NOTIFICATION_DELIVERED
@@ -139,7 +139,7 @@ def test_process_letter_callback_data_dao_update_notification_rejected_status_hi
             1,
             DVLA_NOTIFICATION_REJECTED,
             str(LetterCostThreshold.unsorted),
-            date(2024, 3, 1).isoformat(),
+            date(2024, 3, 1),
         )
 
     assert notification.status == NOTIFICATION_TECHNICAL_FAILURE
@@ -164,7 +164,7 @@ def test_process_letter_callback_data_duplicate_update(sample_letter_notificatio
         1,
         DVLA_NOTIFICATION_DISPATCHED,
         str(LetterCostThreshold.unsorted),
-        date(2024, 7, 8).isoformat(),
+        date(2024, 7, 8),
     )
 
     assert sample_letter_notification.status == initial_status

--- a/tests/app/celery/test_process_letter_client_response_tasks.py
+++ b/tests/app/celery/test_process_letter_client_response_tasks.py
@@ -24,7 +24,7 @@ def test_mock_validate_billable_units_logs_error_if_billable_units_do_not_match_
     sample_letter_notification,
     caplog,
 ):
-    validate_billable_units(sample_letter_notification, "5")
+    validate_billable_units(sample_letter_notification, 5)
 
     assert (
         f"Notification with id {sample_letter_notification.id} has 1 billable_units but DVLA says page count is 5"
@@ -37,25 +37,25 @@ def test_process_letter_callback_data_validate_billable_units(mocker, sample_let
     )
 
     process_letter_callback_data(
-        sample_letter_notification.id,
-        "1",
+        str(sample_letter_notification.id),
+        1,
         DVLA_NOTIFICATION_DISPATCHED,
-        LetterCostThreshold.unsorted,
-        date(2024, 8, 10),
+        str(LetterCostThreshold.unsorted),
+        date(2024, 8, 10).isoformat(),
     )
 
-    mock_validate_billable_units.assert_called_once_with(sample_letter_notification, "1")
+    mock_validate_billable_units.assert_called_once_with(sample_letter_notification, 1)
 
 
 @freeze_time("2024-07-05T10:00:00")
 def test_process_letter_callback_data_dao_update_notification_despatched_status(sample_letter_notification):
     assert sample_letter_notification.updated_at is None
     process_letter_callback_data(
-        sample_letter_notification.id,
-        "1",
+        str(sample_letter_notification.id),
+        1,
         DVLA_NOTIFICATION_DISPATCHED,
-        LetterCostThreshold.unsorted,
-        date(2024, 7, 9),
+        str(LetterCostThreshold.unsorted),
+        date(2024, 7, 9).isoformat(),
     )
 
     assert sample_letter_notification.status == NOTIFICATION_DELIVERED
@@ -77,11 +77,11 @@ def test_process_letter_callback_data_dao_update_notification_rejected_status(sa
 
     with pytest.raises(NotificationTechnicalFailureException):
         process_letter_callback_data(
-            sample_letter_notification.id,
-            "1",
+            str(sample_letter_notification.id),
+            1,
             DVLA_NOTIFICATION_REJECTED,
-            LetterCostThreshold.sorted,
-            date(2024, 7, 8),
+            str(LetterCostThreshold.sorted),
+            date(2024, 7, 8).isoformat(),
         )
 
     assert sample_letter_notification.status == NOTIFICATION_TECHNICAL_FAILURE
@@ -101,11 +101,11 @@ def test_process_letter_callback_data_dao_update_notification_despatched_status_
     notification.updated_at = datetime.now() - timedelta(days=1)
 
     process_letter_callback_data(
-        notification.id,
-        "1",
+        str(notification.id),
+        1,
         DVLA_NOTIFICATION_DISPATCHED,
-        LetterCostThreshold.sorted,
-        date(2024, 7, 10),
+        str(LetterCostThreshold.sorted),
+        date(2024, 7, 10).isoformat(),
     )
 
     assert notification.status == NOTIFICATION_DELIVERED
@@ -135,11 +135,11 @@ def test_process_letter_callback_data_dao_update_notification_rejected_status_hi
 
     with pytest.raises(NotificationTechnicalFailureException):
         process_letter_callback_data(
-            notification.id,
-            "1",
+            str(notification.id),
+            1,
             DVLA_NOTIFICATION_REJECTED,
-            LetterCostThreshold.unsorted,
-            date(2024, 3, 1),
+            str(LetterCostThreshold.unsorted),
+            date(2024, 3, 1).isoformat(),
         )
 
     assert notification.status == NOTIFICATION_TECHNICAL_FAILURE
@@ -160,11 +160,11 @@ def test_process_letter_callback_data_duplicate_update(sample_letter_notificatio
     sample_letter_notification.updated_at = yesterday
 
     process_letter_callback_data(
-        sample_letter_notification.id,
-        "1",
+        str(sample_letter_notification.id),
+        1,
         DVLA_NOTIFICATION_DISPATCHED,
-        LetterCostThreshold.unsorted,
-        date(2024, 7, 8),
+        str(LetterCostThreshold.unsorted),
+        date(2024, 7, 8).isoformat(),
     )
 
     assert sample_letter_notification.status == initial_status

--- a/tests/app/notifications/test_notifications_letter_callbacks.py
+++ b/tests/app/notifications/test_notifications_letter_callbacks.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 
 import pytest
 from flask import json, url_for
@@ -320,7 +321,7 @@ def test_process_letter_callback_calls_process_letter_callback_data_task(
     mock_task.assert_called_once_with(
         queue="letter-callbacks",
         kwargs={
-            "notification_id": "cfce9e7b-1534-4c07-a66d-3cf9172f7640",
+            "notification_id": uuid.UUID("cfce9e7b-1534-4c07-a66d-3cf9172f7640"),
             "page_count": 5,
             "dvla_status": status,
             "cost_threshold": LetterCostThreshold.unsorted,

--- a/tests/app/notifications/test_notifications_letter_callbacks.py
+++ b/tests/app/notifications/test_notifications_letter_callbacks.py
@@ -318,7 +318,7 @@ def test_process_letter_callback_calls_process_letter_callback_data_task(
     assert response.status_code == 204, response.json
 
     mock_task.assert_called_once_with(
-        queue="notify-internal-tasks",
+        queue="letter-callbacks",
         kwargs={
             "notification_id": "cfce9e7b-1534-4c07-a66d-3cf9172f7640",
             "page_count": 5,

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -7,7 +7,7 @@ from app.config import QueueNames
 def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()
-    assert len(queues) == 17
+    assert len(queues) == 18
     assert {
         QueueNames.PERIODIC,
         QueueNames.DATABASE,
@@ -25,6 +25,7 @@ def test_queue_names_all_queues_correct():
         QueueNames.LETTERS,
         QueueNames.SES_CALLBACKS,
         QueueNames.SMS_CALLBACKS,
+        QueueNames.LETTER_CALLBACKS,
         QueueNames.BROADCASTS,
     } == set(queues)
 


### PR DESCRIPTION
being a bit more explicit with type hints should hopefully remind us that the values in the task are just json dumped, so aren't rich enums or date objects

----

note: i've tested this manually locally by using `curl` and sending an example payload they provided us, but with my own db's UUID swapped. seems to work end-to-end (as well as my local setup works, which is barely at all)