### PR TITLE
`get_all_templates_for_service`: reduce overfetching with `load_only`

### DIFF
--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -2,13 +2,13 @@ from datetime import datetime
 
 from flask import current_app
 from sqlalchemy import asc, desc
-from sqlalchemy.orm import Session, scoped_session
+from sqlalchemy.orm import Session, defaultload, load_only, scoped_session
 
 from app import db
 from app.constants import LETTER_TYPE, SECOND_CLASS
 from app.dao.dao_utils import VersionOptions, autocommit, version_class
 from app.dao.users_dao import get_user_by_id
-from app.models import Template, TemplateHistory, TemplateRedacted
+from app.models import Template, TemplateFolder, TemplateHistory, TemplateRedacted
 from app.utils import retryable_query
 
 
@@ -64,25 +64,24 @@ def dao_get_template_by_id(template_id, version=None):
     return Template.query.filter_by(id=template_id).one()
 
 
-def dao_get_all_templates_for_service(service_id, template_type=None):
+def dao_get_all_templates_for_service(service_id, template_type=None, no_detail=False) -> list[Template]:
     if template_type is not None:
-        return (
-            Template.query.filter_by(service_id=service_id, template_type=template_type, hidden=False, archived=False)
-            .order_by(
-                asc(Template.name),
-                asc(Template.template_type),
-            )
-            .all()
+        base_query = Template.query.filter_by(
+            service_id=service_id, template_type=template_type, hidden=False, archived=False
+        )
+    else:
+        base_query = Template.query.filter_by(service_id=service_id, hidden=False, archived=False)
+
+    if no_detail:
+        base_query = base_query.options(
+            load_only(Template.template_type, Template.hidden, Template.name, raiseload=True),
+            defaultload(Template.folder).load_only(TemplateFolder.id),  # type: ignore # mypy bug?
         )
 
-    return (
-        Template.query.filter_by(service_id=service_id, hidden=False, archived=False)
-        .order_by(
-            asc(Template.name),
-            asc(Template.template_type),
-        )
-        .all()
-    )
+    return base_query.order_by(
+        asc(Template.name),
+        asc(Template.template_type),
+    ).all()
 
 
 def dao_get_template_versions(service_id, template_id):

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -157,7 +157,7 @@ def get_user_and_accounts(user_id):
             joinedload(User.services),
             joinedload(User.organisations)
             .joinedload(Organisation.services)
-            .load_only(Service.active, Service.restricted),
+            .load_only(Service.active, Service.restricted, raiseload=True),
         )
         .one()
     )

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -187,7 +187,7 @@ def get_precompiled_template_for_service(service_id):
 
 @template_blueprint.route("", methods=["GET"])
 def get_all_templates_for_service(service_id):
-    templates = dao_get_all_templates_for_service(service_id=service_id)
+    templates = dao_get_all_templates_for_service(service_id=service_id, no_detail=True)
     data = template_schema_no_detail.dump(templates, many=True)
     return jsonify(data=data)
 

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -12,6 +12,7 @@ from freezegun import freeze_time
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from pypdf.errors import PdfReadError
 
+from app import db
 from app.constants import EMAIL_TYPE, LETTER_TYPE, SMS_TYPE
 from app.dao.template_email_files_dao import dao_get_template_email_files_by_template_id
 from app.dao.templates_dao import (
@@ -578,20 +579,27 @@ def test_should_get_only_templates_for_that_service(admin_request, notify_db_ses
     assert {template["id"] for template in json_resp_2["data"]} == {str(id_3)}
 
 
+@pytest.mark.parametrize("in_folder", (False, True))
 @pytest.mark.parametrize("template_type", (EMAIL_TYPE, SMS_TYPE, LETTER_TYPE))
-def test_should_not_return_content_and_subject_if_requested(admin_request, sample_service, template_type):
-    create_template(sample_service, template_type=template_type)
+def test_get_all_templates_folder_info(admin_request, sample_service, template_type, in_folder):
+    parent_folder = create_template_folder(service=sample_service, name="my parent folder")
+    template = create_template(sample_service, template_type=template_type, folder=parent_folder if in_folder else None)
+
+    db.session.commit()
+
     json_response = admin_request.get(
         "template.get_all_templates_for_service",
         service_id=sample_service.id,
     )
-    assert json_response["data"][0].keys() == {
-        "folder",
-        "id",
-        "is_precompiled_letter",
-        "name",
-        "template_type",
-    }
+    assert json_response["data"] == [
+        {
+            "folder": str(parent_folder.id) if in_folder else None,
+            "id": str(template.id),
+            "is_precompiled_letter": template.is_precompiled_letter,
+            "name": template.name,
+            "template_type": template.template_type,
+        }
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Similar to #4821 (which appeared to give us a >30% performance improvement), reducing the degree to which we overfetch fields should reduce the amount of (uninterruptible) time the ORM & db connector has to spend interpreting the wide result rows.

This view is one of api's next big sinners in hogging CPU time.