### PR TITLE
Automate setting the free allowance for high volume services

### DIFF
--- a/app/billing/rest.py
+++ b/app/billing/rest.py
@@ -82,9 +82,7 @@ def create_or_update_free_sms_fragment_limit(service_id):
     return jsonify(form), 201
 
 
-def update_free_sms_fragment_limit_data(service_id, free_sms_fragment_limit, financial_year_start=None):
-    # TODO: `financial_year_start` parameter can be removed, but has been kept temporarily so nothing breaks
-    # during deployment
+def update_free_sms_fragment_limit_data(service_id, free_sms_fragment_limit):
     current_year = get_current_financial_year_start_year()
 
     dao_create_or_update_annual_billing_for_year(service_id, free_sms_fragment_limit, current_year)

--- a/app/billing/rest.py
+++ b/app/billing/rest.py
@@ -7,6 +7,7 @@ from app.billing.billing_schemas import (
 )
 from app.dao.annual_billing_dao import (
     dao_create_or_update_annual_billing_for_year,
+    dao_get_default_annual_allowance_for_service,
     dao_get_free_sms_fragment_limit_for_year,
     set_default_free_allowance_for_service,
 )
@@ -15,6 +16,7 @@ from app.dao.fact_billing_dao import (
     fetch_usage_for_service_annual,
     fetch_usage_for_service_by_month,
 )
+from app.dao.services_dao import dao_fetch_service_by_id
 from app.errors import register_errors
 from app.models import Service
 from app.schema_validation import validate
@@ -83,6 +85,19 @@ def create_or_update_free_sms_fragment_limit(service_id):
 
 
 def update_free_sms_fragment_limit_data(service_id, free_sms_fragment_limit):
-    current_year = get_current_financial_year_start_year()
+    """
+    Update the free allowance for a service for this year.
 
-    dao_create_or_update_annual_billing_for_year(service_id, free_sms_fragment_limit, current_year)
+    If updating the free allowance now means that a service has the default allowance for its
+    org type, we set `has_custom_allowance` to False, otherwise it is True.
+    """
+    current_year = get_current_financial_year_start_year()
+    service = dao_fetch_service_by_id(service_id, with_users=False)
+    default_free_allowance = dao_get_default_annual_allowance_for_service(service, current_year)
+
+    dao_create_or_update_annual_billing_for_year(
+        service_id,
+        free_sms_fragment_limit,
+        current_year,
+        has_custom_allowance=default_free_allowance != free_sms_fragment_limit,
+    )

--- a/app/constants.py
+++ b/app/constants.py
@@ -323,6 +323,7 @@ LETTER_TEST_API_FILENAME = "test letter submitted via api"
 
 # Miscellaneous
 MOBILE_TYPE = "mobile"
+HIGH_VOLUME_SERVICE_THRESHOLD = 400_000
 
 # Guest lists
 GUEST_LIST_RECIPIENT_TYPE = [MOBILE_TYPE, EMAIL_TYPE]

--- a/app/dao/annual_billing_dao.py
+++ b/app/dao/annual_billing_dao.py
@@ -9,7 +9,13 @@ from app.models import AnnualBilling, DefaultAnnualAllowance
 
 
 @autocommit
-def dao_create_or_update_annual_billing_for_year(service_id, free_sms_fragment_limit, financial_year_start):
+def dao_create_or_update_annual_billing_for_year(
+    service_id,
+    free_sms_fragment_limit,
+    financial_year_start,
+    high_volume_service_last_year=None,
+    has_custom_allowance=None,
+):
     result = dao_get_free_sms_fragment_limit_for_year(service_id, financial_year_start)
 
     if result:
@@ -20,6 +26,13 @@ def dao_create_or_update_annual_billing_for_year(service_id, free_sms_fragment_l
             financial_year_start=financial_year_start,
             free_sms_fragment_limit=free_sms_fragment_limit,
         )
+
+    if high_volume_service_last_year is not None:
+        result.high_volume_service_last_year = high_volume_service_last_year
+
+    if has_custom_allowance is not None:
+        result.has_custom_allowance = has_custom_allowance
+
     db.session.add(result)
     return result
 

