### PR TITLE
Ensure changes to preferences are committed to DB

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -266,6 +266,7 @@ def unsubscribe_user_from_notify_services(service_id, email_address):
 
     setattr(user, attribute_to_update, False)
     db.session.add(user)
+    db.session.commit()
 
     redis_store.delete(f"user-{user.id}")
 


### PR DESCRIPTION
For some reason SQLAlchemy is not committing the changes made to the user here.

I also tried:
- hard coding the attribute (eg `user.take_part_in_research = False`)
- using `sqlalchemy.orm.attributes.set_attribute` instead of `setattr`

Neither of these worked without also adding a `commit`.

I couldn’t find a way to replicate the problem in a test, but running the app locally I can confirm this works.