### PR TITLE
Rename 0847_returned_letter_callback to 0487_returned_letter_callback

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0847_returned_letter_callback
+0487_returned_letter_callback

--- a/migrations/versions/0487_returned_letter_callback.py
+++ b/migrations/versions/0487_returned_letter_callback.py
@@ -4,7 +4,7 @@ Create Date: 2025-01-24 12:05:58.010551
 
 from alembic import op
 
-revision = "0847_returned_letter_callback"
+revision = "0487_returned_letter_callback"
 down_revision = "0486_letter_rates_feb_2025"
 
 


### PR DESCRIPTION
 This fixes the typo in the name of the migration script and keeps it consistent with current naming convention