### PR TITLE
fix: Recipient of join request email

### DIFF
--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -176,7 +176,7 @@ def send_service_invite_request(
             saved_notification = persist_notification(
                 template_id=template.id,
                 template_version=template.version,
-                recipient="notify-join-service-request@digital.cabinet-office.gov.uk",
+                recipient=recipient.email_address,
                 service=notify_service,
                 personalisation={
                     "approver_name": recipient.name,

--- a/tests/app/service_invite/test_service_invite_rest.py
+++ b/tests/app/service_invite/test_service_invite_rest.py
@@ -388,6 +388,7 @@ def test_request_invite_to_service_email_is_sent_to_valid_service_managers(
     assert manager_notification.personalisation["service_name"] == sample_service.name
     assert manager_notification.personalisation["reason_given"] == expected_reason_given
     assert manager_notification.personalisation["reason"] == expected_reason
+    assert manager_notification.to == service_manager_1.email_address
     assert (
         manager_notification.personalisation["url"]
         == f"{invite_link_host}/services/{sample_service.id}/users/invite/{user_requesting_invite.id}"


### PR DESCRIPTION
## Summary
- Request of join service currently has a mock email address 
- this PR changes this to the actual recipient address

