### PR TITLE
Notification: add `ix_notifications_service_id_ntype_created_at`

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1467,6 +1467,7 @@ class Notification(db.Model):
         Index("ix_notifications_notification_type_composite", "notification_type", "status", "created_at"),
         Index("ix_notifications_service_created_at", "service_id", "created_at"),
         Index("ix_notifications_service_id_composite", "service_id", "notification_type", "status", "created_at"),
+        Index("ix_notifications_service_id_ntype_created_at", "service_id", "notification_type", "created_at"),
         # unsubscribe_link value should be null for non-email notifications
         CheckConstraint(
             "notification_type = 'email' OR unsubscribe_link is null",

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0479_notifications_atv_union_all
+0480_ntfcns_cpst_idx_nostatus

--- a/migrations/versions/0480_ntfcns_cpst_idx_nostatus.py
+++ b/migrations/versions/0480_ntfcns_cpst_idx_nostatus.py
@@ -1,0 +1,26 @@
+"""
+Create Date: 2024-12-02 21:30:07.663503
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0480_ntfcns_cpst_idx_nostatus"
+down_revision = "0479_notifications_atv_union_all"
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_notifications_service_id_ntype_created_at",
+            "notifications",
+            ["service_id", "notification_type", "created_at"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index("ix_notifications_service_id_ntype_created_at", table_name="notifications")


### PR DESCRIPTION
Create this index alongside `ix_notifications_service_id_composite` to see which gets more extended use over time, then we can consider which to keep.

Most notifications queries are for more than one status type, which means the existing index almost never uses its ability to scan in `created_at` order.