### PR TITLE
feat: Add service column confirmed_unique_name

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -580,6 +580,7 @@ class Service(db.Model, Versioned):
     go_live_user = db.relationship("User", foreign_keys=[go_live_user_id])
     go_live_at = db.Column(db.DateTime, nullable=True)
     has_active_go_live_request = db.Column(db.Boolean, default=False, nullable=False)
+    confirmed_unique = db.Column(db.Boolean, default=False, nullable=False)
 
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), index=True, nullable=True)
     organisation = db.relationship("Organisation", backref="services")

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0501_drop_inbound_api_table
+0502_add_confirmed_unique

--- a/migrations/versions/0502_add_confirmed_unique.py
+++ b/migrations/versions/0502_add_confirmed_unique.py
@@ -1,0 +1,23 @@
+"""
+Create Date: 2025-05-23 15:34:27.333353
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = '0502_add_confirmed_unique'
+down_revision = '0501_drop_inbound_api_table'
+
+
+confirmed_unique = "confirmed_unique"
+
+
+def upgrade():
+    op.add_column("services", sa.Column(confirmed_unique, sa.Boolean(), nullable=False, server_default=sa.false()))
+    op.add_column("services_history", sa.Column(confirmed_unique, sa.Boolean(), nullable=False, server_default=sa.false()))
+
+
+def downgrade():
+    op.drop_column("services_history", confirmed_unique)
+    op.drop_column("services", confirmed_unique)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -267,6 +267,7 @@ def test_get_service_by_id(admin_request, sample_service):
         "billing_contact_names",
         "billing_reference",
         "broadcast_channel",
+        "confirmed_unique",
         "consent_to_research",
         "contact_link",
         "count_as_live",


### PR DESCRIPTION
## Summary
Migration to add new column for services table. This will be used to know if users have confirmed their unique service already when trying to change the Service name on the dashboard during the "make service live" journey

## Testing:

- [ ] Run admin - made sure it worked with new changes
- [ ] Checked admin Services page are working
- [ ] Clear cache and see if new field is available


### Ticket:
- [Confirm Service is Unique](https://trello.com/c/vG9OowgU/1302-make-your-service-live-5-6-add-the-confirm-your-service-is-unique-task)