### PR TITLE
Use `many=True` to serialise collection

### DIFF
--- a/app/template_email_files/rest.py
+++ b/app/template_email_files/rest.py
@@ -57,10 +57,7 @@ def create_template_email_file(service_id, template_id):
 @template_email_files_blueprint.route("", methods=["GET"])
 def get_template_email_files(service_id, template_id):
     fetched_template_email_files = dao_get_template_email_files_by_template_id(template_id)
-    template_email_files = []
-    for template_email_file in fetched_template_email_files:
-        template_email_files += [template_email_files_schema.dump(template_email_file)]
-
+    template_email_files = template_email_files_schema.dump(fetched_template_email_files, many=True)
     return jsonify(data=template_email_files), 200
 
 


### PR DESCRIPTION
Building up a list item-by-item is not very Pythonic. If we weren’t using Marshmallow we would use a list comprehension, but since we are we can use its `many=True` argument. See https://marshmallow.readthedocs.io/en/stable/quickstart.html#handling-collections-of-objects