### PR TITLE
Remove nvm

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -162,16 +162,3 @@ RUN \
 RUN \
     service postgresql start \
     && su - postgres -c "psql -c \"alter user postgres with password 'postgres';\""
-
-
-ENV NODE_VERSION=20.10.0
-ENV NVM_VERSION=0.39.7
-
-RUN \
-    echo "Installing NVM & Node" \
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | bash \
-    && source ~/.nvm/nvm.sh \
-    && nvm install $NODE_VERSION \
-    && npm install -g squawk-cli@1.1.0
-
-ENV PATH=/root/.nvm/versions/node/v${NODE_VERSION}/bin:$PATH

--- a/requirements_for_test.in
+++ b/requirements_for_test.in
@@ -5,3 +5,4 @@ flaky==3.8.0
 moto==5.0.11
 pytest-httpserver==1.0.8
 trustme==0.9.0
+squawk-cli==1.4.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -366,6 +366,8 @@ sqlalchemy==1.4.41
     #   alembic
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
+squawk-cli==1.4.0
+    # via -r requirements_for_test.in
 statsd==4.0.1
     # via
     #   -r requirements.txt


### PR DESCRIPTION
The change is part of the removing nvm as part of ITHC report. More details on [this card](https://trello.com/c/jFpYYlGh/1087-remove-nvm-from-docker-images-verify-shell-script-before-executing). We use node only for `squawk-cli` so removing the installation via npm and installing via pip/uv.

squawk-migration-check has been successful with this change.
<img width="320" alt="image" src="https://github.com/user-attachments/assets/bd1e8d07-414c-4fd1-b039-e938860d6ce2" />
