### PR TITLE
Bump gunicorn to 23.0.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,8 +7,6 @@ flask-marshmallow==1.3.0
 Flask-Migrate==3.1.0
 flask-sqlalchemy==3.0.5
 click-datetime==0.2
-# We originally pinned this due to eventlet v0.33 compatibility issues. That was supposedly fixed in version v21.0.0 and we merged v21.2.0 for a while. Until we ran a load test again, and identified that the bumped version of gunicorn led to a 33%+ drop-off in performance/requests per second that the API was able to handle. If a version greater than 21.2.0 is released, and it either gives us something we need or we think it addresses said performance issues, make sure to run a load test in staging before releasing to production.
-gunicorn[eventlet] @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
 iso8601==2.1.0
 jsonschema[format]==4.23.0
 marshmallow-sqlalchemy==0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -96,10 +96,8 @@ govuk-bank-holidays==0.15
     # via notifications-utils
 greenlet==3.0.3
     # via eventlet
-gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
-    # via
-    #   -r requirements.in
-    #   notifications-utils
+gunicorn==23.0.0
+    # via notifications-utils
 idna==3.7
     # via
     #   jsonschema
@@ -153,6 +151,7 @@ ordered-set==4.1.0
     # via notifications-utils
 packaging==23.2
     # via
+    #   gunicorn
     #   marshmallow
     #   marshmallow-sqlalchemy
 phonenumbers==8.13.52
@@ -212,8 +211,6 @@ segno==1.6.1
     # via notifications-utils
 sentry-sdk==1.38.0
     # via -r requirements.in
-setuptools==75.6.0
-    # via gunicorn
 six==1.16.0
     # via
     #   click-repl

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -154,7 +154,7 @@ greenlet==3.0.3
     # via
     #   -r requirements.txt
     #   eventlet
-gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
+gunicorn==23.0.0
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -234,6 +234,7 @@ packaging==23.2
     # via
     #   -r requirements.txt
     #   black
+    #   gunicorn
     #   marshmallow
     #   marshmallow-sqlalchemy
     #   pytest
@@ -350,10 +351,6 @@ segno==1.6.1
     #   notifications-utils
 sentry-sdk==1.38.0
     # via -r requirements.txt
-setuptools==75.6.0
-    # via
-    #   -r requirements.txt
-    #   gunicorn
 six==1.16.0
     # via
     #   -r requirements.txt


### PR DESCRIPTION
The API is using a version of Gunicorn which is 3 years and 6 months out of date.
https://github.com/benoitc/gunicorn/commit/1299ea9e967a61ae2edebe191082fd169b864c64

It has a high severity security vulnerability:
https://security.snyk.io/package/pip/gunicorn/21.0.0

Additionally, because we are referencing a dependency by SHA, Dependabot can’t work out what version we are using and doesn’t flag this vulnerability.

In order to deploy this we need to figure out:
- if we still expect the possibility of a performance regression
- how to test this