### PR TITLE
Add composite template index on notification history

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0507_n_history_service_id_index
+0508_n_history_templates_index

--- a/migrations/versions/0508_n_history_templates_index.py
+++ b/migrations/versions/0508_n_history_templates_index.py
@@ -1,0 +1,22 @@
+"""
+Create Date: 2025-07-07 11:03:04.356066
+"""
+
+from alembic import op
+
+revision = '0508_n_history_templates_index'
+down_revision = '0507_n_history_service_id_index'
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_notification_history_template_composite on notification_history (template_id, template_version)"
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_notification_history_template_composite"
+        )


### PR DESCRIPTION
This is a temporary change to allow us to delete the old emergency alerts data. The `notification_history` table has this foreign key constraint, which makes trying to delete the template history for emergency alerts too slow to be feasible:
```sql
"notification_history_templates_history_fkey" FOREIGN KEY (template_id, template_version) REFERENCES templates_history(id, version)
```

This commit adds a composite index which matches the foreign key constraint.

---

After this PR, there should be enough indexes in place on the `notification_history` table to allow the emergency alerts data to be deleted both from that table and from the tables which have a foreign key constraint on it.

```sql
Indexes:
    "notification_history_pkey" PRIMARY KEY, btree (id)
    "ix_notification_history_api_key_id" btree (api_key_id)
    "ix_notification_history_created_at" btree (created_at)
    "ix_notification_history_job_id" btree (job_id)
    "ix_notification_history_reference" btree (reference)
    "ix_notification_history_service_id" btree (service_id)
    "ix_notification_history_service_id_composite" btree (service_id, key_type, notification_type, created_at)
    "ix_notification_history_template_composite" btree (template_id, template_version)
Foreign-key constraints:
    "fk_notification_history_notification_status" FOREIGN KEY (notification_status) REFERENCES notification_status_types(name)
    "notification_history_api_key_id_fkey" FOREIGN KEY (api_key_id) REFERENCES api_keys(id)
    "notification_history_job_id_fkey" FOREIGN KEY (job_id) REFERENCES jobs(id)
    "notification_history_key_type_fkey" FOREIGN KEY (key_type) REFERENCES key_types(name)
    "notification_history_service_id_fkey" FOREIGN KEY (service_id) REFERENCES services(id)
    "notification_history_templates_history_fkey" FOREIGN KEY (template_id, template_version) REFERENCES templates_history(id, version)
```