### PR TITLE
`dao_get_notification_outcomes_for_job`: omit redundant `service_id` condition

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -30,10 +30,10 @@ from app.models import (
 from app.utils import midnight_n_days_ago
 
 
-def dao_get_notification_outcomes_for_job(service_id, job_id):
+def dao_get_notification_outcomes_for_job(job_id):
     notification_statuses = (
         db.session.query(func.count(Notification.status).label("count"), Notification.status)
-        .filter(Notification.service_id == service_id, Notification.job_id == job_id)
+        .filter(Notification.job_id == job_id)
         .group_by(Notification.status)
         .all()
     )
@@ -44,7 +44,7 @@ def dao_get_notification_outcomes_for_job(service_id, job_id):
                 FactNotificationStatus.notification_count.label("count"),
                 FactNotificationStatus.notification_status.label("status"),
             )
-            .filter(FactNotificationStatus.service_id == service_id, FactNotificationStatus.job_id == job_id)
+            .filter(FactNotificationStatus.job_id == job_id)
             .all()
         )
     return notification_statuses

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -50,7 +50,7 @@ register_errors(job_blueprint)
 @job_blueprint.route("/<job_id>", methods=["GET"])
 def get_job_by_service_and_job_id(service_id, job_id):
     job = dao_get_job_by_service_id_and_job_id(service_id, job_id)
-    statistics = dao_get_notification_outcomes_for_job(service_id, job_id)
+    statistics = dao_get_notification_outcomes_for_job(job_id)
     data = job_schema.dump(job)
 
     data["statistics"] = [{"status": statistic[1], "count": statistic[0]} for statistic in statistics]
@@ -227,7 +227,7 @@ def get_paginated_jobs(
             statistics = fetch_notification_statuses_for_job(job_data["id"])
         else:
             # notifications table
-            statistics = dao_get_notification_outcomes_for_job(service_id, job_data["id"])
+            statistics = dao_get_notification_outcomes_for_job(job_data["id"])
         job_data["statistics"] = [{"status": statistic.status, "count": statistic.count} for statistic in statistics]
 
     return {

--- a/app/upload/rest.py
+++ b/app/upload/rest.py
@@ -58,7 +58,7 @@ def get_paginated_uploads(service_id, limit_days, page):
                 statistics = fetch_notification_statuses_for_job(upload.id)
             else:
                 # notifications table
-                statistics = dao_get_notification_outcomes_for_job(service_id, upload.id)
+                statistics = dao_get_notification_outcomes_for_job(upload.id)
             upload_dict["statistics"] = [
                 {"status": statistic.status, "count": statistic.count} for statistic in statistics
             ]

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -38,7 +38,7 @@ def test_should_count_of_statuses_for_notifications_associated_with_job(sample_t
     create_notification(sample_template, job=sample_job, status="sending")
     create_notification(sample_template, job=sample_job, status="delivered")
 
-    results = dao_get_notification_outcomes_for_job(sample_template.service_id, sample_job.id)
+    results = dao_get_notification_outcomes_for_job(sample_job.id)
     assert {row.status: row.count for row in results} == {
         "created": 3,
         "sending": 1,
@@ -47,7 +47,7 @@ def test_should_count_of_statuses_for_notifications_associated_with_job(sample_t
 
 
 def test_should_return_zero_length_array_if_no_notifications_for_job(sample_service, sample_job):
-    assert len(dao_get_notification_outcomes_for_job(sample_job.id, sample_service.id)) == 0
+    assert len(dao_get_notification_outcomes_for_job(sample_service.id)) == 0
 
 
 def test_should_return_notifications_only_for_this_job(sample_template):
@@ -57,19 +57,8 @@ def test_should_return_notifications_only_for_this_job(sample_template):
     create_notification(sample_template, job=job_1, status="created")
     create_notification(sample_template, job=job_2, status="sent")
 
-    results = dao_get_notification_outcomes_for_job(sample_template.service_id, job_1.id)
+    results = dao_get_notification_outcomes_for_job(job_1.id)
     assert {row.status: row.count for row in results} == {"created": 1}
-
-
-def test_should_return_notifications_only_for_this_service(sample_notification_with_job):
-    other_service = create_service(service_name="one")
-    other_template = create_template(service=other_service)
-    other_job = create_job(other_template)
-
-    create_notification(other_template, job=other_job)
-
-    assert len(dao_get_notification_outcomes_for_job(sample_notification_with_job.service_id, other_job.id)) == 0
-    assert len(dao_get_notification_outcomes_for_job(other_service.id, sample_notification_with_job.id)) == 0
 
 
 def test_create_sample_job(sample_template):


### PR DESCRIPTION
This is called repeatedly by `get_uploads_by_service`.

Filtering by `service_id` makes postgres use two indexes rather than one, resulting in a more complex query that touches more data.

(incidentally, it does this because multi-column statistics have limitations with nullable columns - otherwise I'd hope postgres' extended statistics for the notifications table would see that a simple filter in an index scan would probably remove 0 rows)

The added safety of filtering these results by service is a nice-to-have but I'd argue here we're only returning aggregated counts, not including any sensitive data, which hugely limits the worst-case-scenario.

It's hard to get exact performance figures for queries like this that "warm up" very quickly, but an `EXPLAIN (ANALYZE, BUFFERS) ...` showed that the new query touches about half the number of storage blocks than the previous did (cached or uncached).