### PR TITLE
`NotificationHistory`: add dependency & most-common-value extended statistics

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1871,6 +1871,18 @@ class NotificationHistory(db.Model):
         Index("ix_notification_history_created_at", "created_at", postgresql_concurrently=True),
     )
 
+    __extended_statistics__ = (
+        # dependencies
+        ("st_dep_notification_history_service_id_api_key_id", ("service_id", "api_key_id"), ("dependencies",)),
+        ("st_dep_notification_history_service_id_job_id", ("service_id", "job_id"), ("dependencies",)),
+        ("st_dep_notification_history_service_id_tpt_id", ("service_id", "template_id"), ("dependencies",)),
+        (
+            "st_dep_notification_history_job_id_tpt_id_ntfcn_type",
+            ("job_id", "template_id", "notification_type"),
+            ("dependencies",),
+        ),
+    )
+
 
 class LetterCostThreshold(enum.StrEnum):
     sorted = "sorted"

--- a/app/models.py
+++ b/app/models.py
@@ -1881,6 +1881,10 @@ class NotificationHistory(db.Model):
             ("job_id", "template_id", "notification_type"),
             ("dependencies",),
         ),
+        # most common values
+        ("st_mcv_notification_history_ntfcn_type_status", ("notification_type", "notification_status"), ("mcv",)),
+        ("st_mcv_notification_history_service_id_key_type", ("service_id", "key_type"), ("mcv",)),
+        ("st_mcv_notification_history_service_id_ntfcn_type", ("service_id", "notification_type"), ("mcv",)),
     )
 
 

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0473_jobs_xstats_deps
+0474_ntfcn_hist_xstats_dep

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0474_ntfcn_hist_xstats_dep
+0475_ntfcn_hist_xstats_mcv

--- a/migrations/versions/0474_ntfcn_hist_xstats_dep.py
+++ b/migrations/versions/0474_ntfcn_hist_xstats_dep.py
@@ -1,0 +1,32 @@
+"""
+Create Date: 2024-11-13T16:34
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0474_ntfcn_hist_xstats_dep"
+down_revision = "0473_jobs_xstats_deps"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_notification_history_service_id_api_key_id (dependencies) ON service_id, api_key_id FROM notification_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notification_history_service_id_job_id (dependencies) ON service_id, job_id FROM notification_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notification_history_service_id_tpt_id (dependencies) ON service_id, template_id FROM notification_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notification_history_job_id_tpt_id_ntfcn_type (dependencies) ON job_id, template_id, notification_type FROM notification_history"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_notification_history_service_id_api_key_id")
+    op.execute("DROP STATISTICS st_dep_notification_history_service_id_job_id")
+    op.execute("DROP STATISTICS st_dep_notification_history_service_id_tpt_id")
+    op.execute("DROP STATISTICS st_dep_notification_history_job_id_tpt_id_ntfcn_type")

--- a/migrations/versions/0475_ntfcn_hist_xstats_mcv.py
+++ b/migrations/versions/0475_ntfcn_hist_xstats_mcv.py
@@ -1,0 +1,28 @@
+"""
+Create Date: 2024-11-13T16:34
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0475_ntfcn_hist_xstats_mcv"
+down_revision = "0474_ntfcn_hist_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_mcv_notification_history_ntfcn_type_status (mcv) ON notification_type, notification_status FROM notification_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_mcv_notification_history_service_id_key_type (mcv) ON service_id, key_type FROM notification_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_mcv_notification_history_service_id_ntfcn_type (mcv) ON service_id, notification_type FROM notification_history"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_mcv_notification_history_ntfcn_type_status")
+    op.execute("DROP STATISTICS st_mcv_notification_history_service_id_key_type")
+    op.execute("DROP STATISTICS st_mcv_notification_history_service_id_ntfcn_type")

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -23,7 +23,14 @@ from app.constants import (
     PRECOMPILED_TEMPLATE_NAME,
     SMS_TYPE,
 )
-from app.models import FactNotificationStatus, Job, LetterCostThreshold, Notification, ServiceGuestList
+from app.models import (
+    FactNotificationStatus,
+    Job,
+    LetterCostThreshold,
+    Notification,
+    NotificationHistory,
+    ServiceGuestList,
+)
 from tests.app.db import (
     create_inbound_number,
     create_letter_contact,
@@ -407,6 +414,7 @@ def test_notification_references_template_history(client, sample_template):
         FactNotificationStatus,
         Job,
         Notification,
+        NotificationHistory,
     ),
 )
 def test_extended_statistics_presence(notify_db_session, model):


### PR DESCRIPTION
The same statistics as recently added for `Notification`, though they will likely be less effective what with the statistics being diluted over a longer period.