### PR TITLE
Update service_callback_api field in ServiceSchema

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -226,13 +226,12 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
     custom_email_sender_name = fields.String(allow_none=True)
     # this can only be set via custom_email_sender_name or name
     email_sender_local_part = fields.String(dump_only=True)
-    service_callback_api = fields.Method("service_delivery_status_callback_api")
+    service_callback_api = fields.Method("service_callback_api_details")
 
-    def service_delivery_status_callback_api(self, service):
+    def service_callback_api_details(self, service):
         return [
-            callback.id
+            {"callback_id": str(callback.id), "callback_type": callback.callback_type}
             for callback in service.service_callback_api
-            if callback.callback_type == app.constants.ServiceCallbackTypes.delivery_status.value
         ]
 
     def _get_allowed_broadcast_provider(self, service):
@@ -331,13 +330,12 @@ class DetailedServiceSchema(BaseSchema):
     name = fields.String()
     custom_email_sender_name = fields.String(required=False)
     email_sender_local_part = fields.String()
-    service_callback_api = fields.Method("service_delivery_status_callback_api")
+    service_callback_api = fields.Method("service_callback_api_details")
 
-    def service_delivery_status_callback_api(self, service):
+    def service_callback_api_details(self, service):
         return [
-            callback.id
+            {"callback_id": str(callback.id), "callback_type": callback.callback_type}
             for callback in service.service_callback_api
-            if callback.callback_type == app.constants.ServiceCallbackTypes.delivery_status.value
         ]
 
     class Meta(BaseSchema.Meta):


### PR DESCRIPTION
service_callback_api now also includes returned_letter callback type, so this field is no longer a list of ids filtered on the delivery_status callback type.
The choice of representing the data in dicts, with callback_id and callback_type as keys, is to aid filtering in the front end as to what type of callback is being considered ie
delivery_status or returned_letter.

Needs to wait until this PR is deployed: https://github.com/alphagov/notifications-admin/pull/5382