### PR TITLE
Add endpoints for returned letter callback

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -270,6 +270,7 @@ VERIFY_CODE_TYPES = [EMAIL_TYPE, SMS_TYPE]
 class ServiceCallbackTypes(enum.StrEnum):
     delivery_status = "delivery_status"
     complaint = "complaint"
+    returned_letter = "returned_letter"
 
 
 # Branding values

--- a/app/letters/rest.py
+++ b/app/letters/rest.py
@@ -3,8 +3,10 @@ from flask import Blueprint, jsonify, request
 from app.celery.tasks import process_returned_letters_list
 from app.config import QueueNames
 from app.dao.letter_rate_dao import dao_get_current_letter_rates
+from app.dao.returned_letters_dao import fetch_returned_letters
 from app.letters.letter_schemas import letter_references
 from app.schema_validation import validate
+from app.utils import DATE_FORMAT, DATETIME_FORMAT_NO_TIMEZONE
 from app.v2.errors import register_errors
 
 letter_job = Blueprint("letter-job", __name__)
@@ -33,3 +35,28 @@ def create_process_returned_letters_job():
 @letter_rates_blueprint.route("/", methods=["GET"])
 def get_letter_rates():
     return jsonify([rate.serialize() for rate in dao_get_current_letter_rates()])
+
+
+def fetch_returned_letter_data(service_id, report_date):
+    results = fetch_returned_letters(service_id=service_id, report_date=report_date)
+    json_results = [
+        {
+            "notification_id": x.notification_id,
+            # client reference can only be added on API letters
+            "client_reference": x.client_reference if x.api_key_id else None,
+            "reported_at": x.reported_at.strftime(DATE_FORMAT),
+            "created_at": x.created_at.strftime(DATETIME_FORMAT_NO_TIMEZONE),
+            # it doesn't make sense to show hidden/precompiled templates
+            "template_name": x.template_name if not x.hidden else None,
+            "template_id": x.template_id if not x.hidden else None,
+            "template_version": x.template_version if not x.hidden else None,
+            "user_name": x.user_name or "API",
+            "email_address": x.email_address or "API",
+            "original_file_name": x.original_file_name,
+            "job_row_number": x.job_row_number,
+            # the file name for a letter uploaded via the UI
+            "uploaded_letter_file_name": x.client_reference if x.hidden and not x.api_key_id else None,
+        }
+        for x in results
+    ]
+    return json_results

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -110,6 +110,13 @@ def create_returned_letter_callback_api(service_id):
     return _create_service_callback_api(service_id, callback_type)
 
 
+@service_callback_blueprint.route("/returned-letter-api/<uuid:callback_api_id>", methods=["POST"])
+def update_returned_letter_callback_api(service_id, callback_api_id):
+    callback_type = ServiceCallbackTypes.returned_letter.value
+    to_update = _update_service_callback_api(callback_api_id, service_id, callback_type)
+    return jsonify(data=to_update.serialize()), 200
+
+
 # helper callback methods
 def _create_service_callback_api(service_id, callback_type):
     data = request.get_json()

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -123,6 +123,13 @@ def fetch_returned_letter_callback_api(service_id, callback_api_id):
     return _fetch_service_callback_api(callback_api_id, service_id, callback_type)
 
 
+@service_callback_blueprint.route("/returned-letter-api/<uuid:callback_api_id>", methods=["DELETE"])
+def remove_returned_letter_callback_api(service_id, callback_api_id):
+    callback_type = ServiceCallbackTypes.returned_letter.value
+    _remove_service_callback_api(callback_api_id, service_id, callback_type)
+    return "", 204
+
+
 # helper callback methods
 def _create_service_callback_api(service_id, callback_type):
     data = request.get_json()

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -103,6 +103,13 @@ def remove_delivery_receipt_callback_api(service_id, callback_api_id):
     return "", 204
 
 
