### PR TITLE
Rename join a service routes

### DIFF
--- a/app/dao/service_join_requests_dao.py
+++ b/app/dao/service_join_requests_dao.py
@@ -68,6 +68,30 @@ def dao_update_service_join_request(
     return service_join_request
 
 
+@autocommit
+def dao_update_service_join_request_by_id(
+    request_id: UUID,
+    service_id: UUID,
+    status: Literal["approved", "rejected", "pending", "cancelled"],
+    status_changed_by_id: UUID,
+    reason: str = None,
+) -> ServiceJoinRequest:
+    service_join_request = dao_get_service_join_request_by_id_and_service_id(
+        request_id=request_id, service_id=service_id
+    )
+
+    if status:
+        service_join_request.status = status
+        service_join_request.status_changed_by_id = status_changed_by_id
+        service_join_request.status_changed_at = datetime.utcnow()
+
+    if reason is not None:
+        service_join_request.reason = reason
+
+    db.session.add(service_join_request)
+    return service_join_request
+
+
 def dao_cancel_pending_service_join_requests(requester_id: UUID, approver_id: UUID, service_id: UUID) -> None:
     pending_requests = ServiceJoinRequest.query.filter_by(
         requester_id=requester_id, service_id=service_id, status=SERVICE_JOIN_REQUEST_PENDING

--- a/app/dao/service_join_requests_dao.py
+++ b/app/dao/service_join_requests_dao.py
@@ -36,6 +36,14 @@ def dao_get_service_join_request_by_id(request_id: UUID) -> ServiceJoinRequest |
     )
 
 
+def dao_get_service_join_request_by_id_and_service_id(*, request_id: UUID, service_id: UUID):
+    return (
+        ServiceJoinRequest.query.filter_by(id=request_id, service_id=service_id)
+        .options(db.joinedload("contacted_service_users"))
+        .one()
+    )
+
+
 @autocommit
 def dao_update_service_join_request(
     request_id: UUID,

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -178,7 +178,6 @@ from app.utils import (
     midnight_n_days_ago,
     utc_string_to_bst_string,
 )
-from app.v2.errors import ValidationError
 
 service_blueprint = Blueprint("service", __name__)
 
@@ -1291,10 +1290,7 @@ def create_contact_list(service_id):
 def create_service_join_request(service_id: uuid.UUID):
     data = request.get_json()
 
-    try:
-        validate(data, service_join_request_schema)
-    except ValidationError as err:
-        raise InvalidRequest(message=err.messages, status_code=400) from err
+    validate(data, service_join_request_schema)
 
     new_request = dao_create_service_join_request(
         requester_id=data["requester_id"],

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -79,6 +79,7 @@ from app.dao.service_join_requests_dao import (
     dao_cancel_pending_service_join_requests,
     dao_create_service_join_request,
     dao_get_service_join_request_by_id,
+    dao_get_service_join_request_by_id_and_service_id,
     dao_update_service_join_request,
 )
 from app.dao.service_letter_contact_dao import (
@@ -1309,6 +1310,15 @@ def get_service_join_request(request_id: uuid.UUID):
 
     if not service_join_request:
         raise InvalidRequest(message=f"Service join request with ID {request_id} not found.", status_code=404)
+
+    return jsonify(service_join_request.serialize()), 200
+
+
+@service_blueprint.route("/<uuid:service_id>/service-join-request/<uuid:request_id>", methods=["GET"])
+def get_service_join_request_by_id(service_id: uuid.UUID, request_id: uuid.UUID):
+    service_join_request = dao_get_service_join_request_by_id_and_service_id(
+        request_id=request_id, service_id=service_id
+    )
 
     return jsonify(service_join_request.serialize()), 200
 

--- a/app/service/service_join_request_schema.py
+++ b/app/service/service_join_request_schema.py
@@ -7,9 +7,10 @@ service_join_request_schema = {
     "properties": {
         "requester_id": {"type": "string", "format": "uuid"},
         "contacted_user_ids": {"type": "array", "minItems": 1, "items": {"type": "string", "format": "uuid"}},
+        "invite_link_host": {"type": "string"},
         "reason": {"type": ["string", "null"], "description": "Optional reason for the request"},
     },
-    "required": ["requester_id", "contacted_user_ids"],
+    "required": ["requester_id", "contacted_user_ids", "invite_link_host"],
     "additionalProperties": False,
 }
 


### PR DESCRIPTION
This moves code around and temporarily duplicates it so that we can rename the join a service URLs before the feature goes live. See individual commits for full details.

**The route to create a join request**
We had a 2 routes to create a join request
1. `/service/<uuid:service_id>/service-join-request` - this is the URL we want, but didn't contain much functionality
2. `/service/<service_id>/invite/request-for/<user_to_invite_id>` this contained the functionality, but we decided not to use this URL

This moves the functionality from 2. into 1.

**The routes to get and update a join request**
We decided we wanted to change the URLs from 
* `GET /service/service-join-request/<uuid:request_id>` to `GET /service/<service_id>/service-join-request/<uuid:request_id>`
* `POST /service/update-service-join-request-status/<uuid:request_id>` to `POST /service/<service_id>/service-join-request/<uuid:request_id>`

This adds the new routes (the old ones will be removed later), which required new DAO functions which take a service id