### PR TITLE
Promptly update the status for jobs that completed processing

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -277,6 +277,11 @@ class Config:
                 "schedule": crontab(minute="*/10"),
                 "options": {"queue": QueueNames.PERIODIC},
             },
+            "update-status-of-fully-processed-jobs": {
+                "task": "update-status-of-fully-processed-jobs",
+                "schedule": crontab(minute="*/1"),
+                "options": {"queue": QueueNames.PERIODIC},
+            },
             "replay-created-notifications": {
                 "task": "replay-created-notifications",
                 "schedule": crontab(minute="0, 15, 30, 45"),


### PR DESCRIPTION
Every minute, run a task that updates the status for jobs that finished processing all rows to the following status: JOB_STATUS_FINISHED_ALL_NOTIFICATIONS_CREATED.

This is so cancelling letter jobs works as expected.

Before this PR, users would have to wait around 30 minutes after sending a job before being able to cancel letters. This is a confusing experience, and it has led to a user thinking they cancelled their letters when they have not.

To test this code, I have:
1. run the apps locally with the celery beat (`make beat up`)
2. created a letter job
3. tried to cancel, failed
4. waited a couple minutes, succeeded