### PR TITLE
Update the logic that determines when a user is allowed to be removed from a service or archived

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -8,7 +8,12 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import db, redis_store
-from app.constants import EMAIL_AUTH_TYPE, NOTIFY_FEATURES_AND_IMPROVEMENTS_SERVICE_ID, NOTIFY_RESEARCH_SERVICE_ID
+from app.constants import (
+    EMAIL_AUTH_TYPE,
+    MANAGE_SETTINGS,
+    NOTIFY_FEATURES_AND_IMPROVEMENTS_SERVICE_ID,
+    NOTIFY_RESEARCH_SERVICE_ID,
+)
 from app.dao.dao_utils import autocommit
 from app.dao.organisation_dao import dao_remove_user_from_organisation
 from app.dao.organisation_user_permissions_dao import organisation_user_permissions_dao
@@ -190,6 +195,38 @@ def dao_archive_user(user):
     user.state = "inactive"
 
     db.session.add(user)
+
+
+def _count_manage_settings_users(service):
+    active_users = [u for u in service.users if u.state == "active"]
+
+    return sum(MANAGE_SETTINGS in u.get_permissions(service_id=service.id) for u in active_users)
+
+
+def _min_manage_settings_users(service):
+    return 1 if service.restricted and not service.has_active_go_live_request else 2
+
+
+def _can_remove_manage_settings_user(service):
+    """
+    Returns False if removing a single user with `manage_settings`
+    would leave the service with too few such users.
+    """
+    return _count_manage_settings_users(service) - 1 >= _min_manage_settings_users(service)
+
+
+def user_can_be_removed_from_service(user, service):
+    active_users = [u for u in service.users if u.state == "active"]
+
+    # Must always leave at least one active user
+    if len(active_users) == 1:
+        return False
+
+    # Removing users without the `manage_settings` permission is always safe
+    if MANAGE_SETTINGS not in user.get_permissions(service_id=service.id):
+        return True
+
+    return _can_remove_manage_settings_user(service)
 
 
 def user_can_be_archived(user):

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -171,7 +171,7 @@ def get_user_and_accounts(user_id):
 @autocommit
 def dao_archive_user(user):
     if not user_can_be_archived(user):
-        msg = "User can’t be removed from a service - check all services have another team member with manage_settings"
+        msg = "User cannot be removed from a service"
         raise InvalidRequest(msg, 400)
 
     permission_dao.remove_user_service_permissions_for_all_services(user)
@@ -230,19 +230,7 @@ def user_can_be_removed_from_service(user, service):
 
 
 def user_can_be_archived(user):
-    active_services = [x for x in user.services if x.active]
-
-    for service in active_services:
-        other_active_users = [x for x in service.users if x.state == "active" and x != user]
-
-        if not other_active_users:
-            return False
-
-        if not any("manage_settings" in user.get_permissions(service.id) for user in other_active_users):
-            # no-one else has manage settings
-            return False
-
-    return True
+    return all(user_can_be_removed_from_service(user, service) for service in user.services if service.active)
 
 
 def get_users_for_research(start_date: date, end_date: date) -> list[User]:

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -128,7 +128,7 @@ from app.dao.unsubscribe_request_dao import (
     get_unsubscribe_requests_statistics_dao,
     update_unsubscribe_request_report_processed_by_date_dao,
 )
