### PR TITLE
Refactor `increment_daily_limit_cache` to be easier to follow

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -161,11 +161,7 @@ def persist_notification(
     # if simulated create a Notification model to return but do not persist the Notification to the dB
     if not simulated:
         dao_create_notification(notification)
-        increment_daily_limit_caches(
-            service,
-            notification,
-            key_type,
-        )
+        increment_daily_limit_caches(service, notification, key_type)
 
     return notification
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -165,20 +165,19 @@ def persist_notification(
             service,
             notification,
             key_type,
-            international_sms=notification_type == SMS_TYPE and str(notification.phone_prefix) != UK_PREFIX,
         )
 
     return notification
 
 
-def increment_daily_limit_caches(service, notification, key_type, international_sms=False):
+def increment_daily_limit_caches(service, notification, key_type):
     if key_type == KEY_TYPE_TEST or not current_app.config["REDIS_ENABLED"]:
         return
 
     increment_daily_limit_cache(service.id)
     increment_daily_limit_cache(service.id, notification.notification_type)
 
-    if notification.notification_type == SMS_TYPE and international_sms:
+    if notification.notification_type == SMS_TYPE and str(notification.phone_prefix) != UK_PREFIX:
         increment_daily_limit_cache(service.id, INTERNATIONAL_SMS_TYPE)
 
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -162,8 +162,8 @@ def persist_notification(
     if not simulated:
         dao_create_notification(notification)
         increment_daily_limit_caches(
-            service.id,
-            notification_type,
+            service,
+            notification,
             key_type,
             international_sms=notification_type == SMS_TYPE and str(notification.phone_prefix) != UK_PREFIX,
         )
@@ -171,15 +171,15 @@ def persist_notification(
     return notification
 
 
-def increment_daily_limit_caches(service_id, notification_type, key_type, international_sms=False):
+def increment_daily_limit_caches(service, notification, key_type, international_sms=False):
     if key_type == KEY_TYPE_TEST or not current_app.config["REDIS_ENABLED"]:
         return
 
-    increment_daily_limit_cache(service_id)
-    increment_daily_limit_cache(service_id, notification_type)
+    increment_daily_limit_cache(service.id)
+    increment_daily_limit_cache(service.id, notification.notification_type)
 
-    if notification_type == SMS_TYPE and international_sms:
-        increment_daily_limit_cache(service_id, INTERNATIONAL_SMS_TYPE)
+    if notification.notification_type == SMS_TYPE and international_sms:
+        increment_daily_limit_cache(service.id, INTERNATIONAL_SMS_TYPE)
 
 
 def increment_daily_limit_cache(service_id, notification_type=None):


### PR DESCRIPTION
By splitting the code which talks to Redis from the code which figures out which caches to set it should be easier to follow what is going on.

It also reduces duplication of the Redis-talking code and lets us put all the logic for international SMS in one place, rather than double-checking and using [flag arguments](https://martinfowler.com/bliki/FlagArgument.html).