### PR TITLE
Add international_sms_message_limit to ServiceSchema

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -221,6 +221,7 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
     email_branding = field_for(models.Service, "email_branding")
     organisation = field_for(models.Service, "organisation")
     email_message_limit = field_for(models.Service, "email_message_limit", required=True)
+    international_sms_message_limit = field_for(models.Service, "international_sms_message_limit", required=False)
     sms_message_limit = field_for(models.Service, "sms_message_limit", required=True)
     letter_message_limit = field_for(models.Service, "letter_message_limit", required=True)
     go_live_at = field_for(models.Service, "go_live_at", format=DATETIME_FORMAT_NO_TIMEZONE)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -783,6 +783,31 @@ def test_update_service_sets_volumes(
 
 
 @pytest.mark.parametrize(
+    "daily_limit_type, limit_size",
+    [
+        ["email_message_limit", 1123456],
+        ["international_sms_message_limit", 1123],
+        ["sms_message_limit", 1123456],
+        ["letter_message_limit", 123456],
+    ],
+)
+def test_update_service_sets_daily_limits(
+    admin_request,
+    sample_service,
+    daily_limit_type,
+    limit_size,
+):
+    admin_request.post(
+        "service.update_service",
+        service_id=sample_service.id,
+        _data={
+            daily_limit_type: limit_size,
+        },
+    )
+    assert getattr(sample_service, daily_limit_type) == limit_size
+
+
+@pytest.mark.parametrize(
     "value, expected_status, expected_persisted",
     (
         (True, 200, True),


### PR DESCRIPTION
Also test updating service daily message limits.

This PR needs to be merged in before the admin one: https://github.com/alphagov/notifications-admin/pull/5437