### PR TITLE
gunicorn: use `psutil` to emit post-request log output for long requests

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -12,3 +12,47 @@ worker_connections = 256
 statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
 keepalive = 90
 timeout = int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30))  # though has little effect with eventlet worker_class
+
+debug_post_threshold = os.getenv("NOTIFY_GUNICORN_DEBUG_POST_REQUEST_LOG_THRESHOLD_SECONDS", None)
+if debug_post_threshold:
+    debug_post_threshold_float = float(debug_post_threshold)
+
+    def pre_request(worker, req):
+        # using os.times() to avoid additional imports before eventlet monkeypatching
+        req._pre_request_elapsed = os.times().elapsed
+
+    def _tuples_to_lists(value):
+        if isinstance(value, tuple):
+            # convert to list for more compact (and json-able) representation
+            return list(value)
+
+        return value
+
+    def post_request(worker, req, environ, resp):
+        elapsed = os.times().elapsed - req._pre_request_elapsed
+        if elapsed > debug_post_threshold_float:
+            import json
+            import time
+
+            import psutil
+
+            # consume this iterator to give cpu_percent calculation a "start time" to work with
+            list(psutil.process_iter(["cpu_percent"]))
+            time.sleep(0.1)  # period over which to calculate cpu_percent
+
+            attrs = ["pid", "name", "cpu_percent", "status", "memory_info"]
+
+            context = {
+                "request_time": elapsed,
+                "processes": json.dumps(
+                    [
+                        attrs,
+                        [[_tuples_to_lists(p.info[a]) for a in attrs] for p in psutil.process_iter(attrs)],
+                    ]
+                ),
+            }
+            worker.log.info(
+                "post-request diagnostics for request of %(request_time)ss",
+                context,
+                extra=context,
+            )

--- a/requirements.in
+++ b/requirements.in
@@ -19,6 +19,9 @@ psycopg2-binary==2.9.10
 PyJWT==2.10.1
 SQLAlchemy==1.4.41
 
+# temporary for debug output
+psutil>=6.0.0,<7.0.0
+
 notifications-python-client==10.0.1
 
 # Run `make bump-utils` to update to the latest version

--- a/requirements.txt
+++ b/requirements.txt
@@ -165,6 +165,8 @@ prometheus-client==0.14.1
     #   gds-metrics
 prompt-toolkit==3.0.31
     # via click-repl
+psutil==6.1.1
+    # via -r requirements.in
 psycopg2-binary==2.9.10
     # via -r requirements.in
 pycurl==7.44.1

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -256,6 +256,8 @@ prompt-toolkit==3.0.31
     # via
     #   -r requirements.txt
     #   click-repl
+psutil==6.1.1
+    # via -r requirements.txt
 psycopg2-binary==2.9.10
     # via -r requirements.txt
 pycparser==2.21


### PR DESCRIPTION
https://trello.com/c/M4vBaTPb/971-instrument-eventlet-to-get-to-the-bottom-of-0900-glitches

This is ugly and nasty and should be removed as soon as we've finished using it. we have to perform our own request timing because we can't reasonably access the flask-level annotations from the gunicorn side.

Performing this from gunicorn has the advantage of being executed *after* a response is sent, and so the 100ms delay this causes (or unexpected errors this results in for that matter) shouldn't prevent a user from getting their response.