### PR TITLE
Remove unused code relating to SMS free allowance and service_domain

### DIFF
--- a/app/billing/rest.py
+++ b/app/billing/rest.py
@@ -8,7 +8,6 @@ from app.billing.billing_schemas import (
 from app.dao.annual_billing_dao import (
     dao_create_or_update_annual_billing_for_year,
     dao_get_free_sms_fragment_limit_for_year,
-    dao_update_annual_billing_for_future_years,
     set_default_free_allowance_for_service,
 )
 from app.dao.date_util import get_current_financial_year_start_year
@@ -90,7 +89,3 @@ def update_free_sms_fragment_limit_data(service_id, free_sms_fragment_limit, fin
         financial_year_start = current_year
 
     dao_create_or_update_annual_billing_for_year(service_id, free_sms_fragment_limit, financial_year_start)
-    # if we're trying to update historical data, don't touch other rows.
-    # Otherwise, make sure that future years will get the new updated value.
-    if financial_year_start >= current_year:
-        dao_update_annual_billing_for_future_years(service_id, free_sms_fragment_limit, financial_year_start)

--- a/app/billing/rest.py
+++ b/app/billing/rest.py
@@ -78,14 +78,13 @@ def create_or_update_free_sms_fragment_limit(service_id):
     update_free_sms_fragment_limit_data(
         service_id,
         free_sms_fragment_limit=form.get("free_sms_fragment_limit"),
-        financial_year_start=form.get("financial_year_start"),
     )
     return jsonify(form), 201
 
 
-def update_free_sms_fragment_limit_data(service_id, free_sms_fragment_limit, financial_year_start):
+def update_free_sms_fragment_limit_data(service_id, free_sms_fragment_limit, financial_year_start=None):
+    # TODO: `financial_year_start` parameter can be removed, but has been kept temporarily so nothing breaks
+    # during deployment
     current_year = get_current_financial_year_start_year()
-    if not financial_year_start:
-        financial_year_start = current_year
 
-    dao_create_or_update_annual_billing_for_year(service_id, free_sms_fragment_limit, financial_year_start)
+    dao_create_or_update_annual_billing_for_year(service_id, free_sms_fragment_limit, current_year)

--- a/app/dao/annual_billing_dao.py
+++ b/app/dao/annual_billing_dao.py
@@ -24,13 +24,6 @@ def dao_create_or_update_annual_billing_for_year(service_id, free_sms_fragment_l
     return result
 
 
-@autocommit
-def dao_update_annual_billing_for_future_years(service_id, free_sms_fragment_limit, financial_year_start):
-    AnnualBilling.query.filter(
-        AnnualBilling.service_id == service_id, AnnualBilling.financial_year_start > financial_year_start
-    ).update({"free_sms_fragment_limit": free_sms_fragment_limit})
-
-
 def dao_get_free_sms_fragment_limit_for_year(service_id, financial_year_start=None):
     if not financial_year_start:
         financial_year_start = get_current_financial_year_start_year()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -274,7 +274,6 @@ def create_service():
     if not data.get("user_id"):
         errors = {"user_id": ["Missing data for required field."]}
         raise InvalidRequest(errors, status_code=400)
-    data.pop("service_domain", None)
 
     # validate json with marshmallow
     service_schema.load(data)

--- a/tests/app/billing/test_rest.py
+++ b/tests/app/billing/test_rest.py
@@ -28,23 +28,6 @@ def test_create_update_free_sms_fragment_limit_invalid_schema(admin_request, sam
     assert "errors" in json_response
 
 
-def test_create_free_sms_fragment_limit_current_year_updates_future_years(admin_request, sample_service):
-    current_year = get_current_financial_year_start_year()
-    future_billing = create_annual_billing(sample_service.id, 1, current_year + 1)
-
-    admin_request.post(
-        "billing.create_or_update_free_sms_fragment_limit",
-        service_id=sample_service.id,
-        _data={"free_sms_fragment_limit": 9999},
-        _expected_status=201,
-    )
-
-    current_billing = dao_get_free_sms_fragment_limit_for_year(sample_service.id, current_year)
-    assert future_billing.free_sms_fragment_limit == 9999
-    assert current_billing.financial_year_start == current_year
-    assert current_billing.free_sms_fragment_limit == 9999
-
-
 @pytest.mark.parametrize("update_existing", [True, False])
 def test_create_or_update_free_sms_fragment_limit_past_year_doenst_update_other_years(
     admin_request, sample_service, update_existing

--- a/tests/app/dao/test_annual_billing_dao.py
+++ b/tests/app/dao/test_annual_billing_dao.py
@@ -6,12 +6,11 @@ from freezegun import freeze_time
 from app.dao.annual_billing_dao import (
     dao_create_or_update_annual_billing_for_year,
     dao_get_free_sms_fragment_limit_for_year,
-    dao_update_annual_billing_for_future_years,
     set_default_free_allowance_for_service,
 )
 from app.dao.date_util import get_current_financial_year_start_year
 from app.models import AnnualBilling
-from tests.app.db import create_annual_billing, create_service
+from tests.app.db import create_service
 
 
 def test_dao_update_free_sms_fragment_limit(notify_db_session, sample_service):
@@ -29,22 +28,6 @@ def test_create_annual_billing(sample_service):
     free_limit = dao_get_free_sms_fragment_limit_for_year(sample_service.id, 2016)
 
     assert free_limit.free_sms_fragment_limit == 9999
-
-
-def test_dao_update_annual_billing_for_future_years(notify_db_session, sample_service):
-    current_year = get_current_financial_year_start_year()
-    limits = [1, 2, 3, 4]
-    create_annual_billing(sample_service.id, limits[0], current_year - 1)
-    create_annual_billing(sample_service.id, limits[2], current_year + 1)
-    create_annual_billing(sample_service.id, limits[3], current_year + 2)
-
-    dao_update_annual_billing_for_future_years(sample_service.id, 9999, current_year)
-
-    assert dao_get_free_sms_fragment_limit_for_year(sample_service.id, current_year - 1).free_sms_fragment_limit == 1
-    # current year is not created
-    assert dao_get_free_sms_fragment_limit_for_year(sample_service.id, current_year) is None
-    assert dao_get_free_sms_fragment_limit_for_year(sample_service.id, current_year + 1).free_sms_fragment_limit == 9999
-    assert dao_get_free_sms_fragment_limit_for_year(sample_service.id, current_year + 2).free_sms_fragment_limit == 9999
 
 
 @pytest.mark.parametrize(

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -412,58 +412,6 @@ def test_create_service(
     assert service_sms_senders[0].sms_sender == current_app.config["FROM_NUMBER"]
 
 
-@pytest.mark.parametrize(
-    "domain, expected_org",
-    (
-        (None, False),
-        ("", False),
-        ("unknown.gov.uk", False),
-        ("unknown-example.gov.uk", False),
-        ("example.gov.uk", True),
-        ("test.gov.uk", True),
-        ("test.example.gov.uk", True),
-    ),
-)
-def test_create_service_with_domain_sets_organisation(
-    admin_request,
-    sample_user,
-    domain,
-    expected_org,
-):
-    red_herring_org = create_organisation(name="Sub example")
-    create_domain("specific.example.gov.uk", red_herring_org.id)
-    create_domain("aaaaaaaa.example.gov.uk", red_herring_org.id)
-
-    org = create_organisation()
-    create_domain("example.gov.uk", org.id)
-    create_domain("test.gov.uk", org.id)
-
-    another_org = create_organisation(name="Another")
-    create_domain("cabinet-office.gov.uk", another_org.id)
-    create_domain("cabinetoffice.gov.uk", another_org.id)
-
-    sample_user.email_address = f"test@{domain}"
-
-    data = {
-        "name": "created service",
-        "user_id": str(sample_user.id),
-        "email_message_limit": 1000,
-        "sms_message_limit": 1000,
-        "letter_message_limit": 1000,
-        "restricted": False,
-        "active": False,
-        "created_by": str(sample_user.id),
-        "service_domain": domain,
-    }
-
-    json_resp = admin_request.post("service.create_service", _data=data, _expected_status=201)
-
-    if expected_org:
-        assert json_resp["data"]["organisation"] == str(org.id)
-    else:
-        assert json_resp["data"]["organisation"] is None
-
-
 def test_create_service_should_create_annual_billing_for_service(admin_request, sample_user):
     data = {
         "name": "created service",


### PR DESCRIPTION
Best reviewed commit by commit.

This tidies up the code around updating the free SMS fragment limit to remove the ability to update future years, which isn't something we currently do or plan to do. There's a corresponding admin change here https://github.com/alphagov/notifications-admin/pull/5365

It also removes unused code relating to the `service_domain` argument when creating a service