### PR TITLE
Use `TemplateHistorySchema` to serialise template versions

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -441,7 +441,7 @@ class TemplateSchemaNoDetail(TemplateSchema):
         exclude = []
 
 
-class TemplateHistorySchema(BaseSchema):
+class TemplateHistorySchema(BaseSchema, UUIDsAsStringsMixin):
     reply_to = fields.Method("get_reply_to", allow_none=True)
     reply_to_text = fields.Method("get_reply_to_text", allow_none=True)
     process_type = field_for(models.Template, "process_type")

--- a/app/serialised_models.py
+++ b/app/serialised_models.py
@@ -58,7 +58,7 @@ class SerialisedTemplate(SerialisedModel):
     @redis_cache.set("service-{service_id}-template-{template_id}-version-{version}")
     def get_dict(template_id, service_id, version):
         from app.dao import templates_dao
-        from app.schemas import template_schema
+        from app.schemas import template_history_schema, template_schema
 
         fetched_template = templates_dao.dao_get_template_by_id_and_service_id(
             template_id=template_id,
@@ -66,7 +66,11 @@ class SerialisedTemplate(SerialisedModel):
             version=version,
         )
 
-        template_dict = template_schema.dump(fetched_template)
+        if version:
+            template_dict = template_history_schema.dump(fetched_template)
+        else:
+            template_dict = template_schema.dump(fetched_template)
+
         db.session.commit()
 
         return {"data": template_dict}

--- a/tests/app/test_serialised_models.py
+++ b/tests/app/test_serialised_models.py
@@ -1,0 +1,130 @@
+import json
+from unittest.mock import ANY
+
+from freezegun import freeze_time
+
+from app.serialised_models import SerialisedTemplate
+from tests.app.db import create_template
+
+EXPECTED_TEMPLATE_ATTRIBUTES = {
+    "archived",
+    "coerce_value_to_type",
+    "content",
+    "from_id_and_service_id",
+    "get_dict",
+    "has_unsubscribe_link",
+    "id",
+    "postage",
+    "process_type",
+    "reply_to_text",
+    "subject",
+    "template_type",
+    "version",
+}
+
+
+@freeze_time("2025-08-06 01:02:03")
+def test_template_caches_in_redis_with_correct_keys(
+    admin_request,
+    sample_service,
+    mocker,
+):
+    mock_redis_set = mocker.patch("app.serialised_models.redis_cache.redis_client.set")
+
+    sample_template = create_template(service=sample_service)
+
+    template = SerialisedTemplate.from_id_and_service_id(sample_template.id, sample_service.id)
+
+    mock_redis_set.assert_called_once_with(
+        f"service-{sample_service.id}-template-{sample_template.id}-version-None",
+        ANY,
+        ex=2419200,
+    )
+
+    assert json.loads(mock_redis_set.call_args_list[0][0][1]) == {
+        "data": {
+            "archived": False,
+            "content": "Dear Sir/Madam, Hello. Yours Truly, The Government.",
+            "created_at": "2025-08-06T01:02:03.000000Z",
+            "created_by": str(sample_template.created_by.id),
+            "folder": None,
+            "has_unsubscribe_link": False,
+            "hidden": False,
+            "id": str(sample_template.id),
+            "is_precompiled_letter": False,
+            "letter_attachment": None,
+            "letter_languages": None,
+            "letter_welsh_content": None,
+            "letter_welsh_subject": None,
+            "name": "sms Template Name",
+            "postage": None,
+            "process_type": "normal",
+            "redact_personalisation": False,
+            "reply_to_text": "testing",
+            "reply_to": None,
+            "service_letter_contact": None,
+            "service": str(sample_service.id),
+            "subject": None,
+            "template_redacted": ANY,
+            "template_type": "sms",
+            "updated_at": None,
+            "version": 1,
+        }
+    }
+
+    assert {attr for attr in dir(template) if not attr.startswith("_")} == EXPECTED_TEMPLATE_ATTRIBUTES
+
+
+@freeze_time("2025-08-06 01:02:03")
+def test_template_version_caches_in_redis_with_correct_keys(
+    admin_request,
+    sample_service,
+    mocker,
+):
+    mock_redis_set = mocker.patch("app.serialised_models.redis_cache.redis_client.set")
+
+    sample_template = create_template(service=sample_service)
+
+    template = SerialisedTemplate.from_id_and_service_id(sample_template.id, sample_service.id, version=1)
+
+    mock_redis_set.assert_called_once_with(
+        f"service-{sample_service.id}-template-{sample_template.id}-version-1",
+        ANY,
+        ex=2419200,
+    )
+
+    assert json.loads(mock_redis_set.call_args_list[0][0][1]) == {
+        "data": {
+            "archived": False,
+            "content": "Dear Sir/Madam, Hello. Yours Truly, The Government.",
+            "created_at": "2025-08-06 01:02:03.000000",
+            "created_by": {
+                "id": str(sample_template.created_by.id),
+                "email_address": "notify@digital.cabinet-office.gov.uk",
+                "name": "Test User",
+            },
+            "has_unsubscribe_link": False,
+            "hidden": False,
+            "id": str(sample_template.id),
+            "is_precompiled_letter": False,
+            "letter_attachment": None,
+            "letter_languages": None,
+            "letter_welsh_content": None,
+            "letter_welsh_subject": None,
+            "name": "sms Template Name",
+            "postage": None,
+            "process_type": "normal",
+            "reply_to_text": "testing",
+            "reply_to": None,
+            "service_letter_contact": None,
+            "service": str(sample_service.id),
+            "subject": None,
+            "template_redacted": ANY,
+            "template_type": "sms",
+            "unsubscribe_requests": [],
+            "updated_at": None,
+            "version": 1,
+        }
+    }
+
+    assert {attr for attr in dir(template) if not attr.startswith("_")} == EXPECTED_TEMPLATE_ATTRIBUTES


### PR DESCRIPTION
 ## Admin app

Gets a serialised template version from here:
https://github.com/alphagov/notifications-api/blob/12b0aebfca0d2a1506cb208c12a58022b52c9c40/app/template/rest.py#L206-L208

Caches this in Redis here:
https://github.com/alphagov/notifications-admin/blob/cdd2286251446a04d2ae885cfc0da79acc39cb9e/app/notify_client/service_api_client.py#L256

 ## API

Gets serialised template version from here:
https://github.com/alphagov/notifications-api/blob/12b0aebfca0d2a1506cb208c12a58022b52c9c40/app/serialised_models.py#L69

Caches this in Redis here (against the same key used by the admin app):
https://github.com/alphagov/notifications-api/blob/12b0aebfca0d2a1506cb208c12a58022b52c9c40/app/serialised_models.py#L58

***

The API is using:
- `TemplateHistorySchema` to serialise a template version for the admin app
- `TemplateSchema` to serialise a template version for its own use

This means that, depending on who gets there first, data will be cached in different formats against the same key.

***

This pull request makes sure that:
- the current version of a template is always serialised using `TemplateSchema`
- previous versions of a template are always serialised using `TemplateHistorySchema`

This should make no difference to the data the API is using, because `SerialisedTemplate` restricts which attributes can be accessed, and none of these attributes are the ones which differ between the two schemas.