### PR TITLE
Change timing of daily check for letters pending virus scan

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -373,9 +373,9 @@ class Config:
             },
             "check-if-letters-still-pending-virus-check-nightly": {
                 "task": "check-if-letters-still-pending-virus-check",
-                "schedule": crontab(hour=20, minute=0),
-                # check back two entire days, once per day, just in case things slipped through the net somehow
-                "kwargs": {"max_minutes_ago_to_check": 60 * 24 * 2},
+                "schedule": crontab(hour=16, minute=0),
+                # check back three entire days, once per day, just in case things slipped through the net somehow
+                "kwargs": {"max_minutes_ago_to_check": 60 * 24 * 3},
                 "options": {"queue": QueueNames.PERIODIC},
             },
             "check-for-services-with-high-failure-rates-or-sending-to-tv-numbers": {


### PR DESCRIPTION
This was taking place at 2000 UTC, meaning that if any letters were found to still be pending virus check it was too late for them to make the evening's print run (which has a cut of time of 1730 local time).

Moving the check earlier means that any letters this task picks up should be able to make the print run for the day. I've also extended the number of days we check by one, since we did see once case where this number of attempts wasn't long enough.