### PR TITLE
Adjust the times that the we check for letters pending virus check

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -422,15 +422,15 @@ class Config:
             "check-if-letters-still-pending-virus-check-ten-minutely": {
                 "task": "check-if-letters-still-pending-virus-check",
                 "schedule": crontab(minute="*/10"),
-                # check last half hour, every ten minutes
-                "kwargs": {"max_minutes_ago_to_check": 30},
+                # check last two hours, every ten minutes
+                "kwargs": {"max_minutes_ago_to_check": 120},
                 "options": {"queue": QueueNames.PERIODIC},
             },
             "check-if-letters-still-pending-virus-check-nightly": {
                 "task": "check-if-letters-still-pending-virus-check",
                 "schedule": crontab(hour=20, minute=0),
-                # check back two entire days, once per day, just in case things slipped through the net somehow
-                "kwargs": {"max_minutes_ago_to_check": 60 * 24 * 2},
+                # check back three entire days, once per day, just in case things slipped through the net somehow
+                "kwargs": {"max_minutes_ago_to_check": 60 * 24 * 3},
                 "options": {"queue": QueueNames.PERIODIC},
             },
             "check-for-services-with-high-failure-rates-or-sending-to-tv-numbers": {


### PR DESCRIPTION
In rare cases (for a particular service where we know the letters don't get processed well) we see letters that still haven't gone through the sanitisation process with the number of retries we already do.

While we know the "real fix" is to upgrade PyMyPDF in template-preview, this will take some planning. For now, we increase the number of times we retry letters still pending virus check to try and ensure that every letter always ends up in the created state.

[Trello card](https://trello.com/c/PS6tLnKT/1799-add-more-retries-to-the-task-that-checks-for-letters-still-pending-virus-check)