### PR TITLE
Log when a different key type is used to get a notification

### DIFF
--- a/app/v2/notifications/get_notifications.py
+++ b/app/v2/notifications/get_notifications.py
@@ -27,6 +27,14 @@ def get_notification_by_id(notification_id):
     notification = notifications_dao.get_notification_with_personalisation(
         authenticated_service.id, notification_id, key_type=None
     )
+
+    if api_user.key_type != notification.key_type:
+        current_app.logger.warning(
+            "Key type for get_notification_by_id (%s) does not match key type used to send notification (%s)",
+            api_user.key_type,
+            notification.key_type,
+        )
+
     return jsonify(notification.serialize_with_cost_data()), 200
 
 
@@ -35,6 +43,13 @@ def get_pdf_for_notification(notification_id):
     _data = {"notification_id": notification_id}
     validate(_data, notification_by_id)
     notification = notifications_dao.get_notification_by_id(notification_id, authenticated_service.id, _raise=True)
+
+    if api_user.key_type != notification.key_type:
+        current_app.logger.warning(
+            "Key type for get_pdf_for_notification (%s) does not match key type used to send notification (%s)",
+            api_user.key_type,
+            notification.key_type,
+        )
 
     if notification.notification_type != LETTER_TYPE:
         raise BadRequestError(message="Notification is not a letter")

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1312,14 +1312,21 @@ def api_client_request(client, notify_user):
         app = client.application
 
         @staticmethod
-        def get(service_id, endpoint, _api_key_type="normal", _expected_status=200, **endpoint_kwargs):
+        def get(
+            service_id,
+            endpoint,
+            _api_key_type="normal",
+            _expected_status=200,
+            _expected_content_type="application/json",
+            **endpoint_kwargs,
+        ):
             resp = client.get(
                 url_for(endpoint, **(endpoint_kwargs or {})),
                 headers=[create_service_authorization_header(service_id, _api_key_type)],
             )
             json_resp = resp.json
             assert resp.status_code == _expected_status
-            assert resp.headers["Content-type"] == "application/json"
+            assert resp.headers["Content-type"] == _expected_content_type
             return json_resp
 
         @staticmethod

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -629,6 +629,62 @@ def test_get_notification_by_id_renames_letter_statuses(
     assert json_response["status"] == expected_status
 
 
+@pytest.mark.parametrize(
+    "key_type",
+    ("test", "team", pytest.param("normal", marks=pytest.mark.xfail)),
+)
+def test_get_notification_by_id_logs_on_different_key_type(
+    api_client_request,
+    sample_template,
+    sms_rate,
+    caplog,
+    key_type,
+):
+    notification = create_notification(template=sample_template, key_type="normal")
+
+    with caplog.at_level("WARNING"):
+        api_client_request.get(
+            notification.service_id,
+            "v2_notifications.get_notification_by_id",
+            notification_id=notification.id,
+            _api_key_type=key_type,
+        )
+    assert (
+        f"Key type for get_notification_by_id ({key_type}) does not match key type used to send notification (normal)"
+    ) in caplog.messages
+
+
+@pytest.mark.parametrize(
+    "key_type",
+    ("test", "team", pytest.param("normal", marks=pytest.mark.xfail)),
+)
+def test_get_pdf_for_notification_logs_on_different_key_type(
+    api_client_request,
+    sample_letter_template,
+    letter_rate,
+    caplog,
+    key_type,
+    mocker,
+):
+    mocker.patch(
+        "app.v2.notifications.get_notifications.get_letter_pdf_and_metadata",
+        return_value=(b"foo", {"message": "", "invalid_pages": "", "page_count": "1"}),
+    )
+    notification = create_notification(template=sample_letter_template, key_type="normal")
+
+    with caplog.at_level("WARNING"):
+        api_client_request.get(
+            notification.service_id,
+            "v2_notifications.get_pdf_for_notification",
+            notification_id=notification.id,
+            _api_key_type=key_type,
+            _expected_content_type="application/pdf",
+        )
+    assert (
+        f"Key type for get_pdf_for_notification ({key_type}) does not match key type used to send notification (normal)"
+    ) in caplog.messages
+
+
 def test_get_pdf_for_notification_returns_pdf_content(
     client,
     sample_letter_notification,


### PR DESCRIPTION
At the moment getting notifications for a service filters by key type: https://github.com/alphagov/notifications-api/blob/d8ab6a490dbb75e198c96bf875c1eb60c56b775c/app/v2/notifications/get_notifications.py#L79

This means you can’t use a ‘test’ key to get notifications sent with a ‘live’ key. This is good and sensible.

The endpoints for getting a single notification do not have the same restriction. So in the unlikely case where you knew the ID of a notification you could fetch it with any type of key.

This is a wrinkle we’d like to iron out. However we want to make sure that doing so isn’t going to be very disruptive, so the first step is to log when this is happening, in case there are any legitimate use cases we haven’t thought of.