### PR TITLE
Add job_id index to notification_history

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0505_n_history_api_key_index
+0506_n_history_job_id_index

--- a/migrations/versions/0506_n_history_job_id_index.py
+++ b/migrations/versions/0506_n_history_job_id_index.py
@@ -1,0 +1,22 @@
+"""
+Create Date: 2025-07-04 09:28:38.029592
+"""
+
+from alembic import op
+
+revision = '0506_n_history_job_id_index'
+down_revision = '0505_n_history_api_key_index'
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_notification_history_job_id on notification_history (job_id)"
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_notification_history_job_id"
+        )


### PR DESCRIPTION
This is a temporary change to allow us to delete the old emergency alerts data. The `job_id` foreign key constraint on the `notification_history` table means that when attempting to delete the jobs, Postgres also needs to check the `notification_history` table which is taking too long without an index.

It was not possible to send a broadcast as a job, but there are still broadcast services in the database which have rows in the `jobs` table because in some cases, we converted an existing "normal" service to a broadcast service.