### PR TITLE
Refactor: Economy mail transit dates to max 8 days

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.5.1
+# This file was automatically copied from notifications-utils@99.7.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil>=6.0.0,<7.0.0
 notifications-python-client==10.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.5.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.7.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -150,7 +150,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d669a9544cc87372a10af8786d3bb172593261fa
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@8b39f0006709662df689d52055867bca0a897230
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -220,7 +220,7 @@ moto==5.0.11
     # via -r requirements_for_test.in
 notifications-python-client==10.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d669a9544cc87372a10af8786d3bb172593261fa
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@8b39f0006709662df689d52055867bca0a897230
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.5.1
+# This file was automatically copied from notifications-utils@99.7.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.5.1
+# This file was automatically copied from notifications-utils@99.7.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -199,8 +199,8 @@ def test_get_notification_by_id_invalid_id(api_client_request, sample_notificati
         (6, "second", "2000-06-06T15:00:00.000000Z"),  # Created Thu 1 Jun, printed Fri 2 Jun, delivered Tue 6 Jun
         (12, "first", "2000-12-05T16:00:00.000000Z"),  # Created Fri 1 Dec, printed Mon 4 Dec, delivered Tue 5 Dec
         (6, "first", "2000-06-03T15:00:00.000000Z"),  # Created Thu 1 Jun, printed Fri 2 Jun, delivered Sat 3 Jun
-        (12, "economy", "2000-12-11T16:00:00.000000Z"),  # Created Fri 1 Dec, printed Mon 4 Dec, delivered Mon 11 Dec
-        (6, "economy", "2000-06-09T15:00:00.000000Z"),  # Created Thu 1 Jun, printed Fri 2 Jun, delivery Mon 9 Jun
+        (12, "economy", "2000-12-14T16:00:00.000000Z"),  # Created Fri 1 Dec, printed Mon 4 Dec, delivered Thu 14 Dec
+        (6, "economy", "2000-06-13T15:00:00.000000Z"),  # Created Thu 1 Jun, printed Fri 2 Jun, delivery Fri 13 Jun
     ],
 )
 def test_get_notification_adds_delivery_estimate_for_letters(


### PR DESCRIPTION
### Summary
- An update for transit dates for economy mail was done in notifications-utils to increase delivery date to 8 days
- In here, tests are being updated to reflect this change

### Ticket:
- [Economy mail - extend dates](https://trello.com/c/h8jUSWcj/1270-launch-economy-postage-code)