### PR TITLE
Add service ID to non compatible characters log line

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -62,8 +62,9 @@ def send_sms_to_provider(notification: Notification) -> None:
 
         if non_compatible_characters := SanitiseSMS.get_non_compatible_characters(template.unsanitised_content):
             current_app.logger.warning(
-                "%s character(s) replaced with ? in SMS content for notification %s",
+                "%s character(s) replaced with ? in SMS content for service %s and notification %s",
                 len(non_compatible_characters),
+                service.id,
                 notification.id,
             )
 

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -367,7 +367,10 @@ def test_should_log_sms_sent_with_downgraded_content(mocker, caplog):
     assert (
         "test",
         30,
-        f"3 character(s) replaced with ? in SMS content for notification {db_notification.id}",
+        (
+            f"3 character(s) replaced with ? in SMS content for service {db_notification.service_id} "
+            f"and notification {db_notification.id}"
+        ),
     ) in caplog.record_tuples
 
 


### PR DESCRIPTION
Log lines emitted from Celery workers don’t populate the `service_id` field, that only happens in Flask apps.

As a workaround, we can put the service ID into the message itself. Once downloaded this will allow up to group the log messages by service ID for analysis.