### PR TITLE
skip old letters in still_pending_virus_check task

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -316,10 +316,11 @@ def replay_created_notifications():
 
 
 @notify_celery.task(name="check-if-letters-still-pending-virus-check")
-def check_if_letters_still_pending_virus_check():
+def check_if_letters_still_pending_virus_check(max_minutes_ago_to_check: int = 30):
+    # this task runs every ten minutes, so allowing a couple of runs
+    # if this task doesn't run for some reason, we may need to manually trigger it with a longer max_minutes_ago value
     letters = []
-
-    for letter in dao_precompiled_letters_still_pending_virus_check():
+    for letter in dao_precompiled_letters_still_pending_virus_check(max_minutes_ago_to_check):
         # find letter in the scan bucket
         filename = generate_letter_pdf_filename(
             letter.reference, letter.created_at, ignore_folder=True, postage=letter.postage

--- a/app/config.py
+++ b/app/config.py
@@ -331,9 +331,18 @@ class Config:
                 "schedule": crontab(day_of_week="mon-fri", hour=7, minute=0),
                 "options": {"queue": QueueNames.PERIODIC},
             },
-            "check-if-letters-still-pending-virus-check": {
+            "check-if-letters-still-pending-virus-check-ten-minutely": {
                 "task": "check-if-letters-still-pending-virus-check",
                 "schedule": crontab(minute="*/10"),
+                # check last half hour, every ten minutes
+                "kwargs": {"max_minutes_ago_to_check": 30},
+                "options": {"queue": QueueNames.PERIODIC},
+            },
+            "check-if-letters-still-pending-virus-check-nightly": {
+                "task": "check-if-letters-still-pending-virus-check",
+                "schedule": crontab(hour=20, minute=0),
+                # check back two entire days, once per day, just in case things slipped through the net somehow
+                "kwargs": {"max_minutes_ago_to_check": 60 * 24 * 2},
                 "options": {"queue": QueueNames.PERIODIC},
             },
             "check-for-services-with-high-failure-rates-or-sending-to-tv-numbers": {

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -815,12 +815,16 @@ def letters_missing_from_sending_bucket(seconds_to_subtract):
     return notifications
 
 
-def dao_precompiled_letters_still_pending_virus_check():
-    ten_minutes_ago = datetime.utcnow() - timedelta(seconds=600)
+def dao_precompiled_letters_still_pending_virus_check(max_minutes_ago_to_check):
+    earliest_timestamp_to_check = datetime.utcnow() - timedelta(minutes=max_minutes_ago_to_check)
+    ten_minutes_ago = datetime.utcnow() - timedelta(minutes=10)
 
     notifications = (
         Notification.query.filter(
-            Notification.created_at < ten_minutes_ago, Notification.status == NOTIFICATION_PENDING_VIRUS_CHECK
+            Notification.created_at > earliest_timestamp_to_check,
+            Notification.created_at < ten_minutes_ago,
+            Notification.status == NOTIFICATION_PENDING_VIRUS_CHECK,
+            Notification.notification_type == LETTER_TYPE,
         )
         .order_by(Notification.created_at)
         .all()

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -488,14 +488,20 @@ def test_check_if_letters_still_pending_virus_check_restarts_scan_for_stuck_lett
     create_notification(
         template=sample_letter_template,
         status=NOTIFICATION_PENDING_VIRUS_CHECK,
-        created_at=datetime.utcnow() - timedelta(seconds=601),
+        created_at=datetime.utcnow() - timedelta(minutes=10, seconds=1),
         reference="one",
     )
     create_notification(
         template=sample_letter_template,
         status=NOTIFICATION_PENDING_VIRUS_CHECK,
-        created_at=datetime.utcnow() - timedelta(seconds=599),
+        created_at=datetime.utcnow() - timedelta(minutes=9, seconds=59),
         reference="still has time to send",
+    )
+    create_notification(
+        template=sample_letter_template,
+        status=NOTIFICATION_PENDING_VIRUS_CHECK,
+        created_at=datetime.utcnow() - timedelta(minutes=30, seconds=1),
+        reference="too old for us to bother with",
     )
     expected_filename = "NOTIFY.ONE.D.2.C.20190530134959.PDF"
 


### PR DESCRIPTION
previously, we were just selecting all letters more than 10 mins old with status pending_virus_check. However, this involves checking statuses all the way back through time - given this task runs every ten minutes, we don't need to check the status of letters created a day ago as they'll already have been fixed for example.

For now, just start with 30 minutes as the maximum time, in case the scheduled task doesn't run for any reason.

If it doesn't run multiple times in a row, then we'd need to run the task manually with a longer margin at least once - so I've made it an optional parameter so we can manually trigger the task