### PR TITLE
Add `show-outdated-requirements` make command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@113.5.1
+# This file was automatically copied from notifications-utils@113.6.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_COMMIT ?= $(shell git rev-parse HEAD)
 VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 PYTHON_EXECUTABLE_PREFIX := $(shell test -d "$${VIRTUALENV_ROOT}" && echo "$${VIRTUALENV_ROOT}/bin/" || echo "")
 
-EXCLUDE_REQUIREMENTS_NEWER_THAN_DAYS ?= 30
+EXCLUDE_REQUIREMENTS_NEWER_THAN_DAYS ?= 7
 
 
 ## DEVELOPMENT

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,10 @@ freeze-requirements: ## Pin all requirements including sub dependencies into req
 	uv pip compile requirements_for_test.in -o requirements_for_test.txt $(EXTRA_UV_PIP_COMPILE_FLAGS)
 	uv pip sync requirements_for_test.txt
 
+.PHONY: show-outdated-requirements
+show-outdated-requirements: ## Audit requirements.in
+	python -c "from notifications_utils.version_tools import show_outdated_requirements; show_outdated_requirements()"
+
 .PHONY: bump-utils
 bump-utils:  # Bump notifications-utils package to latest version
 	${PYTHON_EXECUTABLE_PREFIX}python -c "from notifications_utils.version_tools import upgrade_version; upgrade_version()"

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil>=6.0.0,<7.0.0
 notifications-python-client~=10.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@113.5.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@113.6.1
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ SQLAlchemy~=2.0
 pyorc~=0.10
 
 # temporary for debug output
-psutil>=6.0.0,<7.0.0
+psutil~=6.0
 
 notifications-python-client~=10.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -162,7 +162,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@6356f2c4544118a09c112ebf854fa867051bbed1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@c720a3fc2cf724dd6f4c3a0f45dabd87012491b3
     # via -r requirements.in
 opentelemetry-api==1.40.0
     # via
@@ -320,6 +320,7 @@ packaging==26.0
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
+    #   requirements-parser
     #   wheel
 phonenumbers==9.0.25
     # via notifications-utils
@@ -371,6 +372,8 @@ requests==2.32.5
     #   notifications-python-client
     #   notifications-utils
     #   opentelemetry-exporter-otlp-proto-http
+requirements-parser==0.13.0
+    # via notifications-utils
 rfc3339-validator==0.1.4
     # via jsonschema
 rfc3987==1.3.8

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -241,7 +241,7 @@ mypy-extensions==1.1.0
     # via mypy
 notifications-python-client==10.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@6356f2c4544118a09c112ebf854fa867051bbed1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@c720a3fc2cf724dd6f4c3a0f45dabd87012491b3
     # via -r requirements.txt
 opentelemetry-api==1.40.0
     # via
@@ -416,6 +416,7 @@ packaging==26.0
     #   opentelemetry-instrumentation-flask
     #   opentelemetry-instrumentation-sqlalchemy
     #   pytest
+    #   requirements-parser
     #   wheel
 pathspec==1.0.4
     # via mypy
@@ -520,6 +521,10 @@ requests==2.32.5
     #   responses
 requests-mock==1.12.1
     # via -r requirements_for_test_common.in
+requirements-parser==0.13.0
+    # via
+    #   -r requirements.txt
+    #   notifications-utils
 responses==0.26.0
     # via moto
 rfc3339-validator==0.1.4

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@113.5.1
+# This file was automatically copied from notifications-utils@113.6.1
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@113.5.1
+# This file was automatically copied from notifications-utils@113.6.1
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
Implements https://github.com/alphagov/notifications-utils/pull/1342

***

Example output from this repo:

<img width="848" height="879" alt="image" src="https://github.com/user-attachments/assets/47fc1515-1fd4-45b6-b79f-66b659178090" />
