### PR TITLE
Don’t use Marshmallow to serialize all templates

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -105,6 +105,7 @@ from app.models_types import (
     SerializedServiceSmsSender,
     SerializedTemplateEmailFile,
     SerializedTemplateFolder,
+    SerializedTemplateNoDetail,
     SerializedUnsubscribeRequestReport,
     SerializedUser,
     SerializedUserForList,
@@ -1253,6 +1254,15 @@ class Template(TemplateBase):
         fields["service_id"] = fields.pop("service")
         fields["folder"] = folder
         return cls(**fields)
+
+    def serialize_no_detail(self) -> SerializedTemplateNoDetail:
+        return SerializedTemplateNoDetail(
+            folder=str(self.folder.id) if self.folder else None,
+            id=str(self.id),
+            is_precompiled_letter=self.is_precompiled_letter,
+            name=self.name,
+            template_type=self.template_type,
+        )
 
 
 class TemplateRedacted(db.Model):

--- a/app/models_types.py
+++ b/app/models_types.py
@@ -360,3 +360,11 @@ class SerializedTemplateEmailFile(TypedDict):
     retention_period: int
     validate_users_email: bool
     pending: bool
+
+
+class SerializedTemplateNoDetail(TypedDict):
+    folder: str | None
+    id: str
+    is_precompiled_letter: bool
+    name: str
+    template_type: str

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -437,18 +437,6 @@ class TemplateSchema(BaseTemplateSchema, UUIDsAsStringsMixin):
                 raise ValidationError("Invalid template subject", "subject")
 
 
-class TemplateSchemaNoDetail(TemplateSchema):
-    class Meta(TemplateSchema.Meta):
-        fields = [
-            "folder",
-            "id",
-            "is_precompiled_letter",
-            "name",
-            "template_type",
-        ]
-        exclude: list[str] = []
-
-
 class TemplateHistorySchema(BaseTemplateSchema, UUIDsAsStringsMixin):
     created_by = fields.Nested(UserSchema, only=["id", "name", "email_address"], dump_only=True)
 
@@ -738,7 +726,6 @@ user_update_password_schema_load_json = UserUpdatePasswordSchema(only=("_passwor
 service_schema = ServiceSchema()
 detailed_service_schema = DetailedServiceSchema()
 template_schema = TemplateSchema()
-template_schema_no_detail = TemplateSchemaNoDetail()
 template_email_files_schema = TemplateEmailFilesSchema()
 api_key_schema = ApiKeySchema()
 job_schema = JobSchema()

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -43,7 +43,6 @@ from app.schema_validation import validate
 from app.schemas import (
     template_history_schema,
     template_schema,
-    template_schema_no_detail,
 )
 from app.template.template_schemas import (
     post_create_template_schema,
@@ -188,7 +187,7 @@ def get_precompiled_template_for_service(service_id):
 @template_blueprint.route("", methods=["GET"])
 def get_all_templates_for_service(service_id):
     templates = dao_get_all_templates_for_service(service_id=service_id, no_detail=True)
-    data = template_schema_no_detail.dump(templates, many=True)
+    data = [template.serialize_no_detail() for template in templates]
     return jsonify(data=data)
 
 


### PR DESCRIPTION
There can be a lot of templates, this can take time, we can remove a bit of overhead by not using Marshmallow.

Benchmarked with 1,000 templates.

# Before

<img width="402" height="72" alt="Screenshot 2026-05-26 at 11 24 18" src="https://github.com/user-attachments/assets/390f28bc-a8d5-4588-a500-7b924bde59a2" />

# After

<img width="371" height="72" alt="Screenshot 2026-05-26 at 11 17 47" src="https://github.com/user-attachments/assets/f7f70656-4a31-4d4b-84f5-b5717d44d302" />

7&times; faster