### PR TITLE
Bump utils to 117.0.1, remove StatsD

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.4.0
+# This file was automatically copied from notifications-utils@117.0.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,7 +25,6 @@ from notifications_utils import request_helper
 from notifications_utils.celery import NotifyCelery
 from notifications_utils.clients.redis.redis_client import RedisClient
 from notifications_utils.clients.signing.signing_client import Signing
-from notifications_utils.clients.statsd.statsd_client import StatsdClient
 from notifications_utils.clients.zendesk.zendesk_client import ZendeskClient
 from notifications_utils.eventlet import EventletTimeout
 from notifications_utils.local_vars import LazyLocalGetter
@@ -54,7 +53,6 @@ migrate = Migrate()
 ma = Marshmallow()
 notify_celery = NotifyCelery()
 signing = Signing()
-statsd_client = StatsdClient()
 redis_store = RedisClient()
 metrics = GDSMetrics()
 
@@ -75,7 +73,7 @@ memo_resetters: list[Callable] = []
 _firetext_client_context_var: ContextVar[FiretextClient] = ContextVar("firetext_client")
 get_firetext_client: LazyLocalGetter[FiretextClient] = LazyLocalGetter(
     _firetext_client_context_var,
-    lambda: FiretextClient(current_app, statsd_client=statsd_client),
+    lambda: FiretextClient(current_app),
     expected_type=FiretextClient,
 )
 memo_resetters.append(lambda: get_firetext_client.clear())
@@ -84,7 +82,7 @@ firetext_client = LocalProxy(get_firetext_client)
 _mmg_client_context_var: ContextVar[MMGClient] = ContextVar("mmg_client")
 get_mmg_client: LazyLocalGetter[MMGClient] = LazyLocalGetter(
     _mmg_client_context_var,
-    lambda: MMGClient(current_app, statsd_client=statsd_client),
+    lambda: MMGClient(current_app),
     expected_type=MMGClient,
 )
 memo_resetters.append(lambda: get_mmg_client.clear())
@@ -93,7 +91,7 @@ mmg_client = LocalProxy(get_mmg_client)
 _aws_ses_client_context_var: ContextVar[AwsSesClient] = ContextVar("aws_ses_client")
 get_aws_ses_client: LazyLocalGetter[AwsSesClient] = LazyLocalGetter(
     _aws_ses_client_context_var,
-    lambda: AwsSesClient(current_app.config["AWS_REGION"], statsd_client=statsd_client),
+    lambda: AwsSesClient(current_app.config["AWS_REGION"]),
     expected_type=AwsSesClient,
 )
 memo_resetters.append(lambda: get_aws_ses_client.clear())
