### PR TITLE
Reduce timeout for provider requests to 10 seconds

### DIFF
--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -72,7 +72,7 @@ class FiretextClient(SmsClient):
             data["receipt"] = self.receipt_url
 
         try:
-            response = self.requests_session.request("POST", self.url, data=data, timeout=60)
+            response = self.requests_session.request("POST", self.url, data=data, timeout=10)
             response.raise_for_status()
             try:
                 json.loads(response.text)

--- a/app/clients/sms/mmg.py
+++ b/app/clients/sms/mmg.py
@@ -102,7 +102,7 @@ class MMGClient(SmsClient):
                 self.mmg_url,
                 data=json.dumps(data),
                 headers={"Content-Type": "application/json", "Authorization": f"Basic {self.api_key}"},
-                timeout=60,
+                timeout=10,
             )
 
             response.raise_for_status()


### PR DESCRIPTION
Reduce the provider client timeouts to 10s as an [incident action ](https://docs.google.com/document/d/1XAT8AxkfttPz5BJHPRkse4CvYCy4qZuo-s7M8ZzXtdg/edit?tab=t.0#heading=h.1ds10as673np)

I tested this on dev-a, https://concourse.notify.tools/teams/dev-a/pipelines/deploy-notify/jobs/functional-tests/builds/542

https://trello.com/c/fl85fBbA/1551-reduce-timeout-for-provider-requests-to-10-seconds