### PR TITLE
Remove unused "upload_letters" service permission

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -237,7 +237,6 @@ INTERNATIONAL_SMS_TYPE = "international_sms"
 INBOUND_SMS_TYPE = "inbound_sms"
 EMAIL_AUTH = "email_auth"
 EDIT_FOLDER_PERMISSIONS = "edit_folder_permissions"
-UPLOAD_LETTERS = "upload_letters"
 INTERNATIONAL_LETTERS = "international_letters"
 SMS_TO_UK_LANDLINES = "sms_to_uk_landlines"
 SERVICE_PERMISSION_TYPES = [
@@ -249,7 +248,6 @@ SERVICE_PERMISSION_TYPES = [
     INBOUND_SMS_TYPE,
     EMAIL_AUTH,
     EDIT_FOLDER_PERMISSIONS,
-    UPLOAD_LETTERS,
     INTERNATIONAL_LETTERS,
     SMS_TO_UK_LANDLINES,
 ]

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0503_remove_old_permissions
+0504_remove_upload_letters

--- a/migrations/versions/0317_uploads_for_all.py
+++ b/migrations/versions/0317_uploads_for_all.py
@@ -8,11 +8,10 @@ Create Date: 2019-05-13 10:44:51.867661
 
 from alembic import op
 
-from app.constants import UPLOAD_LETTERS
-
 revision = "0317_uploads_for_all"
 down_revision = "0316_int_letters_permission"
 
+UPLOAD_LETTERS = "upload_letters"
 
 def upgrade():
     op.execute(

--- a/migrations/versions/0504_remove_upload_letters.py
+++ b/migrations/versions/0504_remove_upload_letters.py
@@ -1,0 +1,19 @@
+"""
+Create Date: 2025-06-05 13:51:16.404831
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0504_remove_upload_letters'
+down_revision = '0503_remove_old_permissions'
+
+
+def upgrade():
+    op.execute("DELETE from service_permissions where permission = 'upload_letters'")
+    op.execute("DELETE from service_permission_types where name = 'upload_letters'")
+
+
+def downgrade():
+    op.execute("INSERT INTO service_permission_types values ('upload_letters')")


### PR DESCRIPTION
This wasn't being checked and is no longer given to new services as a default service permission. The final stage of removing it is now to drop it from the database and code.

⚠️ The service cache must be cleared after this change to avoid errors with services appearing to have the (now non-existent) upload-letters permission ⚠️