### PR TITLE
Stop giving new services the `UPLOAD_LETTER` permission

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -17,7 +17,6 @@ from app.constants import (
     NON_CROWN_ORGANISATION_TYPES,
     NOTIFICATION_PERMANENT_FAILURE,
     SMS_TYPE,
-    UPLOAD_LETTERS,
 )
 from app.dao.dao_utils import VersionOptions, autocommit, version_class
 from app.dao.date_util import get_current_financial_year
@@ -71,7 +70,6 @@ DEFAULT_SERVICE_PERMISSIONS = [
     EMAIL_TYPE,
     LETTER_TYPE,
     INTERNATIONAL_SMS_TYPE,
-    UPLOAD_LETTERS,
     INTERNATIONAL_LETTERS,
 ]
 

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -17,7 +17,6 @@ from app.constants import (
     KEY_TYPE_TEST,
     LETTER_TYPE,
     SMS_TYPE,
-    UPLOAD_LETTERS,
 )
 from app.dao.inbound_numbers_dao import (
     dao_get_available_inbound_numbers,
@@ -537,15 +536,15 @@ def test_create_service_returns_service_with_default_permissions(notify_db_sessi
     service = dao_fetch_service_by_id(service.id)
     _assert_service_permissions(
         service.permissions,
-        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS),
+        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS),
     )
 
 
 @pytest.mark.parametrize(
     "permission_to_remove, permissions_remaining",
     [
-        (SMS_TYPE, (EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS)),
-        (EMAIL_TYPE, (SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS)),
+        (SMS_TYPE, (EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS)),
+        (EMAIL_TYPE, (SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS)),
     ],
 )
 def test_remove_permission_from_service_by_id_returns_service_with_correct_permissions(
@@ -564,7 +563,6 @@ def test_removing_all_permission_returns_service_with_no_permissions(notify_db_s
     dao_remove_service_permission(service_id=service.id, permission=EMAIL_TYPE)
     dao_remove_service_permission(service_id=service.id, permission=LETTER_TYPE)
     dao_remove_service_permission(service_id=service.id, permission=INTERNATIONAL_SMS_TYPE)
-    dao_remove_service_permission(service_id=service.id, permission=UPLOAD_LETTERS)
     dao_remove_service_permission(service_id=service.id, permission=INTERNATIONAL_LETTERS)
 
     service = dao_fetch_service_by_id(service.id)
@@ -580,14 +578,14 @@ def test_create_service_by_id_adding_and_removing_letter_returns_service_without
     service = dao_fetch_service_by_id(service.id)
     _assert_service_permissions(
         service.permissions,
-        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS),
+        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS),
     )
 
     dao_remove_service_permission(service_id=service.id, permission=LETTER_TYPE)
     service = dao_fetch_service_by_id(service.id)
 
     _assert_service_permissions(
-        service.permissions, (SMS_TYPE, EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS)
+        service.permissions, (SMS_TYPE, EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS)
     )
 
 
@@ -730,7 +728,7 @@ def test_delete_service_and_associated_objects(notify_db_session):
     user.organisations = [organisation]
 
     assert ServicePermission.query.count() == len(
-        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS)
+        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS)
     )
 
     delete_service_and_all_associated_db_objects(service)

--- a/tests/app/service/send_notification/test_send_pdf_letter_notification.py
+++ b/tests/app/service/send_notification/test_send_pdf_letter_notification.py
@@ -2,7 +2,7 @@ import pytest
 from freezegun import freeze_time
 from notifications_utils.s3 import S3ObjectNotFound
 
-from app.constants import EMAIL_TYPE, LETTER_TYPE, UPLOAD_LETTERS
+from app.constants import EMAIL_TYPE, LETTER_TYPE, SMS_TYPE
 from app.dao.notifications_dao import get_notification_by_id
 from app.service.send_notification import send_pdf_letter_notification
 from app.v2.errors import BadRequestError, TooManyRequestsError
@@ -24,7 +24,7 @@ def post_data(sample_service_full_permissions, fake_uuid):
     "permissions",
     [
         [EMAIL_TYPE],
-        [UPLOAD_LETTERS],
+        [SMS_TYPE],
     ],
 )
 def test_send_pdf_letter_notification_raises_error_if_service_does_not_have_permission(

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -29,7 +29,6 @@ from app.constants import (
     SERVICE_JOIN_REQUEST_APPROVED,
     SERVICE_JOIN_REQUEST_CANCELLED,
     SMS_TYPE,
-    UPLOAD_LETTERS,
 )
 from app.dao.organisation_dao import dao_add_service_to_organisation
 from app.dao.report_requests_dao import dao_create_report_request
@@ -315,8 +314,7 @@ def test_get_service_list_has_default_permissions(admin_request, service_factory
     json_resp = admin_request.get("service.get_services")
     assert len(json_resp["data"]) == 3
     assert all(
-        set(json["permissions"])
-        == {EMAIL_TYPE, SMS_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS}
+        set(json["permissions"]) == {EMAIL_TYPE, SMS_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE, INTERNATIONAL_LETTERS}
         for json in json_resp["data"]
     )
 
@@ -329,7 +327,6 @@ def test_get_service_by_id_has_default_service_permissions(admin_request, sample
         SMS_TYPE,
         INTERNATIONAL_SMS_TYPE,
         LETTER_TYPE,
-        UPLOAD_LETTERS,
         INTERNATIONAL_LETTERS,
     }
 


### PR DESCRIPTION
We don't check this service permission, it existed as a feature flag when we were developing the upload letter feature, but now [all services can upload letters](https://github.com/alphagov/notifications-api/pull/2735).

As a first step towards removing it from the database we need to ensure we stop giving it to every new service that gets created.