### PR TITLE
Remove cffi from production dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,6 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements.in
 
-cffi==1.15.1
 celery[sqs]==5.4.0
 Flask-Bcrypt==1.0.1
 flask-marshmallow==0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,8 +40,6 @@ certifi==2023.7.22
     # via
     #   requests
     #   sentry-sdk
-cffi==1.15.1
-    # via -r requirements.in
 charset-normalizer==2.1.1
     # via requests
 click==8.1.3
@@ -163,8 +161,6 @@ prompt-toolkit==3.0.31
     # via click-repl
 psycopg2-binary==2.9.6
     # via -r requirements.in
-pycparser==2.21
-    # via cffi
 pycurl==7.44.1
     # via
     #   celery

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -64,9 +64,7 @@ certifi==2023.7.22
     #   requests
     #   sentry-sdk
 cffi==1.15.1
-    # via
-    #   -r requirements.txt
-    #   cryptography
+    # via cryptography
 charset-normalizer==2.1.1
     # via
     #   -r requirements.txt
@@ -255,9 +253,7 @@ prompt-toolkit==3.0.31
 psycopg2-binary==2.9.6
     # via -r requirements.txt
 pycparser==2.21
-    # via
-    #   -r requirements.txt
-    #   cffi
+    # via cffi
 pycurl==7.44.1
     # via -r requirements.txt
 pyjwt==2.5.0


### PR DESCRIPTION
We don’t use this directly in our application code.

Looks like it’s only a subdependency of our test code (via `cryptography` and then `moto`).

We can remove the line which specifies it and let pip’s dependency resolution handle which versions we need and where.

***

We pinned this in 2017 because a later version failed to build:  https://github.com/alphagov/notifications-api/commit/c362bd06b0e6c111a523af0f339471dbf91474f2

In 2018 a newer version fixed this failure but we never removed the pin: https://github.com/alphagov/notifications-api/pull/1718/commits/a29f4ed117dc7fc19eaee58abf22cfc06b00af4f