### PR TITLE
Make service callback methods generic

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -265,10 +265,12 @@ WEBAUTHN_AUTH_TYPE = "webauthn_auth"
 USER_AUTH_TYPES = [SMS_AUTH_TYPE, EMAIL_AUTH_TYPE, WEBAUTHN_AUTH_TYPE]
 VERIFY_CODE_TYPES = [EMAIL_TYPE, SMS_TYPE]
 
+
 # Service callbacks
-DELIVERY_STATUS_CALLBACK_TYPE = "delivery_status"
-COMPLAINT_CALLBACK_TYPE = "complaint"
-SERVICE_CALLBACK_TYPES = [DELIVERY_STATUS_CALLBACK_TYPE, COMPLAINT_CALLBACK_TYPE]
+class ServiceCallbackTypes(enum.StrEnum):
+    delivery_status = "delivery_status"
+    complaint = "complaint"
+
 
 # Branding values
 BRANDING_GOVUK = "govuk"  # Deprecated outside migrations

--- a/app/dao/service_callback_api_dao.py
+++ b/app/dao/service_callback_api_dao.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from app import db
-from app.constants import COMPLAINT_CALLBACK_TYPE, DELIVERY_STATUS_CALLBACK_TYPE
+from app.constants import ServiceCallbackTypes
 from app.dao.dao_utils import autocommit, version_class
 from app.models import ServiceCallbackApi
 
@@ -34,12 +34,14 @@ def get_service_callback_api(service_callback_api_id, service_id, callback_type)
 
 def get_service_delivery_status_callback_api_for_service(service_id):
     return ServiceCallbackApi.query.filter_by(
-        service_id=service_id, callback_type=DELIVERY_STATUS_CALLBACK_TYPE
+        service_id=service_id, callback_type=ServiceCallbackTypes.delivery_status.value
     ).first()
 
 
 def get_service_complaint_callback_api_for_service(service_id):
-    return ServiceCallbackApi.query.filter_by(service_id=service_id, callback_type=COMPLAINT_CALLBACK_TYPE).first()
+    return ServiceCallbackApi.query.filter_by(
+        service_id=service_id, callback_type=ServiceCallbackTypes.complaint.value
+    ).first()
 
 
 @autocommit

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -232,7 +232,7 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
         return [
             callback.id
             for callback in service.service_callback_api
-            if callback.callback_type == app.constants.DELIVERY_STATUS_CALLBACK_TYPE
+            if callback.callback_type == app.constants.ServiceCallbackTypes.delivery_status.value
         ]
 
     def _get_allowed_broadcast_provider(self, service):
@@ -337,7 +337,7 @@ class DetailedServiceSchema(BaseSchema):
         return [
             callback.id
             for callback in service.service_callback_api
-            if callback.callback_type == app.constants.DELIVERY_STATUS_CALLBACK_TYPE
+            if callback.callback_type == app.constants.ServiceCallbackTypes.delivery_status.value
         ]
 
     class Meta(BaseSchema.Meta):

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -95,20 +95,10 @@ def fetch_delivery_receipt_callback_api(service_id, callback_api_id):
     return _fetch_service_callback_api(callback_api_id, service_id, callback_type)
 
 
-def _fetch_service_callback_api(callback_api_id, service_id, callback_type):
-    callback_api = get_service_callback_api(callback_api_id, service_id, callback_type)
-    return jsonify(data=callback_api.serialize()), 200
-
-
 @service_callback_blueprint.route("/delivery-receipt-api/<uuid:callback_api_id>", methods=["DELETE"])
 def remove_service_callback_api(service_id, callback_api_id):
-    callback_api = get_service_callback_api(callback_api_id, service_id, DELIVERY_STATUS_CALLBACK_TYPE)
-
-    if not callback_api:
-        error = "Service delivery receipt callback API not found"
-        raise InvalidRequest(error, status_code=404)
-
-    delete_service_callback_api(callback_api)
+    callback_type = DELIVERY_STATUS_CALLBACK_TYPE
+    _remove_service_callback_api(callback_api_id, service_id, callback_type)
     return "", 204
 
 
@@ -137,6 +127,19 @@ def _update_service_callback_api(callback_api_id, service_id, callback_type):
         bearer_token=data.get("bearer_token", None),
     )
     return to_update
