### PR TITLE
Drop `process_type` columns and table

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0511_process_type_nullable
+0514_drop_process_type_3

--- a/migrations/versions/0512_drop_process_type_1.py
+++ b/migrations/versions/0512_drop_process_type_1.py
@@ -1,0 +1,22 @@
+"""
+Create Date: 2025-08-12 11:11:11.111111
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0512_drop_process_type_1"
+down_revision = "0511_process_type_nullable"
+
+
+def upgrade():
+    op.drop_column("templates_history", "process_type")
+
+
+def downgrade():
+    # Copied from migrations/0063_templates_process_type.py
+    op.add_column("templates_history", sa.Column("process_type", sa.String(length=255), nullable=True))
+    op.create_index(op.f("ix_templates_history_process_type"), "templates_history", ["process_type"], unique=False)
+    op.create_foreign_key(
+        "templates_history_process_type_fkey", "templates_history", "template_process_type", ["process_type"], ["name"]
+    )

--- a/migrations/versions/0513_drop_process_type_2.py
+++ b/migrations/versions/0513_drop_process_type_2.py
@@ -1,0 +1,22 @@
+"""
+Create Date: 2025-08-12 11:11:11.111111
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0513_drop_process_type_2"
+down_revision = "0512_drop_process_type_1"
+
+
+def upgrade():
+    op.drop_column("templates", "process_type")
+
+
+def downgrade():
+    # Copied from migrations/0063_templates_process_type.py
+    op.add_column("templates", sa.Column("process_type", sa.String(length=255), nullable=True))
+    op.create_index(op.f("ix_templates_process_type"), "templates", ["process_type"], unique=False)
+    op.create_foreign_key(
+        "templates_process_type_fkey", "templates", "template_process_type", ["process_type"], ["name"]
+    )

--- a/migrations/versions/0514_drop_process_type_3.py
+++ b/migrations/versions/0514_drop_process_type_3.py
@@ -1,0 +1,23 @@
+"""
+Create Date: 2025-08-12 11:11:11.111111
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0514_drop_process_type_3"
+down_revision = "0513_drop_process_type_2"
+
+
+def upgrade():
+    op.drop_table("template_process_type")
+
+
+def downgrade():
+    # Copied from migrations/0063_templates_process_type.py
+    op.create_table(
+        "template_process_type",
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.PrimaryKeyConstraint("name"),
+    )
+    op.execute("INSERT INTO template_process_type VALUES ('normal'), ('priority')")


### PR DESCRIPTION
This is the final step in removing the priority queue entirely:

- [x] https://github.com/alphagov/notifications-api/pull/3711
- [x] https://github.com/alphagov/notifications-admin/pull/4567
- [x] https://github.com/alphagov/notifications-api/pull/4540
- [x] https://github.com/alphagov/notifications-api/pull/4541 
- [ ] https://github.com/alphagov/notifications-api/pull/4542 👈🏻 **you are here**

***

Squak issues:

```
/tmp/upgrade.sql:2:2: warning: ban-drop-column

   2 | -- Running upgrade 0511_process_type_nullable -> 0512_drop_process_type
   3 | 
   4 | ALTER TABLE templates DROP COLUMN process_type;

  note: Dropping a column may break existing clients.

/tmp/upgrade.sql:6:2: warning: ban-drop-column

   6 | ALTER TABLE templates_history DROP COLUMN process_type;

  note: Dropping a column may break existing clients.

/tmp/upgrade.sql:8:2: warning: ban-drop-table

   8 | DROP TABLE template_process_type;

  note: Dropping a table may break existing clients.

find detailed examples and solutions for each rule at https://squawkhq.com/docs/rules
Found 3 issues in 1 file (checked 1 source file)
```