### PR TITLE
Bump utils to 97.0.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.4
+# This file was automatically copied from notifications-utils@97.0.5
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil>=6.0.0,<7.0.0
 notifications-python-client==10.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@97.0.4
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@97.0.5
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -147,7 +147,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@689fdfb98b4e50be14d1a912c4c3afe80b512ac2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d9258f3c7cd213845eb0d1fa5726413669d03f06
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -219,7 +219,7 @@ moto==5.0.11
     # via -r requirements_for_test.in
 notifications-python-client==10.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@689fdfb98b4e50be14d1a912c4c3afe80b512ac2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d9258f3c7cd213845eb0d1fa5726413669d03f06
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.4
+# This file was automatically copied from notifications-utils@97.0.5
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.4
+# This file was automatically copied from notifications-utils@97.0.5
 
 exclude = [
     "migrations/versions/",


### PR DESCRIPTION
 ## 97.0.5

* Fix mailto: URLs in Markdown links

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/97.0.4...97.0.5