### PR TITLE
Drop composite template index on notification history

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0517_remove_broadcast_sequence
+0518_drop_n_hist_templates_index

--- a/migrations/versions/0518_drop_n_hist_templates_index.py
+++ b/migrations/versions/0518_drop_n_hist_templates_index.py
@@ -1,0 +1,22 @@
+"""
+Create Date: 2025-09-18 09:19:47.763586
+"""
+
+from alembic import op
+
+revision = '0518_drop_n_hist_templates_index'
+down_revision = '0517_remove_broadcast_sequence'
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_notification_history_template_composite"
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_notification_history_template_composite on notification_history (template_id, template_version)"
+        )


### PR DESCRIPTION
This was [added to allow the emergency alerts data to be deleted](https://github.com/alphagov/notifications-api/pull/4514). Now that this has been done, we can drop the index.