### PR TITLE
sqlalchemy init: dispose engine after events are set up

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -191,8 +191,8 @@ def create_app(application):
 
     # set up sqlalchemy events
     setup_sqlalchemy_events(application)
-    with application.app_context():
-        db.engine.dispose()
+    # with application.app_context():
+    #     db.engine.dispose()
 
     return application
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -506,6 +506,9 @@ def setup_sqlalchemy_events(app):  # noqa: C901
                 # round-trip of latency to every request.
                 cursor.execute("SET max_parallel_workers_per_gather = 0")
 
+            cursor.execute("COMMIT")
+            cursor.execute("BEGIN")
+
         @event.listens_for(db.engine, "close")
         def close(dbapi_connection, connection_record):
             # connection closed (probably only happens with overflow connections)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -506,6 +506,7 @@ def setup_sqlalchemy_events(app):  # noqa: C901
         def close(dbapi_connection, connection_record):
             # connection closed (probably only happens with overflow connections)
             TOTAL_DB_CONNECTIONS.dec()
+            current_app.logger.info("Closing connection")
 
         @event.listens_for(db.engine, "checkout")
         def checkout(dbapi_connection, connection_record, connection_proxy):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -191,8 +191,8 @@ def create_app(application):
 
     # set up sqlalchemy events
     setup_sqlalchemy_events(application)
-    # with application.app_context():
-    #     db.engine.dispose()
+    with application.app_context():
+        current_app.logger.info(db.engine.pool.status())
 
     return application
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -191,6 +191,8 @@ def create_app(application):
 
     # set up sqlalchemy events
     setup_sqlalchemy_events(application)
+    with application.app_context():
+        db.engine.dispose()
 
     return application
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -515,6 +515,12 @@ def setup_sqlalchemy_events(app):  # noqa: C901
                 # connection given to a web worker
                 TOTAL_CHECKED_OUT_DB_CONNECTIONS.inc()
 
+                cursor = dbapi_connection.cursor()
+                cursor.execute("SHOW statement_timeout")
+                st = cursor.fetchone()[0]
+                if st != current_app.config["DATABASE_STATEMENT_TIMEOUT_MS"]:
+                    current_app.logger.warning("Statement timeout is %s!", st)
+
                 # this will overwrite any previous checkout_at timestamp
                 connection_record.info["checkout_at"] = time.monotonic()
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -486,6 +486,7 @@ def setup_sqlalchemy_events(app):  # noqa: C901
                 "SET application_name = %s",
                 (current_app.config["NOTIFY_APP_NAME"],),
             )
+            current_app.logger.info("Set application_name")
 
             if current_app.config["DATABASE_DEFAULT_DISABLE_PARALLEL_QUERY"]:
                 # by default disable parallel query because it allows large analytic-style


### PR DESCRIPTION
to drop all current connections and ensure all connections in our pool were initialized using the newly installed hooks