### PR TITLE
Add fixtures for API client integration tests to functional test fixtures

### DIFF
--- a/app/functional_tests_fixtures/__init__.py
+++ b/app/functional_tests_fixtures/__init__.py
@@ -152,7 +152,7 @@ def apply_fixtures():
 
     current_app.logger.info("--> Ensure service sms senders exists")
     _create_service_sms_senders(service.id, "07700900500", True, inbound_number_id)
-    _create_service_sms_senders(service.id, "func tests", False, None)
+    sms_sender = _create_service_sms_senders(service.id, "func tests", False, None)
 
     current_app.logger.info("--> Ensure service inbound api exists")
     _create_service_inbound_api(service.id, service_admin_user.id)
@@ -184,6 +184,7 @@ export FUNCTIONAL_TESTS_API_AUTH_SECRET='{current_app.config['INTERNAL_CLIENT_AP
 
 export FUNCTIONAL_TESTS_SERVICE_EMAIL_REPLY_TO='{test_email_username}+{environment}-reply-to@{email_domain}'
 export FUNCTIONAL_TESTS_SERVICE_EMAIL_REPLY_TO_ID='{email_reply_to.id}'
+export FUNCTIONAL_TESTS_SERVICE_SMS_SENDER_ID='{sms_sender.id}'
 export FUNCTIONAL_TESTS_SERVICE_INBOUND_NUMBER=07700900500
 
 export FUNCTIONAL_TEST_SMS_TEMPLATE_ID={template2_id}
@@ -458,9 +459,9 @@ def _create_service_sms_senders(service_id, sms_sender, is_default, inbound_numb
 
     for service_sms_sender in service_sms_senders:
         if service_sms_sender.sms_sender == sms_sender:
-            return
+            return service_sms_sender
 
-    dao_add_sms_sender_for_service(service_id, sms_sender, is_default, inbound_number_id)
+    return dao_add_sms_sender_for_service(service_id, sms_sender, is_default, inbound_number_id)
 
 
 def _create_service_inbound_api(service_id, user_id):

--- a/app/functional_tests_fixtures/__init__.py
+++ b/app/functional_tests_fixtures/__init__.py
@@ -143,7 +143,9 @@ def apply_fixtures():
     _create_service_email_reply_to(
         service.id, f"{test_email_username}+{environment}-reply-to-default@{email_domain}", True
     )
-    _create_service_email_reply_to(service.id, f"{test_email_username}+{environment}-reply-to@{email_domain}", False)
+    email_reply_to = _create_service_email_reply_to(
+        service.id, f"{test_email_username}+{environment}-reply-to@{email_domain}", False
+    )
 
     current_app.logger.info("--> Ensure service permissions exists")
     _create_service_permissions(service.id)
@@ -181,6 +183,7 @@ export FUNCTIONAL_TESTS_SERVICE_API_TEST_KEY='{function_tests_test_key_name}-{se
 export FUNCTIONAL_TESTS_API_AUTH_SECRET='{current_app.config['INTERNAL_CLIENT_API_KEYS']['notify-functional-tests'][0]}'
 
 export FUNCTIONAL_TESTS_SERVICE_EMAIL_REPLY_TO='{test_email_username}+{environment}-reply-to@{email_domain}'
+export FUNCTIONAL_TESTS_SERVICE_EMAIL_REPLY_TO_ID='{email_reply_to.id}'
 export FUNCTIONAL_TESTS_SERVICE_INBOUND_NUMBER=07700900500
 
 export FUNCTIONAL_TEST_SMS_TEMPLATE_ID={template2_id}
@@ -422,7 +425,7 @@ def _create_service_email_reply_to(service_id, email_address, is_default):
 
     for service_email_reply_to in service_email_reply_tos:
         if service_email_reply_to.email_address == email_address:
-            return
+            return service_email_reply_to
 
     service_email_reply_to = ServiceEmailReplyTo()
 
@@ -430,7 +433,7 @@ def _create_service_email_reply_to(service_id, email_address, is_default):
     service_email_reply_to.is_default = is_default
     service_email_reply_to.email_address = email_address
 
-    add_reply_to_email_address_for_service(service_id, email_address, is_default)
+    return add_reply_to_email_address_for_service(service_id, email_address, is_default)
 
 
 def _create_service_permissions(service_id, permissions=None):


### PR DESCRIPTION
[Trello card](https://trello.com/c/D1m5uleD/952-run-api-client-integration-tests-as-part-of-new-pipeline)

We're working to update the API client integration tests to use the same set of fixtures as the functional tests, so that they can be run in every environment (instead of being tied specifically to preview), without needing to manually "clickops" the required services and templates into each environment.

This will be useful when testing changes in a dev environment, and will also be necessary before we can achieve our goal of retiring the preview environment.

This PR adds the necessary additional fixtures to get the API clients working. It'll be followed up by PRs in each of the API client repos to make the necessary adjustments to have them use these new fixtures.