### PR TITLE
Alert on letters in technical-failure status via Zendesk

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -59,6 +59,7 @@ from app.dao.jobs_dao import (
 )
 from app.dao.notifications_dao import (
     SlowProviderDeliveryReport,
+    dao_letters_in_technical_failure,
     dao_old_letters_with_created_status,
     dao_precompiled_letters_still_pending_virus_check,
     get_slow_text_message_delivery_reports_by_provider,
@@ -424,6 +425,36 @@ def check_if_letters_still_in_created():
             current_app.logger.error(
                 "%(notification_count)s letter notifications created before 17:30 yesterday "
                 "still have 'created' status",
+                extra,
+                extra=extra,
+            )
+
+
+@notify_celery.task(name="check-if-letters-in-technical-failure")
+def check_if_letters_in_technical_failure():
+    technical_failed_letters = dao_letters_in_technical_failure(session=db.session_bulk, retry_attempts=2)
+
+    if len(technical_failed_letters) > 0:
+        msg = (
+            f"{len(technical_failed_letters)} letters have 'technical-failure' status. "
+            "Follow runbook to resolve: "
+            "https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook"
+            "#fixing-letters-in-technical-failure."
+        )
+
+        if current_app.should_send_zendesk_alerts:
+            ticket = NotifySupportTicket(
+                subject=f"[{current_app.config['NOTIFY_ENVIRONMENT']}] Letters in 'technical-failure' status",
+                message=msg,
+                ticket_type=NotifySupportTicket.TYPE_TASK,
+                notify_ticket_type=NotifyTicketType.TECHNICAL,
+                notify_task_type="notify_task_letters_technical_failure_status",
+            )
+            zendesk_client.send_ticket_to_zendesk(ticket)
+
+            extra = {"notification_count": len(technical_failed_letters)}
+            current_app.logger.error(
+                "%(notification_count)s letter notifications have 'technical-failure' status",
                 extra,
                 extra=extra,
             )

--- a/app/config.py
+++ b/app/config.py
@@ -421,6 +421,11 @@ class Config:
                 "schedule": crontab(day_of_week="mon-fri", hour=7, minute=0),
                 "options": {"queue": QueueNames.PERIODIC},
             },
+            "check-if-letters-in-technical-failure": {
+                "task": "check-if-letters-in-technical-failure",
+                "schedule": crontab(hour=7, minute=0),
+                "options": {"queue": QueueNames.PERIODIC},
+            },
             "check-if-letters-still-pending-virus-check-ten-minutely": {
                 "task": "check-if-letters-still-pending-virus-check",
                 "schedule": crontab(minute="*/10"),

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -41,6 +41,7 @@ from app.constants import (
     NOTIFICATION_STATUS_TYPES,
     NOTIFICATION_STATUS_TYPES_COMPLETED,
     NOTIFICATION_STATUS_TYPES_DEPRECATED,
+    NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
     SMS_TYPE,
 )
@@ -942,6 +943,23 @@ def dao_old_letters_with_created_status():
         .all()
     )
     return notifications
