### PR TITLE
gunicorn: set `worker_connections` to 8

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -17,7 +17,7 @@ def child_exit(server, worker):
 
 workers = 4
 worker_class = "eventlet"
-worker_connections = 256
+worker_connections = 8  # limit runaway greenthread creation
 statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
 keepalive = 90
 timeout = int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30))  # though has little effect with eventlet worker_class


### PR DESCRIPTION
A low value for this setting, this is to limit the effect of runaway greenthread creation when we're doing expensive per-thread lazy resource initialization (think api clients..)

Ideally we'd have some mechanism for throttling greenthread creation instead, but in normal circumstances use we don't get anywhere near 8 simultaneous connections per worker pid.