### PR TITLE
Give new services the token bucket permission

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -234,6 +234,7 @@ EMAIL_AUTH = "email_auth"
 EDIT_FOLDER_PERMISSIONS = "edit_folder_permissions"
 INTERNATIONAL_LETTERS = "international_letters"
 SMS_TO_UK_LANDLINES = "sms_to_uk_landlines"
+TOKEN_BUCKET = "token_bucket"
 SERVICE_PERMISSION_TYPES = [
     EMAIL_TYPE,
     SMS_TYPE,
@@ -244,6 +245,7 @@ SERVICE_PERMISSION_TYPES = [
     EDIT_FOLDER_PERMISSIONS,
     INTERNATIONAL_LETTERS,
     SMS_TO_UK_LANDLINES,
+    TOKEN_BUCKET,
 ]
 
 # List of available permissions

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -17,6 +17,7 @@ from app.constants import (
     NON_CROWN_ORGANISATION_TYPES,
     NOTIFICATION_PERMANENT_FAILURE,
     SMS_TYPE,
+    TOKEN_BUCKET,
 )
 from app.dao.dao_utils import VersionOptions, autocommit, version_class
 from app.dao.date_util import get_current_financial_year
@@ -71,6 +72,7 @@ DEFAULT_SERVICE_PERMISSIONS = [
     LETTER_TYPE,
     INTERNATIONAL_SMS_TYPE,
     INTERNATIONAL_LETTERS,
+    TOKEN_BUCKET,
 ]
 
 

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -17,6 +17,7 @@ from app.constants import (
     KEY_TYPE_TEST,
     LETTER_TYPE,
     SMS_TYPE,
+    TOKEN_BUCKET,
 )
 from app.dao.inbound_numbers_dao import (
     dao_get_available_inbound_numbers,
@@ -536,15 +537,15 @@ def test_create_service_returns_service_with_default_permissions(notify_db_sessi
     service = dao_fetch_service_by_id(service.id)
     _assert_service_permissions(
         service.permissions,
-        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS),
+        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS, TOKEN_BUCKET),
     )
 
 
 @pytest.mark.parametrize(
     "permission_to_remove, permissions_remaining",
     [
-        (SMS_TYPE, (EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS)),
-        (EMAIL_TYPE, (SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS)),
+        (SMS_TYPE, (EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS, TOKEN_BUCKET)),
+        (EMAIL_TYPE, (SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS, TOKEN_BUCKET)),
     ],
 )
 def test_remove_permission_from_service_by_id_returns_service_with_correct_permissions(
@@ -564,6 +565,7 @@ def test_removing_all_permission_returns_service_with_no_permissions(notify_db_s
     dao_remove_service_permission(service_id=service.id, permission=LETTER_TYPE)
     dao_remove_service_permission(service_id=service.id, permission=INTERNATIONAL_SMS_TYPE)
     dao_remove_service_permission(service_id=service.id, permission=INTERNATIONAL_LETTERS)
+    dao_remove_service_permission(service_id=service.id, permission=TOKEN_BUCKET)
 
     service = dao_fetch_service_by_id(service.id)
     assert len(service.permissions) == 0
@@ -578,14 +580,14 @@ def test_create_service_by_id_adding_and_removing_letter_returns_service_without
     service = dao_fetch_service_by_id(service.id)
     _assert_service_permissions(
         service.permissions,
-        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS),
+        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS, TOKEN_BUCKET),
     )
 
     dao_remove_service_permission(service_id=service.id, permission=LETTER_TYPE)
     service = dao_fetch_service_by_id(service.id)
 
     _assert_service_permissions(
-        service.permissions, (SMS_TYPE, EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS)
+        service.permissions, (SMS_TYPE, EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS, TOKEN_BUCKET)
     )
 
 
@@ -728,7 +730,7 @@ def test_delete_service_and_associated_objects(notify_db_session):
     user.organisations = [organisation]
 
     assert ServicePermission.query.count() == len(
-        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS)
+        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, INTERNATIONAL_LETTERS, TOKEN_BUCKET)
     )
 
     delete_service_and_all_associated_db_objects(service)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -28,6 +28,7 @@ from app.constants import (
     SERVICE_JOIN_REQUEST_APPROVED,
     SERVICE_JOIN_REQUEST_CANCELLED,
     SMS_TYPE,
+    TOKEN_BUCKET,
 )
 from app.dao.organisation_dao import dao_add_service_to_organisation
 from app.dao.report_requests_dao import dao_create_report_request
@@ -309,7 +310,15 @@ def test_get_service_list_has_default_permissions(admin_request, service_factory
     json_resp = admin_request.get("service.get_services")
     assert len(json_resp["data"]) == 3
     assert all(
-        set(json["permissions"]) == {EMAIL_TYPE, SMS_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE, INTERNATIONAL_LETTERS}
+        set(json["permissions"])
+        == {
+            EMAIL_TYPE,
+            SMS_TYPE,
+            INTERNATIONAL_SMS_TYPE,
+            LETTER_TYPE,
+            INTERNATIONAL_LETTERS,
+            TOKEN_BUCKET,
+        }
         for json in json_resp["data"]
     )
 
@@ -323,6 +332,7 @@ def test_get_service_by_id_has_default_service_permissions(admin_request, sample
         INTERNATIONAL_SMS_TYPE,
         LETTER_TYPE,
         INTERNATIONAL_LETTERS,
+        TOKEN_BUCKET,
     }
 
 


### PR DESCRIPTION
We’re going to give all existing services this permission. We need to make sure that services created after we’ve done the migration also get the permission.

We can merge this any time before the migration. Merging further in advance of the migration means we can soft launch the feature by giving it only to new services (which are unlikely to start at very high rates of sending anyway).