### PR TITLE
Move logging of non-GSM-7 characters to `send_to_providers`

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from urllib import parse
 
 from flask import current_app
+from notifications_utils.sanitise_text import SanitiseSMS
 from notifications_utils.template import (
     HTMLEmailTemplate,
     PlainTextEmailTemplate,
@@ -58,6 +59,14 @@ def send_sms_to_provider(notification: Notification) -> None:
             prefix=service.name,
             show_prefix=service.prefix_sms,
         )
+
+        if non_compatible_characters := SanitiseSMS.get_non_compatible_characters(template.unsanitised_content):
+            current_app.logger.warning(
+                "%s character(s) replaced with ? in SMS content for notification %s",
+                len(non_compatible_characters),
+                notification.id,
+            )
+
         created_at = notification.created_at
         key_type = notification.key_type
         try:

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -8,7 +8,6 @@ from flask import abort, current_app, jsonify, request
 from gds_metrics import Histogram
 from notifications_utils.formatters import url
 from notifications_utils.insensitive_dict import InsensitiveSet
-from notifications_utils.sanitise_text import SanitiseSMS
 
 from app import (
     api_user,
@@ -256,16 +255,6 @@ def process_sms_or_email_notification(
 
     # validate content length after url is replaced in personalisation.
     check_is_message_too_long(template_with_content)
-
-    if notification_type == SMS_TYPE:
-        if non_compatible_characters := SanitiseSMS.get_non_compatible_characters(
-            template_with_content.unsanitised_content
-        ):
-            current_app.logger.warning(
-                "%s character(s) replaced with ? in SMS content for notification %s",
-                len(non_compatible_characters),
-                notification_id,
-            )
 
     response = create_response_for_post_notification(
         notification_id=notification_id,

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -338,6 +338,39 @@ def test_should_send_sms_with_downgraded_content(notify_db_session, mocker):
     )
 
 
+def test_should_log_sms_sent_with_downgraded_content(mocker, caplog):
+    service = create_service(service_name="Unicode test")
+    template = create_template(service, content="Hello ((name))")
+    db_notification = create_notification(
+        template=template,
+        personalisation={
+            " Name": (
+                "Ŵ"  # Welsh, sent as-is
+                "Ł"  # Polish Ł, gets downgraded to L
+                "🍍🍍🍌🥝"  # Other non-GSM characters, replaced with ? and logged
+            )
+        },
+    )
+
+    mocker.patch("app.mmg_client.send_sms")
+
+    send_to_providers.send_sms_to_provider(db_notification)
+
+    mmg_client.send_sms.assert_called_once_with(
+        to=ANY,
+        content="Unicode test: Hello ŴL????",
+        reference=ANY,
+        sender=ANY,
+        international=False,
+    )
+
+    assert (
+        "test",
+        30,
+        f"3 character(s) replaced with ? in SMS content for notification {db_notification.id}",
+    ) in caplog.record_tuples
+
+
 def test_send_sms_should_use_service_sms_sender(sample_service, sample_template, mocker):
     mocker.patch("app.mmg_client.send_sms")
 

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1652,36 +1652,3 @@ def test_post_sms_notification_returns_400_with_correct_error_message_if_empty_s
 
     assert error_json["status_code"] == 400
     assert error_json["errors"] == [{"error": "ValidationError", "message": "phone_number Not enough digits"}]
-
-
-def test_post_sms_notification_logs_non_compatible_characters(
-    api_client_request, sample_template_with_placeholders, caplog, mocker
-):
-    mocker.patch("app.celery.provider_tasks.deliver_sms.apply_async")
-    data = {
-        "phone_number": "+447700900855",
-        "template_id": str(sample_template_with_placeholders.id),
-        "personalisation": {
-            " Name": (
-                "Ŵ"  # Welsh, sent as-is
-                "Ł"  # Polish Ł, gets downgraded to L
-                "🍍🍍🍌🥝"  # Other non-GSM characters, replaced with ? and logged
-            )
-        },
-    }
-
-    resp_json = api_client_request.post(
-        sample_template_with_placeholders.service_id,
-        "v2_notifications.post_notification",
-        notification_type="sms",
-        _data=data,
-    )
-
-    assert resp_json["content"]["body"] == "Hello ŴL????\nYour thing is due soon"
-    notification_id = resp_json["id"]
-
-    assert (
-        "test",
-        30,
-        f"3 character(s) replaced with ? in SMS content for notification {notification_id}",
-    ) in caplog.record_tuples


### PR DESCRIPTION
This makes sure we catch all SMS notifications, not just those sent via the API.