### PR TITLE
Set up OpenTelemetry auto-instrumentation for Celery workers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@111.0.0
+# This file was automatically copied from notifications-utils@113.3.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -29,3 +29,25 @@ notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@11
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 
 sentry-sdk[flask,celery,sqlalchemy]~=1.45
+
+opentelemetry-distro[otlp]
+opentelemetry-instrumentation-asyncio
+opentelemetry-instrumentation-dbapi
+opentelemetry-instrumentation-logging
+opentelemetry-instrumentation-sqlite3
+opentelemetry-instrumentation-threading
+opentelemetry-instrumentation-urllib
+opentelemetry-instrumentation-wsgi
+opentelemetry-instrumentation-boto3sqs
+opentelemetry-instrumentation-botocore
+opentelemetry-instrumentation-celery
+opentelemetry-instrumentation-click
+opentelemetry-instrumentation-flask
+opentelemetry-instrumentation-grpc
+opentelemetry-instrumentation-jinja2
+opentelemetry-instrumentation-psycopg2
+opentelemetry-instrumentation-redis
+opentelemetry-instrumentation-requests
+opentelemetry-instrumentation-sqlalchemy
+opentelemetry-instrumentation-system-metrics
+opentelemetry-instrumentation-urllib3

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ psutil>=6.0.0,<7.0.0
 notifications-python-client==10.0.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@111.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@113.3.0
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -94,10 +94,16 @@ fqdn==1.5.1
     # via jsonschema
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.in
+googleapis-common-protos==1.74.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
 govuk-bank-holidays==0.19
     # via notifications-utils
 greenlet==3.3.2
     # via eventlet
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 gunicorn==25.1.0
     # via
     #   -r requirements.in
@@ -155,21 +161,175 @@ notifications-python-client==10.0.1
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@58855282da48d522d0639e3f7732027f6ac73ab3
     # via -r requirements.in
 opentelemetry-api==1.40.0
-    # via notifications-utils
+    # via
+    #   notifications-utils
+    #   opentelemetry-distro
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-psycopg2
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-sqlite3
+    #   opentelemetry-instrumentation-system-metrics
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-propagator-aws-xray
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-distro==0.61b0
+    # via -r requirements.in
+opentelemetry-exporter-otlp==1.40.0
+    # via opentelemetry-distro
+opentelemetry-exporter-otlp-proto-common==1.40.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.40.0
+    # via opentelemetry-exporter-otlp
+opentelemetry-exporter-otlp-proto-http==1.40.0
+    # via opentelemetry-exporter-otlp
+opentelemetry-instrumentation==0.61b0
+    # via
+    #   opentelemetry-distro
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-psycopg2
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-sqlite3
+    #   opentelemetry-instrumentation-system-metrics
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+opentelemetry-instrumentation-asyncio==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-boto3sqs==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-botocore==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-celery==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-click==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-dbapi==0.61b0
+    # via
+    #   -r requirements.in
+    #   opentelemetry-instrumentation-psycopg2
+    #   opentelemetry-instrumentation-sqlite3
+opentelemetry-instrumentation-flask==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-grpc==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-jinja2==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-logging==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-psycopg2==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-redis==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-requests==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-sqlalchemy==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-sqlite3==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-system-metrics==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-threading==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-urllib==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-urllib3==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-wsgi==0.61b0
+    # via
+    #   -r requirements.in
+    #   opentelemetry-instrumentation-flask
+opentelemetry-propagator-aws-xray==1.0.2
+    # via opentelemetry-instrumentation-botocore
+opentelemetry-proto==1.40.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.40.0
+    # via
+    #   opentelemetry-distro
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.61b0
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+opentelemetry-util-http==0.61b0
+    # via
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
 ordered-set==4.1.0
     # via notifications-utils
 packaging==26.0
     # via
     #   gunicorn
     #   kombu
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-sqlalchemy
 phonenumbers==9.0.25
     # via notifications-utils
 prometheus-client==0.24.1
     # via gds-metrics
 prompt-toolkit==3.0.52
     # via click-repl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==6.1.1
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   opentelemetry-instrumentation-system-metrics
 psycopg2-binary==2.9.10
     # via -r requirements.in
 pycurl==7.45.7
@@ -203,6 +363,7 @@ requests==2.32.5
     #   govuk-bank-holidays
     #   notifications-python-client
     #   notifications-utils
+    #   opentelemetry-exporter-otlp-proto-http
 rfc3339-validator==0.1.4
     # via jsonschema
 rfc3987==1.3.8
@@ -235,7 +396,12 @@ statsd==4.0.1
 typing-extensions==4.15.0
     # via
     #   alembic
+    #   grpcio
     #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   sqlalchemy
 tzdata==2025.3
     # via
@@ -265,5 +431,18 @@ werkzeug==3.1.6
     # via flask
 wheel==0.44.0
     # via click-datetime
+wrapt==1.17.3
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-urllib3
 zipp==3.23.0
     # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -152,7 +152,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@900cb380b9f92b23886586207f44c99893d2b56b
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@58855282da48d522d0639e3f7732027f6ac73ab3
     # via -r requirements.in
 opentelemetry-api==1.40.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -228,7 +228,7 @@ mypy-extensions==1.1.0
     # via mypy
 notifications-python-client==10.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@900cb380b9f92b23886586207f44c99893d2b56b
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@58855282da48d522d0639e3f7732027f6ac73ab3
     # via -r requirements.txt
 opentelemetry-api==1.40.0
     # via

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -143,6 +143,11 @@ freezegun==1.5.5
     # via -r requirements_for_test_common.in
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.txt
+googleapis-common-protos==1.74.0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
 govuk-bank-holidays==0.19
     # via
     #   -r requirements.txt
