### PR TITLE
celery workers: set default `worker_max_tasks_per_child`

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -286,6 +286,7 @@ class Config:
         },
         "result_expires": 0,
         "timezone": "UTC",
+        "worker_max_tasks_per_child": int(os.getenv("CELERYD_WORKER_MAX_TASKS_PER_CHILD", 20_000)),
         "imports": [
             "app.celery.tasks",
             "app.celery.scheduled_tasks",


### PR DESCRIPTION
This is quite a high default to ensure that all celery workers will restart their child processes *eventually*, mostly targeted at avoiding the effects of creeping memory usage.

I estimate that our busiest celery workers tend to do about 3 tasks/sec/process, so this value should have them restarting every few hours.

Value read from an env var so we can easily vary this by worker if we want to.