### PR TITLE
Bump utils to 92.0.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.1
+# This file was automatically copied from notifications-utils@92.0.2
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.0
+# This file was automatically copied from notifications-utils@92.0.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.1
+# This file was automatically copied from notifications-utils@92.0.2
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.0
+# This file was automatically copied from notifications-utils@92.0.1
 
 [tool.black]
 line-length = 120

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ lxml==4.9.3
 notifications-python-client==8.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@92.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@92.0.2
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ lxml==4.9.3
 notifications-python-client==8.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@92.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@92.0.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ bcrypt==4.0.0
     # via flask-bcrypt
 billiard==4.2.0
     # via celery
-blinker==1.6.2
+blinker==1.9.0
     # via
     #   flask
     #   gds-metrics
@@ -30,7 +30,7 @@ botocore==1.34.100
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.3
+cachetools==5.5.0
     # via notifications-utils
 celery==5.4.0
     # via
@@ -66,7 +66,7 @@ docopt==0.6.2
     # via notifications-python-client
 eventlet==0.35.2
     # via gunicorn
-flask==3.0.0
+flask==3.1.0
     # via
     #   flask-bcrypt
     #   flask-marshmallow
@@ -92,7 +92,7 @@ fqdn==1.5.1
     # via jsonschema
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.in
-govuk-bank-holidays==0.14
+govuk-bank-holidays==0.15
     # via notifications-utils
 greenlet==3.0.3
     # via eventlet
@@ -108,7 +108,7 @@ iso8601==1.1.0
     # via -r requirements.in
 isoduration==20.11.0
     # via jsonschema
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via
     #   flask
     #   notifications-utils
@@ -147,7 +147,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55cb9e55d4916334ff599201b881a39c412e15cb
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@7793546055d819904c76da73628b64d3eda255c4
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -155,7 +155,7 @@ packaging==23.2
     # via
     #   marshmallow
     #   marshmallow-sqlalchemy
-phonenumbers==8.13.48
+phonenumbers==8.13.52
     # via notifications-utils
 prometheus-client==0.14.1
     # via
@@ -186,9 +186,9 @@ python-dateutil==2.8.2
     #   celery
 python-json-logger==2.0.7
     # via notifications-utils
-pytz==2024.1
+pytz==2024.2
     # via notifications-utils
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via notifications-utils
 redis==4.5.4
     # via flask-redis
@@ -204,7 +204,7 @@ rfc3987==1.3.8
     # via jsonschema
 s3transfer==0.10.1
     # via boto3
-segno==1.5.2
+segno==1.6.1
     # via notifications-utils
 sentry-sdk==1.38.0
     # via -r requirements.in
@@ -247,5 +247,5 @@ wcwidth==0.2.5
     # via prompt-toolkit
 webcolors==1.12
     # via jsonschema
-werkzeug==3.0.3
+werkzeug==3.1.3
     # via flask

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -36,7 +36,7 @@ billiard==4.2.0
     #   celery
 black==24.10.0
     # via -r requirements_for_test_common.in
-blinker==1.6.2
+blinker==1.9.0
     # via
     #   -r requirements.txt
     #   flask
@@ -52,7 +52,7 @@ botocore==1.34.100
     #   boto3
     #   moto
     #   s3transfer
-cachetools==5.3.3
+cachetools==5.5.0
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -117,7 +117,7 @@ execnet==2.1.1
     # via pytest-xdist
 flaky==3.8.0
     # via -r requirements_for_test.in
-flask==3.0.0
+flask==3.1.0
     # via
     #   -r requirements.txt
     #   flask-bcrypt
@@ -147,7 +147,7 @@ freezegun==1.5.1
     # via -r requirements_for_test_common.in
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.txt
-govuk-bank-holidays==0.14
+govuk-bank-holidays==0.15
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -170,7 +170,7 @@ iso8601==1.1.0
     # via -r requirements.txt
 isoduration==20.11.0
     # via -r requirements.txt
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via
     #   -r requirements.txt
     #   flask
@@ -223,7 +223,7 @@ mypy-extensions==1.0.0
     # via black
 notifications-python-client==8.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55cb9e55d4916334ff599201b881a39c412e15cb
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@7793546055d819904c76da73628b64d3eda255c4
     # via -r requirements.txt
 ordered-set==4.1.0
     # via
@@ -238,7 +238,7 @@ packaging==23.2
     #   pytest
 pathspec==0.12.1
     # via black
-phonenumbers==8.13.48
+phonenumbers==8.13.52
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -303,11 +303,11 @@ python-json-logger==2.0.7
     # via
     #   -r requirements.txt
     #   notifications-utils
-pytz==2024.1
+pytz==2024.2
     # via
     #   -r requirements.txt
     #   notifications-utils
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -339,7 +339,7 @@ s3transfer==0.10.1
     # via
     #   -r requirements.txt
     #   boto3
-segno==1.5.2
+segno==1.6.1
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -399,7 +399,7 @@ wcwidth==0.2.5
     #   prompt-toolkit
 webcolors==1.12
     # via -r requirements.txt
-werkzeug==3.0.3
+werkzeug==3.1.3
     # via
     #   -r requirements.txt
     #   flask

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.1
+# This file was automatically copied from notifications-utils@92.0.2
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.0
+# This file was automatically copied from notifications-utils@92.0.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4


### PR DESCRIPTION
 ## 92.0.2

* Downgrade minimum version of `requests` to 2.32.3

## 92.0.1

* Bumps core dependencies to latest versions

 ## 92.0.0

* Restores old validation code so later utils changes can be added to api, admin etc.

 ## 91.1.2

* Adds rule N804 (invalid-first-argument-name-for-class-method) to linter config

 ## 91.1.1

* Remove hangul filler character from rendered emails

 ## 91.1.0

* bump all libs in requirements_for_test_common.in

 ## 91.0.4

* Don’t copy config when bumping utils version

 ## 91.0.3

* Fix validating supported international country codes for phone numbers without a leading "+" that look a bit like UK numbers

 ## 91.0.2

* Bumps requests to newer version

 ## 91.0.1

* Adds public utility method to check if a phonenumber is international (with correct handling for OFCOM TV numbers)
* Updates PhoneNumber.get_international_phone_info to return the correct info for OFCOM TV numbers

 ## 91.0.0

* BREAKING CHANGE: All standalone functions for validating, normalising and formatting phone numbers has been removed from notifications_utils/recipient_validation/phone_number.py, and are replaced and encapsualated entirely with a single `PhoneNumber` class. All code that relies on validation, normalisation or fomratting of a phone number must be re-written to use instances of `PhoneNumber` instead.

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/90.0.0...92.0.2