### PR TITLE
gunicorn: revert `worker_connections` to original 256

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -17,7 +17,7 @@ def child_exit(server, worker):
 
 workers = 4
 worker_class = "eventlet"
-worker_connections = 32  # limit runaway greenthread creation
+worker_connections = 16  # limit runaway greenthread creation
 statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
 keepalive = 90
 timeout = int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30))  # though has little effect with eventlet worker_class

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -17,7 +17,7 @@ def child_exit(server, worker):
 
 workers = 4
 worker_class = "eventlet"
-worker_connections = 8  # limit runaway greenthread creation
+worker_connections = 256
 statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
 keepalive = 90
 timeout = int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30))  # though has little effect with eventlet worker_class

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -17,7 +17,7 @@ def child_exit(server, worker):
 
 workers = 4
 worker_class = "eventlet"
-worker_connections = 16  # limit runaway greenthread creation
+worker_connections = 8  # limit runaway greenthread creation
 statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
 keepalive = 90
 timeout = int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30))  # though has little effect with eventlet worker_class


### PR DESCRIPTION
I have a better theory now as to why we "need" so many connections and think we should go back to the original value until we have thought this out a bit more.