### PR TITLE
[DO NOT MERGE] Enable replica identity using index on notifications

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0552_update_letter_pricing
+0553_create_replacation_slot

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0553_create_replacation_slot
+0554_notification_id_date_status

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0554_notification_id_date_status
+0555_enable_replica_id_index

--- a/migrations/versions/0553_create_replacation_slot.py
+++ b/migrations/versions/0553_create_replacation_slot.py
@@ -1,0 +1,45 @@
+"""
+Create Date: 2026-07-01T16:39:58
+"""
+
+from alembic import op
+
+revision = "0553_create_replacation_slot"
+down_revision = "0552_update_letter_pricing"
+
+
+def upgrade():
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_replication_slots
+                WHERE slot_name = 'notify_dashboard_replication_slot'
+            ) THEN
+                PERFORM 1
+                FROM pg_create_logical_replication_slot('notify_dashboard_replication_slot', 'wal2json');
+            END IF;
+        END
+        $$;
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM pg_replication_slots
+                WHERE slot_name = 'notify_dashboard_replication_slot'
+            ) THEN
+                PERFORM pg_drop_replication_slot('notify_dashboard_replication_slot');
+            END IF;
+        END
+        $$;
+        """
+    )

--- a/migrations/versions/0554_notification_id_date_status.py
+++ b/migrations/versions/0554_notification_id_date_status.py
@@ -1,0 +1,43 @@
+"""
+Create Date: 2026-07-02T00:00:00
+"""
+
+from alembic import op
+
+revision = "0554_notification_id_date_status"
+down_revision = "0553_create_replacation_slot"
+
+
+def upgrade():
+    op.execute("SET lock_timeout = '1s';")
+    op.execute("SET statement_timeout = '5s';")
+
+    # We need a unique index on (id, notification_status) for REPLICA IDENTITY USING INDEX.
+    # Build a validated check first so PostgreSQL can avoid a table scan when setting NOT NULL.
+    with op.get_context().autocommit_block():
+        op.execute(
+            "ALTER TABLE notifications "
+            "ADD CONSTRAINT ck_notifications_notification_status_not_null "
+            "CHECK (notification_status IS NOT NULL) NOT VALID;"
+        )
+        op.execute(
+            "ALTER TABLE notifications "
+            "VALIDATE CONSTRAINT ck_notifications_notification_status_not_null;"
+        )
+        op.execute("ALTER TABLE notifications ALTER COLUMN notification_status SET NOT NULL;")
+
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_notifications_id_date_status "
+            "ON notifications (id, created_at, notification_status);"
+        )
+
+def downgrade():
+    op.execute("ALTER TABLE notifications ALTER COLUMN notification_status DROP NOT NULL;")
+    op.execute("ALTER TABLE notifications DROP CONSTRAINT IF EXISTS ck_notifications_notification_status_not_null;")
+
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_notifications_id_date_status;"
+        )

--- a/migrations/versions/0555_enable_replica_id_index.py
+++ b/migrations/versions/0555_enable_replica_id_index.py
@@ -1,0 +1,15 @@
+"""
+Create Date: 2026-07-02T00:00:00
+"""
+
+from alembic import op
+
+revision = "0555_enable_replica_id_index"
+down_revision = "0554_notification_id_date_status"
+
+
+def upgrade():
+    op.execute("ALTER TABLE notifications REPLICA IDENTITY USING INDEX ix_notifications_id_date_status;")
+
+def downgrade():
+    op.execute("ALTER TABLE notifications REPLICA IDENTITY DEFAULT;")


### PR DESCRIPTION
## What

Add migration to enable replica identity using index on notifications

## Why

This will allow us to listen to changes made to the date and status