### PR TITLE
Notification: add multi-variate extended statistics including basic declarative/testing mechanism

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1490,6 +1490,10 @@ class Notification(db.Model):
         ("st_dep_notifications_service_id_job_id", ("service_id", "job_id"), ("dependencies",)),
         ("st_dep_notifications_service_id_template_id", ("service_id", "template_id"), ("dependencies",)),
         ("st_dep_notifications_template_id_notification_type", ("template_id", "notification_type"), ("dependencies",)),
+        # most common values
+        ("st_mcv_notifications_notification_type_status", ("notification_type", "notification_status"), ("mcv",)),
+        ("st_mcv_notifications_service_id_key_type", ("service_id", "key_type"), ("mcv",)),
+        ("st_mcv_notifications_service_id_notification_type", ("service_id", "notification_type"), ("mcv",)),
     )
 
     @property

--- a/app/models.py
+++ b/app/models.py
@@ -1484,6 +1484,14 @@ class Notification(db.Model):
         ),
     )
 
+    __extended_statistics__ = (
+        # dependencies
+        ("st_dep_notifications_service_id_api_key_id", ("service_id", "api_key_id"), ("dependencies",)),
+        ("st_dep_notifications_service_id_job_id", ("service_id", "job_id"), ("dependencies",)),
+        ("st_dep_notifications_service_id_template_id", ("service_id", "template_id"), ("dependencies",)),
+        ("st_dep_notifications_template_id_notification_type", ("template_id", "notification_type"), ("dependencies",)),
+    )
+
     @property
     def personalisation(self):
         if self._personalisation:

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0468
+0469_notifications_xstats_dep

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0469_notifications_xstats_dep
+0470_notifications_xstats_mcv

--- a/migrations/versions/0469_notifications_xstats_dep.py
+++ b/migrations/versions/0469_notifications_xstats_dep.py
@@ -1,0 +1,32 @@
+"""
+Create Date: 2024-11-06 13:51:53.222714
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0469_notifications_xstats_dep"
+down_revision = "0468"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_notifications_service_id_api_key_id (dependencies) ON service_id, api_key_id FROM notifications"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notifications_service_id_job_id (dependencies) ON service_id, job_id FROM notifications"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notifications_service_id_template_id (dependencies) ON service_id, template_id FROM notifications"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notifications_template_id_notification_type (dependencies) ON template_id, notification_type FROM notifications"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_notifications_service_id_api_key_id")
+    op.execute("DROP STATISTICS st_dep_notifications_service_id_job_id")
+    op.execute("DROP STATISTICS st_dep_notifications_service_id_template_id")
+    op.execute("DROP STATISTICS st_dep_notifications_template_id_notification_type")

--- a/migrations/versions/0470_notifications_xstats_mcv.py
+++ b/migrations/versions/0470_notifications_xstats_mcv.py
@@ -1,0 +1,28 @@
+"""
+Create Date: 2024-11-06 16:25:17.550808
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0470_notifications_xstats_mcv"
+down_revision = "0469_notifications_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_mcv_notifications_notification_type_status (mcv) ON notification_type, notification_status FROM notifications"
+    )
+    op.execute(
+        "CREATE STATISTICS st_mcv_notifications_service_id_key_type (mcv) ON service_id, key_type FROM notifications"
+    )
+    op.execute(
+        "CREATE STATISTICS st_mcv_notifications_service_id_notification_type (mcv) ON service_id, notification_type FROM notifications"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_mcv_notifications_notification_type_status")
+    op.execute("DROP STATISTICS st_mcv_notifications_service_id_key_type")
+    op.execute("DROP STATISTICS st_mcv_notifications_service_id_notification_type")


### PR DESCRIPTION
Individual commits have more detail.

The more interesting thing here is the addition of `__extended_statistics__` on a model, which is something that's only consumed by the new `test_extended_statistics_presence` test to ensure this "declaration" of extended statistics matches those as provisioned by the migrations.

Running these migrations should take negligible time - the new statistics aren't actually collected until the database does its next `ANALYZE` run for the table.