### PR TITLE
WIP: Make `receipt_iso_timestamp` mandatory in `process_sms_client_response` and `process_ses_results`

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -25,7 +25,7 @@ from app.notifications.notifications_ses_callback import (
 def process_ses_results(  # noqa: C901
     self: Task,
     response: dict,
-    receipt_iso_timestamp: str | None = None,
+    receipt_iso_timestamp: str,
 ):
     try:
         ses_message = json.loads(response["Message"])
@@ -50,17 +50,12 @@ def process_ses_results(  # noqa: C901
             except ValueError:
                 pass  # None it is, then
 
-        receipt_dt = None
-        if receipt_iso_timestamp is not None:
-            try:
-                receipt_dt = datetime.fromisoformat(receipt_iso_timestamp).replace(tzinfo=None)
-            except ValueError:
-                pass  # None it is, then
+        receipt_dt = datetime.fromisoformat(receipt_iso_timestamp).replace(tzinfo=None)
 
         uniform_now = datetime.utcnow()
         common_extra = {
             "receipt_received_at": receipt_dt,
-            "receipt_received_ago": (uniform_now - receipt_dt).total_seconds() if receipt_dt is not None else None,
+            "receipt_received_ago": (uniform_now - receipt_dt).total_seconds(),
         }
         try:
             notification = notifications_dao.dao_get_notification_or_history_by_reference(reference=reference)

--- a/app/celery/process_sms_client_response_tasks.py
+++ b/app/celery/process_sms_client_response_tasks.py
@@ -32,9 +32,9 @@ def process_sms_client_response(
     status,
     provider_reference,
     client_name,
-    detailed_status_code=None,
-    delivery_iso_timestamp: str | None = None,
-    receipt_iso_timestamp: str | None = None,
+    detailed_status_code,
+    delivery_iso_timestamp: str | None,
+    receipt_iso_timestamp: str,
 ):
     # validate reference
     try:
@@ -66,12 +66,7 @@ def process_sms_client_response(
                 except ValueError:
                     pass  # None it is, then
 
-            receipt_dt = None
-            if receipt_iso_timestamp is not None:
-                try:
-                    receipt_dt = datetime.fromisoformat(receipt_iso_timestamp)
-                except ValueError:
-                    pass  # None it is, then
+            receipt_dt = datetime.fromisoformat(receipt_iso_timestamp)
 
             uniform_now = datetime.utcnow()
             extra = {
@@ -81,7 +76,7 @@ def process_sms_client_response(
                 "detailed_status": detailed_status,
                 "detailed_status_code": detailed_status_code,
                 "receipt_received_at": receipt_dt,
-                "receipt_received_ago": (uniform_now - receipt_dt).total_seconds() if receipt_dt is not None else None,
+                "receipt_received_ago": (uniform_now - receipt_dt).total_seconds(),
                 "delivered_at": delivery_dt,
                 "delivered_ago": (uniform_now - delivery_dt).total_seconds() if delivery_dt is not None else None,
                 # for sms, we happen to use notification id as the "provider reference"

--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -64,7 +64,7 @@ def send_email_response(reference, to, service_id):
         body = ses_notification_callback(reference)
 
     process_ses_results.apply_async(
-        [body],
+        [body, datetime.utcnow().isoformat()],
         queue=QueueNames.RESEARCH_MODE,
         MessageGroupId=str(service_id),
     )

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -27,7 +27,9 @@ from tests.app.db import (
 def test_process_ses_results(sample_email_template):
     create_notification(sample_email_template, reference="ref1", sent_at=datetime.utcnow(), status="sending")
 
-    assert process_ses_results(response=ses_notification_callback(reference="ref1"))
+    assert process_ses_results(
+        response=ses_notification_callback(reference="ref1"), receipt_iso_timestamp=datetime.utcnow().isoformat()
+    )
 
 
 def test_process_ses_results_retry_called(sample_email_template, mocker):
@@ -35,14 +37,16 @@ def test_process_ses_results_retry_called(sample_email_template, mocker):
 
     mocker.patch("app.dao.notifications_dao.dao_update_notifications_by_reference", side_effect=Exception("EXPECTED"))
     mocked = mocker.patch("app.celery.process_ses_receipts_tasks.process_ses_results.retry")
-    process_ses_results(response=ses_notification_callback(reference="ref1"))
+    process_ses_results(
+        response=ses_notification_callback(reference="ref1"), receipt_iso_timestamp=datetime.utcnow().isoformat()
+    )
     assert mocked.call_count != 0
 
 
 def test_process_ses_results_in_complaint(sample_email_template, mocker):
     notification = create_notification(template=sample_email_template, reference="ref1")
     old_updated_at = notification.updated_at
-    process_ses_results(response=ses_complaint_callback())
+    process_ses_results(response=ses_complaint_callback(), receipt_iso_timestamp=datetime.utcnow().isoformat())
     complaints = Complaint.query.all()
     assert len(complaints) == 1
     assert complaints[0].notification_id == notification.id
@@ -107,7 +111,7 @@ def test_ses_callback_should_not_update_notification_status_if_already_delivered
     )
     notification = create_notification(template=sample_email_template, reference="ref", status="delivered")
 
-    assert process_ses_results(ses_notification_callback(reference="ref")) is None
+    assert process_ses_results(ses_notification_callback(reference="ref"), datetime.utcnow().isoformat()) is None
     assert get_notification_by_id(notification.id).status == "delivered"
 
     mock_dup.assert_called_once_with(notification=notification, status="delivered")
@@ -118,7 +122,7 @@ def test_ses_callback_should_retry_if_notification_is_new(client, notify_db_sess
     mock_retry = mocker.patch("app.celery.process_ses_receipts_tasks.process_ses_results.retry")
 
     with freeze_time("2017-11-17T12:14:03.646Z"), caplog.at_level("ERROR"):
-        assert process_ses_results(ses_notification_callback(reference="ref")) is None
+        assert process_ses_results(ses_notification_callback(reference="ref"), datetime.utcnow().isoformat()) is None
 
     assert caplog.messages == []
     assert mock_retry.call_count == 1
@@ -130,7 +134,7 @@ def test_ses_callback_should_log_if_notification_is_missing(client, notify_db_se
     with freeze_time("2017-11-17T12:34:03.646Z") as frozen_time, caplog.at_level("WARNING"):
         payload = ses_notification_callback(reference="ref")
         frozen_time.tick(400)
-        assert process_ses_results(payload) is None
+        assert process_ses_results(payload, datetime.utcnow().isoformat()) is None
 
     assert "notification not found for reference: ref (update to delivered)" in caplog.messages
     assert mock_retry.call_count == 0
@@ -142,7 +146,7 @@ def test_ses_callback_should_not_retry_if_notification_is_old(client, notify_db_
     with freeze_time("2017-11-21T12:14:03.646Z") as frozen_time, caplog.at_level("ERROR"):
         payload = ses_notification_callback(reference="ref")
         frozen_time.tick(400)
-        assert process_ses_results(payload) is None
+        assert process_ses_results(payload, datetime.utcnow().isoformat()) is None
 
     assert caplog.messages == []
     assert mock_retry.call_count == 0
@@ -167,9 +171,9 @@ def test_ses_callback_should_update_multiple_notification_status_sent(
         status="sending",
         reference="ref3",
     )
-    assert process_ses_results(ses_notification_callback(reference="ref1"))
-    assert process_ses_results(ses_notification_callback(reference="ref2"))
-    assert process_ses_results(ses_notification_callback(reference="ref3"))
+    assert process_ses_results(ses_notification_callback(reference="ref1"), datetime.utcnow().isoformat())
+    assert process_ses_results(ses_notification_callback(reference="ref2"), datetime.utcnow().isoformat())
+    assert process_ses_results(ses_notification_callback(reference="ref3"), datetime.utcnow().isoformat())
     assert send_mock.called
 
 
@@ -249,7 +253,7 @@ def test_ses_callback_should_send_on_complaint_to_user_callback_api(sample_email
         template=sample_email_template, reference="ref1", sent_at=datetime.utcnow(), status="sending"
     )
     response = ses_complaint_callback()
-    assert process_ses_results(response)
+    assert process_ses_results(response, datetime.utcnow().isoformat())
 
     assert send_mock.call_count == 1
     assert signing.decode(send_mock.call_args[0][0][0]) == {

--- a/tests/app/celery/test_process_sms_client_response_tasks.py
+++ b/tests/app/celery/test_process_sms_client_response_tasks.py
@@ -14,7 +14,14 @@ from app.constants import NOTIFICATION_TECHNICAL_FAILURE
 
 def test_process_sms_client_response_raises_error_if_reference_is_not_a_valid_uuid(client):
     with pytest.raises(ValueError):
-        process_sms_client_response(status="000", provider_reference="something-bad", client_name="sms-client")
+        process_sms_client_response(
+            status="000",
+            provider_reference="something-bad",
+            client_name="sms-client",
+            detailed_status_code=None,
+            delivery_iso_timestamp=None,
+            receipt_iso_timestamp=datetime.utcnow().isoformat(),
+        )
 
 
 @pytest.mark.parametrize("client_name", ("Firetext", "MMG"))
@@ -28,6 +35,9 @@ def test_process_sms_response_raises_client_exception_for_unknown_status(
             status="000",
             provider_reference=str(sample_notification.id),
             client_name=client_name,
+            detailed_status_code=None,
+            delivery_iso_timestamp=None,
+            receipt_iso_timestamp=datetime.utcnow().isoformat(),
         )
 
     assert f"{client_name} callback failed: status {'000'} not found." in str(e.value)
@@ -86,10 +96,12 @@ def test_process_sms_client_response_updates_notification_status_when_called_sec
     sample_notification, caplog, detailed_status_code, expected_notification_status, reason
 ):
     sample_notification.status = "sending"
-    process_sms_client_response("2", str(sample_notification.id), "Firetext")
+    process_sms_client_response("2", str(sample_notification.id), "Firetext", None, None, datetime.utcnow().isoformat())
 
     with caplog.at_level("INFO"):
-        process_sms_client_response("1", str(sample_notification.id), "Firetext", detailed_status_code)
+        process_sms_client_response(
+            "1", str(sample_notification.id), "Firetext", detailed_status_code, None, datetime.utcnow().isoformat()
+        )
 
     if detailed_status_code:
         message = f"Updating notification id {sample_notification.id} to status {expected_notification_status}, reason: {reason}"  # noqa
@@ -104,7 +116,9 @@ def test_process_sms_client_response_updates_notification_status_to_pending_with
 ):
     sample_notification.status = "sending"
 
-    process_sms_client_response("2", str(sample_notification.id), "Firetext", detailed_status_code)
+    process_sms_client_response(
+        "2", str(sample_notification.id), "Firetext", detailed_status_code, None, datetime.utcnow().isoformat()
+    )
 
     assert sample_notification.status == "pending"
 
@@ -113,10 +127,12 @@ def test_process_sms_client_response_updates_notification_status_when_detailed_s
     sample_notification, caplog
 ):
     sample_notification.status = "sending"
-    process_sms_client_response("2", str(sample_notification.id), "Firetext")
+    process_sms_client_response("2", str(sample_notification.id), "Firetext", None, None, datetime.utcnow().isoformat())
 
     with caplog.at_level("WARNING"):
-        process_sms_client_response("1", str(sample_notification.id), "Firetext", "789")
+        process_sms_client_response(
+            "1", str(sample_notification.id), "Firetext", "789", None, datetime.utcnow().isoformat()
+        )
 
     assert (
         f"Failure code 789 from Firetext not recognised when processing notification {sample_notification.id}"
@@ -128,7 +144,14 @@ def test_process_sms_client_response_updates_notification_status_when_detailed_s
 def test_sms_response_does_not_send_callback_if_notification_is_not_in_the_db(sample_service, mocker):
     send_mock = mocker.patch("app.celery.process_sms_client_response_tasks.check_and_queue_callback_task")
     reference = str(uuid.uuid4())
-    process_sms_client_response(status="3", provider_reference=reference, client_name="MMG")
+    process_sms_client_response(
+        status="3",
+        provider_reference=reference,
+        client_name="MMG",
+        detailed_status_code=None,
+        delivery_iso_timestamp=None,
+        receipt_iso_timestamp=datetime.utcnow().isoformat(),
+    )
     send_mock.assert_not_called()
 
 
@@ -140,7 +163,7 @@ def test_process_sms_client_response_records_statsd_metrics(sample_notification,
     sample_notification.status = "sending"
     sample_notification.sent_at = datetime.utcnow()
 
-    process_sms_client_response("0", str(sample_notification.id), "Firetext")
+    process_sms_client_response("0", str(sample_notification.id), "Firetext", None, None, datetime.utcnow().isoformat())
 
     statsd_client.incr.assert_any_call("callback.firetext.delivered")
     statsd_client.timing_with_dates.assert_any_call(
@@ -150,14 +173,14 @@ def test_process_sms_client_response_records_statsd_metrics(sample_notification,
 
 def test_process_sms_updates_billable_units_if_zero(sample_notification):
     sample_notification.billable_units = 0
-    process_sms_client_response("3", str(sample_notification.id), "MMG")
+    process_sms_client_response("3", str(sample_notification.id), "MMG", None, None, datetime.utcnow().isoformat())
 
     assert sample_notification.billable_units == 1
 
 
 def test_process_sms_response_does_not_send_service_callback_for_pending_notifications(sample_notification, mocker):
     send_mock = mocker.patch("app.celery.process_sms_client_response_tasks.check_and_queue_callback_task")
-    process_sms_client_response("2", str(sample_notification.id), "Firetext")
+    process_sms_client_response("2", str(sample_notification.id), "Firetext", None, None, datetime.utcnow().isoformat())
     send_mock.assert_not_called()
 
 
@@ -165,12 +188,12 @@ def test_outcome_statistics_called_for_successful_callback(sample_notification, 
     send_mock = mocker.patch("app.celery.process_sms_client_response_tasks.check_and_queue_callback_task")
     reference = str(sample_notification.id)
 
-    process_sms_client_response("3", reference, "MMG")
+    process_sms_client_response("3", reference, "MMG", None, None, datetime.utcnow().isoformat())
     send_mock.assert_called_once_with(sample_notification)
 
 
 def test_process_sms_updates_sent_by_with_client_name_if_not_in_noti(sample_notification):
     sample_notification.sent_by = None
-    process_sms_client_response("3", str(sample_notification.id), "MMG")
+    process_sms_client_response("3", str(sample_notification.id), "MMG", None, None, datetime.utcnow().isoformat())
 
     assert sample_notification.sent_by == "mmg"


### PR DESCRIPTION
https://trello.com/c/25A3gpXh/1358-replace-statsd-instrumentation-across-notify-with-otel

(Not strictly related to this ticket, but it's relevant because I want to use `receipt_iso_timestamp` in a metric)

When adding attributes to an existing Celery task we have to make them optional, so that task invocations that were queued before the new attributes were introduced can still work.

These attributes were all added a long time ago though, so that risk shouldn't exist anymore. This commit makes them all mandatory, and updates our tests accordingly.

I've also made `receipt_iso_timestamp` non-nullable and removed the error handling around its parsing, because it's generated by us at the point where we receive the callback, and therefore can't ever be invalid (and if it ever is invalid then we have a bug).