### PR TITLE
Tv number international info fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@90.0.0
+# This file was automatically copied from notifications-utils@91.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -612,8 +612,7 @@ def dao_get_notifications_by_recipient_or_reference(
     error_out=True,
 ):
     if notification_type == SMS_TYPE:
-        normalised = try_parse_and_format_phone_number(search_term)
-
+        normalised = try_parse_and_format_phone_number(search_term, with_country_code=False)
         for character in {"(", ")", " ", "-"}:
             normalised = normalised.replace(character, "")
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -12,7 +12,6 @@ from notifications_utils.international_billing_rates import (
 )
 from notifications_utils.recipient_validation.email_address import validate_and_format_email_address
 from notifications_utils.recipient_validation.errors import InvalidEmailError
-from notifications_utils.recipient_validation.phone_number import try_validate_and_format_phone_number
 from notifications_utils.timezones import convert_bst_to_utc, convert_utc_to_bst
 from sqlalchemy import and_, asc, desc, func, literal, or_, union
 from sqlalchemy.dialects.postgresql import insert
@@ -57,6 +56,7 @@ from app.utils import (
     escape_special_characters,
     get_london_midnight_in_utc,
     midnight_n_days_ago,
+    try_parse_and_format_phone_number,
 )
 
 FIELDS_TO_TRANSFER_TO_NOTIFICATION_HISTORY = [
@@ -612,7 +612,7 @@ def dao_get_notifications_by_recipient_or_reference(
     error_out=True,
 ):
     if notification_type == SMS_TYPE:
-        normalised = try_validate_and_format_phone_number(search_term)
+        normalised = try_parse_and_format_phone_number(search_term)
 
         for character in {"(", ")", " ", "-"}:
             normalised = normalised.replace(character, "")
@@ -639,7 +639,6 @@ def dao_get_notifications_by_recipient_or_reference(
 
     normalised = escape_special_characters(normalised)
     search_term = escape_special_characters(search_term)
-
     filters = [
         Notification.service_id == service_id,
         or_(
@@ -653,7 +652,6 @@ def dao_get_notifications_by_recipient_or_reference(
         filters.append(Notification.status.in_(statuses))
     if notification_type:
         filters.append(Notification.notification_type == notification_type)
-
     results = (
         db.session.query(Notification)
         .filter(*filters)

--- a/app/inbound_sms/rest.py
+++ b/app/inbound_sms/rest.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, jsonify, request
-from notifications_utils.recipient_validation.phone_number import try_validate_and_format_phone_number
 
 from app.dao.inbound_sms_dao import (
     dao_count_inbound_sms_for_service,
@@ -11,6 +10,7 @@ from app.dao.service_data_retention_dao import fetch_service_data_retention_by_n
 from app.errors import register_errors
 from app.inbound_sms.inbound_sms_schemas import get_inbound_sms_for_service_schema
 from app.schema_validation import validate
+from app.utils import try_parse_and_format_phone_number
 
 inbound_sms = Blueprint("inbound_sms", __name__, url_prefix="/service/<uuid:service_id>/inbound-sms")
 
@@ -24,7 +24,7 @@ def post_inbound_sms_for_service(service_id):
 
     if user_number:
         # we use this to normalise to an international phone number - but this may fail if it's an alphanumeric
-        user_number = try_validate_and_format_phone_number(user_number, international=True)
+        user_number = try_parse_and_format_phone_number(user_number)
 
     inbound_data_retention = fetch_service_data_retention_by_notification_type(service_id, "sms")
     limit_days = inbound_data_retention.days_of_retention if inbound_data_retention else 7

--- a/app/models.py
+++ b/app/models.py
@@ -8,10 +8,7 @@ from notifications_utils.insensitive_dict import InsensitiveDict
 from notifications_utils.letter_timings import get_letter_timings
 from notifications_utils.recipient_validation.email_address import validate_email_address
 from notifications_utils.recipient_validation.errors import InvalidRecipientError
-from notifications_utils.recipient_validation.phone_number import (
-    try_validate_and_format_phone_number,
-    validate_phone_number,
-)
+from notifications_utils.recipient_validation.phone_number import PhoneNumber
 from notifications_utils.recipient_validation.postal_address import (
     address_lines_1_to_6_and_postcode_keys,
 )
@@ -80,6 +77,7 @@ from app.utils import (
     get_dt_string_or_none,
     get_london_midnight_in_utc,
     get_uuid_string_or_none,
+    try_parse_and_format_phone_number,
     url_with_token,
     utc_string_to_bst_string,
 )
@@ -777,7 +775,7 @@ class ServiceSmsSender(db.Model):
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
 
     def get_reply_to_text(self):
-        return try_validate_and_format_phone_number(self.sms_sender)
+        return try_parse_and_format_phone_number(self.sms_sender)
 
     def serialize(self):
         return {
@@ -825,7 +823,8 @@ class ServiceGuestList(db.Model):
 
         try:
             if recipient_type == MOBILE_TYPE:
-                validate_phone_number(recipient, international=True)
+                number = PhoneNumber(recipient)
+                number.validate(allow_international_number=True)
                 instance.recipient = recipient
             elif recipient_type == EMAIL_TYPE:
                 validate_email_address(recipient)
@@ -1128,7 +1127,7 @@ class TemplateBase(db.Model):
         elif self.template_type == EMAIL_TYPE:
             return self.service.get_default_reply_to_email_address()
         elif self.template_type == SMS_TYPE:
-            return try_validate_and_format_phone_number(self.service.get_default_sms_sender())
+            return try_parse_and_format_phone_number(self.service.get_default_sms_sender())
         else:
             return None
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -156,7 +156,7 @@ def persist_notification(
         notification.normalised_to = formatted_recipient
         notification.international = recipient_info.international
         notification.phone_prefix = recipient_info.country_prefix
-        notification.rate_multiplier = recipient_info.billable_units
+        notification.rate_multiplier = recipient_info.rate_multiplier
     elif notification_type == EMAIL_TYPE:
         notification.normalised_to = format_email_address(notification.to)
     elif notification_type == LETTER_TYPE:

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -9,8 +9,6 @@ from notifications_utils.recipient_validation.email_address import (
 )
 from notifications_utils.recipient_validation.phone_number import (
     PhoneNumber,
-    get_international_phone_info,
-    validate_and_format_phone_number,
 )
 from notifications_utils.template import (
     LetterPrintTemplate,
@@ -36,6 +34,7 @@ from app.dao.notifications_dao import (
     dao_delete_notifications_by_id,
 )
 from app.models import Notification
+from app.utils import parse_and_format_phone_number
 from app.v2.errors import BadRequestError, QrCodeTooLongError
 
 REDIS_GET_AND_INCR_DAILY_LIMIT_DURATION_SECONDS = Histogram(
@@ -148,14 +147,12 @@ def persist_notification(
         updated_at=updated_at,
     )
     if notification_type == SMS_TYPE:
-        if service.has_permission(SMS_TO_UK_LANDLINES):
-            phonenumber = PhoneNumber(recipient)
-            phonenumber.validate(allow_international_number=True, allow_uk_landline=True)
-            formatted_recipient = phonenumber.get_normalised_format()
-            recipient_info = phonenumber.get_international_phone_info()
-        else:
-            formatted_recipient = validate_and_format_phone_number(recipient, international=True)
-            recipient_info = get_international_phone_info(formatted_recipient)
+        phonenumber = PhoneNumber(recipient)
+        phonenumber.validate(
+            allow_international_number=True, allow_uk_landline=service.has_permission(SMS_TO_UK_LANDLINES)
+        )
+        formatted_recipient = phonenumber.get_normalised_format()
+        recipient_info = phonenumber.get_international_phone_info()
         notification.normalised_to = formatted_recipient
         notification.international = recipient_info.international
         notification.phone_prefix = recipient_info.country_prefix
@@ -223,7 +220,7 @@ def send_notification_to_queue(notification, queue=None):
 def simulated_recipient(to_address, notification_type):
     if notification_type == SMS_TYPE:
         formatted_simulated_numbers = [
-            validate_and_format_phone_number(number) for number in current_app.config["SIMULATED_SMS_NUMBERS"]
+            parse_and_format_phone_number(number) for number in current_app.config["SIMULATED_SMS_NUMBERS"]
         ]
         return to_address in formatted_simulated_numbers
     else:

--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -4,7 +4,6 @@ from urllib.parse import unquote
 import iso8601
 from flask import Blueprint, abort, current_app, jsonify, request
 from gds_metrics.metrics import Counter
-from notifications_utils.recipient_validation.phone_number import try_validate_and_format_phone_number
 
 from app.celery import service_callback_tasks
 from app.config import QueueNames
@@ -13,6 +12,7 @@ from app.dao.inbound_sms_dao import dao_create_inbound_sms
 from app.dao.services_dao import dao_fetch_service_by_inbound_number
 from app.errors import register_errors
 from app.models import InboundSms
+from app.utils import try_parse_and_format_phone_number
 
 receive_notifications_blueprint = Blueprint("receive_notifications", __name__)
 register_errors(receive_notifications_blueprint)
@@ -135,8 +135,8 @@ def format_mmg_datetime(date):
 
 
 def create_inbound_sms_object(service, content, from_number, provider_ref, date_received, provider_name):
-    user_number = try_validate_and_format_phone_number(
-        from_number, international=True, log_msg=f'Invalid from_number received for service "{service.id}"'
+    user_number = try_parse_and_format_phone_number(
+        from_number, log_msg=f'Invalid from_number received for service "{service.id}"'
     )
 
     provider_date = date_received

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -33,7 +33,7 @@ from app.notifications.process_notifications import (
 )
 from app.serialised_models import SerialisedTemplate
 from app.service.utils import service_allowed_to_send_to
-from app.utils import get_international_phone_info, get_public_notify_type_text, parse_and_format_phone_number
+from app.utils import get_international_phone_info, get_public_notify_type_text
 from app.v2.errors import (
     BadRequestError,
     RateLimitError,

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -9,8 +9,6 @@ from notifications_utils.recipient_validation.email_address import validate_and_
 from notifications_utils.recipient_validation.errors import InvalidPhoneError
 from notifications_utils.recipient_validation.phone_number import (
     PhoneNumber,
-    get_international_phone_info,
-    validate_and_format_phone_number,
 )
 from notifications_utils.recipient_validation.postal_address import PostalAddress
 from sqlalchemy.orm.exc import NoResultFound
@@ -35,7 +33,7 @@ from app.notifications.process_notifications import (
 )
 from app.serialised_models import SerialisedTemplate
 from app.service.utils import service_allowed_to_send_to
-from app.utils import get_public_notify_type_text
+from app.utils import get_international_phone_info, get_public_notify_type_text, parse_and_format_phone_number
 from app.v2.errors import (
     BadRequestError,
     RateLimitError,
@@ -154,11 +152,14 @@ def validate_and_format_recipient(send_to, key_type, service, notification_type,
                     raise BadRequestError(message="Cannot send to international mobile numbers") from e
                 else:
                     raise
-
         else:
-            international_phone_info = check_if_service_can_send_to_number(service, send_to)
-
-        return validate_and_format_phone_number(number=send_to, international=international_phone_info.international)
+            check_if_service_can_send_to_number(service, send_to)
+            phone_number = PhoneNumber(send_to)
+            phone_number.validate(
+                allow_international_number=service.has_permission(INTERNATIONAL_SMS_TYPE),
+                allow_uk_landline=service.has_permission(SMS_TO_UK_LANDLINES),
+            )
+            return phone_number.get_normalised_format()
     elif notification_type == EMAIL_TYPE:
         return validate_and_format_email_address(email_address=send_to)
 
@@ -170,7 +171,6 @@ def check_if_service_can_send_to_number(service, number):
         permissions = [p.permission for p in service.permissions]
     else:
         permissions = service.permissions
-
     if (
         # if number is international and not a crown dependency
         international_phone_info.international

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -17,15 +17,14 @@ from marshmallow_sqlalchemy import field_for
 from notifications_utils.recipient_validation.email_address import validate_email_address
 from notifications_utils.recipient_validation.errors import InvalidEmailError, InvalidPhoneError
 from notifications_utils.recipient_validation.phone_number import (
-    validate_and_format_phone_number,
-    validate_phone_number,
+    PhoneNumber,
 )
 
 import app.constants
 from app import db, ma, models
 from app.dao.permissions_dao import permission_dao
 from app.models import ServicePermission
-from app.utils import DATETIME_FORMAT_NO_TIMEZONE
+from app.utils import DATETIME_FORMAT_NO_TIMEZONE, parse_and_format_phone_number
 
 
 def _validate_positive_number(value, msg="Not a positive integer"):
@@ -131,7 +130,8 @@ class UserSchema(BaseSchema):
     def validate_mobile_number(self, value):
         try:
             if value is not None:
-                validate_phone_number(value, international=True)
+                number = PhoneNumber(value)
+                number.validate(allow_international_number=True)
         except InvalidPhoneError as error:
             raise ValidationError(f"Invalid phone number: {error.get_legacy_v2_api_error_message()}") from error
 
@@ -171,7 +171,8 @@ class UserUpdateAttributeSchema(BaseSchema):
     def validate_mobile_number(self, value):
         try:
             if value is not None:
-                validate_phone_number(value, international=True)
+                number = PhoneNumber(value)
+                number.validate(allow_international_number=True)
         except InvalidPhoneError as error:
             raise ValidationError(f"Invalid phone number: {error.get_legacy_v2_api_error_message()}") from error
 
@@ -573,13 +574,14 @@ class SmsNotificationSchema(NotificationSchema):
     @validates("to")
     def validate_to(self, value):
         try:
-            validate_phone_number(value, international=True)
+            number = PhoneNumber(value)
+            number.validate(allow_international_number=True)
         except InvalidPhoneError as error:
             raise ValidationError(f"Invalid phone number: {error.get_legacy_v2_api_error_message()}") from error
 
     @post_load
     def format_phone_number(self, item, **kwargs):
-        item["to"] = validate_and_format_phone_number(item["to"], international=True)
+        item["to"] = parse_and_format_phone_number(item["to"])
         return item
 
 

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from urllib.parse import urlencode
 
 from flask import Blueprint, abort, current_app, jsonify, request
-from notifications_utils.recipient_validation.phone_number import is_uk_phone_number, use_numeric_sender
+from notifications_utils.recipient_validation.phone_number import PhoneNumber
 from sqlalchemy.exc import IntegrityError
 
 from app.config import QueueNames
@@ -139,7 +139,8 @@ def update_user_attribute(user_id):
 
 
 def get_sms_reply_to_for_notify_service(recipient, template):
-    if not is_uk_phone_number(recipient) and use_numeric_sender(recipient):
+    phone_number = PhoneNumber(recipient)
+    if not phone_number.is_uk_phone_number() and phone_number.should_use_numeric_sender():
         reply_to = current_app.config["NOTIFY_INTERNATIONAL_SMS_SENDER"]
     else:
         reply_to = template.service.get_default_sms_sender()

--- a/app/utils.py
+++ b/app/utils.py
@@ -166,16 +166,18 @@ def utc_string_to_bst_string(utc_string):
     return utc_string_to_aware_gmt_datetime(utc_string).strftime("%Y-%m-%d %H:%M:%S")
 
 
-def try_parse_and_format_phone_number(number: str, log_msg=None) -> str:
+def try_parse_and_format_phone_number(number: str, log_msg=None, with_country_code=True) -> str:
     try:
-        return parse_and_format_phone_number(number)
+        return parse_and_format_phone_number(number, with_country_code=with_country_code)
     except InvalidPhoneError as e:
         current_app.logger.warning("%s: %s", log_msg, e)
         return number
 
 
-def parse_and_format_phone_number(number: str) -> str:
+def parse_and_format_phone_number(number: str, with_country_code=True) -> str:
     phone_number = PhoneNumber(number)
+    if not with_country_code:
+        return str(phone_number.number.national_number)
     return phone_number.get_normalised_format()
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -3,6 +3,8 @@ from urllib.parse import urljoin
 
 import pytz
 from flask import current_app, url_for
+from notifications_utils.recipient_validation.errors import InvalidPhoneError
+from notifications_utils.recipient_validation.phone_number import PhoneNumber
 from notifications_utils.template import (
     HTMLEmailTemplate,
     LetterPrintTemplate,
@@ -162,3 +164,21 @@ def get_ft_billing_data_for_today_updated_at() -> str | None:
 
 def utc_string_to_bst_string(utc_string):
     return utc_string_to_aware_gmt_datetime(utc_string).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def try_parse_and_format_phone_number(number: str, log_msg=None) -> str:
+    try:
+        return parse_and_format_phone_number(number)
+    except InvalidPhoneError as e:
+        current_app.logger.warning("%s: %s", log_msg, e)
+        return number
+
+
+def parse_and_format_phone_number(number: str) -> str:
+    phone_number = PhoneNumber(number)
+    return phone_number.get_normalised_format()
+
+
+def get_international_phone_info(number: str):
+    phone_number = PhoneNumber(number)
+    return phone_number.get_international_phone_info()

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -5,7 +5,6 @@ from datetime import datetime
 
 from flask import abort, current_app, jsonify, request
 from gds_metrics import Histogram
-from notifications_utils.recipient_validation.phone_number import try_validate_and_format_phone_number
 
 from app import (
     api_user,
@@ -55,6 +54,7 @@ from app.notifications.validators import (
     validate_template,
 )
 from app.schema_validation import validate
+from app.utils import try_parse_and_format_phone_number
 from app.v2.errors import BadRequestError
 from app.v2.notifications import v2_notification_blueprint
 from app.v2.notifications.create_response import (
@@ -396,7 +396,7 @@ def get_reply_to_text(notification_type, form, template):
             str(authenticated_service.id), service_sms_sender_id, notification_type
         )
         if sms_sender_id:
-            reply_to = try_validate_and_format_phone_number(sms_sender_id)
+            reply_to = try_parse_and_format_phone_number(sms_sender_id)
         else:
             reply_to = template.reply_to_text
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@90.0.0
+# This file was automatically copied from notifications-utils@91.0.0
 
 [tool.black]
 line-length = 120

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ lxml==4.9.3
 notifications-python-client==8.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@90.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@91.0.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@90.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@91.0.1
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -159,7 +159,7 @@ packaging==23.2
     # via
     #   marshmallow
     #   marshmallow-sqlalchemy
-phonenumbers==8.13.48
+phonenumbers==8.13.50
     # via notifications-utils
 prometheus-client==0.14.1
     # via

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -184,7 +184,7 @@ mypy-extensions==1.0.0
     # via black
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@90.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@91.0.1
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -196,7 +196,7 @@ packaging==24.2
     #   pytest
 pathspec==0.12.1
     # via black
-phonenumbers==8.13.49
+phonenumbers==8.13.50
     # via notifications-utils
 platformdirs==4.3.6
     # via black

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@90.0.0
+# This file was automatically copied from notifications-utils@91.0.0
 
 beautifulsoup4==4.11.1
 pytest==7.2.0

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -7,7 +7,6 @@ from unittest.mock import ANY, call
 import pytest
 from flask import current_app
 from freezegun import freeze_time
-from notifications_utils.recipient_validation.phone_number import validate_and_format_phone_number
 from requests import HTTPError
 
 import app
@@ -29,6 +28,7 @@ from app.delivery.send_to_providers import get_html_email_options, get_logo_url
 from app.exceptions import NotificationTechnicalFailureException
 from app.models import EmailBranding, Notification
 from app.serialised_models import SerialisedService
+from app.utils import parse_and_format_phone_number
 from tests.app.db import (
     create_email_branding,
     create_notification,
@@ -236,7 +236,7 @@ def test_send_sms_should_use_template_version_from_notification_not_latest(sampl
     send_to_providers.send_sms_to_provider(db_notification)
 
     mmg_client.send_sms.assert_called_once_with(
-        to=validate_and_format_phone_number("+447234123123"),
+        to=parse_and_format_phone_number("+447234123123"),
         content="Sample service: This is a template:\nwith a newline",
         reference=str(db_notification.id),
         sender=current_app.config["FROM_NUMBER"],

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -358,8 +358,7 @@ def test_simulated_recipient(notify_api, to_address, notification_type, expected
         ("7900900123", False, "44", 1),  # UK
         ("+447900900123", False, "44", 1),  # UK
         ("07700910222", True, "44", 1),  # UK (Jersey)
-        ("07700900222", False, "44", 1),  # TV number
-        ("73122345678", True, "7", 4),  # Russia
+        ("74957108855", True, "7", 4),  # Russia
         ("360623400400", True, "36", 3),
     ],  # Hungary
 )
@@ -475,14 +474,14 @@ def test_persist_notification_with_international_info_does_not_store_for_email(s
 @pytest.mark.parametrize(
     "recipient, expected_recipient_normalised",
     [
-        ("7900900123", "447900900123"),
-        ("+447900   900 123", "447900900123"),
-        ("  07700900222", "447700900222"),
-        ("07700900222", "447700900222"),
-        (" 73122345678", "73122345678"),
-        ("360623400400", "360623400400"),
-        ("-077-00900222-", "447700900222"),
-        ("(360623(400400)", "360623400400"),
+        ("7900900123", "447900900123"),  # uk number adding country code correctly
+        ("+447900   900 123", "447900900123"),  # uk number stripping whitespace and leading plus
+        ("  07700900222", "447700900222"),  # uk number stripping whitespace and adding country code
+        ("07700900222", "447700900222"),  # uk number stripping leading zero and adding country code
+        (" 74952122020", "74952122020"),  # russian number that looks like a uk mobile
+        ("36705450911", "36705450911"),  # hungarian number to test international numbers
+        ("-077-00900222-", "447700900222"),  # uk mobile test stripping hyphens
+        ("(3670545(0911))", "36705450911"),  # hungarian number to test international numbers (stripping brackets)
     ],
 )
 def test_persist_sms_notification_stores_normalised_number(

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -357,7 +357,7 @@ def test_simulated_recipient(notify_api, to_address, notification_type, expected
     [
         ("7900900123", False, "44", 1),  # UK
         ("+447900900123", False, "44", 1),  # UK
-        ("07700910222", True, "44", 1),  # UK (Jersey)
+        ("07797292290", True, "44", 1),  # UK (Jersey)
         ("74957108855", True, "7", 4),  # Russia
         ("360623400400", True, "36", 3),
     ],  # Hungary

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -7,7 +7,6 @@ from boto3.exceptions import Boto3Error
 from freezegun import freeze_time
 from notifications_utils.recipient_validation.email_address import validate_and_format_email_address
 from notifications_utils.recipient_validation.errors import InvalidPhoneError
-from notifications_utils.recipient_validation.phone_number import validate_and_format_phone_number
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.constants import EMAIL_TYPE, KEY_TYPE_NORMAL, LETTER_TYPE, SMS_TO_UK_LANDLINES, SMS_TYPE
@@ -19,6 +18,7 @@ from app.notifications.process_notifications import (
     simulated_recipient,
 )
 from app.serialised_models import SerialisedTemplate
+from app.utils import parse_and_format_phone_number
 from app.v2.errors import BadRequestError, QrCodeTooLongError
 from tests.app.db import create_api_key, create_job, create_service, create_template
 from tests.conftest import set_config
@@ -345,7 +345,7 @@ def test_simulated_recipient(notify_api, to_address, notification_type, expected
     if notification_type == "email":
         formatted_address = validate_and_format_email_address(to_address)
     else:
-        formatted_address = validate_and_format_phone_number(to_address)
+        formatted_address = parse_and_format_phone_number(to_address)
 
     is_simulated_address = simulated_recipient(formatted_address, notification_type)
 

--- a/tests/app/service/send_notification/test_send_one_off_notification.py
+++ b/tests/app/service/send_notification/test_send_one_off_notification.py
@@ -100,14 +100,14 @@ def test_send_one_off_notification_calls_persist_correctly_for_international_sms
 
     post_data = {
         "template_id": str(template.id),
-        "to": "+1 555 0100",
+        "to": "+1415-771-1401",
         "personalisation": {"name": "foo"},
         "created_by": str(service.created_by_id),
     }
 
     send_one_off_notification(service.id, post_data)
 
-    assert persist_mock.call_args[1]["recipient"] == "+1 555 0100"
+    assert persist_mock.call_args[1]["recipient"] == "+1415-771-1401"
 
 
 def test_send_one_off_notification_calls_persist_correctly_for_email(persist_mock, celery_mock, notify_db_session):

--- a/tests/app/service/test_service_guest_list.py
+++ b/tests/app/service/test_service_guest_list.py
@@ -25,7 +25,7 @@ def test_get_guest_list_separates_emails_and_phones(client, sample_service):
         [
             ServiceGuestList.from_string(sample_service.id, EMAIL_TYPE, "service@example.com"),
             ServiceGuestList.from_string(sample_service.id, MOBILE_TYPE, "07123456789"),
-            ServiceGuestList.from_string(sample_service.id, MOBILE_TYPE, "+1800-555-555"),
+            ServiceGuestList.from_string(sample_service.id, MOBILE_TYPE, "+1415-771-1401"),
         ]
     )
 
@@ -33,7 +33,7 @@ def test_get_guest_list_separates_emails_and_phones(client, sample_service):
     assert response.status_code == 200
     json_resp = json.loads(response.get_data(as_text=True))
     assert json_resp["email_addresses"] == ["service@example.com"]
-    assert sorted(json_resp["phone_numbers"]) == sorted(["+1800-555-555", "07123456789"])
+    assert sorted(json_resp["phone_numbers"]) == sorted(["+1415-771-1401", "07123456789"])
 
 
 def test_get_guest_list_404s_with_unknown_service_id(client):

--- a/tests/app/test_schemas.py
+++ b/tests/app/test_schemas.py
@@ -82,13 +82,12 @@ def test_user_update_schema_accepts_valid_attribute_pairs(user_attribute, user_v
 
 @pytest.mark.parametrize(
     "user_attribute, user_value",
-    [("name", None), ("name", ""), ("email_address", "bademail@...com"), ("mobile_number", "+44077009")],
+    [("name", None), ("name", ""), ("email_address", "bademail@...com"), ("mobile_number", "06000400200")],
 )
 def test_user_update_schema_rejects_invalid_attribute_pairs(user_attribute, user_value):
     from app.schemas import user_update_schema_load_json
 
     update_dict = {user_attribute: user_value}
-
     with pytest.raises(ValidationError):
         user_update_schema_load_json.load(update_dict)
 

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -1080,10 +1080,10 @@ def test_search_for_users_by_email_handles_incorrect_data_format(notify_db_sessi
 @pytest.mark.parametrize(
     "number, expected_reply_to",
     [
-        ("1-403-123-4567", "notify_international_sender"),
-        ("27 123 4569 2312", "notify_international_sender"),
-        ("30 123 4567 7890", "Notify"),
-        ("+20 123 4567 7890", "Notify"),
+        ("1 415-771-1401", "notify_international_sender"),
+        ("27 21 404 0571", "notify_international_sender"),
+        ("+30 21 0889 4501", "Notify"),
+        ("+20 65 3615756", "Notify"),
     ],
 )
 def test_get_sms_reply_to_for_notify_service(team_member_mobile_edit_template, number, expected_reply_to):


### PR DESCRIPTION
Reverts the revert of `remove-old-phonenumber-validation` branch and adds a fix for tv numbers that was causing functional tests to fail, OFCOM TV numbers are now considered as non-international UK numbers by `notifications_utils.recipient_validation.phone_number.PhoneNumber`