### PR TITLE
`Notification`: add `ix_notifications_failed_service_id_composite`

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -18,6 +18,7 @@ NOTIFICATION_RETURNED_LETTER = "returned-letter"
 
 # Raw notification status values grouped into types
 NOTIFICATION_STATUS_TYPES_FAILED = [
+    # if changing this group, update ix_notifications_failed_service_id_composite to match
     NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
     NOTIFICATION_PERMANENT_FAILURE,

--- a/app/models.py
+++ b/app/models.py
@@ -1488,6 +1488,13 @@ class Notification(db.Model):
                 "client_reference": "gin_trgm_ops",
             },
         ),
+        Index(
+            "ix_notifications_failed_service_id_composite",
+            "service_id",
+            "notification_type",
+            "created_at",
+            postgresql_where=status.in_(NOTIFICATION_STATUS_TYPES_FAILED),
+        ),
     )
 
     __extended_statistics__ = (

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0475_ntfcn_hist_xstats_mcv
+0476_notifications_failed_idx

--- a/migrations/versions/0476_notifications_failed_idx.py
+++ b/migrations/versions/0476_notifications_failed_idx.py
@@ -1,0 +1,36 @@
+"""
+Create Date: 2024-11-15 14:01:27.039958
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0476_notifications_failed_idx"
+down_revision = "0475_ntfcn_hist_xstats_mcv"
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_notifications_failed_service_id_composite",
+            "notifications",
+            ["service_id", "notification_type", "created_at"],
+            unique=False,
+            postgresql_where=sa.text(
+                "notification_status IN ('technical-failure', 'temporary-failure', 'permanent-failure', 'validation-failed', 'virus-scan-failed', 'returned-letter')"
+            ),
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_notifications_failed_service_id_composite",
+            table_name="notifications",
+            postgresql_where=sa.text(
+                "notification_status IN ('technical-failure', 'temporary-failure', 'permanent-failure', 'validation-failed', 'virus-scan-failed', 'returned-letter')"
+            ),
+            postgresql_concurrently=True,
+        )


### PR DESCRIPTION
Notifications with failed status are comparatively rare and tend to sit in cold regions of the table. Added to them being composed of several different individual status types (which, searched for together, rules out a lot of standard index operations), postgres finds it hard to query these efficiently.

This is a partial index only covering `NOTIFICATION_STATUS_TYPES_FAILED` (which conveniently at time of writing is the same set of status types requested together by admin), so it should be a small index that should allow such a query to completely disregard the `notification_status` clause and start reading out the results in `created_at` order with very little more filtering.

This is aimed at speeding up pages such as `/services/.../notifications/email?status=failed` which can be very slow.

I should probably add a comment to admin alongside this making a similar note to check api's indexes if changing the status type groups on that end.