### PR TITLE
models: add dependency statistics to more models

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0520_launch_token_bucket
+0536_inbound_sms_xstats_dep

--- a/migrations/versions/0521_inbound_sms_hist_xstats_dep.py
+++ b/migrations/versions/0521_inbound_sms_hist_xstats_dep.py
@@ -1,0 +1,20 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0521_inbound_sms_hist_xstats_dep"
+down_revision = "0520_launch_token_bucket"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_inb_sms_hist_service_id_ntfy_num_provider (dependencies) ON service_id, notify_number, provider FROM inbound_sms_history"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_inb_sms_hist_service_id_ntfy_num_provider")

--- a/migrations/versions/0522_inv_org_usrs_xstats_dep.py
+++ b/migrations/versions/0522_inv_org_usrs_xstats_dep.py
@@ -1,0 +1,20 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0522_inv_org_usrs_xstats_dep"
+down_revision = "0521_inbound_sms_hist_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_inv_org_users_inv_by_id_org_id (dependencies) ON invited_by_id, organisation_id FROM invited_organisation_users"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_inv_org_users_inv_by_id_org_id")

--- a/migrations/versions/0523_invited_users_xstats_dep.py
+++ b/migrations/versions/0523_invited_users_xstats_dep.py
@@ -1,0 +1,20 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0523_invited_users_xstats_dep"
+down_revision = "0522_inv_org_usrs_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_inv_users_user_id_service_id (dependencies) ON user_id, service_id FROM invited_users"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_inv_users_user_id_service_id")

--- a/migrations/versions/0524_jobs_xstats_dep.py
+++ b/migrations/versions/0524_jobs_xstats_dep.py
@@ -1,0 +1,20 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0524_jobs_xstats_dep"
+down_revision = "0523_invited_users_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_jobs_service_id_created_by_id (dependencies) ON service_id, created_by_id FROM jobs"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_jobs_service_id_created_by_id")

--- a/migrations/versions/0525_notifications_xstats_dep.py
+++ b/migrations/versions/0525_notifications_xstats_dep.py
@@ -1,0 +1,48 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0525_notifications_xstats_dep"
+down_revision = "0524_jobs_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_notifications_service_id_cby_id (dependencies) ON service_id, created_by_id FROM notifications"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notifications_ntfcn_type_sent_by (dependencies) ON notification_type, sent_by FROM notifications"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notifications_ntfcn_type_intnl (dependencies) ON notification_type, international FROM notifications"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notifications_ntfcn_type_doc_dl (dependencies) ON notification_type, document_download_count FROM notifications"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notifications_sent_by_postage (dependencies) ON sent_by, postage FROM notifications"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notifications_ntfcn_type_postage (dependencies) ON notification_type, postage FROM notifications"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notifications_phone_prefix_intnl (dependencies) ON phone_prefix, international FROM notifications"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notifications_ntfcn_type_phone_prefix (dependencies) ON notification_type, phone_prefix FROM notifications"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_notifications_service_id_cby_id")
+    op.execute("DROP STATISTICS st_dep_notifications_ntfcn_type_sent_by")
+    op.execute("DROP STATISTICS st_dep_notifications_ntfcn_type_intnl")
+    op.execute("DROP STATISTICS st_dep_notifications_ntfcn_type_doc_dl")
+    op.execute("DROP STATISTICS st_dep_notifications_sent_by_postage")
+    op.execute("DROP STATISTICS st_dep_notifications_ntfcn_type_postage")
+    op.execute("DROP STATISTICS st_dep_notifications_phone_prefix_intnl")
+    op.execute("DROP STATISTICS st_dep_notifications_ntfcn_type_phone_prefix")

