### PR TITLE
Bump utils to 101.3.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@101.2.0
+# This file was automatically copied from notifications-utils@101.3.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil>=6.0.0,<7.0.0
 notifications-python-client==10.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@101.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@101.3.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -150,7 +150,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@db63d6b30f95512695bff55c3f61306bbff96d3b
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@dd749865080ca7262c974c6bf0b12c3a3c739515
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -220,7 +220,7 @@ moto==5.0.11
     # via -r requirements_for_test.in
 notifications-python-client==10.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@db63d6b30f95512695bff55c3f61306bbff96d3b
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@dd749865080ca7262c974c6bf0b12c3a3c739515
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@101.2.0
+# This file was automatically copied from notifications-utils@101.3.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@101.2.0
+# This file was automatically copied from notifications-utils@101.3.1
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
 ## 101.3.1

* Fix rendering of parentheses in some HTML email clients

 ## 101.3.0

* Upgrade Python version to 3.13
* Adjust get_remote_version() to compensate for changes in locals() in Python 3.13

 ## 101.2.1

* Remove `clients.redis.rate_limit_cache_key` (no longer used)

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/101.2.0...101.3.1