### PR TITLE
export flask env vars to ensure subshells pick them up

### DIFF
--- a/scripts/test_sql_migration_downgrade.sh
+++ b/scripts/test_sql_migration_downgrade.sh
@@ -4,8 +4,9 @@ set -Eeuo pipefail
 BOLDGREEN="\033[1;32m"
 ENDCOLOR="\033[0m"
 
-FLASK_APP="application.py"
-NOTIFY_ENVIRONMENT="development"
+# need to export these for the `flask db heads` subshell to pick them up
+export FLASK_APP="application.py"
+export NOTIFY_ENVIRONMENT="development"
 MIGRATION_TEST_DATABASE_DB_NAME="migration_test"
 
 MIGRATION_TEST_DATABASE_URI=${SQLALCHEMY_DATABASE_URI:-"postgresql://postgres:postgres@localhost/"}


### PR DESCRIPTION
`flask db heads` was failing on concourse becasue it couldn't find the FLASK_APP environment variable

Turns out, `$(<command>)` executes its contents inside a subshell

subshells are passed in any variables that were defined with `export`.

if the variable was just defined FOO=bar, then subshells won't receive that variable, UNLESS it's a simple bash function like `$(echo $FOO)`

this means that those FLASK_APP and NOTIFY_ENVIRONMENT will be set in whatever shell you call ./scripts/test_sql_migration_downgrade.sh from, but that's just a sacrifice we have to make to ensure that the script works