### PR TITLE
Bump Flask-SQLAlchemy to highest version that supports SQLAlchemy 1.x

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ celery[sqs]==5.4.0
 Flask-Bcrypt==1.0.1
 flask-marshmallow==0.14.0
 Flask-Migrate==3.1.0
-flask-sqlalchemy==3.0.2
+flask-sqlalchemy==3.0.5
 click-datetime==0.2
 # We originally pinned this due to eventlet v0.33 compatibility issues. That was supposedly fixed in version v21.0.0 and we merged v21.2.0 for a while. Until we ran a load test again, and identified that the bumped version of gunicorn led to a 33%+ drop-off in performance/requests per second that the API was able to handle. If a version greater than 21.2.0 is released, and it either gives us something we need or we think it addresses said performance issues, make sure to run a load test in staging before releasing to production.
 gunicorn[eventlet] @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,7 +84,7 @@ flask-migrate==3.1.0
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils
-flask-sqlalchemy==3.0.2
+flask-sqlalchemy==3.0.5
     # via
     #   -r requirements.in
     #   flask-migrate

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -137,7 +137,7 @@ flask-redis==0.4.0
     # via
     #   -r requirements.txt
     #   notifications-utils
-flask-sqlalchemy==3.0.2
+flask-sqlalchemy==3.0.5
     # via
     #   -r requirements.txt
     #   flask-migrate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,9 @@ def _notify_db(notify_api, worker_id):
     # create a database for this worker thread -
     current_app.config["SQLALCHEMY_DATABASE_URI"] = db_uri
 
+    # get rid of the old SQLAlchemy instance because we can’t have multiple on the same app
+    notify_api.extensions.pop("sqlalchemy")
+
     # reinitalise the db so it picks up on the new test database name
     db.init_app(notify_api)
     create_test_db(current_app.config["SQLALCHEMY_DATABASE_URI"])


### PR DESCRIPTION
3.1 and higher require SQLAlchemy 2.x which we don’t want to upgrade to yet: https://flask-sqlalchemy.readthedocs.io/en/stable/changes/#version-3-1-0

3.0.3 introduced a check to make sure an app can’t have multiple SQLAlchemy instances bound to it: https://github.com/pallets-eco/flask-sqlalchemy/pull/1151

We were falling foul of this check, so let’s make sure we have an entirely fresh instance of SQLAlchemy for each test.

This doesn’t seem to have a performance implication on how long the tests take to run.