### PR TITLE
Add new SMS rate valid from 1 April 2025

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0491_letter_rates_april_2025
+0492_sms_rate_april_2025

--- a/migrations/versions/0492_sms_rate_april_2025.py
+++ b/migrations/versions/0492_sms_rate_april_2025.py
@@ -1,0 +1,24 @@
+"""
+Create Date: 2025-03-26 14:13:45.410295
+"""
+
+import uuid
+
+from alembic import op
+
+revision = '0492_sms_rate_april_2025'
+down_revision = '0491_letter_rates_april_2025'
+
+
+def upgrade():
+    op.execute(
+        "INSERT INTO rates (id, valid_from, rate, notification_type) "
+        f"VALUES('{uuid.uuid4()}', '2025-03-31 23:00:00', 0.0233, 'sms')"
+    )
+
+
+def downgrade():
+    """
+    We'll want to check and run downgrades manually since this will involve decisions
+    about billing for any messages sent with the rates that have been removed.
+    """


### PR DESCRIPTION
The base SMS rate is changing from 1 April 2025

[Trello card](https://trello.com/c/orF9qBDa/1231-sms-price-changes)