### PR TITLE
Remove old callback URLs

### DIFF
--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -27,9 +27,6 @@ service_callback_blueprint = Blueprint("service_callback", __name__, url_prefix=
 register_errors(service_callback_blueprint)
 
 
-@service_callback_blueprint.route("/inbound-api", methods=["POST"])
-@service_callback_blueprint.route("/delivery-receipt-api", methods=["POST"])
-@service_callback_blueprint.route("/returned-letter-api", methods=["POST"])
 @service_callback_blueprint.route("/callback-api", methods=["POST"])
 def create_service_callback_api(service_id):
     data = request.get_json()
@@ -54,9 +51,6 @@ def create_service_callback_api(service_id):
     return jsonify(data=callback_api.serialize()), 201
 
 
-@service_callback_blueprint.route("/inbound-api/<uuid:callback_api_id>", methods=["POST"])
-@service_callback_blueprint.route("/delivery-receipt-api/<uuid:callback_api_id>", methods=["POST"])
-@service_callback_blueprint.route("/returned-letter-api/<uuid:callback_api_id>", methods=["POST"])
 @service_callback_blueprint.route("/callback-api/<uuid:callback_api_id>", methods=["POST"])
 def update_service_callback_api(callback_api_id, service_id):
     data = request.get_json()
@@ -79,9 +73,6 @@ def update_service_callback_api(callback_api_id, service_id):
     return jsonify(data=to_update.serialize()), 200
 
 
-@service_callback_blueprint.route("/inbound-api/<uuid:callback_api_id>", methods=["GET"])
-@service_callback_blueprint.route("/delivery-receipt-api/<uuid:callback_api_id>", methods=["GET"])
-@service_callback_blueprint.route("/returned-letter-api/<uuid:callback_api_id>", methods=["GET"])
 @service_callback_blueprint.route("/callback-api/<uuid:callback_api_id>", methods=["GET"])
 def fetch_service_callback_api(callback_api_id, service_id):
     callback_type = request.args.get("callback_type")
@@ -100,9 +91,6 @@ REMOVE_SERVICE_CALLBACK_ERROR_MESSAGES = {
 }
 
 
-@service_callback_blueprint.route("/inbound-api/<uuid:callback_api_id>", methods=["DELETE"])
-@service_callback_blueprint.route("/delivery-receipt-api/<uuid:callback_api_id>", methods=["DELETE"])
-@service_callback_blueprint.route("/returned-letter-api/<uuid:callback_api_id>", methods=["DELETE"])
 @service_callback_blueprint.route("/callback-api/<uuid:callback_api_id>", methods=["DELETE"])
 def remove_service_callback_api(callback_api_id, service_id):
     callback_type = request.args.get("callback_type")


### PR DESCRIPTION
As of https://github.com/alphagov/notifications-admin/pull/5425 the admin app is no longer using these specific URLs. Instead it’s using the generic `/callback-api` one.

***

How this fits into the overall refactor:

- [x] Add callback types to schemas for callback related CRUD API endpoints: https://github.com/alphagov/notifications-api/pull/4405
- [x] Start sending callback types from the admin app to CRUD API endpoints: https://github.com/alphagov/notifications-admin/pull/5417
- [x] Merge CRUD API endpoints so there is one endpoint for each operation and callback type, and add generic URLs for these endpoints: https://github.com/alphagov/notifications-api/pull/4402
- [x] Make admin use new URLs, and consolidate the service callback methods of the `service_api_client`: https://github.com/alphagov/notifications-admin/pull/5425
- [ ] Remove redundant URLs from API&emsp;**👈🏻 You are here**

***

See this document for more context: https://docs.google.com/document/d/1Oo8VbB3tdJMLPM6WslJlbbwANA33_lJcN3a6AKkCL7A/edit?tab=t.0