### PR TITLE
Refactor api callback endpoints

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -272,7 +272,7 @@ class ServiceCallbackTypes(enum.StrEnum):
     delivery_status = "delivery_status"
     complaint = "complaint"
     returned_letter = "returned_letter"
-    inbound_sms = "sms"
+    inbound_sms = "inbound_sms"
 
 
 # Branding values

--- a/app/constants.py
+++ b/app/constants.py
@@ -272,6 +272,7 @@ class ServiceCallbackTypes(enum.StrEnum):
     delivery_status = "delivery_status"
     complaint = "complaint"
     returned_letter = "returned_letter"
+    inbound_sms = "sms"
 
 
 # Branding values

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -77,23 +77,6 @@ def update_service_callback_api(callback_api_id, service_id):
     return jsonify(data=to_update.serialize()), 200
 
 
-@service_callback_blueprint.route("/delivery-receipt-api/<uuid:callback_api_id>", methods=["GET"])
-def fetch_delivery_receipt_callback_api(service_id, callback_api_id):
-    callback_type = ServiceCallbackTypes.delivery_status.value
-    return _fetch_service_callback_api(callback_api_id, service_id, callback_type)
-
-
-@service_callback_blueprint.route("/returned-letter-api/<uuid:callback_api_id>", methods=["GET"])
-def fetch_returned_letter_callback_api(service_id, callback_api_id):
-    callback_type = ServiceCallbackTypes.returned_letter.value
-    return _fetch_service_callback_api(callback_api_id, service_id, callback_type)
-
-
-def _fetch_service_callback_api(callback_api_id, service_id, callback_type):
-    callback_api = get_service_callback_api(callback_api_id, service_id, callback_type)
-    return jsonify(data=callback_api.serialize()), 200
-
-
 @service_callback_blueprint.route("/inbound-api/<uuid:callback_api_id>", methods=["GET"])
 @service_callback_blueprint.route("/delivery-receipt-api/<uuid:callback_api_id>", methods=["GET"])
 @service_callback_blueprint.route("/returned-letter-api/<uuid:callback_api_id>", methods=["GET"])

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -30,6 +30,7 @@ register_errors(service_callback_blueprint)
 @service_callback_blueprint.route("/inbound-api", methods=["POST"])
 @service_callback_blueprint.route("/delivery-receipt-api", methods=["POST"])
 @service_callback_blueprint.route("/returned-letter-api", methods=["POST"])
+@service_callback_blueprint.route("/callback-api", methods=["POST"])
 def create_service_callback_api(service_id):
     data = request.get_json()
     validate(data, create_service_callback_api_schema)
@@ -56,6 +57,7 @@ def create_service_callback_api(service_id):
 @service_callback_blueprint.route("/inbound-api/<uuid:callback_api_id>", methods=["POST"])
 @service_callback_blueprint.route("/delivery-receipt-api/<uuid:callback_api_id>", methods=["POST"])
 @service_callback_blueprint.route("/returned-letter-api/<uuid:callback_api_id>", methods=["POST"])
+@service_callback_blueprint.route("/callback-api/<uuid:callback_api_id>", methods=["POST"])
 def update_service_callback_api(callback_api_id, service_id):
     data = request.get_json()
     validate(data, update_service_callback_api_schema)
@@ -80,6 +82,7 @@ def update_service_callback_api(callback_api_id, service_id):
 @service_callback_blueprint.route("/inbound-api/<uuid:callback_api_id>", methods=["GET"])
 @service_callback_blueprint.route("/delivery-receipt-api/<uuid:callback_api_id>", methods=["GET"])
 @service_callback_blueprint.route("/returned-letter-api/<uuid:callback_api_id>", methods=["GET"])
+@service_callback_blueprint.route("/callback-api/<uuid:callback_api_id>", methods=["GET"])
 def fetch_service_callback_api(callback_api_id, service_id):
     callback_type = request.args.get("callback_type")
     if callback_type == ServiceCallbackTypes.inbound_sms.value:
