### PR TITLE
Add economy mail postage to letters volume email

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -12,6 +12,8 @@ from app.aws import s3
 from app.celery.provider_tasks import deliver_letter
 from app.config import QueueNames, TaskNames
 from app.constants import (
+    ECONOMY_CLASS,
+    FIRST_CLASS,
     INTERNATIONAL_LETTERS,
     INTERNATIONAL_POSTAGE_TYPES,
     KEY_TYPE_NORMAL,
@@ -22,6 +24,7 @@ from app.constants import (
     NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_VALIDATION_FAILED,
     NOTIFICATION_VIRUS_SCAN_FAILED,
+    SECOND_CLASS,
 )
 from app.cronitor import cronitor
 from app.dao.notifications_dao import (
@@ -185,19 +188,24 @@ def send_letters_volume_email_to_dvla(letters_volumes, date):
         "total_volume": 0,
         "first_class_volume": 0,
         "second_class_volume": 0,
+        "economy_mail_volume": 0,
         "international_volume": 0,
         "total_sheets": 0,
         "first_class_sheets": 0,
         "second_class_sheets": 0,
+        "economy_mail_sheets": 0,
         "international_sheets": 0,
         "date": date.strftime("%d %B %Y"),
     }
     for item in letters_volumes:
         personalisation["total_volume"] += item.letters_count
         personalisation["total_sheets"] += item.sheets_count
-        if f"{item.postage}_class_volume" in personalisation:
+        if item.postage in (FIRST_CLASS, SECOND_CLASS):
             personalisation[f"{item.postage}_class_volume"] = item.letters_count
             personalisation[f"{item.postage}_class_sheets"] = item.sheets_count
+        elif item.postage == ECONOMY_CLASS:
+            personalisation["economy_mail_volume"] = item.letters_count
+            personalisation["economy_mail_sheets"] = item.sheets_count
         else:
             personalisation["international_volume"] += item.letters_count
             personalisation["international_sheets"] += item.sheets_count

--- a/app/constants.py
+++ b/app/constants.py
@@ -116,7 +116,6 @@ SECOND_CLASS = "second"
 ECONOMY_CLASS = "economy"
 EUROPE = "europe"
 REST_OF_WORLD = "rest-of-world"
-ECONOMY_CLASS = "economy"
 
 # Aggregated letter postage types
 POSTAGE_TYPES = [FIRST_CLASS, SECOND_CLASS, ECONOMY_CLASS, EUROPE, REST_OF_WORLD]

--- a/migrations/versions/0347_add_dvla_volumes_template.py
+++ b/migrations/versions/0347_add_dvla_volumes_template.py
@@ -37,6 +37,7 @@ def upgrade():
             "",
             "((first_class_volume)) first class letters (((first_class_sheets)) sheets).",
             "((second_class_volume)) second class letters (((second_class_sheets)) sheets).",
+            "((economy_mail_volume)) economy mail letters (((economy_mail_sheets)) sheets).",
             "((international_volume)) international letters (((international_sheets)) sheets).",
             "",
             "Thanks",

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -379,6 +379,7 @@ def test_send_letters_volume_email_to_dvla(notify_db_session, mock_celery_task, 
     letters_volumes = [
         MockVolume("first", 5, 7),
         MockVolume("second", 4, 12),
+        MockVolume("economy", 2, 4),
         MockVolume("europe", 1, 3),
         MockVolume("rest-of-world", 1, 2),
     ]
@@ -395,13 +396,15 @@ def test_send_letters_volume_email_to_dvla(notify_db_session, mock_celery_task, 
         assert str(email.template_id) == current_app.config["LETTERS_VOLUME_EMAIL_TEMPLATE_ID"]
         assert email.to in current_app.config["DVLA_EMAIL_ADDRESSES"]
         assert email.personalisation == {
-            "total_volume": 11,
+            "total_volume": 13,
             "first_class_volume": 5,
             "second_class_volume": 4,
+            "economy_mail_volume": 2,
             "international_volume": 2,
-            "total_sheets": 24,
+            "total_sheets": 28,
             "first_class_sheets": 7,
             "second_class_sheets": 12,
+            "economy_mail_sheets": 4,
             "international_sheets": 5,
             "date": "17 February 2020",
         }

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -800,6 +800,7 @@ def letter_volumes_email_template(notify_service):
             "",
             "((first_class_volume)) first class letters (((first_class_sheets)) sheets).",
             "((second_class_volume)) second class letters (((second_class_sheets)) sheets).",
+            "((economy_mail_volume)) economy mail letters (((economy_mail_sheets)) sheets).",
             "((international_volume)) international letters (((international_sheets)) sheets).",
             "",
             "Thanks",


### PR DESCRIPTION
The automated email we send to the DVLA each night needs updating to
include economy mail letters, otherwise these will be counted in the
international letters section.

The templates will need to updated manually. Updating the template in
the migration ensures that new environments that are created will have
the correct content.