### PR TITLE
chore: remove deprecated contacted_users table

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0477_create_sjr_contacted_users
+0478_drop_contacted_users

--- a/migrations/versions/0478_drop_contacted_users.py
+++ b/migrations/versions/0478_drop_contacted_users.py
@@ -1,0 +1,30 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0478_drop_contacted_users"
+down_revision = "0477_create_sjr_contacted_users"
+
+
+def upgrade():
+    op.drop_table("contacted_users")
+
+
+def downgrade():
+    op.create_table(
+        "contacted_users",
+        sa.Column(
+            "service_join_request_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("service_join_requests.id"),
+            primary_key=True,
+        ),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), primary_key=True),
+    )
+
+    op.execute(
+        """
+        INSERT INTO contacted_users (service_join_request_id, user_id)
+        SELECT service_join_request_id, user_id FROM service_join_request_contacted_users;
+        """
+    )


### PR DESCRIPTION
## Summary
- Drop deprecated contacted_users table
- This is part of a table renaming process. At a [previous PR](https://github.com/alphagov/notifications-api/pull/4265) we created a table called service_join_request_contacted_users and copied the data from contacted_users there.
- Now, we are simply deleting the depracted table

Note: The following error comes from lint

```
/tmp/upgrade.sql:2:2: warning: ban-drop-table
```

As explained, at this point the data from the table has been copied over and it's no longer in use.

## Testing
**Data was copied successfully from contact_users to service_join_request_contacted_users, which means we can deprecate the table**

![Screenshot 2024-11-26 at 10 39 16](https://github.com/user-attachments/assets/92b20d28-206b-4ebf-9cba-88efe5e3afd5)

**Also, after making a request, the request is being saved on the new table**

![Screenshot 2024-11-26 at 10 43 17](https://github.com/user-attachments/assets/552dfae3-bae1-45c9-8a0b-8c6260a403e0)

## Ticket:
https://trello.com/c/kgwSzxw2/1051-rename-contactedserviceusers-table