### PR TITLE
Add unique constraint to OrganisationPermission model

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -369,6 +369,7 @@ class OrganisationPermission(db.Model):
         unique=False,
         nullable=False,
     )
+    __table_args__ = (UniqueConstraint("organisation_id", "permission", name="uix_organisation_permission"),)
 
 
 class OrganisationUserPermissions(db.Model):

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0492_sms_rate_april_2025
+0493_unique_org_permissions

--- a/migrations/versions/0493_unique_org_permissions.py
+++ b/migrations/versions/0493_unique_org_permissions.py
@@ -1,0 +1,17 @@
+"""
+Create Date: 2025-04-04 16:37:49.511033
+"""
+
+from alembic import op
+
+revision = '0493_unique_org_permissions'
+down_revision = '0492_sms_rate_april_2025'
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute("CREATE UNIQUE INDEX CONCURRENTLY uix_organisation_permission ON organisation_permissions (organisation_id, permission)")
+        op.execute("ALTER TABLE organisation_permissions ADD CONSTRAINT uix_organisation_permission UNIQUE USING INDEX uix_organisation_permission")
+
+def downgrade():
+    op.drop_constraint('uix_organisation_permission', 'organisation_permissions', type_='unique')


### PR DESCRIPTION
At the moment, there's nothing to stop an organisation having lots of rows for the same permission in the database. While the frontend code shouldn't be adding duplicate rows let's make sure that scenario doesn't occur and give unexpected behaviour.

If creating the table from scratch this could have worked like the `service_permissions` table, with the `organisation_id` and `permission` columns forming a composite primary key. However, since the table exists it's a lot of effort to change it to that format.

There is only one type of organisation permission available, `can_ask_to_join_a_service`, and it's for a feature that has not launched, so making this change now is safe - the organisation_permission table only has a couple of rows of data.