### PR TITLE
More OTel metrics

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -125,9 +125,9 @@ def process_ses_results(  # noqa: C901
 
         statsd_client.incr(f"callback.ses.{notification_status}")
 
-        delivered_at = delivery_dt or datetime.utcnow()
         record_deliver_duration(
-            (delivered_at - notification.created_at).total_seconds(),
+            callback_duration=(receipt_dt - notification.created_at).total_seconds() if receipt_dt else None,
+            deliver_duration=(delivery_dt - notification.created_at).total_seconds() if delivery_dt else None,
             key_type=notification.key_type,
             notification_status=notification.status,
             notification_type="email",

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -17,6 +17,7 @@ from app.notifications.notifications_ses_callback import (
     determine_notification_bounce_type,
     handle_complaint,
 )
+from app.otel_metrics.notification import record_deliver_duration
 
 
 @notify_celery.task(
@@ -123,6 +124,15 @@ def process_ses_results(  # noqa: C901
             )
 
         statsd_client.incr(f"callback.ses.{notification_status}")
+
+        delivered_at = delivery_dt or datetime.utcnow()
+        record_deliver_duration(
+            (delivered_at - notification.created_at).total_seconds(),
+            key_type=notification.key_type,
+            notification_status=notification.status,
+            notification_type="email",
+            provider_name="ses",
+        )
 
         if notification.sent_at:
             statsd_client.timing_with_dates(

--- a/app/celery/process_sms_client_response_tasks.py
+++ b/app/celery/process_sms_client_response_tasks.py
@@ -17,7 +17,7 @@ from app.dao.templates_dao import dao_get_template_by_id
 from app.notifications.notifications_ses_callback import (
     check_and_queue_callback_task,
 )
-from app.otel_metrics.notification import record_international_sms
+from app.otel_metrics.notification import record_deliver_duration, record_international_sms
 
 sms_response_mapper = {
     "MMG": get_mmg_responses,
@@ -57,10 +57,10 @@ def process_sms_client_response(
 
     # validate status
     try:
+        delivery_dt = None
         try:
             notification_status, detailed_status = response_parser(status, detailed_status_code)
 
-            delivery_dt = None
             if delivery_iso_timestamp is not None:
                 try:
                     delivery_dt = datetime.fromisoformat(delivery_iso_timestamp)
@@ -96,7 +96,10 @@ def process_sms_client_response(
             )
         except KeyError as e:
             _process_for_status(
-                notification_status="technical-failure", client_name=client_name, provider_reference=provider_reference
+                notification_status="technical-failure",
+                client_name=client_name,
+                provider_reference=provider_reference,
+                delivered_at=delivery_dt or datetime.utcnow(),
             )
             raise ClientException(f"{client_name} callback failed: status {status} not found.") from e
 
@@ -104,13 +107,16 @@ def process_sms_client_response(
             notification_status=notification_status,
             client_name=client_name,
             provider_reference=provider_reference,
+            delivered_at=delivery_dt or datetime.utcnow(),
             detailed_status_code=detailed_status_code,
         )
     except OperationalError:
         self.retry(queue=QueueNames.RETRY)
 
 
-def _process_for_status(notification_status, client_name, provider_reference, detailed_status_code=None):
+def _process_for_status(
+    notification_status, client_name, provider_reference, delivered_at: datetime, detailed_status_code=None
+):
     # record stats
     notification = notifications_dao.update_notification_status_by_id(
         notification_id=provider_reference,
@@ -122,6 +128,15 @@ def _process_for_status(notification_status, client_name, provider_reference, de
         return
 
     statsd_client.incr(f"callback.{client_name.lower()}.{notification_status}")
+
+    record_deliver_duration(
+        (delivered_at - notification.created_at).total_seconds(),
+        key_type=notification.key_type,
+        notification_status=notification.status,
+        notification_type="sms",
+        provider_name=client_name.lower(),
+        sms_international=notification.international,
+    )
 
     if notification.sent_at:
         statsd_client.timing_with_dates(

--- a/app/celery/process_sms_client_response_tasks.py
+++ b/app/celery/process_sms_client_response_tasks.py
@@ -58,6 +58,7 @@ def process_sms_client_response(
     # validate status
     try:
         delivery_dt = None
+        receipt_dt = None
         try:
             notification_status, detailed_status = response_parser(status, detailed_status_code)
 
@@ -67,7 +68,6 @@ def process_sms_client_response(
                 except ValueError:
                     pass  # None it is, then
 
-            receipt_dt = None
             if receipt_iso_timestamp is not None:
                 try:
                     receipt_dt = datetime.fromisoformat(receipt_iso_timestamp)
@@ -99,7 +99,8 @@ def process_sms_client_response(
                 notification_status="technical-failure",
                 client_name=client_name,
                 provider_reference=provider_reference,
-                delivered_at=delivery_dt or datetime.utcnow(),
+                delivery_dt=delivery_dt,
+                receipt_dt=receipt_dt,
             )
             raise ClientException(f"{client_name} callback failed: status {status} not found.") from e
 
@@ -107,7 +108,8 @@ def process_sms_client_response(
             notification_status=notification_status,
             client_name=client_name,
             provider_reference=provider_reference,
-            delivered_at=delivery_dt or datetime.utcnow(),
+            delivery_dt=delivery_dt,
+            receipt_dt=receipt_dt,
             detailed_status_code=detailed_status_code,
         )
     except OperationalError:
@@ -115,7 +117,12 @@ def process_sms_client_response(
 
 
 def _process_for_status(
-    notification_status, client_name, provider_reference, delivered_at: datetime, detailed_status_code=None
+    notification_status,
+    client_name,
+    provider_reference,
+    delivery_dt: datetime | None,
+    receipt_dt: datetime | None,
+    detailed_status_code=None,
 ):
     # record stats
     notification = notifications_dao.update_notification_status_by_id(
@@ -130,7 +137,8 @@ def _process_for_status(
     statsd_client.incr(f"callback.{client_name.lower()}.{notification_status}")
 
     record_deliver_duration(
-        (delivered_at - notification.created_at).total_seconds(),
+        callback_duration=(receipt_dt - notification.created_at).total_seconds() if receipt_dt else None,
+        deliver_duration=(delivery_dt - notification.created_at).total_seconds() if delivery_dt else None,
         key_type=notification.key_type,
         notification_status=notification.status,
         notification_type="sms",

--- a/app/celery/process_sms_client_response_tasks.py
+++ b/app/celery/process_sms_client_response_tasks.py
@@ -17,6 +17,7 @@ from app.dao.templates_dao import dao_get_template_by_id
 from app.notifications.notifications_ses_callback import (
     check_and_queue_callback_task,
 )
+from app.otel_metrics.notification import record_international_sms
 
 sms_response_mapper = {
     "MMG": get_mmg_responses,
@@ -146,3 +147,6 @@ def _process_for_status(notification_status, client_name, provider_reference, de
         check_and_queue_callback_task(notification)
         if notification.international:
             statsd_client.incr(f"international-sms.{notification_status}.{notification.phone_prefix}")
+            record_international_sms(
+                1, notification_status=notification_status, sms_country_code=notification.phone_prefix
+            )

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -32,6 +32,7 @@ from app.dao.provider_details_dao import (
 from app.delivery import send_to_providers
 from app.exceptions import NotificationTechnicalFailureException
 from app.letters.utils import LetterPDFNotFound, find_letter_pdf_in_s3
+from app.otel_metrics.notification import record_send_duration
 
 
 @notify_celery.task(
@@ -151,16 +152,24 @@ def deliver_letter(self, notification_id):
         ) from e
 
     try:
-        dvla_client.send_letter(
-            notification_id=str(notification.id),
-            reference=str(notification.reference),
-            address=postal_address,
-            postage=notification.postage,
-            service_id=str(notification.service_id),
-            organisation_id=str(notification.service.organisation_id),
-            pdf_file=file_bytes,
-            callback_url=_get_callback_url(notification_id),
-        )
+        try:
+            dvla_client.send_letter(
+                notification_id=str(notification.id),
+                reference=str(notification.reference),
+                address=postal_address,
+                postage=notification.postage,
+                service_id=str(notification.service_id),
+                organisation_id=str(notification.service.organisation_id),
+                pdf_file=file_bytes,
+                callback_url=_get_callback_url(notification_id),
+            )
+        finally:
+            record_send_duration(
+                (datetime.utcnow() - notification.created_at).total_seconds(),
+                key_type=notification.key_type,
+                notification_type="letter",
+                provider_name="dvla",
+            )
         update_letter_to_sending(notification)
     except DvlaRetryableException as e:
         if isinstance(e, DvlaThrottlingException):

--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -10,6 +10,7 @@ from app.clients.email import (
     EmailClientException,
     EmailClientNonRetryableException,
 )
+from app.otel_metrics.provider import record_request_duration
 
 ses_response_map = {
     "Permanent": {
@@ -65,6 +66,7 @@ class AwsSesClient(EmailClient):
         self._client = boto3.client("sesv2", region_name=region)
         self.statsd_client = statsd_client
 
+    @record_request_duration(notification_type="email", provider_name="ses")
     def send_email(
         self,
         *,

--- a/app/clients/email/aws_ses_stub.py
+++ b/app/clients/email/aws_ses_stub.py
@@ -5,6 +5,7 @@ import requests
 from flask import current_app
 
 from app.clients.email import EmailClient, EmailClientException
+from app.otel_metrics.provider import record_request_duration
 
 
 class AwsSesStubClientException(EmailClientException):
@@ -26,6 +27,7 @@ class AwsSesStubClient(EmailClient):
         self.url = stub_url
         self.requests_session = requests.Session()
 
+    @record_request_duration(notification_type="email", provider_name="ses_stub")
     def send_email(
         self,
         *,

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -16,6 +16,7 @@ from urllib3.util.ssl_ import create_urllib3_context
 
 from app.clients import ClientException
 from app.constants import ECONOMY_CLASS, EUROPE, FIRST_CLASS, INTERNATIONAL_POSTAGE_TYPES, REST_OF_WORLD
+from app.otel_metrics.provider import record_request_duration
 
 
 class DvlaException(ClientException):
@@ -254,6 +255,7 @@ class DVLAClient:
             "X-API-Key": self.dvla_api_key.get(),
         }
 
+    @record_request_duration(notification_type="letter", provider_name="dvla")
     def send_letter(
         self,
         *,

--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -4,6 +4,7 @@ import logging
 import requests
 
 from app.clients.sms import SmsClient, SmsClientResponseException
+from app.otel_metrics.provider import record_request_duration
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,7 @@ class FiretextClient(SmsClient):
         self.url = self.current_app.config.get("FIRETEXT_URL")
         self.receipt_url = self.current_app.config.get("FIRETEXT_RECEIPT_URL")
 
+    @record_request_duration(notification_type="sms", provider_name="firetext")
     def try_send_sms(self, to, content, reference, international, sender):
         data = {
             "apiKey": self.international_api_key if international else self.api_key,

--- a/app/clients/sms/mmg.py
+++ b/app/clients/sms/mmg.py
@@ -3,6 +3,7 @@ import json
 import requests
 
 from app.clients.sms import SmsClient, SmsClientResponseException
+from app.otel_metrics.provider import record_request_duration
 
 # For some extra context, see google drive: GOV.UK Notify -> SMS suppliers -> Detailed failure statuses
 mmg_response_map = {
@@ -88,6 +89,7 @@ class MMGClient(SmsClient):
         self.mmg_url = self.current_app.config.get("MMG_URL")
         self.receipt_url = self.current_app.config.get("MMG_RECEIPT_URL")
 
+    @record_request_duration(notification_type="sms", provider_name="mmg")
     def try_send_sms(self, to, content, reference, international, sender):
         data = {"reqType": "BULK", "MSISDN": to, "msg": content, "sender": sender, "cid": reference, "multi": True}
 

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -34,6 +34,7 @@ from app.dao.provider_details_dao import (
 )
 from app.exceptions import NotificationTechnicalFailureException
 from app.models import Notification
+from app.otel_metrics.notification import record_international_sms
 from app.serialised_models import SerialisedProviders, SerialisedService, SerialisedTemplate
 
 
@@ -99,6 +100,9 @@ def send_sms_to_provider(notification: Notification) -> None:
                 update_notification_to_sending(notification, provider)
                 if notification.international:
                     statsd_client.incr(f"international-sms.{NOTIFICATION_SENT}.{notification.phone_prefix}")
+                    record_international_sms(
+                        1, notification_status=NOTIFICATION_SENT, sms_country_code=notification.phone_prefix
+                    )
 
         delta_seconds = (datetime.utcnow() - created_at).total_seconds()
         statsd_client.timing("sms.total-time", delta_seconds)

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -34,7 +34,7 @@ from app.dao.provider_details_dao import (
 )
 from app.exceptions import NotificationTechnicalFailureException
 from app.models import Notification
-from app.otel_metrics.notification import record_international_sms
+from app.otel_metrics.notification import record_international_sms, record_send_duration
 from app.serialised_models import SerialisedProviders, SerialisedService, SerialisedTemplate
 
 
@@ -60,49 +60,57 @@ def send_sms_to_provider(notification: Notification) -> None:
         )
         created_at = notification.created_at
         key_type = notification.key_type
-        if notification.key_type == KEY_TYPE_TEST:
-            update_notification_to_sending(notification, provider)
-            send_sms_response(provider.name, str(notification.id), notification.to)
-
-        else:
-            try:
-                # End DB session here so that we don't have a connection stuck open waiting on the call
-                # to one of the SMS providers
-                # We don't want to tie our DB connections being open to the performance of our SMS
-                # providers as a slow down of our providers can cause us to run out of DB connections
-                # Therefore we pull all the data from our DB models into `send_sms_kwargs`now before
-                # closing the session (as otherwise it would be reopened immediately)
-                send_sms_kwargs = {
-                    "to": notification.normalised_to,
-                    "content": str(template),
-                    "reference": str(notification.id),
-                    "sender": notification.reply_to_text,
-                    "international": notification.international,
-                }
-                db.session.close()  # no commit needed as no changes to objects have been made above
-                provider.send_sms(**send_sms_kwargs)
-            except Exception as e:
-                notification.billable_units = template.fragment_count
-                dao_update_notification(notification)
-
-                if redis_store.exceeded_rate_limit(
-                    f"{provider.name}-error-rate", SMS_PROVIDER_ERROR_THRESHOLD, SMS_PROVIDER_ERROR_INTERVAL
-                ):
-                    dao_reduce_sms_provider_priority(provider.name, time_threshold=timedelta(minutes=1))
-                    current_app.logger.warning(
-                        "Error threshold exceeded for provider %s",
-                        provider.name,
-                        extra={"provider_name": provider.name},
-                    )
-                raise e
-            else:
-                notification.billable_units = template.fragment_count
+        try:
+            if notification.key_type == KEY_TYPE_TEST:
                 update_notification_to_sending(notification, provider)
-                if notification.international:
-                    statsd_client.incr(f"international-sms.{NOTIFICATION_SENT}.{notification.phone_prefix}")
-                    record_international_sms(
-                        1, notification_status=NOTIFICATION_SENT, sms_country_code=notification.phone_prefix
-                    )
+                send_sms_response(provider.name, str(notification.id), notification.to)
+
+            else:
+                try:
+                    # End DB session here so that we don't have a connection stuck open waiting on the call
+                    # to one of the SMS providers
+                    # We don't want to tie our DB connections being open to the performance of our SMS
+                    # providers as a slow down of our providers can cause us to run out of DB connections
+                    # Therefore we pull all the data from our DB models into `send_sms_kwargs`now before
+                    # closing the session (as otherwise it would be reopened immediately)
+                    send_sms_kwargs = {
+                        "to": notification.normalised_to,
+                        "content": str(template),
+                        "reference": str(notification.id),
+                        "sender": notification.reply_to_text,
+                        "international": notification.international,
+                    }
+                    db.session.close()  # no commit needed as no changes to objects have been made above
+                    provider.send_sms(**send_sms_kwargs)
+                except Exception as e:
+                    notification.billable_units = template.fragment_count
+                    dao_update_notification(notification)
+
+                    if redis_store.exceeded_rate_limit(
+                        f"{provider.name}-error-rate", SMS_PROVIDER_ERROR_THRESHOLD, SMS_PROVIDER_ERROR_INTERVAL
+                    ):
+                        dao_reduce_sms_provider_priority(provider.name, time_threshold=timedelta(minutes=1))
+                        current_app.logger.warning(
+                            "Error threshold exceeded for provider %s",
+                            provider.name,
+                            extra={"provider_name": provider.name},
+                        )
+                    raise e
+                else:
+                    notification.billable_units = template.fragment_count
+                    update_notification_to_sending(notification, provider)
+                    if notification.international:
+                        statsd_client.incr(f"international-sms.{NOTIFICATION_SENT}.{notification.phone_prefix}")
+                        record_international_sms(
+                            1, notification_status=NOTIFICATION_SENT, sms_country_code=notification.phone_prefix
+                        )
+        finally:
+            record_send_duration(
+                (datetime.utcnow() - created_at).total_seconds(),
+                key_type=key_type,
+                notification_type="sms",
+                provider_name=provider.name,
+            )
 
         delta_seconds = (datetime.utcnow() - created_at).total_seconds()
         statsd_client.timing("sms.total-time", delta_seconds)
@@ -164,27 +172,33 @@ def send_email_to_provider(notification):
         )
         created_at = notification.created_at
         key_type = notification.key_type
-        if notification.key_type == KEY_TYPE_TEST:
-            notification.reference = str(create_uuid())
-            update_notification_to_sending(notification, provider)
-            send_email_response(notification.reference, notification.to, notification.service_id)
-        else:
-            email_sender_name = service.custom_email_sender_name or service.name
-            from_address = (
-                f'"{email_sender_name}" <{service.email_sender_local_part}@{current_app.config["NOTIFY_EMAIL_DOMAIN"]}>'
-            )
+        try:
+            if notification.key_type == KEY_TYPE_TEST:
+                notification.reference = str(create_uuid())
+                update_notification_to_sending(notification, provider)
+                send_email_response(notification.reference, notification.to, notification.service_id)
+            else:
+                email_sender_name = service.custom_email_sender_name or service.name
+                from_address = f'"{email_sender_name}" <{service.email_sender_local_part}@{current_app.config["NOTIFY_EMAIL_DOMAIN"]}>'  # noqa: E501
 
-            reference = provider.send_email(
-                from_address=from_address,
-                to_address=notification.normalised_to,
-                subject=plain_text_email.subject,
-                body=str(plain_text_email),
-                html_body=str(html_email),
-                reply_to_address=notification.reply_to_text,
-                headers=_get_email_headers(notification, template),
+                reference = provider.send_email(
+                    from_address=from_address,
+                    to_address=notification.normalised_to,
+                    subject=plain_text_email.subject,
+                    body=str(plain_text_email),
+                    html_body=str(html_email),
+                    reply_to_address=notification.reply_to_text,
+                    headers=_get_email_headers(notification, template),
+                )
+                notification.reference = reference
+                update_notification_to_sending(notification, provider)
+        finally:
+            record_send_duration(
+                (datetime.utcnow() - created_at).total_seconds(),
+                key_type=key_type,
+                notification_type="email",
+                provider_name=provider.name,
             )
-            notification.reference = reference
-            update_notification_to_sending(notification, provider)
         delta_seconds = (datetime.utcnow() - created_at).total_seconds()
 
         if key_type == KEY_TYPE_TEST:

--- a/app/otel_metrics/README.md
+++ b/app/otel_metrics/README.md
@@ -1,0 +1,5 @@
+This module was named `otel_metrics` so it wouldn't conflict with the `metrics`
+field in `app/__init__.py`.
+
+Once we've migrated away from the GDS metrics lib entirely we can rename this
+module to simply `metrics`.

--- a/app/otel_metrics/notification.py
+++ b/app/otel_metrics/notification.py
@@ -1,6 +1,8 @@
 import json
 
+from notifications_utils.semconv import TASK_DURATION_HISTOGRAM_BUCKETS, set_error_type
 from opentelemetry.metrics import get_meter
+from opentelemetry.util.types import AttributeValue
 
 _meter = get_meter(__name__)
 
@@ -11,6 +13,13 @@ _international_sms = _meter.create_counter(
         "Number of international text messages sent; "
         "might be recorded multiple times per notification as it changes status from pending to delivered/failure"
     ),
+)
+
+_send_duration = _meter.create_histogram(
+    "notification.send.duration",
+    unit="s",
+    description="Elapsed time between notification creation and sending to provider",
+    explicit_bucket_boundaries_advisory=TASK_DURATION_HISTOGRAM_BUCKETS,
 )
 
 _deliver_duration = _meter.create_histogram(
@@ -55,6 +64,26 @@ def record_international_sms(amount: int, notification_status: str, sms_country_
             "notification.status": notification_status,
             "notification.sms.country_code": sms_country_code,
         },
+    )
+
+
+def record_send_duration(duration: float, key_type: str, notification_type: str, provider_name: str) -> None:
+    """
+    Records a sample with the given `duration` and attributes for histogram metric `notification.send.duration`, and
+    captures the fully-qualified name of the current exception (if any) as attribute `error.type`.
+    """
+
+    attributes: dict[str, AttributeValue] = {
+        "key.type": key_type,
+        "notification.type": notification_type,
+        "provider.name": provider_name,
+    }
+
+    set_error_type(attributes)
+
+    _send_duration.record(
+        duration,
+        attributes,
     )
 
 

--- a/app/otel_metrics/notification.py
+++ b/app/otel_metrics/notification.py
@@ -1,0 +1,26 @@
+from opentelemetry.metrics import get_meter
+
+_meter = get_meter(__name__)
+
+_international_sms = _meter.create_counter(
+    "notification.sms.internationals",
+    unit="{notification}",
+    description=(
+        "Number of international text messages sent; "
+        "might be recorded multiple times per notification as it changes status from pending to delivered/failure"
+    ),
+)
+
+
+def record_international_sms(amount: int, notification_status: str, sms_country_code: str) -> None:
+    """
+    Increments counter metric `notification.sms.internationals`, with the given attributes, by `amount`.
+    """
+
+    _international_sms.add(
+        amount,
+        {
+            "notification.status": notification_status,
+            "notification.sms.country_code": sms_country_code,
+        },
+    )

--- a/app/otel_metrics/notification.py
+++ b/app/otel_metrics/notification.py
@@ -22,6 +22,38 @@ _send_duration = _meter.create_histogram(
     explicit_bucket_boundaries_advisory=TASK_DURATION_HISTOGRAM_BUCKETS,
 )
 
+# Buckets ranging from 1 second to 30 hours
+DELIVER_DURATION_HISTOGRAM_BUCKETS = [
+    1,
+    2,
+    4,
+    8,
+    15,
+    30,
+    60,
+    120,
+    240,
+    480,
+    900,
+    1800,
+    3600,
+    7200,
+    14400,
+    28800,
+    54000,
+    108000,
+]
+
+_callback_duration = _meter.create_histogram(
+    "notification.callback.duration",
+    unit="s",
+    description=(
+        "Elapsed time between notification creation datetime and receipt of a callback from the provider; "
+        "might be recorded multiple times per notification as it changes status from pending to delivered/failure"
+    ),
+    explicit_bucket_boundaries_advisory=DELIVER_DURATION_HISTOGRAM_BUCKETS,
+)
+
 _deliver_duration = _meter.create_histogram(
     "notification.deliver.duration",
     unit="s",
@@ -29,27 +61,7 @@ _deliver_duration = _meter.create_histogram(
         "Elapsed time between notification creation datetime and delivery datetime reported by provider; "
         "might be recorded multiple times per notification as it changes status from pending to delivered/failure"
     ),
-    # Buckets ranging from 1 second to 30 hours
-    explicit_bucket_boundaries_advisory=[
-        1,
-        2,
-        4,
-        8,
-        15,
-        30,
-        60,
-        120,
-        240,
-        480,
-        900,
-        1800,
-        3600,
-        7200,
-        14400,
-        28800,
-        54000,
-        108000,
-    ],
+    explicit_bucket_boundaries_advisory=DELIVER_DURATION_HISTOGRAM_BUCKETS,
 )
 
 
@@ -88,7 +100,8 @@ def record_send_duration(duration: float, key_type: str, notification_type: str,
 
 
 def record_deliver_duration(
-    duration: float,
+    callback_duration: float | None,
+    deliver_duration: float | None,
     key_type: str,
     notification_status: str,
     notification_type: str,
@@ -110,4 +123,7 @@ def record_deliver_duration(
         # OTel semconv specifically dictates JSON encoding for booleans
         attrs["notification.sms.international"] = json.dumps(sms_international)
 
-    _deliver_duration.record(duration, attrs)
+    if callback_duration is not None:
+        _callback_duration.record(callback_duration, attrs)
+    if deliver_duration is not None:
+        _deliver_duration.record(deliver_duration, attrs)

--- a/app/otel_metrics/notification.py
+++ b/app/otel_metrics/notification.py
@@ -1,3 +1,5 @@
+import json
+
 from opentelemetry.metrics import get_meter
 
 _meter = get_meter(__name__)
@@ -9,6 +11,36 @@ _international_sms = _meter.create_counter(
         "Number of international text messages sent; "
         "might be recorded multiple times per notification as it changes status from pending to delivered/failure"
     ),
+)
+
+_deliver_duration = _meter.create_histogram(
+    "notification.deliver.duration",
+    unit="s",
+    description=(
+        "Elapsed time between notification creation datetime and delivery datetime reported by provider; "
+        "might be recorded multiple times per notification as it changes status from pending to delivered/failure"
+    ),
+    # Buckets ranging from 1 second to 30 hours
+    explicit_bucket_boundaries_advisory=[
+        1,
+        2,
+        4,
+        8,
+        15,
+        30,
+        60,
+        120,
+        240,
+        480,
+        900,
+        1800,
+        3600,
+        7200,
+        14400,
+        28800,
+        54000,
+        108000,
+    ],
 )
 
 
@@ -24,3 +56,29 @@ def record_international_sms(amount: int, notification_status: str, sms_country_
             "notification.sms.country_code": sms_country_code,
         },
     )
+
+
+def record_deliver_duration(
+    duration: float,
+    key_type: str,
+    notification_status: str,
+    notification_type: str,
+    provider_name: str,
+    sms_international: bool | None = None,
+) -> None:
+    """
+    Records a sample with the given `duration` and attributes for histogram metric `notification.deliver.duration`.
+    """
+
+    attrs = {
+        "key.type": key_type,
+        "notification.status": notification_status,
+        "notification.type": notification_type,
+        "provider.name": provider_name,
+    }
+
+    if sms_international is not None:
+        # OTel semconv specifically dictates JSON encoding for booleans
+        attrs["notification.sms.international"] = json.dumps(sms_international)
+
+    _deliver_duration.record(duration, attrs)

--- a/app/otel_metrics/provider.py
+++ b/app/otel_metrics/provider.py
@@ -1,0 +1,45 @@
+import functools
+from collections.abc import Callable
+from time import monotonic
+
+from notifications_utils.semconv import HTTP_DURATION_HISTOGRAM_BUCKETS, set_error_type
+from opentelemetry.metrics import get_meter
+from opentelemetry.util.types import AttributeValue
+
+_meter = get_meter(__name__)
+
+_request_duration = _meter.create_histogram(
+    "provider.request.duration",
+    unit="s",
+    description="Duration of (HTTP) requests to providers",
+    explicit_bucket_boundaries_advisory=HTTP_DURATION_HISTOGRAM_BUCKETS,
+)
+
+
+def record_request_duration[**P, T](
+    notification_type: str, provider_name: str
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """
+    Returns a decorator that instruments the duration of the decorated function as histogram `provider.request.duration`
+    with the given attributes, and captures the fully-qualified name of any exception the function raises as attribute
+    `error.type`.
+    """
+
+    def decorator(func: Callable[P, T]) -> Callable[P, T]:
+
+        @functools.wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            start_time = monotonic()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                attributes: dict[str, AttributeValue] = {
+                    "notification.type": notification_type,
+                    "provider.name": provider_name,
+                }
+                set_error_type(attributes)
+                _request_duration.record(monotonic() - start_time, attributes)
+
+        return wrapper
+
+    return decorator

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -17,7 +17,7 @@ from app.notifications.notifications_ses_callback import (
     remove_emails_from_bounce,
     remove_emails_from_complaint,
 )
-from app.otel_metrics.notification import _deliver_duration
+from app.otel_metrics.notification import _callback_duration, _deliver_duration
 from tests.app.db import (
     create_notification,
     create_service_callback_api,
@@ -68,6 +68,7 @@ def test_ses_callback_should_update_notification_status(
 ):
     with freeze_time("2001-01-01T12:00:00") as frozen_time:
         record_deliver_duration_mock = mocker.patch.object(_deliver_duration, "record")
+        record_callback_duration_mock = mocker.patch.object(_callback_duration, "record")
         mocker.patch("app.statsd_client.incr")
         mocker.patch("app.statsd_client.timing_with_dates")
         send_mock = mocker.patch("app.celery.process_ses_receipts_tasks.check_and_queue_callback_task")
@@ -96,6 +97,15 @@ def test_ses_callback_should_update_notification_status(
         statsd_client.incr.assert_any_call("callback.ses.delivered")
         record_deliver_duration_mock.assert_called_once_with(
             1.0,
+            {
+                "key.type": "normal",
+                "notification.status": "delivered",
+                "notification.type": "email",
+                "provider.name": "ses",
+            },
+        )
+        record_callback_duration_mock.assert_called_once_with(
+            2.0,
             {
                 "key.type": "normal",
                 "notification.status": "delivered",

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -17,6 +17,7 @@ from app.notifications.notifications_ses_callback import (
     remove_emails_from_bounce,
     remove_emails_from_complaint,
 )
+from app.otel_metrics.notification import _deliver_duration
 from tests.app.db import (
     create_notification,
     create_service_callback_api,
@@ -66,6 +67,7 @@ def test_ses_callback_should_update_notification_status(
     client, notify_db_session, sample_email_template, caplog, mocker
 ):
     with freeze_time("2001-01-01T12:00:00") as frozen_time:
+        record_deliver_duration_mock = mocker.patch.object(_deliver_duration, "record")
         mocker.patch("app.statsd_client.incr")
         mocker.patch("app.statsd_client.timing_with_dates")
         send_mock = mocker.patch("app.celery.process_ses_receipts_tasks.check_and_queue_callback_task")
@@ -75,6 +77,8 @@ def test_ses_callback_should_update_notification_status(
             reference="ref",
         )
         assert get_notification_by_id(notification.id).status == "sending"
+
+        frozen_time.tick(1)
 
         payload = ses_notification_callback(reference="ref")
 
@@ -90,13 +94,22 @@ def test_ses_callback_should_update_notification_status(
             "callback.ses.delivered.elapsed-time", datetime.utcnow(), notification.sent_at
         )
         statsd_client.incr.assert_any_call("callback.ses.delivered")
+        record_deliver_duration_mock.assert_called_once_with(
+            1.0,
+            {
+                "key.type": "normal",
+                "notification.status": "delivered",
+                "notification.type": "email",
+                "provider.name": "ses",
+            },
+        )
         updated_notification = Notification.query.get(notification.id)
         send_mock.assert_called_once_with(updated_notification)
 
         record = next(r for r in caplog.records if "SES successful delivery" in r.msg)
-        assert record.delivered_at == datetime(2001, 1, 1, 12, 0)
+        assert record.delivered_at == datetime(2001, 1, 1, 12, 0, 1)
         assert record.delivered_ago == 2
-        assert record.receipt_received_at == datetime(2001, 1, 1, 12, 0, 1)
+        assert record.receipt_received_at == datetime(2001, 1, 1, 12, 0, 2)
         assert record.receipt_received_ago == 1
 
 

--- a/tests/app/celery/test_process_sms_client_response_tasks.py
+++ b/tests/app/celery/test_process_sms_client_response_tasks.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 from freezegun import freeze_time
@@ -10,7 +10,7 @@ from app.celery.process_sms_client_response_tasks import (
 )
 from app.clients import ClientException
 from app.constants import NOTIFICATION_TECHNICAL_FAILURE
-from app.otel_metrics.notification import _international_sms
+from app.otel_metrics.notification import _international_sms, _deliver_duration
 
 
 def test_process_sms_client_response_raises_error_if_reference_is_not_a_valid_uuid(client):
@@ -134,20 +134,32 @@ def test_sms_response_does_not_send_callback_if_notification_is_not_in_the_db(sa
 
 
 @freeze_time("2001-01-01T12:00:00")
-def test_process_sms_client_response_records_statsd_metrics(sample_notification, client, mocker):
+def test_process_sms_client_response_records_metrics(sample_notification, client, mocker):
+    record_deliver_duration_mock = mocker.patch.object(_deliver_duration, "record")
     mocker.patch("app.statsd_client.incr")
     mocker.patch("app.statsd_client.timing_with_dates")
 
     sample_notification.status = "sending"
-    sample_notification.sent_at = datetime.utcnow()
+    sample_notification.created_at = datetime.utcnow()
+    sample_notification.sent_at = sample_notification.created_at
 
-    process_sms_client_response("0", str(sample_notification.id), "Firetext")
+    process_sms_client_response("0", str(sample_notification.id), "Firetext", delivery_iso_timestamp="2001-01-01T12:00:42")
 
     statsd_client.incr.assert_any_call("callback.firetext.delivered")
     statsd_client.timing_with_dates.assert_any_call(
         "callback.firetext.delivered.elapsed-time", datetime.utcnow(), sample_notification.sent_at
     )
 
+    record_deliver_duration_mock.assert_called_once_with(
+        42.0,
+        {
+            "key.type": "normal",
+            "notification.status": "delivered",
+            "notification.type": "sms",
+            "notification.sms.international": "false",
+            "provider.name": "firetext",
+        },
+    )
 
 def test_process_sms_client_response_records_international_sms_metrics(sample_notification, mocker):
     add_international_sms_mock = mocker.patch.object(_international_sms, "add")

--- a/tests/app/celery/test_process_sms_client_response_tasks.py
+++ b/tests/app/celery/test_process_sms_client_response_tasks.py
@@ -10,6 +10,7 @@ from app.celery.process_sms_client_response_tasks import (
 )
 from app.clients import ClientException
 from app.constants import NOTIFICATION_TECHNICAL_FAILURE
+from app.otel_metrics.notification import _international_sms
 
 
 def test_process_sms_client_response_raises_error_if_reference_is_not_a_valid_uuid(client):
@@ -145,6 +146,23 @@ def test_process_sms_client_response_records_statsd_metrics(sample_notification,
     statsd_client.incr.assert_any_call("callback.firetext.delivered")
     statsd_client.timing_with_dates.assert_any_call(
         "callback.firetext.delivered.elapsed-time", datetime.utcnow(), sample_notification.sent_at
+    )
+
+
+def test_process_sms_client_response_records_international_sms_metrics(sample_notification, mocker):
+    add_international_sms_mock = mocker.patch.object(_international_sms, "add")
+
+    sample_notification.international = True
+    sample_notification.phone_prefix = "852"
+
+    process_sms_client_response(status="3", provider_reference=str(sample_notification.id), client_name="MMG")
+
+    add_international_sms_mock.assert_called_once_with(
+        1,
+        {
+            "notification.status": "delivered",
+            "notification.sms.country_code": "852",
+        },
     )
 
 

--- a/tests/app/celery/test_process_sms_client_response_tasks.py
+++ b/tests/app/celery/test_process_sms_client_response_tasks.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import pytest
 from freezegun import freeze_time
@@ -10,7 +10,7 @@ from app.celery.process_sms_client_response_tasks import (
 )
 from app.clients import ClientException
 from app.constants import NOTIFICATION_TECHNICAL_FAILURE
-from app.otel_metrics.notification import _international_sms, _deliver_duration
+from app.otel_metrics.notification import _deliver_duration, _international_sms
 
 
 def test_process_sms_client_response_raises_error_if_reference_is_not_a_valid_uuid(client):
@@ -143,7 +143,9 @@ def test_process_sms_client_response_records_metrics(sample_notification, client
     sample_notification.created_at = datetime.utcnow()
     sample_notification.sent_at = sample_notification.created_at
 
-    process_sms_client_response("0", str(sample_notification.id), "Firetext", delivery_iso_timestamp="2001-01-01T12:00:42")
+    process_sms_client_response(
+        "0", str(sample_notification.id), "Firetext", delivery_iso_timestamp="2001-01-01T12:00:42"
+    )
 
     statsd_client.incr.assert_any_call("callback.firetext.delivered")
     statsd_client.timing_with_dates.assert_any_call(
@@ -160,6 +162,7 @@ def test_process_sms_client_response_records_metrics(sample_notification, client
             "provider.name": "firetext",
         },
     )
+
 
 def test_process_sms_client_response_records_international_sms_metrics(sample_notification, mocker):
     add_international_sms_mock = mocker.patch.object(_international_sms, "add")

--- a/tests/app/celery/test_process_sms_client_response_tasks.py
+++ b/tests/app/celery/test_process_sms_client_response_tasks.py
@@ -10,7 +10,7 @@ from app.celery.process_sms_client_response_tasks import (
 )
 from app.clients import ClientException
 from app.constants import NOTIFICATION_TECHNICAL_FAILURE
-from app.otel_metrics.notification import _deliver_duration, _international_sms
+from app.otel_metrics.notification import _callback_duration, _deliver_duration, _international_sms
 
 
 def test_process_sms_client_response_raises_error_if_reference_is_not_a_valid_uuid(client):
@@ -136,6 +136,7 @@ def test_sms_response_does_not_send_callback_if_notification_is_not_in_the_db(sa
 @freeze_time("2001-01-01T12:00:00")
 def test_process_sms_client_response_records_metrics(sample_notification, client, mocker):
     record_deliver_duration_mock = mocker.patch.object(_deliver_duration, "record")
+    record_callback_duration_mock = mocker.patch.object(_callback_duration, "record")
     mocker.patch("app.statsd_client.incr")
     mocker.patch("app.statsd_client.timing_with_dates")
 
@@ -144,7 +145,11 @@ def test_process_sms_client_response_records_metrics(sample_notification, client
     sample_notification.sent_at = sample_notification.created_at
 
     process_sms_client_response(
-        "0", str(sample_notification.id), "Firetext", delivery_iso_timestamp="2001-01-01T12:00:42"
+        "0",
+        str(sample_notification.id),
+        "Firetext",
+        delivery_iso_timestamp="2001-01-01T12:00:42",
+        receipt_iso_timestamp="2001-01-01T12:00:50",
     )
 
     statsd_client.incr.assert_any_call("callback.firetext.delivered")
@@ -154,6 +159,16 @@ def test_process_sms_client_response_records_metrics(sample_notification, client
 
     record_deliver_duration_mock.assert_called_once_with(
         42.0,
+        {
+            "key.type": "normal",
+            "notification.status": "delivered",
+            "notification.type": "sms",
+            "notification.sms.international": "false",
+            "provider.name": "firetext",
+        },
+    )
+    record_callback_duration_mock.assert_called_once_with(
+        50.0,
         {
             "key.type": "normal",
             "notification.status": "delivered",

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -1,4 +1,6 @@
-from datetime import datetime
+from contextlib import nullcontext
+from datetime import datetime, timedelta
+from typing import Any
 from uuid import UUID
 
 import boto3
@@ -9,6 +11,7 @@ from flask import current_app
 from freezegun import freeze_time
 from moto import mock_aws
 from notifications_utils.recipient_validation.postal_address import PostalAddress
+from pytest_mock import MockerFixture
 
 import app
 from app.celery import provider_tasks
@@ -38,6 +41,8 @@ from app.constants import (
     NOTIFICATION_TECHNICAL_FAILURE,
 )
 from app.exceptions import NotificationTechnicalFailureException
+from app.models import Organisation, Template
+from app.otel_metrics.notification import _send_duration
 from tests.app.db import create_notification
 
 
@@ -521,4 +526,149 @@ def test_get_callback_url_returns_unique_callback_for_notification(notify_api, f
     assert callback_url == (
         "http://localhost:6011/notifications/letter/status?"
         "token=IjZjZTQ2NmQwLWZkNmEtMTFlNS04MmY1LWUwYWNjYjlkMTFhNiI._E6xCZE858swMk0xoYI_KHoTKd8"
+    )
+
+
+@freeze_time("2026-01-01 09:00:00")
+@pytest.mark.parametrize(
+    "key_type, phone_number, international, country_code, should_raise",
+    [
+        ("normal", "+447700900855", False, "44", False),
+        ("normal", "+15555550199", True, "1", False),
+        ("test", "+447700900855", False, "44", False),
+        ("normal", "+447700900855", False, "44", True),
+    ],
+)
+def test_deliver_sms_records_duration_histogram(
+    mocker: MockerFixture,
+    sample_template: Template,
+    key_type: str,
+    phone_number: str,
+    international: bool,
+    country_code: str,
+    should_raise: bool,
+) -> None:
+    record_send_duration_mock = mocker.patch.object(_send_duration, "record")
+    mocker.patch("app.celery.provider_tasks.deliver_sms.retry", side_effect=MaxRetriesExceededError())
+    mocker.patch("app.delivery.send_to_providers.send_sms_response")
+    mocker.patch("app.mmg_client.send_sms", side_effect=RuntimeError() if should_raise else None)
+
+    notification = create_notification(
+        template=sample_template,
+        to_field=phone_number,
+        international=international,
+        phone_prefix=country_code,
+        key_type=key_type,
+        created_at=datetime.utcnow() - timedelta(minutes=1),
+    )
+
+    with pytest.raises(NotificationTechnicalFailureException) if should_raise else nullcontext():
+        deliver_sms(notification.id)
+
+    expected_attributes = {
+        "key.type": key_type,
+        "notification.type": "sms",
+        "provider.name": "mmg",
+    }
+
+    if should_raise:
+        expected_attributes["error.type"] = "builtins.RuntimeError"
+
+    record_send_duration_mock.assert_called_once_with(
+        60.0,
+        expected_attributes,
+    )
+
+
+@freeze_time("2026-01-01 09:00:00")
+@pytest.mark.parametrize(
+    "key_type, should_raise",
+    [
+        ("normal", False),
+        ("test", False),
+        ("normal", True),
+    ],
+)
+def test_deliver_email_records_duration_histogram(
+    mocker: MockerFixture,
+    sample_email_template: Template,
+    key_type: str,
+    should_raise: bool,
+) -> None:
+    record_send_duration_mock = mocker.patch.object(_send_duration, "record")
+    mocker.patch("app.celery.provider_tasks.deliver_email.retry", side_effect=MaxRetriesExceededError())
+    mocker.patch(
+        "app.aws_ses_client.send_email", return_value="reference", side_effect=RuntimeError() if should_raise else None
+    )
+    mocker.patch("app.delivery.send_to_providers.send_email_response")
+
+    notification = create_notification(
+        template=sample_email_template,
+        key_type=key_type,
+        created_at=datetime.utcnow() - timedelta(minutes=1),
+    )
+
+    with pytest.raises(NotificationTechnicalFailureException) if should_raise else nullcontext():
+        deliver_email(notification.id)
+
+    expected_attributes = {
+        "key.type": key_type,
+        "notification.type": "email",
+        "provider.name": "ses",
+    }
+
+    if should_raise:
+        expected_attributes["error.type"] = "builtins.RuntimeError"
+
+    record_send_duration_mock.assert_called_once_with(
+        60.0,
+        expected_attributes,
+    )
+
+
+@mock_aws
+@freeze_time("2026-01-01 09:00:01")
+@pytest.mark.parametrize("should_raise", [False, True])
+def test_deliver_letter_records_duration_histogram(
+    mocker: MockerFixture,
+    sample_letter_template: Any,  # sqlalchemy types are weird
+    sample_organisation: Organisation,
+    should_raise: bool,
+) -> None:
+    record_send_duration_mock = mocker.patch.object(_send_duration, "record")
+    mocker.patch(
+        "app.celery.provider_tasks.dvla_client.send_letter", side_effect=RuntimeError() if should_raise else None
+    )
+    mocker.patch("app.celery.provider_tasks._get_callback_url", return_value="example.com?token=1")
+
+    letter = create_notification(
+        template=sample_letter_template,
+        to_field="A. User\nMy Street,\nLondon,\nSW1 1AA",
+        personalisation={"address_line_1": "Provided as PDF"},
+        status=NOTIFICATION_CREATED,
+        reference="ref1",
+        created_at=datetime.now() - timedelta(minutes=1),
+    )
+    sample_letter_template.service.organisation = sample_organisation
+
+    pdf_bucket = current_app.config["S3_BUCKET_LETTERS_PDF"]
+    s3 = boto3.client("s3", region_name="eu-west-1")
+    s3.create_bucket(Bucket=pdf_bucket, CreateBucketConfiguration={"LocationConstraint": "eu-west-1"})
+    s3.put_object(Bucket=pdf_bucket, Key="2026-01-01/NOTIFY.REF1.D.2.C.20260101090000.PDF", Body=b"file")
+
+    with pytest.raises(NotificationTechnicalFailureException) if should_raise else nullcontext():
+        deliver_letter(letter.id)
+
+    expected_attributes = {
+        "key.type": "normal",
+        "notification.type": "letter",
+        "provider.name": "dvla",
+    }
+
+    if should_raise:
+        expected_attributes["error.type"] = "builtins.RuntimeError"
+
+    record_send_duration_mock.assert_called_once_with(
+        60.0,
+        expected_attributes,
     )

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -27,6 +27,7 @@ from app.delivery import send_to_providers
 from app.delivery.send_to_providers import get_html_email_options, get_logo_url
 from app.exceptions import NotificationTechnicalFailureException
 from app.models import EmailBranding, Notification
+from app.otel_metrics.notification import _international_sms
 from app.serialised_models import (
     SerialisedProvider,
     SerialisedProviders,
@@ -635,6 +636,7 @@ def test_should_set_notification_billable_units_and_reduce_provider_priority_if_
 
 
 def test_should_send_sms_to_international_providers(sample_template, mocker):
+    add_international_sms_mock = mocker.patch.object(_international_sms, "add")
     mocker.patch("app.mmg_client.send_sms")
     mocker.patch("app.firetext_client.send_sms")
 
@@ -650,6 +652,7 @@ def test_should_send_sms_to_international_providers(sample_template, mocker):
         international=True,
         reply_to_text=sample_template.service.get_default_sms_sender(),
         normalised_to="601117224412",
+        phone_prefix="60",
     )
 
     send_to_providers.send_sms_to_provider(notification_international)
@@ -660,6 +663,14 @@ def test_should_send_sms_to_international_providers(sample_template, mocker):
         reference=str(notification_international.id),
         sender=current_app.config["FROM_NUMBER"],
         international=True,
+    )
+
+    add_international_sms_mock.assert_called_once_with(
+        1,
+        {
+            "notification.status": "sent",
+            "notification.sms.country_code": "60",
+        },
     )
 
     assert notification_international.status == "sent"

--- a/tests/app/otel_metrics/test_provider.py
+++ b/tests/app/otel_metrics/test_provider.py
@@ -1,0 +1,29 @@
+from datetime import timedelta
+
+import pytest
+from freezegun import freeze_time
+from pytest_mock import MockerFixture
+
+from app.otel_metrics.provider import _request_duration, record_request_duration
+
+
+def test_record_request_duration(mocker: MockerFixture) -> None:
+    with freeze_time() as frozen_time:
+        record_mock = mocker.patch.object(_request_duration, "record")
+
+        @record_request_duration("email", "ses")
+        def foo() -> None:
+            frozen_time.tick(timedelta(seconds=42))
+            raise RuntimeError
+
+        with pytest.raises(RuntimeError):
+            foo()
+
+        record_mock.assert_called_once_with(
+            42.0,
+            {
+                "error.type": "builtins.RuntimeError",
+                "notification.type": "email",
+                "provider.name": "ses",
+            },
+        )


### PR DESCRIPTION
https://trello.com/c/25A3gpXh/1358-replace-statsd-instrumentation-across-notify-with-otel

Probably best reviewed with whitespace changes hidden.

Adds the following metrics, which should hopefully replace the existing StatsD ones (the dashboards will be updated in a future PR).

The names are automatically normalised to follow the Prometheus naming convention by the OTel collector, so e.g. `provider.request.duration` becomes `provider_request_duration_seconds`. I have deliberately chosen names that do not conflict with the existing metrics that go via the StatsD exporter, so we can have both stacks running in parallel.

---

#### `provider.request.duration {error.type, notification.type, provider.name}`

Duration of (HTTP) requests to providers

<img width="1332" height="627" alt="Screenshot 2026-04-15 at 16 34 10" src="https://github.com/user-attachments/assets/a8486a18-7fb8-474f-82a9-277a8019d067" />

---

#### `notification.sms.internationals {notification.status, notification.sms.country_code}`

Number of international text messages sent

No screenshot for this one, but the behaviour should be identical to the existing `notify_international_sms_total` metric reported by StatsD.

---

#### `notification.send.duration {error.type, key.type, notification.type, provider.name}`

Elapsed time between notification creation and sending to provider

<img width="1321" height="646" alt="Screenshot 2026-04-15 at 17 04 01" src="https://github.com/user-attachments/assets/3dd7df82-1915-4d15-a862-94ac42248d2d" />

---

#### `notification.deliver.duration {key.type, notification.status, notification.type, provider.name}`

Elapsed time between notification creation datetime and delivery datetime reported by provider

<img width="1322" height="648" alt="Screenshot 2026-04-15 at 16 35 24" src="https://github.com/user-attachments/assets/3c2f5dc1-39eb-411f-8d47-38092beb8c4e" />