+
+
+def _fetch_service_callback_api(callback_api_id, service_id, callback_type):
+    callback_api = get_service_callback_api(callback_api_id, service_id, callback_type)
+    return jsonify(data=callback_api.serialize()), 200
+
+
+def _remove_service_callback_api(callback_api_id, service_id, callback_type):
+    callback_api = get_service_callback_api(callback_api_id, service_id, callback_type)
+    if not callback_api:
+        error = "Service delivery receipt callback API not found"
+        raise InvalidRequest(error, status_code=404)
+    delete_service_callback_api(callback_api)
 
 
 def handle_sql_error(e, table_name):

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -90,7 +90,7 @@ def update_delivery_receipt_callback_api(service_id, callback_api_id):
 
 
 @service_callback_blueprint.route("/delivery-receipt-api/<uuid:callback_api_id>", methods=["GET"])
-def fetch_service_callback_api(service_id, callback_api_id):
+def fetch_delivery_receipt_callback_api(service_id, callback_api_id):
     callback_type = DELIVERY_STATUS_CALLBACK_TYPE
     return _fetch_service_callback_api(callback_api_id, service_id, callback_type)
 

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -78,16 +78,20 @@ def remove_service_inbound_api(service_id, inbound_api_id):
 
 @service_callback_blueprint.route("/delivery-receipt-api", methods=["POST"])
 def create_service_callback_api(service_id):
+    callback_type = DELIVERY_STATUS_CALLBACK_TYPE
+    return _create_service_callback_api(service_id, callback_type)
+
+
+def _create_service_callback_api(service_id, callback_type):
     data = request.get_json()
     validate(data, create_service_callback_api_schema)
     data["service_id"] = service_id
-    data["callback_type"] = DELIVERY_STATUS_CALLBACK_TYPE
+    data["callback_type"] = callback_type
     callback_api = ServiceCallbackApi(**data)
     try:
         save_service_callback_api(callback_api)
     except SQLAlchemyError as e:
         return handle_sql_error(e, "service_callback_api")
-
     return jsonify(data=callback_api.serialize()), 201
 
 

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, jsonify, request
 from sqlalchemy.exc import SQLAlchemyError
 
