### PR TITLE
Bump utils to 116.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.4.0
+# This file was automatically copied from notifications-utils@116.1.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil~=6.0
 notifications-python-client~=10.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@115.4.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@116.1.0
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -800,7 +800,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0a40a62a04c06e6f09ecea5d2c03daa9bd2f684d
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79a5807653c2752e61db68e63acbc7bcab0d69c2
     # via -r requirements.in
 opentelemetry-api==1.40.0 \
     --hash=sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1127,7 +1127,7 @@ mypy-extensions==1.1.0 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0a40a62a04c06e6f09ecea5d2c03daa9bd2f684d
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79a5807653c2752e61db68e63acbc7bcab0d69c2
     # via -r requirements.txt
 opentelemetry-api==1.40.0 \
     --hash=sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.4.0
+# This file was automatically copied from notifications-utils@116.1.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.4.0
+# This file was automatically copied from notifications-utils@116.1.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.4.0
+# This file was automatically copied from notifications-utils@116.1.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
 ## 116.1.0

* Add `interruptible_io` moodule.
* `RecipientCSV`: use `InterruptibleIterableList` for cached rows property

 ## 116.0.0

* Add `BaseSMSTemplate.count_of_characters_above_limit`
* Add `BaseSMSTemplate.non_gsm_characters`
* Add `BaseSMSTemplate.count_of_characters_above_previous_fragment_boundary`
* Fix edge case where wrong fragment count would be shown with Welsh placeholder name
* Removes `notifications_utils.template.get_sms_fragment_count` (not used outside this repo)
* Removes `notifications_utils.template.non_gsm_characters` (not used outside this repo)
* Removes `notifications_utils.template.count_extended_gsm_chars` (not used outside this repo)

 ## 115.4.1

Add `dir="auto"` attribute to sms_preview_template message wrapper

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/115.4.0...116.1.0