### PR TITLE
`get_organisations_and_services_for_user`: use `selectinload` loading

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -4,7 +4,7 @@ from secrets import SystemRandom
 
 from flask import current_app
 from sqlalchemy import func
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import db, redis_store
@@ -159,9 +159,9 @@ def get_user_and_accounts(user_id):
         .options(
             # eagerly load the user's services and organisations, and also the org's other services
             # (though only enough information to determine their liveness)
-            joinedload(User.services),
+            selectinload(User.services),
             joinedload(User.organisations)
-            .joinedload(Organisation.services)
+            .selectinload(Organisation.services)
             .load_only(Service.active, Service.restricted, raiseload=True),
         )
         .one()


### PR DESCRIPTION
This should avoid us fetching the cartesian product of the number of organisations the user's in, the number of services those organisations have, and the number of services the user's directly in - which can get quite big (50k+ rows) for some users.

Expecting this to make the worst case scenario for this view significantly faster.