### PR TITLE
Pass encryption_key to generate_token

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -845,6 +845,7 @@ def functional_test_fixtures():
         SQLALCHEMY_DATABASE_URI
         REDIS_URL
         SECRET_KEY
+        TOKEN_SECRET_KEY
         INTERNAL_CLIENT_API_KEYS
         ADMIN_BASE_URL
         API_HOST_NAME

--- a/app/config.py
+++ b/app/config.py
@@ -108,6 +108,7 @@ class Config:
 
     # encyption secret/salt
     SECRET_KEY = os.getenv("SECRET_KEY")
+    TOKEN_SECRET_KEY = os.getenv("TOKEN_SECRET_KEY")
     DANGEROUS_SALT = os.getenv("DANGEROUS_SALT")
 
     # DB conection string
@@ -614,6 +615,7 @@ class Development(Config):
     }
 
     SECRET_KEY = "dev-notify-secret-key"
+    TOKEN_SECRET_KEY = "5YNWU0e_pN5ZyaSZvBd5uZb_sZlrVDFeOjiea6dq4zQ="
     DANGEROUS_SALT = "dev-notify-salt"
 
     MMG_INBOUND_SMS_AUTH = ["testkey"]

--- a/app/one_click_unsubscribe/rest.py
+++ b/app/one_click_unsubscribe/rest.py
@@ -27,7 +27,11 @@ def one_click_unsubscribe(notification_id, token):
 
     try:
         email_address = check_token(
-            token, current_app.config["SECRET_KEY"], current_app.config["DANGEROUS_SALT"], max_age_seconds
+            token,
+            current_app.config["SECRET_KEY"],
+            current_app.config["DANGEROUS_SALT"],
+            max_age_seconds,
+            current_app.config["TOKEN_SECRET_KEY"],
         )
     except BadData as e:
         errors = {"unsubscribe request": "This is not a valid unsubscribe link."}

