### PR TITLE
sqlalchemy: set `connect_timeout` to 4 seconds

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -182,7 +182,7 @@ class Config:
         "pool_timeout": 30,
         "pool_recycle": 300,
         "connect_args": {
-            "connect_timeout": "5",  # seconds
+            "connect_timeout": "4",  # seconds
             "tcp_user_timeout": "5000",  # milliseconds
             # statement_timeout is overridden in setup_sqlalchemy_events, but not all our
             # invocations heed those event hooks (e.g. alembic migrations), so this is set


### PR DESCRIPTION
We're currently seeing some unusual 5 second waits in api-web that aren't yielding the greenthread. If it's _this_ 5s timeout that's responsible, changing it to 4s should cause us to start seeing 4s waits instead.