### PR TITLE
Set the status of outdated report requests to deleted

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -40,6 +40,7 @@ from app.dao.notifications_dao import (
     get_service_ids_with_notifications_before,
     move_notifications_to_notification_history,
 )
+from app.dao.report_requests_dao import update_report_requests_status_to_deleted
 from app.dao.service_data_retention_dao import (
     fetch_service_data_retention_for_all_services_by_notification_type,
 )
@@ -394,3 +395,14 @@ def delete_unneeded_notification_history_for_specific_hour(start_datetime: str, 
     )
 
     delete_notification_history_between_two_datetimes(start_datetime, end_datetime)
+
+
+@notify_celery.task(name="update-report-status-to-deleted")
+@cronitor("update-report-status-to-deleted")
+def update_report_status_to_deleted():
+    try:
+        update_report_requests_status_to_deleted()
+        current_app.logger.info("Successfully updated report status to deleted.")
+    except SQLAlchemyError as e:
+        current_app.logger.error("Failed to update report status to deleted: %s", str(e))
+        raise

--- a/app/config.py
+++ b/app/config.py
@@ -343,6 +343,11 @@ class Config:
                 "schedule": crontab(hour=2, minute=0),
                 "options": {"queue": QueueNames.PERIODIC},
             },
+            "update-report-status-to-deleted": {
+                "task": "update-report-status-to-deleted",
+                "schedule": crontab(hour=2, minute=00),
+                "options": {"queue": QueueNames.PERIODIC},
+            },
             "remove_sms_email_jobs": {
                 "task": "remove_sms_email_jobs",
                 "schedule": crontab(hour=4, minute=0),

--- a/app/dao/report_requests_dao.py
+++ b/app/dao/report_requests_dao.py
@@ -76,3 +76,16 @@ def dao_get_oldest_ongoing_report_request(
 def dao_update_report_request(report_request: ReportRequest) -> ReportRequest:
     db.session.add(report_request)
     return report_request
+
+
+def update_report_requests_status_to_deleted():
+    day_1 = datetime.utcnow() - timedelta(days=1)
+    day_5 = datetime.utcnow() - timedelta(days=5)
+
+    ReportRequest.query.filter(
+        ReportRequest.status != REPORT_REQUEST_DELETED,
+        ReportRequest.created_at < day_1,
+        ReportRequest.created_at >= day_5,
+    ).update({"status": REPORT_REQUEST_DELETED, "updated_at": datetime.utcnow()}, synchronize_session=False)
+
+    db.session.commit()

--- a/app/dao/report_requests_dao.py
+++ b/app/dao/report_requests_dao.py
@@ -4,7 +4,12 @@ from uuid import UUID
 from sqlalchemy import and_, or_
 
 from app import db
-from app.constants import REPORT_REQUEST_IN_PROGRESS, REPORT_REQUEST_NOTIFICATIONS, REPORT_REQUEST_PENDING
+from app.constants import (
+    REPORT_REQUEST_DELETED,
+    REPORT_REQUEST_IN_PROGRESS,
+    REPORT_REQUEST_NOTIFICATIONS,
+    REPORT_REQUEST_PENDING,
+)
 from app.dao.dao_utils import autocommit
 from app.models import ReportRequest
 
@@ -17,6 +22,14 @@ def dao_create_report_request(report_request: ReportRequest):
 
 def dao_get_report_request_by_id(service_id: UUID, report_id: UUID) -> ReportRequest:
     return ReportRequest.query.filter_by(service_id=service_id, id=report_id).one()
+
+
+def dao_get_active_report_request_by_id(service_id: UUID, report_id: UUID) -> ReportRequest:
+    return ReportRequest.query.filter(
+        ReportRequest.service_id == service_id,
+        ReportRequest.id == report_id,
+        ReportRequest.status != REPORT_REQUEST_DELETED,
+    ).one()
 
 
 def dao_get_oldest_ongoing_report_request(

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -47,8 +47,8 @@ from app.dao.fact_notification_status_dao import (
 from app.dao.organisation_dao import dao_get_organisation_by_service_id
 from app.dao.report_requests_dao import (
     dao_create_report_request,
+    dao_get_active_report_request_by_id,
     dao_get_oldest_ongoing_report_request,
-    dao_get_report_request_by_id,
 )
 from app.dao.returned_letters_dao import (
     fetch_most_recent_returned_letter,
@@ -1525,7 +1525,7 @@ def _fetch_returned_letter_data(service_id, report_date):
 
 @service_blueprint.route("/<uuid:service_id>/report-request/<uuid:request_id>", methods=["GET"])
 def get_report_request_by_id(service_id, request_id):
-    request = dao_get_report_request_by_id(service_id, request_id)
+    request = dao_get_active_report_request_by_id(service_id, request_id)
     return jsonify(data=request.serialize())
 
 

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -31,6 +31,7 @@ from app.celery.nightly_tasks import (
     s3,
     save_daily_notification_processing_time,
     timeout_notifications,
+    update_report_status_to_deleted,
 )
 from app.constants import EMAIL_TYPE, LETTER_TYPE, SMS_TYPE
 from app.models import FactProcessingTime, UnsubscribeRequest, UnsubscribeRequestHistory, UnsubscribeRequestReport
@@ -755,3 +756,11 @@ def test_delete_test_notifications_for_service_and_type_stops_if_nothing_deleted
 
     mock_delete.assert_called_once_with(notification_type, service_id, datetime_to_delete_before)
     assert not mock_task_call.called
+
+
+def test_delete_unneeded_notification_history_for_specific_hour2(mocker):
+    delete_mock = mocker.patch("app.celery.nightly_tasks.update_report_requests_status_to_deleted")
+
+    update_report_status_to_deleted()
+
+    delete_mock.assert_called_once_with()

--- a/tests/app/dao/test_report_requests_dao.py
+++ b/tests/app/dao/test_report_requests_dao.py
@@ -2,8 +2,10 @@ from datetime import datetime, timedelta
 
 import pytest
 from flask import current_app
+from sqlalchemy.orm.exc import NoResultFound
 
 from app.constants import (
+    REPORT_REQUEST_DELETED,
     REPORT_REQUEST_FAILED,
     REPORT_REQUEST_IN_PROGRESS,
     REPORT_REQUEST_NOTIFICATIONS,
@@ -11,6 +13,7 @@ from app.constants import (
 )
 from app.dao.report_requests_dao import (
     dao_create_report_request,
+    dao_get_active_report_request_by_id,
     dao_get_oldest_ongoing_report_request,
     dao_get_report_request_by_id,
     dao_update_report_request,
@@ -344,3 +347,44 @@ def test_dao_update_report_request(sample_service, sample_user):
 
     assert report_request.status == REPORT_REQUEST_IN_PROGRESS
     assert report_request.updated_at
+
+
+def test_dao_get_active_report_request_by_id_when_deleted_report(sample_service, sample_user):
+    sample_parameter = {"notification_status": "sending"}
+
+    report_request = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=REPORT_REQUEST_DELETED,
+        parameter=sample_parameter,
+    )
+
+    dao_create_report_request(report_request)
+
+    with pytest.raises(NoResultFound) as e:
+        dao_get_active_report_request_by_id(sample_service.id, report_request.id)
+
+    assert "No row was found when one was required" in str(e.value)
+
+
+def test_dao_get_active_report_request_by_id_when_active_report(sample_service, sample_user):
+    sample_parameter = {"notification_status": "sending"}
+
+    report_request = ReportRequest(
+        user_id=sample_user.id,
+        service_id=sample_service.id,
+        report_type=REPORT_REQUEST_NOTIFICATIONS,
+        status=REPORT_REQUEST_IN_PROGRESS,
+        parameter=sample_parameter,
+    )
+
+    dao_create_report_request(report_request)
+    report = dao_get_report_request_by_id(sample_service.id, report_request.id)
+
+    assert report.id == report_request.id
+    assert report.service_id == sample_service.id
+    assert report.user_id == sample_user.id
+    assert report.report_type == REPORT_REQUEST_NOTIFICATIONS
+    assert report.status == REPORT_REQUEST_IN_PROGRESS
+    assert report.parameter == sample_parameter


### PR DESCRIPTION
Generated report request files are stored in an S3 bucket with a 1-day lifecycle policy. After the files are deleted from S3, the related database entries become redundant, so we mark them as 'deleted'. We keep these deleted report requests for a while to support stats or investigations. More info on this [card](https://trello.com/c/qsDngRr6/1349-daily-job-to-update-s3-files-as-deleted-phase-1b).

First need to merge https://github.com/alphagov/notifications-api/pull/4506
