### PR TITLE
Stop SMS from starting with the service name by default

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -539,7 +539,7 @@ class Service(db.Model, Versioned):
     restricted = db.Column(db.Boolean, index=False, unique=False, nullable=False)
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=False)
     created_by = db.relationship("User", foreign_keys=[created_by_id])
-    prefix_sms = db.Column(db.Boolean, nullable=False, default=True)
+    prefix_sms = db.Column(db.Boolean, nullable=False, default=False)
     organisation_type = db.Column(
         db.String(255),
         db.ForeignKey("organisation_types.name"),

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -106,7 +106,7 @@ def test_create_service(notify_db_session):
     assert service_db.name == "service name"
     assert service_db.id == service.id
     assert service_db.email_sender_local_part == "service.name"
-    assert service_db.prefix_sms is True
+    assert service_db.prefix_sms is False
     assert service.active is True
     assert user in service_db.users
     assert service_db.organisation_type == "central"
@@ -133,7 +133,7 @@ def test_create_service_with_organisation(notify_db_session):
     organisation = Organisation.query.get(organisation.id)
     assert service_db.name == "service_name"
     assert service_db.id == service.id
-    assert service_db.prefix_sms is True
+    assert service_db.prefix_sms is False
     assert service.active is True
     assert user in service_db.users
     assert service_db.organisation_type == "local"

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -132,7 +132,7 @@ def test_should_send_personalised_template_to_correct_sms_provider_and_persist(s
 
     mmg_client.send_sms.assert_called_once_with(
         to="447234123123",
-        content="Sample service: Hello Jo\nHere is <em>some HTML</em> & entities",
+        content="Hello Jo\nHere is <em>some HTML</em> & entities",
         reference=str(db_notification.id),
         sender=current_app.config["FROM_NUMBER"],
         international=False,

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -250,7 +250,7 @@ def test_get_service_by_id(admin_request, sample_service):
     assert json_resp["data"]["name"] == sample_service.name
     assert json_resp["data"]["id"] == str(sample_service.id)
     assert json_resp["data"]["email_branding"] is None
-    assert json_resp["data"]["prefix_sms"] is True
+    assert json_resp["data"]["prefix_sms"] is False
     assert json_resp["data"]["allowed_broadcast_provider"] is None
     assert json_resp["data"]["broadcast_channel"] is None
 


### PR DESCRIPTION
For new services, text messages now won't start with the service name by default. The setting to start text messages with the service name can still be toggled on or off on the settings page.

https://trello.com/c/gSnH4310/1093-switch-off-start-text-messages-with-service-name-by-default