--- a/app/organisation/invite_rest.py
+++ b/app/organisation/invite_rest.py
@@ -126,7 +126,11 @@ def validate_invitation_token(token):
 
     try:
         invited_user_id = check_token(
-            token, current_app.config["SECRET_KEY"], current_app.config["DANGEROUS_SALT"], max_age_seconds
+            token,
+            current_app.config["SECRET_KEY"],
+            current_app.config["DANGEROUS_SALT"],
+            max_age_seconds,
+            current_app.config["TOKEN_SECRET_KEY"],
         )
     except SignatureExpired as e:
         errors = {

--- a/app/organisation/invite_rest.py
+++ b/app/organisation/invite_rest.py
@@ -104,7 +104,10 @@ def update_org_invite_status(organisation_id, invited_org_user_id):
 
 def invited_org_user_url(invited_org_user_id, invite_link_host=None):
     token = generate_token(
-        str(invited_org_user_id), current_app.config["SECRET_KEY"], current_app.config["DANGEROUS_SALT"]
+        str(invited_org_user_id),
+        current_app.config["SECRET_KEY"],
+        current_app.config["DANGEROUS_SALT"],
+        current_app.config["TOKEN_SECRET_KEY"],
     )
 
     if invite_link_host is None:

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -105,7 +105,11 @@ def validate_service_invitation_token(token):
 
     try:
         invited_user_id = check_token(
-            token, current_app.config["SECRET_KEY"], current_app.config["DANGEROUS_SALT"], max_age_seconds
+            token,
+            current_app.config["SECRET_KEY"],
+            current_app.config["DANGEROUS_SALT"],
+            max_age_seconds,
+            current_app.config["TOKEN_SECRET_KEY"],
         )
     except SignatureExpired as e:
         errors = {

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -84,7 +84,12 @@ def update_invited_user(service_id, invited_user_id):
 
 
 def invited_user_url(invited_user_id, invite_link_host=None):
-    token = generate_token(str(invited_user_id), current_app.config["SECRET_KEY"], current_app.config["DANGEROUS_SALT"])
+    token = generate_token(
+        str(invited_user_id),
+        current_app.config["SECRET_KEY"],
+        current_app.config["DANGEROUS_SALT"],
+        current_app.config["TOKEN_SECRET_KEY"],
+    )
 
     if invite_link_host is None:
         invite_link_host = current_app.config["ADMIN_BASE_URL"]

--- a/app/utils.py
+++ b/app/utils.py
@@ -79,7 +79,12 @@ def batched[A](iterable: Iterable[A], n: int, *, strict: bool = False) -> Genera
 
 
 def url_with_token(data, url: str, base_url: str | None = None) -> str:
-    token = generate_token(data, current_app.config["SECRET_KEY"], current_app.config["DANGEROUS_SALT"])
+    token = generate_token(
+        data,
+        current_app.config["SECRET_KEY"],
+        current_app.config["DANGEROUS_SALT"],
+        current_app.config["TOKEN_SECRET_KEY"],
+    )
     base_url = (base_url or current_app.config["ADMIN_BASE_URL"]) + url
     return urljoin(base_url, token)
 

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -7,7 +7,7 @@ import pytest
 from flask import current_app
 from freezegun import freeze_time
 from notifications_utils.s3 import S3ObjectNotFound
-from notifications_utils.url_safe_token import generate_token
+from notifications_utils.url_safe_token import check_token
 from sqlalchemy.orm import Session
 
 from app.utils import (
@@ -79,24 +79,41 @@ def test_url_with_token_unsubscribe_link(sample_email_notification, hostnames, n
     notification_id = sample_email_notification.id
     base_url = hostnames.api
     url = f"/unsubscribe/{str(notification_id)}/"
-    token = generate_token(data, notify_api.config["SECRET_KEY"], notify_api.config["DANGEROUS_SALT"])
 
-    expected_unsubscribe_link = f"{base_url}/unsubscribe/{notification_id}/{token}"
-    generated_unsubscribe_link = url_with_token(data, url=url, base_url=base_url)
-
-    assert generated_unsubscribe_link == expected_unsubscribe_link
+    expected_unsubscribe_link_preamble = f"{base_url}/unsubscribe/{notification_id}/"
+    generated_url = url_with_token(data, url=url, base_url=base_url)
+    url_fragments = generated_url.split("/")
+    token = url_fragments[-1]
+    decrypted_data = check_token(
+        token,
+        notify_api.config["SECRET_KEY"],
+        notify_api.config["DANGEROUS_SALT"],
+        1000,
+        notify_api.config["TOKEN_SECRET_KEY"],
+    )
+    assert expected_unsubscribe_link_preamble == "/".join(url_fragments[:-1]) + "/"
+    assert decrypted_data == data
 
 
 def test_url_with_token__create_confirmation_url(hostnames, notify_api):
+
     data = json.dumps({"user_id": str(uuid.uuid4()), "email": "foo@bar.com"})
     base_url = hostnames.admin
     url = "/your-account/email/confirm/"
-    token = generate_token(str(data), notify_api.config["SECRET_KEY"], notify_api.config["DANGEROUS_SALT"])
 
-    expected_unsubscribe_link = f"{base_url}/your-account/email/confirm/{token}"
-    generated_unsubscribe_link = url_with_token(data, url=url, base_url=base_url)
-
-    assert generated_unsubscribe_link == expected_unsubscribe_link
+    expected_confirmation_link_preamble = f"{base_url}/your-account/email/confirm/"
+    generated_url = url_with_token(data, url=url, base_url=base_url)
+    url_fragments = generated_url.split("/")
+    token = url_fragments[-1]
+    decrypted_data = check_token(
+        token,
+        notify_api.config["SECRET_KEY"],
+        notify_api.config["DANGEROUS_SALT"],
+        1000,
+        notify_api.config["TOKEN_SECRET_KEY"],
+    )
+    assert expected_confirmation_link_preamble == "/".join(url_fragments[:-1]) + "/"
+    assert decrypted_data == data
 
 
 def test_try_download_template_email_file_from_s3(mocker, sample_service, fake_uuid, mock_utils_s3_download):

--- a/tests/app/user/test_rest_verify.py
+++ b/tests/app/user/test_rest_verify.py
@@ -394,15 +394,15 @@ def test_reset_failed_login_count_returns_404_when_user_does_not_exist(client):
     (
         (
             {},
-            "{hostnames.admin}/email-auth/%2E",
+            "{hostnames.admin}/email-auth/gAA",
         ),
         (
             {"to": None},
-            "{hostnames.admin}/email-auth/%2E",
+            "{hostnames.admin}/email-auth/gAA",
         ),
         (
             {"to": None, "email_auth_link_host": "https://example.com"},
-            "https://example.com/email-auth/%2E",
+            "https://example.com/email-auth/gAA",
         ),
     ),
 )


### PR DESCRIPTION
 This will start all new tokens being encrypted by passing in the encryption key
  to generate_token.
    
  It is important that everywhere has rolled out check_token first before this is
  rolled out

See https://github.com/alphagov/notifications-utils/pull/1336