--- a/migrations/versions/0526_ntfcn_hist_xstats_dep.py
+++ b/migrations/versions/0526_ntfcn_hist_xstats_dep.py
@@ -1,0 +1,48 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0526_ntfcn_hist_xstats_dep"
+down_revision = "0525_notifications_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_notification_history_ntfcn_type_postage (dependencies) ON notification_type, postage FROM notification_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notification_history_ntfcn_type_sent_by (dependencies) ON notification_type, sent_by FROM notification_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notification_history_sent_by_postage (dependencies) ON sent_by, postage FROM notification_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notification_history_ntfcn_type_doc_dl (dependencies) ON notification_type, document_download_count FROM notification_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notification_history_phone_prefix_intnl (dependencies) ON phone_prefix, international FROM notification_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notification_history_ntfcn_type_intnl (dependencies) ON notification_type, international FROM notification_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notification_history_service_id_cby_id (dependencies) ON service_id, created_by_id FROM notification_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_notification_history_ntfcn_type_phone_prefix (dependencies) ON notification_type, phone_prefix FROM notification_history"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_notification_history_ntfcn_type_postage")
+    op.execute("DROP STATISTICS st_dep_notification_history_ntfcn_type_sent_by")
+    op.execute("DROP STATISTICS st_dep_notification_history_sent_by_postage")
+    op.execute("DROP STATISTICS st_dep_notification_history_ntfcn_type_doc_dl")
+    op.execute("DROP STATISTICS st_dep_notification_history_phone_prefix_intnl")
+    op.execute("DROP STATISTICS st_dep_notification_history_ntfcn_type_intnl")
+    op.execute("DROP STATISTICS st_dep_notification_history_service_id_cby_id")
+    op.execute("DROP STATISTICS st_dep_notification_history_ntfcn_type_phone_prefix")

--- a/migrations/versions/0527_permissions_xstats_dep.py
+++ b/migrations/versions/0527_permissions_xstats_dep.py
@@ -1,0 +1,20 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0527_permissions_xstats_dep"
+down_revision = "0526_ntfcn_hist_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_permissions_service_id_user_id (dependencies) ON service_id, user_id FROM permissions"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_permissions_service_id_user_id")

--- a/migrations/versions/0528_report_requests_xstats_dep.py
+++ b/migrations/versions/0528_report_requests_xstats_dep.py
@@ -1,0 +1,20 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0528_report_requests_xstats_dep"
+down_revision = "0527_permissions_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_report_requests_service_id_user_id (dependencies) ON service_id, user_id FROM report_requests"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_report_requests_service_id_user_id")

--- a/migrations/versions/0529_templates_xstats_dep.py
+++ b/migrations/versions/0529_templates_xstats_dep.py
@@ -1,0 +1,40 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0529_templates_xstats_dep"
+down_revision = "0528_report_requests_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_templates_tpt_type_postage (dependencies) ON template_type, postage FROM templates"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_templates_service_id_sv_let_cct_id (dependencies) ON service_id, service_letter_contact_id FROM templates"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_templates_service_id_ctd_by_id (dependencies) ON service_id, created_by_id FROM templates"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_templates_tpt_type_letter_lang (dependencies) ON template_type, letter_languages FROM templates"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_templates_service_id_let_att_id (dependencies) ON service_id, letter_attachment_id FROM templates"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_templates_tpt_type_has_unsub_lnk (dependencies) ON template_type, has_unsubscribe_link FROM templates"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_templates_tpt_type_postage")
+    op.execute("DROP STATISTICS st_dep_templates_service_id_sv_let_cct_id")
+    op.execute("DROP STATISTICS st_dep_templates_service_id_ctd_by_id")
+    op.execute("DROP STATISTICS st_dep_templates_tpt_type_letter_lang")
+    op.execute("DROP STATISTICS st_dep_templates_service_id_let_att_id")
+    op.execute("DROP STATISTICS st_dep_templates_tpt_type_has_unsub_lnk")

--- a/migrations/versions/0530_template_folder_xstats_dep.py
+++ b/migrations/versions/0530_template_folder_xstats_dep.py
@@ -1,0 +1,20 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0530_template_folder_xstats_dep"
+down_revision = "0529_templates_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_template_folder_service_id_parent_id (dependencies) ON service_id, parent_id FROM template_folder"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_template_folder_service_id_parent_id")

