### PR TITLE
Fix excessive calls to dao get organisation domains

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -1,5 +1,3 @@
-from itertools import chain
-
 from flask import current_app
 from sqlalchemy.orm import Session, scoped_session
 from sqlalchemy.sql.expression import func
@@ -28,9 +26,7 @@ def dao_get_organisations():
 
 
 def dao_get_organisation_domains():
-    organisations = dao_get_organisations()
-
-    return [domain.domain for domain in chain.from_iterable(org.domains for org in organisations)]
+    return db.session.scalars(db.session.query(Domain.domain)).all()
 
 
 def dao_count_organisations_with_live_services():

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -199,7 +199,10 @@ def dao_archive_user(user):
 
 
 def _count_gov_users_with_manage_settings(service):
-    active_government_users = [u for u in service.users if u.state == "active" and is_gov_user(u.email_address)]
+    organisation_domains = dao_get_organisation_domains()
+    active_government_users = [
+        u for u in service.users if u.state == "active" and is_gov_user(u.email_address, organisation_domains)
+    ]
 
     return sum(MANAGE_SETTINGS in u.get_permissions(service_id=service.id) for u in active_government_users)
 
@@ -227,13 +230,15 @@ def users_permissions_can_be_changed(user, service, new_permissions):
         return True
 
     # If the user is not a government user, it's always safe
-    if not is_gov_user(user.email_address):
+    if not is_gov_user(user.email_address, dao_get_organisation_domains()):
         return True
 
     return _can_remove_gov_user_with_manage_settings(service)
 
 
-def user_can_be_removed_from_service(user, service):
+def user_can_be_removed_from_service(user, service, organisation_domains=None):
+    if not organisation_domains:
+        organisation_domains = dao_get_organisation_domains()
     active_users = [u for u in service.users if u.state == "active"]
 
     # Must always leave at least one active user
@@ -245,14 +250,19 @@ def user_can_be_removed_from_service(user, service):
         return True
 
     # Removing users who are not government users is always safe
-    if not is_gov_user(user.email_address):
+    if not is_gov_user(user.email_address, organisation_domains):
         return True
 
     return _can_remove_gov_user_with_manage_settings(service)
 
 
 def user_can_be_archived(user):
-    return all(user_can_be_removed_from_service(user, service) for service in user.services if service.active)
+    organisation_domains = dao_get_organisation_domains()
+    return all(
+        user_can_be_removed_from_service(user, service, organisation_domains)
+        for service in user.services
+        if service.active
+    )
 
 
 def get_users_for_research(start_date: date, end_date: date) -> list[User]:
@@ -320,7 +330,7 @@ def unsubscribe_user_from_notify_services(service_id, email_address):
     return True
 
 
-def is_gov_user(email_address):
+def is_gov_user(email_address, organisation_domains):
     return email_address_ends_with(email_address, GOVERNMENT_EMAIL_DOMAIN_NAMES) or email_address_ends_with(
-        email_address, dao_get_organisation_domains()
+        email_address, organisation_domains
     )

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from app import db
 from app.constants import EMAIL_AUTH_TYPE, OrganisationUserPermissionTypes
 from app.dao.date_util import parse_date_range
+from app.dao.organisation_dao import dao_get_organisation_domains
 from app.dao.organisation_user_permissions_dao import organisation_user_permissions_dao
 from app.dao.service_user_dao import (
     dao_get_service_user,
@@ -878,4 +879,4 @@ def test_get_users_list_multiple_filters(
 def test_is_gov_user(notify_db_session, email_address):
     create_organisation(domains=["other.com"])
 
-    assert is_gov_user(email_address) is True
+    assert is_gov_user(email_address, dao_get_organisation_domains()) is True


### PR DESCRIPTION
Remove calls to `dao_get_organisation_domains()` from for loops where possible.

These calls to `dao_get_organisation_domains()` are redundant (but also crucially aren't cached). For organisations with a large number of team members in their services, this has resulted in timeouts when they have tried to do things like updating and deleting a team member from their service.

By only calling this method once before the loop/list comprehension, it should be much more efficient.