### PR TITLE
Update error message when trying to cancel incomplete letter job

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -219,7 +219,7 @@ def can_letter_job_be_cancelled(job):
         return False, "Only letter jobs can be cancelled through this endpoint. This is not a letter job."
 
     if job.job_status != JOB_STATUS_FINISHED_ALL_NOTIFICATIONS_CREATED:
-        return False, "We are still processing these letters, please try again in a minute."
+        return False, "We are still processing these letters, please try again in 5 minutes."
 
     if (not letter_can_be_cancelled(NOTIFICATION_CREATED, job.created_at)) or db.session.query(
         Notification.query.filter(

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -382,7 +382,7 @@ def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_not_stat
     create_notification(template=job.template, job=job, status="created")
     result, errors = can_letter_job_be_cancelled(job)
     assert not result
-    assert errors == "We are still processing these letters, please try again in a minute."
+    assert errors == "We are still processing these letters, please try again in 5 minutes."
 
 
 @freeze_time("2019-06-13 13:00")
@@ -431,7 +431,7 @@ def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_job_not_
     create_notification(template=job.template, job=job, status="created")
     result, errors = can_letter_job_be_cancelled(job)
     assert not result
-    assert errors == "We are still processing these letters, please try again in a minute."
+    assert errors == "We are still processing these letters, please try again in 5 minutes."
 
 
 def test_can_letter_job_be_cancelled_respects_bst(sample_letter_template):


### PR DESCRIPTION
The error message used to tell the user to try in a minute, whereas it can take up to 3 minutes after all notifications are created before the job is actually cancellable.

More context in this PR:
https://github.com/alphagov/notifications-api/pull/4562

Should be merged together with: https://github.com/alphagov/notifications-admin/pull/5599