### PR TITLE
Delete `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[tool:pytest]
-xfail_strict=true


### PR DESCRIPTION
Pytest ignores this file, per this message:
```
configfile: pytest.ini (WARNING: ignoring pytest config in setup.cfg!)
```

The same `xfail` setting is already present here: https://github.com/alphagov/notifications-api/blob/5aa199e2ca975d11aedba312057b774cd5c7ca1f/pytest.ini#L10