### PR TITLE
parse_dvla_file: use `S3_BUCKET_DVLA_RESPONSE` to determine bucket

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -371,8 +371,7 @@ def record_daily_sorted_counts(self, filename):
 
 
 def parse_dvla_file(filename):
-    bucket_location = "{}-ftp".format(current_app.config["NOTIFY_EMAIL_DOMAIN"])
-    response_file_content = s3.get_s3_file(bucket_location, filename)
+    response_file_content = s3.get_s3_file(current_app.config["S3_BUCKET_DVLA_RESPONSE"], filename)
     return process_updates_from_file(response_file_content, filename=filename)
 
 

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -108,11 +108,9 @@ def test_update_letter_notifications_statuses_raises_dvla_exception(notify_api, 
 def test_update_letter_notifications_statuses_calls_with_correct_bucket_location(notify_api, mocker):
     s3_mock = mocker.patch("app.celery.tasks.s3.get_s3_object")
 
-    with set_config(notify_api, "NOTIFY_EMAIL_DOMAIN", "foo.bar"):
+    with set_config(notify_api, "S3_BUCKET_DVLA_RESPONSE", "foo.bar-ftp"):
         update_letter_notifications_statuses(filename="NOTIFY-20170823160812-RSP.TXT")
-        s3_mock.assert_called_with(
-            "{}-ftp".format(current_app.config["NOTIFY_EMAIL_DOMAIN"]), "NOTIFY-20170823160812-RSP.TXT"
-        )
+        s3_mock.assert_called_with(current_app.config["S3_BUCKET_DVLA_RESPONSE"], "NOTIFY-20170823160812-RSP.TXT")
 
 
 def test_update_letter_notifications_statuses_builds_updates_from_content(notify_api, mocker):


### PR DESCRIPTION
Instead of reverse-constructing the bucket name from the `NOTIFY_EMAIL_DOMAIN`, which is a technique that fails as soon as e.g. we have to deviate from this naming scheme due to bucket length limitations.