### PR TITLE
Bump utils to 90.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file is automatically copied from notifications-utils@89.0.0
+# This file was automatically copied from notifications-utils@90.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# This file is automatically copied from notifications-utils@89.0.0
+# This file was automatically copied from notifications-utils@90.0.0
 
 [tool.black]
 line-length = 120

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ lxml==4.9.3
 notifications-python-client==8.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@89.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@90.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@89.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@90.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -184,7 +184,7 @@ mypy-extensions==1.0.0
     # via black
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@89.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@90.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file is automatically copied from notifications-utils@89.0.0
+# This file was automatically copied from notifications-utils@90.0.0
 
 beautifulsoup4==4.11.1
 pytest==7.2.0


### PR DESCRIPTION
 ## 90.0.0

* Allow leading empty columns in CSV files
* Change second argument of `formatters.strip_all_whitespace` (this argument is not used in other apps)

 ## 89.2.0

* Use github API rather than fetching from their CDN in version_tools

 ## 89.1.0

* Change version_tools to a package that uses importlib to grab common reqs/config, rather than fetching common files from github. This repo's usage of those common files are now symlinks to the sources of truth found within notification_utils/version_tools/

 ## 89.0.1

* Raise an exception if we cant fetch remote github files in version_tools.py

 ## 89.0.0
***

Complete changes: https://github.com/alphagov/notifications-utils/compare/89.0.0...90.0.0