### PR TITLE
Upgrade to python 3.13

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm AS base
+FROM python:3.13-slim-bookworm AS base
 
 COPY --from=ghcr.io/astral-sh/uv:0.5.28 /uv /uvx /bin/
 

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ Flask-Migrate==3.1.0
 flask-sqlalchemy==3.0.5
 click-datetime==0.2
 gunicorn[eventlet]==23.0.0
-eventlet==0.39.1
+eventlet==0.40.0
 iso8601==2.1.0
 jsonschema[format]==4.23.0
 marshmallow-sqlalchemy==0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,6 @@ amqp==5.1.1
     # via kombu
 arrow==1.2.3
     # via isoduration
-async-timeout==4.0.3
-    # via redis
 attrs==24.3.0
     # via
     #   jsonschema
@@ -64,7 +62,7 @@ dnspython==2.6.1
     # via eventlet
 docopt==0.6.2
     # via notifications-python-client
-eventlet==0.39.1
+eventlet==0.40.0
     # via
     #   -r requirements.in
     #   gunicorn
@@ -96,7 +94,7 @@ gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6
     # via -r requirements.in
 govuk-bank-holidays==0.15
     # via notifications-utils
-greenlet==3.2.2
+greenlet==3.2.3
     # via eventlet
 gunicorn==23.0.0
     # via

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -12,10 +12,6 @@ arrow==1.2.3
     # via
     #   -r requirements.txt
     #   isoduration
-async-timeout==4.0.3
-    # via
-    #   -r requirements.txt
-    #   redis
 attrs==24.3.0
     # via
     #   -r requirements.txt
@@ -105,7 +101,7 @@ docopt==0.6.2
     # via
     #   -r requirements.txt
     #   notifications-python-client
-eventlet==0.39.1
+eventlet==0.40.0
     # via
     #   -r requirements.txt
     #   gunicorn
@@ -147,7 +143,7 @@ govuk-bank-holidays==0.15
     # via
     #   -r requirements.txt
     #   notifications-utils
-greenlet==3.2.2
+greenlet==3.2.3
     # via
     #   -r requirements.txt
     #   eventlet


### PR DESCRIPTION
This PR is part of the spike investigating a possible upgrade from python 3.11 to python 3.13 as described in [this](https://trello.com/c/5Q3MAJVP/) card