### PR TITLE
Only reduce SMS provider priority for 50 errors in a minute

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -338,6 +338,9 @@ class CacheKeys:
     NUMBER_OF_TIMES_OVER_SLOW_SMS_DELIVERY_THRESHOLD = "slow-sms-delivery:number-of-times-over-threshold"
 
 
+SMS_PROVIDER_ERROR_THRESHOLD = 50
+SMS_PROVIDER_ERROR_INTERVAL = 60
+
 # Admin API error codes
 QR_CODE_TOO_LONG = "qr-code-too-long"
 


### PR DESCRIPTION
We were reducing priority for a single 5xx error, which meant that a very low percentage of errors when sending SMS could result in a large drop in traffic to a provider which then takes hours to be restored to the resting points.

This reuses the function we have for rate limiting to check for a number of events over an interval. In this case, we check for 50 errors over 60 seconds and only reduce the priority if this rate is exceeded. There are no changes to how we handle provider priority if SMS delivery is slow.