### PR TITLE
Bump non-SQLAlchemy dependencies to latest versions

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,23 +4,23 @@
 cffi==1.15.1
 celery[sqs]==5.4.0
 Flask-Bcrypt==1.0.1
-flask-marshmallow==0.14.0
+flask-marshmallow==1.3.0
 Flask-Migrate==3.1.0
 flask-sqlalchemy==3.0.2
 click-datetime==0.2
 # We originally pinned this due to eventlet v0.33 compatibility issues. That was supposedly fixed in version v21.0.0 and we merged v21.2.0 for a while. Until we ran a load test again, and identified that the bumped version of gunicorn led to a 33%+ drop-off in performance/requests per second that the API was able to handle. If a version greater than 21.2.0 is released, and it either gives us something we need or we think it addresses said performance issues, make sure to run a load test in staging before releasing to production.
 gunicorn[eventlet] @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
-iso8601==1.1.0
-jsonschema[format]==4.16.0
+iso8601==2.1.0
+jsonschema[format]==4.23.0
 marshmallow-sqlalchemy==0.28.1
 marshmallow==3.18.0
 # Requests pinned to 2.32.2 until https://github.com/psf/requests/issues/6730 is fixed. Once so, we can remove this pin
 requests==2.32.2
-psycopg2-binary==2.9.6
-PyJWT==2.5.0
+psycopg2-binary==2.9.10
+PyJWT==2.10.0
 SQLAlchemy==1.4.41
 
-notifications-python-client==8.0.1
+notifications-python-client==10.0.1
 
 # Run `make bump-utils` to update to the latest version
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@92.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,10 @@ arrow==1.2.3
     # via isoduration
 async-timeout==4.0.3
     # via redis
-attrs==22.1.0
-    # via jsonschema
+attrs==24.3.0
+    # via
+    #   jsonschema
+    #   referencing
 awscrt==0.20.9
     # via botocore
 bcrypt==4.0.0
@@ -78,7 +80,7 @@ flask==3.1.0
     #   sentry-sdk
 flask-bcrypt==1.0.1
     # via -r requirements.in
-flask-marshmallow==0.14.0
+flask-marshmallow==1.3.0
     # via -r requirements.in
 flask-migrate==3.1.0
     # via -r requirements.in
@@ -104,7 +106,7 @@ idna==3.7
     # via
     #   jsonschema
     #   requests
-iso8601==1.1.0
+iso8601==2.1.0
     # via -r requirements.in
 isoduration==20.11.0
     # via jsonschema
@@ -122,8 +124,10 @@ jmespath==1.0.1
     #   botocore
 jsonpointer==2.3
     # via jsonschema
-jsonschema==4.16.0
+jsonschema==4.23.0
     # via -r requirements.in
+jsonschema-specifications==2024.10.1
+    # via jsonschema
 kombu==5.3.7
     # via celery
 mako==1.2.3
@@ -143,7 +147,7 @@ marshmallow-sqlalchemy==0.28.1
     # via -r requirements.in
 mistune==0.8.4
     # via notifications-utils
-notifications-python-client==8.0.1
+notifications-python-client==10.0.1
     # via -r requirements.in
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@7793546055d819904c76da73628b64d3eda255c4
     # via -r requirements.in
@@ -161,7 +165,7 @@ prometheus-client==0.14.1
     #   gds-metrics
 prompt-toolkit==3.0.31
     # via click-repl
-psycopg2-binary==2.9.6
+psycopg2-binary==2.9.10
     # via -r requirements.in
 pycparser==2.21
     # via cffi
@@ -169,14 +173,12 @@ pycurl==7.44.1
     # via
     #   celery
     #   kombu
-pyjwt==2.5.0
+pyjwt==2.10.0
     # via
     #   -r requirements.in
     #   notifications-python-client
 pypdf==3.17.0
     # via notifications-utils
-pyrsistent==0.18.1
-    # via jsonschema
 python-dateutil==2.8.2
     # via
     #   arrow
@@ -190,6 +192,10 @@ pyyaml==6.0.2
     # via notifications-utils
 redis==4.5.4
     # via flask-redis
+referencing==0.35.1
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.32.2
     # via
     #   -r requirements.in
@@ -200,6 +206,10 @@ rfc3339-validator==0.1.4
     # via jsonschema
 rfc3987==1.3.8
     # via jsonschema
+rpds-py==0.22.3
+    # via
+    #   jsonschema
+    #   referencing
 s3transfer==0.10.1
     # via boto3
 segno==1.6.1
@@ -211,7 +221,6 @@ setuptools==75.6.0
 six==1.16.0
     # via
     #   click-repl
-    #   flask-marshmallow
     #   python-dateutil
     #   rfc3339-validator
 smartypants==2.0.1

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -16,10 +16,11 @@ async-timeout==4.0.3
     # via
     #   -r requirements.txt
     #   redis
-attrs==22.1.0
+attrs==24.3.0
     # via
     #   -r requirements.txt
     #   jsonschema
+    #   referencing
 awscrt==0.20.9
     # via
     #   -r requirements.txt
@@ -129,7 +130,7 @@ flask==3.1.0
     #   notifications-utils
 flask-bcrypt==1.0.1
     # via -r requirements.txt
