### PR TITLE
Doc dl bug

### DIFF
--- a/app/clients/document_download.py
+++ b/app/clients/document_download.py
@@ -9,7 +9,7 @@ class DocumentDownloadError(Exception):
         self.status_code = status_code
 
     @classmethod
-    def from_exception(cls, e):
+    def from_exception(cls, e: requests.RequestException):
         message = e.response.json()["error"]
         status_code = e.response.status_code
         return cls(message, status_code)

--- a/app/clients/document_download.py
+++ b/app/clients/document_download.py
@@ -9,9 +9,9 @@ class DocumentDownloadError(Exception):
         self.status_code = status_code
 
     @classmethod
-    def from_exception(cls, e: requests.RequestException):
+    def from_exception(cls, e: requests.RequestException, status_code: int | None = None):
         message = e.response.json()["error"]
-        status_code = e.response.status_code
+        status_code = status_code or e.response.status_code
         return cls(message, status_code)
 
 
@@ -73,11 +73,11 @@ class DocumentDownloadClient:
         except requests.RequestException as e:
             # if doc dl responds with a non-400, (eg 403) it's referring to credentials that the API and Doc DL use.
             # we don't want to tell users about that, so anything that isn't a 400 (virus scan failed or file type
-            # unrecognised) should be raised as a 500 internal server error here.
+            # unrecognised) or 413 (file too big) should be raised as a 500 internal server error here.
             if e.response is None:
                 raise Exception(f"Unhandled document download error: {repr(e)}") from e
-            elif e.response.status_code == 400:
-                error = DocumentDownloadError.from_exception(e)
+            elif e.response.status_code in {400, 413}:
+                error = DocumentDownloadError.from_exception(e, status_code=400)
                 current_app.logger.info("Document download request failed with error: %s", error.message)
                 raise error from e
             else:

--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.authentication.auth import AuthError
+from app.clients.document_download import DocumentDownloadError
 from app.errors import InvalidRequest
 
 
@@ -112,6 +113,14 @@ def register_errors(blueprint):
     def invalid_data(error):
         current_app.logger.info(error)
         response = jsonify(error.to_dict_v2()), error.status_code
+        return response
+
+    @blueprint.errorhandler(DocumentDownloadError)
+    def document_download_error(error: DocumentDownloadError):
+        current_app.logger.info(error)
+        # cast it to a BadRequestError to ensure we format the error well
+        bad_request_exc = BadRequestError(message=error.message)
+        response = jsonify(bad_request_exc.to_dict_v2()), error.status_code
         return response
 
     @blueprint.errorhandler(JsonSchemaValidationError)

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -18,7 +18,6 @@ from app.celery.letters_pdf_tasks import (
     sanitise_letter,
 )
 from app.celery.research_mode_tasks import create_fake_letter_callback
-from app.clients.document_download import DocumentDownloadError
 from app.config import QueueNames, TaskNames
 from app.constants import (
     DEFAULT_DOCUMENT_DOWNLOAD_RETENTION_PERIOD,
@@ -271,17 +270,14 @@ def process_document_uploads(personalisation_data, service, send_to: str, simula
 
             filename = personalisation_data[key].get("filename")
 
-            try:
-                personalisation_data[key] = document_download_client.upload_document(
-                    service.id,
-                    personalisation_data[key]["file"],
-                    personalisation_data[key].get("is_csv"),
-                    confirmation_email=send_to if confirm_email is not False else None,
-                    retention_period=retention_period,
-                    filename=filename,
-                )
-            except DocumentDownloadError as e:
-                raise BadRequestError(message=e.message, status_code=e.status_code) from e
+            personalisation_data[key] = document_download_client.upload_document(
+                service.id,
+                personalisation_data[key]["file"],
+                personalisation_data[key].get("is_csv"),
+                confirmation_email=send_to if confirm_email is not False else None,
+                retention_period=retention_period,
+                filename=filename,
+            )
 
     return personalisation_data, len(file_keys)
 

--- a/tests/app/clients/test_document_download.py
+++ b/tests/app/clients/test_document_download.py
@@ -110,17 +110,19 @@ def test_upload_document_retention_period(
         assert "retention_period" not in request_json
 
 
-def test_should_raise_400s_as_DocumentDownloadErrors(document_download, mock_onwards_request_headers):
+@pytest.mark.parametrize("status", [400, 413])
+def test_should_raise_user_errors_as_DocumentDownloadErrors(document_download, mock_onwards_request_headers, status):
     with pytest.raises(DocumentDownloadError) as excinfo, requests_mock.Mocker() as request_mock:
         request_mock.post(
             "https://document-download-internal/services/service-id/documents",
             json={"error": "Invalid mime type"},
-            status_code=400,
+            status_code=status,
         )
 
         document_download.upload_document("service-id", "abababab")
 
     assert excinfo.value.message == "Invalid mime type"
+    # 413 gets converted to 400 as well
     assert excinfo.value.status_code == 400
 
 


### PR DESCRIPTION
### move doc dl error handling to /v2/errors.py

add a test for it too

### convert doc dl 413s to 400s

this means we don't throw a 500 internal server error. rather than returning 413, it feels a bit simpler for users who aren't using our rest clients to just get a 400 the same as they would for other issues with the file relevant message to display
