### PR TITLE
Enforce NOT NULL constraint on notification_status

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0553_add_reason_to_provider
+0556_add_notify_status_idx

--- a/migrations/versions/0554_add_notif_status_constraint.py
+++ b/migrations/versions/0554_add_notif_status_constraint.py
@@ -1,0 +1,23 @@
+"""
+Create Date: 2026-07-20T00:00:00
+"""
+
+from alembic import op
+
+revision = "0554_add_notif_status_constraint"
+down_revision = "0553_add_reason_to_provider"
+
+
+def upgrade():
+    op.execute(
+        "-- squawk-ignore require-timeout-settings\n"
+        "ALTER TABLE notifications "
+        "ADD CONSTRAINT ck_notifications_notification_status_not_null "
+        "CHECK (notification_status IS NOT NULL) NOT VALID;"
+    )
+
+
+def downgrade():
+    op.execute(
+        "ALTER TABLE notifications DROP CONSTRAINT IF EXISTS ck_notifications_notification_status_not_null;"
+    )

--- a/migrations/versions/0555_add_notify_status_not_null.py
+++ b/migrations/versions/0555_add_notify_status_not_null.py
@@ -1,0 +1,20 @@
+"""
+Create Date: 2026-07-20T00:00:00
+"""
+
+from alembic import op
+
+revision = "0555_add_notify_status_not_null"
+down_revision = "0554_add_notif_status_constraint"
+
+
+def upgrade():
+    op.execute(
+        "ALTER TABLE notifications "
+        "VALIDATE CONSTRAINT ck_notifications_notification_status_not_null;"
+    )
+    op.execute("ALTER TABLE notifications ALTER COLUMN notification_status SET NOT NULL;")
+
+
+def downgrade():
+    op.execute("ALTER TABLE notifications ALTER COLUMN notification_status DROP NOT NULL;")

--- a/migrations/versions/0556_add_notify_status_idx.py
+++ b/migrations/versions/0556_add_notify_status_idx.py
@@ -1,0 +1,24 @@
+"""
+Create Date: 2026-07-20T00:00:00
+"""
+
+from alembic import op
+
+revision = "0556_add_notify_status_idx"
+down_revision = "0555_add_notify_status_not_null"
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_notifications_id_status "
+            "ON notifications (id, notification_status);"
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_notifications_id_status;"
+        )


### PR DESCRIPTION
## What

Enforce NOT NULL constraint on notification_status

## Why

Without NOT NULL - we cannot create an index for notification_status column

Checked DB:

```sql
SELECT count(*)
 FROM notifications where notification_status is NULL;

Result was 0
```

## Context

This is needed as we need to implement the following replica identity:

```sql
ALTER TABLE notifications REPLICA IDENTITY USING INDEX ix_notifications_id_status;
```

Without adding this index we would have to put the replica on the whole table which will keep track of old values of every column which is not needed.
