### PR TITLE
`process_ses_results`, `process_sms_client_response`: supply receipt timestamp to `send_delivery_status_to_service`

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -136,7 +136,7 @@ def process_ses_results(  # noqa: C901
             provider_name="ses",
         )
 
-        check_and_queue_callback_task(notification)
+        check_and_queue_callback_task(notification, receipt_dt=receipt_dt)
 
         return True
 

--- a/app/celery/process_sms_client_response_tasks.py
+++ b/app/celery/process_sms_client_response_tasks.py
@@ -158,7 +158,7 @@ def _process_for_status(
         notifications_dao.dao_update_notification(notification)
 
     if notification_status != NOTIFICATION_PENDING:
-        check_and_queue_callback_task(notification)
+        check_and_queue_callback_task(notification, receipt_dt=receipt_dt)
         if notification.international:
             record_international_sms(
                 1, notification_status=notification_status, sms_country_code=notification.phone_prefix

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from flask import current_app
 
 from app.celery.service_callback_tasks import (
@@ -68,13 +70,14 @@ def remove_emails_from_complaint(complaint_dict):
     return complaint_dict["mail"].pop("destination")
 
 
-def check_and_queue_callback_task(notification):
+def check_and_queue_callback_task(notification, *, receipt_dt: datetime | None = None):
     # queue callback task only if the service_callback_api exists
     service_callback_api = get_delivery_status_callback_api_for_service(service_id=notification.service_id)
     if service_callback_api:
         notification_data = create_delivery_status_callback_data(notification, service_callback_api)
         send_delivery_status_to_service.apply_async(
             [str(notification.id), notification_data],
+            {"receipt_iso_timestamp": receipt_dt and receipt_dt.isoformat()},
             queue=QueueNames.CALLBACKS,
             MessageGroupId=str(notification.service_id),
         )

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -108,7 +108,7 @@ def test_ses_callback_should_update_notification_status(
             },
         )
         updated_notification = Notification.query.get(notification.id)
-        send_mock.assert_called_once_with(updated_notification)
+        send_mock.assert_called_once_with(updated_notification, receipt_dt=datetime(2001, 1, 1, 12, 0, 2))
 
         record = next(r for r in caplog.records if "SES successful delivery" in r.msg)
         assert record.delivered_at == datetime(2001, 1, 1, 12, 0, 1)

--- a/tests/app/celery/test_process_sms_client_response_tasks.py
+++ b/tests/app/celery/test_process_sms_client_response_tasks.py
@@ -206,7 +206,7 @@ def test_outcome_statistics_called_for_successful_callback(sample_notification, 
     reference = str(sample_notification.id)
 
     process_sms_client_response("3", reference, "MMG")
-    send_mock.assert_called_once_with(sample_notification)
+    send_mock.assert_called_once_with(sample_notification, receipt_dt=None)
 
 
 def test_process_sms_updates_sent_by_with_client_name_if_not_in_noti(sample_notification):

--- a/tests/app/notifications/test_notifications_ses_callback.py
+++ b/tests/app/notifications/test_notifications_ses_callback.py
@@ -92,6 +92,7 @@ def test_check_and_queue_callback_task(mocker, mock_celery_task, sample_notifica
 
     mock_send.assert_called_once_with(
         [str(sample_notification.id), mock_create.return_value],
+        {"receipt_iso_timestamp": None},
         queue="service-callbacks",
         MessageGroupId=str(sample_notification.service_id),
     )


### PR DESCRIPTION
Second half of https://trello.com/c/kof0w1IT/1529-record-delivery-receipt-callback-latency-as-a-metric, which sits on top of #4868 (so review that first).