### PR TITLE
Pin `notifications-python-client` to latest minor

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ pyorc~=0.10
 # temporary for debug output
 psutil>=6.0.0,<7.0.0
 
-notifications-python-client==10.0.1
+notifications-python-client~=10.0
 
 # Run `make bump-utils` to update to the latest version
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@113.5.1


### PR DESCRIPTION
If there’s a library whose changes we should be able to trust it’s our own.

It’s already at the latest version here:
https://github.com/alphagov/notifications-api/blob/0a16793abb5a75fdfc2bcc27cc721423768f0556/requirements.txt#L163

So no need to (re)freeze requirements.