### PR TITLE
Add common requirements file to Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,7 +81,7 @@ RUN mkdir -p app
 COPY --from=python_build --chown=notify:notify /opt/venv /opt/venv
 
 # Install dev/test requirements
-COPY --chown=notify:notify Makefile requirements.txt requirements_for_test.txt ./
+COPY --chown=notify:notify Makefile requirements.txt requirements_for_test.txt requirements_for_test_common.txt ./
 RUN make bootstrap
 
 COPY --chown=notify:notify . .


### PR DESCRIPTION
Not having `requirements_for_test_common.txt` in the list of files to copy across before running bootstrap caused an error when building the image.