### PR TITLE
Fix generation of random phone numbers in test data

### DIFF
--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -457,7 +457,7 @@ def create_inbound_sms(
     if not service.inbound_number:
         create_inbound_number(
             # create random inbound number
-            notify_number or f"07{random.randint(0, 1e9 - 1):09}",
+            notify_number or f"07{random.randint(100_000_000, 999_999_999)}",
             provider=provider,
             service_id=service.id,
         )


### PR DESCRIPTION
This had 2 problems:
- starting from `1` meant that it could generate a non-valid phone number like `071`, except for the use of 0-padded string formatting (which is a pretty niche/non-intuitive feature)
- ending with a number specified in scientfic notation means that number is a float, and floats are not valid arguments to `randint` as of Python 3.12

`randint` is an alias of `randrange`, and _What’s new in Python 3.12_ says:
> Formerly, randrange(10.0) losslessly converted to randrange(10). Now, it raises a TypeError. 

– https://docs.python.org/3/whatsnew/3.12.html#changes-in-the-python-api