### PR TITLE
Added `has_files` as an argument for `shatter-job-rows` tasks

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -447,7 +447,9 @@ def check_for_missing_rows_in_completed_jobs():
 
             extra = {"job_row_number": row_to_process.missing_row, "job_id": job.id}
             current_app.logger.info("Processing missing row %(job_row_number)s for job %(job_id)s", extra, extra=extra)
-            process_job_row(template.template_type, task_args_kwargs, str(job.service_id))
+            process_job_row(
+                template.template_type, task_args_kwargs, has_files=False, message_group_id=str(job.service_id)
+            )
 
 
 @notify_celery.task(name="update-status-of-fully-processed-jobs")

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -163,23 +163,31 @@ def shatter_job_rows(
     self,
     template_type: str,
     args_kwargs_seq: Sequence,
+    has_files: bool = False,
 ):
     for task_args_kwargs in args_kwargs_seq:
-        process_job_row(template_type, task_args_kwargs, self.message_group_id)
+        process_job_row(template_type, task_args_kwargs, has_files, self.message_group_id)
 
 
-def process_job_row(template_type, task_args_kwargs, message_group_id=None):
+def process_job_row(template_type, task_args_kwargs, has_files=False, message_group_id=None):
     send_fn = {
         SMS_TYPE: save_sms,
         EMAIL_TYPE: save_email,
         LETTER_TYPE: save_letter,
     }[template_type]
+    if has_files:
+        send_fn.apply_async(
+            *task_args_kwargs,
+            queue=QueueNames.DATABASE_DOCUMENTS,
+            MessageGroupId=message_group_id,
+        )
 
-    send_fn.apply_async(
-        *task_args_kwargs,
-        queue=QueueNames.DATABASE,
-        MessageGroupId=message_group_id,
-    )
+    else:
+        send_fn.apply_async(
+            *task_args_kwargs,
+            queue=QueueNames.DATABASE,
+            MessageGroupId=message_group_id,
+        )
 
 
 def job_complete(job, resumed=False, start=None):

--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,7 @@ from app.constants import EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE, SMS_T
 class QueueNames:
     PERIODIC = "periodic-tasks"
     DATABASE = "database-tasks"
+    DATABASE_DOCUMENTS = "database-tasks-documents"
     SEND_SMS = "send-sms-tasks"
     SEND_EMAIL = "send-email-tasks"
     SEND_LETTER = "send-letter-tasks"
@@ -36,6 +37,7 @@ class QueueNames:
         return [
             QueueNames.PERIODIC,
             QueueNames.DATABASE,
+            QueueNames.DATABASE_DOCUMENTS,
             QueueNames.SEND_SMS,
             QueueNames.SEND_EMAIL,
             QueueNames.SEND_LETTER,

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,13 @@ case "$1" in
     exec $COMMON_CMD create-letters-pdf-tasks,letter-tasks
     ;;
   api-worker-jobs)
-    exec $COMMON_CMD database-tasks,job-tasks
+    exec $COMMON_CMD job-tasks
+    ;;
+  api-worker-jobs-save)
+    exec $COMMON_CMD database-tasks
+    ;;
+  api-worker-jobs-save-documents)
+    exec $COMMON_CMD database-tasks-documents
     ;;
   api-worker-jobs-save)
     exec $COMMON_CMD database-tasks,job-tasks

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -112,6 +112,11 @@ def email_job_with_placeholders(notify_db_session, sample_email_template_with_pl
     return create_job(template=sample_email_template_with_placeholders)
 
 
+@pytest.fixture
+def email_job_with_file_placeholders(notify_db_session, sample_email_template_with_template_email_files):
+    return create_job(template=sample_email_template_with_template_email_files)
+
+
 # -------------- process_job tests -------------- #
 #
 # Most tests simulate the broker by setting message_group_id on the task (via _with_message_group_id)
@@ -144,7 +149,7 @@ def test_should_process_sms_job(sample_job, mocker, mock_celery_task):
                 "row_number": 0,
                 "personalisation": {"phonenumber": "+441234123123"},
                 "client_reference": None,
-            }
+            },
         )
     ]
 
