### PR TITLE
Major utils bump to 98.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.5
+# This file was automatically copied from notifications-utils@98.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil>=6.0.0,<7.0.0
 notifications-python-client==10.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@97.0.5
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@98.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -147,7 +147,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d9258f3c7cd213845eb0d1fa5726413669d03f06
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@794b88afc06bff187a3d58db0ed5f2871bad7ba6
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -219,7 +219,7 @@ moto==5.0.11
     # via -r requirements_for_test.in
 notifications-python-client==10.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d9258f3c7cd213845eb0d1fa5726413669d03f06
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@794b88afc06bff187a3d58db0ed5f2871bad7ba6
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.5
+# This file was automatically copied from notifications-utils@98.0.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.5
+# This file was automatically copied from notifications-utils@98.0.0
 
 exclude = [
     "migrations/versions/",

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -404,9 +404,9 @@ def test_simulated_recipient(notify_api, to_address, notification_type, expected
     [
         ("7900900123", False, "44", 1),  # UK
         ("+447900900123", False, "44", 1),  # UK
-        ("07797292290", True, "44", 1),  # UK (Jersey)
-        ("74957108855", True, "7", 4),  # Russia
-        ("360623400400", True, "36", 3),
+        ("07797292290", True, "44", 2),  # UK (Jersey)
+        ("74957108855", True, "7", 10),  # Russia
+        ("360623400400", True, "36", 2),
     ],  # Hungary
 )
 def test_persist_notification_with_international_info_stores_correct_info(


### PR DESCRIPTION
This brings in the international text message rate multipliers for 1 April 2025 onwards.