### PR TITLE
Stop incrementing overall message limit for services

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -170,14 +170,13 @@ def increment_daily_limit_caches(service, notification, key_type):
     if key_type == KEY_TYPE_TEST or not current_app.config["REDIS_ENABLED"]:
         return
 
-    increment_daily_limit_cache(service.id)
     increment_daily_limit_cache(service.id, notification.notification_type)
 
     if notification.notification_type == SMS_TYPE and str(notification.phone_prefix) != UK_PREFIX:
         increment_daily_limit_cache(service.id, INTERNATIONAL_SMS_TYPE)
 
 
-def increment_daily_limit_cache(service_id, notification_type=None):
+def increment_daily_limit_cache(service_id, notification_type):
     cache_key = redis.daily_limit_cache_key(service_id, notification_type=notification_type)
     if redis_store.get(cache_key) is None:
         # if cache does not exist set the cache to 1 with an expiry of 24 hours,

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -286,7 +286,6 @@ def test_persist_notification_increments_cache_for_trial_or_live_service(
         )
 
         assert mock_incr.call_args_list == [
-            mocker.call(f"{service.id}-2016-01-01-count"),
             mocker.call(f"{service.id}-sms-2016-01-01-count"),
         ]
 
@@ -321,7 +320,6 @@ def test_persist_notification_sets_daily_limit_cache_if_one_does_not_exist(
         )
 
         assert mock_set.call_args_list == [
-            mocker.call(f"{service.id}-2016-01-01-count", 1, ex=86400),
             mocker.call(f"{service.id}-sms-2016-01-01-count", 1, ex=86400),
         ]
 
@@ -353,7 +351,6 @@ def test_persist_notification_increments_cache_for_international_sms(notify_api,
         )
 
         assert mock_incr.call_args_list == [
-            mocker.call(f"{service.id}-2016-01-01-count"),
             mocker.call(f"{service.id}-sms-2016-01-01-count"),
             mocker.call(f"{service.id}-international_sms-2016-01-01-count"),
         ]
@@ -388,7 +385,6 @@ def test_persist_notification_doesnt_increment_cache_for_international_sms_when_
         )
 
         assert mock_incr.call_args_list == [
-            mocker.call(f"{service.id}-2016-01-01-count"),
             mocker.call(f"{service.id}-sms-2016-01-01-count"),
         ]
 
@@ -415,7 +411,6 @@ def test_persist_notification_doesnt_increment_cache_for_international_sms_with_
         )
 
         assert mock_incr.call_args_list == [
-            mocker.call(f"{service.id}-2016-01-01-count"),
             mocker.call(f"{service.id}-email-2016-01-01-count"),
         ]
 
@@ -449,7 +444,6 @@ def test_persist_notification_increments_cache_for_international_sms_if_the_cach
         )
 
         assert mock_set.call_args_list == [
-            mocker.call(f"{service.id}-2016-01-01-count", 1, ex=86400),
             mocker.call(f"{service.id}-sms-2016-01-01-count", 1, ex=86400),
             mocker.call(f"{service.id}-international_sms-2016-01-01-count", 1, ex=86400),
         ]


### PR DESCRIPTION
We stopped checking the overall message limit in https://github.com/alphagov/notifications-api/pull/3706

We dropped the database column entirely in https://github.com/alphagov/notifications-api/pull/3712

This was part of the work to move to a per-channel message limit.

We are still keeping track of how many messages each service has sent each day in Redis, but we never look at this value.

This is an unnecessary extra call to Redis each time a message is sent, and [confuses](https://github.com/alphagov/notifications-api/pull/4465#discussion_r2099846523) people reading the code.