### PR TITLE
job tasks: use `shatter_job_rows` to create individual row tasks

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -50,11 +50,14 @@ from app.notifications.process_notifications import persist_notification
 from app.notifications.validators import check_service_over_daily_message_limit
 from app.serialised_models import SerialisedService, SerialisedTemplate
 from app.service.utils import service_allowed_to_send_to
+from app.utils import batched
 from app.v2.errors import TooManyRequestsError
+
+DEFAULT_SHATTER_JOB_ROWS_BATCH_SIZE = 32
 
 
 @notify_celery.task(name="process-job")
-def process_job(job_id, sender_id=None):
+def process_job(job_id, sender_id=None, shatter_batch_size=DEFAULT_SHATTER_JOB_ROWS_BATCH_SIZE):
     start = datetime.utcnow()
     job = dao_get_job_by_id(job_id)
     current_app.logger.info("Starting process-job task for job id %s with status: %s", job_id, job.job_status)
@@ -81,8 +84,18 @@ def process_job(job_id, sender_id=None):
 
     current_app.logger.info("Starting job %s processing %s notifications", job_id, job.notification_count)
 
-    for row in recipient_csv.get_rows():
-        process_row(row, template, job, service, sender_id=sender_id)
+    for shatter_batch in batched(recipient_csv.get_rows(), n=shatter_batch_size):
+        batch_args_kwargs = [
+            get_id_task_args_kwargs_for_job_row(row, template, job, service, sender_id=sender_id)[1]
+            for row in shatter_batch
+        ]
+        shatter_job_rows.apply_async(
+            (
+                template.template_type,
+                batch_args_kwargs,
+            ),
+            queue=QueueNames.JOBS,
+        )
 
     job_complete(job, start=start)
 
@@ -134,8 +147,7 @@ def get_recipient_csv_and_template_and_sender_id(job):
     return recipient_csv, template, meta_data.get("sender_id")
 
 
-def process_row(row, template, job, service, sender_id=None):
-    template_type = template.template_type
+def get_id_task_args_kwargs_for_job_row(row, template, job, service, sender_id=None):
     encoded = signing.encode(
         {
             "template": str(template.id),
@@ -149,25 +161,18 @@ def process_row(row, template, job, service, sender_id=None):
         }
     )
 
-    send_fns = {SMS_TYPE: save_sms, EMAIL_TYPE: save_email, LETTER_TYPE: save_letter}
-
-    send_fn = send_fns[template_type]
+    notification_id = create_uuid()
+    task_args = (
+        str(service.id),
+        notification_id,
+        encoded,
+    )
 
     task_kwargs = {}
     if sender_id:
         task_kwargs["sender_id"] = sender_id
 
-    notification_id = create_uuid()
-    send_fn.apply_async(
-        (
-            str(service.id),
-            notification_id,
-            encoded,
-        ),
-        task_kwargs,
-        queue=QueueNames.DATABASE,
-    )
-    return notification_id
+    return notification_id, (task_args, task_kwargs)
 
 
 def __sending_limits_for_job_exceeded(service, job, job_id):
@@ -493,7 +498,7 @@ def check_billable_units(notification_update):
 
 
 @notify_celery.task(name="process-incomplete-jobs")
-def process_incomplete_jobs(job_ids):
+def process_incomplete_jobs(job_ids, shatter_batch_size=DEFAULT_SHATTER_JOB_ROWS_BATCH_SIZE):
     jobs = [dao_get_job_by_id(job_id) for job_id in job_ids]
 
     # reset the processing start time so that the check_job_status scheduled task doesn't pick this job up again
@@ -504,10 +509,10 @@ def process_incomplete_jobs(job_ids):
 
     current_app.logger.info("Resuming job(s) %s", job_ids)
     for job_id in job_ids:
-        process_incomplete_job(job_id)
+        process_incomplete_job(job_id, shatter_batch_size=shatter_batch_size)
 
 
-def process_incomplete_job(job_id):
+def process_incomplete_job(job_id, shatter_batch_size=DEFAULT_SHATTER_JOB_ROWS_BATCH_SIZE):
     job = dao_get_job_by_id(job_id)
 
     last_notification_added = dao_get_last_notification_added_for_job_id(job_id)
@@ -521,9 +526,21 @@ def process_incomplete_job(job_id):
 
     recipient_csv, template, sender_id = get_recipient_csv_and_template_and_sender_id(job)
 
-    for row in recipient_csv.get_rows():
-        if row.index > resume_from_row:
-            process_row(row, template, job, job.service, sender_id=sender_id)
+    for shatter_batch in batched(
+        (row for row in recipient_csv.get_rows() if row.index > resume_from_row),
+        n=shatter_batch_size,
+    ):
+        batch_args_kwargs = [
+            get_id_task_args_kwargs_for_job_row(row, template, job, job.service, sender_id=sender_id)[1]
+            for row in shatter_batch
+        ]
+        shatter_job_rows.apply_async(
+            (
+                template.template_type,
+                batch_args_kwargs,
+            ),
+            queue=QueueNames.JOBS,
+        )
 
     job_complete(job, resumed=True)
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -28,7 +28,11 @@ from app.celery.letters_pdf_tasks import (
     get_pdf_for_templated_letter,
     resanitise_pdf,
 )
-from app.celery.tasks import process_row, record_daily_sorted_counts
+from app.celery.tasks import (
+    get_id_task_args_kwargs_for_job_row,
+    process_job_row,
+    record_daily_sorted_counts,
+)
 from app.config import QueueNames
 from app.constants import KEY_TYPE_TEST, NOTIFICATION_CREATED, SMS_TYPE
 from app.dao.annual_billing_dao import (
@@ -733,7 +737,10 @@ def process_row_from_job(job_id, job_row_number):
         placeholders=template.placeholders,
     ).get_rows():
         if row.index == job_row_number:
-            notification_id = process_row(row, template, job, job.service)
+            notification_id, task_args_kwargs = get_id_task_args_kwargs_for_job_row(row, template, job, job.service)
+
+            process_job_row(template.template_type, task_args_kwargs)
+
             current_app.logger.info(
                 "Process row %s for job %s created notification_id: %s", job_row_number, job_id, notification_id
             )

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from itertools import islice
 from urllib.parse import urljoin
 
 import pytz
@@ -51,6 +52,19 @@ def get_prev_next_pagination_links(current_page, next_page_exists, endpoint, **k
     if next_page_exists:
         links["next"] = True
     return links
+
+
+# "approximate equivalent" of itertools.batched from python 3.12's documentation. remove once we upgrade
+# past python 3.12 and use itertools' version instead
+def batched(iterable, n, *, strict=False):
+    # batched('ABCDEFG', 3) → ABC DEF G
+    if n < 1:
+        raise ValueError("n must be at least one")
+    iterator = iter(iterable)
+    while batch := tuple(islice(iterator, n)):
+        if strict and len(batch) != n:
+            raise ValueError("batched(): incomplete batch")
+        yield batch
 
 
 def url_with_token(data, url, base_url=None):


### PR DESCRIPTION
Part 2 of #4284 - see that for more details.

Note I've been extra cautious of nearing the SQS size limit and further reduced the batch size to 32. This should allow for 8KiB per notification (which I presume is _after_ compression?).