### PR TITLE
Send economy postage to dvla

### DIFF
--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -87,6 +87,9 @@ def _create_fake_letter_callback_data(notification_id: uuid.UUID, billable_units
     elif postage == "second":
         postage = "2ND"
         mailing_product = "MM"
+    elif postage == "economy":
+        postage = "2ND"
+        mailing_product = "UNSORTEDE"
     elif postage == "europe":
         postage = "INTERNATIONAL"
         mailing_product = "INT EU"

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -15,12 +15,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.ssl_ import create_urllib3_context
 
 from app.clients import ClientException
-from app.constants import (
-    EUROPE,
-    FIRST_CLASS,
-    INTERNATIONAL_POSTAGE_TYPES,
-    REST_OF_WORLD,
-)
+from app.constants import ECONOMY_CLASS, EUROPE, FIRST_CLASS, INTERNATIONAL_POSTAGE_TYPES, REST_OF_WORLD
 
 
 class DvlaException(ClientException):
@@ -265,7 +260,7 @@ class DVLAClient:
         notification_id: str,
         reference: str,
         address: PostalAddress,
-        postage: Literal["first", "second", "europe", "rest-of-world"],
+        postage: Literal["first", "second", "europe", "rest-of-world", "economy"],
         service_id: str,
         organisation_id: str,
         pdf_file: bytes,
@@ -343,6 +338,8 @@ class DVLAClient:
             json_payload["standardParams"]["despatchMethod"] = "INTERNATIONAL_EU"
         elif postage == REST_OF_WORLD:
             json_payload["standardParams"]["despatchMethod"] = "INTERNATIONAL_ROW"
+        elif postage == ECONOMY_CLASS:
+            json_payload["standardParams"]["despatchMethod"] = "ECONOMY"
 
         return json_payload
 

--- a/app/constants.py
+++ b/app/constants.py
@@ -115,6 +115,7 @@ FIRST_CLASS = "first"
 SECOND_CLASS = "second"
 EUROPE = "europe"
 REST_OF_WORLD = "rest-of-world"
+ECONOMY_CLASS = "economy"
 
 # Aggregated letter postage types
 POSTAGE_TYPES = [FIRST_CLASS, SECOND_CLASS, EUROPE, REST_OF_WORLD]

--- a/app/notifications/notifications_letter_callback.py
+++ b/app/notifications/notifications_letter_callback.py
@@ -52,7 +52,16 @@ dvla_letter_callback_schema = {
                                 "properties": {
                                     "key": {"const": "mailingProduct"},
                                     "value": {
-                                        "enum": ["UNCODED", "MM UNSORTED", "UNSORTED", "MM", "INT EU", "INT ROW"]
+                                        "enum": [
+                                            "UNCODED",
+                                            "MM UNSORTED",
+                                            "UNSORTED",
+                                            "MM",
+                                            "INT EU",
+                                            "INT ROW",
+                                            "UNSORTEDE",
+                                            "MM ECONOMY",
+                                        ]
                                     },
                                 }
                             },
@@ -180,9 +189,8 @@ def extract_properties_from_request(request_data) -> LetterUpdate:
 
 
 def _get_cost_threshold(mailing_product: str, postage: str) -> LetterCostThreshold:
-    if mailing_product == "MM" and postage == "2ND":
+    if (mailing_product == "MM" or mailing_product == "MM ECONOMY") and postage == "2ND":
         return LetterCostThreshold("sorted")
-
     return LetterCostThreshold("unsorted")
 
 

--- a/tests/app/celery/test_research_mode_tasks.py
+++ b/tests/app/celery/test_research_mode_tasks.py
@@ -120,6 +120,7 @@ def test_failure_firetext_callback(phone_number):
     [
         ("1", "first", "1ST", "UNCODED"),
         ("3", "second", "2ND", "MM"),
+        ("4", "economy", "2ND", "UNSORTEDE"),
         ("5", "europe", "INTERNATIONAL", "INT EU"),
         ("2", "rest-of-world", "INTERNATIONAL", "INT ROW"),
     ],

--- a/tests/app/clients/test_dvla.py
+++ b/tests/app/clients/test_dvla.py
@@ -1022,3 +1022,18 @@ class TestDVLAApiClientRestrictedCiphers:
                 )
 
         assert "alert handshake failure" in str(e.value)
+
+
+def test_format_create_print_job_json_adds_despatchMethod_key_for_economy_class_post(dvla_client):
+    formatted_json = dvla_client._format_create_print_job_json(
+        notification_id="my_notification_id",
+        reference="ABCDEFGHIJKL",
+        address=PostalAddress("A. User\nThe road\nCity\nSW1 1AA"),
+        postage="economy",
+        service_id="my_service_id",
+        organisation_id="my_organisation_id",
+        pdf_file=b"pdf_content",
+        callback_url="/my-callback",
+    )
+
+    assert formatted_json["standardParams"]["despatchMethod"] == "ECONOMY"

--- a/tests/app/notifications/test_notifications_letter_callbacks.py
+++ b/tests/app/notifications/test_notifications_letter_callbacks.py
@@ -276,9 +276,11 @@ def test_extract_properties_from_request(mock_dvla_callback_data):
 
 
 @pytest.mark.parametrize("postage", ["1ST", "2ND", "INTERNATIONAL"])
-@pytest.mark.parametrize("mailing_product", ["UNCODED", "MM UNSORTED", "UNSORTED", "MM", "INT EU", "INT ROW"])
+@pytest.mark.parametrize(
+    "mailing_product", ["UNCODED", "MM UNSORTED", "UNSORTED", "MM", "INT EU", "INT ROW", "UNSORTEDE", "MM ECONOMY"]
+)
 def test__get_cost_threshold(mailing_product, postage):
-    if postage == "2ND" and mailing_product == "MM":
+    if (mailing_product == "MM" or mailing_product == "MM ECONOMY") and postage == "2ND":
         expected_cost_threshold = LetterCostThreshold.sorted
     else:
         expected_cost_threshold = LetterCostThreshold.unsorted


### PR DESCRIPTION
There is new "economy" postage option available for letters. Updating the DVLA API request payload to send "ECONOMY" in the despatchMethod. All other logic for the existing postage classes will stay the same.
For the callback the mailingProduct will be shown as 'UNSORTEDE' for UNSORTED ECONOMY and 'MM ECONOMY' for Mailmark Economy.  The postage class will be '2ND' for both.
More details on the [card](https://trello.com/c/zY3ijvpi/1245-send-economy-postage-to-dvla)