-from app.dao.users_dao import get_user_by_id, save_user_attribute
+from app.dao.users_dao import get_user_by_id, save_user_attribute, user_can_be_removed_from_service
 from app.errors import InvalidRequest, register_errors
 from app.letters.utils import adjust_daily_service_limits_for_cancelled_letters, letter_print_day
 from app.models import (
@@ -410,9 +410,8 @@ def remove_user_from_service(service_id, user_id):
         error = "User not found"
         raise InvalidRequest(error, status_code=404)
 
-    elif len(service.users) == 1:
-        error = "You cannot remove the only user for a service"
-        raise InvalidRequest(error, status_code=400)
+    if not user_can_be_removed_from_service(user=user, service=service):
+        raise InvalidRequest("User cannot be removed from the service", status_code=400)
 
     dao_remove_user_from_service(service, user)
     return jsonify({}), 204

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -227,18 +227,22 @@ def test_dao_archive_user(sample_user, sample_organisation, fake_uuid):
     sample_user.current_session_id = fake_uuid
     sample_user.platform_admin = True
 
-    # create 2 services for sample_user to be a member of (each with another active user)
+    # create 2 services for sample_user to be a member of (each with another 2 active users)
     service_1 = create_service(service_name="Service 1")
-    service_1_user = create_user(email="1@test.com")
-    service_1.users = [sample_user, service_1_user]
+    service_1_user_a = create_user(email="1a@test.com")
+    service_1_user_b = create_user(email="1b@test.com")
+    service_1.users = [sample_user, service_1_user_a, service_1_user_b]
     create_permissions(sample_user, service_1, "manage_settings")
-    create_permissions(service_1_user, service_1, "manage_settings", "view_activity")
+    create_permissions(service_1_user_a, service_1, "manage_settings", "view_activity")
+    create_permissions(service_1_user_b, service_1, "manage_settings", "view_activity")
 
     service_2 = create_service(service_name="Service 2")
-    service_2_user = create_user(email="2@test.com")
-    service_2.users = [sample_user, service_2_user]
+    service_2_user_a = create_user(email="2a@test.com")
+    service_2_user_b = create_user(email="2b@test.com")
+    service_2.users = [sample_user, service_2_user_a, service_2_user_b]
     create_permissions(sample_user, service_2, "view_activity")
-    create_permissions(service_2_user, service_2, "manage_settings")
+    create_permissions(service_2_user_a, service_2, "manage_settings")
+    create_permissions(service_2_user_b, service_2, "manage_settings")
 
     # make sample_user an org member with permissions
     sample_organisation.users = [sample_user]
@@ -460,6 +464,31 @@ def test_user_cannot_be_archived_if_the_other_service_members_do_not_have_the_ma
 
     assert len(sample_service.users) == 3
     assert not user_can_be_archived(active_user)
+
+
+def test_user_cannot_be_archived_unless_they_can_be_removed_from_every_service(sample_service, notify_db_session):
+    user_to_archive = create_user(email="1@test.com")
+    user_two = create_user(email="2@test.com")
+    user_three = create_user(email="3@test.com")
+
+    sample_service.users = [user_to_archive, user_two, user_three]
+
+    create_permissions(user_to_archive, sample_service, "manage_settings")
+    create_permissions(user_two, sample_service, "manage_settings", "view_activity")
+    create_permissions(user_three, sample_service, "manage_settings", "send_emails", "send_letters", "send_texts")
+
+    service_two = create_service(user_to_archive, "service two")
+    service_two.users = [user_to_archive, user_two]
+    create_permissions(user_two, service_two, "manage_settings", "view_activity")
+
+    notify_db_session.commit()
+
+    # user belongs to both services with "manage_settings" but is only allowed to be removed from one of
+    # the services, the other doesn't have enough team members, so can't be archived
+    assert len(sample_service.users) == 3
+    assert len(service_two.users) == 2
+
+    assert not user_can_be_archived(user_to_archive)
 
 
 def test_get_users_for_research(notify_db_session):

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -31,6 +31,7 @@ from app.dao.users_dao import (
     save_user_attribute,
     update_user_password,
     user_can_be_archived,
+    user_can_be_removed_from_service,
 )
 from app.errors import InvalidRequest
 from app.models import OrganisationUserPermissions, Permission, User, VerifyCode
@@ -275,6 +276,127 @@ def test_dao_archive_user(sample_user, sample_organisation, fake_uuid):
     assert not sample_user.check_password("password")
     assert not sample_user.platform_admin
     assert sample_user.get_organisation_permissions() == {}
+
+
+@pytest.mark.parametrize("user_permission", ["manage_settings", "view_activity"])
+def test_user_can_be_removed_from_service_is_false_if_service_has_one_active_user(
+    sample_service,
+    notify_db_session,
+    user_permission,
+):
+    active_user = create_user()
+    create_permissions(active_user, sample_service, user_permission)
+    pending_user = create_user(state="pending")
+    create_permissions(pending_user, sample_service, user_permission)
+    inactive_user = create_user(state="inactive")
+    create_permissions(inactive_user, sample_service, user_permission)
+
+    sample_service.users = [active_user]
+    notify_db_session.commit()
+
+    assert user_can_be_removed_from_service(user=active_user, service=sample_service) is False
+
+
+@pytest.mark.parametrize("service_in_trial_mode", [True, False])
+@pytest.mark.parametrize(
+    "num_admin_users, num_non_admin_users",
+    [
+        (1, 1),
+        (1, 3),
+        (2, 1),
+        (4, 1),
+        (4, 5),
+    ],
+)
+def test_user_can_be_removed_from_service_when_user_does_not_have_manage_settings(
+    sample_service,
+    notify_db_session,
+    service_in_trial_mode,
+    num_admin_users,
+    num_non_admin_users,
+):
+    admin_users = [create_user() for i in range(num_admin_users)]
+    for user in admin_users:
+        create_permissions(user, sample_service, "manage_settings")
+
+    non_admin_users = [create_user() for i in range(num_non_admin_users)]
+    for user in non_admin_users:
+        create_permissions(user, sample_service, "view_activity")
+
+    sample_service.users = [*admin_users, *non_admin_users]
+    sample_service.restricted = service_in_trial_mode
+    notify_db_session.commit()
+
+    assert user_can_be_removed_from_service(user=non_admin_users[0], service=sample_service) is True
+
+
+@pytest.mark.parametrize(
+    "num_admin_users, num_non_admin_users, has_go_live_request, can_be_removed",
+    [
+        (1, 3, True, False),
+        (1, 3, False, False),
+        (2, 0, True, False),
+        (2, 0, False, True),
+        (2, 4, True, False),
+        (2, 4, False, True),
+        (3, 2, True, True),
+        (3, 2, False, True),
+    ],
+)
+def test_user_can_be_removed_from_service_when_service_is_trial_mode_and_user_has_manage_settings(
+    sample_service,
+    notify_db_session,
+    num_admin_users,
+    num_non_admin_users,
+    has_go_live_request,
+    can_be_removed,
+):
+    admin_users = [create_user() for i in range(num_admin_users)]
+    for user in admin_users:
+        create_permissions(user, sample_service, "manage_settings")
+
+    non_admin_users = [create_user() for i in range(num_non_admin_users)]
+    for user in non_admin_users:
+        create_permissions(user, sample_service, "view_activity")
+
+    sample_service.users = [*admin_users, *non_admin_users]
+    sample_service.restricted = True
+    sample_service.has_active_go_live_request = has_go_live_request
+    notify_db_session.commit()
+
+    assert user_can_be_removed_from_service(user=admin_users[0], service=sample_service) is can_be_removed
+
+
+@pytest.mark.parametrize(
+    "num_admin_users, num_non_admin_users, can_be_removed",
+    [
+        (1, 1, False),
+        (1, 5, False),
+        (2, 0, False),
+        (2, 10, False),
+        (3, 2, True),
+        (6, 0, True),
+    ],
+)
+def test_user_can_be_removed_from_service_when_service_is_live_and_user_has_manage_settings(
+    sample_service,
+    notify_db_session,
+    num_admin_users,
+    num_non_admin_users,
+    can_be_removed,
+):
+    admin_users = [create_user() for i in range(num_admin_users)]
+    for user in admin_users:
+        create_permissions(user, sample_service, "manage_settings")
+
+    non_admin_users = [create_user() for i in range(num_non_admin_users)]
+    for user in non_admin_users:
+        create_permissions(user, sample_service, "view_activity")
+
+    sample_service.users = [*admin_users, *non_admin_users]
+    notify_db_session.commit()
+
+    assert user_can_be_removed_from_service(user=admin_users[0], service=sample_service) is can_be_removed
 
 
 def test_user_can_be_archived_if_they_do_not_belong_to_any_services(sample_user):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1453,48 +1453,51 @@ def test_add_unknown_user_to_service_returns404(notify_api, notify_db_session, s
             assert result["message"] == expected_message
 
 
-def test_remove_user_from_service(client, sample_user_service_permission):
-    second_user = create_user(email="new@digital.cabinet-office.gov.uk")
+def test_remove_user_from_service(sample_user_service_permission, admin_request):
+    second_user = create_user(email="new_2@digital.cabinet-office.gov.uk")
+    third_user = create_user(email="new_3@digital.cabinet-office.gov.uk")
+
     service = sample_user_service_permission.service
 
-    # Simulates successfully adding a user to the service
+    # Adds 2 additional users to the service so it is possible to remove 1
     dao_add_user_to_service(
         service,
         second_user,
         permissions=[Permission(service_id=service.id, user_id=second_user.id, permission="manage_settings")],
     )
-
-    endpoint = url_for("service.remove_user_from_service", service_id=str(service.id), user_id=str(second_user.id))
-    auth_header = create_admin_authorization_header()
-    resp = client.delete(endpoint, headers=[("Content-Type", "application/json"), auth_header])
-    assert resp.status_code == 204
-
-
-def test_remove_non_existant_user_from_service(client, sample_user_service_permission):
-    second_user = create_user(email="new@digital.cabinet-office.gov.uk")
-    endpoint = url_for(
-        "service.remove_user_from_service",
-        service_id=str(sample_user_service_permission.service.id),
-        user_id=str(second_user.id),
+    dao_add_user_to_service(
+        service,
+        third_user,
+        permissions=[Permission(service_id=service.id, user_id=second_user.id, permission="manage_settings")],
     )
-    auth_header = create_admin_authorization_header()
-    resp = client.delete(endpoint, headers=[("Content-Type", "application/json"), auth_header])
-    assert resp.status_code == 404
+
+    admin_request.delete(
+        "service.remove_user_from_service",
+        service_id=service.id,
+        user_id=second_user.id,
+    )
 
 
-def test_cannot_remove_only_user_from_service(notify_api, notify_db_session, sample_user_service_permission):
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            endpoint = url_for(
-                "service.remove_user_from_service",
-                service_id=str(sample_user_service_permission.service.id),
-                user_id=str(sample_user_service_permission.user.id),
-            )
-            auth_header = create_admin_authorization_header()
-            resp = client.delete(endpoint, headers=[("Content-Type", "application/json"), auth_header])
-            assert resp.status_code == 400
-            result = resp.json
-            assert result["message"] == "You cannot remove the only user for a service"
+def test_remove_non_existent_user_from_service(sample_user_service_permission, admin_request):
+    second_user = create_user(email="new@digital.cabinet-office.gov.uk")
+
+    response = admin_request.delete(
+        "service.remove_user_from_service",
+        service_id=sample_user_service_permission.service.id,
+        user_id=second_user.id,
+        _expected_status=404,
+    )
+    assert response["message"] == "User not found"
+
+
+def test_cannot_remove_only_user_from_service(admin_request, sample_user_service_permission):
+    response = admin_request.delete(
+        "service.remove_user_from_service",
+        service_id=sample_user_service_permission.service.id,
+        user_id=sample_user_service_permission.user.id,
+        _expected_status=400,
+    )
+    assert response["message"] == "User cannot be removed from the service"
 
 
 # This test is just here verify get_service_and_api_key_history that is a temp solution

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -360,9 +360,7 @@ def test_archive_user_when_user_cannot_be_archived(mocker, admin_request, sample
     mocker.patch("app.dao.users_dao.user_can_be_archived", return_value=False)
 
     json_resp = admin_request.post("user.archive_user", user_id=sample_user.id, _expected_status=400)
-    msg = "User can’t be removed from a service - check all services have another team member with manage_settings"
-
-    assert json_resp["message"] == msg
+    assert json_resp["message"] == "User cannot be removed from a service"
 
 
 def test_fetch_user_by_email(admin_request, notify_db_session):


### PR DESCRIPTION
This updates the logic that determines when a user is allowed to be removed from a service or archived.

The checks before were quite basic:
- You couldn't remove the user from a service if they were the only user
- You couldn't archive a user if that would leave any of their services with no active users or no users with the `manage_settings` permission

We now want all live services or trial mode services that have requested to go live to have 2 users with the `manage_settings` permission. Trial mode services without a go-live request must have at least one.

We don't want a situation where an existing live service that only has 1 user with the with the `manage_settings` permission is blocked from removing a different user because their service doesn't meet the team member requirements. So users without the `manage_settings` permission can always be removed and it's only when trying to remove a team member with the `manage_settings` permission that we raise an error if this would result in too few users with the permission.

[Trello card](https://trello.com/c/ZVJ7qdu1/1692-error-for-removing-a-penultimate-user-with-manage-settings-permissions)

**Merge after**
- [x] https://github.com/alphagov/notifications-admin/pull/5903