### PR TITLE
Update callback endpoints to only use service callback api

### DIFF
--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -11,7 +11,7 @@ from app import memo_resetters, notify_celery, signing
 from app.config import QueueNames
 from app.dao.inbound_sms_dao import dao_get_inbound_sms_by_id
 from app.dao.returned_letters_dao import fetch_returned_letter_callback_data_dao
-from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service
+from app.dao.service_callback_api_dao import get_service_callback_api_by_callback_type
 from app.utils import DATETIME_FORMAT
 
 # thread-local copies of persistent requests.Session
@@ -101,7 +101,8 @@ def send_complaint_to_service(self, complaint_data):
 
 @notify_celery.task(bind=True, name="send-inbound-sms", max_retries=5, default_retry_delay=300)
 def send_inbound_sms_to_service(self, inbound_sms_id, service_id):
-    inbound_api = get_service_inbound_api_for_service(service_id=service_id)
+    inbound_api = get_service_callback_api_by_callback_type(service_id, "inbound_sms")
+
     if not inbound_api:
         # No API data has been set for this service
         return

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -41,10 +41,10 @@ from app.models import (
     Organisation,
     Permission,
     Service,
+    ServiceCallbackApi,
     ServiceContactList,
     ServiceDataRetention,
     ServiceEmailReplyTo,
-    ServiceInboundApi,
     ServiceJoinRequest,
     ServiceLetterContact,
     ServicePermission,
@@ -367,7 +367,7 @@ def delete_service_and_all_associated_db_objects(service):
 
     _delete(InboundSms.query.filter_by(service=service))
     _delete(InboundSmsHistory.query.filter_by(service=service))
-    _delete(ServiceInboundApi.query.filter_by(service=service))
+    _delete(ServiceCallbackApi.query.filter_by(service=service))
 
     _delete(UnsubscribeRequest.query.filter_by(service_id=service.id))
     _delete(UnsubscribeRequestReport.query.filter_by(service_id=service.id))
@@ -377,7 +377,6 @@ def delete_service_and_all_associated_db_objects(service):
     for service_join_request in service_join_requests:
         service_join_request.contacted_service_users = []
     _delete(service_join_requests)
-
     _delete(ServiceSmsSender.query.filter_by(service=service))
     _delete(InboundNumber.query.filter_by(service=service))
     _delete(ServiceEmailReplyTo.query.filter_by(service=service))

--- a/app/functional_tests_fixtures/__init__.py
+++ b/app/functional_tests_fixtures/__init__.py
@@ -36,11 +36,11 @@ from app.dao.organisation_dao import (
     dao_update_organisation,
 )
 from app.dao.permissions_dao import permission_dao
+from app.dao.service_callback_api_dao import get_service_callback_api_by_callback_type, save_service_callback_api
 from app.dao.service_email_reply_to_dao import (
     add_reply_to_email_address_for_service,
     dao_get_reply_to_by_service_id,
 )
-from app.dao.service_inbound_api_dao import get_service_inbound_api_for_service, save_service_inbound_api
 from app.dao.service_letter_contact_dao import add_letter_contact_for_service, dao_get_letter_contacts_by_service_id
 from app.dao.service_permissions_dao import (
     dao_add_service_permission,
@@ -69,8 +69,8 @@ from app.models import (
     Organisation,
     Permission,
     Service,
+    ServiceCallbackApi,
     ServiceEmailReplyTo,
-    ServiceInboundApi,
     User,
 )
 from app.schemas import api_key_schema, template_schema
@@ -592,16 +592,18 @@ def _create_service_sms_senders(service_id, sms_sender, is_default, inbound_numb
 
 
 def _create_service_inbound_api(service_id, user_id):
-    inbound_api = get_service_inbound_api_for_service(service_id)
+    inbound_api = get_service_callback_api_by_callback_type(service_id, "inbound_sms")
 
     if inbound_api is None:
-        inbound_api = ServiceInboundApi(
-            service_id=service_id, url="https://5c6b93352e82dab5d82d02e5178c2d57.m.pipedream.net", updated_by_id=user_id
+        inbound_api = ServiceCallbackApi(
+            service_id=service_id,
+            url="https://5c6b93352e82dab5d82d02e5178c2d57.m.pipedream.net",
+            updated_by_id=user_id,
+            callback_type="inbound_sms",
         )
-
     inbound_api.bearer_token = "1234567890"
 
-    save_service_inbound_api(inbound_api)
+    save_service_callback_api(inbound_api)
 
 
 def _create_inbound_sms(service, count):

--- a/app/platform_admin/rest.py
+++ b/app/platform_admin/rest.py
@@ -23,7 +23,6 @@ from app.models import (
     ServiceContactList,
     ServiceDataRetention,
     ServiceEmailReplyTo,
-    ServiceInboundApi,
     ServiceSmsSender,
     Template,
     TemplateFolder,
@@ -52,7 +51,6 @@ FIND_BY_UUID_MODELS = {
     "inbound_number": InboundNumber,
     "api_key": ApiKey,
     "template_folder": TemplateFolder,
-    "service_inbound_api": ServiceInboundApi,
     "service_callback_api": ServiceCallbackApi,
     "complaint": Complaint,
     "inbound_sms": InboundSms,
@@ -74,7 +72,6 @@ FIND_BY_UUID_EXTRA_CONTEXT = {
     "service_sms_sender": {"service_id"},
     "api_key": {"service_id"},
     "template_folder": {"service_id"},
-    "service_inbound_api": {"service_id"},
     "service_callback_api": {"service_id"},
     "inbound_sms": {"service_id"},
 }

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -10,7 +10,6 @@ from app.dao.service_callback_api_dao import (
     save_service_callback_api,
 )
 from app.dao.service_inbound_api_dao import (
-    delete_service_inbound_api,
     get_service_inbound_api,
     reset_service_inbound_api,
     save_service_inbound_api,
@@ -110,27 +109,12 @@ REMOVE_SERVICE_CALLBACK_ERROR_MESSAGES = {
 @service_callback_blueprint.route("/callback-api/<uuid:callback_api_id>", methods=["DELETE"])
 def remove_service_callback_api(callback_api_id, service_id):
     callback_type = request.args.get("callback_type")
-    if callback_type == ServiceCallbackTypes.inbound_sms.value:
-        service_inbound_api = get_service_inbound_api(callback_api_id, service_id)
-        if not service_inbound_api:
-            error = REMOVE_SERVICE_CALLBACK_ERROR_MESSAGES[callback_type]
-            raise InvalidRequest(error, status_code=404)
-        delete_service_inbound_api(service_inbound_api)
-
-        service_callback_api = get_service_callback_api_by_callback_type(service_id, callback_type)
-        if service_callback_api:
-            # It is possible there would be no inbound_sms callback data in the service_callback_api table,
-            # during this transition stage. In such a case we do not want to raise an error. At this stage we
-            # are more interested in service_inbound_api errors.
-            delete_service_callback_api(service_callback_api)
-        return "", 204
-    else:
-        callback_api = get_service_callback_api(callback_api_id, service_id, callback_type)
-        if not callback_api:
-            error = REMOVE_SERVICE_CALLBACK_ERROR_MESSAGES[callback_type]
-            raise InvalidRequest(error, status_code=404)
-        delete_service_callback_api(callback_api)
-        return "", 204
+    callback_api = get_service_callback_api(callback_api_id, service_id, callback_type)
+    if not callback_api:
+        error = REMOVE_SERVICE_CALLBACK_ERROR_MESSAGES[callback_type]
+        raise InvalidRequest(error, status_code=404)
+    delete_service_callback_api(callback_api)
+    return "", 204
 
 
 def handle_sql_error(e, table_name):

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -5,13 +5,10 @@ from app.constants import ServiceCallbackTypes
 from app.dao.service_callback_api_dao import (
     delete_service_callback_api,
     get_service_callback_api,
-    get_service_callback_api_by_callback_type,
     reset_service_callback_api,
     save_service_callback_api,
 )
 from app.dao.service_inbound_api_dao import (
-    get_service_inbound_api,
-    reset_service_inbound_api,
     save_service_inbound_api,
 )
 from app.errors import InvalidRequest, register_errors
@@ -59,37 +56,14 @@ def update_service_callback_api(callback_api_id, service_id):
     data = request.get_json()
     validate(data, update_service_callback_api_schema)
     callback_type = data["callback_type"]
-
-    if callback_type == ServiceCallbackTypes.inbound_sms.value:
-        inbound_sms_update = get_service_inbound_api(callback_api_id, service_id)
-        reset_service_inbound_api(
-            inbound_sms_update,
-            data["updated_by_id"],
-            data.get("url", None),
-            data.get("bearer_token", None),
-        )
-        # The callback_api_id for inbound_sms is retrieved from the service_inbound_api table and
-        # won't be applicable to the service_callback_api table. Since both tables are being written to
-        # the callback_api entry in the service_callback_api is also retrieved and updated. However, there will
-        # callback_data in the service_inbound_api table that won't exist in the service_callback_api table
-        if service_callback_update := get_service_callback_api_by_callback_type(service_id, callback_type):
-            reset_service_callback_api(
-                service_callback_update,
-                data["updated_by_id"],
-                data.get("url", None),
-                data.get("bearer_token", None),
-            )
-        return jsonify(data=inbound_sms_update.serialize()), 200
-
-    else:
-        to_update = get_service_callback_api(callback_api_id, service_id, callback_type)
-        reset_service_callback_api(
-            to_update,
-            data["updated_by_id"],
-            data.get("url", None),
-            data.get("bearer_token", None),
-        )
-        return jsonify(data=to_update.serialize()), 200
+    to_update = get_service_callback_api(callback_api_id, service_id, callback_type)
+    reset_service_callback_api(
+        to_update,
+        data["updated_by_id"],
+        data.get("url", None),
+        data.get("bearer_token", None),
+    )
+    return jsonify(data=to_update.serialize()), 200
 
 
 @service_callback_blueprint.route("/callback-api/<uuid:callback_api_id>", methods=["GET"])
@@ -99,7 +73,7 @@ def fetch_service_callback_api(callback_api_id, service_id):
     return jsonify(data=callback_api.serialize()), 200
 
 
-REMOVE_SERVICE_CALLBACK_ERROR_MESSAGES = {
+SERVICE_CALLBACK_ERROR_MESSAGES = {
     ServiceCallbackTypes.inbound_sms.value: "Service inbound API not found",
     ServiceCallbackTypes.delivery_status.value: "Service delivery receipt API not found",
     ServiceCallbackTypes.returned_letter.value: "Service returned letter API not found",
@@ -111,7 +85,7 @@ def remove_service_callback_api(callback_api_id, service_id):
     callback_type = request.args.get("callback_type")
     callback_api = get_service_callback_api(callback_api_id, service_id, callback_type)
     if not callback_api:
-        error = REMOVE_SERVICE_CALLBACK_ERROR_MESSAGES[callback_type]
+        error = SERVICE_CALLBACK_ERROR_MESSAGES[callback_type]
         raise InvalidRequest(error, status_code=404)
     delete_service_callback_api(callback_api)
     return "", 204

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -96,11 +96,7 @@ def update_service_callback_api(callback_api_id, service_id):
 @service_callback_blueprint.route("/callback-api/<uuid:callback_api_id>", methods=["GET"])
 def fetch_service_callback_api(callback_api_id, service_id):
     callback_type = request.args.get("callback_type")
-    if callback_type == ServiceCallbackTypes.inbound_sms.value:
-        callback_api = get_service_inbound_api(callback_api_id, service_id)
-    else:
-        callback_api = get_service_callback_api(callback_api_id, service_id, callback_type)
-
+    callback_api = get_service_callback_api(callback_api_id, service_id, callback_type)
     return jsonify(data=callback_api.serialize()), 200
 
 

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -21,6 +21,7 @@ from app.celery.service_callback_tasks import (
 from app.constants import (
     KEY_TYPE_NORMAL,
     NOTIFICATION_RETURNED_LETTER,
+    ServiceCallbackTypes,
 )
 from app.utils import DATETIME_FORMAT
 from tests.app.db import (
@@ -34,7 +35,6 @@ from tests.app.db import (
     create_service,
     create_service_callback_api,
     create_service_contact_list,
-    create_service_inbound_api,
     create_template,
 )
 
@@ -186,8 +186,11 @@ def test_send_complaint_to_service_sends_callback_to_service(notify_db_session, 
 
 
 def test_send_inbound_sms_to_service_sends_callback_to_service(notify_api, sample_service, mocker):
-    create_service_inbound_api(
-        service=sample_service, url="https://some.service.gov.uk/", bearer_token="something_unique"
+    create_service_callback_api(
+        callback_type=ServiceCallbackTypes.inbound_sms.value,
+        service=sample_service,
+        url="https://some.service.gov.uk/",
+        bearer_token="something_unique",
     )
     inbound_sms = create_inbound_sms(
         service=sample_service,
@@ -215,7 +218,7 @@ def test_send_inbound_sms_to_service_sends_callback_to_service(notify_api, sampl
 def test_send_inbound_sms_to_service_does_not_send_callback_when_inbound_sms_does_not_exist(
     notify_api, sample_service, mocker
 ):
-    create_service_inbound_api(service=sample_service)
+    create_service_callback_api(service=sample_service, callback_type=ServiceCallbackTypes.inbound_sms.value)
     send_callback_mock = mocker.patch("app.celery.service_callback_tasks._send_data_to_service_callback_api")
 
     with pytest.raises(SQLAlchemyError):

--- a/tests/app/platform_admin/test_rest.py
+++ b/tests/app/platform_admin/test_rest.py
@@ -21,7 +21,6 @@ from app.models import (
     ServiceContactList,
     ServiceDataRetention,
     ServiceEmailReplyTo,
-    ServiceInboundApi,
     ServiceSmsSender,
     Template,
     TemplateFolder,
@@ -42,7 +41,6 @@ from tests.app.db import (
     create_service_callback_api,
     create_service_contact_list,
     create_service_data_retention,
-    create_service_inbound_api,
     create_service_with_inbound_number,
     create_template_folder,
 )
@@ -85,9 +83,6 @@ class TestFindByUUID:
         elif model == TemplateFolder:
             sample_service = request.getfixturevalue("sample_service")
             create_template_folder(sample_service)
-        elif model == ServiceInboundApi:
-            sample_service = request.getfixturevalue("sample_service")
-            create_service_inbound_api(sample_service)
         elif model == ServiceCallbackApi:
             sample_service = request.getfixturevalue("sample_service")
             create_service_callback_api("delivery_status", sample_service)

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -199,16 +199,26 @@ def test_update_service_callback_api_updates_bearer_token(admin_request, sample_
     assert callback_api.bearer_token == f"different_token_{callback_type}"
 
 
-def test_fetch_service_inbound_api(admin_request, sample_service):
-    service_inbound_api = create_service_inbound_api(service=sample_service)
+@pytest.mark.parametrize(
+    "callback_type, path",
+    [
+        (ServiceCallbackTypes.inbound_sms.value, "inbound-sms"),
+        (ServiceCallbackTypes.delivery_status.value, "delivery-status"),
+        (ServiceCallbackTypes.returned_letter.value, "returned-letter"),
+    ],
+)
+def test_fetch_service_callback_api(admin_request, sample_service, callback_type, path):
+    service_callback_api = create_service_callback_api(
+        service=sample_service, callback_type=callback_type, url=f"https://something.com/{path}"
+    )
 
     response = admin_request.get(
         "service_callback.fetch_service_callback_api",
         service_id=sample_service.id,
-        callback_api_id=service_inbound_api.id,
-        callback_type="inbound_sms",
+        callback_api_id=service_callback_api.id,
+        callback_type=callback_type,
     )
-    assert response["data"] == service_inbound_api.serialize()
+    assert response["data"] == service_callback_api.serialize()
 
 
 @pytest.mark.parametrize(

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -3,7 +3,7 @@ import uuid
 import pytest
 
 from app.constants import ServiceCallbackTypes
-from app.models import ServiceCallbackApi, ServiceInboundApi
+from app.models import ServiceCallbackApi
 from tests.app.db import create_service_callback_api
 
 
@@ -33,26 +33,6 @@ def test_create_service_callback_api(admin_request, sample_service, callback_typ
     assert resp_json["updated_by_id"] == str(sample_service.users[0].id)
     assert resp_json["created_at"]
     assert not resp_json["updated_at"]
-
-
-def test_create_service_callback_api_writes_to_both_callback_tables_for_inbound_sms(admin_request, sample_service):
-    data = {
-        "url": "https://some_service/inbound-sms",
-        "bearer_token": "some-unique-string",
-        "updated_by_id": str(sample_service.users[0].id),
-        "callback_type": ServiceCallbackTypes.inbound_sms.value,
-    }
-
-    admin_request.post(
-        "service_callback.create_service_callback_api", service_id=sample_service.id, _data=data, _expected_status=201
-    )
-
-    service_inbound_api_object = ServiceInboundApi.query.one()
-    service_callback_api_object = ServiceCallbackApi.query.one()
-
-    assert service_inbound_api_object.url == service_callback_api_object.url
-    assert service_inbound_api_object.bearer_token == service_callback_api_object.bearer_token
-    assert service_callback_api_object.callback_type == ServiceCallbackTypes.inbound_sms.value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Now that that the migration has completed and the `service_callback_api` and `service_callback_api_history` tables both contain `inbound_sms` data, we want to decouple `service_inbound_api` from all callback code.
The redundant `service_inbound_api` code will not be removed in this PR, that will be done in a subsequent PR.

This PR is dependent on this PR https://github.com/alphagov/notifications-admin/pull/5451 being merged in first as this would be a breaking change for the Admin app.

***

[Overall plan](https://docs.google.com/document/d/1Oo8VbB3tdJMLPM6WslJlbbwANA33_lJcN3a6AKkCL7A/edit?tab=t.0):
- [x] [Add inbound_sms type](https://github.com/alphagov/notifications-api/pull/4431#pullrequestreview-2772182640) to service_callback_type table
- [x] Start writing to existing `service_callback_api`  and `service_inbound_api` sms tables for inbound SMS callbacks (need to consider updating and deleting too)
- [x] Migrate the data from `service_inbound_api` to `service_callback_api` table and from `service_inbound_api_history` to `service_callback_api_history` 
- [ ] Start reading from `service_callback_api` table for inbound SMS callbacks
- [ ] Remove the else statements in the API view endpoints and DAO methods, and everything related to the `service_inbound_api` table – in other words stop updating/deleting the old table &ensp;**👈 you are here**
- [ ] Migration to remove the `service_inbound_api` and `service_inbound_api_history` tables

