### PR TITLE
Reports marked as deleted should return a not found (404) error

### DIFF
--- a/app/dao/report_requests_dao.py
+++ b/app/dao/report_requests_dao.py
@@ -4,7 +4,12 @@ from uuid import UUID
 from sqlalchemy import and_, or_
 
 from app import db
-from app.constants import REPORT_REQUEST_IN_PROGRESS, REPORT_REQUEST_NOTIFICATIONS, REPORT_REQUEST_PENDING
+from app.constants import (
+    REPORT_REQUEST_DELETED,
+    REPORT_REQUEST_IN_PROGRESS,
+    REPORT_REQUEST_NOTIFICATIONS,
+    REPORT_REQUEST_PENDING,
+)
 from app.dao.dao_utils import autocommit
 from app.models import ReportRequest
 
@@ -17,6 +22,14 @@ def dao_create_report_request(report_request: ReportRequest):
 
 def dao_get_report_request_by_id(service_id: UUID, report_id: UUID) -> ReportRequest:
     return ReportRequest.query.filter_by(service_id=service_id, id=report_id).one()
+
+
+def dao_get_active_report_request_by_id(service_id: UUID, report_id: UUID) -> ReportRequest | None:
+    return ReportRequest.query.filter(
+        ReportRequest.service_id == service_id,
+        ReportRequest.id == report_id,
+        ReportRequest.status != REPORT_REQUEST_DELETED,
+    ).first()
 
 
 def dao_get_oldest_ongoing_report_request(

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -47,8 +47,8 @@ from app.dao.fact_notification_status_dao import (
 from app.dao.organisation_dao import dao_get_organisation_by_service_id
 from app.dao.report_requests_dao import (
     dao_create_report_request,
+    dao_get_active_report_request_by_id,
     dao_get_oldest_ongoing_report_request,
-    dao_get_report_request_by_id,
 )
 from app.dao.returned_letters_dao import (
     fetch_most_recent_returned_letter,
@@ -1525,7 +1525,11 @@ def _fetch_returned_letter_data(service_id, report_date):
 
 @service_blueprint.route("/<uuid:service_id>/report-request/<uuid:request_id>", methods=["GET"])
 def get_report_request_by_id(service_id, request_id):
-    request = dao_get_report_request_by_id(service_id, request_id)
+    request = dao_get_active_report_request_by_id(service_id, request_id)
+
+    if not request:
+        raise InvalidRequest(f"Report request {request_id} not found for service {service_id}", status_code=404)
+
     return jsonify(data=request.serialize())
 
 


### PR DESCRIPTION
Users should not be able to access status reports that have been deleted by the admin. The report’s CSV file is deleted from S3 after one day, and a scheduled job marks the report as ‘deleted’ so the data can still be used for investigation. The admin handles 404 errors, so until the row is removed from the database, users should see a report unavailable message in the admin panel. More info on this [card](https://trello.com/c/qsDngRr6/1349-daily-job-to-update-s3-files-as-deleted-phase-1b).