### PR TITLE
Include sanitised content info in send_email V2 endpoint api response

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -128,8 +128,17 @@ def post_notification(notification_type):
 
     check_service_has_permission(authenticated_service, notification_type)
 
-    personalisation = _prepare_personalisation_for_post_notification(
-        personalisation=form.get("personalisation", {}), sanitise_content_for=form.get("sanitise_content_for", [])
+    unsanitised_personalisation = form.get("personalisation", {})
+    personalisation = (
+        _prepare_personalisation_for_post_notification(
+            personalisation=unsanitised_personalisation, sanitise_content_for=form.get("sanitise_content_for", [])
+        )
+        if notification_type == "email"
+        else unsanitised_personalisation
+    )
+
+    sanitised_content = (
+        _get_sanitised_content(unsanitised_personalisation, personalisation) if notification_type == "email" else {}
     )
 
     template, template_with_content = validate_template(
@@ -164,7 +173,7 @@ def post_notification(notification_type):
             unsubscribe_link=form.get("one_click_unsubscribe_url", None),
         )
 
-    return jsonify(notification), 201
+    return jsonify(notification | sanitised_content), 201
 
 
 def _prepare_personalisation_for_post_notification(personalisation, sanitise_content_for):
@@ -199,6 +208,16 @@ def _could_be_accidental_link(link):
 
 def _break_up_link(link):
     return re.sub(r"\.", ". ", link)
+
+
+def _get_sanitised_content(unsanitised_personalisation, personalisation):
+    return {
+        "sanitised_content": {
+            key: {"unsanitised": unsanitised_personalisation[key], "sanitised": personalisation[key]}
+            for key, value in personalisation.items()
+            if personalisation[key] != unsanitised_personalisation[key]
+        }
+    }
 
 
 def process_sms_or_email_notification(

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -738,14 +738,21 @@ def test_post_email_notification_sanitise_content_for_selected_personalisation(
         "sanitise_content_for": [placeholder_name],
     }
 
-    resp_json = api_client_request.post(
+    response = api_client_request.post(
         sample_email_template_with_distinct_placeholders.service_id,
         "v2_notifications.post_notification",
         notification_type="email",
         _data=data,
     )
 
-    assert validate(resp_json, post_email_response) == resp_json
+    assert validate(response, post_email_response) == response
+    assert response["sanitised_content"] == {
+        "First_Name": {
+            "sanitised": "Amala, please \\[click this evil link\\]\\(\\)",
+            "unsanitised": "Amala, please [click this evil link](https://evil.link)",
+        }
+    }
+
     notification = Notification.query.one()
 
     assert notification.content == (
@@ -765,6 +772,46 @@ def test_post_email_notification_sanitise_content_for_selected_personalisation(
         '[click this evil link]()<br>Please confirm your registration on <a style="word-wrap: break-word; '
         'color: #1D70B8;" href="https://pab.gov.uk/123">Pigeons\' Affair Bureau website</a></p>'
     )
+
+
+@pytest.mark.parametrize(
+    "template_type, recipient_dict, has_sanitised_content",
+    (
+        ("email", {"email_address": "amala@example.com"}, True),
+        ("sms", {"phone_number": "07900111222"}, False),
+        (
+            "letter",
+            {
+                "personalisation": {
+                    "address_line_1": "Amala Pidge",
+                    "address_line_2": "6 Dove St",
+                    "address_line_3": "SW1 1AA",
+                }
+            },
+            False,
+        ),
+    ),
+)
+def test_post_email_notification_response_has_sanitised_content_info_for_emails_only(
+    api_client_request, sample_service, mocker, template_type, recipient_dict, has_sanitised_content
+):
+    template = create_template(service=sample_service, template_type=template_type)
+    mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
+    mocker.patch("app.celery.provider_tasks.deliver_sms.apply_async")
+    mocker.patch("app.celery.letters_pdf_tasks.get_pdf_for_templated_letter.apply_async")
+    data = {
+        "template_id": template.id,
+    } | recipient_dict
+
+    response = api_client_request.post(
+        template.service_id,
+        "v2_notifications.post_notification",
+        notification_type=template_type,
+        _data=data,
+        _api_key_type="test",
+    )
+
+    assert ("sanitised_content" in response) == has_sanitised_content
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When a request to send an email has sanitise_content_for arg, we check the content of specified placeholders for potentially malicious content.

During the user research, service users requested to be notified when this is activated, so that they could investigate.

This PR sends the information about the content we changed, and how it looks before and after.

The information is included in the response. "sanitised_content" key is included in the response for all send_email requests (so it's less error-prone for our service users), but not for send_sms and send_letter requests.