@@ -151,6 +156,10 @@ greenlet==3.3.2
     # via
     #   -r requirements.txt
     #   eventlet
+grpcio==1.80.0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 gunicorn==25.1.0
     # via
     #   -r requirements.txt
@@ -234,6 +243,162 @@ opentelemetry-api==1.40.0
     # via
     #   -r requirements.txt
     #   notifications-utils
+    #   opentelemetry-distro
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-psycopg2
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-sqlite3
+    #   opentelemetry-instrumentation-system-metrics
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-propagator-aws-xray
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-distro==0.61b0
+    # via -r requirements.txt
+opentelemetry-exporter-otlp==1.40.0
+    # via -r requirements.txt
+opentelemetry-exporter-otlp-proto-common==1.40.0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.40.0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-exporter-otlp
+opentelemetry-exporter-otlp-proto-http==1.40.0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-exporter-otlp
+opentelemetry-instrumentation==0.61b0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-distro
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-psycopg2
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-sqlite3
+    #   opentelemetry-instrumentation-system-metrics
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+opentelemetry-instrumentation-asyncio==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-boto3sqs==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-botocore==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-celery==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-click==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-dbapi==0.61b0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-instrumentation-psycopg2
+    #   opentelemetry-instrumentation-sqlite3
+opentelemetry-instrumentation-flask==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-grpc==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-jinja2==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-logging==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-psycopg2==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-redis==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-requests==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-sqlalchemy==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-sqlite3==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-system-metrics==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-threading==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-urllib==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-urllib3==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-wsgi==0.61b0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-instrumentation-flask
+opentelemetry-propagator-aws-xray==1.0.2
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-instrumentation-botocore
+opentelemetry-proto==1.40.0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.40.0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-distro
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.61b0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+opentelemetry-util-http==0.61b0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
 ordered-set==4.1.0
     # via
     #   -r requirements.txt
@@ -243,6 +408,9 @@ packaging==26.0
     #   -r requirements.txt
     #   gunicorn
     #   kombu
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-sqlalchemy
     #   pytest
 pathspec==1.0.4
     # via mypy
@@ -260,8 +428,15 @@ prompt-toolkit==3.0.52
     # via
     #   -r requirements.txt
     #   click-repl
+protobuf==6.33.6
+    # via
+    #   -r requirements.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==6.1.1
-    # via -r requirements.txt
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-instrumentation-system-metrics
 psycopg2-binary==2.9.10
     # via -r requirements.txt
 pycparser==3.0
@@ -333,6 +508,7 @@ requests==2.32.5
     #   moto
     #   notifications-python-client
     #   notifications-utils
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-mock
     #   responses
 requests-mock==1.12.1
@@ -398,8 +574,13 @@ typing-extensions==4.15.0
     #   -r requirements.txt
     #   alembic
     #   beautifulsoup4
+    #   grpcio
     #   mypy
     #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   sqlalchemy
 tzdata==2025.3
     # via
@@ -442,6 +623,20 @@ wheel==0.44.0
     # via
     #   -r requirements.txt
     #   click-datetime
+wrapt==1.17.3
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-urllib3
 xmltodict==1.0.4
     # via moto
 zipp==3.23.0

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@111.0.0
+# This file was automatically copied from notifications-utils@113.3.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@111.0.0
+# This file was automatically copied from notifications-utils@113.3.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/run_celery.py
+++ b/run_celery.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 
+import os
+
 import notifications_utils.logging.celery as celery_logging
+from celery.signals import worker_process_init
+from notifications_utils.semconv import set_service_instance_id
+from opentelemetry.instrumentation import auto_instrumentation
 
 from app.performance import init_performance_monitoring
 
@@ -28,3 +33,10 @@ from app.notify_api_flask_app import NotifyApiFlaskApp  # noqa
 application = NotifyApiFlaskApp("delivery")
 create_app(application)
 celery_logging.set_up_logging(application.config)
+
+
+@worker_process_init.connect
+def init_worker(**_) -> None:
+    if os.environ.get("OTEL_SERVICE_NAME") is not None:
+        set_service_instance_id()
+        auto_instrumentation.initialize()


### PR DESCRIPTION
https://trello.com/c/25A3gpXh/1358-replace-statsd-instrumentation-across-notify-with-otel

Sets up OTel auto-instrumentation for Celery workers. This gives us automatic context/baggage propagation as well as a handful of metrics (although the automatic propagation won't work properly until we set up auto-instrumentation for our web apps). By configuring the OTel SDK we also enable the new Celery histogram metrics added in alphagov/notifications-utils#1298.

The newly added metrics follow a different naming convention to the existing StatsD-based ones, and so do not conflict with them.

Tested in dev-b: the new Celery duration metrics are reported correctly, and more importantly the values we're getting for them match the values generated by the existing StatsD instrumentation (`sum(celery_task_duration_seconds_count{celery_task_status="retry"})` == `sum(notify_celery_retry_time_summary_count)` and `sum(celery_task_duration_seconds_count{celery_task_status="failure"})` == `notify_celery_failures_total`).

The other StatsD-based metrics will be re-implemented in OTel in future PRs, I just wanted to keep this change as small as possible.