### PR TITLE
Remove duplicated workers from entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,12 +39,6 @@ case "$1" in
   api-worker-jobs-save-documents)
     exec $COMMON_CMD database-tasks-documents
     ;;
-  api-worker-jobs-save)
-    exec $COMMON_CMD database-tasks,job-tasks
-    ;;
-  api-worker-jobs-save-documents)
-    exec $COMMON_CMD database-tasks,job-tasks
-    ;;
   api-worker-research)
     exec $COMMON_CMD research-mode-tasks
     ;;


### PR DESCRIPTION
`api-worker-jobs-save` and `api-worker-jobs-save-documents` were listed twice in the entrypoint. These removes the second places there were listed, which are the ones that aren't used.