### PR TITLE
Allow fixture incoming sms number to be overridden by environment variable

### DIFF
--- a/app/functional_tests_fixtures/__init__.py
+++ b/app/functional_tests_fixtures/__init__.py
@@ -99,6 +99,7 @@ def apply_fixtures():
     govuk_service_id = current_app.config["NOTIFY_SERVICE_ID"]
 
     org_name = os.getenv("FUNCTIONAL_TEST_ORGANISATION_NAME", "Functional Tests Org")
+    incoming_number = os.getenv("FUNCTIONAL_TEST_INBOUND_NUMBER", "07700900500")
 
     env_var_dict = _create_db_objects(
         functional_test_password,
@@ -111,6 +112,7 @@ def apply_fixtures():
         function_tests_test_key_name,
         govuk_service_id,
         org_name,
+        incoming_number,
     )
 
     functional_test_config = "\n".join(f"export {k}='{v}'" for k, v in env_var_dict.items())
@@ -147,6 +149,7 @@ def _create_db_objects(
     function_tests_test_key_name,
     govuk_service_id,
     org_name,
+    incoming_number,
 ) -> dict[str, str]:
     current_app.logger.info("Creating functional test fixtures for %s:", environment)
 
@@ -189,7 +192,7 @@ def _create_db_objects(
     api_key_test_key = _create_api_key(function_tests_test_key_name, service.id, service_admin_user.id, "test")
 
     current_app.logger.info("--> Ensure inbound number exists")
-    inbound_number_id = _create_inbound_numbers(service.id, service_admin_user.id)
+    inbound_number_id = _create_inbound_numbers(service.id, service_admin_user.id, incoming_number)
 
     current_app.logger.info("--> Ensure service letter contact exists")
     letter_contact = _create_service_letter_contact(
@@ -281,7 +284,7 @@ def _create_db_objects(
     _create_service_permissions(service.id)
 
     current_app.logger.info("--> Ensure service sms senders exists")
-    _create_service_sms_senders(service.id, "07700900500", True, inbound_number_id)
+    _create_service_sms_senders(service.id, incoming_number, True, inbound_number_id)
     sms_sender = _create_service_sms_senders(service.id, "func tests", False, None)
 
     current_app.logger.info("--> Ensure service inbound api exists")
@@ -315,7 +318,7 @@ def _create_db_objects(
         "FUNCTIONAL_TESTS_SERVICE_EMAIL_REPLY_TO_3": f"{test_email_username}+{environment}-reply-to+3@{email_domain}",
         "FUNCTIONAL_TESTS_SERVICE_EMAIL_REPLY_TO_ID": email_reply_to.id,
         "FUNCTIONAL_TESTS_SERVICE_SMS_SENDER_ID": sms_sender.id,
-        "FUNCTIONAL_TESTS_SERVICE_INBOUND_NUMBER": "07700900500",
+        "FUNCTIONAL_TESTS_SERVICE_INBOUND_NUMBER": incoming_number,
         "FUNCTIONAL_TEST_SMS_TEMPLATE_ID": sms_template.id,
         "FUNCTIONAL_TEST_EMAIL_TEMPLATE_ID": email_template.id,
         "FUNCTIONAL_TEST_LETTER_TEMPLATE_ID": letter_template.id,
@@ -324,7 +327,7 @@ def _create_db_objects(
         "REQUEST_BIN_API_TOKEN": request_bin_api_token,
         # API client integration test environment variables
         "SERVICE_ID": service.id,
-        "FUNCTIONAL_TEST_NUMBER": "07700900500",
+        "FUNCTIONAL_TEST_NUMBER": incoming_number,
         "EMAIL_TEMPLATE_ID": api_client_integration_test_email_template.id,
         "SMS_TEMPLATE_ID": api_client_integration_test_sms_template.id,
         "LETTER_TEMPLATE_ID": api_client_integration_test_letter_template.id,

--- a/tests/app/functional_test_fixtures/test_functional_test_fixtures.py
+++ b/tests/app/functional_test_fixtures/test_functional_test_fixtures.py
@@ -44,6 +44,7 @@ def test_create_db_objects_sets_db_up(notify_api, notify_service):
                 function_tests_test_key_name,
                 govuk_service_id,
                 "Functional Tests Org",
+                "07700900500",
             )
 
     assert variables["FUNCTIONAL_TESTS_API_HOST"] == "http://localhost:6011"


### PR DESCRIPTION
https://trello.com/c/aFz24oI9/1157-make-smoke-tests-run-with-fixtures

What
----

Allow fixture incoming sms number to be overridden by environment variable

Why
----

This will allow the fixtures work with provider tests where an incoming number has been setup for an environment.