### PR TITLE
Change provider balance on slow delivery every 5 minutes

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -131,8 +131,8 @@ def delete_invitations():
 def switch_current_sms_provider_on_slow_delivery():
     """
     Reduce provider's priority if at least 15% of notifications took more than 5 minutes to be delivered
-    in the last ten minutes. If both providers are slow, don't do anything. If we changed the providers in the
-    last ten minutes, then don't update them again either.
+    in the last 15 minutes. If both providers are slow, don't do anything. If we changed the providers in the
+    last 5 minutes, then don't update them again either.
     """
     slow_delivery_notifications = is_delivery_slow_for_providers(
         created_within_minutes=15,
@@ -146,7 +146,7 @@ def switch_current_sms_provider_on_slow_delivery():
         for provider_name, is_slow in slow_delivery_notifications.items():
             if is_slow:
                 current_app.logger.warning("Slow delivery notifications detected for provider %s", provider_name)
-                dao_reduce_sms_provider_priority(provider_name, time_threshold=timedelta(minutes=10))
+                dao_reduce_sms_provider_priority(provider_name, time_threshold=timedelta(minutes=5))
 
 
 def _check_slow_text_message_delivery_reports_and_raise_error_if_needed(reports: list[SlowProviderDeliveryReport]):

--- a/app/dao/provider_details_dao.py
+++ b/app/dao/provider_details_dao.py
@@ -107,11 +107,11 @@ def dao_reduce_sms_provider_priority(identifier, *, time_threshold):
 @autocommit
 def dao_adjust_provider_priority_back_to_resting_points():
     """
-    Provided that neither SMS provider has been modified in the last hour, move both providers by 10 percentage points
-    each towards their defined resting points (set in SMS_PROVIDER_RESTING_POINTS in config.py).
+    Provided that neither SMS provider has been modified in the last 15 minutes, move both providers
+    by 10 percentage points each towards their defined resting points (set in SMS_PROVIDER_RESTING_POINTS in config.py).
     """
     amount_to_reduce_by = 10
-    time_threshold = timedelta(hours=1)
+    time_threshold = timedelta(minutes=15)
 
     providers = _get_sms_providers_for_update(time_threshold)
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -139,7 +139,7 @@ def test_switch_current_sms_provider_on_slow_delivery_switches_when_one_provider
     switch_current_sms_provider_on_slow_delivery()
 
     mock_is_slow.assert_called_once_with(created_within_minutes=15, delivered_within_minutes=5, threshold=0.15)
-    mock_reduce.assert_called_once_with("firetext", time_threshold=timedelta(minutes=10))
+    mock_reduce.assert_called_once_with("firetext", time_threshold=timedelta(minutes=5))
 
 
 @freeze_time("2017-05-01 14:00:00")

--- a/tests/app/dao/test_provider_details_dao.py
+++ b/tests/app/dao/test_provider_details_dao.py
@@ -285,7 +285,7 @@ def test_adjust_provider_priority_back_to_resting_points_updates_all_providers(
 
     dao_adjust_provider_priority_back_to_resting_points()
 
-    mock_get_providers.assert_called_once_with(timedelta(hours=1))
+    mock_get_providers.assert_called_once_with(timedelta(minutes=15))
     mock_adjust.assert_any_call(mmg, new_mmg)
     mock_adjust.assert_any_call(firetext, new_firetext)
 


### PR DESCRIPTION
Instead of every 10 minutes - this way we react faster, and fewer text messages get delayed.

This becomes more important as we now send lots of login codes for various organisations.

Also rebalance back to the middle every 15 minutes, instead of every 1 hour.

Those two changes together make our providers balancing act more dynamic - hopefully it will help us deliver messages quickly when one of the providers has delivery issues, while also giving them traffic back more quickly when they recover.

Check commit messages for more detail.