### PR TITLE
refactor: move notifications and jobs to read replica

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -1246,10 +1246,12 @@ def fetch_volumes_by_service(
     return results
 
 
+@retryable_query()
 def get_count_of_notifications_sent(
     service_id,
     template_types,
     limit_days,
+    session: Session | scoped_session = db.session,
 ):
     filters = [
         FactBilling.service_id == service_id,
@@ -1257,7 +1259,7 @@ def get_count_of_notifications_sent(
         FactBilling.notification_type.in_(template_types),
     ]
 
-    query = FactBilling.query.filter(*filters)
+    query = session.query(FactBilling).filter(*filters)
 
     notifications_count = query.with_entities(func.sum(FactBilling.notifications_sent)).scalar()
 

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -160,9 +160,12 @@ def update_fact_notification_status(
     return deleted_row_count
 
 
-def fetch_notification_status_for_service_by_month(start_date, end_date, service_id):
+@retryable_query()
+def fetch_notification_status_for_service_by_month(
+    start_date, end_date, service_id, session: Session | scoped_session = db.session
+):
     return (
-        db.session.query(
+        session.query(
             func.date_trunc("month", FactNotificationStatus.bst_date).label("month"),
             FactNotificationStatus.notification_type,
             FactNotificationStatus.notification_status,
@@ -183,9 +186,10 @@ def fetch_notification_status_for_service_by_month(start_date, end_date, service
     )
 
 
-def fetch_notification_status_for_service_for_day(bst_day, service_id):
+@retryable_query()
+def fetch_notification_status_for_service_for_day(bst_day, service_id, session: Session | scoped_session = db.session):
     return (
-        db.session.query(
+        session.query(
             # return current month as a datetime so the data has the same shape as the ft_notification_status query
             literal(bst_day.replace(day=1), type_=DateTime).label("month"),
             Notification.notification_type,

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -8,6 +8,7 @@ from notifications_utils.letter_timings import (
     letter_can_be_cancelled,
 )
 from sqlalchemy import and_, asc, desc, func
+from sqlalchemy.orm import Session, scoped_session
 
 from app import db, redis_store
 from app.constants import (
@@ -31,7 +32,7 @@ from app.models import (
     ServiceDataRetention,
     Template,
 )
-from app.utils import midnight_n_days_ago
+from app.utils import midnight_n_days_ago, retryable_query
 
 
 def dao_get_notification_outcomes_for_job(job_id):
@@ -85,11 +86,13 @@ def dao_get_jobs_by_service_id(
     )
 
 
+@retryable_query()
 def dao_get_scheduled_job_stats(
     service_id,
+    session: Session | scoped_session = db.session,
 ):
     return (
-        db.session.query(
+        session.query(
             func.count(Job.id),
             func.min(Job.scheduled_for),
         )

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -242,10 +242,18 @@ def dao_update_notification(notification):
     db.session.add(notification)
 
 
-def get_notifications_for_job(service_id, job_id, filter_dict=None, page=1, page_size=None):
+@retryable_query()
+def get_notifications_for_job(
+    service_id,
+    job_id,
+    filter_dict=None,
+    page=1,
+    page_size=None,
+    session: Session | scoped_session = db.session,
+):
     if page_size is None:
         page_size = current_app.config["PAGE_SIZE"]
-    query = Notification.query.filter_by(service_id=service_id, job_id=job_id)
+    query = session.query(Notification).filter_by(service_id=service_id, job_id=job_id)
     query = _filter_query(query, filter_dict)
     return query.order_by(asc(Notification.job_row_number)).paginate(page=page, per_page=page_size)
 

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -171,8 +171,11 @@ def dao_fetch_live_services_data(session: Session | scoped_session = db.session)
     return [row._asdict() for row in data]
 
 
-def dao_fetch_service_by_id(service_id, only_active=False, with_users=True):
-    query = Service.query.filter_by(id=service_id)
+@retryable_query()
+def dao_fetch_service_by_id(
+    service_id, only_active=False, with_users=True, session: Session | scoped_session = db.session
+):
+    query = session.query(Service).filter_by(id=service_id)
 
     if with_users:
         query = query.options(joinedload(Service.users))

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -3,6 +3,7 @@ from datetime import UTC
 import dateutil
 from flask import Blueprint, current_app, jsonify, request
 
+from app import db
 from app.aws.s3 import get_job_metadata_from_s3
 from app.celery.tasks import process_job
 from app.config import QueueNames
@@ -191,7 +192,7 @@ def create_job(service_id):
 
 @job_blueprint.route("/scheduled-job-stats", methods=["GET"])
 def get_scheduled_job_stats(service_id):
-    count, soonest_scheduled_for = dao_get_scheduled_job_stats(service_id)
+    count, soonest_scheduled_for = dao_get_scheduled_job_stats(service_id, session=db.session_bulk, retry_attempts=2)
     return (
         jsonify(
             count=count,

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -85,7 +85,13 @@ def get_all_notifications_for_service_job(service_id, job_id):
     page = data["page"] if "page" in data else 1
     page_size = data["page_size"] if "page_size" in data else current_app.config.get("PAGE_SIZE")
     paginated_notifications = get_notifications_for_job(
-        service_id, job_id, filter_dict=data, page=page, page_size=page_size
+        service_id,
+        job_id,
+        filter_dict=data,
+        page=page,
+        page_size=page_size,
+        session=db.session_bulk,
+        retry_attempts=2,
     )
 
     kwargs = request.args.to_dict()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -693,7 +693,7 @@ def search_for_notification_by_to_field(service_id, search_term, statuses, notif
 @service_blueprint.route("/<uuid:service_id>/notifications/monthly", methods=["GET"])
 def get_monthly_notification_stats(service_id):
     # check service_id validity
-    dao_fetch_service_by_id(service_id)
+    dao_fetch_service_by_id(service_id, session=db.session_bulk, retry_attempts=2)
 
     try:
         year = int(request.args.get("year", "NaN"))
@@ -704,12 +704,19 @@ def get_monthly_notification_stats(service_id):
 
     data = statistics.create_empty_monthly_notification_status_stats_dict(year)
 
-    stats = fetch_notification_status_for_service_by_month(start_date, end_date, service_id)
+    session = db.session_bulk
+    retry_attempts = 2
+
+    stats = fetch_notification_status_for_service_by_month(
+        start_date, end_date, service_id, session=session, retry_attempts=retry_attempts
+    )
     statistics.add_monthly_notification_status_stats(data, stats)
 
     now = datetime.utcnow()
     if end_date > now:
-        todays_deltas = fetch_notification_status_for_service_for_day(convert_utc_to_bst(now), service_id=service_id)
+        todays_deltas = fetch_notification_status_for_service_for_day(
+            convert_utc_to_bst(now), service_id=service_id, session=session, retry_attempts=retry_attempts
+        )
         statistics.add_monthly_notification_status_stats(data, todays_deltas)
 
     return jsonify(data=data)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -591,6 +591,8 @@ def count_notifications_for_service(service_id):
         service_id=service_id,
         template_types=template_types,
         limit_days=limit_days,
+        session=db.session_bulk,
+        retry_attempts=2,
     )
 
     return jsonify({"notifications_sent_count": notification_count}), 200

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -457,24 +457,54 @@ def test_save_notification_no_job_id(sample_template):
     assert data.get("job_id") is None
 
 
-def test_get_all_notifications_for_job(sample_job):
+@pytest.mark.parametrize(
+    "session,expected_bind_key",
+    (
+        (db.session, None),
+        (db.session_bulk, "bulk"),
+    ),
+    ids=("default", "bulk"),
+)
+def test_get_all_notifications_for_job(sample_job, session, expected_bind_key):
+    service_id = sample_job.service.id
+    job_id = sample_job.id
+
     for _ in range(5):
         try:
             create_notification(template=sample_job.template, job=sample_job)
         except IntegrityError:
             pass
 
-    notifications_from_db = get_notifications_for_job(sample_job.service.id, sample_job.id).items
+    notifications_from_db = []
+
+    with QueryRecorder() as query_recorder:
+        notifications_from_db = get_notifications_for_job(service_id, job_id, session=session).items
+
+    assert {query_info.bind_key for query_info in query_recorder.queries} == {expected_bind_key}
+
     assert len(notifications_from_db) == 5
 
 
-def test_get_all_notifications_for_job_by_status(sample_job):
-    notifications = partial(get_notifications_for_job, sample_job.service.id, sample_job.id)
+@pytest.mark.parametrize(
+    "session,expected_bind_key",
+    (
+        (db.session, None),
+        (db.session_bulk, "bulk"),
+    ),
+    ids=("default", "bulk"),
+)
+def test_get_all_notifications_for_job_by_status(sample_job, session, expected_bind_key):
+    notifications = partial(get_notifications_for_job, sample_job.service.id, sample_job.id, session=session)
 
     for status in NOTIFICATION_STATUS_TYPES:
         create_notification(template=sample_job.template, job=sample_job, status=status)
 
-    assert len(notifications().items) == len(NOTIFICATION_STATUS_TYPES)
+    with QueryRecorder() as query_recorder:
+        all_for_job = notifications().items
+
+    assert {query_info.bind_key for query_info in query_recorder.queries} == {expected_bind_key}
+
+    assert len(all_for_job) == len(NOTIFICATION_STATUS_TYPES)
 
     for status in NOTIFICATION_STATUS_TYPES:
         if status == "failed":

--- a/tests/app/dao/test_fact_billing_dao.py
+++ b/tests/app/dao/test_fact_billing_dao.py
@@ -2042,7 +2042,12 @@ test_cases = [
     test_cases,
     ids=["All template types within 7 days", "Only SMS template type within 7 days", "Limit days exclude all data"],
 )
-def test_get_count_of_notifications_sent(sample_service, test_case):
+@pytest.mark.parametrize(
+    "session,expected_bind_key",
+    ((db.session, None), (db.session_bulk, "bulk")),
+    ids=("default", "bulk"),
+)
+def test_get_count_of_notifications_sent(sample_service, test_case, session, expected_bind_key):
     assert len(FactBilling.query.all()) == 0
 
     sms_template = create_template(service=sample_service, template_type="sms")
@@ -2056,9 +2061,18 @@ def test_get_count_of_notifications_sent(sample_service, test_case):
             notifications_sent=notification_data["notifications_sent"],
         )
 
-    count = get_count_of_notifications_sent(
-        service_id=sample_service.id, template_types=test_case.template_types, limit_days=test_case.limit_days
-    )
+    count = 0
+    service_id = sample_service.id
+
+    with QueryRecorder() as query_recorder:
+        count = get_count_of_notifications_sent(
+            service_id=service_id,
+            template_types=test_case.template_types,
+            limit_days=test_case.limit_days,
+            session=session,
+        )
+
+    assert {query_info.bind_key for query_info in query_recorder.queries} == {expected_bind_key}
 
     assert count == test_case.expected_count
 

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -47,7 +47,15 @@ from tests.app.db import (
 from tests.utils import QueryRecorder
 
 
-def test_fetch_notification_status_for_service_by_month(notify_db_session):
+@pytest.mark.parametrize(
+    "session,expected_bind_key",
+    (
+        (db.session, None),
+        (db.session_bulk, "bulk"),
+    ),
+    ids=("default", "bulk"),
+)
+def test_fetch_notification_status_for_service_by_month(notify_db_session, session, expected_bind_key):
     service_1 = create_service(service_name="service_1")
     service_2 = create_service(service_name="service_2")
 
@@ -67,10 +75,18 @@ def test_fetch_notification_status_for_service_by_month(notify_db_session):
     # not included - test keys
     create_ft_notification_status(date(2018, 1, 3), "sms", service_1, key_type=KEY_TYPE_TEST)
 
-    results = sorted(
-        fetch_notification_status_for_service_by_month(date(2018, 1, 1), date(2018, 2, 28), service_1.id),
-        key=lambda x: (x.month, x.notification_type, x.notification_status),
-    )
+    results = []
+    start_date = date(2018, 1, 1)
+    end_date = date(2018, 2, 28)
+    service_id = service_1.id
+
+    with QueryRecorder() as query_recorder:
+        results = sorted(
+            fetch_notification_status_for_service_by_month(start_date, end_date, service_id, session=session),
+            key=lambda x: (x.month, x.notification_type, x.notification_status),
+        )
+
+    assert {query_info.bind_key for query_info in query_recorder.queries} == {expected_bind_key}
 
     assert len(results) == 4
 

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -8,6 +8,7 @@ import pytest
 from freezegun import freeze_time
 from sqlalchemy.exc import IntegrityError
 
+from app import db
 from app.constants import EMAIL_TYPE, JOB_STATUS_FINISHED, LETTER_TYPE, SMS_TYPE
 from app.dao.jobs_dao import (
     can_letter_job_be_cancelled,
@@ -18,6 +19,7 @@ from app.dao.jobs_dao import (
     dao_get_jobs_older_than_data_retention,
     dao_get_notification_outcomes_for_job,
     dao_get_scheduled_job_by_id_and_service_id,
+    dao_get_scheduled_job_stats,
     dao_set_scheduled_jobs_to_pending,
     dao_update_job,
     find_jobs_that_completed_processing,
@@ -34,6 +36,7 @@ from tests.app.db import (
     create_service_contact_list,
     create_template,
 )
+from tests.utils import QueryRecorder
 
 
 def test_should_count_of_statuses_for_notifications_associated_with_job(sample_template, sample_job):
@@ -159,6 +162,29 @@ def test_get_jobs_for_service_in_processed_at_then_created_at_order(notify_db_se
 
     for index in range(len(created_jobs)):
         assert jobs[index].id == created_jobs[index].id
+
+
+@pytest.mark.parametrize(
+    "session,expected_bind_key",
+    (
+        (db.session, None),
+        (db.session_bulk, "bulk"),
+    ),
+    ids=("default", "bulk"),
+)
+def test_dao_get_scheduled_job_stats_uses_expected_session_binding(notify_db_session, session, expected_bind_key):
+    service = create_service(service_name="service with scheduled jobs")
+    template = create_template(service=service)
+    create_job(template, job_status="scheduled", scheduled_for=datetime.utcnow() + timedelta(hours=1))
+    service_id = service.id
+
+    with QueryRecorder() as query_recorder:
+        count, soonest_scheduled_for = dao_get_scheduled_job_stats(service_id, session=session)
+
+    assert {query_info.bind_key for query_info in query_recorder.queries} == {expected_bind_key}
+
+    assert count == 1
+    assert soonest_scheduled_for is not None
 
 
 def test_get_jobs_for_service_by_contact_list(sample_template):

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -7,6 +7,7 @@ import pytest
 from freezegun import freeze_time
 
 import app.celery.tasks
+from app import db
 from app.celery.tasks import process_job
 from app.constants import JOB_STATUS_PENDING, JOB_STATUS_TYPES
 from app.dao.templates_dao import dao_update_template
@@ -987,6 +988,18 @@ def test_get_jobs_should_retrieve_from_ft_notification_status_for_old_jobs(admin
         mocker.call(f"job-{resp_json['data'][1]['id']}-notification-outcomes"),
         mocker.call(f"job-{resp_json['data'][2]['id']}-notification-outcomes"),
     ]
+
+
+@freeze_time("2017-07-17 07:17")
+def test_get_scheduled_job_stats_uses_session_bulk(admin_request, sample_template, mocker):
+    mock_get_stats = mocker.patch(
+        "app.job.rest.dao_get_scheduled_job_stats",
+        return_value=(0, None),
+    )
+
+    admin_request.get("job.get_scheduled_job_stats", service_id=sample_template.service.id)
+
+    mock_get_stats.assert_called_once_with(sample_template.service.id, session=db.session_bulk, retry_attempts=2)
 
 
 @freeze_time("2017-07-17 07:17")


### PR DESCRIPTION
## Summary
Directed queries from the following endpoints to read replica

- /service/{service_id}/job/scheduled-job-stats
- /service/{service_id}/job/{job_id}/notifications
- /service/{service_id}/job
- /service/{service_id}/notifications/count
- /service/{service_id}/notifications/monthly

###  Ticket
[DB Replica - Admin Dashboard: Notifications & Jobs](https://trello.com/c/rb1NBhGU/1737-db-replica-admin-dashboard-notifications-jobs)