### PR TITLE
Add new callback types

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0486_letter_rates_feb_2025
+0847_insert_new_callback_types

--- a/migrations/versions/0847_insert_new_callback_types.py
+++ b/migrations/versions/0847_insert_new_callback_types.py
@@ -1,0 +1,19 @@
+"""
+Create Date: 2025-01-17 12:30:50.050539
+"""
+
+from alembic import op
+
+revision = '0847_insert_new_callback_types'
+down_revision = '0486_letter_rates_feb_2025'
+
+
+def upgrade():
+    insert_returned_letter_callback_type = "INSERT INTO service_callback_type VALUES ('returned_letters')"
+    insert_inbound_sms_callback_type = "INSERT INTO service_callback_type VALUES ('inbound_sms')"
+    op.execute(insert_returned_letter_callback_type)
+    op.execute(insert_inbound_sms_callback_type)
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
This PR adds a new callback type returned_letters to the service_callback_api table described in [this](https://trello.com/c/5SuwTyC1/175-create-a-new-type-of-callback-in-service-callback-api-table-returnedletter) card.
It also adds an inbound_sms callback_type in preparation for future work to merge the service_inbound_api into the service_callback_api table.