### PR TITLE
feat: Add duplication check and stale timeout logic to report-requests 

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -491,6 +491,8 @@ class Config:
     CHECK_SLOW_TEXT_MESSAGE_DELIVERY = os.environ.get("CHECK_SLOW_TEXT_MESSAGE_DELIVERY", "0") == "1"
     WEEKLY_USER_RESEARCH_EMAIL_ENABLED = os.environ.get("WEEKLY_USER_RESEARCH_EMAIL_ENABLED", "0") == "1"
 
+    REPORT_REQUEST_NOTIFICATIONS_TIMEOUT_MINUTES = 30
+
 
 ######################
 # Config overrides ###

--- a/app/dao/report_requests_dao.py
+++ b/app/dao/report_requests_dao.py
@@ -1,6 +1,10 @@
+from datetime import datetime, timedelta
 from uuid import UUID
 
+from sqlalchemy import and_, or_
+
 from app import db
+from app.constants import REPORT_REQUEST_IN_PROGRESS, REPORT_REQUEST_NOTIFICATIONS, REPORT_REQUEST_PENDING
 from app.dao.dao_utils import autocommit
 from app.models import ReportRequest
 
@@ -8,7 +12,48 @@ from app.models import ReportRequest
 @autocommit
 def dao_create_report_request(report_request: ReportRequest):
     db.session.add(report_request)
+    return report_request
 
 
 def dao_get_report_request_by_id(service_id: UUID, report_id: UUID) -> ReportRequest:
     return ReportRequest.query.filter_by(service_id=service_id, id=report_id).one()
+
+
+def dao_get_oldest_ongoing_report_request(
+    report_request: ReportRequest, timeout_minutes: int | None = None
+) -> ReportRequest | None:
+    query = ReportRequest.query.filter(
+        ReportRequest.user_id == report_request.user_id,
+        ReportRequest.service_id == report_request.service_id,
+        ReportRequest.report_type == report_request.report_type,
+        ReportRequest.status.in_([REPORT_REQUEST_PENDING, REPORT_REQUEST_IN_PROGRESS]),
+    )
+
+    # Apply timeout cutoff logic:
+    # - If `updated_at` is set, we check if it's within the timeout window
+    # - If `updated_at` is None, we fall back to using `created_at`
+    # This ensures we exclude stale requests (older than `timeout` minutes),
+    # while still considering those that may not have been updated yet.
+
+    if timeout_minutes is not None:
+        cutoff = datetime.utcnow() - timedelta(minutes=timeout_minutes)
+        query = query.filter(
+            or_(
+                and_(
+                    ReportRequest.updated_at.is_not(None),
+                    ReportRequest.updated_at > cutoff,
+                ),
+                and_(
+                    ReportRequest.updated_at.is_(None),
+                    ReportRequest.created_at > cutoff,
+                ),
+            )
+        )
+
+    if report_request.report_type == REPORT_REQUEST_NOTIFICATIONS:
+        query = query.filter(
+            ReportRequest._parameter["notification_type"].astext == report_request.parameter["notification_type"],
+            ReportRequest._parameter["notification_status"].astext == report_request.parameter["notification_status"],
+        )
+
+    return query.order_by(ReportRequest.created_at.asc()).first()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1,4 +1,5 @@
 import itertools
+import json
 import uuid
 from datetime import datetime
 
@@ -43,7 +44,11 @@ from app.dao.fact_notification_status_dao import (
     fetch_stats_for_all_services_by_date_range,
 )
 from app.dao.organisation_dao import dao_get_organisation_by_service_id
