### PR TITLE
Add settings for new queue and worker

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -26,6 +26,7 @@ class QueueNames:
     LETTER_CALLBACKS = "letter-callbacks"
     ANTIVIRUS = "antivirus-tasks"
     SANITISE_LETTERS = "sanitise-letter-tasks"
+    REPORT_REQUESTS_NOTIFICATIONS = "report-requests-notifications-tasks"
     BROADCASTS = "broadcast-tasks"
     GOVUK_ALERTS = "govuk-alerts"
 
@@ -50,6 +51,7 @@ class QueueNames:
             QueueNames.SMS_CALLBACKS,
             QueueNames.LETTER_CALLBACKS,
             QueueNames.BROADCASTS,
+            QueueNames.REPORT_REQUESTS_NOTIFICATIONS,
         ]
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,6 +61,9 @@ case "$1" in
   api-worker-service-callbacks)
     exec $COMMON_CMD service-callbacks,service-callbacks-retry
     ;;
+  api-worker-report-requests-notifications)
+    exec $COMMON_CMD report-requests-notifications-tasks
+    ;;
   celery-beat)
     exec celery -A run_celery.notify_celery beat --loglevel=INFO
     ;;

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -7,7 +7,7 @@ from app.config import QueueNames
 def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()
-    assert len(queues) == 18
+    assert len(queues) == 19
     assert {
         QueueNames.PERIODIC,
         QueueNames.DATABASE,
@@ -27,6 +27,7 @@ def test_queue_names_all_queues_correct():
         QueueNames.SMS_CALLBACKS,
         QueueNames.LETTER_CALLBACKS,
         QueueNames.BROADCASTS,
+        QueueNames.REPORT_REQUESTS_NOTIFICATIONS,
     } == set(queues)
 
 


### PR DESCRIPTION
This adds the settings for a new worker, `api-worker-report-requests-notifications`, and a queue that it will pull messages from `report-requests-notifications-tasks`.

These will be used for the tasks of generating large notification reports.