### PR TITLE
`RedisClient`: improve robustness

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.3.1
+# This file was automatically copied from notifications-utils@115.4.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/config.py
+++ b/app/config.py
@@ -147,6 +147,8 @@ class Config:
     # URL of redis instance
     REDIS_URL = os.getenv("REDIS_URL")
     REDIS_ENABLED = False if os.environ.get("REDIS_ENABLED") == "0" else True
+    REDIS_SOCKET_TIMEOUT = 5
+    REDIS_SOCKET_CONNECT_TIMEOUT = 5
 
     ENABLE_SQS_MESSAGE_GROUP_IDS = os.environ.get("ENABLE_SQS_MESSAGE_GROUP_IDS", "1") == "1"
 

--- a/application.py
+++ b/application.py
@@ -15,9 +15,11 @@ application = NotifyApiFlaskApp("app")
 create_app(application)
 
 if utils_eventlet.using_eventlet:
+    http_serve_timeout_seconds = int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30))
     application.wsgi_app = utils_eventlet.EventletTimeoutMiddleware(  # type: ignore[method-assign]
         application.wsgi_app,
-        timeout_seconds=int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30)),
+        timeout_seconds=http_serve_timeout_seconds,
+        soft_timeout_seconds=http_serve_timeout_seconds - 0.5,
     )
 
     if application.config["NOTIFY_EVENTLET_STATS"]:

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil~=6.0
 notifications-python-client~=10.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@115.3.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@115.4.0
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -800,7 +800,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@fad26d684f87a832cc54cee072844ad5dccd2305
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0a40a62a04c06e6f09ecea5d2c03daa9bd2f684d
     # via -r requirements.in
 opentelemetry-api==1.40.0 \
     --hash=sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1127,7 +1127,7 @@ mypy-extensions==1.1.0 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@fad26d684f87a832cc54cee072844ad5dccd2305
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0a40a62a04c06e6f09ecea5d2c03daa9bd2f684d
     # via -r requirements.txt
 opentelemetry-api==1.40.0 \
     --hash=sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.3.1
+# This file was automatically copied from notifications-utils@115.4.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.3.1
+# This file was automatically copied from notifications-utils@115.4.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.3.1
+# This file was automatically copied from notifications-utils@115.4.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
This bumps -utils to include https://github.com/alphagov/notifications-utils/pull/1353 and configures some things for those improvements to actually take effect.

Here I'm setting our `SoftEventletTimeout` to 29.5s, which is when most requests will timeout following this (admin already has its set to 29s). The remaining 0.5s grace period gives a request a chance to finish up successfully if it was waiting on a redis call that was non-critical.

(have tested this on a dev env quite a bit, triggering a redis failover during our FTs, and this slightly reduces the failures we get)