### PR TITLE
Purge seeded user for functional tests

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -58,7 +58,7 @@ from app.dao.services_dao import (
 )
 from app.dao.templates_dao import dao_create_template, dao_get_template_by_id
 from app.dao.users_dao import (
-    delete_model_user,
+    delete_user_and_all_associated_db_objects,
     delete_user_verify_codes,
     get_user_by_email,
 )
@@ -149,7 +149,7 @@ def purge_functional_test_data(user_email_prefix):
 
                 print(f"Deleting user {usr.id} which is not part of any services")
                 delete_user_verify_codes(usr)
-                delete_model_user(usr)
+                delete_user_and_all_associated_db_objects(usr)
 
 
 @notify_command()

--- a/app/commands.py
+++ b/app/commands.py
@@ -153,6 +153,33 @@ def purge_functional_test_data(user_email_prefix):
 
 
 @notify_command()
+@click.option(
+    "-s",
+    "--service-id",
+    required=True,
+    help="""
+    Service id of the functional test seeded service
+""",
+)
+def delete_functional_test_service(service_id):
+    """
+    Removes a service, designed to be used on the functional tests seeded service.
+    After the services is deleted, also deletes any users who are now orphaned
+    """
+    service = dao_fetch_service_by_id(service_id)
+    users = list(service.users)
+    print(f"Deleting service {service.id} {service.name}")
+    delete_service_and_all_associated_db_objects(service)
+
+    for user in users:
+        print(len(user.services), user.services)
+        if not user.services:
+            print(f"Deleting user {user.id} {user.email_address}")
+            delete_user_verify_codes(user)
+            delete_user_and_all_associated_db_objects(user)
+
+
+@notify_command()
 def backfill_notification_statuses():
     """
     DEPRECATED. Populates notification_status.

--- a/app/commands.py
+++ b/app/commands.py
@@ -128,7 +128,7 @@ def purge_functional_test_data(user_email_prefix):
         # Make sure the full email includes a uuid in it
         # Just in case someone decides to use a similar email address.
         try:
-            uuid.UUID(usr.email_address.split("@")[0].split("+")[1])
+            uuid.UUID(usr.email_address.split("@")[0].split("+")[-1])
         except ValueError:
             print(f"Skipping {usr.email_address} as the user email doesn't contain a UUID.")
         else:

--- a/app/commands.py
+++ b/app/commands.py
@@ -133,23 +133,21 @@ def purge_functional_test_data(user_email_prefix):
             print(f"Skipping {usr.email_address} as the user email doesn't contain a UUID.")
         else:
             services = dao_fetch_all_services_by_user(usr.id)
-            if services:
-                print(f"Deleting user {usr.id} which is part of services")
-                for service in services:
-                    delete_service_and_all_associated_db_objects(service)
-            else:
-                services_created_by_this_user = dao_fetch_all_services_created_by_user(usr.id)
-                if services_created_by_this_user:
-                    # user is not part of any services but may still have been the one to create the service
-                    # sometimes things get in this state if the tests fail half way through
-                    # Remove the service they created (but are not a part of) so we can then remove the user
-                    print(f"Deleting services created by {usr.id}")
-                    for service in services_created_by_this_user:
-                        delete_service_and_all_associated_db_objects(service)
+            for service in services:
+                print(f"Deleting service {service.id=} {service.name=} that {usr.id} belongs to")
+                delete_service_and_all_associated_db_objects(service)
 
-                print(f"Deleting user {usr.id} which is not part of any services")
-                delete_user_verify_codes(usr)
-                delete_user_and_all_associated_db_objects(usr)
+            services_created_by_this_user = dao_fetch_all_services_created_by_user(usr.id)
+            for service in services_created_by_this_user:
+                # user may still have been the one to create the service
+                # sometimes things get in this state if the tests fail half way through
+                # Remove the service they created (but are not a part of) so we can then remove the user
+                print(f"Deleting service {service.id=} {service.name=} created by {usr.id}")
+                delete_service_and_all_associated_db_objects(service)
+
+            print(f"Deleting user {usr.id} which is not part of any services")
+            delete_user_verify_codes(usr)
+            delete_user_and_all_associated_db_objects(usr)
 
 
 @notify_command()

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -32,6 +32,8 @@ from app.models import (
     ApiKey,
     FactBilling,
     InboundNumber,
+    InboundSms,
+    InboundSmsHistory,
     InvitedUser,
     Job,
     Notification,
@@ -41,6 +43,7 @@ from app.models import (
     Service,
     ServiceContactList,
     ServiceEmailReplyTo,
+    ServiceInboundApi,
     ServiceLetterContact,
     ServicePermission,
     ServiceSmsSender,
@@ -353,9 +356,12 @@ def delete_service_and_all_associated_db_objects(service):
     subq = db.session.query(Template.id).filter_by(service=service).subquery()
     _delete_commit(TemplateRedacted.query.filter(TemplateRedacted.template_id.in_(subq)))
 
+    _delete_commit(InboundSms.query.filter_by(service=service))
+    _delete_commit(InboundSmsHistory.query.filter_by(service=service))
+    _delete_commit(ServiceInboundApi.query.filter_by(service=service))
+
     _delete_commit(ServiceSmsSender.query.filter_by(service=service))
     _delete_commit(ServiceEmailReplyTo.query.filter_by(service=service))
-    _delete_commit(ServiceLetterContact.query.filter_by(service=service))
     _delete_commit(ServiceContactList.query.filter_by(service=service))
     _delete_commit(InvitedUser.query.filter_by(service=service))
     _delete_commit(Permission.query.filter_by(service=service))
@@ -364,6 +370,7 @@ def delete_service_and_all_associated_db_objects(service):
     _delete_commit(Job.query.filter_by(service=service))
     _delete_commit(Template.query.filter_by(service=service))
     _delete_commit(TemplateHistory.query.filter_by(service_id=service.id))
+    _delete_commit(ServiceLetterContact.query.filter_by(service=service))
     _delete_commit(ServicePermission.query.filter_by(service_id=service.id))
     _delete_commit(ApiKey.query.filter_by(service=service))
     _delete_commit(ApiKey.get_history_model().query.filter_by(service_id=service.id))

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -349,45 +349,40 @@ def dao_remove_user_from_service(service, user):
 
 
 def delete_service_and_all_associated_db_objects(service):
-    def _delete_commit(query):
+    def _delete(query):
         query.delete(synchronize_session=False)
-        db.session.commit()
 
     subq = db.session.query(Template.id).filter_by(service=service).subquery()
-    _delete_commit(TemplateRedacted.query.filter(TemplateRedacted.template_id.in_(subq)))
+    _delete(TemplateRedacted.query.filter(TemplateRedacted.template_id.in_(subq)))
 
-    _delete_commit(InboundSms.query.filter_by(service=service))
-    _delete_commit(InboundSmsHistory.query.filter_by(service=service))
-    _delete_commit(ServiceInboundApi.query.filter_by(service=service))
+    _delete(InboundSms.query.filter_by(service=service))
+    _delete(InboundSmsHistory.query.filter_by(service=service))
+    _delete(ServiceInboundApi.query.filter_by(service=service))
 
-    _delete_commit(ServiceSmsSender.query.filter_by(service=service))
-    _delete_commit(ServiceEmailReplyTo.query.filter_by(service=service))
-    _delete_commit(ServiceContactList.query.filter_by(service=service))
-    _delete_commit(InvitedUser.query.filter_by(service=service))
-    _delete_commit(Permission.query.filter_by(service=service))
-    _delete_commit(NotificationHistory.query.filter_by(service=service))
-    _delete_commit(Notification.query.filter_by(service=service))
-    _delete_commit(Job.query.filter_by(service=service))
-    _delete_commit(Template.query.filter_by(service=service))
-    _delete_commit(TemplateHistory.query.filter_by(service_id=service.id))
-    _delete_commit(ServiceLetterContact.query.filter_by(service=service))
-    _delete_commit(ServicePermission.query.filter_by(service_id=service.id))
-    _delete_commit(ApiKey.query.filter_by(service=service))
-    _delete_commit(ApiKey.get_history_model().query.filter_by(service_id=service.id))
-    _delete_commit(AnnualBilling.query.filter_by(service_id=service.id))
+    _delete(ServiceSmsSender.query.filter_by(service=service))
+    _delete(ServiceEmailReplyTo.query.filter_by(service=service))
+    _delete(ServiceContactList.query.filter_by(service=service))
+    _delete(InvitedUser.query.filter_by(service=service))
+    _delete(Permission.query.filter_by(service=service))
+    _delete(NotificationHistory.query.filter_by(service=service))
+    _delete(Notification.query.filter_by(service=service))
+    _delete(Job.query.filter_by(service=service))
+    _delete(Template.query.filter_by(service=service))
+    _delete(TemplateHistory.query.filter_by(service_id=service.id))
+    _delete(ServiceLetterContact.query.filter_by(service=service))
+    _delete(ServicePermission.query.filter_by(service_id=service.id))
+    _delete(ApiKey.query.filter_by(service=service))
+    _delete(ApiKey.get_history_model().query.filter_by(service_id=service.id))
+    _delete(AnnualBilling.query.filter_by(service_id=service.id))
 
     verify_codes = VerifyCode.query.join(User).filter(User.id.in_([x.id for x in service.users]))
     list(map(db.session.delete, verify_codes))
-    db.session.commit()
     users = list(service.users)
     for user in users:
         user.organisations = []
         service.users.remove(user)
-    _delete_commit(Service.get_history_model().query.filter_by(id=service.id))
+    _delete(Service.get_history_model().query.filter_by(id=service.id))
     db.session.delete(service)
-    db.session.commit()
-    for user in users:
-        db.session.delete(user)
     db.session.commit()
 
 

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -349,6 +349,10 @@ def dao_remove_user_from_service(service, user):
 
 
 def delete_service_and_all_associated_db_objects(service):
+    """
+    To be used with functional test services only! This irrevocably deletes data, use with extreme caution!
+    """
+
     def _delete(query):
         query.delete(synchronize_session=False)
 
@@ -360,6 +364,7 @@ def delete_service_and_all_associated_db_objects(service):
     _delete(ServiceInboundApi.query.filter_by(service=service))
 
     _delete(ServiceSmsSender.query.filter_by(service=service))
+    _delete(InboundNumber.query.filter_by(service=service))
     _delete(ServiceEmailReplyTo.query.filter_by(service=service))
     _delete(ServiceContactList.query.filter_by(service=service))
     _delete(InvitedUser.query.filter_by(service=service))
@@ -381,8 +386,10 @@ def delete_service_and_all_associated_db_objects(service):
     for user in users:
         user.organisations = []
         service.users.remove(user)
+
     _delete(Service.get_history_model().query.filter_by(id=service.id))
-    db.session.delete(service)
+    _delete(Service.query.filter_by(id=service.id))
+
     db.session.commit()
 
 

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -742,11 +742,12 @@ def test_delete_service_and_associated_objects(notify_db_session):
     assert Job.query.count() == 0
     assert Notification.query.count() == 0
     assert Permission.query.count() == 0
-    assert User.query.count() == 0
     assert InvitedUser.query.count() == 0
     assert Service.query.count() == 0
     assert Service.get_history_model().query.count() == 0
     assert ServicePermission.query.count() == 0
+    # we don't delete users as part of this function (see delete_user_and_all_associated_db_objects)
+    assert User.query.count() == 1
     # the organisation hasn't been deleted
     assert Organisation.query.count() == 1
 


### PR DESCRIPTION
i've tested this locally (and you can to!)


```sh
SQLALCHEMY_DATABASE_URI="postgresql://notify:notify@localhost:5433/notification_api" flask command functional-test-fixtures

psql postgresql://notify:notify@localhost:5433/notification_api -c "select id from services where id != 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'"

SQLALCHEMY_DATABASE_URI="postgresql://notify:notify@localhost:5433/notification_api" flask command delete-functional-test-service --service-id <id from prev thing>
```

this is idempotentish - in that you can then create fixtures successfully again, and then tear them down successfully.

my ambition is to run this on preview 💣 🚮 