+
+
+@retryable_query()
+def dao_letters_in_technical_failure(session: Session | scoped_session = db.session):
+    start_dt = datetime.utcnow() - timedelta(days=3)
+    end_dt = datetime.utcnow()
+    return (
+        session.query(Notification)
+        .filter(
+            Notification.notification_type == LETTER_TYPE,
+            Notification.status == NOTIFICATION_TECHNICAL_FAILURE,
+            Notification.created_at >= start_dt,
+            Notification.created_at < end_dt,
+        )
+        .order_by(Notification.created_at)
+        .all()
+    )
 
 
 @retryable_query()

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -27,6 +27,7 @@ from app.celery.scheduled_tasks import (
     check_for_low_available_inbound_sms_numbers,
     check_for_missing_rows_in_completed_jobs,
     check_for_services_with_high_failure_rates_or_sending_to_tv_numbers,
+    check_if_letters_in_technical_failure,
     check_if_letters_still_in_created,
     check_if_letters_still_pending_virus_check,
     check_job_status,
@@ -665,6 +666,57 @@ def test_check_if_letters_still_in_created_during_utc(sample_letter_template, ca
         ticket_type="task",
         notify_ticket_type=NotifyTicketType.TECHNICAL,
         notify_task_type="notify_task_letters_created_status",
+    )
+    mock_send_ticket_to_zendesk.assert_called_once()
+
+
+def test_check_if_letters_in_technical_failure(sample_letter_template, caplog, mocker):
+    mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
+    mock_send_ticket_to_zendesk = mocker.patch(
+        "app.celery.scheduled_tasks.zendesk_client.send_ticket_to_zendesk",
+        autospec=True,
+    )
+
+    with caplog.at_level("ERROR"):
+        create_notification(
+            template=sample_letter_template,
+            status="technical-failure",
+            created_at=datetime.utcnow() - timedelta(hours=6),
+        )
+        create_notification(
+            template=sample_letter_template,
+            status="technical-failure",
+            created_at=datetime.utcnow() - timedelta(minutes=10),
+        )
+        create_notification(
+            template=sample_letter_template,
+            status="technical-failure",
+            created_at=datetime.utcnow() - timedelta(days=2),
+        )
+        create_notification(
+            template=sample_letter_template,
+            status="technical-failure",
+            created_at=datetime.utcnow() - timedelta(days=3),
+        )
+        create_notification(
+            template=sample_letter_template,
+            status="technical-failure",
+            created_at=datetime.utcnow() - timedelta(days=4),
+        )
+        check_if_letters_in_technical_failure()
+
+    assert "3 letter notifications have 'technical-failure' status" in caplog.messages
+    mock_create_ticket.assert_called_once_with(
+        ANY,
+        message=(
+            "3 letters have 'technical-failure' status. "
+            "Follow runbook to resolve: "
+            "https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#fixing-letters-in-technical-failure."
+        ),
+        subject="[test] Letters in 'technical-failure' status",
+        ticket_type="task",
+        notify_ticket_type=NotifyTicketType.TECHNICAL,
+        notify_task_type="notify_task_letters_technical_failure_status",
     )
     mock_send_ticket_to_zendesk.assert_called_once()
 

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -34,6 +34,7 @@ from app.dao.notifications_dao import (
     dao_get_notification_or_history_by_reference,
     dao_get_notifications_by_recipient_or_reference,
     dao_get_notifications_processing_time_stats,
+    dao_letters_in_technical_failure,
     dao_record_letter_despatched_on_by_id,
     dao_timeout_notifications,
     dao_update_notification,
@@ -2166,3 +2167,32 @@ def test_fetch_service_data_retention_by_for_all_services_by_notification_type_u
         get_service_ids_with_notifications_before("email", datetime.utcnow(), session=session)
 
     assert {query_info.bind_key for query_info in query_recorder.queries} == {expected_bind_key}
+
+
+@pytest.mark.parametrize(
+    "session,expected_bind_key",
+    (
+        (db.session, None),
+        (db.session_bulk, "bulk"),
+    ),
+    ids=("default", "bulk"),
+)
+def test_dao_letters_in_technical_failure(sample_letter_template, sample_email_template, session, expected_bind_key):
+
+    letter_tf_1 = create_notification(template=sample_letter_template, status="technical-failure")
+    letter_tf_2 = create_notification(template=sample_letter_template, status="technical-failure")
+
+    create_notification(template=sample_letter_template, status="delivered")
+    create_notification(template=sample_letter_template, status="created")
+
+    create_notification(template=sample_email_template, status="technical-failure")
+
+    results = []
+
+    with QueryRecorder() as query_recorder:
+        results = dao_letters_in_technical_failure(session=session)
+
+    assert {query_info.bind_key for query_info in query_recorder.queries} == {expected_bind_key}
+
+    assert len(results) == 2
+    assert {n.id for n in results} == {letter_tf_1.id, letter_tf_2.id}


### PR DESCRIPTION
Letters stuck in `technical-failure` can be silently left unresolved. During a recent incident, letters in technical-failure that were unrelated to the incident added noise and made triage harder. By alerting on this state, we ensure every letter in technical-failure is either fixed or explicitly moved to a different failure state. [Card](https://trello.com/c/EdTYjeJU/1819-create-a-zendesk-alert-for-letters-that-go-into-technical-failure) for more details.
Test zendesk ticket on the card.