### PR TITLE
Allow X-Forwarded-For overrides for the incoming ip address

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.8.0
+# This file was automatically copied from notifications-utils@100.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -33,6 +33,7 @@ from notifications_utils.logging import flask as utils_logging
 from sqlalchemy import event
 from werkzeug.exceptions import HTTPException as WerkzeugHTTPException
 from werkzeug.local import LocalProxy
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from app.clients import NotificationProviderClients
 from app.clients.cbc_proxy import CBCProxyClient
@@ -401,6 +402,9 @@ def register_v2_blueprints(application):
 
 
 def init_app(app):
+    # Configure ProxyFix middleware to handle X-Forwarded-For headers
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=0, x_port=0, x_prefix=0)
+
     @app.before_request
     def record_request_details():
         CONCURRENT_REQUESTS.inc()

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil>=6.0.0,<7.0.0
 notifications-python-client==10.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.8.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@bfc6372b5fea95e6439d67b351522391c8802339
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -150,7 +150,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a97b36f6a32e7bb917152c8cd716fe65fa15ac9f
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@bfc6372b5fea95e6439d67b351522391c8802339
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -181,11 +181,12 @@ pyjwt==2.10.1
     #   notifications-python-client
 pypdf==3.17.0
     # via notifications-utils
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   arrow
     #   botocore
     #   celery
+    #   notifications-utils
 python-json-logger==3.3.0
     # via notifications-utils
 pytz==2024.2

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -220,7 +220,7 @@ moto==5.0.11
     # via -r requirements_for_test.in
 notifications-python-client==10.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a97b36f6a32e7bb917152c8cd716fe65fa15ac9f
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@bfc6372b5fea95e6439d67b351522391c8802339
     # via -r requirements.txt
 ordered-set==4.1.0
     # via
@@ -280,7 +280,7 @@ pytest-testmon==2.1.1
     # via -r requirements_for_test_common.in
 pytest-xdist==3.6.1
     # via -r requirements_for_test_common.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements.txt
     #   arrow
@@ -288,6 +288,7 @@ python-dateutil==2.8.2
     #   celery
     #   freezegun
     #   moto
+    #   notifications-utils
 python-json-logger==3.3.0
     # via
     #   -r requirements.txt

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.8.0
+# This file was automatically copied from notifications-utils@100.0.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.8.0
+# This file was automatically copied from notifications-utils@100.0.0
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
https://trello.com/c/CjPJrFAk/1160-notifications-api-recording-all-remoteaddr-as-internal-ips

What
----

Allow X-Forwarded-For overrides for the incoming ip address

Why
----

This should show the X-Forwarded-For ips in our logs.