### PR TITLE
Update checks for the minimum team members for a service to take email domain into account

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.0.1
+# This file was automatically copied from notifications-utils@115.2.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -1,3 +1,5 @@
+from itertools import chain
+
 from flask import current_app
 from sqlalchemy.orm import Session, scoped_session
 from sqlalchemy.sql.expression import func
@@ -23,6 +25,12 @@ from app.utils import escape_special_characters, get_archived_db_column_value, r
 
 def dao_get_organisations():
     return Organisation.query.order_by(Organisation.active.desc(), Organisation.name.asc()).all()
+
+
+def dao_get_organisation_domains():
+    organisations = dao_get_organisations()
+
+    return [domain.domain for domain in chain.from_iterable(org.domains for org in organisations)]
 
 
 def dao_count_organisations_with_live_services():

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, timedelta
 from secrets import SystemRandom
 
 from flask import current_app
+from notifications_utils.user import GOVERNMENT_EMAIL_DOMAIN_NAMES, email_address_ends_with
 from sqlalchemy import func
 from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.orm.exc import NoResultFound
@@ -15,7 +16,7 @@ from app.constants import (
     NOTIFY_RESEARCH_SERVICE_ID,
 )
 from app.dao.dao_utils import autocommit
-from app.dao.organisation_dao import dao_remove_user_from_organisation
+from app.dao.organisation_dao import dao_get_organisation_domains, dao_remove_user_from_organisation
 from app.dao.organisation_user_permissions_dao import organisation_user_permissions_dao
 from app.dao.permissions_dao import permission_dao
 from app.dao.service_user_dao import dao_get_service_users_by_user_id
@@ -309,3 +310,9 @@ def unsubscribe_user_from_notify_services(service_id, email_address):
     redis_store.delete(f"user-{user.id}")
 
     return True
+
+
+def is_gov_user(email_address):
+    return email_address_ends_with(email_address, GOVERNMENT_EMAIL_DOMAIN_NAMES) or email_address_ends_with(
+        email_address, dao_get_organisation_domains()
+    )

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -198,22 +198,22 @@ def dao_archive_user(user):
     db.session.add(user)
 
 
-def _count_manage_settings_users(service):
-    active_users = [u for u in service.users if u.state == "active"]
+def _count_gov_users_with_manage_settings(service):
+    active_government_users = [u for u in service.users if u.state == "active" and is_gov_user(u.email_address)]
 
-    return sum(MANAGE_SETTINGS in u.get_permissions(service_id=service.id) for u in active_users)
+    return sum(MANAGE_SETTINGS in u.get_permissions(service_id=service.id) for u in active_government_users)
 
 
-def _min_manage_settings_users(service):
+def _min_gov_users_with_manage_settings(service):
     return 1 if service.restricted and not service.has_active_go_live_request else 2
 
 
-def _can_remove_manage_settings_user(service):
+def _can_remove_gov_user_with_manage_settings(service):
     """
-    Returns False if removing a single user with `manage_settings`
-    would leave the service with too few such users.
+    Returns False if removing a single user with a government email address and
+    `manage_settings` permission would leave the service with too few such users.
     """
-    return _count_manage_settings_users(service) - 1 >= _min_manage_settings_users(service)
+    return _count_gov_users_with_manage_settings(service) - 1 >= _min_gov_users_with_manage_settings(service)
 
 
 def users_permissions_can_be_changed(user, service, new_permissions):
@@ -226,7 +226,11 @@ def users_permissions_can_be_changed(user, service, new_permissions):
     if not had_permission or will_have_permission:
         return True
 
-    return _can_remove_manage_settings_user(service)
+    # If the user is not a government user, it's always safe
+    if not is_gov_user(user.email_address):
+        return True
+
+    return _can_remove_gov_user_with_manage_settings(service)
 
 
 def user_can_be_removed_from_service(user, service):
@@ -240,7 +244,11 @@ def user_can_be_removed_from_service(user, service):
     if MANAGE_SETTINGS not in user.get_permissions(service_id=service.id):
         return True
 
