### PR TITLE
Use one SQL query to get all domains

### DIFF
--- a/app/dao/organisation_dao.py
+++ b/app/dao/organisation_dao.py
@@ -1,5 +1,3 @@
-from itertools import chain
-
 from flask import current_app
 from sqlalchemy.orm import Session, scoped_session
 from sqlalchemy.sql.expression import func
@@ -28,9 +26,7 @@ def dao_get_organisations():
 
 
 def dao_get_organisation_domains():
-    organisations = dao_get_organisations()
-
-    return [domain.domain for domain in chain.from_iterable(org.domains for org in organisations)]
+    return db.session.scalars(db.session.query(Domain.domain)).all()
 
 
 def dao_count_organisations_with_live_services():


### PR DESCRIPTION
Domains must have an organisation ID, so are always associated with an organisation:
https://github.com/alphagov/notifications-api/blob/aee7023565123843ea614acd27fe473ed1bcb26a/app/models.py#L380

The previous query gets all the domains for all organisations, no matter whether they are archived, have no services, etc.

This does the same thing but in one SQL query, rather than firing off one query per organisation.

Tested here:
https://github.com/alphagov/notifications-api/blob/aee7023565123843ea614acd27fe473ed1bcb26a/tests/app/dao/test_organisation_dao.py#L61-L73