### PR TITLE
Fixing email stub provider

### DIFF
--- a/app/clients/email/aws_ses_stub.py
+++ b/app/clients/email/aws_ses_stub.py
@@ -26,7 +26,17 @@ class AwsSesStubClient(EmailClient):
         self.url = stub_url
         self.requests_session = requests.Session()
 
-    def send_email(self, source, to_addresses, subject, body, html_body="", reply_to_address=None):
+    def send_email(
+        self,
+        *,
+        from_address: str,
+        to_address: str,
+        subject: str,
+        body: str,
+        html_body: str,
+        reply_to_address: str | None,
+        headers: list[dict[str, str]],
+    ) -> str:
         try:
             start_time = monotonic()
             response = self.session.request("POST", self.url, data={"id": "dummy-data"}, timeout=60)

--- a/app/clients/email/aws_ses_stub.py
+++ b/app/clients/email/aws_ses_stub.py
@@ -39,7 +39,7 @@ class AwsSesStubClient(EmailClient):
     ) -> str:
         try:
             start_time = monotonic()
-            response = self.session.request("POST", self.url, data={"id": "dummy-data"}, timeout=60)
+            response = self.requests_session.request("POST", self.url, data={"id": "dummy-data"}, timeout=60)
             response.raise_for_status()
             response_json = json.loads(response.text)
 


### PR DESCRIPTION
What
----

Fixing email stub provider after sesv2 upgrade and unsubscribe header changes

Why
----

Looks like this was broken by the following PRs:

https://github.com/alphagov/notifications-api/pull/4079
https://github.com/alphagov/notifications-api/pull/4082
https://github.com/alphagov/notifications-api/pull/4179