@@ -404,7 +409,10 @@ def test_should_not_create_shatter_task_for_empty_file(sample_job, mocker, mock_
     assert mock_shatter_job_rows.called is False
 
 
-def test_should_process_email_job(email_job_with_placeholders, mocker, mock_celery_task):
+@pytest.mark.parametrize("send_file", [True, False])
+def test_should_process_email_job(
+    email_job_with_placeholders, email_job_with_file_placeholders, mocker, mock_celery_task, send_file
+):
     email_csv = """email_address,name
     test@test.com,foo
     """
@@ -416,36 +424,38 @@ def test_should_process_email_job(email_job_with_placeholders, mocker, mock_cele
     mock_encode = mocker.patch("app.signing.encode", return_value="something_encoded")
     mocker.patch("app.celery.tasks.create_uuid", return_value="some_uuid")
 
-    with _with_message_group_id(process_job, str(email_job_with_placeholders.service_id)):
-        process_job(email_job_with_placeholders.id)
+    email_job = email_job_with_file_placeholders if send_file else email_job_with_placeholders
 
-    s3.get_job_and_metadata_from_s3.assert_called_once_with(
-        service_id=str(email_job_with_placeholders.service.id),
-        job_id=str(email_job_with_placeholders.id),
-    )
+    with _with_message_group_id(process_job, str(email_job_with_placeholders.service_id)):
+        process_job(email_job.id)
+
+        s3.get_job_and_metadata_from_s3.assert_called_once_with(
+            service_id=str(email_job.service.id),
+            job_id=str(email_job.id),
+        )
 
     assert mock_encode.mock_calls == [
         call(
             {
-                "template": str(email_job_with_placeholders.template.id),
-                "template_version": email_job_with_placeholders.template.version,
-                "job": str(email_job_with_placeholders.id),
+                "template": str(email_job.template.id),
+                "template_version": email_job.template.version,
+                "job": str(email_job.id),
                 "to": "test@test.com",
                 "row_number": 0,
                 "personalisation": {"emailaddress": "test@test.com", "name": "foo"},
                 "client_reference": None,
-            }
+            },
         )
     ]
 
     assert mock_shatter_job_rows.mock_calls == [
         call(
             (
-                email_job_with_placeholders.template.template_type,
+                email_job.template.template_type,
                 [
                     (
                         (
-                            str(email_job_with_placeholders.service_id),
+                            str(email_job.service_id),
                             "some_uuid",
                             "something_encoded",
                         ),
@@ -454,15 +464,18 @@ def test_should_process_email_job(email_job_with_placeholders, mocker, mock_cele
                 ],
             ),
             queue="job-tasks",
-            MessageGroupId=str(email_job_with_placeholders.service_id),
+            MessageGroupId=str(email_job.service_id),
         )
     ]
 
-    job = jobs_dao.dao_get_job_by_id(email_job_with_placeholders.id)
+    job = jobs_dao.dao_get_job_by_id(email_job.id)
     assert job.job_status == "finished"
 
 
-def test_should_process_email_job_with_sender_id(email_job_with_placeholders, mocker, mock_celery_task, fake_uuid):
+@pytest.mark.parametrize("send_file", [True, False])
+def test_should_process_email_job_with_sender_id(
+    email_job_with_placeholders, email_job_with_file_placeholders, mocker, mock_celery_task, fake_uuid, send_file
+):
     email_csv = """email_address,name
     test@test.com,foo
     """
@@ -473,21 +486,22 @@ def test_should_process_email_job_with_sender_id(email_job_with_placeholders, mo
     mock_shatter_job_rows = mock_celery_task(shatter_job_rows)
     mock_encode = mocker.patch("app.signing.encode", return_value="something_encoded")
     mocker.patch("app.celery.tasks.create_uuid", return_value="some_uuid")
+    email_job = email_job_with_file_placeholders if send_file else email_job_with_placeholders
 
-    with _with_message_group_id(process_job, str(email_job_with_placeholders.service_id)):
-        process_job(email_job_with_placeholders.id, sender_id=fake_uuid)
+    with _with_message_group_id(process_job, str(email_job.service_id)):
+        process_job(email_job.id, sender_id=fake_uuid)
 
     s3.get_job_and_metadata_from_s3.assert_called_once_with(
-        service_id=str(email_job_with_placeholders.service.id),
-        job_id=str(email_job_with_placeholders.id),
+        service_id=str(email_job.service.id),
+        job_id=str(email_job.id),
     )
 
     assert mock_encode.mock_calls == [
         call(
             {
-                "template": str(email_job_with_placeholders.template.id),
-                "template_version": email_job_with_placeholders.template.version,
-                "job": str(email_job_with_placeholders.id),
+                "template": str(email_job.template.id),
+                "template_version": email_job.template.version,
+                "job": str(email_job.id),
                 "to": "test@test.com",
                 "row_number": 0,
                 "personalisation": {"emailaddress": "test@test.com", "name": "foo"},
@@ -499,11 +513,11 @@ def test_should_process_email_job_with_sender_id(email_job_with_placeholders, mo
     assert mock_shatter_job_rows.mock_calls == [
         call(
             (
-                email_job_with_placeholders.template.template_type,
+                email_job.template.template_type,
                 [
                     (
                         (
-                            str(email_job_with_placeholders.service_id),
+                            str(email_job.service_id),
                             "some_uuid",
                             "something_encoded",
                         ),
@@ -512,11 +526,11 @@ def test_should_process_email_job_with_sender_id(email_job_with_placeholders, mo
                 ],
             ),
             queue="job-tasks",
-            MessageGroupId=str(email_job_with_placeholders.service_id),
+            MessageGroupId=str(email_job.service_id),
         )
     ]
 
-    job = jobs_dao.dao_get_job_by_id(email_job_with_placeholders.id)
+    job = jobs_dao.dao_get_job_by_id(email_job.id)
     assert job.job_status == "finished"
 
 
@@ -554,7 +568,7 @@ def test_should_process_letter_job(sample_letter_job, mocker, mock_celery_task):
                     "postcode": "A_POST",
                 },
                 "client_reference": None,
-            }
+            },
         )
     ]
 
@@ -613,7 +627,7 @@ def test_should_process_all_sms_job(sample_job_with_placeholdered_template, mock
                 "row_number": 0,
                 "personalisation": {"phonenumber": "+441234123121", "name": "chris"},
                 "client_reference": None,
-            }
+            },
         ),
         call(
             {
@@ -624,7 +638,7 @@ def test_should_process_all_sms_job(sample_job_with_placeholdered_template, mock
                 "row_number": 1,
                 "personalisation": {"phonenumber": "+441234123122", "name": "chris"},
                 "client_reference": None,
-            }
+            },
         ),
         ANY,
         ANY,
@@ -1165,6 +1179,7 @@ def test_shatter_job_rows(template_type, send_fn, mock_celery_task, mocker):
                     {} if template_type == LETTER_TYPE else {"sender_id": "2"},
                 ),
             ],
+            False,
         )
     assert mock_send_fn.mock_calls == [
         call(

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -8,10 +8,11 @@ from app.config import Config, QueueNames
 def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()
-    assert len(queues) == 18
+    assert len(queues) == 19
     assert {
         QueueNames.PERIODIC,
         QueueNames.DATABASE,
+        QueueNames.DATABASE_DOCUMENTS,
         QueueNames.SEND_SMS,
         QueueNames.SEND_EMAIL,
         QueueNames.SEND_LETTER,


### PR DESCRIPTION
adds branching logic to put `save-email` tasks  with `has_documents` true onto the dedicated queue for emails with files, `database-tasks-documents`

This needs deploying to all workers before https://github.com/alphagov/notifications-api/pull/4795 can be deployed, otherwise workers will get called with an argument that they can't handle.

TODO:
- [x] [Add Valid Startup Command](https://github.com/alphagov/notifications-api/pull/4792)
-  [x] [New queue and worker](https://github.com/alphagov/notifications-aws/pull/2884)
-  [ ] [Add new argument has_documents to shatter-job-rows task](https://github.com/alphagov/notifications-api/pull/4784/changes)
-  [ ] [Call shatter-job-rows task with has_documents argument ](https://github.com/alphagov/notifications-api/pull/4795/changes)