### PR TITLE
Raise error if changing a user's permissions would result in a service have too few users with `manage_settings`

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -215,6 +215,19 @@ def _can_remove_manage_settings_user(service):
     return _count_manage_settings_users(service) - 1 >= _min_manage_settings_users(service)
 
 
+def users_permissions_can_be_changed(user, service, new_permissions):
+    current_permissions = user.get_permissions(service_id=service.id)
+
+    had_permission = MANAGE_SETTINGS in current_permissions
+    will_have_permission = MANAGE_SETTINGS in new_permissions
+
+    # If we're not removing the permission, it's always safe
+    if not had_permission or will_have_permission:
+        return True
+
+    return _can_remove_manage_settings_user(service)
+
+
 def user_can_be_removed_from_service(user, service):
     active_users = [u for u in service.users if u.state == "active"]
 

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -37,6 +37,7 @@ from app.dao.users_dao import (
     save_user_attribute,
     update_user_password,
     use_user_code,
+    users_permissions_can_be_changed,
 )
 from app.dao.webauthn_credential_dao import (
     dao_get_webauthn_credential_by_user_and_id,
@@ -473,9 +474,16 @@ def set_permissions(user_id, service_id):
     data = request.get_json()
     validate(data, post_set_permissions_schema)
 
+    permissions = [p["permission"] for p in data["permissions"]]
     permission_list = [
         Permission(service_id=service_id, user_id=user_id, permission=p["permission"]) for p in data["permissions"]
     ]
+
+    if not users_permissions_can_be_changed(user, service, new_permissions=permissions):
+        raise InvalidRequest(
+            "Cannot change user permissions - service would have too few users with manage_settings",
+            400,
+        )
 
     permission_dao.set_user_service_permission(user, service, permission_list, _commit=True, replace=True)
 

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -32,6 +32,7 @@ from app.dao.users_dao import (
     update_user_password,
     user_can_be_archived,
     user_can_be_removed_from_service,
+    users_permissions_can_be_changed,
 )
 from app.errors import InvalidRequest
 from app.models import OrganisationUserPermissions, Permission, User, VerifyCode
@@ -280,6 +281,127 @@ def test_dao_archive_user(sample_user, sample_organisation, fake_uuid):
     assert not sample_user.check_password("password")
     assert not sample_user.platform_admin
     assert sample_user.get_organisation_permissions() == {}
+
+
+@pytest.mark.parametrize(
+    "new_permissions",
+    [
+        ["manage_settings"],
+        ["view_activity"],
+        ["send_messages", "manage_settings", "manage_api_keys"],
+    ],
+)
+def test_users_permissions_can_be_changed_when_user_does_not_have_manage_settings_originally(
+    sample_service,
+    notify_db_session,
+    new_permissions,
+):
+    user = create_user()
+    create_permissions(user, sample_service, "view_activity")
+
+    sample_service.users = [user]
+    notify_db_session.commit()
+
+    assert users_permissions_can_be_changed(user, sample_service, new_permissions) is True
+
+
+def test_users_permissions_can_be_changed_when_user_is_keeping_manage_settings_permission(
+    sample_service,
+    notify_db_session,
+):
+    user = create_user()
+    create_permissions(user, sample_service, "manage_settings")
+
+    sample_service.users = [user]
+    notify_db_session.commit()
+
+    assert (
+        users_permissions_can_be_changed(user, sample_service, ["send_messages", "manage_settings", "manage_api_keys"])
+        is True
+    )
+
+
+@pytest.mark.parametrize(
+    "num_admin_users, num_non_admin_users, permissions_can_be_changed",
+    [
+        (1, 1, False),
+        (1, 5, False),
+        (2, 0, False),
+        (2, 10, False),
+        (3, 2, True),
+        (6, 0, True),
+    ],
+)
+def test_users_permissions_can_be_changed_when_removing_manage_settings_from_user_of_live_service(
+    sample_service,
+    notify_db_session,
+    num_admin_users,
+    num_non_admin_users,
+    permissions_can_be_changed,
+):
+    admin_users = [create_user() for i in range(num_admin_users)]
+    for user in admin_users:
+        create_permissions(user, sample_service, "manage_settings")
+
+    non_admin_users = [create_user() for i in range(num_non_admin_users)]
+    for user in non_admin_users:
+        create_permissions(user, sample_service, "view_activity")
+
+    sample_service.users = [*admin_users, *non_admin_users]
+    notify_db_session.commit()
+
+    assert (
+        users_permissions_can_be_changed(
+            admin_users[0],
+            sample_service,
+            ["manage_templates", "manage_api_keys"],
+        )
+        is permissions_can_be_changed
+    )
+
+
+@pytest.mark.parametrize(
+    "num_admin_users, num_non_admin_users, has_go_live_request, permissions_can_be_changed",
+    [
+        (1, 3, True, False),
+        (1, 3, False, False),
+        (2, 0, True, False),
+        (2, 0, False, True),
+        (2, 4, True, False),
+        (2, 4, False, True),
+        (3, 2, True, True),
+        (3, 2, False, True),
+    ],
+)
+def test_users_permissions_can_be_changed_when_removing_manage_settings_from_user_of_trial_mode_service(
+    sample_service,
+    notify_db_session,
+    num_admin_users,
+    num_non_admin_users,
+    has_go_live_request,
+    permissions_can_be_changed,
+):
+    admin_users = [create_user() for i in range(num_admin_users)]
+    for user in admin_users:
+        create_permissions(user, sample_service, "manage_settings")
+
+    non_admin_users = [create_user() for i in range(num_non_admin_users)]
+    for user in non_admin_users:
+        create_permissions(user, sample_service, "view_activity")
+
+    sample_service.users = [*admin_users, *non_admin_users]
+    sample_service.restricted = True
+    sample_service.has_active_go_live_request = has_go_live_request
+    notify_db_session.commit()
+
+    assert (
+        users_permissions_can_be_changed(
+            admin_users[0],
+            sample_service,
+            ["manage_templates", "manage_api_keys"],
+        )
+        is permissions_can_be_changed
+    )
 
 
 @pytest.mark.parametrize("user_permission", ["manage_settings", "view_activity"])

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -449,10 +449,28 @@ def test_set_user_permissions_remove_old(admin_request, sample_user, sample_serv
     assert query.first().permission == MANAGE_SETTINGS
 
 
+def test_set_user_permissions_when_permissions_cannot_be_changed(admin_request, sample_user, sample_service):
+    data = {"permissions": [{"permission": MANAGE_TEMPLATES}]}
+
+    result = admin_request.post(
+        "user.set_permissions",
+        user_id=str(sample_user.id),
+        service_id=str(sample_service.id),
+        _data=data,
+        _expected_status=400,
+    )
+
+    assert result["message"] == "Cannot change user permissions - service would have too few users with manage_settings"
+
+    # check the user still has the original permissions
+    query = Permission.query.filter_by(user=sample_user)
+    assert query.count() == 8
+
+
 def test_set_user_folder_permissions(admin_request, sample_user, sample_service):
     tf1 = create_template_folder(sample_service)
     tf2 = create_template_folder(sample_service)
-    data = {"permissions": [], "folder_permissions": [str(tf1.id), str(tf2.id)]}
+    data = {"permissions": [{"permission": MANAGE_SETTINGS}], "folder_permissions": [str(tf1.id), str(tf2.id)]}
 
     admin_request.post(
         "user.set_permissions",
@@ -503,7 +521,7 @@ def test_set_user_folder_permissions_does_not_affect_permissions_for_other_servi
     service_2_user.folders = [tf3]
     dao_update_service_user(service_2_user)
 
-    data = {"permissions": [], "folder_permissions": [str(tf2.id)]}
+    data = {"permissions": [{"permission": MANAGE_SETTINGS}], "folder_permissions": [str(tf2.id)]}
 
     admin_request.post(
         "user.set_permissions",
@@ -526,7 +544,7 @@ def test_update_user_folder_permissions(admin_request, sample_user, sample_servi
     service_user.folders = [tf1, tf2]
     dao_update_service_user(service_user)
 
-    data = {"permissions": [], "folder_permissions": [str(tf2.id), str(tf3.id)]}
+    data = {"permissions": [{"permission": MANAGE_SETTINGS}], "folder_permissions": [str(tf2.id), str(tf3.id)]}
 
     admin_request.post(
         "user.set_permissions",
@@ -549,7 +567,7 @@ def test_remove_user_folder_permissions(admin_request, sample_user, sample_servi
     service_user.folders = [tf1, tf2]
     dao_update_service_user(service_user)
 
-    data = {"permissions": [], "folder_permissions": []}
+    data = {"permissions": [{"permission": MANAGE_SETTINGS}], "folder_permissions": []}
 
     admin_request.post(
         "user.set_permissions",


### PR DESCRIPTION
We want to check if changing a user's permissions for a service would
result in the service having too few users with the `manage_settings`
permission, so this adds in a function that can be used to check.

The minimum number of users with `manage_settings` is 2 users for live
services and trial services which have requested to go live, and 1 for
trial services without a go-live request.

We then use the new function in the endpoint which changes user permissions -
if changing a user's permissions would result in too few users for the
service having the `manage_settings` permission, we raise an
error that the admin app can catch and handle.

**Merge after**
- [x]  https://github.com/alphagov/notifications-admin/pull/5913