### PR TITLE
Refactor: create table service_join_request_contacted_users

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2908,7 +2908,7 @@ class SerializedServiceJoinRequest:
 
 
 contacted_users = db.Table(
-    "contacted_users",
+    "service_join_request_contacted_users",
     db.Model.metadata,
     db.Column(
         "service_join_request_id", UUID(as_uuid=True), db.ForeignKey("service_join_requests.id"), primary_key=True

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0476_notifications_failed_idx
+0477_create_sjr_contacted_users

--- a/migrations/versions/0477_create_sjr_contacted_users.py
+++ b/migrations/versions/0477_create_sjr_contacted_users.py
@@ -1,0 +1,36 @@
+"""
+Create Date: 2024-11-22
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0477_create_sjr_contacted_users"
+down_revision = "0476_notifications_failed_idx"
+
+
+def upgrade():
+    # 1. Create service_join_request_contacted_users
+    op.create_table(
+        "service_join_request_contacted_users",
+        sa.Column(
+            "service_join_request_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("service_join_requests.id"),
+            primary_key=True,
+        ),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), primary_key=True),
+    )
+
+    # 2. Copy data from the old table to the new
+    op.execute(
+        """
+        INSERT INTO service_join_request_contacted_users (service_join_request_id, user_id)
+        SELECT service_join_request_id, user_id FROM contacted_users;
+        """
+    )
+
+
+def downgrade():
+    op.drop_table("service_join_request_contacted_users")


### PR DESCRIPTION
## Summary
- Created a new table service_join_request_contacted_users.
- Copied data from soon to be deprecated contacted_users to newly created table (PR that [follows this one](https://github.com/alphagov/notifications-api/pull/4270))
- Refactored ServiceJoinRequest model to reference new table.

## Tested
- downgrade [script passes](https://github.com/alphagov/notifications-api/blob/fe6f9bf14e97261344ba21fc2b207ff8b105a657/scripts/test_sql_migration_downgrade.sh) with success

## Ticket:
https://trello.com/c/kgwSzxw2/1051-rename-contactedserviceusers-table