### PR TITLE
Bump utils to 95.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@94.0.1
+# This file was automatically copied from notifications-utils@95.1.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from app.serialised_models import SerialisedService
 
-GENERAL_TOKEN_ERROR_MESSAGE = "Invalid token: make sure your API token matches the example at https://docs.notifications.service.gov.uk/rest-api.html#authorisation-header"  # noqa
+GENERAL_TOKEN_ERROR_MESSAGE = "Invalid token: make sure your API token matches the example at https://docs.notifications.service.gov.uk/rest-api.html#authorisation-header"
 
 AUTH_DB_CONNECTION_DURATION_SECONDS = Histogram(
     "auth_db_connection_duration_seconds",

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil>=6.0.0,<7.0.0
 notifications-python-client==10.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@94.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@95.1.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -147,7 +147,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d6311c3ab83b8225265277f781157c48f9318ae9
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@361486ff4960b5d02c162118b1fd64b097f9cb96
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -219,7 +219,7 @@ moto==5.0.11
     # via -r requirements_for_test.in
 notifications-python-client==10.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d6311c3ab83b8225265277f781157c48f9318ae9
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@361486ff4960b5d02c162118b1fd64b097f9cb96
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@94.0.1
+# This file was automatically copied from notifications-utils@95.1.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@94.0.1
+# This file was automatically copied from notifications-utils@95.1.1
 
 exclude = [
     "migrations/versions/",
@@ -31,5 +31,6 @@ select = [
     "RSE",  # flake8-raise
     "PIE",  # flake8-pie
     "N804",  # First argument of a class method should be named `cls`
+    "RUF100",  # Checks for noqa directives that are no longer applicable
 ]
 ignore = []

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -818,7 +818,7 @@ def test_check_for_services_with_high_failure_rates_or_sending_to_tv_numbers(
         "app.celery.scheduled_tasks.dao_find_services_sending_to_tv_numbers", return_value=sms_to_tv_numbers
     )
 
-    zendesk_actions = "\nYou can find instructions for this ticket in our manual:\nhttps://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#deal-with-services-with-high-failure-rates-or-sending-sms-to-tv-numbers"  # noqa
+    zendesk_actions = "\nYou can find instructions for this ticket in our manual:\nhttps://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#deal-with-services-with-high-failure-rates-or-sending-sms-to-tv-numbers"
 
     with caplog.at_level("WARNING"):
         check_for_services_with_high_failure_rates_or_sending_to_tv_numbers()

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -296,10 +296,10 @@ def test_service_can_send_to_recipient_fails_when_ignoring_guest_list(
         ("team", "Can’t send to this recipient using a team-only API key"),
         (
             "normal",
-            "Can’t send to this recipient when service is in trial mode – see https://www.notifications.service.gov.uk/trial-mode",  # noqa
+            "Can’t send to this recipient when service is in trial mode – see https://www.notifications.service.gov.uk/trial-mode",
         ),
     ],
-)  # noqa
+)
 def test_service_can_send_to_recipient_fails_when_recipient_is_not_on_team(
     recipient,
     key_type,

--- a/tests/app/service/test_statistics_rest.py
+++ b/tests/app/service/test_statistics_rest.py
@@ -202,7 +202,7 @@ def test_get_monthly_notification_stats_combines_todays_data_and_historic_stats(
     create_ft_notification_status(datetime(2016, 5, 1), template=sample_template, count=1)
     create_ft_notification_status(
         datetime(2016, 6, 1), template=sample_template, notification_status="created", count=2
-    )  # noqa
+    )
 
     create_notification(sample_template, created_at=datetime(2016, 6, 5), status="created")
     create_notification(sample_template, created_at=datetime(2016, 6, 5), status="delivered")

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -214,7 +214,7 @@ def test_should_raise_error_if_service_does_not_exist_on_create(client, sample_u
             BROADCAST_TYPE,
             None,
             {"template_type": ["Creating broadcast message templates is not allowed"]},
-        ),  # noqa
+        ),
         ([EMAIL_TYPE], SMS_TYPE, None, {"template_type": ["Creating text message templates is not allowed"]}),
         ([SMS_TYPE], EMAIL_TYPE, "subject", {"template_type": ["Creating email templates is not allowed"]}),
         ([SMS_TYPE], LETTER_TYPE, "subject", {"template_type": ["Creating letter templates is not allowed"]}),


### PR DESCRIPTION
Blocked until: 
- [x] https://github.com/alphagov/notifications-api/pull/4389

***

## 95.1.1

* Add `RUF100` rule to linter config (checks for inapplicable uses of `# noqa`)

 ## 95.1.0

* Adds log message and statsd metric for retried celery tasks

 ## 95.0.0

* Reverts 92.0.0 to restore new validation code

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/94.0.1...95.1.1