### PR TITLE
Add returned letter callback type

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -276,6 +276,7 @@ class ServiceCallbackTypes(enum.StrEnum):
     delivery_status = "delivery_status"
     complaint = "complaint"
     returned_letters = "returned_letters"
+    inbound_sms = "inbound_sms"
 
 
 # Branding values

--- a/app/constants.py
+++ b/app/constants.py
@@ -268,7 +268,15 @@ VERIFY_CODE_TYPES = [EMAIL_TYPE, SMS_TYPE]
 # Service callbacks
 DELIVERY_STATUS_CALLBACK_TYPE = "delivery_status"
 COMPLAINT_CALLBACK_TYPE = "complaint"
-SERVICE_CALLBACK_TYPES = [DELIVERY_STATUS_CALLBACK_TYPE, COMPLAINT_CALLBACK_TYPE]
+RETURNED_LETTERS_CALLBACK = "returned_letters"
+SERVICE_CALLBACK_TYPES = [DELIVERY_STATUS_CALLBACK_TYPE, COMPLAINT_CALLBACK_TYPE, RETURNED_LETTERS_CALLBACK]
+
+
+class ServiceCallbackTypes(enum.StrEnum):
+    delivery_status = "delivery_status"
+    complaint = "complaint"
+    returned_letters = "returned_letters"
+
 
 # Branding values
 BRANDING_GOVUK = "govuk"  # Deprecated outside migrations

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0485_add_job_status_fin_allrws
+0486_insert_returned_letter

--- a/migrations/versions/0486_insert_returned_letter.py
+++ b/migrations/versions/0486_insert_returned_letter.py
@@ -5,8 +5,8 @@ Create Date: 2025-01-16 11:15:04.021579
 from alembic import op
 
 
-revision = '0486_insert_returned_letter'
-down_revision = '0485_add_job_status_fin_allrws'
+revision = "0486_insert_returned_letter"
+down_revision = "0485_add_job_status_fin_allrws"
 
 
 def upgrade():

--- a/migrations/versions/0486_insert_returned_letter.py
+++ b/migrations/versions/0486_insert_returned_letter.py
@@ -1,0 +1,19 @@
+"""
+Create Date: 2025-01-16 11:15:04.021579
+"""
+
+from alembic import op
+
+
+revision = '0486_insert_returned_letter'
+down_revision = '0485_add_job_status_fin_allrws'
+
+
+def upgrade():
+    insert_returned_letter_callback_type = "INSERT INTO service_callback_type VALUES ('returned_letters')"
+    op.execute(insert_returned_letter_callback_type)
+
+
+def downgrade():
+    delete_returned_letter_callback_type = "DELETE FROM service_callback_type WHERE name = 'returned_letters'"
+    op.execute(delete_returned_letter_callback_type)

--- a/migrations/versions/0486_insert_returned_letter.py
+++ b/migrations/versions/0486_insert_returned_letter.py
@@ -11,9 +11,13 @@ down_revision = "0485_add_job_status_fin_allrws"
 
 def upgrade():
     insert_returned_letter_callback_type = "INSERT INTO service_callback_type VALUES ('returned_letters')"
+    insert_inbound_sms_callback_type = "INSERT INTO service_callback_type VALUES ('inbound_sms')"
     op.execute(insert_returned_letter_callback_type)
+    op.execute(insert_inbound_sms_callback_type)
 
 
 def downgrade():
     delete_returned_letter_callback_type = "DELETE FROM service_callback_type WHERE name = 'returned_letters'"
+    delete_inbound_sms_callback_type = "DELETE FROM service_callback_type WHERE name = 'inbound_sms'"
     op.execute(delete_returned_letter_callback_type)
+    op.execute(delete_inbound_sms_callback_type)


### PR DESCRIPTION
This PR adds a new callback type `returned_letters` to the `service_callback_api` table described in [this](https://trello.com/c/5SuwTyC1/175-create-a-new-type-of-callback-in-service-callback-api-table-returnedletter) card.
It also adds an `inbound_sms` callback_type in preparation for future work to merge the service_inbound_api with the `service_callback_api` table.