### PR TITLE
Treat crown dependency numbers as domestic when checking limits

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -7,6 +7,7 @@ from notifications_utils.clients import redis
 from notifications_utils.recipient_validation.email_address import (
     format_email_address,
 )
+from notifications_utils.recipient_validation.phone_number import UK_PREFIX
 from notifications_utils.template import (
     LetterPrintTemplate,
     PlainTextEmailTemplate,
@@ -164,7 +165,7 @@ def persist_notification(
             service.id,
             notification_type,
             key_type,
-            international_sms=notification.international,
+            international_sms=str(notification.phone_prefix) != UK_PREFIX,
         )
 
     return notification

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -7,9 +7,7 @@ from notifications_utils.clients.redis import (
 )
 from notifications_utils.recipient_validation.email_address import validate_and_format_email_address
 from notifications_utils.recipient_validation.errors import InvalidPhoneError
-from notifications_utils.recipient_validation.phone_number import (
-    PhoneNumber,
-)
+from notifications_utils.recipient_validation.phone_number import PhoneNumber
 from notifications_utils.recipient_validation.postal_address import PostalAddress
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -159,7 +157,8 @@ def validate_and_return_extended_phone_number_info(service, send_to, key_type, c
 
         recipient_data = _get_extended_phone_number_info(phone_number, send_to)
 
-        if recipient_data["international"] and check_intl_sms_limit:
+        # UK_PREFIX includes standard domestic numbers, and crown dependency
+        if check_intl_sms_limit and not phone_number.is_uk_phone_number():
             check_service_over_daily_message_limit(service, key_type, notification_type=INTERNATIONAL_SMS_TYPE)
 
         return recipient_data

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -360,6 +360,40 @@ def test_persist_notification_increments_cache_for_international_sms(notify_api,
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
+def test_persist_notification_doesnt_increment_cache_for_international_sms_when_num_is_crown_dependency(
+    notify_api, notify_db_session, mocker
+):
+    service = create_service()
+    template = create_template(service=service, template_type="sms")
+    api_key = create_api_key(service=service)
+    mocker.patch("app.notifications.process_notifications.redis_store.get", return_value=1)
+    mock_incr = mocker.patch("app.notifications.process_notifications.redis_store.incr")
+    with set_config(notify_api, "REDIS_ENABLED", True):
+        persist_notification(
+            template_id=template.id,
+            template_version=template.version,
+            recipient={
+                "unformatted_recipient": "+44 7797 100 100",
+                "normalised_to": "+447797100100",
+                "international": True,
+                "phone_prefix": "44",
+                "rate_multiplier": 2,
+            },
+            service=template.service,
+            personalisation={},
+            notification_type="sms",
+            api_key_id=api_key.id,
+            key_type=api_key.key_type,
+            reference="ref2",
+        )
+
+        assert mock_incr.call_args_list == [
+            mocker.call(f"{service.id}-2016-01-01-count"),
+            mocker.call(f"{service.id}-sms-2016-01-01-count"),
+        ]
+
+
+@freeze_time("2016-01-01 11:09:00.061258")
 def test_persist_notification_increments_cache_for_international_sms_if_the_cache_does_not_exist(
     notify_api, notify_db_session, mocker
 ):

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -571,6 +571,26 @@ def test_validate_and_format_recipient_raises_when_service_over_daily_limit_for_
     assert expected_error.fields == []
 
 
+def test_validate_and_format_recipient_doesnt_raise_for_crown_dependency_num_when_service_over_daily_intl_sms_limit(
+    sample_service_full_permissions, mocker
+):
+    service = create_service(
+        international_sms_message_limit=4,
+        service_permissions=["sms", "international_sms"],
+    )
+    mocker.patch("app.redis_store.get", return_value="5")
+
+    result = validate_and_format_recipient("+44 7797 100 100", KEY_TYPE_NORMAL, service, SMS_TYPE)
+
+    assert result == {
+        "international": True,
+        "normalised_to": "447797100100",
+        "unformatted_recipient": "+44 7797 100 100",
+        "phone_prefix": "44",
+        "rate_multiplier": 2,
+    }
+
+
 @pytest.mark.parametrize(
     "recipient, expected_normalised, expected_international, expected_prefix, expected_rate_multiplier",
     [


### PR DESCRIPTION
When checking and adding to daily international sms limit.