### PR TITLE
remove functional test data

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -135,7 +135,12 @@ def purge_functional_test_data(user_email_prefix):
             services = dao_fetch_all_services_by_user(usr.id)
             for service in services:
                 print(f"Deleting service {service.id=} {service.name=} that {usr.id} belongs to")
-                delete_service_and_all_associated_db_objects(service)
+                # This also deletes the functional if the test users are associated
+                # It may require to create essential db object to run functional tests
+                if str(service.id) != current_app.config["NOTIFY_SERVICE_ID"]:
+                    delete_service_and_all_associated_db_objects(service)
+                else:
+                    print(f"Skipping service {service.id=} {service.name=}")
 
             services_created_by_this_user = dao_fetch_all_services_created_by_user(usr.id)
             for service in services_created_by_this_user:

--- a/app/dao/organisation_user_permissions_dao.py
+++ b/app/dao/organisation_user_permissions_dao.py
@@ -11,6 +11,10 @@ class OrganisationUserPermissionsDao(DAOClass):
         query = self.Meta.model.query.filter_by(user=user, organisation=organisation)
         query.delete()
 
+    def remove_user_organisation_permissions_by_user(self, user: User):
+        query = self.Meta.model.query.filter_by(user=user)
+        query.delete()
+
     def set_user_organisation_permission(
         self,
         user: User,

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -93,8 +93,7 @@ def delete_user_and_all_associated_db_objects(user):
     for api_key in ApiKey.query.filter_by(created_by=user):
         db.session.delete(api_key)
 
-    for org in user.organisations:
-        organisation_user_permissions_dao.remove_user_organisation_permissions(user, org)
+    organisation_user_permissions_dao.remove_user_organisation_permissions_by_user(user)
     user.organisations = []
     for service in user.services:
         dao_remove_user_from_service(user=user, service=service)


### PR DESCRIPTION
There are lots of test data in preview environment. This PR is for the removing the test data ([card](https://trello.com/c/bH9JnDjZ/1117-clear-functional-test-data-in-preview)) and re-creating the some of the fixture data.

Steps to removing the test data in preview environment: 
1. Merge this PR
2. Take the snapshot of notify-db in rds and also take database dump locally
3. ssh into ecs `api-web` service
4. Run `flask command purge-functional-test-data -u notify-tests-preview` to delete user data objects.
  * note: takes a while! multiple hours!

> Additional steps for Preview:
a. Remove https://www.notify.works/organisations/63b9557c-22ea-42ac-bcba-edaa50e3ae51/settings/ and https://www.notify.works/organisations/9b37efda-5855-4b18-bc37-6752f95994cb/settings/ Orgs

6. Run `flask command functional-test-fixtures` to create fixture data, this will create tmp environment file for functional-test service
7. `cd /tmp` and `cat functional_test_env.sh` to get the new environment file
8. `PASSWORD_STORE_DIR=$HOME/gds/notifications-credentials pass edit credentials/functional-tests/preview-functional ` and update the new environment file. This will auto commit and require manual PR process.
9. after merging, run `notifications-aws/scripts/upload-credentials/upload-credentials.sh preview` locally to push new environment file to SSM
10. Trigger the admin functional-test-preview pipeline/stage

In case of reverting the process:
1. Revert the PR for credentials
2. Rollback db from local dump, if local dump does not work then follow [these steps](https://docs.publishing.service.gov.uk/manual/howto-backup-and-restore-in-aws-rds.html) to restore from snapshot
3. Trigger admin functional-test-preview pipeline/stage