### PR TITLE
`Notification`: remove `ix_notifications_service_id_composite` index

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1466,7 +1466,6 @@ class Notification(db.Model):
         UniqueConstraint("job_id", "job_row_number", name="uq_notifications_job_row_number"),
         Index("ix_notifications_notification_type_composite", "notification_type", "status", "created_at"),
         Index("ix_notifications_service_created_at", "service_id", "created_at"),
-        Index("ix_notifications_service_id_composite", "service_id", "notification_type", "status", "created_at"),
         Index("ix_notifications_service_id_ntype_created_at", "service_id", "notification_type", "created_at"),
         # unsubscribe_link value should be null for non-email notifications
         CheckConstraint(

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0482_ft_ntfcn_stat_tpt_date_idx
+0483_rm_ntfcn_service_composite

--- a/migrations/versions/0483_rm_ntfcn_service_composite.py
+++ b/migrations/versions/0483_rm_ntfcn_service_composite.py
@@ -1,0 +1,32 @@
+"""
+Create Date: 2024-12-13 10:26:32.802054
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0483_rm_ntfcn_service_composite"
+down_revision = "0482_ft_ntfcn_stat_tpt_date_idx"
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_notifications_service_id_composite",
+            table_name="notifications",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_notifications_service_id_composite",
+            "notifications",
+            ["service_id", "notification_type", "notification_status", "created_at"],
+            if_not_exists=True,
+            unique=False,
+            postgresql_concurrently=True,
+        )


### PR DESCRIPTION
The vast majority of uses of this index have been taken over by `ix_notifications_service_id_ntype_created_at` - let's see if we can do without it.