### PR TITLE
Add predefined queue names so celery will not try to create queues

### DIFF
--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -31,6 +31,27 @@ def test_queue_names_all_queues_correct():
     } == set(queues)
 
 
+def test_predefined_queues():
+    prefix = "test-prefix-"
+    aws_region = "eu-west-1"
+    aws_account_id = "123456789012"
+
+    class_queues = [
+        value for key, value in vars(QueueNames).items() if not key.startswith("_") and isinstance(value, str)
+    ]
+    predefined_queues = QueueNames.predefined_queues(prefix, aws_region, aws_account_id)
+
+    assert len(predefined_queues) == len(class_queues)
+
+    for queue_name in class_queues:
+        full_queue_name = f"{prefix}{queue_name}"
+        assert full_queue_name in predefined_queues
+        assert (
+            predefined_queues[full_queue_name]["url"]
+            == f"https://sqs.{aws_region}.amazonaws.com/{aws_account_id}/{full_queue_name}"
+        )
+
+
 def test_no_celery_beat_tasks_scheduled_over_midnight_between_timezones(notify_api):
     badly_scheduled_tasks = []
 


### PR DESCRIPTION
https://trello.com/c/joBsPfMJ/955-move-sqs-queue-creation-into-terraform-and-clean-up-old-queues

What
----

Add predefined queue names so celery will not try to create queues

Why
----

We want all queues to be created and managed through terraform

Note
----

This change should not be merged before [this pr](https://github.com/alphagov/notifications-aws/pull/2564).