### PR TITLE
feat: Extend protected_sender_ids to include organisation_id column

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2892,6 +2892,7 @@ class ProtectedSenderId(db.Model):
     __tablename__ = "protected_sender_ids"
 
     sender_id = db.Column(db.String, primary_key=True, nullable=False)
+    organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), nullable=True)
 
 
 @dataclass

--- a/app/protected_sender_id/protected_sender_schema.py
+++ b/app/protected_sender_id/protected_sender_schema.py
@@ -4,6 +4,8 @@ protected_sender_request = {
     "type": "object",
     "title": "Protected sender id check",
     "properties": {
-        "sender_id": {"type": ["string", "null"]},
+        "sender_id": {"type": "string", "minLength": 1},
+        "organisation_id": {"type": "string", "format": "uuid"},
     },
+    "required": ["sender_id"],
 }

--- a/app/protected_sender_id/rest.py
+++ b/app/protected_sender_id/rest.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, jsonify, request
 
-from app.errors import InvalidRequest, register_errors
+from app.errors import register_errors
 from app.models import ProtectedSenderId
 from app.protected_sender_id.protected_sender_schema import protected_sender_request
 from app.schema_validation import validate
@@ -12,16 +12,17 @@ register_errors(protected_sender_id_blueprint)
 
 @protected_sender_id_blueprint.route("/check")
 def check_if_sender_id_is_protected():
-    if request.args:
-        validate(request.args, protected_sender_request)
+    payload = request.args
+    validate(payload, protected_sender_request)
 
-    sender_id = request.args.get("sender_id", "")
-    if sender_id == "":
-        raise InvalidRequest(message="sender_id must be passed in", status_code=400)
+    sender_id = payload.get("sender_id")
+    organisation_id = payload.get("organisation_id")
+
     normalised_sender_id = "".join(sender_id.split()).lower()
     result = ProtectedSenderId.query.filter(ProtectedSenderId.sender_id == normalised_sender_id).scalar()
-    if result:
-        is_protected_sender_id = True
-    else:
-        is_protected_sender_id = False
+
+    is_protected_sender_id = result is not None and (
+        organisation_id is None or str(organisation_id) == str(result.organisation_id)
+    )
+
     return jsonify(is_protected_sender_id)

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0477_create_sjr_contacted_users
+0478_add_org_id_to_protected_ids

--- a/migrations/versions/0476_notifications_failed_idx.py
+++ b/migrations/versions/0476_notifications_failed_idx.py
@@ -4,7 +4,6 @@ Create Date: 2024-11-15 14:01:27.039958
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 revision = "0476_notifications_failed_idx"
 down_revision = "0475_ntfcn_hist_xstats_mcv"

--- a/migrations/versions/0478_add_org_id_to_protected_ids.py
+++ b/migrations/versions/0478_add_org_id_to_protected_ids.py
@@ -1,0 +1,27 @@
+"""
+Create Date: 2024-11-22
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0478_add_org_id_to_protected_ids"
+down_revision = "0477_create_sjr_contacted_users"
+
+
+def upgrade():
+    op.add_column(
+        "protected_sender_ids",
+        sa.Column(
+            "organisation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("organisation.id"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("protected_sender_ids", "organisation_id")

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -64,6 +64,7 @@ from app.models import (
     NotificationHistory,
     Organisation,
     Permission,
+    ProtectedSenderId,
     Rate,
     ReturnedLetter,
     Service,
@@ -1339,3 +1340,17 @@ def create_unsubscribe_request_report(
     )
     create_unsubscribe_request_reports_dao(report)
     return report
+
+
+def create_protected_sender_id(
+    sender_id,
+    organisation_id=None,
+):
+    data = ProtectedSenderId(
+        sender_id=sender_id,
+        organisation_id=organisation_id,
+    )
+    db.session.add(data)
+    db.session.commit()
+
+    return data

--- a/tests/app/protected_sender_id/test_rest.py
+++ b/tests/app/protected_sender_id/test_rest.py
@@ -1,11 +1,33 @@
-from app import db
-from app.models import ProtectedSenderId
+import uuid
+
+import pytest
+
+from tests.app.db import create_organisation, create_protected_sender_id
+
+
+@pytest.mark.parametrize(
+    "query_params, expected_error_message",
+    [
+        ({}, "sender_id is a required property"),
+        (
+            {"sender_id": "famous_company", "organisation_id": "invalid-uuid"},
+            "organisation_id badly formed hexadecimal UUID string",
+        ),
+    ],
+    ids=["Missing required field sender_id", "Invalid format for organisation_id"],
+)
+def test_check_protected_sender_id_validation(admin_request, query_params, expected_error_message):
+    response = admin_request.get(
+        "protected-sender-id.check_if_sender_id_is_protected",
+        **query_params,
+        _expected_status=400,
+    )
+
+    assert any(expected_error_message in error["message"] for error in response["errors"])
 
 
 def test_get_check_protected_sender_id(admin_request, notify_db_session):
-    data: ProtectedSenderId = ProtectedSenderId(sender_id="famous_company")
-    db.session.add(data)
-    db.session.commit()
+    create_protected_sender_id(sender_id="famous_company")
 
     response = admin_request.get(
         "protected-sender-id.check_if_sender_id_is_protected",
@@ -15,12 +37,40 @@ def test_get_check_protected_sender_id(admin_request, notify_db_session):
 
 
 def test_get_check_unprotected_sender_id(admin_request, notify_db_session):
-    data: ProtectedSenderId = ProtectedSenderId(sender_id="famous_company")
-    db.session.add(data)
-    db.session.commit()
+    create_protected_sender_id(sender_id="famous_company")
 
     response = admin_request.get(
         "protected-sender-id.check_if_sender_id_is_protected",
         sender_id="government_service",
     )
     assert not response
+
+
+def test_protected_sender_id_with_matching_organisation(admin_request, notify_db_session):
+    organisation_id = str(uuid.uuid4())
+    create_organisation(organisation_id=organisation_id, name="org-1")
+
+    create_protected_sender_id(sender_id="famous_company", organisation_id=organisation_id)
+
+    response = admin_request.get(
+        "protected-sender-id.check_if_sender_id_is_protected",
+        sender_id="famous_company",
+        organisation_id=organisation_id,
+    )
+
+    assert response is True
+
+
+def test_protected_sender_id_with_non_matching_organisation(admin_request, notify_db_session):
+    non_matching_organisation_id = str(uuid.uuid4())
+    correct_org = create_organisation(name="default_organisation")
+
+    create_protected_sender_id(sender_id="famous_company", organisation_id=correct_org.id)
+
+    response = admin_request.get(
+        "protected-sender-id.check_if_sender_id_is_protected",
+        sender_id="famous_company",
+        organisation_id=non_matching_organisation_id,
+    )
+
+    assert response is False


### PR DESCRIPTION
## Summary
- Added organisation_id column with foreign key reference to Organisation table
- Refactored endpoint to receive organisation as an argument - this is intentional so this field remains optional and it also prevents a breaking change
- If a sender_id is found but the organisation does not match, we return false


## Ticket:
https://trello.com/c/6jXOAfRJ/1034-incident-action-put-in-place-restrictions-on-sender-ids-that-can-be-used-by-an-organisation