+# returned letter callback endpoints
+@service_callback_blueprint.route("/returned-letter-api", methods=["POST"])
+def create_returned_letter_callback_api(service_id):
+    callback_type = ServiceCallbackTypes.returned_letter.value
+    return _create_service_callback_api(service_id, callback_type)
+
+
 # helper callback methods
 def _create_service_callback_api(service_id, callback_type):
     data = request.get_json()

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -117,6 +117,12 @@ def update_returned_letter_callback_api(service_id, callback_api_id):
     return jsonify(data=to_update.serialize()), 200
 
 
+@service_callback_blueprint.route("/returned-letter-api/<uuid:callback_api_id>", methods=["GET"])
+def fetch_returned_letter_callback_api(service_id, callback_api_id):
+    callback_type = ServiceCallbackTypes.returned_letter.value
+    return _fetch_service_callback_api(callback_api_id, service_id, callback_type)
+
+
 # helper callback methods
 def _create_service_callback_api(service_id, callback_type):
     data = request.get_json()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -45,7 +45,6 @@ from app.dao.returned_letters_dao import (
     fetch_most_recent_returned_letter,
     fetch_recent_returned_letter_count,
     fetch_returned_letter_summary,
-    fetch_returned_letters,
 )
 from app.dao.service_contact_list_dao import (
     dao_archive_contact_list,
@@ -118,6 +117,7 @@ from app.dao.unsubscribe_request_dao import (
 )
 from app.dao.users_dao import get_user_by_id, save_user_attribute
 from app.errors import InvalidRequest, register_errors
+from app.letters.rest import fetch_returned_letter_data
 from app.letters.utils import adjust_daily_service_limits_for_cancelled_letters, letter_print_day
 from app.models import (
     EmailBranding,
@@ -1116,28 +1116,8 @@ def returned_letter_summary(service_id):
 
 @service_blueprint.route("/<uuid:service_id>/returned-letters", methods=["GET"])
 def get_returned_letters(service_id):
-    results = fetch_returned_letters(service_id=service_id, report_date=request.args.get("reported_at"))
-
-    json_results = [
-        {
-            "notification_id": x.notification_id,
-            # client reference can only be added on API letters
-            "client_reference": x.client_reference if x.api_key_id else None,
-            "reported_at": x.reported_at.strftime(DATE_FORMAT),
-            "created_at": x.created_at.strftime(DATETIME_FORMAT_NO_TIMEZONE),
-            # it doesn't make sense to show hidden/precompiled templates
-            "template_name": x.template_name if not x.hidden else None,
-            "template_id": x.template_id if not x.hidden else None,
-            "template_version": x.template_version if not x.hidden else None,
-            "user_name": x.user_name or "API",
-            "email_address": x.email_address or "API",
-            "original_file_name": x.original_file_name,
-            "job_row_number": x.job_row_number,
-            # the file name for a letter uploaded via the UI
-            "uploaded_letter_file_name": x.client_reference if x.hidden and not x.api_key_id else None,
-        }
-        for x in results
-    ]
+    report_date = request.args.get("reported_at")
+    json_results = fetch_returned_letter_data(service_id, report_date)
 
     return jsonify(sorted(json_results, key=lambda i: i["created_at"], reverse=True))
 

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0486_letter_rates_feb_2025
+0847_returned_letter_callback

--- a/migrations/versions/0847_returned_letter_callback.py
+++ b/migrations/versions/0847_returned_letter_callback.py
@@ -4,8 +4,8 @@ Create Date: 2025-01-24 12:05:58.010551
 
 from alembic import op
 
-revision = '0847_returned_letter_callback'
-down_revision = '0486_letter_rates_feb_2025'
+revision = "0847_returned_letter_callback"
+down_revision = "0486_letter_rates_feb_2025"
 
 
 def upgrade():

--- a/migrations/versions/0847_returned_letter_callback.py
+++ b/migrations/versions/0847_returned_letter_callback.py
@@ -14,4 +14,11 @@ def upgrade():
 
 
 def downgrade():
-    pass
+    delete_returned_letter_callback = "DELETE FROM service_callback_api WHERE callback_type='returned_letter'"
+    delete_returned_letter_callback_history = \
+        "DELETE FROM service_callback_api_history WHERE callback_type='returned_letter'"
+    delete_returned_letter_callback_type = "DELETE FROM service_callback_type WHERE name='returned_letter'"
+
+    op.execute(delete_returned_letter_callback)
+    op.execute(delete_returned_letter_callback_history)
+    op.execute(delete_returned_letter_callback_type)

--- a/migrations/versions/0847_returned_letter_callback.py
+++ b/migrations/versions/0847_returned_letter_callback.py
@@ -1,0 +1,17 @@
+"""
+Create Date: 2025-01-24 12:05:58.010551
+"""
+
+from alembic import op
+
+revision = '0847_returned_letter_callback'
+down_revision = '0486_letter_rates_feb_2025'
+
+
+def upgrade():
+    insert_returned_letter_callback_type = "INSERT INTO service_callback_type VALUES ('returned_letter')"
+    op.execute(insert_returned_letter_callback_type)
+
+
+def downgrade():
+    pass

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -265,3 +265,17 @@ def test_fetch_returned_letter_callback_api(admin_request, sample_service):
     )
 
     assert response["data"] == service_callback_api.serialize()
+
+
+def test_delete_returned_letter_callback_api(admin_request, sample_service):
+    service_callback_api = create_service_callback_api(callback_type="returned_letter",
+                                                       service=sample_service)
+
+    response = admin_request.delete(
+        "service_callback.remove_returned_letter_callback_api",
+        service_id=sample_service.id,
+        callback_api_id=service_callback_api.id,
+    )
+
+    assert response is None
+    assert ServiceCallbackApi.query.count() == 0

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -205,3 +205,19 @@ def test_create_returned_letter_callback_api(admin_request, sample_service):
     assert resp_json["updated_by_id"] == str(sample_service.users[0].id)
     assert resp_json["created_at"]
     assert not resp_json["updated_at"]
+
+
+def test_set_returned_letter_callback_api_raises_404_when_service_does_not_exist(admin_request, notify_db_session):
+    data = {
+        "url": "https://some_service/letter-callback-endpoint",
+        "bearer_token": "some-unique-string",
+        "updated_by_id": str(uuid.uuid4()),
+    }
+
+    resp_json = admin_request.post(
+        "service_callback.create_returned_letter_callback_api",
+        service_id=uuid.uuid4(),
+        _data=data,
+        _expected_status=404,
+    )
+    assert resp_json["message"] == "No result found"

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -182,3 +182,26 @@ def test_delete_delivery_receipt_callback_api(admin_request, sample_service):
 
     assert response is None
     assert ServiceCallbackApi.query.count() == 0
+
+
+def test_create_returned_letter_callback_api(admin_request, sample_service):
+    data = {
+        "url": "https://some_service/returned-letter-endpoint",
+        "bearer_token": "some-unique-string",
+        "updated_by_id": str(sample_service.users[0].id),
+    }
+
+    resp_json = admin_request.post(
+        "service_callback.create_returned_letter_callback_api",
+        service_id=sample_service.id,
+        _data=data,
+        _expected_status=201,
+    )
+
+    resp_json = resp_json["data"]
+    assert resp_json["id"]
+    assert resp_json["service_id"] == str(sample_service.id)
+    assert resp_json["url"] == "https://some_service/returned-letter-endpoint"
+    assert resp_json["updated_by_id"] == str(sample_service.users[0].id)
+    assert resp_json["created_at"]
+    assert not resp_json["updated_at"]

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -209,7 +209,7 @@ def test_create_returned_letter_callback_api(admin_request, sample_service):
 
 def test_set_returned_letter_callback_api_raises_404_when_service_does_not_exist(admin_request, notify_db_session):
     data = {
-        "url": "https://some_service/letter-callback-endpoint",
+        "url": "https://some_service/returned-letter-callback-endpoint",
         "bearer_token": "some-unique-string",
         "updated_by_id": str(uuid.uuid4()),
     }
@@ -221,3 +221,20 @@ def test_set_returned_letter_callback_api_raises_404_when_service_does_not_exist
         _expected_status=404,
     )
     assert resp_json["message"] == "No result found"
