### PR TITLE
Remove 'broadcast' from service permissions in database

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0515_token_bucket_permission
+0516_remove_broadcast_permission

--- a/migrations/versions/0516_remove_broadcast_permission.py
+++ b/migrations/versions/0516_remove_broadcast_permission.py
@@ -1,0 +1,19 @@
+"""
+Create Date: 2025-08-29 08:16:36.817900
+"""
+
+from alembic import op
+
+revision = '0516_remove_broadcast_permission'
+down_revision = '0515_token_bucket_permission'
+
+
+def upgrade():
+    # no services will have this permission (it will have been removed in previous migrations),
+    # but leaving as a precaution or in case this migration gets copied
+    op.execute("DELETE from service_permissions where permission = 'broadcast'")
+    op.execute("DELETE from service_permission_types where name = 'broadcast'")
+
+
+def downgrade():
+    op.execute("INSERT INTO service_permission_types values ('broadcast')")


### PR DESCRIPTION
The `broadcast` service permission was removed from the code in aff95d48502f9e36b98423215f322fb8bcd32017

Rows in the `service_permissions` table which had the `broadcast` permission were deleted in 70472b7b70a4d9a4133ae77c2978c736ceb5e1bf

This now removes `broadcast` as a type of service permission in the database.