-from app.constants import DELIVERY_STATUS_CALLBACK_TYPE
+from app.constants import ServiceCallbackTypes
 from app.dao.service_callback_api_dao import (
     delete_service_callback_api,
     get_service_callback_api,
@@ -76,28 +76,29 @@ def remove_service_inbound_api(service_id, inbound_api_id):
     return "", 204
 
 
+# delivery-receipt callback endpoints
 @service_callback_blueprint.route("/delivery-receipt-api", methods=["POST"])
 def create_delivery_receipt_callback_api(service_id):
-    callback_type = DELIVERY_STATUS_CALLBACK_TYPE
+    callback_type = ServiceCallbackTypes.delivery_status.value
     return _create_service_callback_api(service_id, callback_type)
 
 
 @service_callback_blueprint.route("/delivery-receipt-api/<uuid:callback_api_id>", methods=["POST"])
 def update_delivery_receipt_callback_api(service_id, callback_api_id):
-    callback_type = DELIVERY_STATUS_CALLBACK_TYPE
+    callback_type = ServiceCallbackTypes.delivery_status.value
     to_update = _update_service_callback_api(callback_api_id, service_id, callback_type)
     return jsonify(data=to_update.serialize()), 200
 
 
 @service_callback_blueprint.route("/delivery-receipt-api/<uuid:callback_api_id>", methods=["GET"])
 def fetch_delivery_receipt_callback_api(service_id, callback_api_id):
-    callback_type = DELIVERY_STATUS_CALLBACK_TYPE
+    callback_type = ServiceCallbackTypes.delivery_status.value
     return _fetch_service_callback_api(callback_api_id, service_id, callback_type)
 
 
 @service_callback_blueprint.route("/delivery-receipt-api/<uuid:callback_api_id>", methods=["DELETE"])
-def remove_service_callback_api(service_id, callback_api_id):
-    callback_type = DELIVERY_STATUS_CALLBACK_TYPE
+def remove_delivery_receipt_callback_api(service_id, callback_api_id):
+    callback_type = ServiceCallbackTypes.delivery_status.value
     _remove_service_callback_api(callback_api_id, service_id, callback_type)
     return "", 204
 

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -77,7 +77,7 @@ def remove_service_inbound_api(service_id, inbound_api_id):
 
 
 @service_callback_blueprint.route("/delivery-receipt-api", methods=["POST"])
-def create_service_callback_api(service_id):
+def create_delivery_receipt_callback_api(service_id):
     callback_type = DELIVERY_STATUS_CALLBACK_TYPE
     return _create_service_callback_api(service_id, callback_type)
 

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -91,8 +91,12 @@ def update_delivery_receipt_callback_api(service_id, callback_api_id):
 
 @service_callback_blueprint.route("/delivery-receipt-api/<uuid:callback_api_id>", methods=["GET"])
 def fetch_service_callback_api(service_id, callback_api_id):
-    callback_api = get_service_callback_api(callback_api_id, service_id, DELIVERY_STATUS_CALLBACK_TYPE)
+    callback_type = DELIVERY_STATUS_CALLBACK_TYPE
+    return _fetch_service_callback_api(callback_api_id, service_id, callback_type)
 
+
+def _fetch_service_callback_api(callback_api_id, service_id, callback_type):
+    callback_api = get_service_callback_api(callback_api_id, service_id, callback_type)
     return jsonify(data=callback_api.serialize()), 200
 
 

--- a/tests/app/dao/test_service_callback_api_dao.py
+++ b/tests/app/dao/test_service_callback_api_dao.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy.exc import SQLAlchemyError
 
 from app import signing
-from app.constants import COMPLAINT_CALLBACK_TYPE, DELIVERY_STATUS_CALLBACK_TYPE
+from app.constants import ServiceCallbackTypes
 from app.dao.service_callback_api_dao import (
     get_service_callback_api,
     get_service_delivery_status_callback_api_for_service,
@@ -152,7 +152,7 @@ def test_get_service_callback_api(sample_service):
         url="https://some_service/delivery_callback_endpoint",
         bearer_token="delivery_unique_string",
         updated_by_id=sample_service.users[0].id,
-        callback_type=DELIVERY_STATUS_CALLBACK_TYPE,
+        callback_type=ServiceCallbackTypes.delivery_status,
     )
     save_service_callback_api(service_delivery_callback_api)
 
@@ -161,12 +161,12 @@ def test_get_service_callback_api(sample_service):
         url="https://some_service/complaint_callback_endpoint",
         bearer_token="complaint_unique_string",
         updated_by_id=sample_service.users[0].id,
-        callback_type=COMPLAINT_CALLBACK_TYPE,
+        callback_type=ServiceCallbackTypes.complaint.value,
     )
     save_service_callback_api(service_complaint_callback_api)
 
     delivery_callback_api = get_service_callback_api(
-        service_delivery_callback_api.id, sample_service.id, DELIVERY_STATUS_CALLBACK_TYPE
+        service_delivery_callback_api.id, sample_service.id, ServiceCallbackTypes.delivery_status.value
     )
     assert delivery_callback_api.id is not None
     assert delivery_callback_api.service_id == sample_service.id
@@ -177,7 +177,7 @@ def test_get_service_callback_api(sample_service):
     assert delivery_callback_api.updated_at is None
 
     complaint_callback_api = get_service_callback_api(
-        service_complaint_callback_api.id, sample_service.id, COMPLAINT_CALLBACK_TYPE
+        service_complaint_callback_api.id, sample_service.id, ServiceCallbackTypes.complaint.value
     )
     assert complaint_callback_api.id is not None
     assert complaint_callback_api.service_id == sample_service.id

--- a/tests/app/dao/test_service_callback_api_dao.py
+++ b/tests/app/dao/test_service_callback_api_dao.py
@@ -189,7 +189,7 @@ def test_get_service_callback_api(sample_service):
 
 
 def test_get_service_delivery_status_callback_api_for_service(sample_service):
