### PR TITLE
`get_returned_letters`: also return count of "orphaned" returned letters

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -51,6 +51,7 @@ from app.dao.report_requests_dao import (
     dao_get_oldest_ongoing_report_request,
 )
 from app.dao.returned_letters_dao import (
+    count_orphaned_returned_letters,
     fetch_most_recent_returned_letter,
     fetch_recent_returned_letter_count,
     fetch_returned_letter_summary,
@@ -1128,7 +1129,12 @@ def get_returned_letters(service_id):
     report_date = request.args.get("reported_at")
     json_results = _fetch_returned_letter_data(service_id, report_date)
 
-    return jsonify(sorted(json_results, key=lambda i: i["created_at"], reverse=True))
+    return jsonify(
+        {
+            "returned_letters": sorted(json_results, key=lambda i: i["created_at"], reverse=True),
+            "orphaned_count": count_orphaned_returned_letters(service_id, report_date),
+        }
+    )
 
 
 @service_blueprint.route("/<uuid:service_id>/unsubscribe-request-reports-summary", methods=["GET"])


### PR DESCRIPTION
Related to https://trello.com/c/CQp2fcic/1297-work-out-if-we-can-purge-history-table-and-do-it

These are letters that have a `ReturnedLetter` but the corresponding notification has been purged from history. If we're considering purging more notification history, we're going to end up with more of these "orphaned" `ReturnedLetter` entries, which currently produce subtly illogical results in the admin UI. It's not 100% decided how to handle orphaned returned-letters in the UI, but it's certainly going to need the information to work with.

This is an api-breaking change because this endpoint previously returned a raw json array, with no way to provide extra data in the payload. ~This will need modifications to the admin app before we can consider merging.~ These modifications have been merged in https://github.com/alphagov/notifications-admin/pull/5583