### PR TITLE
Prevent duplicate unsubscribe requests

### DIFF
--- a/app/dao/unsubscribe_request_dao.py
+++ b/app/dao/unsubscribe_request_dao.py
@@ -22,7 +22,7 @@ def create_unsubscribe_request_dao(unsubscribe_data):
 
 
 def get_unsubscribe_request_by_notification_id_dao(notification_id):
-    return UnsubscribeRequest.query.filter_by(notification_id=notification_id).one()
+    return UnsubscribeRequest.query.filter_by(notification_id=notification_id).one_or_none()
 
 
 def get_unsubscribe_requests_statistics_dao(service_id):

--- a/tests/app/one_click_unsubscribe/test_one_click_unsubscribe.py
+++ b/tests/app/one_click_unsubscribe/test_one_click_unsubscribe.py
@@ -39,7 +39,7 @@ def test_valid_one_click_unsubscribe_url(mocker, client, sample_email_notificati
     ]
 
 
-def test_duplicate_unsubscribe_requets(mocker, client, sample_email_notification):
+def test_duplicate_unsubscribe_requests(mocker, client, sample_email_notification):
     token = generate_token(
         sample_email_notification.to, current_app.config["SECRET_KEY"], current_app.config["DANGEROUS_SALT"]
     )

--- a/tests/app/one_click_unsubscribe/test_one_click_unsubscribe.py
+++ b/tests/app/one_click_unsubscribe/test_one_click_unsubscribe.py
@@ -1,13 +1,16 @@
 import uuid
 from unittest.mock import call
 
+import pytest
 from flask import current_app
 from notifications_utils.url_safe_token import generate_token
 
 from app.constants import EMAIL_TYPE
 from app.dao.templates_dao import dao_update_template
 from app.dao.unsubscribe_request_dao import get_unsubscribe_request_by_notification_id_dao
-from tests.app.db import create_notification, create_template
+from app.models import UnsubscribeRequest
+from app.one_click_unsubscribe.rest import is_duplicate_unsubscribe_request
+from tests.app.db import create_notification, create_template, create_unsubscribe_request_and_return_the_notification_id
 
 
 def unsubscribe_url_post(client, notification_id, token):
@@ -34,6 +37,21 @@ def test_valid_one_click_unsubscribe_url(mocker, client, sample_email_notificati
         call(f"service-{sample_email_notification.service.id}-unsubscribe-request-statistics"),
         call(f"service-{sample_email_notification.service.id}-unsubscribe-request-reports-summary"),
     ]
+
+
+def test_duplicate_unsubscribe_requets(mocker, client, sample_email_notification):
+    token = generate_token(
+        sample_email_notification.to, current_app.config["SECRET_KEY"], current_app.config["DANGEROUS_SALT"]
+    )
+    # first unsubscribe request
+    unsubscribe_url_post(client, sample_email_notification.id, token)
+    # duplicate unsubscribe request
+    unsubscribe_url_post(client, sample_email_notification.id, token)
+
+    result = UnsubscribeRequest.query.filter_by(notification_id=sample_email_notification.id).all()
+
+    # The duplicate unsubscribe request shouldn't be added to the unsubscribe_request table
+    assert len(result) == 1
 
 
 def test_unsubscribe_request_object_refers_to_correct_template_version_after_template_updated(client, sample_service):
@@ -119,3 +137,26 @@ def test_invalid_one_click_unsubscribe_url_notification_id(client, sample_email_
     response_json_data = response.get_json()
     assert response.status_code == 404
     assert response_json_data["message"] == {"unsubscribe request": "This is not a valid unsubscribe link."}
+
+
+@pytest.mark.parametrize(
+    "create_previous_unsubscribe_request,is_batched, processed_by_service, expected_result",
+    [(False, False, False, False), (True, True, True, False), (True, False, False, True), (True, True, False, True)],
+)
+def test_is_duplicate_unsubscribe_request(
+    sample_service,
+    sample_email_template,
+    create_previous_unsubscribe_request,
+    is_batched,
+    processed_by_service,
+    expected_result,
+):
+    if create_previous_unsubscribe_request:
+        notification_id = create_unsubscribe_request_and_return_the_notification_id(
+            sample_service, sample_email_template, is_batched, processed_by_service
+        )
+    else:
+        notification_id = uuid.uuid4()
+
+    result = is_duplicate_unsubscribe_request(notification_id)
+    assert result == expected_result


### PR DESCRIPTION
This PR prevents duplicate unsubscribe requests.

A previously mereged [PR](https://github.com/alphagov/notifications-api/pull/4298) was reverted because functional tests had to be updated first.

Reverts alphagov/notifications-api#4299