### PR TITLE
feat: Persist  reason field on service join request creation

### DIFF
--- a/app/dao/service_join_requests_dao.py
+++ b/app/dao/service_join_requests_dao.py
@@ -14,11 +14,15 @@ from app.models import ServiceJoinRequest, User
 
 @autocommit
 def dao_create_service_join_request(
-    requester_id: UUID, service_id: UUID, contacted_user_ids: list[UUID]
+    requester_id: UUID,
+    service_id: UUID,
+    contacted_user_ids: list[UUID],
+    reason: str | None = None,
 ) -> ServiceJoinRequest:
     new_request = ServiceJoinRequest(
         requester_id=requester_id,
         service_id=service_id,
+        reason=reason,
     )
 
     contacted_users = User.query.filter(User.id.in_(contacted_user_ids)).all()
@@ -49,7 +53,7 @@ def dao_update_service_join_request(
     request_id: UUID,
     status: Literal[*SERVICE_JOIN_REQUEST_STATUS_TYPES],
     status_changed_by_id: UUID,
-    reason: str = None,
+    reason: str | None = None,
 ) -> ServiceJoinRequest | None:
     service_join_request = dao_get_service_join_request_by_id(request_id)
 
@@ -103,5 +107,4 @@ def dao_cancel_pending_service_join_requests(requester_id: UUID, approver_id: UU
                 request_id=request.id,
                 status=SERVICE_JOIN_REQUEST_CANCELLED,
                 status_changed_by_id=approver_id,
-                reason="system update due to cancellation",
             )

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1306,6 +1306,7 @@ def create_service_join_request(service_id: uuid.UUID):
         requester_id=data["requester_id"],
         service_id=service_id,
         contacted_user_ids=data["contacted_user_ids"],
+        reason=reason_for_request,
     )
 
     approve_request_url = f"{invite_link_host}/services/{service.id}/join-request/{new_request.id}/approve"
@@ -1427,7 +1428,7 @@ def update_service_join_request(request_id: uuid.UUID):
 
     status = data["status"]
     status_changed_by_id = data["status_changed_by_id"]
-    reason = data.get("reason", None)
+    reason = data.get("reason")
 
     updated_request = dao_update_service_join_request(request_id, status, status_changed_by_id, reason)
 

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -147,6 +147,7 @@ def request_invite_to_service(service_id, user_to_invite_id):
         requester_id=user_to_invite_id,
         service_id=service_id,
         contacted_user_ids=recipients_of_invite_request_ids,
+        reason=reason_for_request,
     )
 
     approve_request_url = (


### PR DESCRIPTION
## PR Summary
- Extended service join requests to persist the `reason` field when we create the request
- Previously we persisted the data during the update of a request, but not during the creation. Now we do it for both.
- The field is by default None if no value is available.

### Ticket:
[Join a service dev work](https://trello.com/c/ozzxcO3o/1221-join-a-service-dev-work)