@@ -104,7 +102,6 @@ get_aws_ses_stub_client: LazyLocalGetter[AwsSesStubClient] = LazyLocalGetter(
     _aws_ses_stub_client_context_var,
     lambda: AwsSesStubClient(
         current_app.config["AWS_REGION"],
-        statsd_client=statsd_client,
         stub_url=current_app.config["SES_STUB_URL"],
     ),
     expected_type=AwsSesStubClient,
@@ -140,7 +137,7 @@ notification_provider_clients = LocalProxy(get_notification_provider_clients)
 _dvla_client_context_var: ContextVar[DVLAClient] = ContextVar("dvla_client")
 get_dvla_client: LazyLocalGetter[DVLAClient] = LazyLocalGetter(
     _dvla_client_context_var,
-    lambda: DVLAClient(current_app, statsd_client=statsd_client),
+    lambda: DVLAClient(current_app),
 )
 memo_resetters.append(lambda: get_dvla_client.clear())
 dvla_client = LocalProxy(get_dvla_client)
@@ -181,8 +178,7 @@ def create_app(application):
     db.init_app(application)
     migrate.init_app(application, db=db)
     ma.init_app(application)
-    statsd_client.init_app(application)
-    utils_logging.init_app(application, statsd_client)
+    utils_logging.init_app(application)
 
     notify_celery.init_app(application)
     signing.init_app(application)

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -6,7 +6,7 @@ from celery.exceptions import Retry
 from flask import current_app, json
 from sqlalchemy.orm.exc import NoResultFound
 
-from app import notify_celery, statsd_client
+from app import notify_celery
 from app.clients.email.aws_ses import get_aws_responses
 from app.config import QueueNames
 from app.constants import NOTIFICATION_PENDING, NOTIFICATION_SENDING
@@ -127,8 +127,6 @@ def process_ses_results(  # noqa: C901
                 references=[reference], update_dict={"status": notification_status}
             )
 
-        statsd_client.incr(f"callback.ses.{notification_status}")
-
         record_deliver_duration(
             callback_duration=(receipt_dt - notification.created_at).total_seconds() if receipt_dt else None,
             deliver_duration=(delivery_dt - notification.created_at).total_seconds() if delivery_dt else None,
@@ -137,11 +135,6 @@ def process_ses_results(  # noqa: C901
             notification_type="email",
             provider_name="ses",
         )
-
-        if notification.sent_at:
-            statsd_client.timing_with_dates(
-                f"callback.ses.{notification_status}.elapsed-time", datetime.utcnow(), notification.sent_at
-            )
 
         check_and_queue_callback_task(notification)
 

--- a/app/celery/process_sms_client_response_tasks.py
+++ b/app/celery/process_sms_client_response_tasks.py
@@ -6,7 +6,7 @@ from flask import current_app
 from notifications_utils.template import SMSMessageTemplate
 from sqlalchemy.exc import OperationalError
 
-from app import notify_celery, statsd_client
+from app import notify_celery
 from app.clients import ClientException
 from app.clients.sms.firetext import get_firetext_responses
 from app.clients.sms.mmg import get_mmg_responses
@@ -134,8 +134,6 @@ def _process_for_status(
     if not notification:
         return
 
-    statsd_client.incr(f"callback.{client_name.lower()}.{notification_status}")
-
     record_deliver_duration(
         callback_duration=(receipt_dt - notification.created_at).total_seconds() if receipt_dt else None,
         deliver_duration=(delivery_dt - notification.created_at).total_seconds() if delivery_dt else None,
@@ -145,13 +143,6 @@ def _process_for_status(
         notification_sms_international=notification.international,
         provider_name=client_name.lower(),
     )
-
-    if notification.sent_at:
-        statsd_client.timing_with_dates(
-            f"callback.{client_name.lower()}.{notification_status}.elapsed-time",
-            datetime.utcnow(),
-            notification.sent_at,
-        )
 
     if notification.billable_units == 0:
         service = notification.service
@@ -169,7 +160,6 @@ def _process_for_status(
     if notification_status != NOTIFICATION_PENDING:
         check_and_queue_callback_task(notification)
         if notification.international:
-            statsd_client.incr(f"international-sms.{notification_status}.{notification.phone_prefix}")
             record_international_sms(
                 1, notification_status=notification_status, sms_country_code=notification.phone_prefix
             )

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -18,7 +18,7 @@ from redis.exceptions import LockError
 from sqlalchemy import and_, between, text
 from sqlalchemy.exc import SQLAlchemyError
 
-from app import db, dvla_client, notify_celery, redis_store, statsd_client, zendesk_client
+from app import db, dvla_client, notify_celery, redis_store, zendesk_client
 from app.aws import s3
 from app.celery.letters_pdf_tasks import get_pdf_for_templated_letter
 from app.celery.tasks import (
@@ -239,19 +239,6 @@ def generate_sms_delivery_stats():
     for delivery_interval in (1, 5, 10):
         providers_slow_delivery_reports = get_slow_text_message_delivery_reports_by_provider(
             created_within_minutes=15, delivered_within_minutes=delivery_interval
-        )
-
-        for report in providers_slow_delivery_reports:
-            statsd_client.gauge(
-                f"slow-delivery.{report.provider}.delivered-within-minutes.{delivery_interval}.ratio", report.slow_ratio
-            )
-
-        total_notifications = sum(report.total_notifications for report in providers_slow_delivery_reports)
-        slow_notifications = sum(report.slow_notifications for report in providers_slow_delivery_reports)
-        ratio_slow_notifications = slow_notifications / total_notifications
-
-        statsd_client.gauge(
-            f"slow-delivery.sms.delivered-within-minutes.{delivery_interval}.ratio", ratio_slow_notifications
         )
 
         # For the 5-minute delivery interval, let's check the percentage of all text messages sent that were slow.

--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -61,10 +61,9 @@ class AwsSesClient(EmailClient):
 
     name = "ses"
 
-    def __init__(self, region, statsd_client):
+    def __init__(self, region):
         super().__init__()
         self._client = boto3.client("sesv2", region_name=region)
-        self.statsd_client = statsd_client
 
     @record_request_duration(notification_type="email", provider_name="ses")
     def send_email(
@@ -103,18 +102,14 @@ class AwsSesClient(EmailClient):
                 ReplyToAddresses=reply_to_addresses,
             )
         except botocore.exceptions.ClientError as e:
-            self.statsd_client.incr("clients.ses.error")
-
             # https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_SendEmail.html#API_SendEmail_Errors
             if e.response["Error"]["Code"] == "InvalidParameterValue":
                 raise EmailClientNonRetryableException(e.response["Error"]["Message"]) from e
             elif e.response["Error"]["Code"] == "TooManyRequestsException":
                 raise AwsSesClientThrottlingSendRateException(str(e)) from e
             else:
-                self.statsd_client.incr("clients.ses.error")
                 raise AwsSesClientException(str(e) + e.response["Error"]["Code"]) from e
         except Exception as e:
-            self.statsd_client.incr("clients.ses.error")
             raise AwsSesClientException(str(e)) from e
         else:
             elapsed_time = monotonic() - start_time
@@ -125,8 +120,6 @@ class AwsSesClient(EmailClient):
                     "duration": elapsed_time,
                 },
             )
-            self.statsd_client.timing("clients.ses.request-time", elapsed_time)
-            self.statsd_client.incr("clients.ses.success")
             return response["MessageId"]
 
 

--- a/app/clients/email/aws_ses_stub.py
+++ b/app/clients/email/aws_ses_stub.py
@@ -21,9 +21,8 @@ class AwsSesStubClient(EmailClient):
 
     name = "ses"
 
-    def __init__(self, region, statsd_client, stub_url):
+    def __init__(self, region, stub_url):
         super().__init__()
-        self.statsd_client = statsd_client
         self.url = stub_url
         self.requests_session = requests.Session()
 
@@ -46,13 +45,10 @@ class AwsSesStubClient(EmailClient):
             response_json = json.loads(response.text)
 
         except Exception as e:
-            self.statsd_client.incr("clients.ses_stub.error")
             raise AwsSesStubClientException(str(e)) from e
         else:
             elapsed_time = monotonic() - start_time
             current_app.logger.info(
                 "AWS SES stub request finished in %.4g seconds", elapsed_time, extra={"duration": elapsed_time}
             )
-            self.statsd_client.timing("clients.ses_stub.request-time", elapsed_time)
-            self.statsd_client.incr("clients.ses_stub.success")
             return response_json["MessageId"]

--- a/app/clients/letter/dvla.py
+++ b/app/clients/letter/dvla.py
@@ -112,19 +112,16 @@ class DVLAClient:
 
     name = "dvla"
 
-    statsd_client = None
-
     _jwt_token = None
     _jwt_expires_at = None
 
-    def __init__(self, application, *, statsd_client):
+    def __init__(self, application):
         self.base_url = application.config["DVLA_API_BASE_URL"]
         self.ciphers = application.config["DVLA_API_TLS_CIPHERS"]
         ssm_client = boto3.client("ssm", region_name=application.config["AWS_REGION"])
         self.dvla_username = SSMParameter(key="/notify/api/dvla_username", ssm_client=ssm_client)
         self.dvla_password = SSMParameter(key="/notify/api/dvla_password", ssm_client=ssm_client)
         self.dvla_api_key = SSMParameter(key="/notify/api/dvla_api_key", ssm_client=ssm_client)
-        self.statsd_client = statsd_client
 
         self.session = requests.Session()
         self.session.mount(self.base_url, _SpecifiedCiphersAdapter(ciphers=self.ciphers))

--- a/app/clients/sms/__init__.py
+++ b/app/clients/sms/__init__.py
@@ -26,10 +26,9 @@ class SmsClient(Client):
     Base Sms client for sending smss.
     """
 
-    def __init__(self, current_app, statsd_client):
+    def __init__(self, current_app):
         super().__init__()
         self.current_app = current_app
-        self.statsd_client = statsd_client
 
         self.requests_session = requests.Session()
         if platform.system() == "Linux":  # these are linux-specific socket options enabling tcp keepalive
@@ -54,9 +53,7 @@ class SmsClient(Client):
                     "provider_name": self.name,
                 },
             )
-            self.statsd_client.incr(f"clients.{self.name}.success")
         else:
-            self.statsd_client.incr(f"clients.{self.name}.error")
             self.current_app.logger.warning(
                 "Provider request for %s failed",
                 self.name,
@@ -76,7 +73,6 @@ class SmsClient(Client):
             raise e
         finally:
             elapsed_time = monotonic() - start_time
-            self.statsd_client.timing(f"clients.{self.name}.request-time", elapsed_time)
             self.current_app.logger.info(
                 "%s request for %s finished in %.4g",
                 self.name,

--- a/app/config.py
+++ b/app/config.py
@@ -499,10 +499,6 @@ class Config:
     if os.getenv("CELERYD_PREFETCH_MULTIPLIER"):
         CELERY["worker_prefetch_multiplier"] = os.getenv("CELERYD_PREFETCH_MULTIPLIER")
 
-    STATSD_HOST = os.getenv("STATSD_HOST")
-    STATSD_PORT = 8125
-    STATSD_ENABLED = bool(STATSD_HOST)
-
     SENDING_NOTIFICATIONS_TIMEOUT_PERIOD = 259200  # 3 days
 
     SIMULATED_EMAIL_ADDRESSES = (

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -9,7 +9,7 @@ from notifications_utils.template import (
     SMSMessageTemplate,
 )
 
-from app import create_uuid, db, notification_provider_clients, redis_store, statsd_client
+from app import create_uuid, db, notification_provider_clients, redis_store
 from app.celery.research_mode_tasks import (
     send_email_response,
     send_sms_response,
@@ -100,7 +100,6 @@ def send_sms_to_provider(notification: Notification) -> None:
                     notification.billable_units = template.fragment_count
                     update_notification_to_sending(notification, provider)
                     if notification.international:
-                        statsd_client.incr(f"international-sms.{NOTIFICATION_SENT}.{notification.phone_prefix}")
                         record_international_sms(
                             1, notification_status=NOTIFICATION_SENT, sms_country_code=notification.phone_prefix
                         )
@@ -112,13 +111,6 @@ def send_sms_to_provider(notification: Notification) -> None:
                 provider_name=provider.name,
             )
 
-        delta_seconds = (datetime.utcnow() - created_at).total_seconds()
-        statsd_client.timing("sms.total-time", delta_seconds)
-
-        if key_type == KEY_TYPE_TEST:
-            statsd_client.timing("sms.test-key.total-time", delta_seconds)
-        else:
-            statsd_client.timing("sms.live-key.total-time", delta_seconds)
     else:
         extra = {"notification_id": notification.id, "notification_status": notification.status}
         current_app.logger.warning(
@@ -199,12 +191,6 @@ def send_email_to_provider(notification):
                 notification_type="email",
                 provider_name=provider.name,
             )
-        delta_seconds = (datetime.utcnow() - created_at).total_seconds()
-
-        if key_type == KEY_TYPE_TEST:
-            statsd_client.timing("email.test-key.total-time", delta_seconds)
-        else:
-            statsd_client.timing("email.live-key.total-time", delta_seconds)
 
 
 def update_notification_to_sending(notification, provider):

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -18,7 +18,6 @@ def child_exit(server, worker):
 workers = int(os.getenv("GUNICORN_WORKERS", "4"))
 worker_class = "eventlet"
 worker_connections = int(os.getenv("GUNICORN_WORKER_CONNECTIONS", "8"))
-statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
 keepalive = int(os.getenv("GUNICORN_KEEPALIVE", "0"))
 timeout = int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30))  # though has little effect with eventlet worker_class
 

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil~=6.0
 notifications-python-client~=10.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@115.4.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@117.0.1
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -800,7 +800,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0a40a62a04c06e6f09ecea5d2c03daa9bd2f684d
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b7b535c0cfb83e80f746568dbe43f8d7ac16f46f
     # via -r requirements.in
 opentelemetry-api==1.40.0 \
     --hash=sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f \
@@ -1585,10 +1585,6 @@ sqlalchemy==2.0.48 \
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
     #   sentry-sdk
-statsd==4.0.1 \
-    --hash=sha256:99763da81bfea8daf6b3d22d11aaccb01a8d0f52ea521daab37e758a4ca7d128 \
-    --hash=sha256:c2676519927f7afade3723aca9ca8ea986ef5b059556a980a867721ca69df093
-    # via notifications-utils
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1127,7 +1127,7 @@ mypy-extensions==1.1.0 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0a40a62a04c06e6f09ecea5d2c03daa9bd2f684d
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b7b535c0cfb83e80f746568dbe43f8d7ac16f46f
     # via -r requirements.txt
 opentelemetry-api==1.40.0 \
     --hash=sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f \
@@ -2050,12 +2050,6 @@ squawk-cli==2.43.0 \
     --hash=sha256:99321a4fb54fa51ada0817546fa693198fd4699ea902be80575a4643e2a33712 \
     --hash=sha256:ece91fa7caa3e2970e5d587493ab56f6013581d50148848a42fbfe9c6c3fe384
     # via -r requirements_for_test.in
-statsd==4.0.1 \
-    --hash=sha256:99763da81bfea8daf6b3d22d11aaccb01a8d0f52ea521daab37e758a4ca7d128 \
-    --hash=sha256:c2676519927f7afade3723aca9ca8ea986ef5b059556a980a867721ca69df093
-    # via
-    #   -r requirements.txt
-    #   notifications-utils
 trustme==1.2.1 \
     --hash=sha256:6528ba2bbc7f2db41f33825c8dd13e3e3eb9d334ba0f909713c8c3139f4ae47f \
     --hash=sha256:d768e5fc57c86dfc5ec9365102e9b092541cd6954b35d8c1eea01a84f35a762a

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.4.0
+# This file was automatically copied from notifications-utils@117.0.1
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.4.0
+# This file was automatically copied from notifications-utils@117.0.1
 
 extend-exclude = [
     "migrations/versions/",

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from freezegun import freeze_time
 
-from app import signing, statsd_client
+from app import signing
 from app.celery.process_ses_receipts_tasks import process_ses_results
 from app.celery.research_mode_tasks import (
     ses_hard_bounce_callback,
@@ -69,8 +69,6 @@ def test_ses_callback_should_update_notification_status(
     with freeze_time("2001-01-01T12:00:00") as frozen_time:
         record_deliver_duration_mock = mocker.patch.object(_deliver_duration, "record")
         record_callback_duration_mock = mocker.patch.object(_callback_duration, "record")
-        mocker.patch("app.statsd_client.incr")
-        mocker.patch("app.statsd_client.timing_with_dates")
         send_mock = mocker.patch("app.celery.process_ses_receipts_tasks.check_and_queue_callback_task")
         notification = create_notification(
             template=sample_email_template,
@@ -91,10 +89,6 @@ def test_ses_callback_should_update_notification_status(
 
         assert process_ses_results(payload, receipt_iso_timestamp)
         assert get_notification_by_id(notification.id).status == "delivered"
-        statsd_client.timing_with_dates.assert_any_call(
-            "callback.ses.delivered.elapsed-time", datetime.utcnow(), notification.sent_at
-        )
-        statsd_client.incr.assert_any_call("callback.ses.delivered")
         record_deliver_duration_mock.assert_called_once_with(
             1.0,
             {

--- a/tests/app/celery/test_process_sms_client_response_tasks.py
+++ b/tests/app/celery/test_process_sms_client_response_tasks.py
@@ -4,7 +4,6 @@ from datetime import datetime
 import pytest
 from freezegun import freeze_time
 
-from app import statsd_client
 from app.celery.process_sms_client_response_tasks import (
     process_sms_client_response,
 )
@@ -137,8 +136,6 @@ def test_sms_response_does_not_send_callback_if_notification_is_not_in_the_db(sa
 def test_process_sms_client_response_records_metrics(sample_notification, client, mocker):
     record_deliver_duration_mock = mocker.patch.object(_deliver_duration, "record")
     record_callback_duration_mock = mocker.patch.object(_callback_duration, "record")
-    mocker.patch("app.statsd_client.incr")
-    mocker.patch("app.statsd_client.timing_with_dates")
 
     sample_notification.status = "sending"
     sample_notification.created_at = datetime.utcnow()
@@ -150,11 +147,6 @@ def test_process_sms_client_response_records_metrics(sample_notification, client
         "Firetext",
         delivery_iso_timestamp="2001-01-01T12:00:42",
         receipt_iso_timestamp="2001-01-01T12:00:50",
-    )
-
-    statsd_client.incr.assert_any_call("callback.firetext.delivered")
-    statsd_client.timing_with_dates.assert_any_call(
-        "callback.firetext.delivered.elapsed-time", datetime.utcnow(), sample_notification.sent_at
     )
 
     record_deliver_duration_mock.assert_called_once_with(

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -191,26 +191,12 @@ def test_generate_sms_delivery_stats(slow_delivery_config_option, expect_check_s
         "app.celery.scheduled_tasks.get_slow_text_message_delivery_reports_by_provider",
         return_value=slow_delivery_reports,
     )
-    mock_statsd = mocker.patch("app.celery.scheduled_tasks.statsd_client.gauge")
     mock_check_slow_delivery = mocker.patch(
         "app.celery.scheduled_tasks._check_slow_text_message_delivery_reports_and_raise_error_if_needed"
     )
 
     with set_config(notify_api, "CHECK_SLOW_TEXT_MESSAGE_DELIVERY", slow_delivery_config_option):
         generate_sms_delivery_stats()
-
-    calls = [
-        call("slow-delivery.mmg.delivered-within-minutes.1.ratio", 0.4),
-        call("slow-delivery.mmg.delivered-within-minutes.5.ratio", 0.4),
-        call("slow-delivery.mmg.delivered-within-minutes.10.ratio", 0.4),
-        call("slow-delivery.firetext.delivered-within-minutes.1.ratio", 0.8),
-        call("slow-delivery.firetext.delivered-within-minutes.5.ratio", 0.8),
-        call("slow-delivery.firetext.delivered-within-minutes.10.ratio", 0.8),
-        call("slow-delivery.sms.delivered-within-minutes.1.ratio", 0.6),
-        call("slow-delivery.sms.delivered-within-minutes.5.ratio", 0.6),
-        call("slow-delivery.sms.delivered-within-minutes.10.ratio", 0.6),
-    ]
-    mock_statsd.assert_has_calls(calls, any_order=True)
 
     assert mock_check_slow_delivery.call_args_list == (
         [mocker.call(slow_delivery_reports)] if expect_check_slow_delivery else []

--- a/tests/app/clients/test_aws_ses.py
+++ b/tests/app/clients/test_aws_ses.py
@@ -60,7 +60,6 @@ def test_should_be_none_if_unrecognised_status_code():
 )
 def test_send_email_handles_reply_to_address(notify_api, mocker, reply_to_address, expected_value):
     boto_mock = mocker.patch.object(aws_ses_client, "_client", create=True)
-    mocker.patch.object(aws_ses_client, "statsd_client", create=True)
 
     with notify_api.app_context():
         aws_ses_client.send_email(
@@ -80,7 +79,6 @@ def test_send_email_handles_reply_to_address(notify_api, mocker, reply_to_addres
 
 def test_send_email_handles_punycode_to_address(notify_api, mocker):
     boto_mock = mocker.patch.object(aws_ses_client, "_client", create=True)
-    mocker.patch.object(aws_ses_client, "statsd_client", create=True)
 
     with notify_api.app_context():
         aws_ses_client.send_email(
@@ -103,7 +101,6 @@ def test_send_email_handles_punycode_to_address(notify_api, mocker):
 
 def test_send_email_sends_content_correctly(notify_api, mocker):
     boto_mock = mocker.patch.object(aws_ses_client, "_client", create=True)
-    mocker.patch.object(aws_ses_client, "statsd_client", create=True)
 
     mock_subject = Mock()
     mock_body = Mock()
@@ -136,12 +133,10 @@ def test_send_email_sends_content_correctly(notify_api, mocker):
 
 def test_send_email_raises_invalid_parameter_value_error_as_EmailClientNonRetryableException(mocker):
     boto_mock = mocker.patch.object(aws_ses_client, "_client", create=True)
-    mocker.patch.object(aws_ses_client, "statsd_client", create=True)
     error_response = {
         "Error": {"Code": "InvalidParameterValue", "Message": "some error message from amazon", "Type": "Sender"}
     }
     boto_mock.send_email.side_effect = botocore.exceptions.ClientError(error_response, "opname")
-    mocker.patch.object(aws_ses_client, "statsd_client", create=True)
 
     with pytest.raises(EmailClientNonRetryableException) as excinfo:
         aws_ses_client.send_email(
@@ -159,7 +154,6 @@ def test_send_email_raises_invalid_parameter_value_error_as_EmailClientNonRetrya
 
 def test_send_email_raises_send_rate_throttling_as_AwsSesClientThrottlingSendRateException(mocker):
     boto_mock = mocker.patch.object(aws_ses_client, "_client", create=True)
-    mocker.patch.object(aws_ses_client, "statsd_client", create=True)
     error_response = {
         "Error": {"Code": "TooManyRequestsException", "Message": "Maximum sending rate exceeded.", "Type": "Sender"}
     }
@@ -179,7 +173,6 @@ def test_send_email_raises_send_rate_throttling_as_AwsSesClientThrottlingSendRat
 
 def test_send_email_does_not_raise_AwsSesClientThrottlingSendRateException_if_non_send_rate_throttling(mocker):
     boto_mock = mocker.patch.object(aws_ses_client, "_client", create=True)
-    mocker.patch.object(aws_ses_client, "statsd_client", create=True)
     error_response = {
         "Error": {"Code": "TooManyRequestsException", "Message": "Daily message quota exceeded", "Type": "Sender"}
     }
@@ -199,12 +192,10 @@ def test_send_email_does_not_raise_AwsSesClientThrottlingSendRateException_if_no
 
 def test_send_email_raises_other_errs_as_AwsSesClientException(notify_api, mocker):
     boto_mock = mocker.patch.object(aws_ses_client, "_client", create=True)
-    mocker.patch.object(aws_ses_client, "statsd_client", create=True)
     error_response = {
         "Error": {"Code": "ServiceUnavailable", "Message": "some error message from amazon", "Type": "Sender"}
     }
     boto_mock.send_email.side_effect = botocore.exceptions.ClientError(error_response, "opname")
-    mocker.patch.object(aws_ses_client, "statsd_client", create=True)
 
     with pytest.raises(AwsSesClientException) as excinfo:
         aws_ses_client.send_email(

--- a/tests/app/clients/test_dvla.py
+++ b/tests/app/clients/test_dvla.py
@@ -5,7 +5,6 @@ import sys
 import time
 from collections import namedtuple
 from datetime import UTC, datetime
-from unittest.mock import Mock
 
 import boto3
 import freezegun
@@ -54,7 +53,7 @@ def ssm():
 
 @pytest.fixture
 def dvla_client(notify_api, client, ssm):
-    dvla_client = DVLAClient(notify_api, statsd_client=Mock())
+    dvla_client = DVLAClient(notify_api)
     yield dvla_client
 
 
@@ -941,10 +940,7 @@ class TestDVLAApiClientRestrictedCiphers:
             method="GET",
         ).respond_with_data("OK")
 
-        dvla_client = DVLAClient(
-            fake_app,
-            statsd_client=mocker.Mock(),
-        )
+        dvla_client = DVLAClient(fake_app)
 
         with ca.cert_pem.tempfile() as ca_temp_path:
             response = dvla_client.session.get(
@@ -957,7 +953,7 @@ class TestDVLAApiClientRestrictedCiphers:
     def test_invalid_ciphers(self, mocker, server_base_url, fake_app):
         with pytest.raises(ssl.SSLError) as e:
             fake_app.config["DVLA_API_TLS_CIPHERS"] = "not-a-valid-cipher"
-            DVLAClient(fake_app, statsd_client=mocker.Mock())
+            DVLAClient(fake_app)
 
         assert "No cipher can be selected." in e.value.args
 
@@ -973,10 +969,7 @@ class TestDVLAApiClientRestrictedCiphers:
         fake_app,
     ):
         fake_app.config["DVLA_API_TLS_CIPHERS"] = ":".join(cipherlist.allowlist)
-        dvla_client = DVLAClient(
-            fake_app,
-            statsd_client=mocker.Mock(),
-        )
+        dvla_client = DVLAClient(fake_app)
 
         httpserver.expect_request(
             "/test",
@@ -1003,10 +996,7 @@ class TestDVLAApiClientRestrictedCiphers:
         fake_app,
     ):
         fake_app.config["DVLA_API_TLS_CIPHERS"] = ":".join(cipherlist.blocklist)
-        dvla_client = DVLAClient(
-            fake_app,
-            statsd_client=mocker.Mock(),
-        )
+        dvla_client = DVLAClient(fake_app)
 
         httpserver.expect_request(
             "/test",

--- a/tests/app/clients/test_sms.py
+++ b/tests/app/clients/test_sms.py
@@ -1,6 +1,5 @@
 import pytest
 
-from app import statsd_client
 from app.clients.sms import SmsClient, SmsClientResponseException
 
 
@@ -12,7 +11,7 @@ def fake_client(notify_api):
         def try_send_sms(self):
             pass
 
-    fake_client = FakeSmsClient(notify_api, statsd_client)
+    fake_client = FakeSmsClient(notify_api)
     return fake_client
 
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -654,27 +654,25 @@ def create_mock_firetext_config(mocker, additional_config=None):
     return mocker.Mock(config=config)
 
 
-def create_mock_firetext_client(mocker, mock_config):
-    statsd_client = mocker.Mock()
-    return FiretextClient(mock_config, statsd_client)
+def create_mock_firetext_client(mock_config):
+    return FiretextClient(mock_config)
 
 
 @pytest.fixture(scope="function")
 def mock_firetext_client(mocker):
     mock_config = create_mock_firetext_config(mocker)
-    return create_mock_firetext_client(mocker, mock_config)
+    return create_mock_firetext_client(mock_config)
 
 
 @pytest.fixture(scope="function")
 def mock_firetext_client_with_receipts(mocker):
     additional_config = {"FIRETEXT_RECEIPT_URL": "https://www.example.com/notifications/sms/firetext"}
     mock_config = create_mock_firetext_config(mocker, additional_config)
-    return create_mock_firetext_client(mocker, mock_config)
+    return create_mock_firetext_client(mock_config)
 
 
 @pytest.fixture(scope="function")
 def mock_mmg_client_with_receipts(mocker):
-    statsd_client = mocker.Mock()
     current_app = mocker.Mock(
         config={
             "MMG_URL": "https://example.com/mmg",
@@ -682,7 +680,7 @@ def mock_mmg_client_with_receipts(mocker):
             "MMG_RECEIPT_URL": "https://www.example.com/notifications/sms/mmg",
         }
     )
-    return MMGClient(current_app, statsd_client)
+    return MMGClient(current_app)
 
 
 @pytest.fixture(scope="function")

--- a/tests/app/v2/test_errors.py
+++ b/tests/app/v2/test_errors.py
@@ -18,9 +18,6 @@ def app_for_test():
     app = flask.Flask(__name__)
     app.config["TESTING"] = True
     init_app(app)
-    from app import statsd_client
-
-    statsd_client.init_app(app)
 
     from app.v2.errors import register_errors
 

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.4.0
+# This file was automatically copied from notifications-utils@117.0.1
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
https://trello.com/c/25A3gpXh/1358-replace-statsd-instrumentation-across-notify-with-otel

Currently live in dev-b (along with the corresponding changes in antivirus and template-preview), FTs are passing.

The StatsD metrics that are removed in this PR all have OpenTelemetry-based equivalents.