### PR TITLE
`Notification` model: replace "failed" partial index with "nondelivered" partial index

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -18,7 +18,6 @@ NOTIFICATION_RETURNED_LETTER = "returned-letter"
 
 # Raw notification status values grouped into types
 NOTIFICATION_STATUS_TYPES_FAILED = [
-    # if changing this group, update ix_notifications_failed_service_id_composite to match
     NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
     NOTIFICATION_PERMANENT_FAILURE,

--- a/app/models.py
+++ b/app/models.py
@@ -1604,11 +1604,11 @@ class Notification(db.Model):
             },
         ),
         Index(
-            "ix_notifications_failed_service_id_composite",
+            "ix_notifications_nondelivered_service_id_composite",
             "service_id",
             "notification_type",
             "created_at",
-            postgresql_where=status.in_(NOTIFICATION_STATUS_TYPES_FAILED),
+            postgresql_where=(status != NOTIFICATION_DELIVERED),
         ),
     )
 

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0549_remove_send_files_via_ui
+0551_drop_ntfcns_failed_idx

--- a/migrations/versions/0550_notifications_nondeliv_idx.py
+++ b/migrations/versions/0550_notifications_nondeliv_idx.py
@@ -1,0 +1,32 @@
+"""
+Create Date: 2026-04-30T11:57:42
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0550_notifications_nondeliv_idx"
+down_revision = "0549_remove_send_files_via_ui"
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_notifications_nondelivered_service_id_composite",
+            "notifications",
+            ["service_id", "notification_type", "created_at"],
+            unique=False,
+            postgresql_where=sa.text("notification_status != 'delivered'"),
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_notifications_nondelivered_service_id_composite",
+            "notifications",
+            postgresql_where=sa.text("notification_status != 'delivered'"),
+            postgresql_concurrently=True,
+        )

--- a/migrations/versions/0551_drop_ntfcns_failed_idx.py
+++ b/migrations/versions/0551_drop_ntfcns_failed_idx.py
@@ -1,0 +1,36 @@
+"""
+Create Date: 2026-04-30T12:08:58
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0551_drop_ntfcns_failed_idx"
+down_revision = "0550_notifications_nondeliv_idx"
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_notifications_failed_service_id_composite",
+            table_name="notifications",
+            postgresql_where=sa.text(
+                "notification_status IN ('technical-failure', 'temporary-failure', 'permanent-failure', 'validation-failed', 'virus-scan-failed', 'returned-letter')"
+            ),
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_notifications_failed_service_id_composite",
+            "notifications",
+            ["service_id", "notification_type", "created_at"],
+            unique=False,
+            postgresql_where=sa.text(
+                "notification_status IN ('technical-failure', 'temporary-failure', 'permanent-failure', 'validation-failed', 'virus-scan-failed', 'returned-letter')"
+            ),
+            postgresql_concurrently=True,
+        )


### PR DESCRIPTION
`delivered` notifications make up over 95% of the `notifications` table. When we need to find notifications of *any* of the other statuses, this index will allow the query planner to scan in in `created_at` order, skipping the vast majority of the rows, provided we're also filtering by `service_id` and `notification_type`.

Judging from the current contents of the `notifications` table, this should barely add 20% to the size of the index compared to the existing "failed statuses" partial index.

The original motivation for this is speeding up `get_notifications` queries for the `sent` status.

For this PR, the "migration isolation" check can be ignored because the changes made to the app code don't actually have any runtime effect (the `Index` objects are for documentation as much as anything - the definitions of the indexes are managed entirely by the migrations.

We also ignore the "squawk" check - it always throws up these errors for `CREATE INDEX CONCURRENTLY` and we've decided this is the way we want to handle this sort of index addition.

Successfully tested on a dev env that this index is indeed still usable for the "failed notifications" queries it was originally created for.