-    service_callback_api = create_service_callback_api(service=sample_service)
+    service_callback_api = create_service_callback_api(callback_type="delivery_status", service=sample_service)
     result = get_service_delivery_status_callback_api_for_service(sample_service.id)
     assert result.id == service_callback_api.id
     assert result.url == service_callback_api.url

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -483,9 +483,7 @@ def create_service_inbound_api(
     return service_inbound_api
 
 
-def create_service_callback_api(
-    service, url="https://something.com", bearer_token="some_super_secret", callback_type="delivery_status"
-):
+def create_service_callback_api(callback_type, service, url="https://something.com", bearer_token="some_super_secret"):
     service_callback_api = ServiceCallbackApi(
         service_id=service.id,
         url=url,

--- a/tests/app/notifications/test_notifications_ses_callback.py
+++ b/tests/app/notifications/test_notifications_ses_callback.py
@@ -79,7 +79,7 @@ def test_check_and_queue_callback_task(mocker, mock_celery_task, sample_notifica
 
     mock_send = mock_celery_task(send_delivery_status_to_service)
 
-    callback_api = create_service_callback_api(service=sample_notification.service)
+    callback_api = create_service_callback_api(callback_type="delivery_status", service=sample_notification.service)
     mock_create.return_value = "encoded_status_update"
 
     check_and_queue_callback_task(sample_notification)

--- a/tests/app/platform_admin/test_rest.py
+++ b/tests/app/platform_admin/test_rest.py
@@ -86,7 +86,7 @@ class TestFindByUUID:
             create_service_inbound_api(sample_service)
         elif model == ServiceCallbackApi:
             sample_service = request.getfixturevalue("sample_service")
-            create_service_callback_api(sample_service)
+            create_service_callback_api("delivery_status", sample_service)
         elif model == Complaint:
             create_complaint()
         elif model == InboundSms:

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -171,11 +171,11 @@ def test_fetch_delivery_receipt_callback_api(admin_request, sample_service):
     assert response["data"] == service_callback_api.serialize()
 
 
-def test_delete_service_callback_api(admin_request, sample_service):
+def test_delete_delivery_receipt_callback_api(admin_request, sample_service):
     service_callback_api = create_service_callback_api("delivery_status", sample_service)
 
     response = admin_request.delete(
-        "service_callback.remove_service_callback_api",
+        "service_callback.remove_delivery_receipt_callback_api",
         service_id=sample_service.id,
         callback_api_id=service_callback_api.id,
     )

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -159,11 +159,11 @@ def test_update_service_callback_api_updates_bearer_token(admin_request, sample_
     assert service_callback_api.bearer_token == "different_token"
 
 
-def test_fetch_service_callback_api(admin_request, sample_service):
+def test_fetch_delivery_receipt_callback_api(admin_request, sample_service):
     service_callback_api = create_service_callback_api(callback_type="delivery_status", service=sample_service)
 
     response = admin_request.get(
-        "service_callback.fetch_service_callback_api",
+        "service_callback.fetch_delivery_receipt_callback_api",
         service_id=sample_service.id,
         callback_api_id=service_callback_api.id,
     )

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -88,7 +88,7 @@ def test_delete_service_inbound_api(admin_request, sample_service):
     assert ServiceInboundApi.query.count() == 0
 
 
-def test_create_service_callback_api(admin_request, sample_service):
+def test_create_delivery_receipt_callback_api(admin_request, sample_service):
     data = {
         "url": "https://some_service/delivery-receipt-endpoint",
         "bearer_token": "some-unique-string",
@@ -108,7 +108,7 @@ def test_create_service_callback_api(admin_request, sample_service):
     assert not resp_json["updated_at"]
 
 
-def test_set_service_callback_api_raises_404_when_service_does_not_exist(admin_request, notify_db_session):
+def test_set_delivery_receipt_callback_api_raises_404_when_service_does_not_exist(admin_request, notify_db_session):
     data = {
         "url": "https://some_service/delivery-receipt-endpoint",
         "bearer_token": "some-unique-string",
@@ -116,18 +116,23 @@ def test_set_service_callback_api_raises_404_when_service_does_not_exist(admin_r
     }
 
     resp_json = admin_request.post(
-        "service_callback.create_service_callback_api", service_id=uuid.uuid4(), _data=data, _expected_status=404
+        "service_callback.create_delivery_receipt_callback_api",
+        service_id=uuid.uuid4(),
+        _data=data,
+        _expected_status=404,
     )
     assert resp_json["message"] == "No result found"
 
 
-def test_update_service_callback_api_updates_url(admin_request, sample_service):
-    service_callback_api = create_service_callback_api(service=sample_service, url="https://original_url.com")
+def test_update_delivery_receipt_callback_api_updates_url(admin_request, sample_service):
+    service_callback_api = create_service_callback_api(
+        callback_type="delivery_status", service=sample_service, url="https://original_url.com"
+    )
 
     data = {"url": "https://another_url.com", "updated_by_id": str(sample_service.users[0].id)}
 
     resp_json = admin_request.post(
-        "service_callback.update_service_callback_api",
+        "service_callback.update_delivery_receipt_callback_api",
         service_id=sample_service.id,
         callback_api_id=service_callback_api.id,
         _data=data,

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -96,7 +96,10 @@ def test_create_delivery_receipt_callback_api(admin_request, sample_service):
     }
 
     resp_json = admin_request.post(
-        "service_callback.create_service_callback_api", service_id=sample_service.id, _data=data, _expected_status=201
+        "service_callback.create_delivery_receipt_callback_api",
+        service_id=sample_service.id,
+        _data=data,
+        _expected_status=201,
     )
 
     resp_json = resp_json["data"]
@@ -142,11 +145,13 @@ def test_update_delivery_receipt_callback_api_updates_url(admin_request, sample_
 
 
 def test_update_service_callback_api_updates_bearer_token(admin_request, sample_service):
-    service_callback_api = create_service_callback_api(service=sample_service, bearer_token="some_super_secret")
+    service_callback_api = create_service_callback_api(
+        callback_type="delivery_status", service=sample_service, bearer_token="some_super_secret"
+    )
     data = {"bearer_token": "different_token", "updated_by_id": str(sample_service.users[0].id)}
 
     admin_request.post(
-        "service_callback.update_service_callback_api",
+        "service_callback.update_delivery_receipt_callback_api",
         service_id=sample_service.id,
         callback_api_id=service_callback_api.id,
         _data=data,
@@ -155,7 +160,7 @@ def test_update_service_callback_api_updates_bearer_token(admin_request, sample_
 
 
 def test_fetch_service_callback_api(admin_request, sample_service):
-    service_callback_api = create_service_callback_api(service=sample_service)
+    service_callback_api = create_service_callback_api(callback_type="delivery_status", service=sample_service)
 
     response = admin_request.get(
         "service_callback.fetch_service_callback_api",
@@ -167,7 +172,7 @@ def test_fetch_service_callback_api(admin_request, sample_service):
 
 
 def test_delete_service_callback_api(admin_request, sample_service):
-    service_callback_api = create_service_callback_api(sample_service)
+    service_callback_api = create_service_callback_api("delivery_status", sample_service)
 
     response = admin_request.delete(
         "service_callback.remove_service_callback_api",

--- a/tests/app/test_schemas.py
+++ b/tests/app/test_schemas.py
@@ -2,7 +2,7 @@ import pytest
 from marshmallow import ValidationError
 from sqlalchemy import desc
 
-from app.constants import COMPLAINT_CALLBACK_TYPE, DELIVERY_STATUS_CALLBACK_TYPE
+from app.constants import ServiceCallbackTypes
 from app.dao.provider_details_dao import (
     dao_update_provider_details,
     get_provider_details_by_identifier,
@@ -159,7 +159,7 @@ def test_service_schema_only_returns_delivery_status_callback_api(sample_service
         url="https://some_service/delivery_callback_endpoint",
         bearer_token="delivery_unique_string",
         updated_by_id=sample_service.users[0].id,
-        callback_type=DELIVERY_STATUS_CALLBACK_TYPE,
+        callback_type=ServiceCallbackTypes.delivery_status,
     )
     save_service_callback_api(service_delivery_callback_api)
 
@@ -168,7 +168,7 @@ def test_service_schema_only_returns_delivery_status_callback_api(sample_service
         url="https://some_service/complaint_callback_endpoint",
         bearer_token="complaint_unique_string",
         updated_by_id=sample_service.users[0].id,
-        callback_type=COMPLAINT_CALLBACK_TYPE,
+        callback_type=ServiceCallbackTypes.complaint.value,
     )
     save_service_callback_api(service_complaint_callback_api)
 

--- a/tests/app/v2/inbound_sms/test_get_inbound_sms.py
+++ b/tests/app/v2/inbound_sms/test_get_inbound_sms.py
@@ -34,6 +34,7 @@ def test_get_inbound_sms_returns_200_when_service_has_callbacks(api_client_reque
         url="https://inbound.example.com",
     )
     create_service_callback_api(
+        callback_type="delivery_status",
         service=sample_service,
         url="https://inbound.example.com",
     )


### PR DESCRIPTION
This PR makes service callback rest methods generic as described in [this](https://trello.com/c/bNai6vrs/213-make-servicecallback-methods-generic) ticket.
Currently those methods deal specifically with delivery-receipts. This lays a foundation for the work to add a returned letter callback  feature.
A `ServiceCallbackTypes` enum has also been added.