### PR TITLE
functional test fixtures: include multiple addresses for reply-to email testing

### DIFF
--- a/app/functional_tests_fixtures/__init__.py
+++ b/app/functional_tests_fixtures/__init__.py
@@ -272,6 +272,8 @@ export FUNCTIONAL_TESTS_SERVICE_API_TEST_KEY='{function_tests_test_key_name}-{se
 export FUNCTIONAL_TESTS_API_AUTH_SECRET='{current_app.config['INTERNAL_CLIENT_API_KEYS']['notify-functional-tests'][0]}'
 
 export FUNCTIONAL_TESTS_SERVICE_EMAIL_REPLY_TO='{test_email_username}+{environment}-reply-to@{email_domain}'
+export FUNCTIONAL_TESTS_SERVICE_EMAIL_REPLY_TO_2='{test_email_username}+{environment}-reply-to+2@{email_domain}'
+export FUNCTIONAL_TESTS_SERVICE_EMAIL_REPLY_TO_3='{test_email_username}+{environment}-reply-to+3@{email_domain}'
 export FUNCTIONAL_TESTS_SERVICE_INBOUND_NUMBER='07700900500'
 
 export FUNCTIONAL_TEST_SMS_TEMPLATE_ID='{sms_template.id}'

--- a/tests/app/functional_test_fixtures/test_functional_test_fixtures.py
+++ b/tests/app/functional_test_fixtures/test_functional_test_fixtures.py
@@ -77,6 +77,14 @@ def test_function_test_fixtures_apply(notify_api, notify_db_session, notify_serv
                 variables["FUNCTIONAL_TESTS_SERVICE_EMAIL_REPLY_TO"]
                 == "notify-tests-preview+dev-env-reply-to@digital.cabinet-office.gov.uk"
             )
+            assert (
+                variables["FUNCTIONAL_TESTS_SERVICE_EMAIL_REPLY_TO_2"]
+                == "notify-tests-preview+dev-env-reply-to+2@digital.cabinet-office.gov.uk"
+            )
+            assert (
+                variables["FUNCTIONAL_TESTS_SERVICE_EMAIL_REPLY_TO_3"]
+                == "notify-tests-preview+dev-env-reply-to+3@digital.cabinet-office.gov.uk"
+            )
             assert variables["FUNCTIONAL_TESTS_SERVICE_INBOUND_NUMBER"] == "07700900500"
             assert "FUNCTIONAL_TEST_SMS_TEMPLATE_ID" in variables
             assert "FUNCTIONAL_TEST_EMAIL_TEMPLATE_ID" in variables


### PR DESCRIPTION
https://trello.com/c/8kQqSeHv/974-enable-the-functional-tests-smoke-tests-provider-tests-in-the-new-deploy-pipeline-on-staging-and-make-sure-they-pass

With these extra env vars set, using https://github.com/alphagov/notifications-functional-tests/pull/555 with `FUNCTIONAL_TESTS_ENABLE_EDIT_REPLY_TO` explicitly set, this allows `test_can_add_and_update_reply_to` to _actually_ pass on dev (and presumably other) environments (rather than just saying it passed having just omitted the body of the test): https://concourse.notify.tools/teams/dev-a/pipelines/deploy-notify/jobs/test/builds/217#L677f545d:54

See also https://concourse.notify.tools/teams/dev-a/pipelines/deploy-notify/jobs/test/builds/215#L677f4457:48, the result of doing the above without this change.

Simply appending `+2` etc. to the email address follows the pattern of what `credentials/functional-tests/preview-functional` appears to do.. and it seems to work.