### PR TITLE
Remove unused `check_reply_to` function

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -237,15 +237,6 @@ def validate_template(template_id, personalisation, service, notification_type, 
     return template, template_with_content
 
 
-def check_reply_to(service_id, reply_to_id, type_):
-    if type_ == EMAIL_TYPE:
-        return check_service_email_reply_to_id(service_id, reply_to_id, type_)
-    elif type_ == SMS_TYPE:
-        return check_service_sms_sender_id(service_id, reply_to_id, type_)
-    elif type_ == LETTER_TYPE:
-        return check_service_letter_contact_id(service_id, reply_to_id, type_)
-
-
 def check_service_email_reply_to_id(service_id, reply_to_id, notification_type):
     if reply_to_id:
         try:


### PR DESCRIPTION
This was added in https://github.com/alphagov/notifications-api/pull/1500 for the internal API, as part of the work to add contact blocks for letters.

The original intention was that a default reply-to could be set on any type of template. We never went through with this and to this day only letters can have a per-template reply-to address (the contact block).

To clean things up we stopped using the generic function in https://github.com/alphagov/notifications-api/pull/4037

We still use the letter-specific function in 2 places on the internal API:
- https://github.com/alphagov/notifications-api/blob/6857eeac6fdf8f54c20f9016c30aa5a49f1b9d7d/app/template/rest.py#L106
- https://github.com/alphagov/notifications-api/blob/6857eeac6fdf8f54c20f9016c30aa5a49f1b9d7d/app/template/rest.py#L131

We only call the underlying, per-channel functions directly when sending a notification:
https://github.com/alphagov/notifications-api/blob/6857eeac6fdf8f54c20f9016c30aa5a49f1b9d7d/app/v2/notifications/post_notifications.py#L385-L407

So we can safely remove this generic function.

I’ve updated the tests so the per-channel functions still have the same coverage.