### PR TITLE
Remove redudant db commit when getting serialised service

### DIFF
--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -12,7 +12,7 @@ from notifications_utils.serialised_model import (
 )
 from werkzeug.utils import cached_property
 
-from app import db, redis_store
+from app import redis_store
 from app.dao.api_key_dao import get_model_api_keys
 from app.dao.services_dao import dao_fetch_service_by_id
 
@@ -67,7 +67,6 @@ class SerialisedTemplate(SerialisedModel):
         )
 
         template_dict = template_schema.dump(fetched_template)
-        db.session.commit()
 
         return {"data": template_dict}
 
@@ -99,7 +98,6 @@ class SerialisedService(SerialisedModel):
         from app.schemas import service_schema
 
         service_dict = service_schema.dump(dao_fetch_service_by_id(service_id))
-        db.session.commit()
 
         return {"data": service_dict}
 
@@ -127,5 +125,4 @@ class SerialisedAPIKeyCollection(SerialisedModelCollection):
         keys = [
             {k: getattr(key, k) for k in SerialisedAPIKey.__annotations__} for key in get_model_api_keys(service_id)
         ]
-        db.session.commit()
         return cls(keys)


### PR DESCRIPTION
We have investigated P1 504 outage and came across following possible issue. This PR is to remove db commit which was added previously to close the  transaction to improve the performance.

First we get redis error - [kibana](https://kibana.logit.io/s/9423a789-282c-4113-908d-0be3b1bc9d1d/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-7d,mode:quick,to:now))&_a=(columns:!(message,request_time,status),filters:!(),index:'8ac115c0-aac1-11e8-88ea-0383c11b333a',interval:auto,query:(language:kuery,query:'%22redis%20error%22'),sort:!('@timestamp',desc)))

then pg connection closed error - [kibana](https://kibana.logit.io/s/9423a789-282c-4113-908d-0be3b1bc9d1d/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-7d,mode:quick,to:now))&_a=(columns:!(message,request_time,status),filters:!(),index:'8ac115c0-aac1-11e8-88ea-0383c11b333a',interval:auto,query:(language:kuery,query:'%22connection%20already%20closed%22'),sort:!('@timestamp',desc)))

Possible scenario we found during the P1 504 outage:
- Redis get disconnected
-  We have [this service](https://kibana.logit.io/s/9423a789-282c-4113-908d-0be3b1bc9d1d/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-7d,mode:quick,to:now))&_a=(columns:!(message,request_time,status),filters:!(),index:'8ac115c0-aac1-11e8-88ea-0383c11b333a',interval:auto,query:(language:kuery,query:'%22api%20key%20not%20found%22%20and%20%227f266c24-ff07-474c-ab73-fe43745d3711%22'),sort:!('@timestamp',desc))) bombarding auth request (200-450 auth request per min) with incorrect token
- All these requests now go to postgres
- When getting serialised service to get api_key for auth, it also does unnecessary db.session.commit() ??
- At the same time RDS has 66% commit queries

![image](https://github.com/user-attachments/assets/1e93f7aa-7aa3-4cea-a771-0976389dbe69)
![image](https://github.com/user-attachments/assets/f1fbe326-cda3-404a-8f74-ed1fd00867cb)
![image](https://github.com/user-attachments/assets/2bd88522-f718-478b-8bcd-24de53cba1a1)
![image](https://github.com/user-attachments/assets/1609f827-0b07-420c-ba49-771913e275df)
