### PR TITLE
job tasks: introduce `shatter_job_rows` to create individual row tasks

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -49,11 +50,14 @@ from app.notifications.process_notifications import persist_notification
 from app.notifications.validators import check_service_over_daily_message_limit
 from app.serialised_models import SerialisedService, SerialisedTemplate
 from app.service.utils import service_allowed_to_send_to
+from app.utils import batched
 from app.v2.errors import TooManyRequestsError
+
+DEFAULT_SHATTER_JOB_ROWS_BATCH_SIZE = 64
 
 
 @notify_celery.task(name="process-job")
-def process_job(job_id, sender_id=None):
+def process_job(job_id, sender_id=None, shatter_batch_size=DEFAULT_SHATTER_JOB_ROWS_BATCH_SIZE):
     start = datetime.utcnow()
     job = dao_get_job_by_id(job_id)
     current_app.logger.info("Starting process-job task for job id %s with status: %s", job_id, job.job_status)
@@ -80,10 +84,42 @@ def process_job(job_id, sender_id=None):
 
     current_app.logger.info("Starting job %s processing %s notifications", job_id, job.notification_count)
 
-    for row in recipient_csv.get_rows():
-        process_row(row, template, job, service, sender_id=sender_id)
+    for shatter_batch in batched(recipient_csv.get_rows(), n=shatter_batch_size):
+        batch_args_kwargs = [
+            get_id_task_args_kwargs_for_job_row(row, template, job, service, sender_id=sender_id)[1]
+            for row in shatter_batch
+        ]
+        shatter_job_rows.apply_async(
+            (
+                template.template_type,
+                batch_args_kwargs,
+            ),
+            queue=QueueNames.JOBS,
+        )
 
     job_complete(job, start=start)
+
+
+@notify_celery.task(name="shatter-job-rows")
+def shatter_job_rows(
+    template_type: str,
+    args_kwargs_seq: Sequence,
+):
+    for task_args_kwargs in args_kwargs_seq:
+        process_job_row(template_type, task_args_kwargs)
+
+
+def process_job_row(template_type, task_args_kwargs):
+    send_fn = {
+        SMS_TYPE: save_sms,
+        EMAIL_TYPE: save_email,
+        LETTER_TYPE: save_letter,
+    }[template_type]
+
+    send_fn.apply_async(
+        *task_args_kwargs,
+        queue=QueueNames.DATABASE,
+    )
 
 
 def job_complete(job, resumed=False, start=None):
@@ -111,8 +147,7 @@ def get_recipient_csv_and_template_and_sender_id(job):
     return recipient_csv, template, meta_data.get("sender_id")
 
 
-def process_row(row, template, job, service, sender_id=None):
-    template_type = template.template_type
+def get_id_task_args_kwargs_for_job_row(row, template, job, service, sender_id=None):
     encoded = signing.encode(
         {
             "template": str(template.id),
@@ -126,25 +161,18 @@ def process_row(row, template, job, service, sender_id=None):
         }
     )
 
-    send_fns = {SMS_TYPE: save_sms, EMAIL_TYPE: save_email, LETTER_TYPE: save_letter}
-
-    send_fn = send_fns[template_type]
+    notification_id = create_uuid()
+    task_args = (
+        str(service.id),
+        notification_id,
+        encoded,
+    )
 
     task_kwargs = {}
     if sender_id:
         task_kwargs["sender_id"] = sender_id
 
-    notification_id = create_uuid()
-    send_fn.apply_async(
-        (
-            str(service.id),
-            notification_id,
-            encoded,
-        ),
-        task_kwargs,
-        queue=QueueNames.DATABASE,
-    )
-    return notification_id
+    return notification_id, (task_args, task_kwargs)
 
 
 def __sending_limits_for_job_exceeded(service, job, job_id):
@@ -470,7 +498,7 @@ def check_billable_units(notification_update):
 
 
 @notify_celery.task(name="process-incomplete-jobs")
-def process_incomplete_jobs(job_ids):
+def process_incomplete_jobs(job_ids, shatter_batch_size=DEFAULT_SHATTER_JOB_ROWS_BATCH_SIZE):
     jobs = [dao_get_job_by_id(job_id) for job_id in job_ids]
 
     # reset the processing start time so that the check_job_status scheduled task doesn't pick this job up again
@@ -481,10 +509,10 @@ def process_incomplete_jobs(job_ids):
 
     current_app.logger.info("Resuming job(s) %s", job_ids)
     for job_id in job_ids:
-        process_incomplete_job(job_id)
+        process_incomplete_job(job_id, shatter_batch_size=shatter_batch_size)
 
 
-def process_incomplete_job(job_id):
+def process_incomplete_job(job_id, shatter_batch_size=DEFAULT_SHATTER_JOB_ROWS_BATCH_SIZE):
     job = dao_get_job_by_id(job_id)
 
     last_notification_added = dao_get_last_notification_added_for_job_id(job_id)
@@ -498,9 +526,21 @@ def process_incomplete_job(job_id):
 
     recipient_csv, template, sender_id = get_recipient_csv_and_template_and_sender_id(job)
 
-    for row in recipient_csv.get_rows():
-        if row.index > resume_from_row:
-            process_row(row, template, job, job.service, sender_id=sender_id)
+    for shatter_batch in batched(
+        (row for row in recipient_csv.get_rows() if row.index > resume_from_row),
+        n=shatter_batch_size,
+    ):
+        batch_args_kwargs = [
+            get_id_task_args_kwargs_for_job_row(row, template, job, job.service, sender_id=sender_id)[1]
+            for row in shatter_batch
+        ]
+        shatter_job_rows.apply_async(
+            (
+                template.template_type,
+                batch_args_kwargs,
+            ),
+            queue=QueueNames.JOBS,
+        )
 
     job_complete(job, resumed=True)
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -28,7 +28,11 @@ from app.celery.letters_pdf_tasks import (
     get_pdf_for_templated_letter,
     resanitise_pdf,
 )
-from app.celery.tasks import process_row, record_daily_sorted_counts
+from app.celery.tasks import (
+    get_id_task_args_kwargs_for_job_row,
+    process_job_row,
+    record_daily_sorted_counts,
+)
 from app.config import QueueNames
 from app.constants import KEY_TYPE_TEST, NOTIFICATION_CREATED, SMS_TYPE
 from app.dao.annual_billing_dao import (
@@ -733,7 +737,10 @@ def process_row_from_job(job_id, job_row_number):
         placeholders=template.placeholders,
     ).get_rows():
         if row.index == job_row_number:
-            notification_id = process_row(row, template, job, job.service)
+            notification_id, task_args_kwargs = get_id_task_args_kwargs_for_job_row(row, template, job, job.service)
+
+            process_job_row(template.template_type, task_args_kwargs)
+
             current_app.logger.info(
                 "Process row %s for job %s created notification_id: %s", job_row_number, job_id, notification_id
             )

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from itertools import islice
 from urllib.parse import urljoin
 
 import pytz
