### PR TITLE
Bump utils to 93.2.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@93.2.0
+# This file was automatically copied from notifications-utils@93.2.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@93.2.0
+# This file was automatically copied from notifications-utils@93.2.1
 
 [tool.black]
 line-length = 120

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil>=6.0.0,<7.0.0
 notifications-python-client==10.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@93.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@93.2.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,9 +95,7 @@ gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6
 govuk-bank-holidays==0.15
     # via notifications-utils
 greenlet==3.0.3
-    # via
-    #   eventlet
-    #   sqlalchemy
+    # via eventlet
 gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
     # via
     #   -r requirements.in
@@ -149,7 +147,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@206f008ef017f8b5ec9b870df04bf35780b7717b
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@27797ff3485a9b8c564b6ae0cebb7aa8cd4fea4f
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -154,7 +154,6 @@ greenlet==3.0.3
     # via
     #   -r requirements.txt
     #   eventlet
-    #   sqlalchemy
 gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
     # via
     #   -r requirements.txt
@@ -225,7 +224,7 @@ mypy-extensions==1.0.0
     # via black
 notifications-python-client==10.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@206f008ef017f8b5ec9b870df04bf35780b7717b
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@27797ff3485a9b8c564b6ae0cebb7aa8cd4fea4f
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@93.2.0
+# This file was automatically copied from notifications-utils@93.2.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4


### PR DESCRIPTION
 ## 93.2.1

* Replaces symlink at `./pyproject.toml` with a duplicate file

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/93.2.0...93.2.1