### PR TITLE
Remove unneeded `noqa` comment

### DIFF
--- a/app/history_meta.py
+++ b/app/history_meta.py
@@ -35,7 +35,7 @@ def _is_versioning_col(col):
     return "version_meta" in col.info
 
 
-def _history_mapper(local_mapper):  # noqa (C901 too complex)
+def _history_mapper(local_mapper):
     cls = local_mapper.class_
 
     # set the "active_history" flag


### PR DESCRIPTION
When we cleaned up this function in 7ea5474a96dd7ef3b3c6dfa17d7ef08b9ad51a85 we made it a lot simpler.

It now passes the cyclomatic complexity check, so we don’t need a comment to exclude it from that check.