### PR TITLE
Don't check international sms limit for jobs in the API

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -268,6 +268,7 @@ def save_sms(
             key_type=KEY_TYPE_NORMAL,
             service=service,
             notification_type=SMS_TYPE,
+            check_intl_sms_limit=False,
         )
         extra_args = {}
 

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1891,6 +1891,33 @@ def test_save_sms_uses_non_default_sms_sender_reply_to_text_if_provided(mocker, 
     assert persisted_notification.reply_to_text == "new-sender"
 
 
+def test_save_sms_doesnt_check_international_sms_limit(
+    mocker,
+    mock_celery_task,
+    notify_api,
+    notify_db_session,
+):
+    service = create_service(international_sms_message_limit=0)
+    template = create_template(service=service)
+
+    notification = _notification_json(template, to="+48697894044")
+    notification_id = uuid.uuid4()
+
+    mock_celery_task(provider_tasks.deliver_sms)
+
+    from tests.conftest import set_config
+
+    with set_config(notify_api, "REDIS_ENABLED", True):
+        save_sms(
+            service.id,
+            notification_id,
+            signing.encode(notification),
+        )
+
+    persisted_notification = Notification.query.one()
+    assert persisted_notification.normalised_to == "48697894044"
+
+
 def test_save_letter_calls_get_pdf_for_templated_letter_task(
     mocker, mock_celery_task, notify_db_session, sample_letter_job
 ):


### PR DESCRIPTION
This check will happen in admin - before user sends the job.

Otherwise the sms would fail to save quietly, which would be a bug.