### PR TITLE
Give all new orgs the join a service permission

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -2,7 +2,7 @@ from flask import current_app
 from sqlalchemy.sql.expression import func
 
 from app import db
-from app.constants import NHS_ORGANISATION_TYPES
+from app.constants import CAN_ASK_TO_JOIN_SERVICE, NHS_ORGANISATION_TYPES
 from app.dao.annual_billing_dao import set_default_free_allowance_for_service
 from app.dao.dao_utils import VersionOptions, autocommit, version_class
 from app.dao.email_branding_dao import dao_get_email_branding_by_id
@@ -12,6 +12,7 @@ from app.models import (
     Domain,
     EmailBranding,
     Organisation,
+    OrganisationPermission,
     OrganisationUserPermissions,
     Service,
     User,
@@ -71,6 +72,11 @@ def dao_create_organisation(organisation):
     if organisation.organisation_type in NHS_ORGANISATION_TYPES:
         organisation.email_branding_id = current_app.config["NHS_EMAIL_BRANDING_ID"]
         organisation.letter_branding_id = current_app.config["NHS_LETTER_BRANDING_ID"]
+
+    join_a_service_permission = OrganisationPermission(
+        organisation_id=organisation.id, permission=CAN_ASK_TO_JOIN_SERVICE
+    )
+    organisation.permissions.append(join_a_service_permission)
 
     db.session.add(organisation)
     db.session.commit()

--- a/app/functional_tests_fixtures/__init__.py
+++ b/app/functional_tests_fixtures/__init__.py
@@ -7,7 +7,6 @@ from flask import current_app
 from sqlalchemy.exc import NoResultFound
 
 from app.constants import (
-    CAN_ASK_TO_JOIN_SERVICE,
     EDIT_FOLDER_PERMISSIONS,
     EMAIL_AUTH,
     EXTRA_LETTER_FORMATTING,
@@ -372,7 +371,6 @@ def _create_organiation(email_domain, org_name="Functional Tests Org"):
 
         dao_create_organisation(org)
 
-    org.set_permissions_list([CAN_ASK_TO_JOIN_SERVICE])
     dao_update_organisation(org.id, domains=[email_domain], can_approve_own_go_live_requests=True)
 
     return org

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -8,7 +8,7 @@ from flask import current_app
 from freezegun import freeze_time
 from sqlalchemy.exc import SQLAlchemyError
 
-from app.constants import INVITE_ACCEPTED, INVITE_CANCELLED
+from app.constants import CAN_ASK_TO_JOIN_SERVICE, INVITE_ACCEPTED, INVITE_CANCELLED
 from app.dao.annual_billing_dao import set_default_free_allowance_for_service
 from app.dao.email_branding_dao import dao_get_email_branding_by_id
 from app.dao.letter_branding_dao import dao_get_letter_branding_by_id
@@ -207,16 +207,18 @@ def test_post_create_organisation(admin_request, notify_db_session, crown):
 
     response = admin_request.post("organisation.create_organisation", _data=data, _expected_status=201)
 
-    organisations = Organisation.query.all()
+    organisation = Organisation.query.one()
 
     assert data["name"] == response["name"]
     assert data["active"] == response["active"]
     assert data["crown"] == response["crown"]
     assert data["organisation_type"] == response["organisation_type"]
 
-    assert len(organisations) == 1
     # check that for non-nhs orgs, default branding is not set
-    assert organisations[0].email_branding_id is None
+    assert organisation.email_branding_id is None
+
+    assert len(organisation.permissions) == 1
+    assert organisation.permissions[0].permission == CAN_ASK_TO_JOIN_SERVICE
 
 
 @pytest.mark.parametrize("org_type", ["nhs_central", "nhs_local", "nhs_gp"])


### PR DESCRIPTION
This will become the default for all organisations, so when an organisation is created we now automatically give them the join a service organisation permission.