### PR TITLE
Kill `DATETIME_FORMAT_NO_TIMEZONE`

### DIFF
--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -11,7 +11,7 @@ from app.config import QueueNames
 from app.dao.inbound_sms_dao import dao_get_inbound_sms_by_id
 from app.dao.returned_letters_dao import fetch_returned_letter_callback_data_dao
 from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
-from app.utils import DATETIME_FORMAT, DATETIME_FORMAT_NO_TIMEZONE
+from app.utils import DATETIME_FORMAT
 
 # thread-local copies of persistent requests.Session
 _requests_session_context_var: ContextVar[requests.Session] = ContextVar("service_callback_requests_session")
@@ -203,7 +203,7 @@ def create_returned_letter_callback_data(notification_id, service_id, service_ca
     data = {
         "notification_id": str(returned_letter_data["notification_id"]),
         "reference": returned_letter_data["client_reference"] if returned_letter_data["api_key_id"] else None,
-        "created_at": returned_letter_data["created_at"].strftime(DATETIME_FORMAT_NO_TIMEZONE),
+        "created_at": returned_letter_data["created_at"].strftime(DATETIME_FORMAT),
         "email_address": returned_letter_data["email_address"] or "API",
         # it doesn't make sense to show hidden/precompiled templates
         "template_name": returned_letter_data["template_name"] if not returned_letter_data["hidden"] else None,

--- a/app/models.py
+++ b/app/models.py
@@ -77,7 +77,6 @@ from app.hashing import check_hash, hashpw
 from app.history_meta import Versioned
 from app.utils import (
     DATETIME_FORMAT,
-    DATETIME_FORMAT_NO_TIMEZONE,
     dict_filter,
     get_dt_string_or_none,
     get_london_midnight_in_utc,
@@ -201,7 +200,7 @@ class User(db.Model):
             "logged_in_at": get_dt_string_or_none(self.logged_in_at),
             "mobile_number": self.mobile_number,
             "organisations": [x.id for x in self.organisations if x.active],
-            "password_changed_at": self.password_changed_at.strftime(DATETIME_FORMAT_NO_TIMEZONE),
+            "password_changed_at": self.password_changed_at.strftime(DATETIME_FORMAT),
             "permissions": self.get_permissions(),
             "organisation_permissions": self.get_organisation_permissions(),
             "platform_admin": self.platform_admin,

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -24,7 +24,7 @@ import app.constants
 from app import db, ma, models
 from app.dao.permissions_dao import permission_dao
 from app.models import ServicePermission
-from app.utils import DATETIME_FORMAT, DATETIME_FORMAT_NO_TIMEZONE, parse_and_format_phone_number
+from app.utils import DATETIME_FORMAT, parse_and_format_phone_number
 
 
 def _validate_positive_number(value, msg="Not a positive integer"):
@@ -87,8 +87,8 @@ class BaseSchema(ma.SQLAlchemyAutoSchema):
 
 class UserSchema(BaseSchema):
     permissions = fields.Method("user_permissions", dump_only=True)
-    password_changed_at = field_for(models.User, "password_changed_at", format=DATETIME_FORMAT_NO_TIMEZONE)
-    created_at = field_for(models.User, "created_at", format=DATETIME_FORMAT_NO_TIMEZONE)
+    password_changed_at = field_for(models.User, "password_changed_at", format=DATETIME_FORMAT)
+    created_at = field_for(models.User, "created_at", format=DATETIME_FORMAT)
     updated_at = FlexibleDateTime()
     logged_in_at = FlexibleDateTime()
     auth_type = field_for(models.User, "auth_type")
@@ -223,7 +223,7 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
     email_message_limit = field_for(models.Service, "email_message_limit", required=True)
     sms_message_limit = field_for(models.Service, "sms_message_limit", required=True)
     letter_message_limit = field_for(models.Service, "letter_message_limit", required=True)
-    go_live_at = field_for(models.Service, "go_live_at", format=DATETIME_FORMAT_NO_TIMEZONE)
+    go_live_at = field_for(models.Service, "go_live_at", format=DATETIME_FORMAT)
     allowed_broadcast_provider = fields.Method(dump_only=True, serialize="_get_allowed_broadcast_provider")
     broadcast_channel = fields.Method(dump_only=True, serialize="_get_broadcast_channel")
     name = fields.String(required=True)
@@ -484,7 +484,7 @@ class TemplateHistorySchema(BaseSchema):
     letter_attachment = fields.Method("get_letter_attachment", allow_none=True)
 
     created_by = fields.Nested(UserSchema, only=["id", "name", "email_address"], dump_only=True)
-    created_at = field_for(models.Template, "created_at", format=DATETIME_FORMAT_NO_TIMEZONE)
+    created_at = field_for(models.Template, "created_at", format=DATETIME_FORMAT)
     updated_at = FlexibleDateTime()
 
     def get_reply_to(self, template):

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -171,7 +171,7 @@ from app.service.utils import get_guest_list_objects
 from app.user.users_schema import post_set_permissions_schema
 from app.utils import (
     DATE_FORMAT,
-    DATETIME_FORMAT_NO_TIMEZONE,
+    DATETIME_FORMAT,
     get_prev_next_pagination_links,
     midnight_n_days_ago,
     utc_string_to_bst_string,
@@ -1092,7 +1092,7 @@ def returned_letter_statistics(service_id):
         return jsonify(
             {
                 "returned_letter_count": 0,
-                "most_recent_report": most_recent.reported_at.strftime(DATETIME_FORMAT_NO_TIMEZONE),
+                "most_recent_report": most_recent.reported_at.strftime(DATETIME_FORMAT),
             }
         )
 
@@ -1101,7 +1101,7 @@ def returned_letter_statistics(service_id):
     return jsonify(
         {
             "returned_letter_count": count.returned_letter_count,
-            "most_recent_report": most_recent.reported_at.strftime(DATETIME_FORMAT_NO_TIMEZONE),
+            "most_recent_report": most_recent.reported_at.strftime(DATETIME_FORMAT),
         }
     )
 
@@ -1402,7 +1402,7 @@ def _fetch_returned_letter_data(service_id, report_date):
             # client reference can only be added on API letters
             "client_reference": x.client_reference if x.api_key_id else None,
             "reported_at": x.reported_at.strftime(DATE_FORMAT),
-            "created_at": x.created_at.strftime(DATETIME_FORMAT_NO_TIMEZONE),
+            "created_at": x.created_at.strftime(DATETIME_FORMAT),
             # it doesn't make sense to show hidden/precompiled templates
             "template_name": x.template_name if not x.hidden else None,
             "template_id": x.template_id if not x.hidden else None,

--- a/app/upload/rest.py
+++ b/app/upload/rest.py
@@ -9,7 +9,7 @@ from app.dao.uploads_dao import (
 )
 from app.errors import register_errors
 from app.schemas import notification_with_template_schema
-from app.utils import pagination_links
+from app.utils import DATETIME_FORMAT, pagination_links
 
 upload_blueprint = Blueprint("upload", __name__, url_prefix="/service/<uuid:service_id>/upload")
 
@@ -37,9 +37,9 @@ def get_paginated_uploads(service_id, limit_days, page):
             "original_file_name": upload.original_file_name,
             "notification_count": upload.notification_count,
             "created_at": (
-                upload.scheduled_for.strftime("%Y-%m-%d %H:%M:%S")
+                upload.scheduled_for.strftime(DATETIME_FORMAT)
                 if upload.scheduled_for
-                else upload.created_at.strftime("%Y-%m-%d %H:%M:%S")
+                else upload.created_at.strftime(DATETIME_FORMAT)
             ),
             "upload_type": upload.upload_type,
             "template_type": upload.template_type,

--- a/app/utils.py
+++ b/app/utils.py
@@ -25,7 +25,6 @@ from app.constants import (
     CacheKeys,
 )
 
-DATETIME_FORMAT_NO_TIMEZONE = "%Y-%m-%d %H:%M:%S.%f"
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"
 local_timezone = pytz.timezone("Europe/London")

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -22,7 +22,7 @@ from app.constants import (
     KEY_TYPE_NORMAL,
     NOTIFICATION_RETURNED_LETTER,
 )
-from app.utils import DATETIME_FORMAT, DATETIME_FORMAT_NO_TIMEZONE
+from app.utils import DATETIME_FORMAT
 from tests.app.db import (
     create_api_key,
     create_complaint,
@@ -252,7 +252,7 @@ def test_send_returned_letter_to_service_sends_callback_to_service(
     expected_data = {
         "notification_id": str(notification.id),
         "reference": notification.client_reference,
-        "date_sent": notification.created_at.strftime(DATETIME_FORMAT_NO_TIMEZONE),
+        "date_sent": notification.created_at.strftime(DATETIME_FORMAT),
         "sent_by": sample_letter_template.service.users[0].email_address,
         "template_name": sample_letter_template.name,
         "template_id": str(sample_letter_template.id),

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -365,7 +365,7 @@ def test_get_service_by_id_returns_go_live_user_and_go_live_at(admin_request, sa
     service = create_service(user=sample_user, go_live_user=sample_user, go_live_at=now)
     json_resp = admin_request.get("service.get_service_by_id", service_id=service.id)
     assert json_resp["data"]["go_live_user"] == str(sample_user.id)
-    assert json_resp["data"]["go_live_at"] == str(now)
+    assert json_resp["data"]["go_live_at"] == now.strftime(DATETIME_FORMAT)
 
 
 @pytest.mark.parametrize(
@@ -3317,7 +3317,7 @@ def test_get_returned_letter_statistics(admin_request, sample_service):
 
     response = admin_request.get("service.returned_letter_statistics", service_id=sample_service.id)
 
-    assert response == {"returned_letter_count": 3, "most_recent_report": "2019-12-10 00:00:00.000000"}
+    assert response == {"returned_letter_count": 3, "most_recent_report": "2019-12-10T00:00:00.000000Z"}
 
 
 @freeze_time("2019-12-11 13:30")
@@ -3335,7 +3335,7 @@ def test_get_returned_letter_statistics_with_old_returned_letters(
 
     assert admin_request.get("service.returned_letter_statistics", service_id=sample_service.id) == {
         "returned_letter_count": 0,
-        "most_recent_report": "2019-12-03 00:00:00.000000",
+        "most_recent_report": "2019-12-03T00:00:00.000000Z",
     }
 
     assert count_mock.called is False
@@ -3449,7 +3449,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[0]["notification_id"] == str(letter_from_job.id)
     assert not response[0]["client_reference"]
     assert response[0]["reported_at"] == "2019-12-11"
-    assert response[0]["created_at"] == "2019-12-10 13:30:00.000000"
+    assert response[0]["created_at"] == "2019-12-10T13:30:00.000000Z"
     assert response[0]["template_name"] == sample_letter_template.name
     assert response[0]["template_id"] == str(sample_letter_template.id)
     assert response[0]["template_version"] == sample_letter_template.version
@@ -3461,7 +3461,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[1]["notification_id"] == str(one_off_letter.id)
     assert not response[1]["client_reference"]
     assert response[1]["reported_at"] == "2019-12-11"
-    assert response[1]["created_at"] == "2019-12-09 13:30:00.000000"
+    assert response[1]["created_at"] == "2019-12-09T13:30:00.000000Z"
     assert response[1]["template_name"] == sample_letter_template.name
     assert response[1]["template_id"] == str(sample_letter_template.id)
     assert response[1]["template_version"] == sample_letter_template.version
@@ -3473,7 +3473,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[2]["notification_id"] == str(api_letter.id)
     assert response[2]["client_reference"] == "api_letter"
     assert response[2]["reported_at"] == "2019-12-11"
-    assert response[2]["created_at"] == "2019-12-08 13:30:00.000000"
+    assert response[2]["created_at"] == "2019-12-08T13:30:00.000000Z"
     assert response[2]["template_name"] == sample_letter_template.name
     assert response[2]["template_id"] == str(sample_letter_template.id)
     assert response[2]["template_version"] == sample_letter_template.version
@@ -3485,7 +3485,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[3]["notification_id"] == str(precompiled_letter.id)
     assert response[3]["client_reference"] == "precompiled letter"
     assert response[3]["reported_at"] == "2019-12-11"
-    assert response[3]["created_at"] == "2019-12-07 13:30:00.000000"
+    assert response[3]["created_at"] == "2019-12-07T13:30:00.000000Z"
     assert not response[3]["template_name"]
     assert not response[3]["template_id"]
     assert not response[3]["template_version"]
@@ -3497,7 +3497,7 @@ def test_get_returned_letter(admin_request, sample_letter_template):
     assert response[4]["notification_id"] == str(uploaded_letter.id)
     assert not response[4]["client_reference"]
     assert response[4]["reported_at"] == "2019-12-11"
-    assert response[4]["created_at"] == "2019-12-06 13:30:00.000000"
+    assert response[4]["created_at"] == "2019-12-06T13:30:00.000000Z"
     assert not response[4]["template_name"]
     assert not response[4]["template_id"]
     assert not response[4]["template_version"]

--- a/tests/app/template/test_rest_history.py
+++ b/tests/app/template/test_rest_history.py
@@ -4,6 +4,7 @@ from datetime import date, datetime
 from flask import url_for
 
 from app.dao.templates_dao import dao_update_template
+from app.utils import DATETIME_FORMAT
 from tests import create_admin_authorization_header
 from tests.app.db import create_letter_contact
 
@@ -27,7 +28,7 @@ def test_template_history_version(notify_api, sample_user, sample_template):
             assert json_resp["data"]["process_type"] == "normal"
             assert json_resp["data"]["created_by"]["name"] == sample_user.name
             assert json_resp["data"]["is_precompiled_letter"] is False
-            assert datetime.strptime(json_resp["data"]["created_at"], "%Y-%m-%d %H:%M:%S.%f").date() == date.today()
+            assert datetime.strptime(json_resp["data"]["created_at"], DATETIME_FORMAT).date() == date.today()
 
 
 def test_previous_template_history_version(notify_api, sample_template):

--- a/tests/app/upload/test_rest.py
+++ b/tests/app/upload/test_rest.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, timedelta
 from freezegun import freeze_time
 
 from app.constants import JOB_STATUS_FINISHED, JOB_STATUS_PENDING, LETTER_TYPE
+from app.utils import DATETIME_FORMAT
 from tests.app.db import (
     create_ft_notification_status,
     create_job,
@@ -81,7 +82,7 @@ def test_get_uploads(admin_request, sample_template, mocker):
         "recipient": None,
         "notification_count": 10,
         "template_type": "sms",
-        "created_at": upload_5.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+        "created_at": upload_5.created_at.strftime(DATETIME_FORMAT),
         "statistics": [],
         "upload_type": "job",
     }
@@ -91,7 +92,7 @@ def test_get_uploads(admin_request, sample_template, mocker):
         "recipient": None,
         "notification_count": 2,
         "template_type": "letter",
-        "created_at": upload_4.created_at.replace(hour=17, minute=30).strftime("%Y-%m-%d %H:%M:%S"),
+        "created_at": upload_4.created_at.replace(hour=17, minute=30).strftime(DATETIME_FORMAT),
         "statistics": [],
         "upload_type": "letter_day",
     }
@@ -101,7 +102,7 @@ def test_get_uploads(admin_request, sample_template, mocker):
         "recipient": None,
         "notification_count": 1,
         "template_type": "sms",
-        "created_at": upload_2.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+        "created_at": upload_2.created_at.strftime(DATETIME_FORMAT),
         "statistics": [],
         "upload_type": "job",
     }


### PR DESCRIPTION
It’s confusing that we arbitrarily serialize datetimes for the admin app in 2 different formats.