### PR TITLE
Log when non-compatible characters are replaced in text messages

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -8,6 +8,7 @@ from flask import abort, current_app, jsonify, request
 from gds_metrics import Histogram
 from notifications_utils.formatters import url
 from notifications_utils.insensitive_dict import InsensitiveSet
+from notifications_utils.sanitise_text import SanitiseSMS
 
 from app import (
     api_user,
@@ -255,6 +256,16 @@ def process_sms_or_email_notification(
 
     # validate content length after url is replaced in personalisation.
     check_is_message_too_long(template_with_content)
+
+    if notification_type == SMS_TYPE:
+        if non_compatible_characters := SanitiseSMS.get_non_compatible_characters(
+            template_with_content.unsanitised_content
+        ):
+            current_app.logger.warning(
+                "%s character(s) replaced with ? in SMS content for notification %s",
+                len(non_compatible_characters),
+                notification_id,
+            )
 
     response = create_response_for_post_notification(
         notification_id=notification_id,

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1652,3 +1652,36 @@ def test_post_sms_notification_returns_400_with_correct_error_message_if_empty_s
 
     assert error_json["status_code"] == 400
     assert error_json["errors"] == [{"error": "ValidationError", "message": "phone_number Not enough digits"}]
+
+
+def test_post_sms_notification_logs_non_compatible_characters(
+    api_client_request, sample_template_with_placeholders, caplog, mocker
+):
+    mocker.patch("app.celery.provider_tasks.deliver_sms.apply_async")
+    data = {
+        "phone_number": "+447700900855",
+        "template_id": str(sample_template_with_placeholders.id),
+        "personalisation": {
+            " Name": (
+                "Ŵ"  # Welsh, sent as-is
+                "Ł"  # Polish Ł, gets downgraded to L
+                "🍍🍍🍌🥝"  # Other non-GSM characters, replaced with ? and logged
+            )
+        },
+    }
+
+    resp_json = api_client_request.post(
+        sample_template_with_placeholders.service_id,
+        "v2_notifications.post_notification",
+        notification_type="sms",
+        _data=data,
+    )
+
+    assert resp_json["content"]["body"] == "Hello ŴL????\nYour thing is due soon"
+    notification_id = resp_json["id"]
+
+    assert (
+        "test",
+        30,
+        f"3 character(s) replaced with ? in SMS content for notification {notification_id}",
+    ) in caplog.record_tuples


### PR DESCRIPTION
We want to know the risk of allowing all unicode characters in text messages.

Existing templates won’t contain non-compatible characters because we validate them out.

Personalisation can contain non-compatible characters but we replace each with a ? at the time of sending. We want to know how often this is happening, because our change would result in these characters not being encoded, but the message costing more.