-    return _can_remove_manage_settings_user(service)
+    # Removing users who are not government users is always safe
+    if not is_gov_user(user.email_address):
+        return True
+
+    return _can_remove_gov_user_with_manage_settings(service)
 
 
 def user_can_be_archived(user):

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil~=6.0
 notifications-python-client~=10.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@115.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@115.2.0
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -800,7 +800,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@be88b9badd025dafe99d256f7661c45a68125c77
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ee41d2202592cf80f4148447cfe07283ee1f03e3
     # via -r requirements.in
 opentelemetry-api==1.40.0 \
     --hash=sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1127,7 +1127,7 @@ mypy-extensions==1.1.0 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@be88b9badd025dafe99d256f7661c45a68125c77
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ee41d2202592cf80f4148447cfe07283ee1f03e3
     # via -r requirements.txt
 opentelemetry-api==1.40.0 \
     --hash=sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.0.1
+# This file was automatically copied from notifications-utils@115.2.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.0.1
+# This file was automatically copied from notifications-utils@115.2.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/tests/app/dao/test_organisation_dao.py
+++ b/tests/app/dao/test_organisation_dao.py
@@ -20,6 +20,7 @@ from app.dao.organisation_dao import (
     dao_get_organisation_by_email_address,
     dao_get_organisation_by_id,
     dao_get_organisation_by_service_id,
+    dao_get_organisation_domains,
     dao_get_organisation_services,
     dao_get_organisations,
     dao_get_users_for_organisation,
@@ -55,6 +56,21 @@ def test_get_organisations_gets_all_organisations_alphabetically_with_active_org
     assert organisations[2] == z_active_org
     assert organisations[3] == a_inactive_org
     assert organisations[4] == z_inactive_org
+
+
+def test_dao_get_organisation_domains(notify_db_session):
+    create_organisation("org_1", domains=["dept_of_health.com", "eg.com"])
+    create_organisation("org_2", domains=["other.com", "number10.com"])
+    create_organisation("org_3", domains=["my_org.gov", "whitechapel.com"])
+
+    assert set(dao_get_organisation_domains()) == {
+        "dept_of_health.com",
+        "eg.com",
+        "other.com",
+        "number10.com",
+        "my_org.gov",
+        "whitechapel.com",
+    }
 
 
 def test_get_organisation_by_id_gets_correct_organisation(notify_db_session):

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -232,16 +232,16 @@ def test_dao_archive_user(sample_user, sample_organisation, fake_uuid):
 
     # create 2 services for sample_user to be a member of (each with another 2 active users)
     service_1 = create_service(service_name="Service 1")
-    service_1_user_a = create_user(email="1a@test.com")
-    service_1_user_b = create_user(email="1b@test.com")
+    service_1_user_a = create_user(email="1a@gov.uk")
+    service_1_user_b = create_user(email="1b@gov.uk")
     service_1.users = [sample_user, service_1_user_a, service_1_user_b]
     create_permissions(sample_user, service_1, "manage_settings")
     create_permissions(service_1_user_a, service_1, "manage_settings", "view_activity")
     create_permissions(service_1_user_b, service_1, "manage_settings", "view_activity")
 
     service_2 = create_service(service_name="Service 2")
-    service_2_user_a = create_user(email="2a@test.com")
-    service_2_user_b = create_user(email="2b@test.com")
+    service_2_user_a = create_user(email="2a@gov.uk")
+    service_2_user_b = create_user(email="2b@gov.uk")
     service_2.users = [sample_user, service_2_user_a, service_2_user_b]
     create_permissions(sample_user, service_2, "view_activity")
     create_permissions(service_2_user_a, service_2, "manage_settings")
@@ -323,38 +323,58 @@ def test_users_permissions_can_be_changed_when_user_is_keeping_manage_settings_p
     )
 
 
+def test_users_permissions_can_be_changed_when_user_is_not_a_government_user(
+    sample_service,
+    notify_db_session,
+):
+    user = create_user(email="user@example.com")
+    create_permissions(user, sample_service, "manage_settings")
+
+    sample_service.users = [user]
+    notify_db_session.commit()
+
+    assert users_permissions_can_be_changed(user, sample_service, ["send_messages", "manage_api_keys"]) is True
+
+
 @pytest.mark.parametrize(
-    "num_admin_users, num_non_admin_users, permissions_can_be_changed",
+    "num_admin_gov_users, num_admin_non_gov_users, num_non_admin_users, permissions_can_be_changed",
     [
-        (1, 1, False),
-        (1, 5, False),
-        (2, 0, False),
-        (2, 10, False),
-        (3, 2, True),
-        (6, 0, True),
+        (1, 0, 1, False),
+        (1, 0, 5, False),
+        (1, 3, 1, False),
+        (1, 3, 5, False),
+        (2, 1, 0, False),
+        (2, 1, 10, False),
+        (3, 1, 2, True),
+        (6, 1, 0, True),
     ],
 )
 def test_users_permissions_can_be_changed_when_removing_manage_settings_from_user_of_live_service(
     sample_service,
     notify_db_session,
-    num_admin_users,
+    num_admin_gov_users,
+    num_admin_non_gov_users,
     num_non_admin_users,
     permissions_can_be_changed,
 ):