-from app.dao.report_requests_dao import dao_create_report_request, dao_get_report_request_by_id
+from app.dao.report_requests_dao import (
+    dao_create_report_request,
+    dao_get_oldest_ongoing_report_request,
+    dao_get_report_request_by_id,
+)
 from app.dao.returned_letters_dao import (
     fetch_most_recent_returned_letter,
     fetch_recent_returned_letter_count,
@@ -1584,25 +1589,53 @@ def get_report_request_by_id(service_id, request_id):
 def create_report_request_by_type(service_id):
     req_json = request.get_json()
     form = validate(request.get_json(), add_report_request_schema)
-    report_type = req_json.get("report_type", None)
 
-    if report_type == "notifications_report":
-        notification_status = form.get("notification_status")
-        notification_type = form.get("notification_type")
-        parameter = {"notification_type": notification_type, "notification_status": notification_status}
-        report_type = REPORT_REQUEST_NOTIFICATIONS
+    # Currently we only support notifications_report, other report types will fail during validation
+    notification_status = form.get("notification_status")
+    notification_type = form.get("notification_type")
+    parameter = {"notification_type": notification_type, "notification_status": notification_status}
+    report_type = REPORT_REQUEST_NOTIFICATIONS
+    timeout_minutes = current_app.config.get("REPORT_REQUEST_NOTIFICATIONS_TIMEOUT_MINUTES")
 
-    try:
-        user_id = req_json.get("user_id")
-        report_request = ReportRequest(
-            user_id=user_id,
-            service_id=service_id,
-            report_type=report_type,
-            status=REPORT_REQUEST_PENDING,
-            parameter=parameter,
+    user_id = req_json.get("user_id")
+
+    dto = ReportRequest(
+        user_id=user_id,
+        service_id=service_id,
+        report_type=report_type,
+        status=REPORT_REQUEST_PENDING,
+        parameter=parameter,
+    )
+
+    # 1. Check for duplicate requests and if found return ongoing request
+    existing_request = dao_get_oldest_ongoing_report_request(dto, timeout_minutes=timeout_minutes)
+
+    if existing_request:
+        current_app.logger.info(
+            "Duplicate report request detected for user %s (service %s) with params %s – returning existing request %s",
+            existing_request.user_id,
+            existing_request.service_id,
+            json.dumps(existing_request.parameter, separators=(",", ":")),
+            existing_request.id,
         )
-        dao_create_report_request(report_request)
-        return jsonify(data=report_request.serialize()), 201
 
-    except ValueError as err:
-        raise InvalidRequest(message=f"{err}", status_code=400) from err
+        return jsonify(data=existing_request.serialize()), 200
+
+    # 2. If no ongoing request is present, create and enqueue the request
+    created_request = dao_create_report_request(dto)
+
+    current_app.logger.info(
+        "Report request %s for user %s (service %s) created with params %s",
+        created_request.id,
+        created_request.user_id,
+        created_request.service_id,
+        json.dumps(created_request.parameter, separators=(",", ":")),
+    )
+
+    # TODO: Remove comments when async function has been implemented
+    # process_report_request.apply_async(
+    #     [str(report_request.service_id), str(report_request.id)],
+    #     queue=QueueNames.REPORT_REQUESTS_NOTIFICATIONS,
+    # )
+
+    return jsonify(data=created_request.serialize()), 201

--- a/tests/app/dao/test_report_requests_dao.py
+++ b/tests/app/dao/test_report_requests_dao.py
@@ -1,12 +1,17 @@
+from datetime import datetime, timedelta
+
 import pytest
+from flask import current_app
 
 from app.constants import (
+    REPORT_REQUEST_FAILED,
     REPORT_REQUEST_IN_PROGRESS,
     REPORT_REQUEST_NOTIFICATIONS,
     REPORT_REQUEST_PENDING,
 )
 from app.dao.report_requests_dao import (
     dao_create_report_request,
+    dao_get_oldest_ongoing_report_request,
     dao_get_report_request_by_id,
 )
 from app.models import ReportRequest
@@ -22,14 +27,14 @@ def test_dao_create_report_request(sample_service, sample_user):
         status=REPORT_REQUEST_IN_PROGRESS,
         parameter=sample_parameter,
     )
-    dao_create_report_request(report_request)
+    result = dao_create_report_request(report_request)
 
-    assert report_request.id is not None
-    assert report_request.service_id == sample_service.id
-    assert report_request.user_id == sample_user.id
-    assert report_request.report_type == REPORT_REQUEST_NOTIFICATIONS
-    assert report_request.status == REPORT_REQUEST_IN_PROGRESS
-    assert report_request.parameter == sample_parameter
+    assert result.id is not None
+    assert result.service_id == sample_service.id
+    assert result.user_id == sample_user.id
+    assert result.report_type == REPORT_REQUEST_NOTIFICATIONS
+    assert result.status == REPORT_REQUEST_IN_PROGRESS
+    assert result.parameter == sample_parameter
 
 
 def test_dao_create_report_where_not_allowed_additional_property(sample_service, sample_user):
@@ -100,3 +105,227 @@ def test_dao_get_report_request_by_id(sample_service, sample_user):
     assert report.report_type == REPORT_REQUEST_NOTIFICATIONS
     assert report.status == REPORT_REQUEST_PENDING
     assert report.parameter == sample_parameter
+
+
+@pytest.mark.parametrize("status", [REPORT_REQUEST_PENDING, REPORT_REQUEST_IN_PROGRESS])
+def test_dao_get_oldest_ongoing_report_request_returns_true_for_recent_matching_notification_request(
+    sample_service, sample_user, status
+):
+    param = {"notification_type": "sms", "notification_status": "sending"}
+
+    report_request = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=status,
+        parameter=param,
+        created_at=datetime.utcnow() - timedelta(minutes=5),
+        updated_at=datetime.utcnow() - timedelta(minutes=2),
+    )
+    dao_create_report_request(report_request)
+    report_request_notification_timeout = current_app.config.get("REPORT_REQUEST_NOTIFICATIONS_TIMEOUT_MINUTES")
+
+    result = dao_get_oldest_ongoing_report_request(report_request, timeout_minutes=report_request_notification_timeout)
+    assert isinstance(result, ReportRequest)
+
+
+def test_dao_get_oldest_ongoing_report_request_returns_false_for_final_state_notification_request(
+    sample_service, sample_user
+):
+    param = {"notification_type": "sms", "notification_status": "sending"}
+
+    final_status = REPORT_REQUEST_FAILED
+    report_request = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=final_status,
+        parameter=param,
+    )
+    dao_create_report_request(report_request)
+    report_request_notification_timeout = current_app.config.get("REPORT_REQUEST_NOTIFICATIONS_TIMEOUT_MINUTES")
+
+    result = dao_get_oldest_ongoing_report_request(report_request, timeout_minutes=report_request_notification_timeout)
+    assert result is None
+
+
+def test_dao_get_oldest_ongoing_report_request_returns_false_for_stale_updated_at_notification_request(
+    sample_service, sample_user
+):
+    param = {"notification_type": "sms", "notification_status": "sending"}
+
+    report_request = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=REPORT_REQUEST_PENDING,
+        parameter=param,
+        updated_at=datetime.utcnow() - timedelta(minutes=45),
+    )
+    dao_create_report_request(report_request)
+    report_request_notification_timeout = current_app.config.get("REPORT_REQUEST_NOTIFICATIONS_TIMEOUT_MINUTES")
+
+    result = dao_get_oldest_ongoing_report_request(report_request, timeout_minutes=report_request_notification_timeout)
+    assert result is None
+
+
+def test_dao_get_oldest_ongoing_report_request_excludes_stale_created_at_when_updated_at_is_none(
+    sample_service, sample_user
+):
+    param = {"notification_type": "sms", "notification_status": "sending"}
+    timeout_minutes = current_app.config.get("REPORT_REQUEST_NOTIFICATIONS_TIMEOUT_MINUTES")
+
+    stale_request = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=REPORT_REQUEST_PENDING,
+        parameter=param,
+        created_at=datetime.utcnow() - timedelta(minutes=45),
+        updated_at=None,
+    )
+
+    fresh_request = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=REPORT_REQUEST_PENDING,
+        parameter=param,
+        created_at=datetime.utcnow() - timedelta(minutes=5),
+        updated_at=None,
+    )
+
+    dao_create_report_request(stale_request)
+    dao_create_report_request(fresh_request)
+
+    result = dao_get_oldest_ongoing_report_request(stale_request, timeout_minutes=timeout_minutes)
+
+    assert result.id == fresh_request.id
+
+
+def test_dao_get_oldest_ongoing_report_request_returns_none_when_no_match_notification_request(
+    sample_service, sample_user
+):
+    param_existing = {"notification_type": "sms", "notification_status": "sending"}
+    param_lookup = {"notification_type": "email", "notification_status": "delivered"}
+
+    existing_request = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=REPORT_REQUEST_PENDING,
+        parameter=param_existing,
+    )
+    dao_create_report_request(existing_request)
+
+    lookup_request = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=REPORT_REQUEST_PENDING,
+        parameter=param_lookup,
+    )
+    report_request_notification_timeout = current_app.config.get("REPORT_REQUEST_NOTIFICATIONS_TIMEOUT_MINUTES")
+
+    result = dao_get_oldest_ongoing_report_request(lookup_request, timeout_minutes=report_request_notification_timeout)
+    assert result is None
+
+
+def test_dao_get_oldest_ongoing_report_request_returns_true_when_updated_at_is_none_and_created_at_recent(
+    sample_service, sample_user
+):
+    param = {"notification_type": "sms", "notification_status": "sending"}
+
+    report_request = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=REPORT_REQUEST_PENDING,
+        parameter=param,
+        updated_at=None,
+        created_at=datetime.utcnow() - timedelta(minutes=10),
+    )
+    dao_create_report_request(report_request)
+
+    timeout = current_app.config.get("REPORT_REQUEST_NOTIFICATIONS_TIMEOUT_MINUTES")
+    result = dao_get_oldest_ongoing_report_request(report_request, timeout_minutes=timeout)
+
+    assert isinstance(result, ReportRequest)
+
+
+def test_dao_get_oldest_ongoing_report_request_returns_true_when_timeout_is_none_even_if_stale(
+    sample_service, sample_user
+):
+    param = {"notification_type": "sms", "notification_status": "sending"}
+
+    report_request = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=REPORT_REQUEST_PENDING,
+        parameter=param,
+        updated_at=datetime.utcnow() - timedelta(minutes=999),
+    )
+    dao_create_report_request(report_request)
+
+    result = dao_get_oldest_ongoing_report_request(report_request)
+
+    assert isinstance(result, ReportRequest)
+
+
+def test_dao_get_oldest_ongoing_report_request_returns_false_if_user_id_different(
+    sample_service, sample_user, notify_user
+):
+    param = {"notification_type": "sms", "notification_status": "sending"}
+
+    existing = ReportRequest(
+        user_id=notify_user.id,  # different user
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=REPORT_REQUEST_PENDING,
+        parameter=param,
+    )
+    dao_create_report_request(existing)
+
+    lookup = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=REPORT_REQUEST_PENDING,
+        parameter=param,
+    )
+
+    timeout = current_app.config.get("REPORT_REQUEST_NOTIFICATIONS_TIMEOUT_MINUTES")
+    assert dao_get_oldest_ongoing_report_request(lookup, timeout_minutes=timeout) is None
+
+
+def test_dao_get_oldest_ongoing_report_request_returns_oldest_when_multiple_matches_exist(sample_service, sample_user):
+    param = {"notification_type": "sms", "notification_status": "sending"}
+
+    newer_request = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=REPORT_REQUEST_PENDING,
+        parameter=param,
+        created_at=datetime.utcnow() - timedelta(minutes=5),
+        updated_at=datetime.utcnow() - timedelta(minutes=2),
+    )
+    older_request = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=REPORT_REQUEST_PENDING,
+        parameter=param,
+        created_at=datetime.utcnow() - timedelta(minutes=15),
+        updated_at=datetime.utcnow() - timedelta(minutes=10),
+    )
+
+    dao_create_report_request(newer_request)
+    dao_create_report_request(older_request)
+
+    timeout = current_app.config.get("REPORT_REQUEST_NOTIFICATIONS_TIMEOUT_MINUTES")
+    result = dao_get_oldest_ongoing_report_request(older_request, timeout_minutes=timeout)
+
+    assert isinstance(result, ReportRequest)
+    assert result.id == older_request.id

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -32,6 +32,7 @@ from app.constants import (
     UPLOAD_LETTERS,
 )
 from app.dao.organisation_dao import dao_add_service_to_organisation
