### PR TITLE
`dao_get_last_date_template_was_used`: restrict `notifications` table search to midnight

### DIFF
--- a/app/template_statistics/rest.py
+++ b/app/template_statistics/rest.py
@@ -47,8 +47,8 @@ def get_template_statistics_for_service_by_day(service_id):
 @template_statistics.route("/last-used/<uuid:template_id>")
 def get_last_used_datetime_for_template(service_id, template_id):
     # Check the template and service exist
-    dao_get_template_by_id_and_service_id(template_id, service_id)
+    template = dao_get_template_by_id_and_service_id(template_id, service_id)
 
-    last_date_used = dao_get_last_date_template_was_used(template_id=template_id, service_id=service_id)
+    last_date_used = dao_get_last_date_template_was_used(template)
 
     return jsonify(last_date_used=last_date_used.strftime(DATETIME_FORMAT) if last_date_used else last_date_used)

--- a/tests/app/dao/notification_dao/test_notification_dao_template_usage.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_template_usage.py
@@ -8,9 +8,7 @@ def test_dao_get_last_date_template_was_used_returns_bst_date_from_stats_table(s
     last_status_date = (datetime.now(UTC) - timedelta(days=2)).date()
     create_ft_notification_status(bst_date=last_status_date, template=sample_template)
 
-    last_used_date = dao_get_last_date_template_was_used(
-        template_id=sample_template.id, service_id=sample_template.service_id
-    )
+    last_used_date = dao_get_last_date_template_was_used(sample_template)
     assert last_used_date == last_status_date
 
 
@@ -18,9 +16,7 @@ def test_dao_get_last_date_template_was_used_only_searches_within_one_year(sampl
     last_status_date = (datetime.now(UTC) - timedelta(days=400)).date()
     create_ft_notification_status(bst_date=last_status_date, template=sample_template)
 
-    last_used_date = dao_get_last_date_template_was_used(
-        template_id=sample_template.id, service_id=sample_template.service_id
-    )
+    last_used_date = dao_get_last_date_template_was_used(sample_template)
     assert last_used_date is None
 
 
@@ -30,13 +26,9 @@ def test_dao_get_last_date_template_was_used_returns_created_at_from_notificatio
 
     last_status_date = (datetime.now(UTC).replace(tzinfo=None) - timedelta(days=2)).date()
     create_ft_notification_status(bst_date=last_status_date, template=sample_template)
-    last_used_date = dao_get_last_date_template_was_used(
-        template_id=sample_template.id, service_id=sample_template.service_id
-    )
+    last_used_date = dao_get_last_date_template_was_used(sample_template)
     assert last_used_date == last_notification_date
 
 
 def test_dao_get_last_date_template_was_used_returns_none_if_never_used(sample_template):
-    assert not dao_get_last_date_template_was_used(
-        template_id=sample_template.id, service_id=sample_template.service_id
-    )
+    assert not dao_get_last_date_template_was_used(sample_template)


### PR DESCRIPTION
Beyond last midnight we should have a record of any notifications in `ft_notification_status`, which should be faster to search (if it isn't, we can address that easily). As long as we ensure we can search notifications in `created_at` order (hence targeting it at a specific index), we can avoid scanning old, cache-cold rows.

Taking the template instance as an argument allows us to extract all the field values we need to fill out these queries while maintaining a convenient calling interface.