--- a/migrations/versions/0531_templates_hist_xstats_dep.py
+++ b/migrations/versions/0531_templates_hist_xstats_dep.py
@@ -1,0 +1,40 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0531_templates_hist_xstats_dep"
+down_revision = "0530_template_folder_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_templates_history_service_id_sv_let_cct_id (dependencies) ON service_id, service_letter_contact_id FROM templates_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_templates_history_service_id_let_att_id (dependencies) ON service_id, letter_attachment_id FROM templates_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_templates_history_tpt_type_letter_lang (dependencies) ON template_type, letter_languages FROM templates_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_templates_history_tpt_type_postage (dependencies) ON template_type, postage FROM templates_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_templates_history_tpt_type_has_unsub_lnk (dependencies) ON template_type, has_unsubscribe_link FROM templates_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_templates_history_service_id_ctd_by_id (dependencies) ON service_id, created_by_id FROM templates_history"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_templates_history_service_id_sv_let_cct_id")
+    op.execute("DROP STATISTICS st_dep_templates_history_service_id_let_att_id")
+    op.execute("DROP STATISTICS st_dep_templates_history_tpt_type_letter_lang")
+    op.execute("DROP STATISTICS st_dep_templates_history_tpt_type_postage")
+    op.execute("DROP STATISTICS st_dep_templates_history_tpt_type_has_unsub_lnk")
+    op.execute("DROP STATISTICS st_dep_templates_history_service_id_ctd_by_id")

--- a/migrations/versions/0532_unsub_req_xstats_dep.py
+++ b/migrations/versions/0532_unsub_req_xstats_dep.py
@@ -1,0 +1,24 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0532_unsub_req_xstats_dep"
+down_revision = "0531_templates_hist_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_unsub_req_service_id_unsub_req_rpt_id (dependencies) ON service_id, unsubscribe_request_report_id FROM unsubscribe_request"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_unsub_req_service_id_tpt_id_ntfcn_id (dependencies) ON service_id, template_id, notification_id FROM unsubscribe_request"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_unsub_req_service_id_unsub_req_rpt_id")
+    op.execute("DROP STATISTICS st_dep_unsub_req_service_id_tpt_id_ntfcn_id")

--- a/migrations/versions/0533_unsub_req_hist_xstats_dep.py
+++ b/migrations/versions/0533_unsub_req_hist_xstats_dep.py
@@ -1,0 +1,24 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0533_unsub_req_hist_xstats_dep"
+down_revision = "0532_unsub_req_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_unsub_req_history_service_id_unsub_req_rpt_id (dependencies) ON service_id, unsubscribe_request_report_id FROM unsubscribe_request_history"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_unsub_req_history_service_id_tpt_id_ntfcn_id (dependencies) ON service_id, template_id, notification_id FROM unsubscribe_request_history"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_unsub_req_history_service_id_unsub_req_rpt_id")
+    op.execute("DROP STATISTICS st_dep_unsub_req_history_service_id_tpt_id_ntfcn_id")

--- a/migrations/versions/0534_api_keys_xstats_dep.py
+++ b/migrations/versions/0534_api_keys_xstats_dep.py
@@ -1,0 +1,20 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0534_api_keys_xstats_dep"
+down_revision = "0533_unsub_req_hist_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_api_keys_service_id_created_by_id (dependencies) ON service_id, created_by_id FROM api_keys"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_api_keys_service_id_created_by_id")

