### PR TITLE
add migration `0487_job_st_fin_allrows_backpop`

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0486_letter_rates_feb_2025
+0487_job_st_fin_allrows_backpop

--- a/migrations/versions/0487_job_st_fin_allrows_backpop.py
+++ b/migrations/versions/0487_job_st_fin_allrows_backpop.py
@@ -1,0 +1,30 @@
+"""
+Create Date: 2025-01-27 10:36:53.370957
+"""
+
+import datetime
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0487_job_st_fin_allrows_backpop"
+down_revision = "0486_letter_rates_feb_2025"
+
+
+def upgrade():
+    jobs = sa.table("jobs", sa.column("job_status", sa.String), sa.column("scheduled_for", sa.DateTime))
+    op.execute(
+        jobs.update()
+        .where(
+            jobs.c.job_status == "finished",
+            jobs.c.scheduled_for < datetime.datetime.utcnow() - datetime.timedelta(days=1),
+        )
+        .values(job_status="finished all notifications created")
+    )
+
+
+def downgrade():
+    # leave 0485_add_job_status_fin_allrws' downgrade responsible for reverting all affected
+    # rows to 'finished'
+    pass


### PR DESCRIPTION
A follow-up to #4323

This updates all "finished" jobs more than 24h since scheduled_for to the new `finished all notifications created` status. why 24h? 24h is how far back the `check-for-missing-rows-in-completed-jobs` celery task will look and so anything older than that won't get converted to `finished all notifications created` automatically.

There *shouldn't* be any jobs that make it to 24h without all rows or being moved to a failed state by then anyway...