### PR TITLE
feat: Prevent economy mail letters from sending temporarily

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -113,6 +113,7 @@ DVLA_TO_NOTIFICATION_STATUS_MAP = {
 # Letter postage zones
 FIRST_CLASS = "first"
 SECOND_CLASS = "second"
+ECONOMY_CLASS = "economy"
 EUROPE = "europe"
 REST_OF_WORLD = "rest-of-world"
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -801,7 +801,7 @@ def dao_get_letters_to_be_printed(print_run_deadline_local, query_limit=10000):
     https://www.mail-archive.com/sqlalchemy@googlegroups.com/msg12443.html
     """
     notifications = (
-        Notification.query.with_entities(Notification.id)
+        Notification.query.with_entities(Notification.id, Notification.postage)
         .filter(
             Notification.created_at < convert_bst_to_utc(print_run_deadline_local),
             Notification.notification_type == LETTER_TYPE,


### PR DESCRIPTION
## PR Summary:
This is a temporary change to prevent economy mail from sending to DVLA.

- Updated `dao_get_letters_to_be_printed` to return postage as well as notification ids
- Extended `send_dvla_letters_via_api` to include filtering logic for economy postage
- If we find economy letters present, we update these to TECHNICAL_FAILURE and log the details of how many economy letters were found

### Ticket:
- [Allow postage to be economy in Notify](https://trello.com/c/Y95RhqNO/1244-allow-postage-to-be-economy-in-notify)
