### PR TITLE
Revert "sqlalchemy: set `connect_timeout` to 4 seconds"

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -187,7 +187,7 @@ class Config:
         "pool_timeout": 30,
         "pool_recycle": 300,
         "connect_args": {
-            "connect_timeout": "4",  # seconds
+            "connect_timeout": "5",  # seconds
             "tcp_user_timeout": "5000",  # milliseconds
             # statement_timeout is overridden in setup_sqlalchemy_events, but not all our
             # invocations heed those event hooks (e.g. alembic migrations), so this is set


### PR DESCRIPTION
Reverts alphagov/notifications-api#4845

This was not the culprit.