### PR TITLE
Remove unused service permissions

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -196,16 +196,10 @@ CANCEL_BROADCASTS = "cancel_broadcasts"
 REJECT_BROADCASTS = "reject_broadcasts"
 INTERNATIONAL_SMS_TYPE = "international_sms"
 INBOUND_SMS_TYPE = "inbound_sms"
-SCHEDULE_NOTIFICATIONS = "schedule_notifications"
 EMAIL_AUTH = "email_auth"
-LETTERS_AS_PDF = "letters_as_pdf"
-PRECOMPILED_LETTER = "precompiled_letter"
-UPLOAD_DOCUMENT = "upload_document"
 EDIT_FOLDER_PERMISSIONS = "edit_folder_permissions"
 UPLOAD_LETTERS = "upload_letters"
 INTERNATIONAL_LETTERS = "international_letters"
-EXTRA_EMAIL_FORMATTING = "extra_email_formatting"
-EXTRA_LETTER_FORMATTING = "extra_letter_formatting"
 SMS_TO_UK_LANDLINES = "sms_to_uk_landlines"
 ECONOMY_LETTER_SENDING = "economy_letter_sending"
 SERVICE_PERMISSION_TYPES = [
@@ -215,15 +209,10 @@ SERVICE_PERMISSION_TYPES = [
     BROADCAST_TYPE,
     INTERNATIONAL_SMS_TYPE,
     INBOUND_SMS_TYPE,
-    SCHEDULE_NOTIFICATIONS,
     EMAIL_AUTH,
-    LETTERS_AS_PDF,
-    UPLOAD_DOCUMENT,
     EDIT_FOLDER_PERMISSIONS,
     UPLOAD_LETTERS,
     INTERNATIONAL_LETTERS,
-    EXTRA_EMAIL_FORMATTING,
-    EXTRA_LETTER_FORMATTING,
     SMS_TO_UK_LANDLINES,
     ECONOMY_LETTER_SENDING,
 ]

--- a/app/constants.py
+++ b/app/constants.py
@@ -198,7 +198,6 @@ INTERNATIONAL_SMS_TYPE = "international_sms"
 INBOUND_SMS_TYPE = "inbound_sms"
 EMAIL_AUTH = "email_auth"
 EDIT_FOLDER_PERMISSIONS = "edit_folder_permissions"
-UPLOAD_LETTERS = "upload_letters"
 INTERNATIONAL_LETTERS = "international_letters"
 SMS_TO_UK_LANDLINES = "sms_to_uk_landlines"
 ECONOMY_LETTER_SENDING = "economy_letter_sending"
@@ -211,7 +210,6 @@ SERVICE_PERMISSION_TYPES = [
     INBOUND_SMS_TYPE,
     EMAIL_AUTH,
     EDIT_FOLDER_PERMISSIONS,
-    UPLOAD_LETTERS,
     INTERNATIONAL_LETTERS,
     SMS_TO_UK_LANDLINES,
     ECONOMY_LETTER_SENDING,

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -17,7 +17,6 @@ from app.constants import (
     NON_CROWN_ORGANISATION_TYPES,
     NOTIFICATION_PERMANENT_FAILURE,
     SMS_TYPE,
-    UPLOAD_LETTERS,
 )
 from app.dao.dao_utils import VersionOptions, autocommit, version_class
 from app.dao.date_util import get_current_financial_year
@@ -71,7 +70,6 @@ DEFAULT_SERVICE_PERMISSIONS = [
     EMAIL_TYPE,
     LETTER_TYPE,
     INTERNATIONAL_SMS_TYPE,
-    UPLOAD_LETTERS,
     INTERNATIONAL_LETTERS,
 ]
 

--- a/app/functional_tests_fixtures/__init__.py
+++ b/app/functional_tests_fixtures/__init__.py
@@ -9,7 +9,6 @@ from sqlalchemy.exc import NoResultFound
 from app.constants import (
     EDIT_FOLDER_PERMISSIONS,
     EMAIL_AUTH,
-    EXTRA_LETTER_FORMATTING,
     INBOUND_SMS_TYPE,
     SECOND_CLASS,
     SEND_EMAILS,
@@ -567,7 +566,7 @@ def _create_service_email_reply_to(service_id, email_address, is_default):
 
 def _create_service_permissions(service_id, permissions=None):
     if permissions is None:
-        permissions = [EDIT_FOLDER_PERMISSIONS, EXTRA_LETTER_FORMATTING, INBOUND_SMS_TYPE, EMAIL_AUTH]
+        permissions = [EDIT_FOLDER_PERMISSIONS, INBOUND_SMS_TYPE, EMAIL_AUTH]
 
     service_permissions = dao_fetch_service_permissions(service_id)
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -20,9 +20,7 @@ from app.constants import (
     ECONOMY_LETTER_SENDING,
     EMAIL_TYPE,
     LETTER_TYPE,
-    PRECOMPILED_LETTER,
     SMS_TYPE,
-    UPLOAD_DOCUMENT,
     CacheKeys,
 )
 
@@ -117,10 +115,6 @@ def get_public_notify_type_text(notify_type, plural=False):
     notify_type_text = notify_type
     if notify_type == SMS_TYPE:
         notify_type_text = "text message"
-    elif notify_type == UPLOAD_DOCUMENT:
-        notify_type_text = "document"
-    elif notify_type == PRECOMPILED_LETTER:
-        notify_type_text = "precompiled letter"
     elif notify_type == BROADCAST_TYPE:
         notify_type_text = "broadcast message"
     elif notify_type == ECONOMY_LETTER_SENDING:

--- a/migrations/versions/0317_uploads_for_all.py
+++ b/migrations/versions/0317_uploads_for_all.py
@@ -8,11 +8,11 @@ Create Date: 2019-05-13 10:44:51.867661
 
 from alembic import op
 
-from app.constants import UPLOAD_LETTERS
-
 revision = "0317_uploads_for_all"
 down_revision = "0316_int_letters_permission"
 
+
+UPLOAD_LETTERS = "upload_letters"
 
 def upgrade():
     op.execute(

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -17,7 +17,6 @@ from app.constants import (
     KEY_TYPE_TEST,
     LETTER_TYPE,
     SMS_TYPE,
-    UPLOAD_LETTERS,
 )
 from app.dao.inbound_numbers_dao import (
     dao_get_available_inbound_numbers,
@@ -537,15 +536,15 @@ def test_create_service_returns_service_with_default_permissions(notify_db_sessi
     service = dao_fetch_service_by_id(service.id)
     _assert_service_permissions(
         service.permissions,
-        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS),
+        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS),
     )
 
 
 @pytest.mark.parametrize(
     "permission_to_remove, permissions_remaining",
     [
-        (SMS_TYPE, (EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS)),
-        (EMAIL_TYPE, (SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS)),
+        (SMS_TYPE, (EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS)),
+        (EMAIL_TYPE, (SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS)),
     ],
 )
 def test_remove_permission_from_service_by_id_returns_service_with_correct_permissions(
@@ -564,7 +563,6 @@ def test_removing_all_permission_returns_service_with_no_permissions(notify_db_s
     dao_remove_service_permission(service_id=service.id, permission=EMAIL_TYPE)
     dao_remove_service_permission(service_id=service.id, permission=LETTER_TYPE)
     dao_remove_service_permission(service_id=service.id, permission=INTERNATIONAL_SMS_TYPE)
-    dao_remove_service_permission(service_id=service.id, permission=UPLOAD_LETTERS)
     dao_remove_service_permission(service_id=service.id, permission=INTERNATIONAL_LETTERS)
 
     service = dao_fetch_service_by_id(service.id)
@@ -580,14 +578,14 @@ def test_create_service_by_id_adding_and_removing_letter_returns_service_without
     service = dao_fetch_service_by_id(service.id)
     _assert_service_permissions(
         service.permissions,
-        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS),
+        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS),
     )
 
     dao_remove_service_permission(service_id=service.id, permission=LETTER_TYPE)
     service = dao_fetch_service_by_id(service.id)
 
     _assert_service_permissions(
-        service.permissions, (SMS_TYPE, EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS)
+        service.permissions, (SMS_TYPE, EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS)
     )
 
 
@@ -730,7 +728,7 @@ def test_delete_service_and_associated_objects(notify_db_session):
     user.organisations = [organisation]
 
     assert ServicePermission.query.count() == len(
-        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS)
+        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS)
     )
 
     delete_service_and_all_associated_db_objects(service)

--- a/tests/app/service/send_notification/test_send_pdf_letter_notification.py
+++ b/tests/app/service/send_notification/test_send_pdf_letter_notification.py
@@ -2,7 +2,7 @@ import pytest
 from freezegun import freeze_time
 from notifications_utils.s3 import S3ObjectNotFound
 
-from app.constants import EMAIL_TYPE, LETTER_TYPE, UPLOAD_LETTERS
+from app.constants import EMAIL_TYPE, LETTER_TYPE
 from app.dao.notifications_dao import get_notification_by_id
 from app.service.send_notification import send_pdf_letter_notification
 from app.v2.errors import BadRequestError, TooManyRequestsError
@@ -20,19 +20,11 @@ def post_data(sample_service_full_permissions, fake_uuid):
     }
 
 
-@pytest.mark.parametrize(
-    "permissions",
-    [
-        [EMAIL_TYPE],
-        [UPLOAD_LETTERS],
-    ],
-)
-def test_send_pdf_letter_notification_raises_error_if_service_does_not_have_permission(
+def test_send_pdf_letter_notification_raises_error_if_service_does_not_have_letter_permission(
     notify_db_session,
-    permissions,
     post_data,
 ):
-    service = create_service(service_permissions=permissions)
+    service = create_service(service_permissions=[EMAIL_TYPE])
 
     with pytest.raises(BadRequestError):
         send_pdf_letter_notification(service.id, post_data)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -28,7 +28,6 @@ from app.constants import (
     SERVICE_JOIN_REQUEST_APPROVED,
     SERVICE_JOIN_REQUEST_CANCELLED,
     SMS_TYPE,
-    UPLOAD_LETTERS,
 )
 from app.dao.organisation_dao import dao_add_service_to_organisation
 from app.dao.report_requests_dao import dao_create_report_request
@@ -314,8 +313,7 @@ def test_get_service_list_has_default_permissions(admin_request, service_factory
     json_resp = admin_request.get("service.get_services")
     assert len(json_resp["data"]) == 3
     assert all(
-        set(json["permissions"])
-        == {EMAIL_TYPE, SMS_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS}
+        set(json["permissions"]) == {EMAIL_TYPE, SMS_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE, INTERNATIONAL_LETTERS}
         for json in json_resp["data"]
     )
 
@@ -328,7 +326,6 @@ def test_get_service_by_id_has_default_service_permissions(admin_request, sample
         SMS_TYPE,
         INTERNATIONAL_SMS_TYPE,
         LETTER_TYPE,
-        UPLOAD_LETTERS,
         INTERNATIONAL_LETTERS,
     }
 


### PR DESCRIPTION
This removes service permissions that had been used as feature flags in the past but which are no longer used.
After this change, they can be removed from the database.

To be merged after https://github.com/alphagov/notifications-admin/pull/5462