--- a/app/dao/annual_billing_dao.py
+++ b/app/dao/annual_billing_dao.py
@@ -86,7 +86,7 @@ def set_default_free_allowance_for_service(service, year_start=None):
         raise ValueError("year_start cannot be in a future financial year")
 
     if _is_high_volume_service(service):
-        free_sms_fragment_allowance = 0
+        next_free_sms_fragment_allowance = 0
         high_volume_service_last_year = True
         has_custom_allowance = False
 
@@ -101,12 +101,12 @@ def set_default_free_allowance_for_service(service, year_start=None):
 
         if last_years_allowance and last_years_allowance.has_custom_allowance:
             # carry over the allowance from last year
-            free_sms_fragment_allowance = last_years_allowance.free_sms_fragment_limit
+            next_free_sms_fragment_allowance = last_years_allowance.free_sms_fragment_limit
             has_custom_allowance = True
         else:
             # get the default for the org
             default_free_sms_fragment_allowance = dao_get_default_annual_allowance_for_service(service, year_start)
-            free_sms_fragment_allowance = default_free_sms_fragment_allowance.allowance
+            next_free_sms_fragment_allowance = default_free_sms_fragment_allowance.allowance
             has_custom_allowance = False
 
     current_app.logger.info(
@@ -116,11 +116,11 @@ def set_default_free_allowance_for_service(service, year_start=None):
         ),
         service.id,
         year_start,
