### PR TITLE
Don’t decrement overall cache when letters are cancelled

### DIFF
--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -262,12 +262,7 @@ def adjust_daily_service_limits_for_cancelled_letters(service_id, no_of_cancelle
         return
 
     letters_cache_key = daily_limit_cache_key(service_id, notification_type=LETTER_TYPE)
-    all_notifications_cache_key = daily_limit_cache_key(service_id)
 
     if (cached_letters_sent := redis_store.get(letters_cache_key)) is not None:
         if (int(cached_letters_sent) - no_of_cancelled_letters) >= 0:
             redis_store.decrby(letters_cache_key, no_of_cancelled_letters)
-
-    if (cached_notifications_sent := redis_store.get(all_notifications_cache_key)) is not None:
-        if (int(cached_notifications_sent) - no_of_cancelled_letters) >= 0:
-            redis_store.decrby(all_notifications_cache_key, no_of_cancelled_letters)

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -446,7 +446,6 @@ def test_adjust_daily_service_limits_for_cancelled_letters_when_cache_keys_do_no
 
         assert mock_redis_get.call_args_list == [
             call(f"{fake_uuid}-letter-2024-01-01-count"),
-            call(f"{fake_uuid}-2024-01-01-count"),
         ]
         assert not mock_redis_decrby.called
 
@@ -463,7 +462,6 @@ def test_adjust_daily_service_limits_for_cancelled_letters_will_not_update_redis
 
         assert mock_redis_get.call_args_list == [
             call(f"{fake_uuid}-letter-2024-01-01-count"),
-            call(f"{fake_uuid}-2024-01-01-count"),
         ]
         assert not mock_redis_decrby.called
 
@@ -485,10 +483,8 @@ def test_adjust_daily_service_limits_for_cancelled_letters_updates_redis(notify_
 
         assert mock_redis_get.call_args_list == [
             call(f"{fake_uuid}-letter-2024-01-01-count"),
-            call(f"{fake_uuid}-2024-01-01-count"),
         ]
 
         assert mock_redis_decrby.call_args_list == [
             call(f"{fake_uuid}-letter-2024-01-01-count", 5),
-            call(f"{fake_uuid}-2024-01-01-count", 5),
         ]


### PR DESCRIPTION
We stopped incrementing the overall cache in https://github.com/alphagov/notifications-api/pull/4479 because it was no longer being checked.

This also means we don’t need to decrement it when cancelling letters (because it will never have been set).