### PR TITLE
Shatter letter delivery tasks

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -235,10 +235,7 @@ def send_dvla_letters_via_api(print_run_deadline_local, batch_size=100):
         (row.id for row in dao_get_letters_to_be_printed(print_run_deadline_local)),
         batch_size,
     ):
-        current_app.logger.info("triggered tasks for %i letters", batch_size)
         shatter_deliver_letter_tasks.apply_async([batch], queue=QueueNames.PERIODIC)
-
-    current_app.logger.info("send-dvla-letters-for-day-via-api - finished queuing")
 
 
 @notify_celery.task(name="shatter-deliver-letters-tasks")

--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -49,6 +49,7 @@ from app.letters.utils import (
     move_scan_to_invalid_pdf_bucket,
 )
 from app.models import Service
+from app.utils import batched
 
 
 @notify_celery.task(bind=True, name="get-pdf-for-templated-letter", max_retries=15, default_retry_delay=300)
@@ -228,14 +229,25 @@ def send_letters_volume_email_to_dvla(letters_volumes, date):
         send_notification_to_queue(saved_notification, queue=QueueNames.NOTIFY)
 
 
-def send_dvla_letters_via_api(print_run_deadline_local):
+def send_dvla_letters_via_api(print_run_deadline_local, batch_size=100):
     current_app.logger.info("send-dvla-letters-for-day-via-api - starting queuing")
-    for i, row in enumerate(dao_get_letters_to_be_printed(print_run_deadline_local)):
-        if i % 10000 == 0:
-            current_app.logger.info("triggered tasks for %i letters", i)
-        deliver_letter.apply_async(kwargs={"notification_id": row.id}, queue=QueueNames.SEND_LETTER)
+    for batch in batched(
+        (row.id for row in dao_get_letters_to_be_printed(print_run_deadline_local)),
+        batch_size,
+    ):
+        current_app.logger.info("triggered tasks for %i letters", batch_size)
+        shatter_deliver_letter_tasks.apply_async([batch], queue=QueueNames.PERIODIC)
 
     current_app.logger.info("send-dvla-letters-for-day-via-api - finished queuing")
+
+
+@notify_celery.task(name="shatter-deliver-letters-tasks")
+def shatter_deliver_letter_tasks(notification_ids):
+    # If the number or size of arguments to this function change, then the default
+    # `batch_size` argument of `send_dvla_letters_via_api` needs updating to keep
+    # within SQS’s maximum message size
+    for id in notification_ids:
+        deliver_letter.apply_async(kwargs={"notification_id": id}, queue=QueueNames.SEND_LETTER)
 
 
 @notify_celery.task(bind=True, name="sanitise-letter", max_retries=15, default_retry_delay=300)


### PR DESCRIPTION
# Before

When delivering letters to DVLA we are bottlenecked by the speed at which we can create SQS messages. This is a problem because we have one task which delivers all the letters, and it creates one SQS message at a time. This task runs for a long time, and we can’t deploy while it’s running.

<img width="1298" alt="image" src="https://github.com/user-attachments/assets/d1ead061-e1be-4eb1-9d0e-20c816bb7203" />

# After 

This change makes it so that one new task (and SQS message) is created for each 100 letters. Each of these new tasks – which can be picked up asynchronously – then create individual tasks for each of its 100 letters.

The overall time taken will probably be about the same, but the maximum time taken by any one task should be greatly reduced.

<img width="1298" alt="image" src="https://github.com/user-attachments/assets/a3223d82-c232-4dac-9500-fcda46083c1f" />

# Estimated increase in performance

  | Number of  letters<sup>1</sup>  | Database time | Time talking to SQS | Total task time
-- | -- | -- | -- | -- 
**Before** | 166,936  | 11 seconds<sup>2</sup> | 29 minutes 15 seconds | 29 minutes 26 seconds<sup>1</sup>
**After** | 166,936  |  11 seconds | 17 seconds | 28 seconds 💥 

1. Taken from last night’s print run
2. Estimated by running the same query manually against production and scaling up based on number of results

***


This is a similar approach taken by `shatter_jobs` in https://github.com/alphagov/notifications-api/pull/4284