### PR TITLE
Drop service inbound api table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -861,40 +861,6 @@ class ServiceGuestList(db.Model):
         return f"Recipient {self.recipient} of type: {self.recipient_type}"
 
 
-class ServiceInboundApi(db.Model, Versioned):
-    __tablename__ = "service_inbound_api"
-    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), index=True, nullable=False, unique=True)
-    service = db.relationship("Service", backref="inbound_api")
-    url = db.Column(db.String(), nullable=False)
-    _bearer_token = db.Column("bearer_token", db.String(), nullable=False)
-    created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow, nullable=False)
-    updated_at = db.Column(db.DateTime, nullable=True)
-    updated_by = db.relationship("User")
-    updated_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=False)
-
-    @property
-    def bearer_token(self):
-        if self._bearer_token:
-            return signing.decode(self._bearer_token)
-        return None
-
-    @bearer_token.setter
-    def bearer_token(self, bearer_token):
-        if bearer_token:
-            self._bearer_token = signing.encode(str(bearer_token))
-
-    def serialize(self):
-        return {
-            "id": str(self.id),
-            "service_id": str(self.service_id),
-            "url": self.url,
-            "updated_by_id": str(self.updated_by_id),
-            "created_at": self.created_at.strftime(DATETIME_FORMAT),
-            "updated_at": get_dt_string_or_none(self.updated_at),
-        }
-
-
 class ServiceCallbackApi(db.Model, Versioned):
     __tablename__ = "service_callback_api"
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -360,7 +360,6 @@ class DetailedServiceSchema(BaseSchema):
             "email_branding",
             "email_message_limit",
             "guest_list",
-            "inbound_api",
             "inbound_number",
             "inbound_sms",
             "jobs",

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0500_update_intl_limit_values
+0501_drop_inbound_api_table

--- a/migrations/versions/0501_drop_inbound_api_table.py
+++ b/migrations/versions/0501_drop_inbound_api_table.py
@@ -12,57 +12,76 @@ down_revision = '0500_update_intl_limit_values'
 
 
 def upgrade():
-    op.drop_index(op.f("ix_service_inbound_api_updated_by_id"), table_name="service_inbound_api")
-    op.drop_index(op.f("ix_service_inbound_api_service_id"), table_name="service_inbound_api")
-    op.drop_table("service_inbound_api")
-    op.drop_index(op.f("ix_service_inbound_api_history_updated_by_id"), table_name="service_inbound_api_history")
-    op.drop_index(op.f("ix_service_inbound_api_history_service_id"), table_name="service_inbound_api_history")
-    op.drop_table("service_inbound_api_history")
+    with op.get_context().autocommit_block():
+        op.drop_index(op.f("ix_service_inbound_api_updated_by_id"), table_name="service_inbound_api",
+                      if_exists=True, postgresql_concurrently=True,)
+
+        op.drop_index(op.f("ix_service_inbound_api_service_id"),
+                      table_name="service_inbound_api",
+                      if_exists=True,
+                      postgresql_concurrently=True,)
+        op.drop_table("service_inbound_api")
+        op.drop_index(op.f("ix_service_inbound_api_history_updated_by_id"),
+                      table_name="service_inbound_api_history",
+                      if_exists=True,
+                      postgresql_concurrently=True,)
+        op.drop_index(op.f("ix_service_inbound_api_history_service_id"),
+                      table_name="service_inbound_api_history",
+                      if_exists=True,
+                      postgresql_concurrently=True,)
+        op.drop_table("service_inbound_api_history")
 
 
 def downgrade():
