### PR TITLE
Remove economy mail feature flag and permission checks

### DIFF
--- a/app/notifications/process_letter_notifications.py
+++ b/app/notifications/process_letter_notifications.py
@@ -1,9 +1,8 @@
 from notifications_utils.recipient_validation.postal_address import PostalAddress
 
 from app import create_random_identifier
-from app.constants import ECONOMY_LETTER_SENDING, LETTER_TYPE
+from app.constants import LETTER_TYPE
 from app.notifications.process_notifications import persist_notification
-from app.notifications.validators import check_service_has_permission
 
 
 def create_letter_notification(
@@ -17,13 +16,6 @@ def create_letter_notification(
     updated_at=None,
     postage=None,
 ):
-    # letter_data.get('postage') is only set for precompiled letters (if international it is set after sanitise)
-    # letters from a template will pass in 'europe' or 'rest-of-world' if None then use postage from template
-    postage = postage or letter_data.get("postage") or template.postage
-
-    if postage == "economy":
-        check_service_has_permission(service, ECONOMY_LETTER_SENDING)
-
     notification = persist_notification(
         template_id=template.id,
         template_version=template.version,
@@ -41,7 +33,9 @@ def create_letter_notification(
         status=status,
         reply_to_text=reply_to_text,
         billable_units=billable_units,
-        postage=postage,
+        # letter_data.get('postage') is only set for precompiled letters (if international it is set after sanitise)
+        # letters from a template will pass in 'europe' or 'rest-of-world' if None then use postage from template
+        postage=postage or letter_data.get("postage") or template.postage,
         updated_at=updated_at,
     )
     return notification

--- a/app/utils.py
+++ b/app/utils.py
@@ -17,7 +17,6 @@ from sqlalchemy import func
 
 from app.constants import (
     BROADCAST_TYPE,
-    ECONOMY_LETTER_SENDING,
     EMAIL_TYPE,
     LETTER_TYPE,
     PRECOMPILED_LETTER,
@@ -123,8 +122,6 @@ def get_public_notify_type_text(notify_type, plural=False):
         notify_type_text = "precompiled letter"
     elif notify_type == BROADCAST_TYPE:
         notify_type_text = "broadcast message"
-    elif notify_type == ECONOMY_LETTER_SENDING:
-        notify_type_text = "economy letter"
 
     return "{}{}".format(notify_type_text, "s" if plural else "")
 

--- a/tests/app/notifications/test_process_letter_notifications.py
+++ b/tests/app/notifications/test_process_letter_notifications.py
@@ -1,13 +1,11 @@
 import pytest
 
 from app.constants import LETTER_TYPE, NOTIFICATION_CREATED
-from app.errors import InvalidRequest
 from app.models import Notification
 from app.notifications.process_letter_notifications import (
     create_letter_notification,
 )
 from app.serialised_models import SerialisedTemplate
-from tests.app.db import create_template
 
 
 def test_create_letter_notification_creates_notification(sample_letter_template, sample_api_key):
@@ -112,22 +110,3 @@ def test_create_letter_notification_with_different_postage(sample_letter_templat
     assert notification == Notification.query.one()
     assert notification.status == NOTIFICATION_CREATED
     assert notification.postage == postage
-
-
-def test_create_letter_raises_error_if_creating_economy_mail_letter_without_permission(sample_service, sample_api_key):
-    data = {
-        "personalisation": {
-            "address_line_1": "The King",
-            "address_line_2": "Buckingham Palace",
-            "postcode": "SW1 1AA",
-        },
-    }
-
-    db_template = create_template(sample_service, template_type="letter", postage="economy")
-
-    template = SerialisedTemplate.from_id_and_service_id(db_template.id, sample_service.id)
-
-    with pytest.raises(InvalidRequest):
-        create_letter_notification(
-            data, template, sample_service, sample_api_key, NOTIFICATION_CREATED, billable_units=3, postage="economy"
-        )

--- a/tests/app/service/send_notification/test_send_one_off_notification.py
+++ b/tests/app/service/send_notification/test_send_one_off_notification.py
@@ -207,25 +207,6 @@ def test_send_one_off_notification_calls_persist_correctly_for_letter(
     )
 
 
-def test_send_one_off_notification_raises_error_if_sending_economy_letter_without_permission(sample_service):
-    template = create_template(service=sample_service, template_type=LETTER_TYPE, postage="economy")
-
-    post_data = {
-        "template_id": str(template.id),
-        "to": "First Last",
-        "personalisation": {
-            "name": "foo",
-            "address_line_1": "First Last",
-            "address_line_2": "1 Example Street",
-            "postcode": "SW1A 1AA",
-        },
-        "created_by": str(sample_service.created_by_id),
-    }
-
-    with pytest.raises(BadRequestError):
-        send_one_off_notification(sample_service.id, post_data)
-
-
 def test_send_one_off_notification_raises_if_invalid_recipient(notify_db_session):
     service = create_service()
     template = create_template(service=service)

--- a/tests/app/service/send_notification/test_send_pdf_letter_notification.py
+++ b/tests/app/service/send_notification/test_send_pdf_letter_notification.py
@@ -6,7 +6,7 @@ from app.constants import EMAIL_TYPE, LETTER_TYPE, UPLOAD_LETTERS
 from app.dao.notifications_dao import get_notification_by_id
 from app.service.send_notification import send_pdf_letter_notification
 from app.v2.errors import BadRequestError, TooManyRequestsError
-from tests.app.db import create_service, create_template
+from tests.app.db import create_service
 
 
 @pytest.fixture
@@ -36,24 +36,6 @@ def test_send_pdf_letter_notification_raises_error_if_service_does_not_have_perm
 
     with pytest.raises(BadRequestError):
         send_pdf_letter_notification(service.id, post_data)
-
-
-def test_send_pdf_letter_notification_raises_error_if_using_economy_postage_without_permission(
-    sample_service,
-    post_data,
-):
-    create_template(
-        sample_service,
-        template_type=LETTER_TYPE,
-        template_name="Pre-compiled PDF",
-        hidden=True,
-    )
-
-    post_data["postage"] = "economy"
-    post_data["created_by"] = sample_service.users[0].id
-
-    with pytest.raises(BadRequestError):
-        send_pdf_letter_notification(sample_service.id, post_data)
 
 
 def test_send_pdf_letter_notification_raises_error_if_service_is_over_daily_message_limit(

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -482,25 +482,6 @@ def test_post_letter_notification_returns_403_if_not_allowed_to_send_notificatio
     assert error_json["errors"] == [{"error": "BadRequestError", "message": expected_message}]
 
 
-def test_post_letter_notification_returns_400_if_not_allowed_to_send_economy_postage(
-    api_client_request,
-    sample_service,
-):
-    template = create_template(sample_service, template_type=LETTER_TYPE, postage="economy")
-
-    data = {"template_id": str(template.id), "personalisation": test_address}
-
-    error_json = api_client_request.post(
-        sample_service.id,
-        "v2_notifications.post_notification",
-        notification_type="letter",
-        _data=data,
-        _expected_status=400,
-    )
-
-    assert error_json["errors"][0]["message"] == "Service is not allowed to send economy letters"
-
-
 def test_post_letter_notification_doesnt_accept_team_key(api_client_request, sample_letter_template, mocker):
     mocker.patch("app.celery.letters_pdf_tasks.get_pdf_for_templated_letter.apply_async")
     data = {


### PR DESCRIPTION
This stops using the economy mail permission feature flag now that it should be rolled out to all services, undoing the work in https://github.com/alphagov/notifications-api/pull/4450

Database permissions will need to be removed separately