### PR TITLE
Cache template version in memory more aggressively

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -257,7 +257,7 @@ def save_sms(
 ):
     notification = signing.decode(encoded_notification)
     service = SerialisedService.from_id(service_id)
-    template = SerialisedTemplate.from_id_and_service_id(
+    template = SerialisedTemplate.from_id_service_id_and_version(
         notification["template"],
         service_id=service.id,
         version=notification["template_version"],
@@ -343,7 +343,7 @@ def save_email(self, service_id, notification_id, encoded_notification, sender_i
     notification = signing.decode(encoded_notification)
 
     service = SerialisedService.from_id(service_id)
-    template = SerialisedTemplate.from_id_and_service_id(
+    template = SerialisedTemplate.from_id_service_id_and_version(
         notification["template"],
         service_id=service.id,
         version=notification["template_version"],
@@ -403,7 +403,7 @@ def save_letter(
     postal_address = PostalAddress.from_personalisation(InsensitiveDict(notification["personalisation"]))
 
     service = SerialisedService.from_id(service_id)
-    template = SerialisedTemplate.from_id_and_service_id(
+    template = SerialisedTemplate.from_id_service_id_and_version(
         notification["template"],
         service_id=service.id,
         version=notification["template_version"],

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -50,7 +50,7 @@ def send_sms_to_provider(notification):
     if notification.status == "created":
         provider = provider_to_use(SMS_TYPE, notification.international)
 
-        template_model = SerialisedTemplate.from_id_and_service_id(
+        template_model = SerialisedTemplate.from_id_service_id_and_version(
             template_id=notification.template_id, service_id=service.id, version=notification.template_version
         )
 
@@ -129,7 +129,7 @@ def send_email_to_provider(notification):
     if notification.status == "created":
         provider = provider_to_use(EMAIL_TYPE)
 
-        template = SerialisedTemplate.from_id_and_service_id(
+        template = SerialisedTemplate.from_id_service_id_and_version(
             template_id=notification.template_id, service_id=service.id, version=notification.template_version
         )
 

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -25,6 +25,8 @@ def memory_cache(*args, ttl=2):
             key=ignore_first_argument_cache_key,
         )
         def wrapper(*args, **kwargs):
+            if not isinstance(getattr(args[0], "__dict__", {}).get(func.__name__), classmethod):
+                raise TypeError("memory_cache can only be used on classmethods")
             return func(*args, **kwargs)
 
         return wrapper

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -13,6 +13,7 @@ from werkzeug.utils import cached_property
 from app import db, redis_store
 from app.dao.api_key_dao import get_model_api_keys
 from app.dao.services_dao import dao_fetch_service_by_id
+from app.utils import is_classmethod
 
 redis_cache = RequestCache(redis_store)
 
@@ -25,7 +26,7 @@ def memory_cache(*args, ttl=2):
             key=ignore_first_argument_cache_key,
         )
         def wrapper(*args, **kwargs):
-            if not isinstance(getattr(args[0], "__dict__", {}).get(func.__name__), classmethod):
+            if not is_classmethod(func, args[0]):
                 raise TypeError("memory_cache can only be used on classmethods")
             return func(*args, **kwargs)
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 from datetime import datetime, timedelta
 from itertools import islice
 from urllib.parse import urljoin
@@ -190,3 +191,9 @@ def parse_and_format_phone_number(number: str, with_country_code=True) -> str:
 def get_international_phone_info(number: str):
     phone_number = PhoneNumber(number)
     return phone_number.get_international_phone_info()
+
+
+def is_classmethod(method, cls):
+    with suppress(AttributeError, KeyError):
+        return isinstance(cls.__dict__[method.__name__], classmethod)
+    return False

--- a/tests/app/test_serialised_models.py
+++ b/tests/app/test_serialised_models.py
@@ -11,6 +11,7 @@ EXPECTED_TEMPLATE_ATTRIBUTES = {
     "coerce_value_to_type",
     "content",
     "from_id_and_service_id",
+    "from_id_service_id_and_version",
     "get_dict",
     "has_unsubscribe_link",
     "id",
@@ -83,7 +84,7 @@ def test_template_version_caches_in_redis_with_correct_keys(
 
     sample_template = create_template(service=sample_service)
 
-    template = SerialisedTemplate.from_id_and_service_id(sample_template.id, sample_service.id, version=1)
+    template = SerialisedTemplate.from_id_service_id_and_version(sample_template.id, sample_service.id, version=1)
 
     mock_redis_set.assert_called_once_with(
         f"service-{sample_service.id}-template-{sample_template.id}-version-1",


### PR DESCRIPTION
Inspired by [recent template preview changes](https://github.com/alphagov/notifications-template-preview/pull/896).

A given version of a template will never change (changes to a template always create a new version).

So we can cache it in memory for longer because the cache will never become stale.

Going from 2 to 30 seconds here as it is:
- an order of magnitude bigger so should be a big performance increase (more chance of a cache hit)
- not wildy big that it might cause memory problems
- not wildly long that it might somehow cause timeouts/shutdown problems