@@ -100,6 +103,7 @@ REMOVE_SERVICE_CALLBACK_ERROR_MESSAGES = {
 @service_callback_blueprint.route("/inbound-api/<uuid:callback_api_id>", methods=["DELETE"])
 @service_callback_blueprint.route("/delivery-receipt-api/<uuid:callback_api_id>", methods=["DELETE"])
 @service_callback_blueprint.route("/returned-letter-api/<uuid:callback_api_id>", methods=["DELETE"])
+@service_callback_blueprint.route("/callback-api/<uuid:callback_api_id>", methods=["DELETE"])
 def remove_service_callback_api(callback_api_id, service_id):
     callback_type = request.args.get("callback_type")
     if callback_type == ServiceCallbackTypes.inbound_sms.value:

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -122,9 +122,10 @@ def test_fetch_service_inbound_api(admin_request, sample_service):
     service_inbound_api = create_service_inbound_api(service=sample_service)
 
     response = admin_request.get(
-        "service_callback.fetch_service_inbound_api",
+        "service_callback.fetch_service_callback_api",
         service_id=sample_service.id,
-        inbound_api_id=service_inbound_api.id,
+        callback_api_id=service_inbound_api.id,
+        callback_type="inbound_sms",
     )
     assert response["data"] == service_inbound_api.serialize()
 
@@ -142,45 +143,14 @@ def test_delete_service_inbound_api(admin_request, sample_service):
     assert ServiceInboundApi.query.count() == 0
 
 
-def test_update_delivery_receipt_callback_api_updates_url(admin_request, sample_service):
-    service_callback_api = create_service_callback_api(
-        callback_type="delivery_status", service=sample_service, url="https://original_url.com"
-    )
-
-    data = {"url": "https://another_url.com", "updated_by_id": str(sample_service.users[0].id)}
-
-    resp_json = admin_request.post(
-        "service_callback.update_delivery_receipt_callback_api",
-        service_id=sample_service.id,
-        callback_api_id=service_callback_api.id,
-        _data=data,
-    )
-    assert resp_json["data"]["url"] == "https://another_url.com"
-    assert service_callback_api.url == "https://another_url.com"
-
-
-def test_update_delivery_receipt_callback_api_updates_bearer_token(admin_request, sample_service):
-    service_callback_api = create_service_callback_api(
-        callback_type="delivery_status", service=sample_service, bearer_token="some_super_secret"
-    )
-    data = {"bearer_token": "different_token", "updated_by_id": str(sample_service.users[0].id)}
-
-    admin_request.post(
-        "service_callback.update_delivery_receipt_callback_api",
-        service_id=sample_service.id,
-        callback_api_id=service_callback_api.id,
-        _data=data,
-    )
-    assert service_callback_api.bearer_token == "different_token"
-
-
 def test_fetch_delivery_receipt_callback_api(admin_request, sample_service):
     service_callback_api = create_service_callback_api(callback_type="delivery_status", service=sample_service)
 
     response = admin_request.get(
-        "service_callback.fetch_delivery_receipt_callback_api",
+        "service_callback.fetch_service_callback_api",
         service_id=sample_service.id,
         callback_api_id=service_callback_api.id,
+        callback_type="delivery_status",
     )
 
     assert response["data"] == service_callback_api.serialize()
@@ -199,45 +169,14 @@ def test_delete_delivery_receipt_callback_api(admin_request, sample_service):
     assert ServiceCallbackApi.query.count() == 0
 
 
-def test_update_returned_letter_callback_api_updates_url(admin_request, sample_service):
-    service_callback_api = create_service_callback_api(
-        callback_type="returned_letter", service=sample_service, url="https://original_url.com"
-    )
-
-    data = {"url": "https://another_url.com", "updated_by_id": str(sample_service.users[0].id)}
-
-    resp_json = admin_request.post(
-        "service_callback.update_returned_letter_callback_api",
-        service_id=sample_service.id,
-        callback_api_id=service_callback_api.id,
-        _data=data,
-    )
-    assert resp_json["data"]["url"] == "https://another_url.com"
-    assert service_callback_api.url == "https://another_url.com"
-
-
-def test_update_returned_letter_callback_api_updates_bearer_token(admin_request, sample_service):
-    service_callback_api = create_service_callback_api(
-        callback_type="returned_letter", service=sample_service, bearer_token="some_super_secret"
-    )
-    data = {"bearer_token": "different_token", "updated_by_id": str(sample_service.users[0].id)}
-
-    admin_request.post(
-        "service_callback.update_returned_letter_callback_api",
-        service_id=sample_service.id,
-        callback_api_id=service_callback_api.id,
-        _data=data,
-    )
-    assert service_callback_api.bearer_token == "different_token"
-
-
 def test_fetch_returned_letter_callback_api(admin_request, sample_service):
     service_callback_api = create_service_callback_api(callback_type="returned_letter", service=sample_service)
 
     response = admin_request.get(
-        "service_callback.fetch_returned_letter_callback_api",
+        "service_callback.fetch_service_callback_api",
         service_id=sample_service.id,
         callback_api_id=service_callback_api.id,
+        callback_type="returned_letter",
     )
 
     assert response["data"] == service_callback_api.serialize()

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -130,66 +130,32 @@ def test_fetch_service_inbound_api(admin_request, sample_service):
     assert response["data"] == service_inbound_api.serialize()
 
 
-def test_delete_service_inbound_api(admin_request, sample_service):
-    service_inbound_api = create_service_inbound_api(sample_service)
-
-    response = admin_request.delete(
-        "service_callback.remove_service_inbound_api",
-        service_id=sample_service.id,
-        inbound_api_id=service_inbound_api.id,
-    )
-
-    assert response is None
-    assert ServiceInboundApi.query.count() == 0
-
-
-def test_fetch_delivery_receipt_callback_api(admin_request, sample_service):
-    service_callback_api = create_service_callback_api(callback_type="delivery_status", service=sample_service)
-
-    response = admin_request.get(
-        "service_callback.fetch_service_callback_api",
-        service_id=sample_service.id,
-        callback_api_id=service_callback_api.id,
-        callback_type="delivery_status",
-    )
-
-    assert response["data"] == service_callback_api.serialize()
-
-
-def test_delete_delivery_receipt_callback_api(admin_request, sample_service):
-    service_callback_api = create_service_callback_api("delivery_status", sample_service)
-
-    response = admin_request.delete(
-        "service_callback.remove_delivery_receipt_callback_api",
-        service_id=sample_service.id,
-        callback_api_id=service_callback_api.id,
-    )
-
-    assert response is None
-    assert ServiceCallbackApi.query.count() == 0
-
-
-def test_fetch_returned_letter_callback_api(admin_request, sample_service):
-    service_callback_api = create_service_callback_api(callback_type="returned_letter", service=sample_service)
-
-    response = admin_request.get(
-        "service_callback.fetch_service_callback_api",
-        service_id=sample_service.id,
-        callback_api_id=service_callback_api.id,
-        callback_type="returned_letter",
-    )
-
-    assert response["data"] == service_callback_api.serialize()
-
-
-def test_delete_returned_letter_callback_api(admin_request, sample_service):
-    service_callback_api = create_service_callback_api(callback_type="returned_letter", service=sample_service)
-
-    response = admin_request.delete(
-        "service_callback.remove_returned_letter_callback_api",
-        service_id=sample_service.id,
-        callback_api_id=service_callback_api.id,
-    )
-
-    assert response is None
-    assert ServiceCallbackApi.query.count() == 0
+@pytest.mark.parametrize(
+    "callback_type",
+    [
+        ServiceCallbackTypes.inbound_sms.value,
+        ServiceCallbackTypes.delivery_status.value,
+        ServiceCallbackTypes.returned_letter.value,
+    ],
+)
+def test_delete_service_callback_api(admin_request, sample_service, callback_type):
+    if callback_type == ServiceCallbackTypes.inbound_sms.value:
+        service_callback_api = create_service_inbound_api(sample_service)
+        response = admin_request.delete(
+            "service_callback.remove_service_callback_api",
+            service_id=sample_service.id,
+            callback_api_id=service_callback_api.id,
+            callback_type=callback_type,
+        )
+        assert response is None
+        assert ServiceInboundApi.query.count() == 0
+    else:
+        service_callback_api = create_service_callback_api(callback_type=callback_type, service=sample_service)
+        response = admin_request.delete(
+            "service_callback.remove_service_callback_api",
+            service_id=sample_service.id,
+            callback_api_id=service_callback_api.id,
+            callback_type=callback_type,
+        )
+        assert response is None
+        assert ServiceCallbackApi.query.count() == 0


### PR DESCRIPTION
This PR updates the service callback helper methods to also support inbound sms callback api.
This helps to keep the code DRY and is also a first step towards potentially merging `inbound_sms_api` into `service_inbound_api`.

This PR is dependent on these 2 PRs being merged in first https://github.com/alphagov/notifications-api/pull/4405 and https://github.com/alphagov/notifications-admin/pull/5417.