### PR TITLE
feat: Add folder permissions for service join update

### DIFF
--- a/app/schema_validation/service_join_request.py
+++ b/app/schema_validation/service_join_request.py
@@ -33,6 +33,7 @@ service_join_request_update_schema = {
             },
             "description": "List of permissions being granted or modified",
         },
+        "folder_permissions": {"type": "array", "items": {"type": "string"}},
         "status_changed_by_id": {"type": "string", "format": "uuid"},
         "status": {
             "type": "string",

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1358,8 +1358,9 @@ def update_service_join_request(request_id: uuid.UUID):
         requester_user = get_user_by_id(updated_request.requester_id)
         approver_user = get_user_by_id(updated_request.status_changed_by_id)
         service = dao_fetch_service_by_id(updated_request.service_id)
+        folder_permissions = data.get("folder_permissions", [])
 
-        dao_add_user_to_service(service, requester_user, permissions)
+        dao_add_user_to_service(service, requester_user, permissions, folder_permissions)
 
         send_service_join_request_decision_email(
             requester_email_address=requester_user.email_address,


### PR DESCRIPTION
## Summary
- Include folder permissions update during service join request flow
- We do this in the current invite-user journey, we just need to make sure the same is done for the service request journey

### Ticket:
[Let folder permissions be selected when approving a service join request](https://trello.com/c/70y7hQOW/1021-let-folder-permissions-be-selected-when-approving-a-service-join-request)