### PR TITLE
feat: add migration for updated_by_id (revoker)

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0551_drop_ntfcns_failed_idx
+0552_api_keys_updated_by_id

--- a/migrations/versions/0552_api_keys_updated_by_id.py
+++ b/migrations/versions/0552_api_keys_updated_by_id.py
@@ -1,0 +1,28 @@
+"""
+Revision ID: 0552_api_keys_updated_by_id
+Revises: 0551_drop_ntfcns_failed_idx
+Create Date: 2026-06-22
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0552_api_keys_updated_by_id"
+down_revision = "0551_drop_ntfcns_failed_idx"
+
+
+def upgrade():
+    op.add_column("api_keys", sa.Column("updated_by_id", postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_index(op.f("ix_api_keys_updated_by_id"), "api_keys", ["updated_by_id"], unique=False)
+    op.create_foreign_key("fk_api_keys_updated_by_id", "api_keys", "users", ["updated_by_id"], ["id"])
+
+    op.add_column("api_keys_history", sa.Column("updated_by_id", postgresql.UUID(as_uuid=True), nullable=True))
+
+
+def downgrade():
+    op.drop_column("api_keys_history", "updated_by_id")
+
+    op.drop_constraint("fk_api_keys_updated_by_id", "api_keys", type_="foreignkey")
+    op.drop_index(op.f("ix_api_keys_updated_by_id"), table_name="api_keys")
+    op.drop_column("api_keys", "updated_by_id")


### PR DESCRIPTION
### Summary

- Added `updated_by_id` field on API Keys and API Keys History table
- Added index for API Key table for this field, but not for the History table as that table is only required by `service_id`

Ticket: https://trello.com/c/BwLKBEc4/645-api-key-history-shows-incorrect-data