### PR TITLE
always provide URI for psql

### DIFF
--- a/scripts/test_sql_migration_downgrade.sh
+++ b/scripts/test_sql_migration_downgrade.sh
@@ -27,8 +27,8 @@ fi
 echo "Testing migrations on ${MIGRATION_TEST_DATABASE_URI}"
 
 # delete any existing test DB
-psql -c "drop database ${MIGRATION_TEST_DATABASE_DB_NAME}" || true
-psql -c "create database ${MIGRATION_TEST_DATABASE_DB_NAME}"
+psql $MIGRATION_TEST_DATABASE_URI -c "drop database ${MIGRATION_TEST_DATABASE_DB_NAME}" || true
+psql $MIGRATION_TEST_DATABASE_URI -c "create database ${MIGRATION_TEST_DATABASE_DB_NAME}"
 
 echo -e "${BOLDGREEN}======== running upgrade (logs hidden) ========${ENDCOLOR}"
 
@@ -42,6 +42,6 @@ SQLALCHEMY_DATABASE_URI=$MIGRATION_TEST_DATABASE_URI flask db downgrade $CURRENT
 echo -e "${BOLDGREEN}============ running upgrade again ============${ENDCOLOR}"
 SQLALCHEMY_DATABASE_URI=$MIGRATION_TEST_DATABASE_URI flask db upgrade
 
-psql -c "drop database ${MIGRATION_TEST_DATABASE_DB_NAME}"
+psql $MIGRATION_TEST_DATABASE_URI -c "drop database ${MIGRATION_TEST_DATABASE_DB_NAME}"
 
 echo -e "${BOLDGREEN}=================== success ===================${ENDCOLOR}"


### PR DESCRIPTION
psql by default connects to a socket /var/run/postgresql/.s.PGSQL.5432 This checks the auth of the linux user running psql (in our docker images, root) and tries to find a matching user in the database. We only have a postgres database user however, so this fails in docker.

If we pass psql a URI that includes a username and password, it'll use those to connect instead, allowing us to succeed