### PR TITLE
Remove outdated todo

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -439,8 +439,6 @@ def get_user(user_id):
 
 @user_blueprint.route("/<uuid:user_id>/service/<uuid:service_id>/permission", methods=["POST"])
 def set_permissions(user_id, service_id):
-    # TODO fix security hole, how do we verify that the user
-    # who is making this request has permission to make the request.
     service_user = dao_get_service_user(user_id, service_id)
     user = get_user_by_id(user_id)
     service = dao_fetch_service_by_id(service_id=service_id)


### PR DESCRIPTION
This todo is no longer accurate and misrepresents that we have a ‘security hole’.

The admin app has taken care of authorizing which users can change permissions since https://github.com/alphagov/notifications-admin/commit/9e710711cb9c9da723c8cb8d540592cb57d1754c

The `TODO:` was added 2 days previously in the _Functionality added and all tests working_ commit:
https://github.com/alphagov/notifications-api/commit/918d40cc9da7ff819ca399ee173f21a725501883#diff-856770ce1eee6ec9509abce6fde06d0f795d88514f04c6ab6518697a9e3bcc08R203-R204