### PR TITLE
Drop api_key_id index on notification_history table

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0518_drop_n_hist_templates_index
+0519_drop_n_hist_api_key_index

--- a/migrations/versions/0519_drop_n_hist_api_key_index.py
+++ b/migrations/versions/0519_drop_n_hist_api_key_index.py
@@ -1,0 +1,21 @@
+"""
+Create Date: 2025-09-22 11:45:33.095877
+"""
+
+from alembic import op
+
+revision = '0519_drop_n_hist_api_key_index'
+down_revision = '0518_drop_n_hist_templates_index'
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_notification_history_api_key_id"
+        )
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_notification_history_api_key_id on notification_history (api_key_id)"
+        )


### PR DESCRIPTION
This was [added to allow the emergency alerts data to be deleted](https://github.com/alphagov/notifications-api/pull/4509). Now that this has been done, we can drop the index.