-        free_sms_fragment_allowance,
+        next_free_sms_fragment_allowance,
     )
     return dao_create_or_update_annual_billing_for_year(
         service.id,
-        free_sms_fragment_allowance,
+        next_free_sms_fragment_allowance,
         year_start,
         high_volume_service_last_year=high_volume_service_last_year,
         has_custom_allowance=has_custom_allowance,

--- a/app/models.py
+++ b/app/models.py
@@ -705,6 +705,8 @@ class AnnualBilling(db.Model):
     free_sms_fragment_limit = db.Column(db.Integer, nullable=False, index=False, unique=False)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    high_volume_service_last_year = db.Column(db.Boolean, unique=False, default=False, nullable=False)
+    has_custom_allowance = db.Column(db.Boolean, unique=False, default=False, nullable=False)
     UniqueConstraint("financial_year_start", "service_id", name="ix_annual_billing_service_id")
     service = db.relationship(Service, backref=db.backref("annual_billing", uselist=True))
 

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0487_returned_letter_callback
+0488_add_annual_billing_columns

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0488_add_annual_billing_columns
+0489_populate_new_billing_cols

--- a/migrations/versions/0488_add_annual_billing_columns.py
+++ b/migrations/versions/0488_add_annual_billing_columns.py
@@ -1,0 +1,20 @@
+"""
+Create Date: 2025-01-27 10:11:14.411859
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0488_add_annual_billing_columns"
+down_revision = "0487_returned_letter_callback"
+
+
+def upgrade():
+    op.add_column("annual_billing", sa.Column("high_volume_service_last_year", sa.Boolean(), nullable=False, server_default=sa.false()))
+    op.add_column("annual_billing", sa.Column("has_custom_allowance", sa.Boolean(), nullable=False, server_default=sa.false()))
+
+
+def downgrade():
+    op.drop_column("annual_billing", "has_custom_allowance")
+    op.drop_column("annual_billing", "high_volume_service_last_year")

--- a/migrations/versions/0489_populate_new_billing_cols.py
+++ b/migrations/versions/0489_populate_new_billing_cols.py
@@ -1,0 +1,71 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0489_populate_new_billing_cols"
+down_revision = "0488_add_annual_billing_columns"
+
+
+def upgrade():
+    # update billing for services we have set to a non-zero value to be has_custom=True
+    op.execute(
+        """
+        UPDATE annual_billing
+        SET has_custom_allowance = true
+        WHERE id in
+        (
+            SELECT
+                ab.id
+            FROM annual_billing ab
+            JOIN services s on ab.service_id = s.id
+            JOIN default_annual_allowance daa on s.organisation_type = daa.organisation_type
+            WHERE
+                ab.financial_year_start = 2024
+                AND daa.valid_from_financial_year_start = 2024
+                AND daa.notification_type = 'sms' and ab.free_sms_fragment_limit != 0
+                AND ab.free_sms_fragment_limit != daa.allowance
+            ORDER BY s.organisation_type, ab.free_sms_fragment_limit
+        )
+        """
+    )
+
+    # update billing for services with a zero allowance last year - either high_volume = true or has_custom = True
+    op.execute(
+        """
+        -- return service id and fy23-24 units used for all services that have zero SMS allowance in fy24
+       WITH prev_fy_stats AS (
+            SELECT
+                ab.id AS annual_billing_24_id,
+                coalesce(sum(billable_units * rate_multiplier), 0) AS units_used_in_23
+            FROM annual_billing ab
+            LEFT OUTER JOIN ft_billing ON
+                ab.service_id = ft_billing.service_id
+                AND notification_type = 'sms'
+                AND bst_date >= '2023-04-01'
+                AND bst_date < '2024-04-01'
+            WHERE
+                ab.financial_year_start = 2024
+                AND ab.free_sms_fragment_limit = 0
+            GROUP BY
+                ab.id
+        )
+        UPDATE annual_billing
+        SET
+            high_volume_service_last_year = prev_fy_stats.units_used_in_23 >= 400000,
+            has_custom_allowance = prev_fy_stats.units_used_in_23 < 400000
+        FROM prev_fy_stats
+        WHERE
+            prev_fy_stats.annual_billing_24_id = annual_billing.id
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        UPDATE annual_billing
+        SET
+            high_volume_service_last_year = false,
+            has_custom_allowance = false
+        """
+    )

--- a/tests/app/billing/test_rest.py
+++ b/tests/app/billing/test_rest.py
@@ -99,7 +99,7 @@ def test_update_free_sms_fragment_limit_data(client, sample_service):
     current_year = get_current_financial_year_start_year()
     create_annual_billing(sample_service.id, free_sms_fragment_limit=250000, financial_year_start=current_year - 1)
 
-    update_free_sms_fragment_limit_data(sample_service.id, 9999, current_year)
+    update_free_sms_fragment_limit_data(sample_service.id, 9999)
 
     annual_billing = dao_get_free_sms_fragment_limit_for_year(sample_service.id, current_year)
     assert annual_billing.free_sms_fragment_limit == 9999

--- a/tests/app/billing/test_rest.py
+++ b/tests/app/billing/test_rest.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime
 
+import pytest
 from freezegun import freeze_time
 
 from app.billing.rest import update_free_sms_fragment_limit_data
@@ -39,8 +40,13 @@ def test_create_or_update_free_sms_fragment_limit_past_year_doesnt_update_other_
         _expected_status=201,
     )
 
-    assert dao_get_free_sms_fragment_limit_for_year(sample_service.id, current_year - 1).free_sms_fragment_limit == 1
-    assert dao_get_free_sms_fragment_limit_for_year(sample_service.id, current_year).free_sms_fragment_limit == 9999
+    annual_billing_last_year = dao_get_free_sms_fragment_limit_for_year(sample_service.id, current_year - 1)
+    assert annual_billing_last_year.free_sms_fragment_limit == 1
+    assert annual_billing_last_year.has_custom_allowance is False
+
+    annual_billing_this_year = dao_get_free_sms_fragment_limit_for_year(sample_service.id, current_year)
+    assert annual_billing_this_year.free_sms_fragment_limit == 9999
+    assert annual_billing_this_year.has_custom_allowance is True
 
 
 def test_create_free_sms_fragment_limit_updates_existing_year(admin_request, sample_service):
@@ -55,6 +61,7 @@ def test_create_free_sms_fragment_limit_updates_existing_year(admin_request, sam
     )
 
     assert annual_billing.free_sms_fragment_limit == 2
+    assert annual_billing.has_custom_allowance is True
 
 
 @freeze_time("2021-04-02 13:00")
@@ -95,14 +102,41 @@ def test_get_free_sms_fragment_limit_current_year_creates_new_row_if_annual_bill
     assert json_response["free_sms_fragment_limit"] == 10000  # based on other organisation type
 
 
-def test_update_free_sms_fragment_limit_data(client, sample_service):
+@pytest.mark.parametrize("high_volume_service_last_year", [True, False])
+def test_update_free_sms_fragment_limit_data(client, sample_service, high_volume_service_last_year):
     current_year = get_current_financial_year_start_year()
-    create_annual_billing(sample_service.id, free_sms_fragment_limit=250000, financial_year_start=current_year - 1)
+    create_annual_billing(
+        sample_service.id,
+        free_sms_fragment_limit=250000,
+        financial_year_start=current_year,
+        high_volume_service_last_year=high_volume_service_last_year,
+    )
 
     update_free_sms_fragment_limit_data(sample_service.id, 9999)
 
     annual_billing = dao_get_free_sms_fragment_limit_for_year(sample_service.id, current_year)
     assert annual_billing.free_sms_fragment_limit == 9999
+    assert annual_billing.high_volume_service_last_year is high_volume_service_last_year
+    assert annual_billing.has_custom_allowance is True
+
+
+def test_update_free_sms_fragment_limit_data_when_updating_to_default(sample_service, mocker):
+    mocker.patch("app.billing.rest.dao_get_default_annual_allowance_for_service", return_value=50)
+
+    current_year = get_current_financial_year_start_year()
+    create_annual_billing(
+        sample_service.id,
+        free_sms_fragment_limit=250000,
+        financial_year_start=current_year - 1,
+        has_custom_allowance=True,
+    )
+
+    update_free_sms_fragment_limit_data(sample_service.id, 50)
+
+    annual_billing = dao_get_free_sms_fragment_limit_for_year(sample_service.id, current_year)
+    assert annual_billing.free_sms_fragment_limit == 50
+    assert annual_billing.high_volume_service_last_year is False
+    assert annual_billing.has_custom_allowance is False
 
 
 def test_get_yearly_usage_by_monthly_from_ft_billing(admin_request, notify_db_session):

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -23,6 +23,7 @@ from app.dao.fact_billing_dao import (
     get_count_of_notifications_sent,
     get_rate,
     get_rates_for_billing,
+    get_sms_fragments_sent_last_financial_year,
     update_ft_billing_letter_despatch,
 )
 from app.dao.notifications_dao import dao_record_letter_despatched_on_by_id
@@ -1516,3 +1517,13 @@ def test_get_count_of_notifications_sent(sample_service, test_case):
     )
 
     assert count == test_case.expected_count
+
+
+@freeze_time("2019-04-02 01:20:00")
+def test_get_sms_fragments_sent_last_financial_year(sample_service, sample_service_billing_fy_2018_variable_rates):
+    sms_template = create_template(sample_service, "sms")
+    # These rows should not get counted since they are before the last fy
+    create_ft_billing("2018-01-01", sms_template)
+    create_ft_billing("2017-08-01", sms_template)
+
+    assert get_sms_fragments_sent_last_financial_year(sample_service.id) == 9

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -599,11 +599,19 @@ def create_letter_contact(service, contact_block, is_default=True, archived=Fals
     return letter_content
 
 
-def create_annual_billing(service_id, free_sms_fragment_limit, financial_year_start):
+def create_annual_billing(
+    service_id,
+    free_sms_fragment_limit,
+    financial_year_start,
+    high_volume_service_last_year=False,
+    has_custom_allowance=False,
+):
     annual_billing = AnnualBilling(
         service_id=service_id,
         free_sms_fragment_limit=free_sms_fragment_limit,
         financial_year_start=financial_year_start,
+        high_volume_service_last_year=high_volume_service_last_year,
+        has_custom_allowance=has_custom_allowance,
     )
     db.session.add(annual_billing)
     db.session.commit()


### PR DESCRIPTION
See individual commits for details.

Our current code to set the free allowance for a service either gives the service the default its organisation type or keeps the free allowance as zero if it was zero for previous years. This has a couple of issues:
- services with a different custom allowance didn't have this persisted to future years
- services which a free allowance of 0 due to being a high volume sender never had this reset if they stopped sending so many messages

Two extra columns have been added to the annual billing table, `high_volume_service_last_year` and `has_custom_allowance`. These let us automatically set the free allowance to 0 for high volume senders and to persist custom free allowances.
