### PR TITLE
notifications-utils: 118.0.0 -> 119.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@118.0.0
+# This file was automatically copied from notifications-utils@119.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil~=6.0
 notifications-python-client~=12.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@118.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@119.0.0
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -846,7 +846,7 @@ mistune==0.8.4 \
 notifications-python-client==12.1.0 \
     --hash=sha256:bc44987acbb72de4cded700447d0d246c020dcd0f0311ff2ca884ce1c4001b76
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@8d2767c338b22d60825399191093282a6d928c0b
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9a6342ba0aa90afb37c6ec2ac501a75aefed8ac3
     # via -r requirements.in
 opentelemetry-api==1.42.1 \
     --hash=sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714 \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1209,7 +1209,7 @@ mypy-extensions==1.1.0 \
 notifications-python-client==12.1.0 \
     --hash=sha256:bc44987acbb72de4cded700447d0d246c020dcd0f0311ff2ca884ce1c4001b76
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@8d2767c338b22d60825399191093282a6d928c0b
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9a6342ba0aa90afb37c6ec2ac501a75aefed8ac3
     # via -r requirements.txt
 opentelemetry-api==1.42.1 \
     --hash=sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714 \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@118.0.0
+# This file was automatically copied from notifications-utils@119.0.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@118.0.0
+# This file was automatically copied from notifications-utils@119.0.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@118.0.0
+# This file was automatically copied from notifications-utils@119.0.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
Notable change incorporated being https://github.com/alphagov/notifications-utils/pull/1369.

This should hopefully cause no user-noticeable change.