### PR TITLE
Update service free allowance when organisation type change

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -1,5 +1,4 @@
 from flask import current_app
-from sqlalchemy import and_
 from sqlalchemy.sql.expression import func
 
 from app import db
@@ -10,7 +9,6 @@ from app.dao.email_branding_dao import dao_get_email_branding_by_id
 from app.dao.letter_branding_dao import dao_get_letter_branding_by_id
 from app.dao.organisation_user_permissions_dao import organisation_user_permissions_dao
 from app.models import (
-    AnnualBilling,
     Domain,
     EmailBranding,
     Organisation,
@@ -41,25 +39,6 @@ def dao_count_organisations_with_live_services():
 
 def dao_get_organisation_services(organisation_id):
     return Organisation.query.filter_by(id=organisation_id).one().services
-
-
-def dao_get_organisation_live_services_and_their_free_allowance(organisation_id, financial_year):
-    return (
-        db.session.query(
-            Service.id,
-            Service.name,
-            Service.active,
-            func.coalesce(AnnualBilling.free_sms_fragment_limit, 0).label("free_sms_fragment_limit"),
-        )
-        .outerjoin(
-            AnnualBilling,
-            and_(Service.id == AnnualBilling.service_id, AnnualBilling.financial_year_start == financial_year),
-        )
-        .filter(
-            Service.organisation_id == organisation_id,
-            Service.restricted.is_(False),
-        )
-    )
 
 
 def dao_get_organisation_by_id(organisation_id):

--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -4,6 +4,7 @@ from sqlalchemy.sql.expression import func
 
 from app import db
 from app.constants import NHS_ORGANISATION_TYPES
+from app.dao.annual_billing_dao import set_default_free_allowance_for_service
 from app.dao.dao_utils import VersionOptions, autocommit, version_class
 from app.dao.email_branding_dao import dao_get_email_branding_by_id
 from app.dao.letter_branding_dao import dao_get_letter_branding_by_id
@@ -117,6 +118,7 @@ def dao_update_organisation(organisation_id, **kwargs):
 
     if "organisation_type" in kwargs:
         _update_organisation_services(organisation, "organisation_type", only_where_none=False)
+        _update_organisation_services_free_allowance(organisation)
 
     if "crown" in kwargs:
         _update_organisation_services(organisation, "crown", only_where_none=False)
@@ -156,6 +158,11 @@ def _update_organisation_services(organisation, attribute, only_where_none=True)
         if getattr(service, attribute) is None or not only_where_none:
             setattr(service, attribute, getattr(organisation, attribute))
         db.session.add(service)
+
+
+def _update_organisation_services_free_allowance(organisation):
+    for service in organisation.services:
+        set_default_free_allowance_for_service(service, year_start=None)
 
 
 @autocommit

--- a/tests/app/dao/test_organisation_dao.py
+++ b/tests/app/dao/test_organisation_dao.py
@@ -20,7 +20,6 @@ from app.dao.organisation_dao import (
     dao_get_organisation_by_email_address,
     dao_get_organisation_by_id,
     dao_get_organisation_by_service_id,
-    dao_get_organisation_live_services_and_their_free_allowance,
     dao_get_organisation_services,
     dao_get_organisations,
     dao_get_users_for_organisation,
@@ -31,7 +30,6 @@ from app.dao.organisation_dao import (
 from app.errors import InvalidRequest
 from app.models import AnnualBilling, Organisation, Service
 from tests.app.db import (
-    create_annual_billing,
     create_domain,
     create_email_branding,
     create_letter_branding,
@@ -536,30 +534,6 @@ def test_dao_add_email_branding_list_to_organisation_pool(sample_organisation):
     assert branding_1 in sample_organisation.email_branding_pool
     assert branding_2 in sample_organisation.email_branding_pool
     assert branding_3 in sample_organisation.email_branding_pool
-
-
-def test_dao_get_organisation_live_services_with_free_allowance(sample_service, sample_organisation):
-    service_with_no_free_allowance = create_service(service_name="service 2")
-
-    create_annual_billing(sample_service.id, free_sms_fragment_limit=10, financial_year_start=2015)
-    create_annual_billing(sample_service.id, free_sms_fragment_limit=20, financial_year_start=2016)
-
-    dao_add_service_to_organisation(sample_service, sample_organisation.id)
-    dao_add_service_to_organisation(service_with_no_free_allowance, sample_organisation.id)
-
-    org_services = (
-        dao_get_organisation_live_services_and_their_free_allowance(sample_organisation.id, 2015)
-        .order_by(Service.name)
-        .all()
-    )
-
-    assert len(org_services) == 2
-
-    assert org_services[0].id == sample_service.id
-    assert org_services[0].free_sms_fragment_limit == 10
-
-    assert org_services[1].id == service_with_no_free_allowance.id
-    assert org_services[1].free_sms_fragment_limit == 0
 
 
 def test_dao_remove_email_branding_from_organisation_pool(sample_organisation):


### PR DESCRIPTION
Update the free allowance when updating organisation type. If the service free allowance has been updated manually then it should keep the manual allowance, this requirement should be handled as part of [this story](https://trello.com/c/i67GtAIi/1113-figure-out-how-to-automatically-handle-high-volume-service-free-allowances). More details on [this card](https://trello.com/c/31ksdlS9/1147-if-you-update-organisation-type-it-doesnt-update-services-free-allowances-for-that-org).
This PR needs to be merged after https://github.com/alphagov/notifications-api/pull/4375