### PR TITLE
Add task to generate report requests

### DIFF
--- a/app/dao/report_requests_dao.py
+++ b/app/dao/report_requests_dao.py
@@ -57,3 +57,9 @@ def dao_get_oldest_ongoing_report_request(
         )
 
     return query.order_by(ReportRequest.created_at.asc()).first()
+
+
+@autocommit
+def dao_update_report_request(report_request: ReportRequest) -> ReportRequest:
+    db.session.add(report_request)
+    return report_request

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from werkzeug.datastructures import MultiDict
 
 from app.aws import s3
+from app.celery.tasks import process_report_request
 from app.config import QueueNames
 from app.constants import (
     EMAIL_TYPE,
@@ -1542,7 +1543,7 @@ def create_report_request_by_type(service_id):
 
     user_id = req_json.get("user_id")
 
-    dto = ReportRequest(
+    report_request = ReportRequest(
         user_id=user_id,
         service_id=service_id,
         report_type=report_type,
@@ -1551,7 +1552,7 @@ def create_report_request_by_type(service_id):
     )
 
     # 1. Check for duplicate requests and if found return ongoing request
-    existing_request = dao_get_oldest_ongoing_report_request(dto, timeout_minutes=timeout_minutes)
+    existing_request = dao_get_oldest_ongoing_report_request(report_request, timeout_minutes=timeout_minutes)
 
     if existing_request:
         current_app.logger.info(
@@ -1565,7 +1566,7 @@ def create_report_request_by_type(service_id):
         return jsonify(data=existing_request.serialize()), 200
 
     # 2. If no ongoing request is present, create and enqueue the request
-    created_request = dao_create_report_request(dto)
+    created_request = dao_create_report_request(report_request)
 
     current_app.logger.info(
         "Report request %s for user %s (service %s) created with params %s",
@@ -1575,10 +1576,9 @@ def create_report_request_by_type(service_id):
         json.dumps(created_request.parameter, separators=(",", ":")),
     )
 
-    # TODO: Remove comments when async function has been implemented
-    # process_report_request.apply_async(
-    #     [str(report_request.service_id), str(report_request.id)],
-    #     queue=QueueNames.REPORT_REQUESTS_NOTIFICATIONS,
-    # )
+    process_report_request.apply_async(
+        kwargs={"service_id": str(report_request.service_id), "report_request_id": str(report_request.id)},
+        queue=QueueNames.REPORT_REQUESTS_NOTIFICATIONS,
+    )
 
     return jsonify(data=created_request.serialize()), 201

--- a/tests/app/dao/test_report_requests_dao.py
+++ b/tests/app/dao/test_report_requests_dao.py
@@ -13,8 +13,10 @@ from app.dao.report_requests_dao import (
     dao_create_report_request,
     dao_get_oldest_ongoing_report_request,
     dao_get_report_request_by_id,
+    dao_update_report_request,
 )
 from app.models import ReportRequest
+from tests.app.db import create_report_request
 
 
 def test_dao_create_report_request(sample_service, sample_user):
@@ -329,3 +331,16 @@ def test_dao_get_oldest_ongoing_report_request_returns_oldest_when_multiple_matc
 
     assert isinstance(result, ReportRequest)
     assert result.id == older_request.id
+
+
+def test_dao_update_report_request(sample_service, sample_user):
+    report_request = create_report_request(sample_user.id, sample_service.id)
+
+    assert report_request.status == REPORT_REQUEST_PENDING
+    assert not report_request.updated_at
+
+    report_request.status = REPORT_REQUEST_IN_PROGRESS
+    dao_update_report_request(report_request)
+
+    assert report_request.status == REPORT_REQUEST_IN_PROGRESS
+    assert report_request.updated_at

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -24,6 +24,7 @@ from app.dao.organisation_dao import (
     dao_create_organisation,
 )
 from app.dao.permissions_dao import permission_dao
+from app.dao.report_requests_dao import dao_create_report_request
 from app.dao.service_callback_api_dao import save_service_callback_api
 from app.dao.service_data_retention_dao import insert_service_data_retention
 from app.dao.service_permissions_dao import dao_add_service_permission
@@ -63,6 +64,7 @@ from app.models import (
     Organisation,
     Permission,
     Rate,
+    ReportRequest,
     ReturnedLetter,
     Service,
     ServiceCallbackApi,
@@ -1363,3 +1365,22 @@ def create_unsubscribe_request_and_return_the_notification_id(
         }
     )
     return notification.id
+
+
+def create_report_request(
+    user_id,
+    service_id,
+    report_type="notifications",
+    status="pending",
+    notification_type="email",
+    notification_status="all",
+):
+    report_request = ReportRequest(
+        user_id=user_id,
+        service_id=service_id,
+        report_type=report_type,
+        status=status,
+        parameter={"notification_type": notification_type, "notification_status": notification_status},
+    )
+
+    return dao_create_report_request(report_request)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -10,6 +10,7 @@ from freezegun import freeze_time
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.celery.provider_tasks import deliver_email
+from app.celery.tasks import process_report_request
 from app.constants import (
     BROADCAST_TYPE,
     EMAIL_AUTH_TYPE,
@@ -4710,7 +4711,11 @@ def test_create_report_request_by_type_should_return_validation_error(
         ("letter", "sending"),
     ],
 )
-def test_create_report_request_by_type(admin_request, sample_service, notification_type, notification_status):
+def test_create_report_request_by_type(
+    admin_request, sample_service, notification_type, notification_status, mock_celery_task
+):
+    process_task_mock = mock_celery_task(process_report_request)
+
     json_resp = admin_request.post(
         "service.create_report_request_by_type",
         service_id=str(sample_service.id),
@@ -4721,6 +4726,14 @@ def test_create_report_request_by_type(admin_request, sample_service, notificati
             "notification_status": notification_status,
         },
         _expected_status=201,
+    )
+
+    process_task_mock.assert_called_once_with(
+        kwargs={
+            "report_request_id": json_resp["data"]["id"],
+            "service_id": str(sample_service.id),
+        },
+        queue="report-requests-notifications-tasks",
     )
 
     assert json_resp["data"]["id"]
@@ -4734,7 +4747,11 @@ def test_create_report_request_by_type(admin_request, sample_service, notificati
     assert json_resp["data"]["created_at"]
 
 
-def test_create_report_request_by_type_returns_existing_request(admin_request, sample_service, sample_user, caplog):
+def test_create_report_request_by_type_returns_existing_request(
+    admin_request, sample_service, sample_user, caplog, mock_celery_task
+):
+    process_task_mock = mock_celery_task(process_report_request)
+
     expected_params = {"notification_type": "sms", "notification_status": "sending"}
     existing_request = ReportRequest(
         user_id=sample_user.id,
@@ -4767,9 +4784,12 @@ def test_create_report_request_by_type_returns_existing_request(admin_request, s
         f" with params {json.dumps(expected_params, separators=(',', ':'))} – returning existing "
         f"request {existing_request.id}" in caplog.messages
     )
+    assert not process_task_mock.called
 
 
-def test_create_report_request_by_type_creates_new_when_no_existing(admin_request, sample_service):
+def test_create_report_request_by_type_creates_new_when_no_existing(admin_request, sample_service, mock_celery_task):
+    process_task_mock = mock_celery_task(process_report_request)
+
     data = {
         "user_id": str(sample_service.created_by_id),
         "report_type": "notifications_report",
@@ -4791,10 +4811,19 @@ def test_create_report_request_by_type_creates_new_when_no_existing(admin_reques
         "notification_status": "failed",
     }
 
+    process_task_mock.assert_called_once_with(
+        kwargs={
+            "report_request_id": response["data"]["id"],
+            "service_id": str(sample_service.id),
+        },
+        queue="report-requests-notifications-tasks",
+    )
+
 
 def test_create_report_request_by_type_creates_new_if_existing_is_stale(
-    admin_request, sample_service, sample_user, caplog
+    admin_request, sample_service, sample_user, caplog, mock_celery_task
 ):
+    process_task_mock = mock_celery_task(process_report_request)
     expected_params = {"notification_type": "email", "notification_status": "failed"}
 
     timeout = current_app.config["REPORT_REQUEST_NOTIFICATIONS_TIMEOUT_MINUTES"]
@@ -4829,4 +4858,11 @@ def test_create_report_request_by_type_creates_new_if_existing_is_stale(
     assert (
         f"Report request {created_request_id} for user {sample_user.id} (service {sample_service.id}) "
         f"created with params {json.dumps(expected_params, separators=(',', ':'))}" in caplog.messages
+    )
+    process_task_mock.assert_called_once_with(
+        kwargs={
+            "report_request_id": response["data"]["id"],
+            "service_id": str(sample_service.id),
+        },
+        queue="report-requests-notifications-tasks",
     )


### PR DESCRIPTION
We have an endpoint to create report requests, and a class which generates the data. This connects the two bits by creating a task which, when called from the endpoint, uses our existing code to generate the data.

The task does nothing if the report request is already in "pending" status. Otherwise it, calls the code to generate the data and updates the status of the report request appropriately.

https://trello.com/c/ubo67aY3/1265-celery-task-report-data-processing