### PR TITLE
config: read `NOTIFY_LOG_LEVEL` and `NOTIFY_LOG_LEVEL_HANDLERS` env vars

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@93.0.0
+# This file was automatically copied from notifications-utils@93.1.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/config.py
+++ b/app/config.py
@@ -123,6 +123,9 @@ class Config:
     # Logging
     DEBUG = False
 
+    NOTIFY_LOG_LEVEL = os.getenv("NOTIFY_LOG_LEVEL", "INFO")
+    NOTIFY_LOG_LEVEL_HANDLERS = os.getenv("NOTIFY_LOG_LEVEL_HANDLERS", NOTIFY_LOG_LEVEL)
+
     NOTIFY_REQUEST_LOG_LEVEL = os.getenv("NOTIFY_REQUEST_LOG_LEVEL", "INFO")
 
     # Cronitor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@93.0.0
+# This file was automatically copied from notifications-utils@93.1.0
 
 [tool.black]
 line-length = 120

--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ SQLAlchemy==1.4.41
 notifications-python-client==10.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@93.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@93.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,7 +95,9 @@ gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6
 govuk-bank-holidays==0.15
     # via notifications-utils
 greenlet==3.0.3
-    # via eventlet
+    # via
+    #   eventlet
+    #   sqlalchemy
 gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
     # via
     #   -r requirements.in
@@ -147,7 +149,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@7322d3573eb54285166cae84da22edfae8067f02
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b5935835e099ef0cfcd099029e39f3eaca2b50a2
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -154,6 +154,7 @@ greenlet==3.0.3
     # via
     #   -r requirements.txt
     #   eventlet
+    #   sqlalchemy
 gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
     # via
     #   -r requirements.txt
@@ -224,7 +225,7 @@ mypy-extensions==1.0.0
     # via black
 notifications-python-client==10.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@7322d3573eb54285166cae84da22edfae8067f02
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b5935835e099ef0cfcd099029e39f3eaca2b50a2
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@93.0.0
+# This file was automatically copied from notifications-utils@93.1.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4


### PR DESCRIPTION
Depends on https://github.com/alphagov/notifications-utils/pull/1185

It would appear `NOTIFY_LOG_LEVEL` was previously not controllable via env vars.