### PR TITLE
`get_notifications_for_service`: add ability to omit `_personalisation` from query

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -16,7 +16,7 @@ from notifications_utils.recipient_validation.phone_number import try_validate_a
 from notifications_utils.timezones import convert_bst_to_utc, convert_utc_to_bst
 from sqlalchemy import and_, asc, desc, func, literal, or_, union
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import defer, joinedload, undefer
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import functions
 from sqlalchemy.sql.expression import case
@@ -251,6 +251,7 @@ def get_notifications_for_service(
     limit_days=None,
     key_type=None,
     with_template=False,
+    with_personalisation=True,
     include_jobs=False,
     include_from_test_key=False,
     older_than=None,
@@ -291,6 +292,8 @@ def get_notifications_for_service(
 
     if with_template:
         query = query.options(joinedload("template"))
+
+    query = query.options((undefer if with_personalisation else defer)("_personalisation"))
 
     query = query.options(joinedload("api_key"))
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -250,7 +250,7 @@ def get_notifications_for_service(
     count_pages=True,
     limit_days=None,
     key_type=None,
-    personalisation=False,
+    with_template=False,
     include_jobs=False,
     include_from_test_key=False,
     older_than=None,
@@ -289,7 +289,7 @@ def get_notifications_for_service(
     query = Notification.query.filter(*filters)
     query = _filter_query(query, filter_dict)
 
-    if personalisation:
+    if with_template:
         query = query.options(joinedload("template"))
 
     query = query.options(joinedload("api_key"))

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -451,6 +451,7 @@ def get_all_notifications_for_service_for_csv(service_id):
         count_pages=False,
         limit_days=limit_days,
         error_out=False,
+        with_personalisation=False,
         include_jobs=True,
         include_from_test_key=False,
         include_one_off=True,

--- a/app/v2/notifications/get_notifications.py
+++ b/app/v2/notifications/get_notifications.py
@@ -77,7 +77,7 @@ def get_notifications():
         str(authenticated_service.id),
         filter_dict=data,
         key_type=api_user.key_type,
-        personalisation=True,
+        with_template=True,
         older_than=data.get("older_than"),
         client_reference=data.get("reference"),
         page_size=current_app.config.get("API_PAGE_SIZE"),


### PR DESCRIPTION
This involves a bit of juggling of options. Firstly this renames the existing argument `personalisation` (which dates back to 2016) to `with_template`, which better describes what it actually does.

Then this adds a new argument `with_personalisation` that, if set `False` (not the default) will defer the loading of the `_personalisation` db column.

`_personalisation` is generally the biggest field in a `notifications` row. The field is rarely used in bulk requests and including it (significantly) inflates the size of intermediate results in the query plan, increasing the size of e.g. external sorts. Omitting it will probably also reduce the amount postgres needs to fetch from its TOAST table.

I'd also be interested in changing the `service.get_all_notifications_for_service` view to omit the personalisation in responses to deliver a similar optimization for a greater number of calls. However that would involve an interface change so I've not done it here.

FWIW, this may not deliver a significant visible speedup for this view itself, but it should reduce the amount it contributes to database cache pollution.