--- a/migrations/versions/0535_ft_billing_xstats_dep.py
+++ b/migrations/versions/0535_ft_billing_xstats_dep.py
@@ -1,0 +1,40 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0535_ft_billing_xstats_dep"
+down_revision = "0534_api_keys_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_ft_billing_service_id_template_id (dependencies) ON service_id, template_id FROM ft_billing"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_ft_billing_ntfcn_type_template_id (dependencies) ON notification_type, template_id FROM ft_billing"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_ft_billing_ntfcn_type_provider (dependencies) ON notification_type, provider FROM ft_billing"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_ft_billing_ntfcn_type_intnl (dependencies) ON notification_type, international FROM ft_billing"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_ft_billing_ntfcn_type_postage (dependencies) ON notification_type, postage FROM ft_billing"
+    )
+    op.execute(
+        "CREATE STATISTICS st_dep_ft_billing_provider_postage (dependencies) ON provider, postage FROM ft_billing"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_ft_billing_service_id_template_id")
+    op.execute("DROP STATISTICS st_dep_ft_billing_ntfcn_type_template_id")
+    op.execute("DROP STATISTICS st_dep_ft_billing_ntfcn_type_provider")
+    op.execute("DROP STATISTICS st_dep_ft_billing_ntfcn_type_intnl")
+    op.execute("DROP STATISTICS st_dep_ft_billing_ntfcn_type_postage")
+    op.execute("DROP STATISTICS st_dep_ft_billing_provider_postage")

--- a/migrations/versions/0536_inbound_sms_xstats_dep.py
+++ b/migrations/versions/0536_inbound_sms_xstats_dep.py
@@ -1,0 +1,20 @@
+"""
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0536_inbound_sms_xstats_dep"
+down_revision = "0535_ft_billing_xstats_dep"
+
+
+def upgrade():
+    op.execute(
+        "CREATE STATISTICS st_dep_inb_sms_service_id_ntfy_num_provider (dependencies) ON service_id, notify_number, provider FROM inbound_sms"
+    )
+
+
+def downgrade():
+    op.execute("DROP STATISTICS st_dep_inb_sms_service_id_ntfy_num_provider")

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -26,12 +26,25 @@ from app.constants import (
 )
 from app.dao.services_dao import dao_add_user_to_service
 from app.models import (
+    ApiKey,
+    FactBilling,
     FactNotificationStatus,
+    InboundSms,
+    InboundSmsHistory,
+    InvitedOrganisationUser,
+    InvitedUser,
     Job,
     LetterCostThreshold,
     Notification,
     NotificationHistory,
+    Permission,
+    ReportRequest,
     ServiceGuestList,
+    Template,
+    TemplateFolder,
+    TemplateHistory,
+    UnsubscribeRequest,
+    UnsubscribeRequestHistory,
 )
 from tests.app.db import (
     create_inbound_number,
@@ -424,10 +437,23 @@ def test_notification_references_template_history(client, sample_template):
 @pytest.mark.parametrize(
     "model",
     (
+        ApiKey,
+        FactBilling,
         FactNotificationStatus,
+        InboundSms,
+        InboundSmsHistory,
+        InvitedOrganisationUser,
+        InvitedUser,
         Job,
         Notification,
         NotificationHistory,
+        Permission,
+        ReportRequest,
+        Template,
+        TemplateFolder,
+        TemplateHistory,
+        UnsubscribeRequest,
+        UnsubscribeRequestHistory,
     ),
 )
 def test_extended_statistics_presence(notify_db_session, model):


### PR DESCRIPTION
"dependency" multivariate statistics are relatively cheap to maintain, and when added to column groups that have some equality-based correlation, allow the query planner to make much better estimates of row counts and therefore much better plans.

Our initial rounds of adding multivariate statistics focused on adding these for tables and columns that we know are commonly used in our heavier queries. These add them for almost anything where a correlation seems likely. This is because beyond the queries performed by the apps, on support we can also tend to run arbitrary, large, queries that we expect to complete in a reasonable time. These can also suffer from poor estimates.

While initially we added multivariate statistics only for the larger tables, here we also add multivariate statistics for smaller tables because poor estimates on these tables can also affect the number of rows retrieved from large tables in complex, join-heavy queries.