### PR TITLE
Bump notify-utils to 97.0.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@95.1.2
+# This file was automatically copied from notifications-utils@97.0.3
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,6 +1,6 @@
 import os
 
-from notifications_utils.gunicorn_defaults import set_gunicorn_defaults
+from notifications_utils.gunicorn.defaults import set_gunicorn_defaults
 
 set_gunicorn_defaults(globals())
 

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil>=6.0.0,<7.0.0
 notifications-python-client==10.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@95.1.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@97.0.3
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -147,7 +147,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@1b1d0ef1a52f7298685719e705ba4671e5338bf3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@3fb3caf0efc9ccbebfe79b3269f84bfd66fc90d5
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -219,7 +219,7 @@ moto==5.0.11
     # via -r requirements_for_test.in
 notifications-python-client==10.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@1b1d0ef1a52f7298685719e705ba4671e5338bf3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@3fb3caf0efc9ccbebfe79b3269f84bfd66fc90d5
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@95.1.2
+# This file was automatically copied from notifications-utils@97.0.3
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@95.1.2
+# This file was automatically copied from notifications-utils@97.0.3
 
 exclude = [
     "migrations/versions/",


### PR DESCRIPTION
# CHANGELOG

## 97.0.3

* Bump minimum jinja2 version to 3.1.6

## 97.0.2

* Fix external link redirect

## 97.0.1

* Fix QR code URL with '&' encoded as '&amp;'

## 97.0.0

* for bilingual letters preview, only show barcodes on the first page (patch).
* rename `include_notify_tag` argument to `includes_first_page` (major).

## 96.0.0

* BREAKING CHANGE: the `gunicorn_defaults` module has been moved to `gunicorn.defaults` to make space for gunicorn-related utils that don't have the restricted-import constraints of the gunicorn defaults. Imports of `notifications_utils.gunicorn_defaults` should be changed to `notifications_utils.gunicorn.defaults`.
* Added `ContextRecyclingEventletWorker` custom gunicorn worker class.

## 95.2.0

* Implement `InsensitiveSet.__contains__`

## 95.1.2

* Fix to the number of arguments the `on_retry` of the `NotifyTask` class takes.

## 95.1.1

* Add `RUF100` rule to linter config (checks for inapplicable uses of `# noqa`)

## 95.1.0

* Adds log message and statsd metric for retried celery tasks

## 95.0.0

* Reverts 92.0.0 to restore new validation code