### PR TITLE
Create international_sms_message_limit column for services table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -543,9 +543,6 @@ class Service(db.Model, Versioned):
     created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.datetime.utcnow)
     active = db.Column(db.Boolean, index=False, unique=False, nullable=False, default=True)
-    letter_message_limit = db.Column(db.BigInteger, index=False, unique=False, nullable=False, default=999_999_999)
-    sms_message_limit = db.Column(db.BigInteger, index=False, unique=False, nullable=False, default=999_999_999)
-    email_message_limit = db.Column(db.BigInteger, index=False, unique=False, nullable=False, default=999_999_999)
     restricted = db.Column(db.Boolean, index=False, unique=False, nullable=False)
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=False)
     created_by = db.relationship("User", foreign_keys=[created_by_id])
@@ -559,10 +556,20 @@ class Service(db.Model, Versioned):
     crown = db.Column(db.Boolean, index=False, nullable=True)
     rate_limit = db.Column(db.Integer, index=False, nullable=False, default=3000)
     contact_link = db.Column(db.String(255), nullable=True, unique=False)
+
+    letter_message_limit = db.Column(db.BigInteger, index=False, unique=False, nullable=False, default=999_999_999)
+    sms_message_limit = db.Column(db.BigInteger, index=False, unique=False, nullable=False, default=999_999_999)
+    international_sms_message_limit = db.Column(
+        db.BigInteger, index=False, unique=False, nullable=False, default=250_000
+    )
+    email_message_limit = db.Column(db.BigInteger, index=False, unique=False, nullable=False, default=999_999_999)
+
     volume_sms = db.Column(db.Integer(), nullable=True, unique=False)
     volume_email = db.Column(db.Integer(), nullable=True, unique=False)
     volume_letter = db.Column(db.Integer(), nullable=True, unique=False)
+
     consent_to_research = db.Column(db.Boolean, nullable=True)
+
     count_as_live = db.Column(db.Boolean, nullable=False, default=True)
     go_live_user_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
     go_live_user = db.relationship("User", foreign_keys=[go_live_user_id])

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0493_unique_org_permissions
+0494_add_intl_sms_limit_column

--- a/migrations/versions/0494_add_intl_sms_limit_column.py
+++ b/migrations/versions/0494_add_intl_sms_limit_column.py
@@ -1,0 +1,28 @@
+"""
+Create Date: 2025-04-09 17:37:32.633786
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0494_add_intl_sms_limit_column'
+down_revision = '0493_unique_org_permissions'
+
+
+def upgrade():
+    op.add_column('services', sa.Column('international_sms_message_limit', sa.BigInteger(), nullable=False, server_default="250000"))
+    op.add_column(
+        "services_history",
+        sa.Column(
+            "international_sms_message_limit",
+            sa.BigInteger(),
+            nullable=False,
+            server_default="250000",
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column('services_history', 'international_sms_message_limit')
+    op.drop_column('services', 'international_sms_message_limit')

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -276,6 +276,7 @@ def test_get_service_by_id(admin_request, sample_service):
         "has_active_go_live_request",
         "id",
         "inbound_api",
+        "international_sms_message_limit",
         "letter_branding",
         "letter_message_limit",
         "name",


### PR DESCRIPTION
The column is non-nullable and defaults to 250k.

In separate PRs, we will:
- create an endpoint to update the new limit
- expose this endpoint to our users (in admin app)
- set the actual limits for services who have not updated it themselves, based on their historical international sms usage.
- check if the services are within the limit when they send international sms, and show them an error message if they are not.