### PR TITLE
Add new task for generating fake letter responses

### DIFF
--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -1,15 +1,16 @@
 import json
 import random
+import uuid
 from contextvars import ContextVar
 from datetime import datetime, timedelta
 
 import requests
-from flask import current_app
+from flask import current_app, jsonify
 from notifications_utils.local_vars import LazyLocalGetter
 from notifications_utils.s3 import s3upload
 from werkzeug.local import LocalProxy
 
-from app import memo_resetters, notify_celery
+from app import memo_resetters, notify_celery, signing
 from app.aws.s3 import file_exists
 from app.celery.process_ses_receipts_tasks import process_ses_results
 from app.config import QueueNames
@@ -59,6 +60,69 @@ def send_email_response(reference, to):
         body = ses_notification_callback(reference)
 
     process_ses_results.apply_async([body], queue=QueueNames.RESEARCH_MODE)
+
+
+def send_letter_response(notification_id: uuid.UUID, billable_units: int, postage: str):
+    signed_notification_id = signing.encode(str(notification_id))
+    api_call = (
+        f"{current_app.config['API_HOST_NAME_INTERNAL']}/notifications/letter/status?token={signed_notification_id}"
+    )
+
+    headers = {"Content-type": "application/json"}
+    data = _create_fake_letter_callback_data(notification_id, billable_units, postage)
+
+    try:
+        response = requests_session.request("POST", api_call, headers=headers, data=json.dumps(data), timeout=30)
+        response.raise_for_status()
+    except requests.HTTPError as e:
+        current_app.logger.error("API POST request on %s failed with status %s", api_call, e.response.status_code)
+        raise e
+    finally:
+        current_app.logger.info("Mocked letter callback request for %s finished", notification_id)
+
+    return jsonify(result="success"), 200
+
+
+def _create_fake_letter_callback_data(notification_id: uuid.UUID, billable_units: int, postage: str):
+    if postage == "first":
+        postage = "1ST"
+        mailing_product = "UNCODED"
+    elif postage == "second":
+        postage = "2ND"
+        mailing_product = "MM"
+    elif postage == "europe":
+        postage = "INTERNATIONAL"
+        mailing_product = "INT EU"
+    else:
+        postage = "INTERNATIONAL"
+        mailing_product = "INT ROW"
+
+    return {
+        "id": "1234",
+        "source": "dvla:resource:osl:print:print-hub-fulfilment:5.18.0",
+        "specVersion": "1",
+        "type": "uk.gov.dvla.osl.osldatadictionaryschemas.print.messages.v2.PrintJobStatus",
+        "time": "2024-04-01T00:00:00Z",
+        "dataContentType": "application/json",
+        "dataSchema": "https://osl-data-dictionary-schemas.engineering.dvla.gov.uk/print/messages/v2/print-job-status.json",
+        "data": {
+            "despatchProperties": [
+                {"key": "totalSheets", "value": str(billable_units)},
+                {"key": "postageClass", "value": postage},
+                {"key": "mailingProduct", "value": mailing_product},
+                {"key": "productionRunDate", "value": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")},
+            ],
+            "jobId": str(notification_id),
+            "jobType": "NOTIFY",
+            "jobStatus": "DESPATCHED",
+            "templateReference": "NOTIFY",
+        },
+        "metadata": {
+            "handler": {"urn": "dvla:resource:osl:print:print-hub-fulfilment:5.18.0"},
+            "origin": {"urn": "dvla:resource:osg:dev:printhub:1.0.1"},
+            "correlationId": "b5d9b2bd-6e8f-4275-bdd3-c8086fe09c52",
+        },
+    }
 
 
 def make_request(notification_type, provider, data, headers):
@@ -151,6 +215,17 @@ def create_fake_letter_response_file(self, reference):
 def _fake_sns_s3_callback(filename):
     message_contents = '{"Records":[{"s3":{"object":{"key":"%s"}}}]}' % (filename)  # noqa
     return json.dumps({"Type": "Notification", "MessageId": "some-message-id", "Message": message_contents})
+
+
+@notify_celery.task(bind=True, name="create-fake-letter-callback", max_retries=3, default_retry_delay=60)
+def create_fake_letter_callback(self, notification_id: uuid.UUID, billable_units: int, postage: str):
+    try:
+        send_letter_response(notification_id, billable_units, postage)
+    except Exception:
+        try:
+            self.retry()
+        except self.MaxRetriesExceededError:
+            current_app.logger.warning("Fake letter callback cound not be created for %s", notification_id)
 
 
 def ses_notification_callback(reference):

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -4,6 +4,8 @@ from unittest.mock import ANY
 import pytest
 from flask import json
 
+from app.celery.letters_pdf_tasks import get_pdf_for_templated_letter
+from app.celery.research_mode_tasks import create_fake_letter_response_file
 from app.config import QueueNames
 from app.constants import (
     EMAIL_TYPE,
@@ -238,7 +240,7 @@ def test_post_letter_notification_throws_error_for_bad_address(
 
 
 def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_delivered(
-    notify_api, api_client_request, sample_letter_template, mocker
+    notify_api, api_client_request, sample_letter_template, mock_celery_task
 ):
     data = {
         "template_id": str(sample_letter_template.id),
@@ -252,10 +254,8 @@ def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_d
         "reference": "foo",
     }
 
-    fake_create_letter_task = mocker.patch("app.celery.letters_pdf_tasks.get_pdf_for_templated_letter.apply_async")
-    fake_create_dvla_response_task = mocker.patch(
-        "app.celery.research_mode_tasks.create_fake_letter_response_file.apply_async"
-    )
+    fake_create_letter_task = mock_celery_task(get_pdf_for_templated_letter)
+    fake_create_dvla_response_task = mock_celery_task(create_fake_letter_response_file)
 
     with set_config_values(notify_api, {"SEND_LETTERS_ENABLED": True}):
         api_client_request.post(
@@ -275,7 +275,7 @@ def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_d
 
 
 def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_sending_and_sends_fake_response_file(
-    notify_api, api_client_request, sample_letter_template, mocker
+    notify_api, api_client_request, sample_letter_template, mock_celery_task
 ):
     data = {
         "template_id": str(sample_letter_template.id),
@@ -289,10 +289,8 @@ def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_s
         "reference": "foo",
     }
 
-    fake_create_letter_task = mocker.patch("app.celery.letters_pdf_tasks.get_pdf_for_templated_letter.apply_async")
-    fake_create_dvla_response_task = mocker.patch(
-        "app.celery.research_mode_tasks.create_fake_letter_response_file.apply_async"
-    )
+    fake_create_letter_task = mock_celery_task(get_pdf_for_templated_letter)
+    fake_create_dvla_response_task = mock_celery_task(create_fake_letter_response_file)
     with set_config_values(notify_api, {"SEND_LETTERS_ENABLED": False}):
         api_client_request.post(
             sample_letter_template.service_id,


### PR DESCRIPTION
We want to mark a letter as being delivered if it's sent using a test key and the `SEND_LETTERS_ENABLED` flag is False. This was being done by putting a fake response file in S3, but now that we are removing the code related to response files we can no longer use this method. This adds a task to create a fake callback instead.

In later PRs, we will then start using the new task and delete the code related to response files.