### PR TITLE
`send_delivery_status_to_service`: accept `receipt_iso_timestamp`

### DIFF
--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from contextvars import ContextVar
+from datetime import datetime
 
 import requests
 from flask import current_app
@@ -9,9 +10,11 @@ from werkzeug.local import LocalProxy
 
 from app import memo_resetters, notify_celery, signing
 from app.config import QueueNames
+from app.constants import ServiceCallbackTypes
 from app.dao.inbound_sms_dao import dao_get_inbound_sms_by_id
 from app.dao.returned_letters_dao import fetch_returned_letter_callback_data_dao
 from app.dao.service_callback_api_dao import get_service_callback_api_by_callback_type
+from app.otel_metrics.service_callback import record_service_callback_forward_duration
 from app.utils import DATETIME_FORMAT
 
 # thread-local copies of persistent requests.Session
@@ -54,7 +57,9 @@ def send_returned_letter_to_service(self, encoded_returned_letter):
 @notify_celery.task(
     bind=True, name="send-delivery-status", max_retries=5, default_retry_delay=300, early_log_level=logging.DEBUG
 )
-def send_delivery_status_to_service(self, notification_id, encoded_status_update):
+def send_delivery_status_to_service(
+    self, notification_id, encoded_status_update, *, receipt_iso_timestamp: str | None = None
+):
     status_update = signing.decode(encoded_status_update)
 
     data = {
@@ -70,14 +75,25 @@ def send_delivery_status_to_service(self, notification_id, encoded_status_update
         "template_version": status_update["template_version"],
     }
 
-    _send_data_to_service_callback_api(
-        self,
-        data,
-        status_update["service_callback_api_url"],
-        status_update["service_callback_api_bearer_token"],
-        data["id"],
-        {"notification_id": data["id"]},
-    )
+    start_dt = datetime.utcnow()
+
+    try:
+        _send_data_to_service_callback_api(
+            self,
+            data,
+            status_update["service_callback_api_url"],
+            status_update["service_callback_api_bearer_token"],
+            data["id"],
+            {"notification_id": data["id"]},
+        )
+    finally:
+        if receipt_iso_timestamp:
+            record_service_callback_forward_duration(
+                (start_dt - datetime.fromisoformat(receipt_iso_timestamp)).total_seconds(),
+                str(ServiceCallbackTypes.delivery_status),
+                self.request.retries,
+                status_update["notification_type"],
+            )
 
 
 @notify_celery.task(bind=True, name="send-complaint", max_retries=5, default_retry_delay=300)

--- a/app/otel_metrics/service_callback.py
+++ b/app/otel_metrics/service_callback.py
@@ -1,0 +1,48 @@
+from notifications_utils.semconv import set_error_type
+from opentelemetry.metrics import get_meter
+from opentelemetry.util.types import AttributeValue
+
+_meter = get_meter(__name__)
+
+# Buckets ranging from 50 milliseconds to 10 minutes
+SERVICE_CALLBACK_FORWARD_DURATION_HISTOGRAM_BUCKETS = [
+    0.05,
+    0.1,
+    0.2,
+    0.5,
+    1,
+    2,
+    5,
+    10,
+    30,
+    60,
+    120,
+    300,
+    600,
+]
+
+_service_callback_forward_duration = _meter.create_histogram(
+    "service_callback.forward.duration",
+    unit="s",
+    description="Elapsed time between provider receipt and start of service callback attempt",
+    explicit_bucket_boundaries_advisory=SERVICE_CALLBACK_FORWARD_DURATION_HISTOGRAM_BUCKETS,
+)
+
+
+def record_service_callback_forward_duration(
+    duration: float,
+    callback_type: str,
+    attempt: int,
+    notification_type: str | None = None,
+):
+    attrs: dict[str, AttributeValue] = {
+        "callback.type": callback_type,
+        "callback.attempt": attempt,
+    }
+
+    if notification_type is not None:
+        attrs["notification.type"] = notification_type
+
+    set_error_type(attrs)
+
+    _service_callback_forward_duration.record(duration, attrs)

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from contextlib import nullcontext
 from datetime import datetime, timedelta
 from unittest import mock
 
@@ -23,6 +24,7 @@ from app.constants import (
     NOTIFICATION_RETURNED_LETTER,
     ServiceCallbackTypes,
 )
+from app.otel_metrics.service_callback import _service_callback_forward_duration
 from app.utils import DATETIME_FORMAT
 from tests.app.db import (
     create_api_key,
@@ -129,28 +131,44 @@ def _set_up_test_data_for_returned_letter_callback(template):
     return callback_api, job, notification_1
 
 
+@freeze_time("2017-06-20T12:34:56")
 @pytest.mark.parametrize("notification_type", ["email", "sms"])
-def test_send_delivery_status_to_service_sends_callback_to_service(notify_db_session, notification_type, mocker):
+@pytest.mark.parametrize("receipt_iso_timestamp", ["2017-06-20T12:34:55", None])
+@pytest.mark.parametrize("callback_successful", [False, True])
+def test_send_delivery_status_to_service_sends_callback_to_service(
+    notify_db_session, notification_type, receipt_iso_timestamp, callback_successful, mocker
+):
     callback_api, template = _set_up_test_data(notification_type, "delivery_status")
-    datestr = datetime(2017, 6, 20)
+    now = datetime.now()
 
     notification = create_notification(
-        template=template, created_at=datestr, updated_at=datestr, sent_at=datestr, status="sent"
+        template=template,
+        created_at=now - timedelta(seconds=5),
+        sent_at=now - timedelta(seconds=4),
+        updated_at=now - timedelta(seconds=2),
+        status="sent",
     )
     encoded_status_update = _set_up_data_for_status_update(callback_api, notification)
 
     send_callback_mock = mocker.patch("app.celery.service_callback_tasks._send_data_to_service_callback_api")
+    if not callback_successful:
+        send_callback_mock.side_effect = ValueError
 
-    send_delivery_status_to_service(notification.id, encoded_status_update=encoded_status_update)
+    service_callback_forward_duration_record_mock = mocker.patch.object(_service_callback_forward_duration, "record")
+
+    with nullcontext() if callback_successful else pytest.raises(ValueError):
+        send_delivery_status_to_service(
+            notification.id, encoded_status_update=encoded_status_update, receipt_iso_timestamp=receipt_iso_timestamp
+        )
 
     expected_data = {
         "id": str(notification.id),
         "reference": notification.client_reference,
         "to": notification.to,
         "status": notification.status,
-        "created_at": datestr.strftime(DATETIME_FORMAT),
-        "completed_at": datestr.strftime(DATETIME_FORMAT),
-        "sent_at": datestr.strftime(DATETIME_FORMAT),
+        "created_at": (now - timedelta(seconds=5)).strftime(DATETIME_FORMAT),
+        "sent_at": (now - timedelta(seconds=4)).strftime(DATETIME_FORMAT),
+        "completed_at": (now - timedelta(seconds=2)).strftime(DATETIME_FORMAT),
         "notification_type": notification_type,
         "template_id": str(template.id),
         "template_version": 1,
@@ -163,6 +181,21 @@ def test_send_delivery_status_to_service_sends_callback_to_service(notify_db_ses
         callback_api.bearer_token,
         expected_data["id"],
         {"notification_id": expected_data["id"]},
+    )
+    assert service_callback_forward_duration_record_mock.mock_calls == (
+        []
+        if receipt_iso_timestamp is None
+        else [
+            mocker.call(
+                1.0,
+                {
+                    "callback.type": "delivery_status",
+                    "callback.attempt": 0,
+                    "notification.type": notification_type,
+                }
+                | ({} if callback_successful else {"error.type": "builtins.ValueError"}),
+            ),
+        ]
     )
 
 


### PR DESCRIPTION
And use for `service_callback_forward_duration` metric.

This is the first half of https://trello.com/c/kof0w1IT/1529-record-delivery-receipt-callback-latency-as-a-metric, which needs to be deployed before the second half goes out because we need to be able to accept the new `receipt_iso_timestamp` kwarg in `send_delivery_status_to_service` before any sending code starts supplying it.

Note how this is recording the latency *excluding* the callback time itself, because we note the `start_dt` just before we begin the request. It will also only emit a metric for successful callbacks. It's likely we'll want to filter the resultant metric for `callback.attempt == 0` in any SLOs so we're not counting retry wait-time, but I do expect information invlving retries will be useful in the future so I'm not excluding retried callbacks entirely.

Note also how I've designed this as a general service callback metric, intending to use it for inbound sms latency too (suitably labeled).

Have tested this along with its other half #4867 and its `-aws` requisite https://github.com/alphagov/notifications-aws/pull/2993 on dev-f.