### PR TITLE
Bump utils to 99.5.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.5.0
+# This file was automatically copied from notifications-utils@99.5.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil>=6.0.0,<7.0.0
 notifications-python-client==10.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.5.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.5.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,7 +68,7 @@ eventlet==0.39.1
     # via
     #   -r requirements.in
     #   gunicorn
-flask==3.1.0
+flask==3.1.1
     # via
     #   flask-bcrypt
     #   flask-marshmallow
@@ -134,6 +134,7 @@ mako==1.2.3
     # via alembic
 markupsafe==2.1.1
     # via
+    #   flask
     #   jinja2
     #   mako
     #   sentry-sdk
@@ -149,7 +150,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0b99dd5a5b0f55a77a537c7fdcf508d76e286a76
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d669a9544cc87372a10af8786d3bb172593261fa
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -113,7 +113,7 @@ execnet==2.1.1
     # via pytest-xdist
 flaky==3.8.0
     # via -r requirements_for_test.in
-flask==3.1.0
+flask==3.1.1
     # via
     #   -r requirements.txt
     #   flask-bcrypt
@@ -201,6 +201,7 @@ mako==1.2.3
 markupsafe==2.1.1
     # via
     #   -r requirements.txt
+    #   flask
     #   jinja2
     #   mako
     #   werkzeug
@@ -219,7 +220,7 @@ moto==5.0.11
     # via -r requirements_for_test.in
 notifications-python-client==10.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0b99dd5a5b0f55a77a537c7fdcf508d76e286a76
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d669a9544cc87372a10af8786d3bb172593261fa
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.5.0
+# This file was automatically copied from notifications-utils@99.5.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.5.0
+# This file was automatically copied from notifications-utils@99.5.1
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
 ## 99.5.1

* Bump minimum Flask version to 3.1.1

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/99.5.0...99.5.1

***

Closes #4470