### PR TITLE
Update the "user-profile" URLs to the new version, "your-account"

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -570,7 +570,7 @@ def _create_verification_url(user, base_url):
 
 def _create_confirmation_url(user, email_address):
     data = json.dumps({"user_id": str(user.id), "email": email_address})
-    url = "/user-profile/email/confirm/"
+    url = "/your-account/email/confirm/"
     return url_with_token(data, url)
 
 

--- a/migrations/versions/0461_user_research_email.py
+++ b/migrations/versions/0461_user_research_email.py
@@ -30,7 +30,7 @@ GOV.UK Notify
 
 ---
 
-If you do not want to take part in user research, you can [unsubscribe from these emails](https://www.notifications.service.gov.uk/user-profile/take-part-in-user-research).    """
+If you do not want to take part in user research, you can [unsubscribe from these emails](https://www.notifications.service.gov.uk/your-account/take-part-in-user-research).    """
 )
 
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -958,7 +958,7 @@ def user_research_email_for_new_users_template(notify_service):
 
         ---
 
-        If you do not want to take part in user research, you can [unsubscribe from these emails](https://www.notifications.service.gov.uk/user-profile/take-part-in-user-research).
+        If you do not want to take part in user research, you can [unsubscribe from these emails](https://www.notifications.service.gov.uk/your-account/take-part-in-user-research).
         """  # noqa
     )
 

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -84,10 +84,10 @@ def test_url_with_token_unsubscribe_link(sample_email_notification, hostnames, n
 def test_url_with_token__create_confirmation_url(hostnames, notify_api):
     data = json.dumps({"user_id": str(uuid.uuid4()), "email": "foo@bar.com"})
     base_url = hostnames.admin
-    url = "/user-profile/email/confirm/"
+    url = "/your-account/email/confirm/"
     token = generate_token(str(data), notify_api.config["SECRET_KEY"], notify_api.config["DANGEROUS_SALT"])
 
-    expected_unsubscribe_link = f"{base_url}/user-profile/email/confirm/{token}"
+    expected_unsubscribe_link = f"{base_url}/your-account/email/confirm/{token}"
     generated_unsubscribe_link = url_with_token(data, url=url, base_url=base_url)
 
     assert generated_unsubscribe_link == expected_unsubscribe_link


### PR DESCRIPTION
**Update URL used to generate an email when a user's email changes**

We send users an email to confirm if they change their email address. This updates the link in this email to the new URL of `/your-account/email/confirm`.

**Update URL in migration that creates new user research email**
This updates the content to contain the new URL. This will only apply to dev environments where the migrations get run from scratch (we'll need to manually make the change in other environments). We don't actually send the email in dev environments, but updating the template keeps things consistent.

---

**Merge after**
- [x] https://github.com/alphagov/notifications-admin/pull/5395