### PR TITLE
Install uv using `COPY` and bump to latest version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.11-slim-bookworm AS base
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV UV_COMPILE_BYTECODE=1
+ENV VIRTUAL_ENV="/opt/venv"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim-bookworm AS base
 
-COPY --from=ghcr.io/astral-sh/uv:0.5.26 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.5.28 /uv /uvx /bin/
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim-bookworm AS base
 
+COPY --from=ghcr.io/astral-sh/uv:0.5.26 /uv /uvx /bin/
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV UV_COMPILE_BYTECODE=1
@@ -28,9 +30,6 @@ RUN echo "Install OS dependencies for python app requirements" &&  \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
 COPY requirements.txt .
-
-RUN pip install uv==0.5.26
-
 
 ENV UV_CACHE_DIR='/tmp/uv-cache/'
 RUN echo "Installing python requirements" && \
@@ -87,7 +86,6 @@ RUN mkdir -p app
 COPY --from=python_build --chown=notify:notify /opt/venv /opt/venv
 
 # Install dev/test requirements
-RUN pip install uv==0.5.26
 COPY --chown=notify:notify Makefile requirements_for_test.txt ./
 ENV UV_CACHE_DIR='/tmp/uv-cache/'
 RUN make bootstrap
@@ -125,8 +123,6 @@ COPY --from=python_build --chown=notify:notify /home/vcap/app/app/version.py app
 COPY --chown=notify:notify . .
 
 ENV SQLALCHEMY_DATABASE_URI=postgresql://postgres:postgres@localhost/
-
-RUN pip3 install uv==0.5.26
 
 ENV UV_CACHE_DIR='/tmp/uv-cache/'
 RUN uv pip sync requirements_for_test.txt


### PR DESCRIPTION
# Put venv location in environment variable

As suggested in https://github.com/astral-sh/uv/issues/11214#issuecomment-2633899802

Without this we’re making an assumption about the venv existing (that we know because we just created it) that uv doesn’t know.

# Install uv from Docker registry

This is one of the recommended ways to install uv in their documentation: https://docs.astral.sh/uv/guides/integration/docker/#installing-uv

It means we don’t need to specify the version number 3 times.

# Bump uv to latest version

We can safely do this because:
- we added the location of the venv to an environment variable in this commit’s grandparent
- the regression in 0.5.27 was fixed in 0.5.28 via https://github.com/astral-sh/uv/pull/11218