### PR TITLE
Copy service_inbound_api data to service_callback_api table

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0498_join_a_service_for_all
+0499_merge_callback_tables

--- a/migrations/versions/0499_merge_callback_tables.py
+++ b/migrations/versions/0499_merge_callback_tables.py
@@ -1,0 +1,45 @@
+"""
+Create Date: 2025-04-24 16:28:42.775750
+"""
+
+from alembic import op
+
+revision = '0499_merge_callback_tables'
+down_revision = '0498_join_a_service_for_all'
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(
+            """
+            INSERT INTO service_callback_api (id, service_id, url, bearer_token, created_at, updated_by_id,
+                                              version, updated_at, callback_type)
+            SELECT id, service_id, url, bearer_token, created_at, updated_by_id,version, updated_at, 'inbound_sms' 
+            FROM  service_inbound_api
+            ON CONFLICT DO NOTHING 
+            
+            """
+    )
+    conn.execute(
+            """
+            INSERT INTO service_callback_api_history (id, service_id, url, bearer_token, created_at, updated_by_id,
+                                              version, updated_at, callback_type)
+            SELECT id, service_id, url, bearer_token, created_at, updated_by_id,version, updated_at, 'inbound_sms' 
+            FROM  service_inbound_api_history
+            ON CONFLICT DO NOTHING
+            """
+    )
+
+
+def downgrade():
+    conn = op.get_bind()
+    conn.execute(
+            """
+            DELETE FROM service_callback_api WHERE callback_type='inbound_sms'
+            """
+    )
+    conn.execute(
+            """
+            DELETE FROM service_callback_api_history WHERE callback_type='inbound_sms'
+            """
+    )


### PR DESCRIPTION
 This moves over data from the service_inbound_api and service_inbound_api_history tables to
 the service_callback_api and service_callback_api_history tables.
 The the service_inbound_api and service_inbound_api_history tables will be dropped in a future migration.

***

[Overall plan](https://docs.google.com/document/d/1Oo8VbB3tdJMLPM6WslJlbbwANA33_lJcN3a6AKkCL7A/edit?tab=t.0):
- [x] [Add inbound_sms type](https://github.com/alphagov/notifications-api/pull/4431#pullrequestreview-2772182640) to service_callback_type table
- [x] Start writing to existing `service_callback_api`  and `service_inbound_api` sms tables for inbound SMS callbacks (need to consider updating and deleting too)
- [ ] Migrate the data from `service_inbound_api` to `service_callback_api` table and from `service_inbound_api_history` to `service_callback_api_history` &ensp;**👈 you are here**
- [ ] Start reading from `service_callback_api` table for inbound SMS callbacks
- [ ] Remove the else statements in the API view endpoints and DAO methods, and everything related to the `service_inbound_api` table – in other words stop updating/deleting the old table
- [ ] Migration to remove the `service_inbound_api` and `service_inbound_api_history` tables
