### PR TITLE
Bump Sentry SDK to 1.45.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -31,4 +31,4 @@ notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@94
 prometheus-client==0.14.1
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 
-sentry-sdk[flask,celery,sqlalchemy]>=1.0.0,<2.0.0
+sentry-sdk[flask,celery,sqlalchemy]==1.45.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -212,7 +212,7 @@ s3transfer==0.10.1
     # via boto3
 segno==1.6.1
     # via notifications-utils
-sentry-sdk==1.38.0
+sentry-sdk==1.45.1
     # via -r requirements.in
 setuptools==75.6.0
     # via gunicorn

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -340,7 +340,7 @@ segno==1.6.1
     # via
     #   -r requirements.txt
     #   notifications-utils
-sentry-sdk==1.38.0
+sentry-sdk==1.45.1
     # via -r requirements.txt
 setuptools==75.6.0
     # via


### PR DESCRIPTION
Fixes GHSA-g92j-qhmh-64v2

Not something that likely affects us, but clears down the only open Dependabot warning on this repo.

This fix was released in sentry-sdk==2.8.0, then also backported to sentry-sdk==1.45.1.

I think we could probably upgrade to Sentry >= 2 without making any changes, but more testing would be needed to validate this. So just going with the backport for now.

Specifying an exact version because that’s our convention.