### PR TITLE
refactor: Return latest delivery date for letters instead of earliest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.2.0
+# This file was automatically copied from notifications-utils@99.5.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/models.py
+++ b/app/models.py
@@ -1717,7 +1717,7 @@ class Notification(db.Model):
 
             serialized["estimated_delivery"] = get_letter_timings(
                 serialized["created_at"], postage=self.postage
-            ).earliest_delivery.strftime(DATETIME_FORMAT)
+            ).latest_delivery.strftime(DATETIME_FORMAT)
 
         return serialized
 

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil>=6.0.0,<7.0.0
 notifications-python-client==10.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.5.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -149,7 +149,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@f2eb2a10e51da9250777e5389d71eeed592455c1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0b99dd5a5b0f55a77a537c7fdcf508d76e286a76
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -185,7 +185,7 @@ python-dateutil==2.8.2
     #   arrow
     #   botocore
     #   celery
-python-json-logger==2.0.7
+python-json-logger==3.3.0
     # via notifications-utils
 pytz==2024.2
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -219,7 +219,7 @@ moto==5.0.11
     # via -r requirements_for_test.in
 notifications-python-client==10.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@f2eb2a10e51da9250777e5389d71eeed592455c1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0b99dd5a5b0f55a77a537c7fdcf508d76e286a76
     # via -r requirements.txt
 ordered-set==4.1.0
     # via
@@ -287,7 +287,7 @@ python-dateutil==2.8.2
     #   celery
     #   freezegun
     #   moto
-python-json-logger==2.0.7
+python-json-logger==3.3.0
     # via
     #   -r requirements.txt
     #   notifications-utils

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.2.0
+# This file was automatically copied from notifications-utils@99.5.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.2.0
+# This file was automatically copied from notifications-utils@99.5.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -194,16 +194,13 @@ def test_get_notification_by_id_invalid_id(api_client_request, sample_notificati
 @pytest.mark.parametrize(
     "created_at_month, postage, estimated_delivery",
     [
-        (12, "second", "2000-12-06T16:00:00.000000Z"),  # 4pm GMT in winter
-        (6, "second", "2000-06-05T15:00:00.000000Z"),  # 4pm BST in summer
-        (12, "first", "2000-12-05T16:00:00.000000Z"),  # 4pm GMT in winter
-        (6, "first", "2000-06-03T15:00:00.000000Z"),  # 4pm BST in summer (two days before 2nd class due to weekends)
-        (
-            12,
-            "economy",
-            "2000-12-07T16:00:00.000000Z",
-        ),  # 4pm GMT in winter (1 extra working day - slower than second class)
-        (6, "economy", "2000-06-06T15:00:00.000000Z"),  # 4pm BST in summer
+        # no print during weekends, no delivery on Sundays
+        (12, "second", "2000-12-07T16:00:00.000000Z"),  # Created Fri 1 Dec, printed Mon 4 Dec, delivered Thu 7 Dec
+        (6, "second", "2000-06-06T15:00:00.000000Z"),  # Created Thu 1 Jun, printed Fri 2 Jun, delivered Tue 6 Jun
+        (12, "first", "2000-12-05T16:00:00.000000Z"),  # Created Fri 1 Dec, printed Mon 4 Dec, delivered Tue 5 Dec
+        (6, "first", "2000-06-03T15:00:00.000000Z"),  # Created Thu 1 Jun, printed Fri 2 Jun, delivered Sat 3 Jun
+        (12, "economy", "2000-12-11T16:00:00.000000Z"),  # Created Fri 1 Dec, printed Mon 4 Dec, delivered Mon 11 Dec
+        (6, "economy", "2000-06-09T15:00:00.000000Z"),  # Created Thu 1 Jun, printed Fri 2 Jun, delivery Mon 9 Jun
     ],
 )
 def test_get_notification_adds_delivery_estimate_for_letters(


### PR DESCRIPTION
### Summary
- By providing latest delivery date we are trying to set a more realist expectation for users  for when they should receive their letters by


### Ticket
- [Update delivery estimates code to accomodate economy postage](https://trello.com/c/JngKcHSO/1272-update-delivery-estimates-code-to-accomodate-economy-postage)