### PR TITLE
 `send_inbound_sms_to_service`: record `service_callback.forward.duration` metric

### DIFF
--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -120,7 +120,7 @@ def send_complaint_to_service(self, complaint_data):
 
 @notify_celery.task(bind=True, name="send-inbound-sms", max_retries=5, default_retry_delay=300)
 def send_inbound_sms_to_service(self, inbound_sms_id, service_id):
-    inbound_api = get_service_callback_api_by_callback_type(service_id, "inbound_sms")
+    inbound_api = get_service_callback_api_by_callback_type(service_id, str(ServiceCallbackTypes.inbound_sms))
 
     if not inbound_api:
         # No API data has been set for this service
@@ -136,9 +136,18 @@ def send_inbound_sms_to_service(self, inbound_sms_id, service_id):
         "date_received": inbound_sms.provider_date.strftime(DATETIME_FORMAT),
     }
 
-    _send_data_to_service_callback_api(
-        self, data, inbound_api.url, inbound_api.bearer_token, data["id"], {"inbound_sms_id": data["id"]}
-    )
+    start_dt = datetime.utcnow()
+
+    try:
+        _send_data_to_service_callback_api(
+            self, data, inbound_api.url, inbound_api.bearer_token, data["id"], {"inbound_sms_id": data["id"]}
+        )
+    finally:
+        record_service_callback_forward_duration(
+            (start_dt - inbound_sms.created_at).total_seconds(),
+            str(ServiceCallbackTypes.inbound_sms),
+            self.request.retries,
+        )
 
 
 def _send_data_to_service_callback_api(self, data, service_callback_url, token, id_display, log_extra):

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -228,20 +228,24 @@ def test_send_complaint_to_service_sends_callback_to_service(notify_db_session, 
         )
 
 
-def test_send_inbound_sms_to_service_sends_callback_to_service(notify_api, sample_service, mocker):
-    create_service_callback_api(
-        callback_type=ServiceCallbackTypes.inbound_sms.value,
-        service=sample_service,
-        url="https://some.service.gov.uk/",
-        bearer_token="something_unique",
-    )
-    inbound_sms = create_inbound_sms(
-        service=sample_service,
-        notify_number="0751421",
-        user_number="447700900111",
-        provider_date=datetime(2017, 6, 20),
-        content="Here is some content",
-    )
+@freeze_time("2017-06-20T12:34:56")
+@pytest.mark.parametrize("callback_successful", [False, True])
+def test_send_inbound_sms_to_service_sends_callback_to_service(notify_api, sample_service, callback_successful, mocker):
+    with freeze_time("2017-06-20T12:34:56"):
+        create_service_callback_api(
+            callback_type=ServiceCallbackTypes.inbound_sms.value,
+            service=sample_service,
+            url="https://some.service.gov.uk/",
+            bearer_token="something_unique",
+        )
+        inbound_sms = create_inbound_sms(
+            service=sample_service,
+            notify_number="0751421",
+            user_number="447700900111",
+            provider_date=datetime(2017, 6, 20, 12, 30),
+            content="Here is some content",
+        )
+
     data = {
         "id": str(inbound_sms.id),
         "source_number": inbound_sms.user_number,
@@ -251,11 +255,29 @@ def test_send_inbound_sms_to_service_sends_callback_to_service(notify_api, sampl
     }
 
     send_callback_mock = mocker.patch("app.celery.service_callback_tasks._send_data_to_service_callback_api")
+    if not callback_successful:
+        send_callback_mock.side_effect = ValueError
 
-    send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
+    service_callback_forward_duration_record_mock = mocker.patch.object(_service_callback_forward_duration, "record")
+
+    with freeze_time("2017-06-20T12:34:59"):
+        with nullcontext() if callback_successful else pytest.raises(ValueError):
+            send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
+
     send_callback_mock.assert_called_once_with(
         mock.ANY, data, "https://some.service.gov.uk/", "something_unique", data["id"], {"inbound_sms_id": data["id"]}
     )
+
+    assert service_callback_forward_duration_record_mock.mock_calls == [
+        mocker.call(
+            3.0,
+            {
+                "callback.type": "inbound_sms",
+                "callback.attempt": 0,
+            }
+            | ({} if callback_successful else {"error.type": "builtins.ValueError"}),
+        ),
+    ]
 
 
 def test_send_inbound_sms_to_service_does_not_send_callback_when_inbound_sms_does_not_exist(
@@ -263,14 +285,17 @@ def test_send_inbound_sms_to_service_does_not_send_callback_when_inbound_sms_doe
 ):
     create_service_callback_api(service=sample_service, callback_type=ServiceCallbackTypes.inbound_sms.value)
     send_callback_mock = mocker.patch("app.celery.service_callback_tasks._send_data_to_service_callback_api")
+    service_callback_forward_duration_record_mock = mocker.patch.object(_service_callback_forward_duration, "record")
 
     with pytest.raises(SQLAlchemyError):
         send_inbound_sms_to_service(inbound_sms_id=uuid.uuid4(), service_id=sample_service.id)
 
     assert send_callback_mock.call_count == 0
+    # we didn't actually make a callback attempt, so we shouldn't record a metric for doing so
+    assert service_callback_forward_duration_record_mock.mock_calls == []
 
 
-def test_send_inbound_sms_to_service_does_not_sent_callback_when_inbound_api_does_not_exist(
+def test_send_inbound_sms_to_service_does_not_send_callback_when_inbound_api_does_not_exist(
     notify_api, sample_service, mocker
 ):
     inbound_sms = create_inbound_sms(
@@ -281,9 +306,13 @@ def test_send_inbound_sms_to_service_does_not_sent_callback_when_inbound_api_doe
         content="Here is some content",
     )
     send_callback_mock = mocker.patch("app.celery.service_callback_tasks._send_data_to_service_callback_api")
+    service_callback_forward_duration_record_mock = mocker.patch.object(_service_callback_forward_duration, "record")
+
     send_inbound_sms_to_service(inbound_sms.id, inbound_sms.service_id)
 
     assert send_callback_mock.call_count == 0
+    # again, we didn't actually make a callback attempt, so we shouldn't record a metric for doing so
+    assert service_callback_forward_duration_record_mock.mock_calls == []
 
 
 def test_send_returned_letter_to_service_sends_callback_to_service(


### PR DESCRIPTION
https://trello.com/c/iHEIWNA1/1530-record-inbound-sms-callback-latency-as-a-metric

Built on top of #4867

This can be done as one PR because we don't need to marshal the receipt timestamp to the celery task (it is contained in the `InboundSms` db row as `created_at`)