### PR TITLE
gunicorn: use local copy of `child_exit` instead of importing from `gds_metrics`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export PROMETHEUS_MULTIPROC_DIR="/tmp"
+
 CONCURRENCY=${CONCURRENCY:-4}
 
 # Define a common command prefix

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,9 +1,18 @@
 import os
 
-from gds_metrics.gunicorn import child_exit  # noqa
 from notifications_utils.gunicorn_defaults import set_gunicorn_defaults
 
 set_gunicorn_defaults(globals())
+
+
+# importing child_exit from gds_metrics.gunicorn has the side effect of eagerly importing
+# prometheus_client, flask, werkzeug and more, which is a bad idea to do before eventlet
+# has done its monkeypatching. use a nested import for the rare cases child_exit is actually
+# called instead.
+def child_exit(server, worker):
+    from prometheus_client import multiprocess
+
+    multiprocess.mark_process_dead(worker.pid)
 
 
 workers = 4


### PR DESCRIPTION
https://trello.com/c/M4vBaTPb/971-instrument-eventlet-to-get-to-the-bottom-of-0900-glitches

This is something that contributes to the error splurge we get every time our applications start - fixing this rules out the possibility of the early-import-of-unpatched-io-routines being related to our issues.

(I have also explicitly tested killing a worker process unexpectedly, hence discovering we need to set `PROMETHEUS_MULTIPROC_DIR` more aggressively)