### PR TITLE
Force `wheel` version to 0.46.3

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -29,6 +29,7 @@ notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@11
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 
 sentry-sdk[flask,celery,sqlalchemy]~=1.45
+wheel>=0.46.2  # Can be removed after merge of https://github.com/click-contrib/click-datetime/pull/13
 
 opentelemetry-distro[otlp]
 opentelemetry-instrumentation-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ click==8.3.1
     #   click-plugins
     #   click-repl
     #   flask
-click-datetime==0.4.0
+click-datetime==0.2
     # via -r requirements.in
 click-didyoumean==0.3.1
     # via celery
@@ -316,6 +316,7 @@ packaging==26.0
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
+    #   wheel
 phonenumbers==9.0.25
     # via notifications-utils
 prometheus-client==0.24.1
@@ -429,8 +430,8 @@ webcolors==25.10.0
     # via jsonschema
 werkzeug==3.1.6
     # via flask
-wheel==0.44.0
-    # via click-datetime
+wheel==0.46.3
+    # via -r requirements.in
 wrapt==1.17.3
     # via
     #   opentelemetry-instrumentation

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -73,7 +73,7 @@ click==8.3.1
     #   click-plugins
     #   click-repl
     #   flask
-click-datetime==0.4.0
+click-datetime==0.2
     # via -r requirements.txt
 click-didyoumean==0.3.1
     # via
@@ -412,6 +412,7 @@ packaging==26.0
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   pytest
+    #   wheel
 pathspec==1.0.4
     # via mypy
 phonenumbers==9.0.25
@@ -619,10 +620,8 @@ werkzeug==3.1.6
     #   flask
     #   moto
     #   pytest-httpserver
-wheel==0.44.0
-    # via
-    #   -r requirements.txt
-    #   click-datetime
+wheel==0.46.3
+    # via -r requirements.txt
 wrapt==1.17.3
     # via
     #   -r requirements.txt


### PR DESCRIPTION
Fixes https://github.com/alphagov/notifications-api/security/dependabot/99

`wheel` was introduced when we upgraded `click-datetime` to version 0.4.

`click-datetime` pins `wheel` to a max version of 0.44.x: https://github.com/click-contrib/click-datetime/blob/942964cf71b5c43a542e63e634c934ab29d3daf3/pyproject.toml#L16

Older versions of `click-datetime` didn’t depend on wheel. By requiring a newer version of `wheel`, we force the previous version of `click-datetime` to be installed, without having to pin to an old version of something.