### PR TITLE
Handling duplicate unsubscribe requests

### DIFF
--- a/app/dao/unsubscribe_request_dao.py
+++ b/app/dao/unsubscribe_request_dao.py
@@ -22,7 +22,7 @@ def create_unsubscribe_request_dao(unsubscribe_data):
 
 
 def get_unsubscribe_request_by_notification_id_dao(notification_id):
-    return UnsubscribeRequest.query.filter_by(notification_id=notification_id).one()
+    return UnsubscribeRequest.query.filter_by(notification_id=notification_id).one_or_none()
 
 
 def get_unsubscribe_requests_statistics_dao(service_id):

--- a/app/one_click_unsubscribe/rest.py
+++ b/app/one_click_unsubscribe/rest.py
@@ -32,6 +32,10 @@ def one_click_unsubscribe(notification_id, token):
         errors = {"unsubscribe request": "This is not a valid unsubscribe link."}
         raise InvalidRequest(errors, status_code=404) from e
 
+    # Check if the unsubscribe request is a duplicate
+    if is_duplicate_unsubscribe_request(notification_id):
+        return jsonify(result="success", message="Unsubscribe successful"), 200
+
     if notification := get_notification_by_id(notification_id):
         unsubscribe_data = get_unsubscribe_request_data(notification, email_address)
 
@@ -83,6 +87,5 @@ def is_duplicate_unsubscribe_request(notification_id):
         report_id = unsubscribe_request.unsubscribe_request_report_id
         if not report_id:
             return True
-
         return False if get_unsubscribe_request_report_by_id_dao(report_id).processed_by_service_at else True
     return False

--- a/app/one_click_unsubscribe/rest.py
+++ b/app/one_click_unsubscribe/rest.py
@@ -8,8 +8,9 @@ from app.dao.notifications_dao import get_notification_by_id
 from app.dao.unsubscribe_request_dao import (
     create_unsubscribe_request_dao,
     get_unbatched_unsubscribe_requests_dao,
-    get_unsubscribe_request_reports_dao, get_unsubscribe_request_by_notification_id_dao,
+    get_unsubscribe_request_by_notification_id_dao,
     get_unsubscribe_request_report_by_id_dao,
+    get_unsubscribe_request_reports_dao,
 )
 from app.errors import InvalidRequest, register_errors
 from app.models import UnsubscribeRequestReport

