### PR TITLE
Add service_id index to notification_history 

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0506_n_history_job_id_index
+0507_n_history_service_id_index

--- a/migrations/versions/0506_n_history_job_id_index.py
+++ b/migrations/versions/0506_n_history_job_id_index.py
@@ -7,6 +7,7 @@ from alembic import op
 revision = '0506_n_history_job_id_index'
 down_revision = '0505_n_history_api_key_index'
 
+# NOTE: This migration was a no-op, since the index already existed
 
 def upgrade():
     with op.get_context().autocommit_block():
@@ -16,7 +17,4 @@ def upgrade():
 
 
 def downgrade():
-    with op.get_context().autocommit_block():
-        op.execute(
-            "DROP INDEX CONCURRENTLY IF EXISTS ix_notification_history_job_id"
-        )
+    pass

--- a/migrations/versions/0507_n_history_service_id_index.py
+++ b/migrations/versions/0507_n_history_service_id_index.py
@@ -1,0 +1,22 @@
+"""
+Create Date: 2025-07-07 08:26:08.720911
+"""
+
+from alembic import op
+
+revision = '0507_n_history_service_id_index'
+down_revision = '0506_n_history_job_id_index'
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_notification_history_service_id on notification_history (service_id)"
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_notification_history_service_id"
+        )


### PR DESCRIPTION
This is a temporary change to allow us to delete the old emergency alerts data.
The service_id foreign key constraint on the notification_history table means
that when attempting to delete the services, Postgres also needs to check the
notification_history table which is taking too long without an index.