### PR TITLE
Update from productionRunDate to transitionDate

### DIFF
--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -113,6 +113,7 @@ def _create_fake_letter_callback_data(notification_id: uuid.UUID, billable_units
             "jobType": "NOTIFY",
             "jobStatus": "DESPATCHED",
             "templateReference": "NOTIFY",
+            "transitionDate": datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
         },
         "metadata": {
             "handler": {"urn": "dvla:resource:osl:print:print-hub-fulfilment:5.18.0"},

--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -127,15 +127,6 @@ def send_a_file_confirm_email_before_download(instance):
     )
 
 
-@format_checker.checks("letter_production_run_date", raises=ValidationError)
-def validate_letter_production_run_date(instance):
-    if isinstance(instance, str):
-        if re.match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+", instance):
-            return True
-
-    raise ValidationError("Datetime format is invalid. It must be in the format %Y-%m-%d %H:%M:%S.%f")
-
-
 def validate(json_to_validate, schema):
     validator = Draft7Validator(schema, format_checker=format_checker)
     errors = list(validator.iter_errors(json_to_validate))

--- a/tests/app/celery/test_research_mode_tasks.py
+++ b/tests/app/celery/test_research_mode_tasks.py
@@ -165,6 +165,7 @@ def test_create_fake_letter_callback_sends_letter_response(
             "jobType": "NOTIFY",
             "jobStatus": "DESPATCHED",
             "templateReference": "NOTIFY",
+            "transitionDate": "2024-07-26T16:30:53Z",
         },
         "metadata": {
             "handler": {"urn": "dvla:resource:osl:print:print-hub-fulfilment:5.18.0"},

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1302,7 +1302,7 @@ def mock_dvla_callback_data():
                 "jobType": "NOTIFY",
                 "jobStatus": "DESPATCHED",
                 "templateReference": "NOTIFY",
-                "transitionDate": "2021-03-31T08:15:07Z",
+                "transitionDate": "2025-03-31T08:15:07Z",
             },
             "metadata": {
                 "handler": {"urn": "dvla:resource:osl:print:print-hub-fulfilment:5.18.0"},

--- a/tests/app/notifications/test_notifications_letter_callbacks.py
+++ b/tests/app/notifications/test_notifications_letter_callbacks.py
@@ -85,6 +85,16 @@ def test_process_letter_callback_gives_error_for_missing_or_invalid_token(client
             {"data": {"jobId": "1234 not a uuid 1234"}},
             "data badly formed hexadecimal UUID string",
         ),
+        # missing `transitionDate` in data
+        (
+            {"data": {"transitionDate": None}},
+            "data transitionDate is a required property",
+        ),
+        # invalid `transitionDate` in format
+        (
+            {"data": {"transitionDate": "2025-03-31T13:15Z"}},
+            "data 2025-03-31T13:15Z is not a date-time",
+        ),
     ],
 )
 def test_process_letter_callback_validation_for_required_fields(
@@ -118,29 +128,8 @@ def test_process_letter_callback_validation_for_required_fields(
                 {"key": "postageClass", "value": "invalid-postage-class"},
                 {"key": "totalSheets", "value": "5"},
                 {"key": "mailingProduct", "value": "MM UNSORTED"},
-                {"key": "productionRunDate", "value": "2024-10-15 08:53:32.361"},
             ],
             "data {key: postageClass, value: invalid-postage-class} is not valid under any of the given schemas",
-        ),
-        # missing totalSheets field
-        (
-            [
-                {"key": "postageClass", "value": "1ST"},
-                {"key": "mailingProduct", "value": "MM UNSORTED"},
-                {"key": "productionRunDate", "value": "2024-10-15 08:53:32.361"},
-            ],
-            "data [{key: postageClass, value: 1ST}, {key: mailingProduct, value: MM UNSORTED}, "
-            "{key: productionRunDate, value: 2024-10-15 08:53:32.361}] is too short",
-        ),
-        # invalid date-time format for productionRunDate
-        (
-            [
-                {"key": "postageClass", "value": "1ST"},
-                {"key": "totalSheets", "value": "5"},
-                {"key": "mailingProduct", "value": "MM UNSORTED"},
-                {"key": "productionRunDate", "value": "invalid-date"},
-            ],
-            "data {key: productionRunDate, value: invalid-date} is not valid under any of the given schemas",
         ),
         # invalid enum for mailingProduct
         (
@@ -148,7 +137,6 @@ def test_process_letter_callback_validation_for_required_fields(
                 {"key": "postageClass", "value": "1ST"},
                 {"key": "totalSheets", "value": "5"},
                 {"key": "mailingProduct", "value": "invalid-mailing-product"},
-                {"key": "productionRunDate", "value": "2024-10-15 08:53:32.361"},
             ],
             "data {key: mailingProduct, value: invalid-mailing-product} is not valid under any of the given schemas",
         ),
