### PR TITLE
`check_for_services_with_high_failure_rates_or_sending_to_tv_numbers`: use `session_bulk`

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -474,11 +474,13 @@ def check_for_services_with_high_failure_rates_or_sending_to_tv_numbers():
     services_with_failures = dao_find_services_with_high_failure_rates(
         start_date=start_date,
         end_date=end_date,
+        session=db.session_bulk,
         retry_attempts=2,
     )
     services_sending_to_tv_numbers = dao_find_services_sending_to_tv_numbers(
         start_date=start_date,
         end_date=end_date,
+        session=db.session_bulk,
         retry_attempts=2,
     )
 


### PR DESCRIPTION
Looks like we forgot to actually specify the db session to use the replica back in #4731 when we made these queries bulk-capable.