### PR TITLE
Notifications: include `job_id` in (`template_id`, `notification_type`) dependency statistic

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1489,7 +1489,11 @@ class Notification(db.Model):
         ("st_dep_notifications_service_id_api_key_id", ("service_id", "api_key_id"), ("dependencies",)),
         ("st_dep_notifications_service_id_job_id", ("service_id", "job_id"), ("dependencies",)),
         ("st_dep_notifications_service_id_template_id", ("service_id", "template_id"), ("dependencies",)),
-        ("st_dep_notifications_template_id_notification_type", ("template_id", "notification_type"), ("dependencies",)),
+        (
+            "st_dep_notifications_job_id_template_id_notification_type",
+            ("job_id", "template_id", "notification_type"),
+            ("dependencies",),
+        ),
         # most common values
         ("st_mcv_notifications_notification_type_status", ("notification_type", "notification_status"), ("mcv",)),
         ("st_mcv_notifications_service_id_key_type", ("service_id", "key_type"), ("mcv",)),

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0470_notifications_xstats_mcv
+0471_notifications_xstats_dep2

--- a/migrations/versions/0471_notifications_xstats_dep2.py
+++ b/migrations/versions/0471_notifications_xstats_dep2.py
@@ -1,0 +1,24 @@
+"""
+Create Date: 2024-11-08 13:25:26.784680
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0471_notifications_xstats_dep2"
+down_revision = "0470_notifications_xstats_mcv"
+
+
+def upgrade():
+    op.execute("DROP STATISTICS st_dep_notifications_template_id_notification_type")
+    op.execute(
+        "CREATE STATISTICS st_dep_notifications_job_id_template_id_notification_type (dependencies) ON job_id, template_id, notification_type FROM notifications"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_notifications_job_id_template_id_notification_type")
+    op.execute(
+        "CREATE STATISTICS st_dep_notifications_template_id_notification_type (dependencies) ON template_id, notification_type FROM notifications"
+    )


### PR DESCRIPTION
Following https://github.com/alphagov/notifications-api/pull/4250, I spotted a couple more relationships I didn't cover in that PR.

All three of these attributes should have a functional dependency between each of them. This is the most concise way to express this, and the planner is still able to use the pairwise relationships when the third attribute isn't involved in the query: https://github.com/postgres/postgres/blob/3cc5e51ab4507b33acc82684b7d79ac43b8a6b5d/src/backend/statistics/dependencies.c#L1555

