### PR TITLE
Allow the admin app to update a user’s platorm admin flag

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -149,7 +149,6 @@ class UserUpdateAttributeSchema(BaseSchema):
             "id",
             "logged_in_at",
             "password_changed_at",
-            "platform_admin",
             "state",
             "updated_at",
             "verify_codes",
@@ -175,6 +174,11 @@ class UserUpdateAttributeSchema(BaseSchema):
                 number.validate(allow_international_number=True)
         except InvalidPhoneError as error:
             raise ValidationError(f"Invalid phone number: {error.get_legacy_v2_api_error_message()}") from error
+
+    @validates("platform_admin")
+    def validate_platform_admin(self, value):
+        if value is not False:
+            raise ValidationError(f"Cannot set platform_admin to {value}")
 
     @validates_schema(pass_original=True)
     def check_unknown_fields(self, data, original_data, **kwargs):

--- a/tests/app/test_schemas.py
+++ b/tests/app/test_schemas.py
@@ -105,7 +105,6 @@ def test_user_update_schema_rejects_invalid_attribute_pairs(user_attribute, user
         "password_changed_at",
         "failed_login_count",
         "state",
-        "platform_admin",
     ],
 )
 def test_user_update_schema_rejects_disallowed_attribute_keys(user_attribute):

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -227,6 +227,32 @@ def test_post_user_attribute(admin_request, sample_user, user_attribute, user_va
     assert getattr(sample_user, user_attribute) == user_value
 
 
+@pytest.mark.parametrize("platform_admin", (True, False))
+@pytest.mark.parametrize(
+    "value, expected_status",
+    (
+        (False, 200),
+        (True, 400),
+        ("foo", 400),
+        (123, 400),
+    ),
+)
+def test_post_user_update_platform_admin(admin_request, sample_user, platform_admin, value, expected_status):
+    sample_user.platform_admin = platform_admin
+
+    json_resp = admin_request.post(
+        "user.update_user_attribute",
+        user_id=sample_user.id,
+        _data={"platform_admin": value},
+        _expected_status=expected_status,
+    )
+    if expected_status == 200:
+        assert json_resp["data"]["platform_admin"] is False
+        assert sample_user.platform_admin is False
+    else:
+        assert sample_user.platform_admin == platform_admin
+
+
 @pytest.mark.parametrize(
     "user_attribute, user_value, arguments",
     [


### PR DESCRIPTION
(to `False` only, for safety)

Supports https://github.com/alphagov/notifications-admin/pull/5427