-    op.create_table(
-        "service_inbound_api_history",
-        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
-        sa.Column("service_id", postgresql.UUID(as_uuid=True), nullable=False),
-        sa.Column("url", sa.String(), nullable=False),
-        sa.Column("bearer_token", sa.String(), nullable=False),
-        sa.Column("created_at", sa.DateTime(), nullable=False),
-        sa.Column("updated_at", sa.DateTime(), nullable=True),
-        sa.Column("updated_by_id", postgresql.UUID(as_uuid=True), nullable=False),
-        sa.Column("version", sa.Integer(), autoincrement=False, nullable=False),
-        sa.PrimaryKeyConstraint("id", "version"),
-    )
-    op.create_index(
-        op.f("ix_service_inbound_api_history_service_id"), "service_inbound_api_history", ["service_id"], unique=False
-    )
-    op.create_index(
-        op.f("ix_service_inbound_api_history_updated_by_id"),
-        "service_inbound_api_history",
-        ["updated_by_id"],
-        unique=False,
-    )
-    op.create_table(
-        "service_inbound_api",
-        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
-        sa.Column("service_id", postgresql.UUID(as_uuid=True), nullable=False),
-        sa.Column("url", sa.String(), nullable=False),
-        sa.Column("bearer_token", sa.String(), nullable=False),
-        sa.Column("created_at", sa.DateTime(), nullable=False),
-        sa.Column("updated_at", sa.DateTime(), nullable=True),
-        sa.Column("updated_by_id", postgresql.UUID(as_uuid=True), nullable=False),
-        sa.Column("version", sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(
-            ["service_id"],
-            ["services.id"],
-        ),
-        sa.ForeignKeyConstraint(
+    with op.get_context().autocommit_block():
+        op.create_table(
+            "service_inbound_api_history",
+            sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+            sa.Column("service_id", postgresql.UUID(as_uuid=True), nullable=False),
+            sa.Column("url", sa.String(), nullable=False),
+            sa.Column("bearer_token", sa.String(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_id", postgresql.UUID(as_uuid=True), nullable=False),
+            sa.Column("version", sa.Integer(), autoincrement=False, nullable=False),
+            sa.PrimaryKeyConstraint("id", "version"),
+        )
+        op.create_index(
+            op.f("ix_service_inbound_api_history_service_id"), "service_inbound_api_history", ["service_id"],
+            unique=False, if_not_exists=True, postgresql_concurrently=True,
+        )
+        op.create_index(
+            op.f("ix_service_inbound_api_history_updated_by_id"),
+            "service_inbound_api_history",
             ["updated_by_id"],
-            ["users.id"],
-        ),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(op.f("ix_service_inbound_api_service_id"), "service_inbound_api", ["service_id"], unique=True)
-    op.create_index(
-        op.f("ix_service_inbound_api_updated_by_id"), "service_inbound_api", ["updated_by_id"], unique=False
-    )
+            unique=False,
+            if_not_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.create_table(
+            "service_inbound_api",
+            sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+            sa.Column("service_id", postgresql.UUID(as_uuid=True), nullable=False),
+            sa.Column("url", sa.String(), nullable=False),
+            sa.Column("bearer_token", sa.String(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_id", postgresql.UUID(as_uuid=True), nullable=False),
+            sa.Column("version", sa.Integer(), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["service_id"],
+                ["services.id"],
+            ),
+            sa.ForeignKeyConstraint(
+                ["updated_by_id"],
+                ["users.id"],
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(op.f("ix_service_inbound_api_service_id"), "service_inbound_api", ["service_id"], unique=True,
+                        if_not_exists=True, postgresql_concurrently=True,)
+        op.create_index(
+            op.f("ix_service_inbound_api_updated_by_id"), "service_inbound_api", ["updated_by_id"], unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )

--- a/migrations/versions/0501_drop_inbound_api_table.py
+++ b/migrations/versions/0501_drop_inbound_api_table.py
@@ -1,0 +1,68 @@
+"""
+Create Date: 2025-05-12 17:34:27.333353
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision = '0501_drop_inbound_api_table'
+down_revision = '0500_update_intl_limit_values'
+
+
+def upgrade():
+    op.drop_index(op.f("ix_service_inbound_api_updated_by_id"), table_name="service_inbound_api")
+    op.drop_index(op.f("ix_service_inbound_api_service_id"), table_name="service_inbound_api")
+    op.drop_table("service_inbound_api")
+    op.drop_index(op.f("ix_service_inbound_api_history_updated_by_id"), table_name="service_inbound_api_history")
+    op.drop_index(op.f("ix_service_inbound_api_history_service_id"), table_name="service_inbound_api_history")
+    op.drop_table("service_inbound_api_history")
+
+
+def downgrade():
+    op.create_table(
+        "service_inbound_api_history",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("service_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("url", sa.String(), nullable=False),
+        sa.Column("bearer_token", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_by_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("version", sa.Integer(), autoincrement=False, nullable=False),
+        sa.PrimaryKeyConstraint("id", "version"),
+    )
+    op.create_index(
+        op.f("ix_service_inbound_api_history_service_id"), "service_inbound_api_history", ["service_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_service_inbound_api_history_updated_by_id"),
+        "service_inbound_api_history",
+        ["updated_by_id"],
+        unique=False,
+    )
+    op.create_table(
+        "service_inbound_api",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("service_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("url", sa.String(), nullable=False),
+        sa.Column("bearer_token", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_by_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["service_id"],
+            ["services.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["updated_by_id"],
+            ["users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_service_inbound_api_service_id"), "service_inbound_api", ["service_id"], unique=True)
+    op.create_index(
+        op.f("ix_service_inbound_api_updated_by_id"), "service_inbound_api", ["updated_by_id"], unique=False
+    )

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -278,7 +278,6 @@ def test_get_service_by_id(admin_request, sample_service):
         "go_live_user",
         "has_active_go_live_request",
         "id",
-        "inbound_api",
         "international_sms_message_limit",
         "letter_branding",
         "letter_message_limit",


### PR DESCRIPTION
This PR contains a migration to drop both the `service_inbound_api` and `service_inbound_api_history` tables.
It also updates the DetailedServiceSchema.
There are a few sqauwk-migration-checks warnings that may need to be silenced.
This PR is dependant on https://github.com/alphagov/notifications-api/pull/4466 being merged in first. It is also linked to this PR https://github.com/alphagov/notifications-admin/pull/5465