### PR TITLE
add stack trace to NoResultFound errors

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -95,7 +95,7 @@ def register_errors(blueprint):  # noqa: C901
     @blueprint.errorhandler(NoResultFound)
     @blueprint.errorhandler(DataError)
     def no_result_found(e):
-        current_app.logger.info(e)
+        current_app.logger.info(e, exc_info=True)
         return jsonify(result="error", message="No result found"), 404
 
     @blueprint.errorhandler(EventletTimeout)

--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -131,7 +131,7 @@ def register_errors(blueprint):
     @blueprint.errorhandler(NoResultFound)
     @blueprint.errorhandler(DataError)
     def no_result_found(e):
-        current_app.logger.info(e)
+        current_app.logger.info(e, exc_info=True)
         return jsonify(status_code=404, errors=[{"error": e.__class__.__name__, "message": "No result found"}]), 404
 
     @blueprint.errorhandler(AuthError)

--- a/tests/app/v2/test_errors.py
+++ b/tests/app/v2/test_errors.py
@@ -113,13 +113,15 @@ def test_validation_error(app_for_test):
             assert {"error": "ValidationError", "message": "template_id is not a valid UUID"} in error["errors"]
 
 
-def test_data_errors(app_for_test):
+def test_data_errors(app_for_test, caplog):
     with app_for_test.test_request_context():
         with app_for_test.test_client() as client:
-            response = client.get(url_for("v2_under_test.raising_data_error"))
+            with caplog.at_level("INFO"):
+                response = client.get(url_for("v2_under_test.raising_data_error"))
             assert response.status_code == 404
             error = response.json
             assert error == {"status_code": 404, "errors": [{"error": "DataError", "message": "No result found"}]}
+            assert caplog.records[0].exc_info is not None
 
 
 def test_document_download_error(app_for_test):


### PR DESCRIPTION
means we can tell a bit more easily which query it found no results for, even if we don't know exactly why. will help a bit with debugging.