### PR TITLE
Drop `daily_sorted_letter` table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2148,19 +2148,6 @@ class AuthType(db.Model):
     name = db.Column(db.String, primary_key=True)
 
 
-class DailySortedLetter(db.Model):
-    __tablename__ = "daily_sorted_letter"
-
-    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    billing_day = db.Column(db.Date, nullable=False, index=True)
-    file_name = db.Column(db.String, nullable=True)
-    unsorted_count = db.Column(db.Integer, nullable=False, default=0)
-    sorted_count = db.Column(db.Integer, nullable=False, default=0)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
-
-    __table_args__ = (UniqueConstraint("file_name", "billing_day", name="uix_file_name_billing_day"),)
-
-
 class FactBillingLetterDespatch(db.Model):
     __tablename__ = "ft_billing_letter_despatch"
 

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0483_rm_ntfcn_service_composite
+0484_rm_daily_sorted_letter

--- a/migrations/versions/0484_rm_daily_sorted_letter.py
+++ b/migrations/versions/0484_rm_daily_sorted_letter.py
@@ -1,0 +1,30 @@
+"""
+Create Date: 2024-12-17 15:12:04.205888
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0484_rm_daily_sorted_letter"
+down_revision = "0483_rm_ntfcn_service_composite"
+
+
+def upgrade():
+    op.drop_index("ix_daily_sorted_letter_billing_day", table_name="daily_sorted_letter")
+    op.drop_table("daily_sorted_letter")
+
+
+def downgrade():
+    op.create_table(
+        "daily_sorted_letter",
+        sa.Column("id", postgresql.UUID(), autoincrement=False, nullable=False),
+        sa.Column("billing_day", sa.DATE(), autoincrement=False, nullable=False),
+        sa.Column("unsorted_count", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column("sorted_count", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column("updated_at", postgresql.TIMESTAMP(), autoincrement=False, nullable=True),
+        sa.Column("file_name", sa.VARCHAR(), autoincrement=False, nullable=True),
+        sa.PrimaryKeyConstraint("id", name="daily_sorted_letter_pkey"),
+        sa.UniqueConstraint("file_name", "billing_day", name="uix_file_name_billing_day"),
+    )
+    op.create_index("ix_daily_sorted_letter_billing_day", "daily_sorted_letter", ["billing_day"], unique=False)


### PR DESCRIPTION
We stopped writing to this table when we started receiving letter delivery status via HTTPS callback instead of via response files in S3. However, since 2023 we've been using the `ft_billing_letter_despatch` table for letter billing and to store more detailed information about which letters were classed as `sorted` vs `unsorted` so this data is not needed.