@@ -196,16 +184,17 @@ def test_process_letter_callback_raises_error_if_token_and_notification_id_in_da
     )
 
 
-@pytest.mark.parametrize("status", ["DESPATCHED", "REJECTED"])
+@pytest.mark.parametrize(
+    "status,transition_date,expected_month,expected_day",
+    [("DESPATCHED", "2025-04-01T23:30:07Z", 4, 2), ("REJECTED", "2025-02-01T23:30:07Z", 2, 1)],
+)
 def test_process_letter_callback_calls_process_letter_callback_data_task(
-    client,
-    mock_celery_task,
-    mock_dvla_callback_data,
-    status,
+    client, mock_celery_task, mock_dvla_callback_data, status, transition_date, expected_month, expected_day
 ):
     mock_task = mock_celery_task(process_letter_callback_data)
     data = mock_dvla_callback_data()
     data["data"]["jobStatus"] = status
+    data["data"]["transitionDate"] = transition_date
 
     response = client.post(
         url_for(
@@ -224,7 +213,7 @@ def test_process_letter_callback_calls_process_letter_callback_data_task(
             "page_count": 5,
             "dvla_status": status,
             "cost_threshold": LetterCostThreshold.unsorted,
-            "despatch_date": datetime.date(2024, 8, 1),
+            "despatch_date": datetime.date(2025, expected_month, expected_day),
         },
     )
 
@@ -259,9 +248,9 @@ def test_extract_properties_from_request(mock_dvla_callback_data):
                 {"key": "totalSheets", "value": "10"},
                 {"key": "postageClass", "value": "1ST"},
                 {"key": "mailingProduct", "value": "MM UNSORTED"},
-                {"key": "productionRunDate", "value": "2024-10-15 04:00:16.287"},
             ],
             "jobStatus": "REJECTED",
+            "transitionDate": "2025-03-31T13:15:07Z",
         }
     }
 
@@ -272,7 +261,7 @@ def test_extract_properties_from_request(mock_dvla_callback_data):
     assert letter_update.page_count == 10
     assert letter_update.status == "REJECTED"
     assert letter_update.cost_threshold == LetterCostThreshold.unsorted
-    assert letter_update.despatch_date == datetime.date(2024, 10, 15)
+    assert letter_update.despatch_date == datetime.date(2025, 3, 31)
 
 
 @pytest.mark.parametrize("postage", ["1ST", "2ND", "INTERNATIONAL"])


### PR DESCRIPTION
Since February 2025, we have noticed a mismatch between the GDS ft_billing report and the DVLA billing report. After looking into it, we found that the issue is linked to a callback change we made at the end of 2024. At that time, we were told to use productionRunDate (Print Date), but the problem started when DVLA changed their report or began using transitionDate instead.

The change we are now making updates the despatched_on value from productionRunDate to transitionDate.

When DVLA sends a callback, details like notification_id, despatched_on, and cost_threshold are stored in the notifications_letter_despatch table. A nightly task then runs to calculate billing and stores it in ft_billing.

Each time we get a callback for a letter, we receive a despatched_on date (previously productionRunDate). If we switch to using transitionDate, it would not affect billing, because the despatched_on date is stored with the notification, and the billing cron job reprocesses new back dated data from the last 10 days.

[Card](https://trello.com/c/NEqCBfAG/1224-fix-discrepancies-on-billing-info-about-second-class-letters) for more information.