### PR TITLE
Add economy letter feature flag

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -205,6 +205,7 @@ INTERNATIONAL_LETTERS = "international_letters"
 EXTRA_EMAIL_FORMATTING = "extra_email_formatting"
 EXTRA_LETTER_FORMATTING = "extra_letter_formatting"
 SMS_TO_UK_LANDLINES = "sms_to_uk_landlines"
+ECONOMY_LETTER_SENDING = "economy_letter_sending"
 SERVICE_PERMISSION_TYPES = [
     EMAIL_TYPE,
     SMS_TYPE,
@@ -222,6 +223,7 @@ SERVICE_PERMISSION_TYPES = [
     EXTRA_EMAIL_FORMATTING,
     EXTRA_LETTER_FORMATTING,
     SMS_TO_UK_LANDLINES,
+    ECONOMY_LETTER_SENDING,
 ]
 
 # List of available permissions

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0496_update_inbound_callback
+0497_add_economy_letter_flag

--- a/migrations/versions/0497_add_economy_letter_flag.py
+++ b/migrations/versions/0497_add_economy_letter_flag.py
@@ -1,0 +1,19 @@
+"""
+Create Date: 2025-04-14 12:14:22.768745
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0497_add_economy_letter_flag'
+down_revision = '0496_update_inbound_callback'
+
+
+def upgrade():
+    op.execute("INSERT INTO service_permission_types VALUES ('economy_letter_sending')")
+
+
+def downgrade():
+    op.execute("DELETE FROM service_permissions WHERE permission = 'economy_letter_sending'")
+    op.execute("DELETE FROM service_permission_types WHERE name = 'economy_letter_sending'")


### PR DESCRIPTION
We have added a service-level permission economy letter feature flag to make sure other teams do not accidentally use the economy rates or options while we are still developing the feature. [Card](https://trello.com/c/k2L5QcH2/1249-service-level-permission-for-economy-rates) for this PR.