### PR TITLE
Delete database sequence that was used for broadcasts

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0516_remove_broadcast_permission
+0517_remove_broadcast_sequence

--- a/migrations/versions/0517_remove_broadcast_sequence.py
+++ b/migrations/versions/0517_remove_broadcast_sequence.py
@@ -1,0 +1,16 @@
+"""
+Create Date: 2025-09-04 15:47:21.596407
+"""
+
+from alembic import op
+
+revision = '0517_remove_broadcast_sequence'
+down_revision = '0516_remove_broadcast_permission'
+
+
+def upgrade():
+    op.execute("drop sequence broadcast_provider_message_number_seq")
+
+
+def downgrade():
+    op.execute("create sequence broadcast_provider_message_number_seq")


### PR DESCRIPTION
This was used in the `broadcast_provider_message_number` table, which was been deleted in a previous migration ([0510_delete_broadcast_tables](https://github.com/alphagov/notifications-api/blob/2f87b51ee83e68d955da36e89f065cc9990f20e7/migrations/versions/0510_delete_broadcast_tables.py)).