### PR TITLE
Row numbers in Returned Letters Report to match row numbers

### DIFF
--- a/app/dao/returned_letters_dao.py
+++ b/app/dao/returned_letters_dao.py
@@ -107,7 +107,9 @@ def fetch_returned_letters(service_id, report_date):
                 User.name.label("user_name"),
                 User.email_address,
                 Job.original_file_name,
-                (table.job_row_number + 1).label("job_row_number"),  # row numbers start at 0
+                # row numbers in notifications db table start at 0, but in spreadsheet uploaded by service user
+                # the recipient rows would start at row 2 (row 1 is column headers).
+                (table.job_row_number + 2).label("job_row_number"),
             )
             .outerjoin(User, table.created_by_id == User.id)
             .outerjoin(Job, table.job_id == Job.id)

--- a/tests/app/dao/test_returned_letters_dao.py
+++ b/tests/app/dao/test_returned_letters_dao.py
@@ -270,7 +270,7 @@ def test_fetch_returned_letters_with_jobs(sample_letter_job):
         None,
         None,
         sample_letter_job.original_file_name,
-        21,
+        22,
     )
 
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3504,7 +3504,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[0]["template_version"] == sample_letter_template.version
     assert response[0]["user_name"] == sample_letter_template.service.users[0].name
     assert response[0]["original_file_name"] == job.original_file_name
-    assert response[0]["job_row_number"] == 3
+    assert response[0]["job_row_number"] == 4
     assert not response[0]["uploaded_letter_file_name"]
 
     assert response[1]["notification_id"] == str(one_off_letter.id)


### PR DESCRIPTION
in the spreadsheet with recipient data uploaded by service users when they sent the letters.

This far, there has been a mismatch:

When our service users send letters in bulk ia Notify page, they do so by uploading a spreadsheet with recipient data and persinalisation. Each row in the spreadsheet becomes a letter.

In such a spreadsheet, first row is for column headers - for example address_line_1, address_line_2, address_line_3, reference. Then recipient rows start from row 2.

When we save the rows in notifications table in our db, we start from index 0 for first recipient. That means that there is a mismatch of 2 rows between our db and the spreadsheet that has been uploaded.

When collating data for Returned Letters Report, for some reason we have been adding 1 to the db row number - which meant there was still a mismatch - this time by one row.

This commit fixes the mismatch - from now on, the row number we present in returned letters report will match the row number in the uploaded spreadsheet.