### PR TITLE
Update create service callback api schema

### DIFF
--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -32,6 +32,10 @@ def create_service_inbound_api(service_id):
     data = request.get_json()
     validate(data, create_service_callback_api_schema)
     data["service_id"] = service_id
+
+    if data.get("callback_type"):
+        del data["callback_type"]
+
     inbound_api = ServiceInboundApi(**data)
     try:
         save_service_inbound_api(inbound_api)
@@ -135,7 +139,12 @@ def _create_service_callback_api(service_id, callback_type):
     data = request.get_json()
     validate(data, create_service_callback_api_schema)
     data["service_id"] = service_id
-    data["callback_type"] = callback_type
+
+    # This is a temporary hack that will be removed in a future update once the admin
+    # app has been updated to include callback_type during callback API calls.
+    if not data.get("callback_type"):
+        data["callback_type"] = callback_type
+
     callback_api = ServiceCallbackApi(**data)
     try:
         save_service_callback_api(callback_api)

--- a/app/service/service_callback_api_schema.py
+++ b/app/service/service_callback_api_schema.py
@@ -5,7 +5,12 @@ create_service_callback_api_schema = {
     "description": "POST service callback/inbound api schema",
     "type": "object",
     "title": "Create service callback/inbound api",
-    "properties": {"url": https_url, "bearer_token": {"type": "string", "minLength": 10}, "updated_by_id": uuid},
+    "properties": {
+        "url": https_url,
+        "bearer_token": {"type": "string", "minLength": 10},
+        "updated_by_id": uuid,
+        "callback_type": {"type": "string"},
+    },
     "required": ["url", "bearer_token", "updated_by_id"],
 }
 
@@ -14,6 +19,11 @@ update_service_callback_api_schema = {
     "description": "POST service callback/inbound api schema",
     "type": "object",
     "title": "Create service callback/inbound api",
-    "properties": {"url": https_url, "bearer_token": {"type": "string", "minLength": 10}, "updated_by_id": uuid},
+    "properties": {
+        "url": https_url,
+        "bearer_token": {"type": "string", "minLength": 10},
+        "updated_by_id": uuid,
+        "callback_type": {"type": "string"},
+    },
     "required": ["updated_by_id"],
 }


### PR DESCRIPTION
This PR updates the create_service_callback_api_schema and `update_service_callback_api_schema` to accommodate 
`callback_type`.
This is lays the foundation for consolidating the service callback endpoints, where filtering will be done on `callback_type`.
`callback_type` is an attribute of the `service_callback_api table` its inclusion makes logical sense.
