### PR TITLE
Serialize timestamps for admin app with subsecond precision

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -24,7 +24,7 @@ import app.constants
 from app import db, ma, models
 from app.dao.permissions_dao import permission_dao
 from app.models import ServicePermission
-from app.utils import DATETIME_FORMAT_NO_TIMEZONE, parse_and_format_phone_number
+from app.utils import DATETIME_FORMAT, DATETIME_FORMAT_NO_TIMEZONE, parse_and_format_phone_number
 
 
 def _validate_positive_number(value, msg="Not a positive integer"):
@@ -39,16 +39,15 @@ def _validate_positive_number(value, msg="Not a positive integer"):
 class FlexibleDateTime(fields.DateTime):
     """
     Allows input data to not contain tz info.
-    Outputs data using the output format that marshmallow version 2 used to use, OLD_MARSHMALLOW_FORMAT
+    Outputs data using our standard format
     """
 
     DEFAULT_FORMAT = "flexible"
-    OLD_MARSHMALLOW_FORMAT = "%Y-%m-%dT%H:%M:%S+00:00"
 
     def __init__(self, *args, allow_none=True, **kwargs):
         super().__init__(*args, allow_none=allow_none, **kwargs)
         self.DESERIALIZATION_FUNCS["flexible"] = parse
-        self.SERIALIZATION_FUNCS["flexible"] = lambda x: x.strftime(self.OLD_MARSHMALLOW_FORMAT)
+        self.SERIALIZATION_FUNCS["flexible"] = lambda x: x.strftime(DATETIME_FORMAT)
 
 
 class UUIDsAsStringsMixin:

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -4,7 +4,6 @@ from datetime import date, datetime, timedelta
 from unittest.mock import ANY
 
 import pytest
-import pytz
 from freezegun import freeze_time
 
 import app.celery.tasks
@@ -228,7 +227,7 @@ def test_create_scheduled_job(client, sample_template, mocker, mock_celery_task,
     resp_json = json.loads(response.get_data(as_text=True))
 
     assert resp_json["data"]["id"] == fake_uuid
-    assert resp_json["data"]["scheduled_for"] == datetime(2016, 1, 5, 11, 59, 0, tzinfo=pytz.UTC).isoformat()
+    assert resp_json["data"]["scheduled_for"] == "2016-01-05T11:59:00.000000Z"
     assert resp_json["data"]["job_status"] == "scheduled"
     assert resp_json["data"]["template"] == str(sample_template.id)
     assert resp_json["data"]["original_file_name"] == "thisisatest.csv"
@@ -714,7 +713,7 @@ def test_get_jobs(admin_request, sample_template, mocker):
     assert len(resp_json["data"]) == 5
     assert resp_json["data"][0] == {
         "archived": False,
-        "created_at": "2017-07-17T07:17:00+00:00",
+        "created_at": "2017-07-17T07:17:00.000000Z",
         "created_by": {
             "id": ANY,
             "name": "Test User",
@@ -841,8 +840,8 @@ def test_get_jobs_should_paginate(admin_request, sample_template, mocker):
     with set_config(admin_request.app, "PAGE_SIZE", 2):
         resp_json = admin_request.get("job.get_jobs_by_service", service_id=sample_template.service_id)
 
-    assert resp_json["data"][0]["created_at"] == "2015-01-01T10:00:00+00:00"
-    assert resp_json["data"][1]["created_at"] == "2015-01-01T09:00:00+00:00"
+    assert resp_json["data"][0]["created_at"] == "2015-01-01T10:00:00.000000Z"
+    assert resp_json["data"][1]["created_at"] == "2015-01-01T09:00:00.000000Z"
     assert resp_json["page_size"] == 2
     assert resp_json["total"] == 10
     assert "links" in resp_json
@@ -859,8 +858,8 @@ def test_get_jobs_accepts_page_parameter(admin_request, sample_template, mocker)
     with set_config(admin_request.app, "PAGE_SIZE", 2):
         resp_json = admin_request.get("job.get_jobs_by_service", service_id=sample_template.service_id, page=2)
 
-    assert resp_json["data"][0]["created_at"] == "2015-01-01T08:00:00+00:00"
-    assert resp_json["data"][1]["created_at"] == "2015-01-01T07:00:00+00:00"
+    assert resp_json["data"][0]["created_at"] == "2015-01-01T08:00:00.000000Z"
+    assert resp_json["data"][1]["created_at"] == "2015-01-01T07:00:00.000000Z"
     assert resp_json["page_size"] == 2
     assert resp_json["total"] == 10
     assert "links" in resp_json

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1488,6 +1488,7 @@ def test_get_service_and_api_key_history(notify_api, sample_service, sample_api_
             assert json_resp["data"]["api_key_history"][0]["id"] == str(sample_api_key.id)
 
 
+@freeze_time("2025-01-02T03:04:05")
 def test_get_all_notifications_for_service_in_order(client, notify_db_session):
     service_1 = create_service(service_name="1")
     service_2 = create_service(service_name="2")
@@ -1511,6 +1512,9 @@ def test_get_all_notifications_for_service_in_order(client, notify_db_session):
     assert resp["notifications"][0]["to"] == notification_3.to
     assert resp["notifications"][1]["to"] == notification_2.to
     assert resp["notifications"][2]["to"] == notification_1.to
+    assert resp["notifications"][0]["created_at"] == "2025-01-02T03:04:05.000000Z"
+    assert resp["notifications"][1]["created_at"] == "2025-01-02T03:04:05.000000Z"
+    assert resp["notifications"][2]["created_at"] == "2025-01-02T03:04:05.000000Z"
     assert response.status_code == 200
 
 

--- a/tests/app/upload/test_rest.py
+++ b/tests/app/upload/test_rest.py
@@ -268,10 +268,10 @@ def test_get_uploaded_letters_by_print_date(admin_request, sample_template):
     assert len(resp_json["notifications"]) == 2
 
     assert resp_json["notifications"][0]["id"] == str(letter_1.id)
-    assert resp_json["notifications"][0]["created_at"] == letter_1.created_at.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    assert resp_json["notifications"][0]["created_at"] == letter_1.created_at.strftime("%Y-%m-%dT%H:%M:%S.000000Z")
 
     assert resp_json["notifications"][1]["id"] == str(letter_2.id)
-    assert resp_json["notifications"][1]["created_at"] == letter_2.created_at.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    assert resp_json["notifications"][1]["created_at"] == letter_2.created_at.strftime("%Y-%m-%dT%H:%M:%S.000000Z")
 
 
 @freeze_time("2020-02-02 14:00")


### PR DESCRIPTION
Otherwise the admin app won’t always be able to sort things in the correct order.

Looking at examples of `def serialize()` in `models.py` we seem to prefer the timestamp with the timezone. So let’s go with that.

The admin app uses the forgiving [`dateutil.parser`](https://dateutil.readthedocs.io/en/stable/parser.html) (via [`notifications_utils.utc_string_to_aware_gmt_datetime`](https://github.com/alphagov/notifications-utils/blob/e4b6f3f3ab8944f760987af3f3039dfeb2910ff2/notifications_utils/timezones.py#L9C5-L18)) to deserialize the strings it gets from the API back into `datetime` objects. So it doesn’t need the string to be in an exact format.