### PR TITLE
otel_metrics: Don't report send duration for letters

### DIFF
--- a/app/celery/process_sms_client_response_tasks.py
+++ b/app/celery/process_sms_client_response_tasks.py
@@ -142,8 +142,8 @@ def _process_for_status(
         key_type=notification.key_type,
         notification_status=notification.status,
         notification_type="sms",
+        notification_sms_international=notification.international,
         provider_name=client_name.lower(),
-        sms_international=notification.international,
     )
 
     if notification.sent_at:

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -32,7 +32,6 @@ from app.dao.provider_details_dao import (
 from app.delivery import send_to_providers
 from app.exceptions import NotificationTechnicalFailureException
 from app.letters.utils import LetterPDFNotFound, find_letter_pdf_in_s3
-from app.otel_metrics.notification import record_send_duration
 
 
 @notify_celery.task(
@@ -152,24 +151,16 @@ def deliver_letter(self, notification_id):
         ) from e
 
     try:
-        try:
-            dvla_client.send_letter(
-                notification_id=str(notification.id),
-                reference=str(notification.reference),
-                address=postal_address,
-                postage=notification.postage,
-                service_id=str(notification.service_id),
-                organisation_id=str(notification.service.organisation_id),
-                pdf_file=file_bytes,
-                callback_url=_get_callback_url(notification_id),
-            )
-        finally:
-            record_send_duration(
-                (datetime.utcnow() - notification.created_at).total_seconds(),
-                key_type=notification.key_type,
-                notification_type="letter",
-                provider_name="dvla",
-            )
+        dvla_client.send_letter(
+            notification_id=str(notification.id),
+            reference=str(notification.reference),
+            address=postal_address,
+            postage=notification.postage,
+            service_id=str(notification.service_id),
+            organisation_id=str(notification.service.organisation_id),
+            pdf_file=file_bytes,
+            callback_url=_get_callback_url(notification_id),
+        )
         update_letter_to_sending(notification)
     except DvlaRetryableException as e:
         if isinstance(e, DvlaThrottlingException):

--- a/app/otel_metrics/README.md
+++ b/app/otel_metrics/README.md
@@ -1,5 +1,12 @@
+# otel_metrics
+
 This module was named `otel_metrics` so it wouldn't conflict with the `metrics`
 field in `app/__init__.py`.
 
 Once we've migrated away from the GDS metrics lib entirely we can rename this
 module to simply `metrics`.
+
+**n.b. when adding new metrics and/or labels here, you must also make a
+corresponding change to
+`terraform/modules/ecs-service/config/otel_mapping_aws_prometheus.yml` in
+`notifications-aws`.**

--- a/app/otel_metrics/notification.py
+++ b/app/otel_metrics/notification.py
@@ -103,10 +103,11 @@ def record_deliver_duration(
     notification_status: str,
     notification_type: str,
     provider_name: str,
-    sms_international: bool | None = None,
+    notification_sms_international: bool | None = None,
 ) -> None:
     """
-    Records a sample with the given `duration` and attributes for histogram metric `notification.deliver.duration`.
+    Records samples with the given duration and attributes for histogram metrics `notification.callback.duration` and
+    `notification.deliver.duration`.
     """
 
     attrs = {
@@ -116,9 +117,9 @@ def record_deliver_duration(
         "provider.name": provider_name,
     }
 
-    if sms_international is not None:
+    if notification_sms_international is not None:
         # OTel semconv specifically dictates JSON encoding for booleans
-        attrs["notification.sms.international"] = json.dumps(sms_international)
+        attrs["notification.sms.international"] = json.dumps(notification_sms_international)
 
     if callback_duration is not None:
         _callback_duration.record(callback_duration, attrs)

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -1,6 +1,5 @@
 from contextlib import nullcontext
 from datetime import datetime, timedelta
-from typing import Any
 from uuid import UUID
 
 import boto3
@@ -41,7 +40,7 @@ from app.constants import (
     NOTIFICATION_TECHNICAL_FAILURE,
 )
 from app.exceptions import NotificationTechnicalFailureException
-from app.models import Organisation, Template
+from app.models import Template
 from app.otel_metrics.notification import _send_duration
 from tests.app.db import create_notification
 
@@ -615,54 +614,6 @@ def test_deliver_email_records_duration_histogram(
         "key.type": key_type,
         "notification.type": "email",
         "provider.name": "ses",
-    }
-
-    if should_raise:
-        expected_attributes["error.type"] = "builtins.RuntimeError"
-
-    record_send_duration_mock.assert_called_once_with(
-        60.0,
-        expected_attributes,
-    )
-
-
-@mock_aws
-@freeze_time("2026-01-01 09:00:01")
-@pytest.mark.parametrize("should_raise", [False, True])
-def test_deliver_letter_records_duration_histogram(
-    mocker: MockerFixture,
-    sample_letter_template: Any,  # sqlalchemy types are weird
-    sample_organisation: Organisation,
-    should_raise: bool,
-) -> None:
-    record_send_duration_mock = mocker.patch.object(_send_duration, "record")
-    mocker.patch(
-        "app.celery.provider_tasks.dvla_client.send_letter", side_effect=RuntimeError() if should_raise else None
-    )
-    mocker.patch("app.celery.provider_tasks._get_callback_url", return_value="example.com?token=1")
-
-    letter = create_notification(
-        template=sample_letter_template,
-        to_field="A. User\nMy Street,\nLondon,\nSW1 1AA",
-        personalisation={"address_line_1": "Provided as PDF"},
-        status=NOTIFICATION_CREATED,
-        reference="ref1",
-        created_at=datetime.now() - timedelta(minutes=1),
-    )
-    sample_letter_template.service.organisation = sample_organisation
-
-    pdf_bucket = current_app.config["S3_BUCKET_LETTERS_PDF"]
-    s3 = boto3.client("s3", region_name="eu-west-1")
-    s3.create_bucket(Bucket=pdf_bucket, CreateBucketConfiguration={"LocationConstraint": "eu-west-1"})
-    s3.put_object(Bucket=pdf_bucket, Key="2026-01-01/NOTIFY.REF1.D.2.C.20260101090000.PDF", Body=b"file")
-
-    with pytest.raises(NotificationTechnicalFailureException) if should_raise else nullcontext():
-        deliver_letter(letter.id)
-
-    expected_attributes = {
-        "key.type": "normal",
-        "notification.type": "letter",
-        "provider.name": "dvla",
     }
 
     if should_raise:


### PR DESCRIPTION
https://trello.com/c/25A3gpXh/1358-replace-statsd-instrumentation-across-notify-with-otel

We send all letters at the same time in the evening, so "elapsed time between notification creation and sending" is meaningless for them.

Also includes a drive-by refactor of `record_deliver_duration` and the readme (see commit messages).