@@ -51,6 +52,19 @@ def get_prev_next_pagination_links(current_page, next_page_exists, endpoint, **k
     if next_page_exists:
         links["next"] = True
     return links
+
+
+# "approximate equivalent" of itertools.batched from python 3.12's documentation. remove once we upgrade
+# past python 3.12 and use itertools' version instead
+def batched(iterable, n, *, strict=False):
+    # batched('ABCDEFG', 3) → ABC DEF G
+    if n < 1:
+        raise ValueError("n must be at least one")
+    iterator = iter(iterable)
+    while batch := tuple(islice(iterator, n)):
+        if strict and len(batch) != n:
+            raise ValueError("batched(): incomplete batch")
+        yield batch
 
 
 def url_with_token(data, url, base_url=None):

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import datetime, timedelta
-from unittest.mock import Mock, call
+from itertools import count
+from unittest.mock import ANY, Mock, call
 
 import pytest
 from celery.exceptions import Retry
@@ -17,16 +18,17 @@ from app import signing
 from app.celery import provider_tasks, tasks
 from app.celery.letters_pdf_tasks import get_pdf_for_templated_letter
 from app.celery.tasks import (
+    get_id_task_args_kwargs_for_job_row,
     get_recipient_csv_and_template_and_sender_id,
     process_incomplete_job,
     process_incomplete_jobs,
     process_job,
     process_returned_letters_list,
-    process_row,
     s3,
     save_email,
     save_letter,
     save_sms,
+    shatter_job_rows,
 )
 from app.config import QueueNames
 from app.constants import (
@@ -79,9 +81,12 @@ def _notification_json(template, to, personalisation=None, job_id=None, row_numb
 
 def test_should_have_decorated_tasks_functions():
     assert process_job.__wrapped__.__name__ == "process_job"
+    assert shatter_job_rows.__wrapped__.__name__ == "shatter_job_rows"
     assert save_sms.__wrapped__.__name__ == "save_sms"
     assert save_email.__wrapped__.__name__ == "save_email"
     assert save_letter.__wrapped__.__name__ == "save_letter"
+    assert process_returned_letters_list.__wrapped__.__name__ == "process_returned_letters_list"
+    assert process_incomplete_jobs.__wrapped__.__name__ == "process_incomplete_jobs"
 
 
 @pytest.fixture
@@ -96,23 +101,44 @@ def test_should_process_sms_job(sample_job, mocker, mock_celery_task):
     mocker.patch(
         "app.celery.tasks.s3.get_job_and_metadata_from_s3", return_value=(load_example_csv("sms"), {"sender_id": None})
     )
-    mock_task = mock_celery_task(save_sms)
-    mocker.patch("app.signing.encode", return_value="something_encoded")
+    mock_task = mock_celery_task(shatter_job_rows)
+    mock_encode = mocker.patch("app.signing.encode", return_value="something_encoded")
     mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
 
     process_job(sample_job.id)
+
     s3.get_job_and_metadata_from_s3.assert_called_once_with(
         service_id=str(sample_job.service.id), job_id=str(sample_job.id)
     )
-    assert signing.encode.call_args[0][0]["to"] == "+441234123123"
-    assert signing.encode.call_args[0][0]["template"] == str(sample_job.template.id)
-    assert signing.encode.call_args[0][0]["template_version"] == sample_job.template.version
-    assert signing.encode.call_args[0][0]["personalisation"] == {"phonenumber": "+441234123123"}
-    assert signing.encode.call_args[0][0]["row_number"] == 0
-    mock_task.assert_called_once_with(
-        (str(sample_job.service_id), "uuid", "something_encoded"), {}, queue="database-tasks"
-    )
+    assert mock_encode.mock_calls == [
+        call(
+            {
+                "template": str(sample_job.template.id),
+                "template_version": sample_job.template.version,
+                "job": str(sample_job.id),
+                "to": "+441234123123",
+                "row_number": 0,
+                "personalisation": {"phonenumber": "+441234123123"},
+                "client_reference": None,
+            }
+        )
+    ]
+
     job = jobs_dao.dao_get_job_by_id(sample_job.id)
+    assert mock_task.mock_calls == [
+        call(
+            (
+                job.template.template_type,
+                [
+                    (
+                        (str(sample_job.service_id), "uuid", "something_encoded"),
+                        {},
+                    )
+                ],
+            ),
+            queue="job-tasks",
+        )
+    ]
     assert job.job_status == "finished"
 
 
@@ -121,27 +147,57 @@ def test_should_process_sms_job_with_sender_id(sample_job, mocker, mock_celery_t
         "app.celery.tasks.s3.get_job_and_metadata_from_s3",
         return_value=(load_example_csv("sms"), {"sender_id": fake_uuid}),
     )
-    mock_celery_task(save_sms)
-    mocker.patch("app.signing.encode", return_value="something_encoded")
+    mock_task = mock_celery_task(shatter_job_rows)
+    mock_encode = mocker.patch("app.signing.encode", return_value="something_encoded")
     mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
 
     process_job(sample_job.id, sender_id=fake_uuid)
 
-    tasks.save_sms.apply_async.assert_called_once_with(
-        (str(sample_job.service_id), "uuid", "something_encoded"), {"sender_id": fake_uuid}, queue="database-tasks"
+    s3.get_job_and_metadata_from_s3.assert_called_once_with(
+        service_id=str(sample_job.service.id), job_id=str(sample_job.id)
     )
+    assert mock_encode.mock_calls == [
+        call(
+            {
+                "template": str(sample_job.template.id),
+                "template_version": sample_job.template.version,
+                "job": str(sample_job.id),
+                "to": "+441234123123",
+                "row_number": 0,
+                "personalisation": {"phonenumber": "+441234123123"},
+                "client_reference": None,
+            }
+        )
+    ]
+
+    job = jobs_dao.dao_get_job_by_id(sample_job.id)
+    assert mock_task.mock_calls == [
+        call(
+            (
+                job.template.template_type,
+                [
+                    (
+                        (str(sample_job.service_id), "uuid", "something_encoded"),
+                        {"sender_id": fake_uuid},
+                    )
+                ],
+            ),
+            queue="job-tasks",
+        )
+    ]
+    assert job.job_status == "finished"
 
 
 def test_should_not_process_job_if_already_pending(sample_template, mocker, mock_celery_task):
     job = create_job(template=sample_template, job_status="scheduled")
 
     mocker.patch("app.celery.tasks.s3.get_job_and_metadata_from_s3")
-    mocker.patch("app.celery.tasks.process_row")
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
 
     process_job(job.id)
 
     assert s3.get_job_and_metadata_from_s3.called is False
-    assert tasks.process_row.called is False
+    assert mock_shatter_job_rows.called is False
 
 
 def test_should_not_process_if_send_limit_is_exceeded(notify_api, notify_db_session, mocker, mock_celery_task):
@@ -152,7 +208,7 @@ def test_should_not_process_if_send_limit_is_exceeded(notify_api, notify_db_sess
         "app.celery.tasks.s3.get_job_and_metadata_from_s3",
         return_value=(load_example_csv("multiple_sms"), {"sender_id": None}),
     )
-    mocker.patch("app.celery.tasks.process_row")
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
     mock_check_message_limit = mocker.patch(
         "app.celery.tasks.check_service_over_daily_message_limit",
         side_effect=TooManyRequestsError("total", "exceeded limit"),
@@ -162,9 +218,9 @@ def test_should_not_process_if_send_limit_is_exceeded(notify_api, notify_db_sess
     job = jobs_dao.dao_get_job_by_id(job.id)
     assert job.job_status == "sending limits exceeded"
     assert s3.get_job_and_metadata_from_s3.called is False
-    assert tasks.process_row.called is False
-    assert mock_check_message_limit.call_args_list == [
-        mocker.call(service, "normal", notification_type=SMS_TYPE, num_notifications=10),
+    assert mock_shatter_job_rows.called is False
+    assert mock_check_message_limit.mock_calls == [
+        call(service, "normal", notification_type=SMS_TYPE, num_notifications=10),
     ]
 
 
@@ -178,7 +234,7 @@ def test_should_not_process_if_send_limit_is_exceeded_by_job_notification_count(
         "app.celery.tasks.s3.get_job_and_metadata_from_s3",
         return_value=(load_example_csv("multiple_sms"), {"sender_id": None}),
     )
-    mock_process_row = mocker.patch("app.celery.tasks.process_row")
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
     mock_check_message_limit = mocker.patch(
         "app.celery.tasks.check_service_over_daily_message_limit", side_effect=TooManyRequestsError("total", 9)
     )
@@ -186,10 +242,10 @@ def test_should_not_process_if_send_limit_is_exceeded_by_job_notification_count(
 
     job = jobs_dao.dao_get_job_by_id(job.id)
     assert job.job_status == "sending limits exceeded"
-    mock_s3.assert_not_called()
-    mock_process_row.assert_not_called()
-    assert mock_check_message_limit.call_args_list == [
-        mocker.call(service, "normal", notification_type=SMS_TYPE, num_notifications=10),
+    assert mock_s3.called is False
+    assert mock_shatter_job_rows.called is False
+    assert mock_check_message_limit.mock_calls == [
+        call(service, "normal", notification_type=SMS_TYPE, num_notifications=10),
     ]
 
 
@@ -202,37 +258,74 @@ def test_should_process_job_if_send_limits_are_not_exceeded(notify_api, notify_d
         "app.celery.tasks.s3.get_job_and_metadata_from_s3",
         return_value=(load_example_csv("multiple_email"), {"sender_id": None}),
     )
-    mock_celery_task(save_email)
-    mocker.patch("app.signing.encode", return_value="something_encoded")
-    mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
+    mocker.patch("app.signing.encode", side_effect=(f"something-encoded-{i}" for i in count()))
+    mocker.patch("app.celery.tasks.create_uuid", side_effect=(f"uuid-{i}" for i in count()))
     mock_check_message_limit = mocker.patch(
         "app.celery.tasks.check_service_over_daily_message_limit", return_value=None
     )
-    process_job(job.id)
+
+    process_job(job.id, shatter_batch_size=3)
 
     s3.get_job_and_metadata_from_s3.assert_called_once_with(service_id=str(job.service.id), job_id=str(job.id))
     job = jobs_dao.dao_get_job_by_id(job.id)
-    assert job.job_status == "finished"
-    tasks.save_email.apply_async.assert_called_with(
-        (
-            str(job.service_id),
-            "uuid",
-            "something_encoded",
+    assert mock_shatter_job_rows.mock_calls == [
+        call(
+            (
+                job.template.template_type,
+                [
+                    ((str(job.service_id), "uuid-0", "something-encoded-0"), {}),
+                    ((str(job.service_id), "uuid-1", "something-encoded-1"), {}),
+                    ((str(job.service_id), "uuid-2", "something-encoded-2"), {}),
+                ],
+            ),
+            queue="job-tasks",
         ),
-        {},
-        queue="database-tasks",
-    )
-    assert mock_check_message_limit.call_args_list == [
-        mocker.call(service, "normal", notification_type=EMAIL_TYPE, num_notifications=10),
+        call(
+            (
+                job.template.template_type,
+                [
+                    ((str(job.service_id), "uuid-3", "something-encoded-3"), {}),
+                    ((str(job.service_id), "uuid-4", "something-encoded-4"), {}),
+                    ((str(job.service_id), "uuid-5", "something-encoded-5"), {}),
+                ],
+            ),
+            queue="job-tasks",
+        ),
+        call(
+            (
+                job.template.template_type,
+                [
+                    ((str(job.service_id), "uuid-6", "something-encoded-6"), {}),
+                    ((str(job.service_id), "uuid-7", "something-encoded-7"), {}),
+                    ((str(job.service_id), "uuid-8", "something-encoded-8"), {}),
+                ],
+            ),
+            queue="job-tasks",
+        ),
+        call(
+            (
+                job.template.template_type,
+                [
+                    ((str(job.service_id), "uuid-9", "something-encoded-9"), {}),
+                ],
+            ),
+            queue="job-tasks",
+        ),
+    ]
+    assert mock_check_message_limit.mock_calls == [
+        call(service, "normal", notification_type=EMAIL_TYPE, num_notifications=10),
     ]
 
+    assert job.job_status == "finished"
 
-def test_should_not_create_save_task_for_empty_file(sample_job, mocker, mock_celery_task):
+
+def test_should_not_create_shatter_task_for_empty_file(sample_job, mocker, mock_celery_task):
     mocker.patch(
         "app.celery.tasks.s3.get_job_and_metadata_from_s3",
         return_value=(load_example_csv("empty"), {"sender_id": None}),
     )
-    mock_celery_task(save_sms)
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
 
     process_job(sample_job.id)
 
@@ -241,7 +334,7 @@ def test_should_not_create_save_task_for_empty_file(sample_job, mocker, mock_cel
     )
     job = jobs_dao.dao_get_job_by_id(sample_job.id)
     assert job.job_status == "finished"
-    assert tasks.save_sms.apply_async.called is False
+    assert mock_shatter_job_rows.called is False
 
 
 def test_should_process_email_job(email_job_with_placeholders, mocker, mock_celery_task):
@@ -249,28 +342,40 @@ def test_should_process_email_job(email_job_with_placeholders, mocker, mock_cele
     test@test.com,foo
     """
     mocker.patch("app.celery.tasks.s3.get_job_and_metadata_from_s3", return_value=(email_csv, {"sender_id": None}))
-    mock_celery_task(save_email)
-    mocker.patch("app.signing.encode", return_value="something_encoded")
-    mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
+    mock_encode = mocker.patch("app.signing.encode", return_value="something_encoded")
+    mocker.patch("app.celery.tasks.create_uuid", return_value="some_uuid")
 
     process_job(email_job_with_placeholders.id)
 
     s3.get_job_and_metadata_from_s3.assert_called_once_with(
         service_id=str(email_job_with_placeholders.service.id), job_id=str(email_job_with_placeholders.id)
     )
-    assert signing.encode.call_args[0][0]["to"] == "test@test.com"
-    assert signing.encode.call_args[0][0]["template"] == str(email_job_with_placeholders.template.id)
-    assert signing.encode.call_args[0][0]["template_version"] == email_job_with_placeholders.template.version
-    assert signing.encode.call_args[0][0]["personalisation"] == {"emailaddress": "test@test.com", "name": "foo"}
-    tasks.save_email.apply_async.assert_called_once_with(
-        (
-            str(email_job_with_placeholders.service_id),
-            "uuid",
-            "something_encoded",
-        ),
-        {},
-        queue="database-tasks",
-    )
+
+    assert mock_encode.mock_calls == [
+        call(
+            {
+                "template": str(email_job_with_placeholders.template.id),
+                "template_version": email_job_with_placeholders.template.version,
+                "job": str(email_job_with_placeholders.id),
+                "to": "test@test.com",
+                "row_number": 0,
+                "personalisation": {"emailaddress": "test@test.com", "name": "foo"},
+                "client_reference": None,
+            }
+        )
+    ]
+
+    assert mock_shatter_job_rows.mock_calls == [
+        call(
+            (
+                email_job_with_placeholders.template.template_type,
+                [((str(email_job_with_placeholders.service_id), "some_uuid", "something_encoded"), {})],
+            ),
+            queue="job-tasks",
+        )
+    ]
+
     job = jobs_dao.dao_get_job_by_id(email_job_with_placeholders.id)
     assert job.job_status == "finished"
 
@@ -280,17 +385,47 @@ def test_should_process_email_job_with_sender_id(email_job_with_placeholders, mo
     test@test.com,foo
     """
     mocker.patch("app.celery.tasks.s3.get_job_and_metadata_from_s3", return_value=(email_csv, {"sender_id": fake_uuid}))
-    mock_celery_task(save_email)
-    mocker.patch("app.signing.encode", return_value="something_encoded")
-    mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
+    mock_encode = mocker.patch("app.signing.encode", return_value="something_encoded")
+    mocker.patch("app.celery.tasks.create_uuid", return_value="some_uuid")
 
     process_job(email_job_with_placeholders.id, sender_id=fake_uuid)
 
-    tasks.save_email.apply_async.assert_called_once_with(
-        (str(email_job_with_placeholders.service_id), "uuid", "something_encoded"),
-        {"sender_id": fake_uuid},
-        queue="database-tasks",
+    s3.get_job_and_metadata_from_s3.assert_called_once_with(
+        service_id=str(email_job_with_placeholders.service.id), job_id=str(email_job_with_placeholders.id)
     )
+
+    assert mock_encode.mock_calls == [
+        call(
+            {
+                "template": str(email_job_with_placeholders.template.id),
+                "template_version": email_job_with_placeholders.template.version,
+                "job": str(email_job_with_placeholders.id),
+                "to": "test@test.com",
+                "row_number": 0,
+                "personalisation": {"emailaddress": "test@test.com", "name": "foo"},
+                "client_reference": None,
+            }
+        )
+    ]
+
+    assert mock_shatter_job_rows.mock_calls == [
+        call(
+            (
+                email_job_with_placeholders.template.template_type,
+                [
+                    (
+                        (str(email_job_with_placeholders.service_id), "some_uuid", "something_encoded"),
+                        {"sender_id": fake_uuid},
+                    )
+                ],
+            ),
+            queue="job-tasks",
+        )
+    ]
+
+    job = jobs_dao.dao_get_job_by_id(email_job_with_placeholders.id)
+    assert job.job_status == "finished"
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
@@ -299,29 +434,46 @@ def test_should_process_letter_job(sample_letter_job, mocker, mock_celery_task):
     A1,A2,A3,A4,A_POST,Alice
     """
     s3_mock = mocker.patch("app.celery.tasks.s3.get_job_and_metadata_from_s3", return_value=(csv, {"sender_id": None}))
-    process_row_mock = mocker.patch("app.celery.tasks.process_row")
+    mock_encode = mocker.patch("app.signing.encode", return_value="something_encoded")
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
     mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
 
     process_job(sample_letter_job.id)
 
     s3_mock.assert_called_once_with(service_id=str(sample_letter_job.service.id), job_id=str(sample_letter_job.id))
 
-    row_call = process_row_mock.mock_calls[0][1]
-    assert row_call[0].index == 0
-    assert row_call[0].recipient == ["A1", "A2", "A3", "A4", None, None, "A_POST", None]
-    assert row_call[0].personalisation == {
-        "addressline1": "A1",
-        "addressline2": "A2",
-        "addressline3": "A3",
-        "addressline4": "A4",
-        "postcode": "A_POST",
-    }
-    assert row_call[2] == sample_letter_job
-    assert row_call[3] == sample_letter_job.service
+    assert mock_encode.mock_calls == [
+        call(
+            {
+                "template": str(sample_letter_job.template.id),
+                "template_version": sample_letter_job.template.version,
+                "job": str(sample_letter_job.id),
+                "to": ["A1", "A2", "A3", "A4", None, None, "A_POST", None],
+                "row_number": 0,
+                "personalisation": {
+                    "addressline1": "A1",
+                    "addressline2": "A2",
+                    "addressline3": "A3",
+                    "addressline4": "A4",
+                    "postcode": "A_POST",
+                },
+                "client_reference": None,
+            }
+        )
+    ]
 
-    assert process_row_mock.call_count == 1
+    assert mock_shatter_job_rows.mock_calls == [
+        call(
+            (
+                sample_letter_job.template.template_type,
+                [((str(sample_letter_job.service_id), "uuid", "something_encoded"), {})],
+            ),
+            queue="job-tasks",
+        )
+    ]
 
-    assert sample_letter_job.job_status == "finished"
+    job = jobs_dao.dao_get_job_by_id(sample_letter_job.id)
+    assert job.job_status == "finished"
 
 
 def test_should_process_all_sms_job(sample_job_with_placeholdered_template, mocker, mock_celery_task):
@@ -329,45 +481,119 @@ def test_should_process_all_sms_job(sample_job_with_placeholdered_template, mock
         "app.celery.tasks.s3.get_job_and_metadata_from_s3",
         return_value=(load_example_csv("multiple_sms"), {"sender_id": None}),
     )
-    mock_celery_task(save_sms)
-    mocker.patch("app.signing.encode", return_value="something_encoded")
-    mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
+    mock_encode = mocker.patch("app.signing.encode", side_effect=(f"something-encoded-{i}" for i in count()))
+    mocker.patch("app.celery.tasks.create_uuid", side_effect=(f"uuid-{i}" for i in count()))
 
-    process_job(sample_job_with_placeholdered_template.id)
+    process_job(sample_job_with_placeholdered_template.id, shatter_batch_size=5)
 
     s3.get_job_and_metadata_from_s3.assert_called_once_with(
         service_id=str(sample_job_with_placeholdered_template.service.id),
         job_id=str(sample_job_with_placeholdered_template.id),
     )
-    assert signing.encode.call_args[0][0]["to"] == "+441234123120"
-    assert signing.encode.call_args[0][0]["template"] == str(sample_job_with_placeholdered_template.template.id)
-    assert signing.encode.call_args[0][0]["template_version"] == sample_job_with_placeholdered_template.template.version
-    assert signing.encode.call_args[0][0]["personalisation"] == {"phonenumber": "+441234123120", "name": "chris"}
-    assert tasks.save_sms.apply_async.call_count == 10
+
+    job_id = sample_job_with_placeholdered_template.id
+    template_id = sample_job_with_placeholdered_template.template_id
+    template_version = sample_job_with_placeholdered_template.template_version
+
+    assert mock_encode.mock_calls == [
+        call(
+            {
+                "template": str(template_id),
+                "template_version": template_version,
+                "job": str(job_id),
+                "to": "+441234123121",
+                "row_number": 0,
+                "personalisation": {"phonenumber": "+441234123121", "name": "chris"},
+                "client_reference": None,
+            }
+        ),
+        call(
+            {
+                "template": str(template_id),
+                "template_version": template_version,
+                "job": str(job_id),
+                "to": "+441234123122",
+                "row_number": 1,
+                "personalisation": {"phonenumber": "+441234123122", "name": "chris"},
+                "client_reference": None,
+            }
+        ),
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        call(
+            {
+                "template": str(template_id),
+                "template_version": template_version,
+                "job": str(job_id),
+                "to": "+441234123120",
+                "row_number": 9,
+                "personalisation": {"phonenumber": "+441234123120", "name": "chris"},
+                "client_reference": None,
+            }
+        ),
+    ]
+
+    template_type = sample_job_with_placeholdered_template.template.template_type
+    service_id = sample_job_with_placeholdered_template.service_id
+
+    assert mock_shatter_job_rows.mock_calls == [
+        call(
+            (
+                template_type,
+                [
+                    ((str(service_id), "uuid-0", "something-encoded-0"), {}),
+                    ((str(service_id), "uuid-1", "something-encoded-1"), {}),
+                    ((str(service_id), "uuid-2", "something-encoded-2"), {}),
+                    ((str(service_id), "uuid-3", "something-encoded-3"), {}),
+                    ((str(service_id), "uuid-4", "something-encoded-4"), {}),
+                ],
+            ),
+            queue="job-tasks",
+        ),
+        call(
+            (
+                template_type,
+                [
+                    ((str(service_id), "uuid-5", "something-encoded-5"), {}),
+                    ((str(service_id), "uuid-6", "something-encoded-6"), {}),
+                    ((str(service_id), "uuid-7", "something-encoded-7"), {}),
+                    ((str(service_id), "uuid-8", "something-encoded-8"), {}),
+                    ((str(service_id), "uuid-9", "something-encoded-9"), {}),
+                ],
+            ),
+            queue="job-tasks",
+        ),
+    ]
+
     job = jobs_dao.dao_get_job_by_id(sample_job_with_placeholdered_template.id)
     assert job.job_status == "finished"
 
 
-# -------------- process_row tests -------------- #
+# -------------- get_id_task_args_kwargs_for_job_row tests -------------- #
 
 
 @pytest.mark.parametrize(
-    "template_type, expected_function",
+    "template_type",
     [
-        (SMS_TYPE, save_sms),
-        (EMAIL_TYPE, save_email),
-        (LETTER_TYPE, save_letter),
+        SMS_TYPE,
+        EMAIL_TYPE,
+        LETTER_TYPE,
     ],
 )
-def test_process_row_sends_letter_task(template_type, expected_function, mocker, mock_celery_task):
+def test_get_id_task_args_kwargs_for_job_row_handles_letter_args(template_type, mocker, mock_celery_task):
     mocker.patch("app.celery.tasks.create_uuid", return_value="noti_uuid")
-    task_mock = mock_celery_task(expected_function)
     signing_mock = mocker.patch("app.celery.tasks.signing.encode", return_value="foo")
     template = Mock(id="template_id", template_type=template_type)
     job = Mock(id="job_id", template_version="temp_vers")
     service = Mock(id="service_id")
 
-    process_row(
+    ret = get_id_task_args_kwargs_for_job_row(
         Row(
             {"foo": "bar", "to": "recip"},
             index="row_num",
@@ -393,27 +619,28 @@ def test_process_row_sends_letter_task(template_type, expected_function, mocker,
             "client_reference": None,
         }
     )
-    task_mock.assert_called_once_with(
+    assert ret == (
+        "noti_uuid",
         (
-            "service_id",
-            "noti_uuid",
-            # encoded data
-            signing_mock.return_value,
+            (
+                "service_id",
+                "noti_uuid",
+                # encoded data
+                signing_mock.return_value,
+            ),
+            {},
         ),
-        {},
-        queue="database-tasks",
     )
 
 
-def test_process_row_when_sender_id_is_provided(mocker, mock_celery_task, fake_uuid):
+def test_get_id_task_args_kwargs_for_job_row_when_sender_id_is_provided(mocker, mock_celery_task, fake_uuid):
     mocker.patch("app.celery.tasks.create_uuid", return_value="noti_uuid")
-    task_mock = mock_celery_task(save_sms)
     signing_mock = mocker.patch("app.celery.tasks.signing.encode", return_value="foo")
     template = Mock(id="template_id", template_type=SMS_TYPE)
     job = Mock(id="job_id", template_version="temp_vers")
     service = Mock(id="service_id")
 
-    process_row(
+    ret = get_id_task_args_kwargs_for_job_row(
         Row(
             {"foo": "bar", "to": "recip"},
             index="row_num",
@@ -429,27 +656,28 @@ def test_process_row_when_sender_id_is_provided(mocker, mock_celery_task, fake_u
         sender_id=fake_uuid,
     )
 
-    task_mock.assert_called_once_with(
+    assert ret == (
+        "noti_uuid",
         (
-            "service_id",
-            "noti_uuid",
-            # encoded data
-            signing_mock.return_value,
+            (
+                "service_id",
+                "noti_uuid",
+                # encoded data
+                signing_mock.return_value,
+            ),
+            {"sender_id": fake_uuid},
         ),
-        {"sender_id": fake_uuid},
-        queue="database-tasks",
     )
 
 
-def test_process_row_when_reference_is_provided(mocker, mock_celery_task, fake_uuid):
+def test_get_id_task_args_kwargs_for_job_row_when_reference_is_provided(mocker, mock_celery_task, fake_uuid):
     mocker.patch("app.celery.tasks.create_uuid", return_value="noti_uuid")
-    mock_celery_task(save_sms)
     signing_mock = mocker.patch("app.celery.tasks.signing.encode", return_value="foo")
     template = Mock(id="template_id", template_type=SMS_TYPE)
     job = Mock(id="job_id", template_version="temp_vers")
     service = Mock(id="service_id")
 
-    process_row(
+    get_id_task_args_kwargs_for_job_row(
         Row(
             {"to": "07900100100", "name": "foo", "reference": "ab1234"},
             index=0,
@@ -476,6 +704,57 @@ def test_process_row_when_reference_is_provided(mocker, mock_celery_task, fake_u
             "client_reference": "ab1234",
         }
     )
+
+
+# -------- shatter_job_rows tests --------------- #
+
+
+@pytest.mark.parametrize(
+    "template_type,send_fn",
+    [
+        (SMS_TYPE, save_sms),
+        (EMAIL_TYPE, save_email),
+        (LETTER_TYPE, save_letter),
+    ],
+)
+def test_shatter_job_rows(template_type, send_fn, mock_celery_task, mocker):
+    mock_send_fn = mock_celery_task(send_fn)
+
+    shatter_job_rows(
+        template_type,
+        [
+            (
+                ("service-id-0", "notification-id-0", "encoded-0"),
+                {} if template_type == LETTER_TYPE else {"sender_id": "0"},
+            ),
+            (
+                ("service-id-1", "notification-id-1", "encoded-1"),
+                {} if template_type == LETTER_TYPE else {"sender_id": "1"},
+            ),
+            (
+                ("service-id-2", "notification-id-2", "encoded-2"),
+                {} if template_type == LETTER_TYPE else {"sender_id": "2"},
+            ),
+        ],
+    )
+
+    assert mock_send_fn.mock_calls == [
+        call(
+            ("service-id-0", "notification-id-0", "encoded-0"),
+            {} if template_type == LETTER_TYPE else {"sender_id": "0"},
+            queue="database-tasks",
+        ),
+        call(
+            ("service-id-1", "notification-id-1", "encoded-1"),
+            {} if template_type == LETTER_TYPE else {"sender_id": "1"},
+            queue="database-tasks",
+        ),
+        call(
+            ("service-id-2", "notification-id-2", "encoded-2"),
+            {} if template_type == LETTER_TYPE else {"sender_id": "2"},
+            queue="database-tasks",
+        ),
+    ]
 
 
 # -------- save_sms and save_email tests -------- #
@@ -1217,14 +1496,14 @@ def test_should_cancel_job_if_service_is_inactive(sample_service, sample_job, mo
     sample_service.active = False
 
     mocker.patch("app.celery.tasks.s3.get_job_from_s3")
-    mocker.patch("app.celery.tasks.process_row")
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
 
     process_job(sample_job.id)
 
     job = jobs_dao.dao_get_job_by_id(sample_job.id)
     assert job.job_status == "cancelled"
-    s3.get_job_from_s3.assert_not_called()
-    tasks.process_row.assert_not_called()
+    assert not s3.get_job_from_s3.mock_calls
+    assert not mock_shatter_job_rows.mock_calls
 
 
 def test_get_email_template_instance(mocker, mock_celery_task, sample_email_template, sample_job):
@@ -1295,12 +1574,6 @@ def test_get_letter_template_instance(mocker, mock_celery_task, sample_job):
 
 
 def test_process_incomplete_job_sms(mocker, mock_celery_task, sample_template):
-    mocker.patch(
-        "app.celery.tasks.s3.get_job_and_metadata_from_s3",
-        return_value=(load_example_csv("multiple_sms"), {"sender_id": None}),
-    )
-    mock_save_sms = mock_celery_task(save_sms)
-
     job = create_job(
         template=sample_template,
         notification_count=10,
@@ -1315,13 +1588,96 @@ def test_process_incomplete_job_sms(mocker, mock_celery_task, sample_template):
 
     assert Notification.query.filter(Notification.job_id == job.id).count() == 2
 
-    process_incomplete_job(str(job.id))
+    mocker.patch(
+        "app.celery.tasks.s3.get_job_and_metadata_from_s3",
+        return_value=(load_example_csv("multiple_sms"), {"sender_id": None}),
+    )
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
+    mock_encode = mocker.patch("app.signing.encode", side_effect=(f"something-encoded-{i}" for i in count()))
+    mocker.patch("app.celery.tasks.create_uuid", side_effect=(f"uuid-{i}" for i in count()))
+
+    process_incomplete_job(str(job.id), shatter_batch_size=3)
+
+    assert mock_encode.mock_calls == [
+        # first two rows already sent
+        call(
+            {
+                "template": str(job.template_id),
+                "template_version": job.template_version,
+                "job": str(job.id),
+                "to": "+441234123123",
+                "row_number": 2,
+                "personalisation": {"phonenumber": "+441234123123"},
+                "client_reference": None,
+            }
+        ),
+        call(
+            {
+                "template": str(job.template_id),
+                "template_version": job.template_version,
+                "job": str(job.id),
+                "to": "+441234123124",
+                "row_number": 3,
+                "personalisation": {"phonenumber": "+441234123124"},
+                "client_reference": None,
+            }
+        ),
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        ANY,
+        call(
+            {
+                "template": str(job.template_id),
+                "template_version": job.template_version,
+                "job": str(job.id),
+                "to": "+441234123120",
+                "row_number": 9,
+                "personalisation": {"phonenumber": "+441234123120"},
+                "client_reference": None,
+            }
+        ),
+    ]
+
+    assert mock_shatter_job_rows.mock_calls == [
+        call(
+            (
+                sample_template.template_type,
+                [
+                    ((str(job.service_id), "uuid-0", "something-encoded-0"), {}),
+                    ((str(job.service_id), "uuid-1", "something-encoded-1"), {}),
+                    ((str(job.service_id), "uuid-2", "something-encoded-2"), {}),
+                ],
+            ),
+            queue="job-tasks",
+        ),
+        call(
+            (
+                sample_template.template_type,
+                [
+                    ((str(job.service_id), "uuid-3", "something-encoded-3"), {}),
+                    ((str(job.service_id), "uuid-4", "something-encoded-4"), {}),
+                    ((str(job.service_id), "uuid-5", "something-encoded-5"), {}),
+                ],
+            ),
+            queue="job-tasks",
+        ),
+        call(
+            (
+                sample_template.template_type,
+                [
+                    ((str(job.service_id), "uuid-6", "something-encoded-6"), {}),
+                    ((str(job.service_id), "uuid-7", "something-encoded-7"), {}),
+                ],
+            ),
+            queue="job-tasks",
+        ),
+    ]
 
     completed_job = Job.query.filter(Job.id == job.id).one()
 
     assert completed_job.job_status == JOB_STATUS_FINISHED
-
-    assert mock_save_sms.call_count == 8  # There are 10 in the file and we've added two already
 
 
 def test_process_incomplete_job_with_notifications_all_sent(mocker, mock_celery_task, sample_template):
@@ -1329,7 +1685,7 @@ def test_process_incomplete_job_with_notifications_all_sent(mocker, mock_celery_
         "app.celery.tasks.s3.get_job_and_metadata_from_s3",
         return_value=(load_example_csv("multiple_sms"), {"sender_id": None}),
     )
-    mock_save_sms = mock_celery_task(save_sms)
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
 
     job = create_job(
         template=sample_template,
@@ -1359,16 +1715,11 @@ def test_process_incomplete_job_with_notifications_all_sent(mocker, mock_celery_
 
     assert completed_job.job_status == JOB_STATUS_FINISHED
 
-    assert mock_save_sms.call_count == 0  # There are 10 in the file and we've added 10 it should not have been called
+    # There are 10 in the file and we've added 10 it should not have been called
+    assert mock_shatter_job_rows.call_count == 0
 
 
 def test_process_incomplete_jobs_sms(mocker, mock_celery_task, sample_template):
-    mocker.patch(
-        "app.celery.tasks.s3.get_job_and_metadata_from_s3",
-        return_value=(load_example_csv("multiple_sms"), {"sender_id": None}),
-    )
-    mock_save_sms = mock_celery_task(save_sms)
-
     job = create_job(
         template=sample_template,
         notification_count=10,
@@ -1400,8 +1751,147 @@ def test_process_incomplete_jobs_sms(mocker, mock_celery_task, sample_template):
 
     assert Notification.query.filter(Notification.job_id == job2.id).count() == 5
 
+    mocker.patch(
+        "app.celery.tasks.s3.get_job_and_metadata_from_s3",
+        return_value=(load_example_csv("multiple_sms"), {"sender_id": None}),
+    )
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
+    mocker.patch("app.signing.encode", side_effect=lambda x: f"encoded-job-{x['job']}-row-{x['row_number']}")
+    mocker.patch("app.celery.tasks.create_uuid", side_effect=(f"uuid-{i}" for i in count()))
+
     jobs = [job.id, job2.id]
-    process_incomplete_jobs(jobs)
+    process_incomplete_jobs(jobs, shatter_batch_size=4)
+
+    assert mock_shatter_job_rows.mock_calls == [
+        call(
+            (
+                job.template.template_type,
+                [
+                    (
+                        (
+                            str(job.service_id),
+                            "uuid-0",
+                            f"encoded-job-{job.id}-row-3",  # sent rows 0-2 inclusive already
+                        ),
+                        {},
+                    ),
+                    (
+                        (
+                            str(job.service_id),
+                            "uuid-1",
+                            f"encoded-job-{job.id}-row-4",
+                        ),
+                        {},
+                    ),
+                    (
+                        (
+                            str(job.service_id),
+                            "uuid-2",
+                            f"encoded-job-{job.id}-row-5",
+                        ),
+                        {},
+                    ),
+                    (
+                        (
+                            str(job.service_id),
+                            "uuid-3",
+                            f"encoded-job-{job.id}-row-6",
+                        ),
+                        {},
+                    ),
+                ],
+            ),
+            queue="job-tasks",
+        ),
+        call(
+            (
+                job.template.template_type,
+                [
+                    (
+                        (
+                            str(job.service_id),
+                            "uuid-4",
+                            f"encoded-job-{job.id}-row-7",
+                        ),
+                        {},
+                    ),
+                    (
+                        (
+                            str(job.service_id),
+                            "uuid-5",
+                            f"encoded-job-{job.id}-row-8",
+                        ),
+                        {},
+                    ),
+                    (
+                        (
+                            str(job.service_id),
+                            "uuid-6",
+                            f"encoded-job-{job.id}-row-9",
+                        ),
+                        {},
+                    ),
+                ],
+            ),
+            queue="job-tasks",
+        ),
+        call(
+            (
+                job2.template.template_type,
+                [
+                    (
+                        (
+                            str(job2.service_id),
+                            "uuid-7",
+                            f"encoded-job-{job2.id}-row-5",  # sent rows 0-4 inclusive already
+                        ),
+                        {},
+                    ),
+                    (
+                        (
+                            str(job2.service_id),
+                            "uuid-8",
+                            f"encoded-job-{job2.id}-row-6",
+                        ),
+                        {},
+                    ),
+                    (
+                        (
+                            str(job2.service_id),
+                            "uuid-9",
+                            f"encoded-job-{job2.id}-row-7",
+                        ),
+                        {},
+                    ),
+                    (
+                        (
+                            str(job2.service_id),
+                            "uuid-10",
+                            f"encoded-job-{job2.id}-row-8",
+                        ),
+                        {},
+                    ),
+                ],
+            ),
+            queue="job-tasks",
+        ),
+        call(
+            (
+                job2.template.template_type,
+                [
+                    (
+                        (
+                            str(job2.service_id),
+                            "uuid-11",
+                            f"encoded-job-{job2.id}-row-9",
+                        ),
+                        {},
+                    )
+                ],
+            ),
+            queue="job-tasks",
+        ),
+    ]
 
     completed_job = Job.query.filter(Job.id == job.id).one()
     completed_job2 = Job.query.filter(Job.id == job2.id).one()
@@ -1410,15 +1900,13 @@ def test_process_incomplete_jobs_sms(mocker, mock_celery_task, sample_template):
 
     assert completed_job2.job_status == JOB_STATUS_FINISHED
 
-    assert mock_save_sms.call_count == 12  # There are 20 in total over 2 jobs we've added 8 already
-
 
 def test_process_incomplete_jobs_no_notifications_added(mocker, mock_celery_task, sample_template):
     mocker.patch(
         "app.celery.tasks.s3.get_job_and_metadata_from_s3",
         return_value=(load_example_csv("multiple_sms"), {"sender_id": None}),
     )
-    mock_save_sms = mock_celery_task(save_sms)
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
 
     job = create_job(
         template=sample_template,
@@ -1431,26 +1919,30 @@ def test_process_incomplete_jobs_no_notifications_added(mocker, mock_celery_task
 
     assert Notification.query.filter(Notification.job_id == job.id).count() == 0
 
-    process_incomplete_job(job.id)
+    process_incomplete_job(job.id, shatter_batch_size=6)
 
     completed_job = Job.query.filter(Job.id == job.id).one()
 
     assert completed_job.job_status == JOB_STATUS_FINISHED
 
-    assert mock_save_sms.call_count == 10  # There are 10 in the csv file
+    assert mock_shatter_job_rows.call_count == 2
+
+    assert (
+        sum(len(task_args_kwargs) for _, ((_, task_args_kwargs),), *_ in mock_shatter_job_rows.mock_calls) == 10
+    )  # There are 10 in the csv file
 
 
-def test_process_incomplete_jobs(mocker, mock_celery_task, sample_template):
+def test_process_incomplete_jobs_empty_ids_arg(mocker, mock_celery_task, sample_template):
     mocker.patch(
         "app.celery.tasks.s3.get_job_and_metadata_from_s3",
         return_value=(load_example_csv("multiple_sms"), {"sender_id": None}),
     )
-    mock_save_sms = mock_celery_task(save_sms)
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
 
     jobs = []
     process_incomplete_jobs(jobs)
 
-    assert mock_save_sms.call_count == 0  # There are no jobs to process so it will not have been called
+    assert mock_shatter_job_rows.call_count == 0  # There are no jobs to process so it will not have been called
 
 
 def test_process_incomplete_job_no_job_in_database(mocker, mock_celery_task, fake_uuid):
@@ -1458,12 +1950,12 @@ def test_process_incomplete_job_no_job_in_database(mocker, mock_celery_task, fak
         "app.celery.tasks.s3.get_job_and_metadata_from_s3",
         return_value=(load_example_csv("multiple_sms"), {"sender_id": None}),
     )
-    mock_save_sms = mock_celery_task(save_sms)
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
 
     with pytest.raises(expected_exception=Exception):
         process_incomplete_job(fake_uuid)
 
-    assert mock_save_sms.call_count == 0  # There is no job in the db it will not have been called
+    assert mock_shatter_job_rows.call_count == 0  # There is no job in the db it will not have been called
 
 
 def test_process_incomplete_job_email(mocker, mock_celery_task, sample_email_template):
@@ -1471,7 +1963,7 @@ def test_process_incomplete_job_email(mocker, mock_celery_task, sample_email_tem
         "app.celery.tasks.s3.get_job_and_metadata_from_s3",
         return_value=(load_example_csv("multiple_email"), {"sender_id": None}),
     )
-    mock_email_saver = mock_celery_task(save_email)
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
 
     job = create_job(
         template=sample_email_template,
@@ -1487,13 +1979,13 @@ def test_process_incomplete_job_email(mocker, mock_celery_task, sample_email_tem
 
     assert Notification.query.filter(Notification.job_id == job.id).count() == 2
 
-    process_incomplete_job(str(job.id))
+    process_incomplete_job(str(job.id), shatter_batch_size=1)
 
     completed_job = Job.query.filter(Job.id == job.id).one()
 
     assert completed_job.job_status == JOB_STATUS_FINISHED
 
-    assert mock_email_saver.call_count == 8  # There are 10 in the file and we've added two already
+    assert mock_shatter_job_rows.call_count == 8  # There are 10 in the file and we've added two already
 
 
 def test_process_incomplete_job_letter(mocker, mock_celery_task, sample_letter_template):
@@ -1501,7 +1993,7 @@ def test_process_incomplete_job_letter(mocker, mock_celery_task, sample_letter_t
         "app.celery.tasks.s3.get_job_and_metadata_from_s3",
         return_value=(load_example_csv("multiple_letter"), {"sender_id": None}),
     )
-    mock_letter_saver = mock_celery_task(save_letter)
+    mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
 
     job = create_job(
         template=sample_letter_template,
@@ -1517,9 +2009,10 @@ def test_process_incomplete_job_letter(mocker, mock_celery_task, sample_letter_t
 
     assert Notification.query.filter(Notification.job_id == job.id).count() == 2
 
-    process_incomplete_job(str(job.id))
+    process_incomplete_job(str(job.id), shatter_batch_size=100)
 
-    assert mock_letter_saver.call_count == 8
+    assert mock_shatter_job_rows.call_count == 1
+    assert len(mock_shatter_job_rows.mock_calls[0][1][0][1]) == 8
 
 
 @freeze_time("2017-01-01")
@@ -1533,7 +2026,7 @@ def test_process_incomplete_jobs_sets_status_to_in_progress_and_resets_processin
         sample_template, processing_started=datetime.utcnow() - timedelta(minutes=31), job_status=JOB_STATUS_ERROR
     )
 
-    process_incomplete_jobs([str(job1.id), str(job2.id)])
+    process_incomplete_jobs([str(job1.id), str(job2.id)], shatter_batch_size=123)
 
     assert job1.job_status == JOB_STATUS_IN_PROGRESS
     assert job1.processing_started == datetime.utcnow()
@@ -1541,7 +2034,10 @@ def test_process_incomplete_jobs_sets_status_to_in_progress_and_resets_processin
     assert job2.job_status == JOB_STATUS_IN_PROGRESS
     assert job2.processing_started == datetime.utcnow()
 
-    assert mock_process_incomplete_job.mock_calls == [call(str(job1.id)), call(str(job2.id))]
+    assert mock_process_incomplete_job.mock_calls == [
+        call(str(job1.id), shatter_batch_size=123),
+        call(str(job2.id), shatter_batch_size=123),
+    ]
 
 
 def test_process_returned_letters_list(sample_letter_template):


### PR DESCRIPTION
In `process_job` and `process_incomplete_job` we're partly bottlenecked by the rate at which we can put SQS messages on the queue, causing the main job-processing task to take longer than it should. this is a problem because it holds a lock on the job row and it can sometimes get killed by ECS scale-in halfway through processing, leaving a zombie lock on the job row amongst possibly other things.

`shatter_job_rows` requires no database connection and its' sole responsibility is to turn a sequence of task args/kwargs pairs into individual tasks.

`DEFAULT_SHATTER_JOB_ROWS_BATCH_SIZE` is chosen with an eye to avoid nearing the SQS message limit for these shatter tasks.

This imports the "example equivalent" of `itertools.batched` which is introduced in python 3.12. we should remove our copy when we upgrade past that.