### PR TITLE
otel_metrics: Give notification.send.duration appropriate buckets

### DIFF
--- a/app/otel_metrics/notification.py
+++ b/app/otel_metrics/notification.py
@@ -1,6 +1,6 @@
 import json
 
-from notifications_utils.semconv import TASK_DURATION_HISTOGRAM_BUCKETS, set_error_type
+from notifications_utils.semconv import set_error_type
 from opentelemetry.metrics import get_meter
 from opentelemetry.util.types import AttributeValue
 
@@ -15,11 +15,28 @@ _international_sms = _meter.create_counter(
     ),
 )
 
+# Buckets ranging from 50 milliseconds to 10 minutes
+SEND_DURATION_HISTOGRAM_BUCKETS = [
+    0.05,
+    0.1,
+    0.2,
+    0.5,
+    1,
+    2,
+    5,
+    10,
+    30,
+    60,
+    120,
+    300,
+    600,
+]
+
 _send_duration = _meter.create_histogram(
     "notification.send.duration",
     unit="s",
     description="Elapsed time between notification creation and sending to provider",
-    explicit_bucket_boundaries_advisory=TASK_DURATION_HISTOGRAM_BUCKETS,
+    explicit_bucket_boundaries_advisory=SEND_DURATION_HISTOGRAM_BUCKETS,
 )
 
 # Buckets ranging from 1 second to 30 hours


### PR DESCRIPTION
https://trello.com/c/25A3gpXh/1358-replace-statsd-instrumentation-across-notify-with-otel

I've based these bucket boundaries on the 1st percentile times we see on a typical day and the 99th percentile times we saw during the recent Firetext outage.

We specifically need a bucket at 10s, because that's how we define our notification send time SLO.

I'm still hopeful that APS will support native histograms sometime soon, in which case we can do away with these explicit bucket boundaries entirely.