+
+
+def test_update_returned_letter_callback_api_updates_url(admin_request, sample_service):
+    service_callback_api = create_service_callback_api(
+        callback_type="returned_letter", service=sample_service, url="https://original_url.com"
+    )
+
+    data = {"url": "https://another_url.com", "updated_by_id": str(sample_service.users[0].id)}
+
+    resp_json = admin_request.post(
+        "service_callback.update_returned_letter_callback_api",
+        service_id=sample_service.id,
+        callback_api_id=service_callback_api.id,
+        _data=data,
+    )
+    assert resp_json["data"]["url"] == "https://another_url.com"
+    assert service_callback_api.url == "https://another_url.com"

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -144,7 +144,7 @@ def test_update_delivery_receipt_callback_api_updates_url(admin_request, sample_
     assert service_callback_api.url == "https://another_url.com"
 
 
-def test_update_service_callback_api_updates_bearer_token(admin_request, sample_service):
+def test_update_delivery_receipt_callback_api_updates_bearer_token(admin_request, sample_service):
     service_callback_api = create_service_callback_api(
         callback_type="delivery_status", service=sample_service, bearer_token="some_super_secret"
     )
@@ -238,3 +238,18 @@ def test_update_returned_letter_callback_api_updates_url(admin_request, sample_s
     )
     assert resp_json["data"]["url"] == "https://another_url.com"
     assert service_callback_api.url == "https://another_url.com"
+
+
+def test_update_returned_letter_callback_api_updates_bearer_token(admin_request, sample_service):
+    service_callback_api = create_service_callback_api(
+        callback_type="returned_letter", service=sample_service, bearer_token="some_super_secret"
+    )
+    data = {"bearer_token": "different_token", "updated_by_id": str(sample_service.users[0].id)}
+
+    admin_request.post(
+        "service_callback.update_returned_letter_callback_api",
+        service_id=sample_service.id,
+        callback_api_id=service_callback_api.id,
+        _data=data,
+    )
+    assert service_callback_api.bearer_token == "different_token"

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -268,8 +268,7 @@ def test_fetch_returned_letter_callback_api(admin_request, sample_service):
 
 
 def test_delete_returned_letter_callback_api(admin_request, sample_service):
-    service_callback_api = create_service_callback_api(callback_type="returned_letter",
-                                                       service=sample_service)
+    service_callback_api = create_service_callback_api(callback_type="returned_letter", service=sample_service)
 
     response = admin_request.delete(
         "service_callback.remove_returned_letter_callback_api",

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -253,3 +253,15 @@ def test_update_returned_letter_callback_api_updates_bearer_token(admin_request,
         _data=data,
     )
     assert service_callback_api.bearer_token == "different_token"
+
+
+def test_fetch_returned_letter_callback_api(admin_request, sample_service):
+    service_callback_api = create_service_callback_api(callback_type="returned_letter", service=sample_service)
+
+    response = admin_request.get(
+        "service_callback.fetch_returned_letter_callback_api",
+        service_id=sample_service.id,
+        callback_api_id=service_callback_api.id,
+    )
+
+    assert response["data"] == service_callback_api.serialize()


### PR DESCRIPTION
This PR adds the necessary endpoints for the returned letter callback feature as described in [this](https://trello.com/c/6qK45O5W/182-when-new-returned-letters-added-to-the-database-send-callbacks-to-services-that-have-callbacks-set-up-for-returned-letters) card.
It also implements the migration to add a `returned_letter` callback_type to the `service_callback_type` table.

The celery tasks will be addressed in another PR.