-    admin_users = [create_user() for i in range(num_admin_users)]
-    for user in admin_users:
+    admin_gov_users = [create_user() for i in range(num_admin_gov_users)]
+    for user in admin_gov_users:
+        create_permissions(user, sample_service, "manage_settings")
+
+    admin_non_gov_users = [create_user(email=f"{i}@example.com") for i in range(num_admin_non_gov_users)]
+    for user in admin_non_gov_users:
         create_permissions(user, sample_service, "manage_settings")
 
     non_admin_users = [create_user() for i in range(num_non_admin_users)]
     for user in non_admin_users:
         create_permissions(user, sample_service, "view_activity")
 
-    sample_service.users = [*admin_users, *non_admin_users]
+    sample_service.users = [*admin_gov_users, *admin_non_gov_users, *non_admin_users]
     notify_db_session.commit()
 
     assert (
         users_permissions_can_be_changed(
-            admin_users[0],
+            admin_gov_users[0],
             sample_service,
             ["manage_templates", "manage_api_keys"],
         )
@@ -363,42 +383,49 @@ def test_users_permissions_can_be_changed_when_removing_manage_settings_from_use
 
 
 @pytest.mark.parametrize(
-    "num_admin_users, num_non_admin_users, has_go_live_request, permissions_can_be_changed",
+    "num_admin_gov_users,num_admin_non_gov_users,num_non_admin_users,has_go_live_request,permissions_can_be_changed",
     [
-        (1, 3, True, False),
-        (1, 3, False, False),
-        (2, 0, True, False),
-        (2, 0, False, True),
-        (2, 4, True, False),
-        (2, 4, False, True),
-        (3, 2, True, True),
-        (3, 2, False, True),
+        (1, 1, 3, True, False),
+        (1, 1, 3, False, False),
+        (2, 0, 0, True, False),
+        (2, 0, 0, False, True),
+        (2, 1, 0, True, False),
+        (2, 1, 0, False, True),
+        (2, 3, 4, True, False),
+        (2, 3, 4, False, True),
+        (3, 2, 2, True, True),
+        (3, 2, 2, False, True),
     ],
 )
 def test_users_permissions_can_be_changed_when_removing_manage_settings_from_user_of_trial_mode_service(
     sample_service,
     notify_db_session,
-    num_admin_users,
+    num_admin_gov_users,
+    num_admin_non_gov_users,
     num_non_admin_users,
     has_go_live_request,
     permissions_can_be_changed,
 ):
-    admin_users = [create_user() for i in range(num_admin_users)]
-    for user in admin_users:
+    admin_gov_users = [create_user() for i in range(num_admin_gov_users)]
+    for user in admin_gov_users:
+        create_permissions(user, sample_service, "manage_settings")
+
+    admin_non_gov_users = [create_user(email=f"{i}@example.com") for i in range(num_admin_non_gov_users)]
+    for user in admin_non_gov_users:
         create_permissions(user, sample_service, "manage_settings")
 
     non_admin_users = [create_user() for i in range(num_non_admin_users)]
     for user in non_admin_users:
         create_permissions(user, sample_service, "view_activity")
 
-    sample_service.users = [*admin_users, *non_admin_users]
+    sample_service.users = [*admin_gov_users, *admin_non_gov_users, *non_admin_users]
     sample_service.restricted = True
     sample_service.has_active_go_live_request = has_go_live_request
     notify_db_session.commit()
 
     assert (
         users_permissions_can_be_changed(
-            admin_users[0],
+            admin_gov_users[0],
             sample_service,
             ["manage_templates", "manage_api_keys"],
         )
@@ -427,7 +454,7 @@ def test_user_can_be_removed_from_service_is_false_if_service_has_one_active_use
 
 @pytest.mark.parametrize("service_in_trial_mode", [True, False])
 @pytest.mark.parametrize(
-    "num_admin_users, num_non_admin_users",
+    "num_admin_gov_users, num_non_admin_users",
     [
         (1, 1),
         (1, 3),
@@ -440,91 +467,147 @@ def test_user_can_be_removed_from_service_when_user_does_not_have_manage_setting
     sample_service,
     notify_db_session,
     service_in_trial_mode,
-    num_admin_users,
+    num_admin_gov_users,
     num_non_admin_users,
 ):
-    admin_users = [create_user() for i in range(num_admin_users)]
-    for user in admin_users:
+    admin_gov_users = [create_user() for i in range(num_admin_gov_users)]
+    for user in admin_gov_users:
         create_permissions(user, sample_service, "manage_settings")
 
     non_admin_users = [create_user() for i in range(num_non_admin_users)]
     for user in non_admin_users:
         create_permissions(user, sample_service, "view_activity")
 
-    sample_service.users = [*admin_users, *non_admin_users]
+    sample_service.users = [*admin_gov_users, *non_admin_users]
     sample_service.restricted = service_in_trial_mode
     notify_db_session.commit()
 
     assert user_can_be_removed_from_service(user=non_admin_users[0], service=sample_service) is True
 
 
+@pytest.mark.parametrize("service_in_trial_mode", [True, False])
 @pytest.mark.parametrize(
-    "num_admin_users, num_non_admin_users, has_go_live_request, can_be_removed",
+    "num_admin_gov_users, num_non_admin_users",
     [
-        (1, 3, True, False),
-        (1, 3, False, False),
-        (2, 0, True, False),
-        (2, 0, False, True),
-        (2, 4, True, False),
-        (2, 4, False, True),
-        (3, 2, True, True),
-        (3, 2, False, True),
+        (0, 1),
+        (1, 0),
+        (1, 1),
+        (1, 3),
+        (2, 1),
+        (4, 1),
+        (4, 5),
     ],
 )
-def test_user_can_be_removed_from_service_when_service_is_trial_mode_and_user_has_manage_settings(
+def test_user_can_be_removed_from_service_when_user_is_not_a_government_user(
     sample_service,
     notify_db_session,
-    num_admin_users,
+    service_in_trial_mode,
+    num_admin_gov_users,
+    num_non_admin_users,
+):
+    admin_gov_users = [create_user() for i in range(num_admin_gov_users)]
+    for user in admin_gov_users:
+        create_permissions(user, sample_service, "manage_settings")
+
+    non_admin_users = [create_user() for i in range(num_non_admin_users)]
+    for user in non_admin_users:
+        create_permissions(user, sample_service, "view_activity")
+
+    admin_non_gov_user = create_user(email="user@example.com")
+    create_permissions(admin_non_gov_user, sample_service, "manage_settings")
+
+    sample_service.users = [*admin_gov_users, *non_admin_users, admin_non_gov_user]
+    sample_service.restricted = service_in_trial_mode
+    notify_db_session.commit()
+
+    assert user_can_be_removed_from_service(user=admin_non_gov_user, service=sample_service) is True
+
+
+@pytest.mark.parametrize(
+    "num_admin_gov_users, num_admin_non_gov_users, num_non_admin_users, has_go_live_request, can_be_removed",
+    [
+        (1, 0, 3, True, False),
+        (1, 1, 3, True, False),
+        (1, 0, 3, False, False),
+        (1, 1, 3, False, False),
+        (2, 0, 0, True, False),
+        (2, 1, 0, True, False),
+        (2, 1, 0, False, True),
+        (2, 0, 4, True, False),
+        (2, 1, 4, True, False),
+        (2, 1, 4, False, True),
+        (3, 1, 2, True, True),
+        (3, 1, 2, False, True),
+    ],
+)
+def test_user_can_be_removed_from_service_when_service_is_trial_mode_and_user_is_gov_user_with_manage_settings(
+    sample_service,
+    notify_db_session,
+    num_admin_gov_users,
+    num_admin_non_gov_users,
     num_non_admin_users,
     has_go_live_request,
     can_be_removed,
 ):
-    admin_users = [create_user() for i in range(num_admin_users)]
-    for user in admin_users:
+    admin_gov_users = [create_user() for i in range(num_admin_gov_users)]
+    for user in admin_gov_users:
+        create_permissions(user, sample_service, "manage_settings")
+
+    admin_non_gov_users = [create_user(email=f"{i}@example.com") for i in range(num_admin_non_gov_users)]
+    for user in admin_non_gov_users:
         create_permissions(user, sample_service, "manage_settings")
 
     non_admin_users = [create_user() for i in range(num_non_admin_users)]
     for user in non_admin_users:
         create_permissions(user, sample_service, "view_activity")
 
-    sample_service.users = [*admin_users, *non_admin_users]
+    sample_service.users = [*admin_gov_users, *admin_non_gov_users, *non_admin_users]
     sample_service.restricted = True
     sample_service.has_active_go_live_request = has_go_live_request
     notify_db_session.commit()
 
-    assert user_can_be_removed_from_service(user=admin_users[0], service=sample_service) is can_be_removed
+    assert user_can_be_removed_from_service(user=admin_gov_users[0], service=sample_service) is can_be_removed
 
 
 @pytest.mark.parametrize(
-    "num_admin_users, num_non_admin_users, can_be_removed",
+    "num_admin_gov_users, num_admin_non_gov_users, num_non_admin_users, can_be_removed",
     [
-        (1, 1, False),
-        (1, 5, False),
-        (2, 0, False),
-        (2, 10, False),
-        (3, 2, True),
-        (6, 0, True),
+        (1, 0, 1, False),
+        (1, 1, 1, False),
+        (1, 0, 5, False),
+        (1, 1, 5, False),
+        (2, 0, 0, False),
+        (2, 1, 0, False),
+        (2, 0, 10, False),
+        (2, 1, 10, False),
+        (3, 1, 2, True),
+        (6, 1, 0, True),
     ],
 )
-def test_user_can_be_removed_from_service_when_service_is_live_and_user_has_manage_settings(
+def test_user_can_be_removed_from_service_when_service_is_live_and_user_is_gov_user_with_manage_settings(
     sample_service,
     notify_db_session,
-    num_admin_users,
+    num_admin_gov_users,
+    num_admin_non_gov_users,
     num_non_admin_users,
     can_be_removed,
 ):
-    admin_users = [create_user() for i in range(num_admin_users)]
-    for user in admin_users:
+    admin_gov_users = [create_user() for i in range(num_admin_gov_users)]
+    for user in admin_gov_users:
+        create_permissions(user, sample_service, "manage_settings")
+
+    admin_non_gov_users = [create_user(email=f"{i}@example.com") for i in range(num_admin_non_gov_users)]
+    for user in admin_non_gov_users:
         create_permissions(user, sample_service, "manage_settings")
 
     non_admin_users = [create_user() for i in range(num_non_admin_users)]
     for user in non_admin_users:
         create_permissions(user, sample_service, "view_activity")
 
-    sample_service.users = [*admin_users, *non_admin_users]
+    sample_service.users = [*admin_gov_users, *admin_non_gov_users, *non_admin_users]
     notify_db_session.commit()
 
-    assert user_can_be_removed_from_service(user=admin_users[0], service=sample_service) is can_be_removed
+    assert user_can_be_removed_from_service(user=admin_gov_users[0], service=sample_service) is can_be_removed
 
 
 def test_user_can_be_archived_if_they_do_not_belong_to_any_services(sample_user):
@@ -540,10 +623,12 @@ def test_user_can_be_archived_if_they_do_not_belong_to_any_active_services(sampl
     assert user_can_be_archived(sample_user)
 
 
-def test_user_can_be_archived_if_the_other_service_members_have_the_manage_settings_permission(sample_service):
-    user_1 = create_user(email="1@test.com")
-    user_2 = create_user(email="2@test.com")
-    user_3 = create_user(email="3@test.com")
+def test_user_can_be_archived_if_the_other_service_members_are_gov_users_with_the_manage_settings_permission(
+    sample_service,
+):
+    user_1 = create_user()
+    user_2 = create_user()
+    user_3 = create_user()
 
     sample_service.users = [user_1, user_2, user_3]
 
@@ -563,9 +648,9 @@ def test_dao_archive_user_raises_error_if_user_cannot_be_archived(sample_user, m
 
 
 def test_user_cannot_be_archived_if_they_belong_to_a_service_with_no_other_active_users(sample_service):
-    active_user = create_user(email="1@test.com")
-    pending_user = create_user(email="2@test.com", state="pending")
-    inactive_user = create_user(email="3@test.com", state="inactive")
+    active_user = create_user(email="1@gov.uk")
+    pending_user = create_user(email="2@gov.uk", state="pending")
+    inactive_user = create_user(email="3@gov.uk", state="inactive")
 
     sample_service.users = [active_user, pending_user, inactive_user]
 
@@ -576,9 +661,9 @@ def test_user_cannot_be_archived_if_they_belong_to_a_service_with_no_other_activ
 def test_user_cannot_be_archived_if_the_other_service_members_do_not_have_the_manage_setting_permission(
     sample_service,
 ):
-    active_user = create_user(email="1@test.com")
-    pending_user = create_user(email="2@test.com")
-    inactive_user = create_user(email="3@test.com")
+    active_user = create_user(email="1@gov.uk")
+    pending_user = create_user(email="2@gov.uk")
+    inactive_user = create_user(email="3@gov.uk")
 
     sample_service.users = [active_user, pending_user, inactive_user]
 
@@ -590,10 +675,26 @@ def test_user_cannot_be_archived_if_the_other_service_members_do_not_have_the_ma
     assert not user_can_be_archived(active_user)
 
 
+def test_user_cannot_be_archived_if_there_are_not_enough_gov_users(sample_service, notify_db_session):
+    gov_user = create_user(email="1@gov.uk")
+    another_gov_user = create_user(email="2@gov.com")
+    non_gov_user = create_user(email="3@gexample.com")
+
+    sample_service.users = [gov_user, another_gov_user, non_gov_user]
+
+    create_permissions(gov_user, sample_service, "manage_settings")
+    create_permissions(another_gov_user, sample_service, "manage_settings")
+    create_permissions(non_gov_user, sample_service, "manage_settings")
+    notify_db_session.commit()
+
+    assert len(sample_service.users) == 3
+    assert not user_can_be_archived(gov_user)
+
+
 def test_user_cannot_be_archived_unless_they_can_be_removed_from_every_service(sample_service, notify_db_session):
-    user_to_archive = create_user(email="1@test.com")
-    user_two = create_user(email="2@test.com")
-    user_three = create_user(email="3@test.com")
+    user_to_archive = create_user(email="1@gov.uk")
+    user_two = create_user(email="2@gov.uk")
+    user_three = create_user(email="3@gov.uk")
 
     sample_service.users = [user_to_archive, user_two, user_three]
 

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -26,6 +26,7 @@ from app.dao.users_dao import (
     get_users_for_research,
     get_users_list,
     increment_failed_login_count,
+    is_gov_user,
     reset_failed_login_count,
     save_model_user,
     save_user_attribute,
@@ -37,6 +38,7 @@ from app.dao.users_dao import (
 from app.errors import InvalidRequest
 from app.models import OrganisationUserPermissions, Permission, User, VerifyCode
 from tests.app.db import (
+    create_organisation,
     create_permissions,
     create_service,
     create_template_folder,
@@ -763,3 +765,16 @@ def test_get_users_list_multiple_filters(
     )
 
     assert len(users) == expected_count
+
+
+@pytest.mark.parametrize(
+    "email_address",
+    [
+        "user@gov.uk",  # email address not belonging to an org
+        "user@other.com",  # email address linked to an org
+    ],
+)
+def test_is_gov_user(notify_db_session, email_address):
+    create_organisation(domains=["other.com"])
+
+    assert is_gov_user(email_address) is True

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.0.1
+# This file was automatically copied from notifications-utils@115.2.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
We now enforce services having two team members with the `manage_settings` permission (unless the service is a trial service which hasn't yet requested to go live). We have new checks for this when trying to [remove a user from a service or archive them](https://github.com/alphagov/notifications-api/pull/4831), and when [changing a user's service permissions](https://github.com/alphagov/notifications-api/pull/4835).

As a next step, we now change this team member requirement to not just two team members with the `manage_settings` permission, but two team members _from a public sector organisation_ so the logic has been updated to reflect this. We don't block existing services who didn't meet the requirements from removing users or changing permissions. New services going live must now meet these conditions.

[Trello card](https://trello.com/c/s1awvlJm/1779-error-for-removing-a-penultimate-user-with-manage-settings-permissions-public-sector-domains)