+from app.dao.report_requests_dao import dao_create_report_request
 from app.dao.service_join_requests_dao import dao_create_service_join_request
 from app.dao.service_user_dao import dao_get_service_user
 from app.dao.services_dao import (
@@ -46,6 +47,7 @@ from app.models import (
     EmailBranding,
     Notification,
     Permission,
+    ReportRequest,
     Service,
     ServiceEmailReplyTo,
     ServiceJoinRequest,
@@ -4709,7 +4711,7 @@ def test_get_report_request_by_id(admin_request, sample_service, sample_report_r
         ),
     ],
 )
-def test_create_report_request_should_return_validation_error(
+def test_create_report_request_by_type_should_return_validation_error(
     admin_request, sample_service, data, error_type, error_message
 ):
     json_resp = admin_request.post(
@@ -4731,7 +4733,7 @@ def test_create_report_request_should_return_validation_error(
         ("letter", "sending"),
     ],
 )
-def test_create_report_request(admin_request, sample_service, notification_type, notification_status):
+def test_create_report_request_by_type(admin_request, sample_service, notification_type, notification_status):
     json_resp = admin_request.post(
         "service.create_report_request_by_type",
         service_id=str(sample_service.id),
@@ -4753,3 +4755,101 @@ def test_create_report_request(admin_request, sample_service, notification_type,
     assert json_resp["data"]["service_id"] == str(sample_service.id)
     assert not json_resp["data"]["updated_at"]
     assert json_resp["data"]["created_at"]
+
+
+def test_create_report_request_by_type_returns_existing_request(admin_request, sample_service, sample_user, caplog):
+    expected_params = {"notification_type": "sms", "notification_status": "sending"}
+    existing_request = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=REPORT_REQUEST_PENDING,
+        parameter=expected_params,
+        created_at=datetime.utcnow() - timedelta(minutes=2),
+    )
+    existing_request = dao_create_report_request(existing_request)
+
+    payload = {
+        "user_id": str(sample_user.id),
+        "report_type": "notifications_report",
+        "notification_type": "sms",
+        "notification_status": "sending",
+    }
+
+    response = admin_request.post(
+        "service.create_report_request_by_type",
+        service_id=str(sample_service.id),
+        _data=payload,
+        _expected_status=200,
+    )
+
+    assert response["data"]["id"] == str(existing_request.id)
+    assert response["data"]["parameter"] == existing_request.parameter
+    assert (
+        f"Duplicate report request detected for user {sample_user.id} (service {sample_service.id})"
+        f" with params {json.dumps(expected_params, separators=(',', ':'))} – returning existing "
+        f"request {existing_request.id}" in caplog.messages
+    )
+
+
+def test_create_report_request_by_type_creates_new_when_no_existing(admin_request, sample_service):
+    data = {
+        "user_id": str(sample_service.created_by_id),
+        "report_type": "notifications_report",
+        "notification_type": "sms",
+        "notification_status": "failed",
+    }
+
+    response = admin_request.post(
+        "service.create_report_request_by_type",
+        service_id=str(sample_service.id),
+        _data=data,
+        _expected_status=201,
+    )
+
+    assert response["data"]["status"] == REPORT_REQUEST_PENDING
+    assert response["data"]["report_type"] == REPORT_REQUEST_NOTIFICATIONS
+    assert response["data"]["parameter"] == {
+        "notification_type": "sms",
+        "notification_status": "failed",
+    }
+
+
+def test_create_report_request_by_type_creates_new_if_existing_is_stale(
+    admin_request, sample_service, sample_user, caplog
+):
+    expected_params = {"notification_type": "email", "notification_status": "failed"}
+
+    timeout = current_app.config["REPORT_REQUEST_NOTIFICATIONS_TIMEOUT_MINUTES"]
+    stale_request = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=REPORT_REQUEST_PENDING,
+        parameter=expected_params,
+        created_at=datetime.utcnow() - timedelta(minutes=timeout + 10),
+        updated_at=None,
+    )
+    stale_request = dao_create_report_request(stale_request)
+
+    data = {
+        "user_id": str(sample_user.id),
+        "report_type": "notifications_report",
+        "notification_type": "email",
+        "notification_status": "failed",
+    }
+
+    response = admin_request.post(
+        "service.create_report_request_by_type",
+        service_id=str(sample_service.id),
+        _data=data,
+        _expected_status=201,
+    )
+
+    created_request_id = response["data"]["id"]
+
+    assert created_request_id != str(stale_request.id)
+    assert (
+        f"Report request {created_request_id} for user {sample_user.id} (service {sample_service.id}) "
+        f"created with params {json.dumps(expected_params, separators=(',', ':'))}" in caplog.messages
+    )


### PR DESCRIPTION
## PR Summary:

- Duplicate detection logic: When a request is submitted, we now check for an existing request with the same user, service, report type, and parameter values (notification_type, notification_status). If a matching request is already in a non-final state (pending or in progress) and is within the timeout window, we return that instead of creating a new one.

- Stale request handling: Requests are considered stale if updated_at is older than the configured timeout. If updated_at is null, we fall back to using created_at.

- Validation-first approach: Only notifications_report is supported at the moment. Any unsupported or invalid inputs will be rejected during schema validation.

- Test coverage: Added and extended tests

### Ticket:
[Lock mechanism to prevent duplicate requests](https://trello.com/c/UuqvwE7H/1219-lock-mechanism-to-prevent-duplicate-requests)