### PR TITLE
Upgrade gunicorn and eventlet

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,8 +7,8 @@ flask-marshmallow==1.3.0
 Flask-Migrate==3.1.0
 flask-sqlalchemy==3.0.5
 click-datetime==0.2
-# We originally pinned this due to eventlet v0.33 compatibility issues. That was supposedly fixed in version v21.0.0 and we merged v21.2.0 for a while. Until we ran a load test again, and identified that the bumped version of gunicorn led to a 33%+ drop-off in performance/requests per second that the API was able to handle. If a version greater than 21.2.0 is released, and it either gives us something we need or we think it addresses said performance issues, make sure to run a load test in staging before releasing to production.
-gunicorn[eventlet] @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
+gunicorn[eventlet]==23.0.0
+eventlet==0.39.1
 iso8601==2.1.0
 jsonschema[format]==4.23.0
 marshmallow-sqlalchemy==0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,8 +64,10 @@ dnspython==2.6.1
     # via eventlet
 docopt==0.6.2
     # via notifications-python-client
-eventlet==0.35.2
-    # via gunicorn
+eventlet==0.39.1
+    # via
+    #   -r requirements.in
+    #   gunicorn
 flask==3.1.0
     # via
     #   flask-bcrypt
@@ -96,7 +98,7 @@ govuk-bank-holidays==0.15
     # via notifications-utils
 greenlet==3.0.3
     # via eventlet
-gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
+gunicorn==23.0.0
     # via
     #   -r requirements.in
     #   notifications-utils
@@ -153,6 +155,7 @@ ordered-set==4.1.0
     # via notifications-utils
 packaging==23.2
     # via
+    #   gunicorn
     #   marshmallow
     #   marshmallow-sqlalchemy
 phonenumbers==8.13.52
@@ -214,8 +217,6 @@ segno==1.6.1
     # via notifications-utils
 sentry-sdk==1.45.1
     # via -r requirements.in
-setuptools==75.6.0
-    # via gunicorn
 six==1.16.0
     # via
     #   click-repl

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -105,7 +105,7 @@ docopt==0.6.2
     # via
     #   -r requirements.txt
     #   notifications-python-client
-eventlet==0.35.2
+eventlet==0.39.1
     # via
     #   -r requirements.txt
     #   gunicorn
@@ -151,7 +151,7 @@ greenlet==3.0.3
     # via
     #   -r requirements.txt
     #   eventlet
-gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
+gunicorn==23.0.0
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -228,6 +228,7 @@ ordered-set==4.1.0
 packaging==23.2
     # via
     #   -r requirements.txt
+    #   gunicorn
     #   marshmallow
     #   marshmallow-sqlalchemy
     #   pytest
@@ -342,10 +343,6 @@ segno==1.6.1
     #   notifications-utils
 sentry-sdk==1.45.1
     # via -r requirements.txt
-setuptools==75.6.0
-    # via
-    #   -r requirements.txt
-    #   gunicorn
 six==1.16.0
     # via
     #   -r requirements.txt


### PR DESCRIPTION
https://trello.com/c/u5f3qgz9/48-upgrade-gunicorn-from-1299ea9e967a61ae2edebe191082fd169b864c64-to-2300

What
----

Upgrade gunicorn and eventlet

Why
----

We are still using a very old version.

Notes
----

[Functional tests passing](https://concourse.notify.tools/teams/dev-d/pipelines/deploy-notify/jobs/functional-tests/builds/59)

