### PR TITLE
Fix empty test assertions

### DIFF
--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -472,9 +472,9 @@ def test_check_service_over_api_rate_limit_when_exceed_rate_limit_request_fails_
         with pytest.raises(RateLimitError) as e:
             check_service_over_api_rate_limit(serialised_service, serialised_api_key.key_type)
 
-        assert app.redis_store.exceeded_rate_limit.called_with(
-            f"{str(sample_service.id)}-{api_key.key_type}", sample_service.rate_limit, 60
-        )
+        assert app.redis_store.exceeded_rate_limit.call_args_list == [
+            mocker.call(f"{str(sample_service.id)}-{api_key.key_type}", sample_service.rate_limit, 60)
+        ]
         assert e.value.status_code == 429
         assert e.value.message == (
             f"Exceeded rate limit for key type {key_type.upper()} of {sample_service.rate_limit} "
@@ -493,7 +493,9 @@ def test_check_service_over_api_rate_limit_when_rate_limit_has_not_exceeded_limi
         serialised_api_key = SerialisedAPIKeyCollection.from_service_id(serialised_service.id)[0]
 
         check_service_over_api_rate_limit(serialised_service, serialised_api_key.key_type)
-        assert app.redis_store.exceeded_rate_limit.called_with(f"{str(sample_service.id)}-{api_key.key_type}", 3000, 60)
+        assert app.redis_store.exceeded_rate_limit.call_args_list == [
+            mocker.call(f"{str(sample_service.id)}-{api_key.key_type}", 3000, 60)
+        ]
 
 
 def test_check_service_over_api_rate_limit_should_do_nothing_if_limiting_is_disabled(sample_service, mocker):

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1453,7 +1453,7 @@ def test_preview_letter_template_precompiled_pdf_file_type(notify_api, client, a
                 file_type="pdf",
             )
 
-            assert mock_get_letter_pdf.called_once_with(notification)
+            mock_get_letter_pdf.assert_called_once_with(notification)
             assert base64.b64decode(resp["content"]) == content
 
 
@@ -1576,7 +1576,7 @@ def test_preview_letter_template_precompiled_for_png_shows_overlay_on_pages_with
 
             with pytest.raises(ValueError):
                 mock_post.last_request.json()
-            assert mock_get_letter_pdf.called_once_with(notification)
+            mock_get_letter_pdf.assert_called_once_with(notification)
             assert base64.b64decode(response["content"]) == expected_returned_content
             assert response["metadata"] == metadata
 
@@ -1645,7 +1645,7 @@ def test_preview_letter_template_precompiled_for_pdf_shows_overlay_on_all_pages_
 
             with pytest.raises(ValueError):
                 mock_post.last_request.json()
-            assert mock_get_letter_pdf.called_once_with(notification)
+            mock_get_letter_pdf.assert_called_once_with(notification)
             assert base64.b64decode(response["content"]) == expected_returned_content
             assert response["metadata"] == metadata
 


### PR DESCRIPTION
`called_with` and `called_once` are not methods of `unittest.Mock`.

Instead they are mocked functions which will:
- accept any arguments
- always return something `True`-ish

This means the assertions in these tests are doing nothing, and changing their arguements or the arguements of the methods they are mocking does not cause the tests to fail.

This commit switches to using methods which do exist.