### PR TITLE
Start using new task to generate fake letter callbacks

### DIFF
--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -221,7 +221,7 @@ def _fake_sns_s3_callback(filename):
 def create_fake_letter_callback(self, notification_id: uuid.UUID, billable_units: int, postage: str):
     try:
         send_letter_response(notification_id, billable_units, postage)
-    except Exception:
+    except requests.HTTPError:
         try:
             self.retry()
         except self.MaxRetriesExceededError:

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -17,7 +17,7 @@ from app.celery.letters_pdf_tasks import (
     get_pdf_for_templated_letter,
     sanitise_letter,
 )
-from app.celery.research_mode_tasks import create_fake_letter_response_file
+from app.celery.research_mode_tasks import create_fake_letter_callback
 from app.clients.document_download import DocumentDownloadError
 from app.config import QueueNames, TaskNames
 from app.constants import (
@@ -331,7 +331,10 @@ def process_letter_notification(
     get_pdf_for_templated_letter.apply_async([str(notification.id)], queue=queue)
 
     if test_key and not current_app.config["SEND_LETTERS_ENABLED"]:
-        create_fake_letter_response_file.apply_async((notification.reference,), queue=queue)
+        create_fake_letter_callback.apply_async(
+            [notification.id, notification.billable_units, notification.postage],
+            queue=queue,
+        )
 
     resp = create_response_for_post_notification(
         notification_id=notification.id,

--- a/tests/app/celery/test_research_mode_tasks.py
+++ b/tests/app/celery/test_research_mode_tasks.py
@@ -262,7 +262,7 @@ def test_create_fake_letter_callback_sends_letter_response(
 
 
 def test_create_fake_letter_callback_retries(notify_api, fake_uuid, mocker):
-    mocker.patch("app.celery.research_mode_tasks.send_letter_response", side_effect=Exception())
+    mocker.patch("app.celery.research_mode_tasks.send_letter_response", side_effect=requests.HTTPError())
     mock_retry = mocker.patch("app.celery.research_mode_tasks.create_fake_letter_callback.retry")
 
     create_fake_letter_callback(uuid.UUID(fake_uuid), 2, "second")
@@ -271,7 +271,7 @@ def test_create_fake_letter_callback_retries(notify_api, fake_uuid, mocker):
 
 
 def test_create_fake_letter_callback_logs_if_max_retries_exceeded(notify_api, fake_uuid, caplog, mocker):
-    mocker.patch("app.celery.research_mode_tasks.send_letter_response", side_effect=Exception())
+    mocker.patch("app.celery.research_mode_tasks.send_letter_response", side_effect=requests.HTTPError())
     mocker.patch(
         "app.celery.research_mode_tasks.create_fake_letter_callback.retry", side_effect=MaxRetriesExceededError()
     )

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -5,7 +5,7 @@ import pytest
 from flask import json
 
 from app.celery.letters_pdf_tasks import get_pdf_for_templated_letter
-from app.celery.research_mode_tasks import create_fake_letter_response_file
+from app.celery.research_mode_tasks import create_fake_letter_callback
 from app.config import QueueNames
 from app.constants import (
     EMAIL_TYPE,
@@ -255,7 +255,7 @@ def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_d
     }
 
     fake_create_letter_task = mock_celery_task(get_pdf_for_templated_letter)
-    fake_create_dvla_response_task = mock_celery_task(create_fake_letter_response_file)
+    fake_create_dvla_response_task = mock_celery_task(create_fake_letter_callback)
 
     with set_config_values(notify_api, {"SEND_LETTERS_ENABLED": True}):
         api_client_request.post(
@@ -290,7 +290,7 @@ def test_post_letter_notification_with_test_key_creates_pdf_and_sets_status_to_s
     }
 
     fake_create_letter_task = mock_celery_task(get_pdf_for_templated_letter)
-    fake_create_dvla_response_task = mock_celery_task(create_fake_letter_response_file)
+    fake_create_dvla_response_task = mock_celery_task(create_fake_letter_callback)
     with set_config_values(notify_api, {"SEND_LETTERS_ENABLED": False}):
         api_client_request.post(
             sample_letter_template.service_id,


### PR DESCRIPTION
The `create-fake-letter-callback` task was [previously added to the code](https://github.com/alphagov/notifications-api/pull/4303), this change starts using it to generate fake letter responses.

The exception it catches has been changed from to `HTTPError`, since `Exception` was not specific enough.