### PR TITLE
Remove `send_files_via_ui` service permission

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -234,7 +234,6 @@ EMAIL_AUTH = "email_auth"
 EDIT_FOLDER_PERMISSIONS = "edit_folder_permissions"
 INTERNATIONAL_LETTERS = "international_letters"
 SMS_TO_UK_LANDLINES = "sms_to_uk_landlines"
-SEND_FILES_VIA_UI = "send_files_via_ui"
 SERVICE_PERMISSION_TYPES = [
     EMAIL_TYPE,
     SMS_TYPE,
@@ -245,7 +244,6 @@ SERVICE_PERMISSION_TYPES = [
     EDIT_FOLDER_PERMISSIONS,
     INTERNATIONAL_LETTERS,
     SMS_TO_UK_LANDLINES,
-    SEND_FILES_VIA_UI,
 ]
 
 # List of available permissions

--- a/app/functional_tests_fixtures/__init__.py
+++ b/app/functional_tests_fixtures/__init__.py
@@ -12,7 +12,6 @@ from app.constants import (
     INBOUND_SMS_TYPE,
     SECOND_CLASS,
     SEND_EMAILS,
-    SEND_FILES_VIA_UI,
     SEND_LETTERS,
     SEND_TEXTS,
     VIEW_ACTIVITY,
@@ -731,7 +730,7 @@ def _create_service_email_reply_to(service_id, email_address, is_default):
 
 def _create_service_permissions(service_id, permissions=None):
     if permissions is None:
-        permissions = [EDIT_FOLDER_PERMISSIONS, INBOUND_SMS_TYPE, EMAIL_AUTH, SEND_FILES_VIA_UI]
+        permissions = [EDIT_FOLDER_PERMISSIONS, INBOUND_SMS_TYPE, EMAIL_AUTH]
 
     service_permissions = dao_fetch_service_permissions(service_id)
 

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0548_letter_rates_from_3_5_26
+0549_remove_send_files_via_ui

--- a/migrations/versions/0549_remove_send_files_via_ui.py
+++ b/migrations/versions/0549_remove_send_files_via_ui.py
@@ -1,0 +1,21 @@
+"""
+
+Create Date: 2026-04-23 14:00:00.0
+Revision ID: 0549_remove_send_files_via_ui
+Revises: "0548_letter_rates_from_3_5_26"
+
+"""
+
+revision = "0549_remove_send_files_via_ui"
+down_revision = "0548_letter_rates_from_3_5_26"
+
+from alembic import op
+from sqlalchemy import text
+
+def upgrade():
+    op.execute("DELETE FROM service_permissions WHERE permission = 'send_files_via_ui'")
+    op.execute("DELETE FROM service_permission_types WHERE name = 'send_files_via_ui'")
+
+def downgrade():
+    op.execute("INSERT INTO service_permission_types VALUES ('send_files_via_ui')")
+


### PR DESCRIPTION
🚨 🚨 🚨 **DO NOT MERGE UNTIL https://github.com/alphagov/notifications-admin/pull/5858 is merged and deployed** 🚨 🚨 🚨 

remove "send_files_via_ui" service permission

removes the "send_files_via_ui" service permission when the send files via email feature is released.