### PR TITLE
Stop using outdated service permissions for functional tests

### DIFF
--- a/app/functional_tests_fixtures/__init__.py
+++ b/app/functional_tests_fixtures/__init__.py
@@ -9,7 +9,6 @@ from sqlalchemy.exc import NoResultFound
 from app.constants import (
     EDIT_FOLDER_PERMISSIONS,
     EMAIL_AUTH,
-    EXTRA_LETTER_FORMATTING,
     INBOUND_SMS_TYPE,
     SECOND_CLASS,
     SEND_EMAILS,
@@ -567,7 +566,7 @@ def _create_service_email_reply_to(service_id, email_address, is_default):
 
 def _create_service_permissions(service_id, permissions=None):
     if permissions is None:
-        permissions = [EDIT_FOLDER_PERMISSIONS, EXTRA_LETTER_FORMATTING, INBOUND_SMS_TYPE, EMAIL_AUTH]
+        permissions = [EDIT_FOLDER_PERMISSIONS, INBOUND_SMS_TYPE, EMAIL_AUTH]
 
     service_permissions = dao_fetch_service_permissions(service_id)
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -19,9 +19,7 @@ from app.constants import (
     BROADCAST_TYPE,
     EMAIL_TYPE,
     LETTER_TYPE,
-    PRECOMPILED_LETTER,
     SMS_TYPE,
-    UPLOAD_DOCUMENT,
     CacheKeys,
 )
 
@@ -116,10 +114,6 @@ def get_public_notify_type_text(notify_type, plural=False):
     notify_type_text = notify_type
     if notify_type == SMS_TYPE:
         notify_type_text = "text message"
-    elif notify_type == UPLOAD_DOCUMENT:
-        notify_type_text = "document"
-    elif notify_type == PRECOMPILED_LETTER:
-        notify_type_text = "precompiled letter"
     elif notify_type == BROADCAST_TYPE:
         notify_type_text = "broadcast message"
 


### PR DESCRIPTION
The "extra_letter_formatting" service permission isn't used or necessary, but before removing it we need to make sure that no new services get given it. This removes it from the functional test fixtures.

It also removes two other unused service permissions from a helper method.