### PR TITLE
Don’t serialise unsubscribe requests in template version response

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -466,6 +466,7 @@ class TemplateHistorySchema(BaseSchema, UUIDsAsStringsMixin):
 
     class Meta(BaseSchema.Meta):
         model = models.TemplateHistory
+        exclude = tuple(set(BaseTemplateSchema.Meta.exclude) - {"jobs"})
 
 
 class ApiKeySchema(BaseSchema):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -386,6 +386,12 @@ class BaseTemplateSchema(BaseSchema):
     reply_to_text = fields.Method("get_reply_to_text", allow_none=True)
     letter_attachment = fields.Method("get_letter_attachment", allow_none=True)
     letter_languages = fields.Method("get_letter_languages", "load_letter_languages", allow_none=True)
+    is_precompiled_letter = fields.Method("get_is_precompiled_letter")
+    process_type = field_for(models.Template, "process_type")
+    updated_at = FlexibleDateTime()
+
+    def get_is_precompiled_letter(self, template):
+        return template.is_precompiled_letter
 
     def get_reply_to(self, template):
         return template.reply_to
@@ -409,17 +415,11 @@ class BaseTemplateSchema(BaseSchema):
 
 class TemplateSchema(BaseTemplateSchema, UUIDsAsStringsMixin):
     created_by = field_for(models.Template, "created_by", required=True)
-    process_type = field_for(models.Template, "process_type")
     redact_personalisation = fields.Method("redact")
-    is_precompiled_letter = fields.Method("get_is_precompiled_letter")
     created_at = FlexibleDateTime()
-    updated_at = FlexibleDateTime()
 
     def redact(self, template):
         return template.redact_personalisation
-
-    def get_is_precompiled_letter(self, template):
-        return template.is_precompiled_letter
 
     @validates_schema
     def validate_type(self, data, **kwargs):
@@ -441,28 +441,9 @@ class TemplateSchemaNoDetail(TemplateSchema):
         exclude = []
 
 
-class TemplateHistorySchema(BaseSchema, UUIDsAsStringsMixin):
-    reply_to = fields.Method("get_reply_to", allow_none=True)
-    reply_to_text = fields.Method("get_reply_to_text", allow_none=True)
-    process_type = field_for(models.Template, "process_type")
-    is_precompiled_letter = fields.Method("get_is_precompiled_letter")
-    letter_attachment = fields.Method("get_letter_attachment", allow_none=True)
-
+class TemplateHistorySchema(BaseTemplateSchema, UUIDsAsStringsMixin):
     created_by = fields.Nested(UserSchema, only=["id", "name", "email_address"], dump_only=True)
     created_at = field_for(models.Template, "created_at", format=DATETIME_FORMAT_NO_TIMEZONE)
-    updated_at = FlexibleDateTime()
-
-    def get_reply_to(self, template):
-        return template.reply_to
-
-    def get_reply_to_text(self, template):
-        return template.get_reply_to_text()
-
-    def get_letter_attachment(self, template):
-        return template.letter_attachment.serialize() if template.letter_attachment_id else None
-
-    def get_is_precompiled_letter(self, template):
-        return template.is_precompiled_letter
 
     class Meta(BaseSchema.Meta):
         model = models.TemplateHistory

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -388,6 +388,7 @@ class BaseTemplateSchema(BaseSchema):
     letter_languages = fields.Method("get_letter_languages", "load_letter_languages", allow_none=True)
     is_precompiled_letter = fields.Method("get_is_precompiled_letter")
     process_type = field_for(models.Template, "process_type")
+    created_at = FlexibleDateTime()
     updated_at = FlexibleDateTime()
 
     def get_is_precompiled_letter(self, template):
@@ -416,7 +417,6 @@ class BaseTemplateSchema(BaseSchema):
 class TemplateSchema(BaseTemplateSchema, UUIDsAsStringsMixin):
     created_by = field_for(models.Template, "created_by", required=True)
     redact_personalisation = fields.Method("redact")
-    created_at = FlexibleDateTime()
 
     def redact(self, template):
         return template.redact_personalisation
@@ -443,7 +443,6 @@ class TemplateSchemaNoDetail(TemplateSchema):
 
 class TemplateHistorySchema(BaseTemplateSchema, UUIDsAsStringsMixin):
     created_by = fields.Nested(UserSchema, only=["id", "name", "email_address"], dump_only=True)
-    created_at = field_for(models.Template, "created_at", format=DATETIME_FORMAT_NO_TIMEZONE)
 
     class Meta(BaseSchema.Meta):
         model = models.TemplateHistory

--- a/tests/app/template/test_rest_history.py
+++ b/tests/app/template/test_rest_history.py
@@ -27,7 +27,7 @@ def test_template_history_version(notify_api, sample_user, sample_template):
             assert json_resp["data"]["process_type"] == "normal"
             assert json_resp["data"]["created_by"]["name"] == sample_user.name
             assert json_resp["data"]["is_precompiled_letter"] is False
-            assert datetime.strptime(json_resp["data"]["created_at"], "%Y-%m-%d %H:%M:%S.%f").date() == date.today()
+            assert datetime.strptime(json_resp["data"]["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ").date() == date.today()
 
 
 def test_previous_template_history_version(notify_api, sample_template):

--- a/tests/app/test_serialised_models.py
+++ b/tests/app/test_serialised_models.py
@@ -121,7 +121,6 @@ def test_template_version_caches_in_redis_with_correct_keys(
             "subject": None,
             "template_redacted": ANY,
             "template_type": "sms",
-            "unsubscribe_requests": [],
             "updated_at": None,
             "version": 1,
         }

--- a/tests/app/test_serialised_models.py
+++ b/tests/app/test_serialised_models.py
@@ -97,7 +97,7 @@ def test_template_version_caches_in_redis_with_correct_keys(
         "data": {
             "archived": False,
             "content": "Dear Sir/Madam, Hello. Yours Truly, The Government.",
-            "created_at": "2025-08-06 01:02:03.000000",
+            "created_at": "2025-08-06T01:02:03.000000Z",
             "created_by": {
                 "id": str(sample_template.created_by.id),
                 "email_address": "notify@digital.cabinet-office.gov.uk",


### PR DESCRIPTION
This could result in massive response sizes if a template gets a lot of unsubscribes.

It’s only here because Marshmallow includes everything by default, and we forgot to exclude it.

***

This PR also does some refactoring to make things like this less likely happen in the future.

***

Doesn’t affect the public API because it does its own serialisation here: https://github.com/alphagov/notifications-api/blob/31fcf69395b6e46ebac4b6852d23d96adcd2c293/app/models.py#L1132-L1151