### PR TITLE
Add create report-request POST endpoint

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -386,3 +386,6 @@ REPORT_REQUEST_STATUS_TYPES = [
     REPORT_REQUEST_FAILED,
     REPORT_REQUEST_DELETED,
 ]
+
+# Request report types
+NOTIFICATION_REPORT = "notifications_report"

--- a/app/service/report_request_schema.py
+++ b/app/service/report_request_schema.py
@@ -1,0 +1,15 @@
+from app.constants import NOTIFICATION_REPORT
+
+add_report_request_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Schema for creating a report request",
+    "type": "object",
+    "properties": {
+        "user_id": {"type": "string", "format": "uuid"},
+        "report_type": {"enum": [NOTIFICATION_REPORT]},
+        "notification_type": {"enum": ["email", "sms", "letter"]},
+        "notification_status": {"enum": ["all", "sending", "delivered", "failed"]},
+    },
+    "required": ["user_id", "report_type"],
+    "additionalProperties": False,
+}


### PR DESCRIPTION
POST report-request endpoint deals with different types of reports. For now it would only handle the necessary logic for 'notifications_report'. More details on [this card](https://trello.com/c/sgeh0FH8/1183-post-endpoint-for-report-request).
At this stage we are not looking to implement the queue function (that’s part of a task) or a lock mechanism.