### PR TITLE
notifications-utils: 98.0.0 -> 99.0.0, reduce early log level for heavily-called celery tasks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@98.0.0
+# This file was automatically copied from notifications-utils@99.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta
 
 import iso8601
@@ -18,7 +19,9 @@ from app.notifications.notifications_ses_callback import (
 )
 
 
-@notify_celery.task(bind=True, name="process-ses-result", max_retries=5, default_retry_delay=300)
+@notify_celery.task(
+    bind=True, name="process-ses-result", max_retries=5, default_retry_delay=300, early_log_level=logging.DEBUG
+)
 def process_ses_results(self, response):
     try:
         ses_message = json.loads(response["Message"])

--- a/app/celery/process_sms_client_response_tasks.py
+++ b/app/celery/process_sms_client_response_tasks.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from datetime import datetime
 
@@ -21,7 +22,9 @@ sms_response_mapper = {
 }
 
 
-@notify_celery.task(bind=True, name="process-sms-client-response", max_retries=5, default_retry_delay=300)
+@notify_celery.task(
+    bind=True, name="process-sms-client-response", max_retries=5, default_retry_delay=300, early_log_level=logging.DEBUG
+)
 def process_sms_client_response(self, status, provider_reference, client_name, detailed_status_code=None):
     # validate reference
     try:

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from uuid import UUID
 
@@ -33,7 +34,9 @@ from app.exceptions import NotificationTechnicalFailureException
 from app.letters.utils import LetterPDFNotFound, find_letter_pdf_in_s3
 
 
-@notify_celery.task(bind=True, name="deliver_sms", max_retries=48, default_retry_delay=300)
+@notify_celery.task(
+    bind=True, name="deliver_sms", max_retries=48, default_retry_delay=300, early_log_level=logging.DEBUG
+)
 def deliver_sms(self, notification_id):
     try:
         current_app.logger.info("Start sending SMS for notification id: %s", notification_id)
@@ -61,7 +64,9 @@ def deliver_sms(self, notification_id):
             raise NotificationTechnicalFailureException(message) from e
 
 
-@notify_celery.task(bind=True, name="deliver_email", max_retries=48, default_retry_delay=300)
+@notify_celery.task(
+    bind=True, name="deliver_email", max_retries=48, default_retry_delay=300, early_log_level=logging.DEBUG
+)
 def deliver_email(self, notification_id):
     try:
         current_app.logger.info("Start sending email for notification id: %s", notification_id)

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from contextvars import ContextVar
 
 import requests
@@ -49,7 +50,9 @@ def send_returned_letter_to_service(self, encoded_returned_letter):
     )
 
 
-@notify_celery.task(bind=True, name="send-delivery-status", max_retries=5, default_retry_delay=300)
+@notify_celery.task(
+    bind=True, name="send-delivery-status", max_retries=5, default_retry_delay=300, early_log_level=logging.DEBUG
+)
 def send_delivery_status_to_service(self, notification_id, encoded_status_update):
     status_update = signing.decode(encoded_status_update)
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Sequence
 from datetime import datetime
 
@@ -299,7 +300,7 @@ def save_sms(
 
 
 @notify_celery.task(bind=True, name="save-email", max_retries=5, default_retry_delay=300)
-def save_email(self, service_id, notification_id, encoded_notification, sender_id=None):
+def save_email(self, service_id, notification_id, encoded_notification, sender_id=None, early_log_level=logging.DEBUG):
     notification = signing.decode(encoded_notification)
 
     service = SerialisedService.from_id(service_id)

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil>=6.0.0,<7.0.0
 notifications-python-client==10.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@98.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,7 +95,9 @@ gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6
 govuk-bank-holidays==0.15
     # via notifications-utils
 greenlet==3.0.3
-    # via eventlet
+    # via
+    #   eventlet
+    #   sqlalchemy
 gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
     # via
     #   -r requirements.in
@@ -147,7 +149,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@794b88afc06bff187a3d58db0ed5f2871bad7ba6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@04323a3b2c1c9618766e2c16363fdacb2830af36
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -151,6 +151,7 @@ greenlet==3.0.3
     # via
     #   -r requirements.txt
     #   eventlet
+    #   sqlalchemy
 gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
     # via
     #   -r requirements.txt
@@ -219,7 +220,7 @@ moto==5.0.11
     # via -r requirements_for_test.in
 notifications-python-client==10.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@794b88afc06bff187a3d58db0ed5f2871bad7ba6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@04323a3b2c1c9618766e2c16363fdacb2830af36
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@98.0.0
+# This file was automatically copied from notifications-utils@99.0.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,10 +1,8 @@
-# This file was automatically copied from notifications-utils@98.0.0
+# This file was automatically copied from notifications-utils@99.0.0
 
-exclude = [
+extend-exclude = [
     "migrations/versions/",
-    "venv*",
     "__pycache__",
-    "node_modules",
     "cache",
     "migrations",
     "build",


### PR DESCRIPTION
This brings in the utils change https://github.com/alphagov/notifications-utils/pull/1213 which means we should get early-log-messages for celery tasks and also should have celery task identifiers available on log messages.

Stop early-log-messages for all tasks we call very heavily to reduce the effect this change has on our log volumes.