### PR TITLE
only increment international SMS limit cache for SMS notifications

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -165,7 +165,7 @@ def persist_notification(
             service.id,
             notification_type,
             key_type,
-            international_sms=str(notification.phone_prefix) != UK_PREFIX,
+            international_sms=notification_type == SMS_TYPE and str(notification.phone_prefix) != UK_PREFIX,
         )
 
     return notification

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -186,7 +186,7 @@ def increment_daily_limit_cache(service_id, notification_type, key_type, interna
         else:
             redis_store.incr(cache_key)
 
-    if international_sms:
+    if notification_type == SMS_TYPE and international_sms:
         _increment_international_sms_daily_limit_cache(service_id)
 
 


### PR DESCRIPTION
we were inadvertently doing this for all notifications. previously we used `notification.international` which resolves to False for emails, but we switched to checking if the prefix is NOT uk - the prefix for emails is None so this was resolving as true.

(fun fact: it would have continued to resolve false for international letters)