### PR TITLE
feat: Create Users List Endpoint for Platform Admins

### DIFF
--- a/app/dao/date_util.py
+++ b/app/dao/date_util.py
@@ -78,3 +78,18 @@ def get_financial_year_for_datetime(start_date):
         return year - 1
     else:
         return year
+
+
+def parse_date_range(date_str: str | None, is_end: bool = False, date_format: str = "%Y-%m-%d") -> datetime | None:
+    """
+    Converts a date string to a datetime object.
+    If `is_end` is True, the time is set to 23:59:59 to include the full day.
+    Otherwise, it defaults to 00:00:00 (midnight).
+    If the input is None, returns None.
+    """
+    if not date_str:
+        return None
+
+    dt = datetime.strptime(date_str, date_format)
+
+    return datetime.combine(dt.date(), time.max if is_end else time.min)  # Start at 00:00:00, end at 23:59:59

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -218,3 +218,32 @@ def get_users_for_research(start_date: date, end_date: date) -> list[User]:
         User.created_at >= start_date,
         User.created_at < end_date,
     ).all()
+
+
+def get_users_list(
+    logged_in_start: datetime | None = None,
+    logged_in_end: datetime | None = None,
+    created_start: datetime | None = None,
+    created_end: datetime | None = None,
+    take_part_in_research: bool | None = None,
+    state: str | None = "active",
+) -> list[User]:
+    filters = []
+
+    if state is not None:
+        filters.append(User.state == state)
+
+    if logged_in_start:
+        filters.append(User.logged_in_at >= logged_in_start)
+    if logged_in_end:
+        filters.append(User.logged_in_at <= logged_in_end)
+
+    if created_start:
+        filters.append(User.created_at >= created_start)
+    if created_end:
+        filters.append(User.created_at <= created_end)
+
+    if take_part_in_research is not None:
+        filters.append(User.take_part_in_research == take_part_in_research)
+
+    return User.query.filter(*filters).all()

--- a/app/models.py
+++ b/app/models.py
@@ -77,6 +77,7 @@ from app.history_meta import Versioned
 from app.utils import (
     DATETIME_FORMAT,
     DATETIME_FORMAT_NO_TIMEZONE,
+    dict_filter,
     get_dt_string_or_none,
     get_london_midnight_in_utc,
     get_uuid_string_or_none,
@@ -179,7 +180,13 @@ class User(db.Model):
 
         return retval
 
-    def serialize(self):
+    def serialize(self, service_filter_keys=None):
+        if service_filter_keys is None:
+            services_data = [x.id for x in self.services if x.active]
+        else:
+            service_filter_keys = list(set(service_filter_keys) | {"id"})
+            services_data = [dict_filter(x, service_filter_keys) for x in self.services if x.active]
+
         return {
             "id": self.id,
             "name": self.name,
@@ -196,7 +203,7 @@ class User(db.Model):
             "permissions": self.get_permissions(),
             "organisation_permissions": self.get_organisation_permissions(),
             "platform_admin": self.platform_admin,
-            "services": [x.id for x in self.services if x.active],
+            "services": services_data,
             "can_use_webauthn": self.can_use_webauthn,
             "state": self.state,
             "take_part_in_research": self.take_part_in_research,

--- a/app/platform_admin/platform_admin_schemas.py
+++ b/app/platform_admin/platform_admin_schemas.py
@@ -1,0 +1,14 @@
+get_users_list_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "minProperties": 1,
+    "properties": {
+        "logged_in_start": {"type": ["string", "null"], "format": "date"},
+        "logged_in_end": {"type": ["string", "null"], "format": "date"},
+        "created_start": {"type": ["string", "null"], "format": "date"},
+        "created_end": {"type": ["string", "null"], "format": "date"},
+        "take_part_in_research": {"type": ["boolean", "null"]},
+    },
+    "required": [],
+    "additionalProperties": False,
+}

--- a/app/utils.py
+++ b/app/utils.py
@@ -176,3 +176,7 @@ def get_ft_billing_data_for_today_updated_at() -> str | None:
 
 def utc_string_to_bst_string(utc_string):
     return utc_string_to_aware_gmt_datetime(utc_string).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def dict_filter(data_obj, keys):
+    return {key: getattr(data_obj, key, None) for key in keys}


### PR DESCRIPTION
## Summary:
This PR introduces a new API endpoint (`/users-list`) for platform admins to fetch a filtered list of users based on various criteria. The filtered data is used to generate a CSV export.

Users can be filtered by:
- Creation date (created_start, created_end)
- Last login date (logged_in_start, logged_in_end)
- Research opt-in status (take_part_in_research)
- User state (defaults to "active")


### Related Ticket:
[Add getting list  users and emails for yearly survey to platform admin](https://trello.com/c/qeSQJ5XB/1138-add-getting-list-users-and-emails-for-yearly-survey-to-platform-admin)