### PR TITLE
`get_all_templates_for_service`: make serialization interruptible

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.3.1
+# This file was automatically copied from notifications-utils@115.5.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -5,6 +5,7 @@ import botocore
 from flask import Blueprint, current_app, jsonify, request
 from flask.ctx import has_request_context
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
+from notifications_utils.interruptible_io import interruptible_iter
 from notifications_utils.pdf import extract_page_from_pdf
 from notifications_utils.template import (
     LetterPreviewTemplate,
@@ -188,7 +189,7 @@ def get_precompiled_template_for_service(service_id):
 @template_blueprint.route("", methods=["GET"])
 def get_all_templates_for_service(service_id):
     templates = dao_get_all_templates_for_service(service_id=service_id, no_detail=True)
-    data = template_schema_no_detail.dump(templates, many=True)
+    data = template_schema_no_detail.dump(interruptible_iter(templates, 32), many=True)
     return jsonify(data=data)
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil~=6.0
 notifications-python-client~=10.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@115.3.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@caa8ce2a62a0a61950d5b53e14d77ba654a8a543
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -800,7 +800,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@fad26d684f87a832cc54cee072844ad5dccd2305
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@caa8ce2a62a0a61950d5b53e14d77ba654a8a543
     # via -r requirements.in
 opentelemetry-api==1.40.0 \
     --hash=sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1127,7 +1127,7 @@ mypy-extensions==1.1.0 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@fad26d684f87a832cc54cee072844ad5dccd2305
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@caa8ce2a62a0a61950d5b53e14d77ba654a8a543
     # via -r requirements.txt
 opentelemetry-api==1.40.0 \
     --hash=sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.3.1
+# This file was automatically copied from notifications-utils@115.5.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.3.1
+# This file was automatically copied from notifications-utils@115.5.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.3.1
+# This file was automatically copied from notifications-utils@115.5.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
Depending on https://github.com/alphagov/notifications-utils/pull/1356

Marshmallow serialization is not particularly fast, for large template lists we can spend quite a while doing this, so don't make this block async.