### PR TITLE
feat: api keys revoker update

### DIFF
--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -17,9 +17,10 @@ def save_model_api_key(api_key):
 
 @autocommit
 @version_class(ApiKey)
-def expire_api_key(service_id, api_key_id):
+def expire_api_key(service_id, api_key_id, updated_by_id=None):
     api_key = ApiKey.query.filter_by(id=api_key_id, service_id=service_id).one()
     api_key.expiry_date = datetime.utcnow()
+    api_key.updated_by_id = updated_by_id
     db.session.add(api_key)
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -939,8 +939,10 @@ class ApiKey(db.Model, Versioned):
     expiry_date = db.Column(db.DateTime)
     created_at = db.Column(db.DateTime, index=False, unique=False, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.datetime.utcnow)
-    created_by = db.relationship("User")
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=False)
+    created_by = db.relationship("User", foreign_keys=[created_by_id])
+    updated_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=True)
+    updated_by = db.relationship("User", foreign_keys=[updated_by_id])
 
     __table_args__ = (
         Index("uix_service_to_key_name", "service_id", "name", unique=True, postgresql_where=expiry_date.is_(None)),

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -701,6 +701,7 @@ class ApiKeyHistorySchema(ma.Schema):
     created_at = FlexibleDateTime()
     updated_at = FlexibleDateTime()
     created_by_id = fields.UUID()
+    updated_by_id = fields.UUID(allow_none=True)
 
 
 class EventSchema(BaseSchema):

--- a/app/service/api_key_schema.py
+++ b/app/service/api_key_schema.py
@@ -1,0 +1,12 @@
+from app.schema_validation.definitions import uuid
+
+post_revoke_api_key_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "POST schema for revoking an API key",
+    "type": "object",
+    "properties": {
+        "created_by": uuid,
+    },
+    "required": [],
+    "additionalProperties": False,
+}

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -156,6 +156,7 @@ from app.schemas import (
     service_schema,
 )
 from app.service import statistics
+from app.service.api_key_schema import post_revoke_api_key_schema
 from app.service.report_request_schema import add_report_request_schema
 from app.service.send_notification import (
     send_one_off_notification,
@@ -353,7 +354,12 @@ def create_api_key(service_id=None):
 
 @service_blueprint.route("/<uuid:service_id>/api-key/revoke/<uuid:api_key_id>", methods=["POST"])
 def revoke_api_key(service_id, api_key_id):
-    expire_api_key(service_id=service_id, api_key_id=api_key_id)
+    data = request.get_json(silent=True) or {}
+    # todo: make created_by required in schema once admin is deployed
+    validate(data, post_revoke_api_key_schema)
+
+    updated_by_id = data.get("created_by", None)
+    expire_api_key(service_id=service_id, api_key_id=api_key_id, updated_by_id=updated_by_id)
     return jsonify(), 202
 
 

--- a/tests/app/dao/test_api_key_dao.py
+++ b/tests/app/dao/test_api_key_dao.py
@@ -13,6 +13,7 @@ from app.dao.api_key_dao import (
     save_model_api_key,
 )
 from app.models import ApiKey
+from tests.app.db import create_user
 
 
 def test_save_api_key_should_create_new_api_key_and_history(sample_service):
@@ -33,13 +34,20 @@ def test_save_api_key_should_create_new_api_key_and_history(sample_service):
 
 
 def test_expire_api_key_should_update_the_api_key_and_create_history_record(notify_api, sample_api_key):
-    expire_api_key(service_id=sample_api_key.service_id, api_key_id=sample_api_key.id)
+    revoker = create_user(email="revoker@digital.cabinet-office.gov.uk")
+
+    expire_api_key(
+        service_id=sample_api_key.service_id,
+        api_key_id=sample_api_key.id,
+        updated_by_id=revoker.id,
+    )
     all_api_keys = get_model_api_keys(service_id=sample_api_key.service_id)
     assert len(all_api_keys) == 1
     assert all_api_keys[0].expiry_date <= datetime.utcnow()
     assert all_api_keys[0].secret == sample_api_key.secret
     assert all_api_keys[0].id == sample_api_key.id
     assert all_api_keys[0].service_id == sample_api_key.service_id
+    assert all_api_keys[0].updated_by_id == revoker.id
 
     all_history = sample_api_key.get_history_model().query.all()
     assert len(all_history) == 2
@@ -48,6 +56,8 @@ def test_expire_api_key_should_update_the_api_key_and_create_history_record(noti
     sorted_all_history = sorted(all_history, key=lambda hist: hist.version)
     sorted_all_history[0].version = 1
     sorted_all_history[1].version = 2
+    assert sorted_all_history[0].updated_by_id is None
+    assert sorted_all_history[1].updated_by_id == revoker.id
 
 
 def test_get_api_key_should_raise_exception_when_api_key_does_not_exist(sample_service, fake_uuid):

--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -62,14 +62,30 @@ def test_revoke_should_expire_api_key_for_service(notify_api, sample_api_key):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             assert ApiKey.query.count() == 1
+            revoker = create_user(email="revoker@digital.cabinet-office.gov.uk")
             auth_header = create_admin_authorization_header()
             response = client.post(
                 url_for("service.revoke_api_key", service_id=sample_api_key.service_id, api_key_id=sample_api_key.id),
-                headers=[auth_header],
+                data=json.dumps({"created_by": str(revoker.id)}),
+                headers=[("Content-Type", "application/json"), auth_header],
             )
             assert response.status_code == 202
             api_keys_for_service = ApiKey.query.get(sample_api_key.id)
             assert api_keys_for_service.expiry_date is not None
+            assert api_keys_for_service.updated_by_id == revoker.id
+
+
+def test_revoke_api_key_without_updated_by_id_still_revokes(client, sample_api_key):
+    auth_header = create_admin_authorization_header()
+    response = client.post(
+        url_for("service.revoke_api_key", service_id=sample_api_key.service_id, api_key_id=sample_api_key.id),
+        data=json.dumps({}),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+    assert response.status_code == 202
+    api_key = ApiKey.query.get(sample_api_key.id)
+    assert api_key.expiry_date is not None
+    assert api_key.updated_by_id is None
 
 
 def test_api_key_should_create_multiple_new_api_key_for_service(notify_api, sample_service):


### PR DESCRIPTION
### Summary
- Added field `created_by` as not required on request body (at the endpoint level, this field was already being propagated from admin)
- Propagate the field until dao to make sure we record details of who updated an api key

Ticket: https://trello.com/c/BwLKBEc4/645-api-key-history-shows-incorrect-data