### PR TITLE
Run Python tests with `-n logical` instead of `-n auto`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ drop-test-dbs-in-docker:
 test: ## Run tests
 	ruff check .
 	ruff format --check .
-	pytest -n auto --maxfail=10 -v
+	pytest -n logical --maxfail=10 -v
 
 .PHONY: watch-tests
 watch-tests: ## Watch tests and run on change


### PR DESCRIPTION
When `psutil` is installed `-n auto` causes the tests to only run in 1 worker on Concourse.

We should revert the PR which introduced psutil<sup>1</sup> at some point. In the meantime we can change the flag to `logical` which chooses the same number of workers as the number of logical CPU cores<sup>2</sup>. If `psutil` is uninstalled at any point then `-n logical` will fall back to the same behaviour as `-n auto`.

TL;DR this makes sure we always run the tests across 2 workers on Concourse which is quicker than 1 worker.

***

1. https://github.com/alphagov/notifications-api/pull/4348
2. https://pytest-xdist.readthedocs.io/en/stable/distribution.html