--- a/app/one_click_unsubscribe/rest.py
+++ b/app/one_click_unsubscribe/rest.py
@@ -83,9 +83,14 @@ def is_duplicate_unsubscribe_request(notification_id):
     the same notification_id of a previously received unsubscribe request that has not yet been processed
     by the service that initiated the notification.
     """
-    if unsubscribe_request := get_unsubscribe_request_by_notification_id_dao(notification_id):
-        report_id = unsubscribe_request.unsubscribe_request_report_id
-        if not report_id:
-            return True
-        return False if get_unsubscribe_request_report_by_id_dao(report_id).processed_by_service_at else True
-    return False
+    unsubscribe_request = get_unsubscribe_request_by_notification_id_dao(notification_id)
+
+    if not unsubscribe_request:
+        return False
+
+    report_id = unsubscribe_request.unsubscribe_request_report_id
+
+    if report_id and get_unsubscribe_request_report_by_id_dao(report_id).processed_by_service_at:
+        return False
+
+    return True

--- a/tests/app/dao/test_unsubscribe_request_dao.py
+++ b/tests/app/dao/test_unsubscribe_request_dao.py
@@ -1,5 +1,4 @@
-import uuid
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from freezegun import freeze_time
 
@@ -22,7 +21,7 @@ from tests.app.db import (
     create_service,
     create_template,
     create_unsubscribe_request,
-    create_unsubscribe_request_report, create_notification,
+    create_unsubscribe_request_report,
 )
 
 

--- a/tests/app/dao/test_unsubscribe_request_dao.py
+++ b/tests/app/dao/test_unsubscribe_request_dao.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+import uuid
+from datetime import datetime, timedelta
 
 from freezegun import freeze_time
 
@@ -21,7 +22,7 @@ from tests.app.db import (
     create_service,
     create_template,
     create_unsubscribe_request,
-    create_unsubscribe_request_report,
+    create_unsubscribe_request_report, create_notification,
 )
 
 

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -81,6 +81,7 @@ from app.models import (
     User,
     WebauthnCredential,
 )
+from app.utils import midnight_n_days_ago
 
 
 def create_user(*, mobile_number="+447700900986", email=None, state="active", id_=None, name="Test User", **kwargs):
@@ -1339,3 +1340,37 @@ def create_unsubscribe_request_report(
     )
     create_unsubscribe_request_reports_dao(report)
     return report
+
+
+def create_unsubscribe_request_and_return_the_notification_id(sample_service, is_batched, processed_by_service):
+    template = create_template(service=sample_service, template_type="email")
+    notification = create_notification(
+        template=template,
+        to_field="example@example.com",
+        sent_at=datetime.now() - timedelta(days=4),
+    )
+
+    unsubscribe_request_report_id = None
+    if is_batched:
+        # Create processed unsubscribe request report
+        unsubscribe_request_report = create_unsubscribe_request_report(
+            sample_service,
+            earliest_timestamp=midnight_n_days_ago(4),
+            latest_timestamp=midnight_n_days_ago(2),
+            processed_by_service_at=midnight_n_days_ago(1) if processed_by_service else None,
+        )
+        unsubscribe_request_report_id = unsubscribe_request_report.id
+
+    # Create an unsubscribe request
+    create_unsubscribe_request_dao(
+        {
+            "notification_id": notification.id,
+            "template_id": notification.template_id,
+            "template_version": notification.template_version,
+            "service_id": sample_service.id,
+            "email_address": notification.to,
+            "created_at": datetime.now(),
+            "unsubscribe_request_report_id": unsubscribe_request_report_id,
+        }
+    )
+    return notification.id

--- a/tests/app/one_click_unsubscribe/test_one_click_unsubscribe.py
+++ b/tests/app/one_click_unsubscribe/test_one_click_unsubscribe.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime, timedelta
 from unittest.mock import call
 
 from flask import current_app
@@ -6,8 +7,11 @@ from notifications_utils.url_safe_token import generate_token
 
 from app.constants import EMAIL_TYPE
 from app.dao.templates_dao import dao_update_template
-from app.dao.unsubscribe_request_dao import get_unsubscribe_request_by_notification_id_dao
-from tests.app.db import create_notification, create_template
+from app.dao.unsubscribe_request_dao import get_unsubscribe_request_by_notification_id_dao, \
+    create_unsubscribe_request_dao
+from app.one_click_unsubscribe.rest import is_duplicate_unsubscribe_request
+from app.utils import midnight_n_days_ago
+from tests.app.db import create_notification, create_template, create_unsubscribe_request_report
 
 
 def unsubscribe_url_post(client, notification_id, token):
@@ -119,3 +123,98 @@ def test_invalid_one_click_unsubscribe_url_notification_id(client, sample_email_
     response_json_data = response.get_json()
     assert response.status_code == 404
     assert response_json_data["message"] == {"unsubscribe request": "This is not a valid unsubscribe link."}
+
+
+def test_is_duplicate_unsubscribe_request_for_non_duplicate_request_1(sample_service):
+    # Test case is when the notification_id does not exist in the unsubscribe_request table
+    result = is_duplicate_unsubscribe_request('9d328a7a-d3f4-4494-a429-63525e7338f4')
+    assert result is False
+
+
+def test_is_duplicate_unsubscribe_request_for_non_duplicate_request_2(sample_service):
+    # Test case is an unsubscribe request that has the same notification_id as a previous request
+    # that has been processed by the service. Only sequential unprocessed unsubscribe requests with the same
+    # notification_id are being considered as duplicate requests.
+    template = create_template(service=sample_service, template_type="email")
+    notification = create_notification(
+        template=template,
+        to_field="example@example.com",
+        sent_at=datetime.now() - timedelta(days=5),
+    )
+    # Create processed unsubscribe request report
+    unsubscribe_request_report = create_unsubscribe_request_report(
+        sample_service,
+        earliest_timestamp=midnight_n_days_ago(3),
+        latest_timestamp=midnight_n_days_ago(1),
+        processed_by_service_at=midnight_n_days_ago(1),
+    )
+    # Create a processed unsubscribe request
+    unsubscribe_request = create_unsubscribe_request_dao(
+        {
+            "notification_id": notification.id,
+            "template_id": notification.template_id,
+            "template_version": notification.template_version,
+            "service_id": sample_service.id,
+            "email_address": notification.to,
+            "created_at": midnight_n_days_ago(2),
+            "unsubscribe_request_report_id": unsubscribe_request_report.id,
+        }
+    )
+    # Simulate a duplicate unsubscribe request with the same notification_id
+    result = is_duplicate_unsubscribe_request(notification.id)
+    assert result is False
+
+
+def test_is_duplicate_unsubscribe_request_for_unbatched_request(sample_service):
+    template = create_template(service=sample_service, template_type="email")
+    notification = create_notification(
+        template=template,
+        to_field="example@example.com",
+        sent_at=datetime.now() - timedelta(days=4),
+    )
+    # Create an unsubscribe request
+    unsubscribe_request_1 = create_unsubscribe_request_dao(
+        {
+            "notification_id": notification.id,
+            "template_id": notification.template_id,
+            "template_version": notification.template_version,
+            "service_id": sample_service.id,
+            "email_address": notification.to,
+            "created_at": datetime.now(),
+            "unsubscribe_request_report_id": None,
+        }
+    )
+    # Simulate a duplicate unsubscribe request with the same notification_id
+    result = is_duplicate_unsubscribe_request(notification.id)
+    assert result is True
+
+
+def test_is_duplicate_unsubscribe_request_for_batched_unprocessed_request(sample_service):
+    template = create_template(service=sample_service, template_type="email")
+    notification = create_notification(
+        template=template,
+        to_field="example@example.com",
+        sent_at=datetime.now() - timedelta(days=4),
+    )
+    # Create processed unsubscribe request report
+    unsubscribe_request_report = create_unsubscribe_request_report(
+        sample_service,
+        earliest_timestamp=midnight_n_days_ago(4),
+        latest_timestamp=midnight_n_days_ago(2),
+        processed_by_service_at=midnight_n_days_ago(1),
+    )
+    # Create an unsubscribe request
+    unsubscribe_request_1 = create_unsubscribe_request_dao(
+        {
+            "notification_id": notification.id,
+            "template_id": notification.template_id,
+            "template_version": notification.template_version,
+            "service_id": sample_service.id,
+            "email_address": notification.to,
+            "created_at": datetime.now(),
+            "unsubscribe_request_report_id": unsubscribe_request_report.id,
+        }
+    )
+    # Simulate a duplicate unsubscribe request with the same notification_id
+    result = is_duplicate_unsubscribe_request(notification.id)
+    assert result is True


### PR DESCRIPTION
Currently duplicate requests can be made using the same unsubscribe link, hence there are occurrences of multiple instances of unsubscribe requests with the same `notification_id` in the `unsubscribe_request` table.

The changes proposed in this PR would prevent duplicate unsubscribe requests from being entered into the `unsubscribe_request` and being added to an unsubscribe request report, as described in this [card](https://trello.com/c/2rwsxzZd/165-duplication-of-one-click-unsubscribe-links-issue)

For the purpose of the work, a duplicate unsubscribe request is being defined as an unsubscribe_request that has
the same notification_id of a previously received unsubscribe request that has not yet been processed by the service that initiated the notification.


