### PR TITLE
Make template `process_type` column nullable

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0510_delete_broadcast_tables
+0511_process_type_nullable

--- a/migrations/versions/0511_process_type_nullable.py
+++ b/migrations/versions/0511_process_type_nullable.py
@@ -1,0 +1,21 @@
+"""
+Create Date: 2025-08-11 11:11:11.111111
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0511_process_type_nullable"
+down_revision = "0510_delete_broadcast_tables"
+
+
+def upgrade():
+    for table in ("templates", "templates_history"):
+        op.alter_column(table, "process_type", existing_type=sa.String(), nullable=True)
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        for table in ("templates", "templates_history"):
+            op.execute(f"UPDATE {table} set process_type = 'normal' where process_type is null")
+            op.alter_column(table, "process_type", existing_type=sa.String(), nullable=False)


### PR DESCRIPTION
We stopped using the priority queue in https://github.com/alphagov/notifications-api/pull/3711

We stopped allowing `process_type` to be set on a per-template basis in https://github.com/alphagov/notifications-admin/pull/4567

This is the first step towards removing the column entirely:
- [x] https://github.com/alphagov/notifications-api/pull/4540 👈🏻 **you are here**
- [ ] https://github.com/alphagov/notifications-api/pull/4541
- [ ] https://github.com/alphagov/notifications-api/pull/4542

***

Squak warnings:

```
/tmp/upgrade.sql:2:2: warning: ban-drop-not-null

   2 | -- Running upgrade 0510_delete_broadcast_tables -> 0511_process_type_nullable
   3 | 
   4 | ALTER TABLE templates ALTER COLUMN process_type DROP NOT NULL;

  note: Dropping a NOT NULL constraint may break existing clients.

/tmp/upgrade.sql:6:2: warning: ban-drop-not-null

   6 | ALTER TABLE templates_history ALTER COLUMN process_type DROP NOT NULL;

  note: Dropping a NOT NULL constraint may break existing clients.
```