### PR TITLE
Upgrade Flask-Migrate to version 4

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ kombu @ git+https://github.com/celery/kombu.git@860e40a6c904c4d8551577d9f4e8c00f
 
 Flask-Bcrypt~=1.0
 flask-marshmallow~=1.4
-Flask-Migrate~=3.1
+Flask-Migrate~=4.1
 flask-sqlalchemy~=3.1
 click-datetime~=0.2
 gunicorn[eventlet]~=25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,7 +86,7 @@ flask-bcrypt==1.0.1
     # via -r requirements.in
 flask-marshmallow==1.4.0
     # via -r requirements.in
-flask-migrate==3.1.0
+flask-migrate==4.1.0
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -131,7 +131,7 @@ flask-bcrypt==1.0.1
     # via -r requirements.txt
 flask-marshmallow==1.4.0
     # via -r requirements.txt
-flask-migrate==3.1.0
+flask-migrate==4.1.0
     # via -r requirements.txt
 flask-redis==0.4.0
     # via


### PR DESCRIPTION
https://github.com/miguelgrinberg/Flask-Migrate/blob/main/CHANGES.md

Don’t see anything which should affect us. Breaking changes seem to be dropping older versions of Python and Flask-SQLAlchemy.

I have run `make drop-test-dbs bootstrap test` locally to show that all the migrations still run.