### PR TITLE
Send `created_at` date when creating letter for print

### DIFF
--- a/app/celery/letters_pdf_tasks.py
+++ b/app/celery/letters_pdf_tasks.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from datetime import time as dt_time
 
 from botocore.exceptions import ClientError as BotoClientError
@@ -87,6 +87,7 @@ def get_pdf_for_templated_letter(self, notification_id):
             "letter_filename": letter_filename,
             "notification_id": str(notification_id),
             "key_type": notification.key_type,
+            "date": notification.created_at.replace(tzinfo=UTC).isoformat(),
         }
 
         encoded_data = signing.encode(letter_data)

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -10,6 +10,7 @@ from celery.exceptions import MaxRetriesExceededError
 from flask import current_app
 from freezegun import freeze_time
 from moto import mock_aws
+from notifications_utils.testing.comparisons import AnyStringMatching
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import signing
@@ -96,6 +97,12 @@ def test_get_pdf_for_templated_letter_happy_path(mocker, sample_letter_notificat
         "letter_filename": "LETTER.PDF",
         "notification_id": str(sample_letter_notification.id),
         "key_type": sample_letter_notification.key_type,
+        "date": AnyStringMatching(
+            # There’s a few ms delay between calling the task and creating the datetime here.
+            # Celery evades `freeze_time` so the best we can say is the date is close enough
+            # to not be in the wrong timezone or format, for example.
+            datetime.now(UTC).strftime(r"^%Y-%m-%dT%H:\d{2}:\d{2}\.\d{6}\+00:00$")
+        ),
     }
 
     mock_celery.assert_called_once_with(


### PR DESCRIPTION
It’s better if the date on a templated letter is the date when the user pressed _Send_ rather than when it was processed by us.

This is because:
- it will reflect what they see in the preview at the time of pressing send
- it won’t change if we have to recreate the PDFs for any reason

In order to do this the API needs to tell template preview when the letter was created.

***

Depends on:
- [x] https://github.com/alphagov/notifications-template-preview/pull/973