### PR TITLE
Fix default value for `ServiceJoinRequest.created_at column`

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2929,7 +2929,7 @@ class ServiceJoinRequest(db.Model):
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     requester_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=False)
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), nullable=False)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow())
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     status = db.Column(
         db.Enum(*SERVICE_JOIN_REQUEST_STATUS_TYPES, name="service_join_request_status_type"),
         nullable=False,


### PR DESCRIPTION
The default value should be a function, but shouldn't _call_ the function. Fixing this means that the `created_at` column now has the datetime that the join request was created, not when the app started up.