### PR TITLE
Pass encrypt key to check all the tokens

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -845,6 +845,7 @@ def functional_test_fixtures():
         SQLALCHEMY_DATABASE_URI
         REDIS_URL
         SECRET_KEY
+        TOKEN_SECRET_KEY
         INTERNAL_CLIENT_API_KEYS
         ADMIN_BASE_URL
         API_HOST_NAME

--- a/app/config.py
+++ b/app/config.py
@@ -108,6 +108,7 @@ class Config:
 
     # encyption secret/salt
     SECRET_KEY = os.getenv("SECRET_KEY")
+    TOKEN_SECRET_KEY = os.getenv("TOKEN_SECRET_KEY")
     DANGEROUS_SALT = os.getenv("DANGEROUS_SALT")
 
     # DB conection string
@@ -614,6 +615,7 @@ class Development(Config):
     }
 
     SECRET_KEY = "dev-notify-secret-key"
+    TOKEN_SECRET_KEY = "5YNWU0e_pN5ZyaSZvBd5uZb_sZlrVDFeOjiea6dq4zQ="
     DANGEROUS_SALT = "dev-notify-salt"
 
     MMG_INBOUND_SMS_AUTH = ["testkey"]

--- a/app/one_click_unsubscribe/rest.py
+++ b/app/one_click_unsubscribe/rest.py
@@ -27,7 +27,11 @@ def one_click_unsubscribe(notification_id, token):
 
     try:
         email_address = check_token(
-            token, current_app.config["SECRET_KEY"], current_app.config["DANGEROUS_SALT"], max_age_seconds
+            token,
+            current_app.config["SECRET_KEY"],
+            current_app.config["DANGEROUS_SALT"],
+            max_age_seconds,
+            current_app.config["TOKEN_SECRET_KEY"],
         )
     except BadData as e:
         errors = {"unsubscribe request": "This is not a valid unsubscribe link."}

--- a/app/organisation/invite_rest.py
+++ b/app/organisation/invite_rest.py
@@ -126,7 +126,11 @@ def validate_invitation_token(token):
 
     try:
         invited_user_id = check_token(
-            token, current_app.config["SECRET_KEY"], current_app.config["DANGEROUS_SALT"], max_age_seconds
+            token,
+            current_app.config["SECRET_KEY"],
+            current_app.config["DANGEROUS_SALT"],
+            max_age_seconds,
+            current_app.config["TOKEN_SECRET_KEY"],
         )
     except SignatureExpired as e:
         errors = {

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -105,7 +105,11 @@ def validate_service_invitation_token(token):
 
     try:
         invited_user_id = check_token(
-            token, current_app.config["SECRET_KEY"], current_app.config["DANGEROUS_SALT"], max_age_seconds
+            token,
+            current_app.config["SECRET_KEY"],
+            current_app.config["DANGEROUS_SALT"],
+            max_age_seconds,
+            current_app.config["TOKEN_SECRET_KEY"],
         )
     except SignatureExpired as e:
         errors = {


### PR DESCRIPTION
Pass encrypt key to check_token
    
This turns on the feature
    
alphagov/notifications-utils#1336
    
By passing in environment variables.
    
 We start checking for encrypted tokens before we encrypt them.
    
 The plan is to keep the signing code around for at least a year,
 so that we don't have eny tokens in things like unsubscribe links.
    
Encryption has been added everywhere for simplicities sake.