-flask-marshmallow==0.14.0
+flask-marshmallow==1.3.0
     # via -r requirements.txt
 flask-migrate==3.1.0
     # via -r requirements.txt
@@ -166,7 +167,7 @@ idna==3.7
     #   trustme
 iniconfig==2.0.0
     # via pytest
-iso8601==1.1.0
+iso8601==2.1.0
     # via -r requirements.txt
 isoduration==20.11.0
     # via -r requirements.txt
@@ -188,8 +189,12 @@ jmespath==1.0.1
     #   botocore
 jsonpointer==2.3
     # via -r requirements.txt
-jsonschema==4.16.0
+jsonschema==4.23.0
     # via -r requirements.txt
+jsonschema-specifications==2024.10.1
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 kombu==5.3.7
     # via
     #   -r requirements.txt
@@ -219,7 +224,7 @@ moto==5.0.11
     # via -r requirements_for_test.in
 mypy-extensions==1.0.0
     # via black
-notifications-python-client==8.0.1
+notifications-python-client==10.0.1
     # via -r requirements.txt
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@7793546055d819904c76da73628b64d3eda255c4
     # via -r requirements.txt
@@ -252,7 +257,7 @@ prompt-toolkit==3.0.31
     # via
     #   -r requirements.txt
     #   click-repl
-psycopg2-binary==2.9.6
+psycopg2-binary==2.9.10
     # via -r requirements.txt
 pycparser==2.21
     # via
@@ -260,7 +265,7 @@ pycparser==2.21
     #   cffi
 pycurl==7.44.1
     # via -r requirements.txt
-pyjwt==2.5.0
+pyjwt==2.10.0
     # via
     #   -r requirements.txt
     #   notifications-python-client
@@ -268,10 +273,6 @@ pypdf==3.17.0
     # via
     #   -r requirements.txt
     #   notifications-utils
-pyrsistent==0.18.1
-    # via
-    #   -r requirements.txt
-    #   jsonschema
 pytest==8.3.4
     # via
     #   -r requirements_for_test_common.in
@@ -314,6 +315,11 @@ redis==4.5.4
     # via
     #   -r requirements.txt
     #   flask-redis
+referencing==0.35.1
+    # via
+    #   -r requirements.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.32.2
     # via
     #   -r requirements.txt
@@ -331,6 +337,11 @@ rfc3339-validator==0.1.4
     # via -r requirements.txt
 rfc3987==1.3.8
     # via -r requirements.txt
+rpds-py==0.22.3
+    # via
+    #   -r requirements.txt
+    #   jsonschema
+    #   referencing
 ruff==0.8.2
     # via -r requirements_for_test_common.in
 s3transfer==0.10.1
@@ -351,7 +362,6 @@ six==1.16.0
     # via
     #   -r requirements.txt
     #   click-repl
-    #   flask-marshmallow
     #   python-dateutil
     #   rfc3339-validator
 smartypants==2.0.1

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3991,7 +3991,7 @@ ServiceJoinRequestTestCase = namedtuple(
             service_id=uuid.uuid4(),
             contacted_user_ids=[],
             expected_status_code=400,
-            expected_response="contacted_user_ids [] is too short",
+            expected_response="contacted_user_ids [] should be non-empty",
         ),
         ServiceJoinRequestTestCase(
             requester_id=None,

--- a/tests/app/template_folder/test_template_folder_rest.py
+++ b/tests/app/template_folder/test_template_folder_rest.py
@@ -232,7 +232,7 @@ def test_update_template_folder_users(admin_request, sample_service):
     [
         ({}, "name is a required property"),
         ({"name": None}, "name None is not of type string"),
-        ({"name": ""}, "name  is too short"),
+        ({"name": ""}, "name  should be non-empty"),
     ],
 )
 def test_update_template_folder_fails_if_missing_name(admin_request, sample_service, data, err):

--- a/tests/app/webauthn/test_rest.py
+++ b/tests/app/webauthn/test_rest.py
@@ -74,7 +74,7 @@ def test_create_webauthn_credential_returns_201(admin_request, sample_user):
         # name is null
         ({"name": None, "credential_data": "ABC123"}, "name None is not of type string"),
         # name is empty
-        ({"name": "", "credential_data": "ABC123"}, "name  is too short"),
+        ({"name": "", "credential_data": "ABC123"}, "name  should be non-empty"),
     ],
 )
 def test_create_webauthn_credential_errors_if_schema_violation(admin_request, sample_user, data, err_msg):
@@ -111,7 +111,7 @@ def test_update_webauthn_credential_returns_200(admin_request, sample_user):
         # name is null
         ({"name": None}, "name None is not of type string"),
         # name is empty
-        ({"name": ""}, "name  is too short"),
+        ({"name": ""}, "name  should be non-empty"),
     ],
 )
 def test_update_webauthn_credential_errors_if_schema_violation(admin_request, sample_user, data, err_msg):


### PR DESCRIPTION
SQLAlchemy and it’s related dependencies have more breaking and interdependent changes which will take time to unpick.

These changes are straightforward and don’t seem to break things.

There are some changes to error messages from JSONSchema but these are ok because:
- they’re only on our internal APIs
- the admin app doesn’t seem to be parsing the content of these error messages: https://github.com/search?q=repo%3Aalphagov%2Fnotifications-admin%20%22is%20too%20short%22&type=code