### PR TITLE
Fix FromAsCasing warning

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm as base
+FROM python:3.11-slim-bookworm AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
@@ -62,7 +62,7 @@ RUN python -m compileall . && \
 ENTRYPOINT [ "/home/vcap/app/entrypoint.sh" ]
 
 ##### Test Image ##############################################################
-FROM production as test
+FROM production AS test
 
 USER root
 RUN echo "Install OS dependencies for test build" && \
@@ -93,7 +93,7 @@ RUN make bootstrap
 COPY --chown=notify:notify . .
 
 ##### Concourse Test Image ##############################################################
-FROM production as concourse_tests
+FROM production AS concourse_tests
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
Fixes the following warning, seen when building
the celery container:

```bash
FromAsCasing: 'as' and 'FROM' keywords' casing do not match
```

My understanding of this error comes from:

https://hackernoon.com/fix-dockerfile-error-warn-fromascasing-as-and-from-keywords-casing-do-not-match