### PR TITLE
Add reason to provider change

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0552_update_letter_pricing
+0553_add_reason_to_provider

--- a/migrations/versions/0553_add_reason_to_provider.py
+++ b/migrations/versions/0553_add_reason_to_provider.py
@@ -1,0 +1,27 @@
+"""
+Create Date: 2026-06-09 12:50:30.454463
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+from sqlalchemy.dialects import postgresql
+
+revision = '0553_add_reason_to_provider'
+down_revision = '0552_update_letter_pricing'
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(text("SET lock_timeout = '60s'"))
+    conn.execute(text("SET statement_timeout = '60s'"))
+    op.add_column('provider_details', sa.Column('reason', sa.String(), nullable=True))
+    op.add_column('provider_details_history', sa.Column('reason', sa.String(), nullable=True))
+
+
+def downgrade():
+    conn = op.get_bind()
+    conn.execute(text("SET lock_timeout = '60s'"))
+    conn.execute(text("SET statement_timeout = '60s'"))
+    op.drop_column('provider_details', 'reason')
+    op.drop_column('provider_details_history', 'reason')


### PR DESCRIPTION
This will allow us to store a reason for a provider ratio change.

So that we know why something was changed.

Changes the database/model and the rest interface.