### PR TITLE
gunicorn: set `worker_connections` to 16

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -17,7 +17,7 @@ def child_exit(server, worker):
 
 workers = 4
 worker_class = "eventlet"
-worker_connections = 8  # limit runaway greenthread creation
+worker_connections = 16  # limit runaway greenthread creation
 statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
 keepalive = 90
 timeout = int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30))  # though has little effect with eventlet worker_class


### PR DESCRIPTION
We may need this amount of concurrency for the functional tests to pass in preview.

Which itself is mildly concerning.