### PR TITLE
`FactNotificationStatus`: add index on `template_id`, `bst_date`

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2218,6 +2218,14 @@ class FactNotificationStatus(db.Model):
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
 
+    __table_args__ = (
+        Index(
+            "ix_ft_notification_status_template_id_bst_date",
+            "template_id",
+            "bst_date",
+        ),
+    )
+
     __extended_statistics__ = (
         # dependencies
         ("st_dep_ft_notification_status_service_id_job_id", ("service_id", "job_id"), ("dependencies",)),

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0481_receipt_service_live_req
+0482_ft_ntfcn_stat_tpt_date_idx

--- a/migrations/versions/0482_ft_ntfcn_stat_tpt_date_idx.py
+++ b/migrations/versions/0482_ft_ntfcn_stat_tpt_date_idx.py
@@ -1,0 +1,27 @@
+"""
+Create Date: 2024-12-10 13:12:35.576446
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0482_ft_ntfcn_stat_tpt_date_idx"
+down_revision = "0481_receipt_service_live_req"
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_ft_notification_status_template_id_bst_date",
+            "ft_notification_status",
+            ["template_id", "bst_date"],
+            if_not_exists=True,
+            unique=False,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index("ix_ft_notification_status_template_id_bst_date", table_name="ft_notification_status")


### PR DESCRIPTION
Aimed at improving search time of `dao_get_last_date_template_was_used`. See also https://github.com/alphagov/notifications-api/pull/4300