### PR TITLE
Add service permission for token bucket rate limit 

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0514_drop_process_type_3
+0515_token_bucket_permission

--- a/migrations/versions/0515_token_bucket_permission.py
+++ b/migrations/versions/0515_token_bucket_permission.py
@@ -1,0 +1,17 @@
+"""
+Create Date: 2025-08-27 00:00:00.000000
+"""
+
+from alembic import op
+
+revision = "0515_token_bucket_permission"
+down_revision = "0514_drop_process_type_3"
+
+
+def upgrade():
+    op.execute("INSERT INTO service_permission_types VALUES ('token_bucket')")
+
+
+def downgrade():
+    op.execute("DELETE FROM service_permissions WHERE permission = 'token_bucket'")
+    op.execute("DELETE FROM service_permission_types WHERE name = 'token_bucket'")


### PR DESCRIPTION
So that:
- we can test in production with our own services
- we can release the new algorithm without a code change
- we can roll back particular services if they have problems