### PR TITLE
`generate_sms_delivery_stats`: record results in new otel metric 

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -90,6 +90,7 @@ from app.models import (
     User,
 )
 from app.notifications.process_notifications import persist_notification, send_notification_to_queue
+from app.otel_metrics.provider import record_sms_legacy_proportion_delivered_within
 from app.utils import get_london_midnight_in_utc
 
 
@@ -256,6 +257,11 @@ def generate_sms_delivery_stats():
         providers_slow_delivery_reports = get_slow_text_message_delivery_reports_by_provider(
             created_within_minutes=15, delivered_within_minutes=delivery_interval
         )
+
+        for report in providers_slow_delivery_reports:
+            record_sms_legacy_proportion_delivered_within(
+                report.slow_ratio, report.provider, delivery_interval * 60, 15 * 60
+            )
 
         # For the 5-minute delivery interval, let's check the percentage of all text messages sent that were slow.
         # TODO: delete this when we have a way to raise these alerts from eg grafana, prometheus, something else.

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -640,16 +640,6 @@ class SlowProviderDeliveryReport:
 def get_slow_text_message_delivery_reports_by_provider(
     created_within_minutes, delivered_within_minutes
 ) -> list[SlowProviderDeliveryReport]:
-    """
-    Returns a dict of providers with the ratio of their messages sent in the
-    last `created_within_minutes` minutes that took over
-    `delivered_within_minutes` minutes to be delivered
-
-    {
-        'mmg': 0.4,
-        'firetext': 0.12
-    }
-    """
     created_since = datetime.utcnow() - timedelta(minutes=created_within_minutes)
     delivery_time = timedelta(minutes=delivered_within_minutes)
     slow_notification_counts = (

--- a/app/otel_metrics/provider.py
+++ b/app/otel_metrics/provider.py
@@ -15,6 +15,16 @@ _request_duration = _meter.create_histogram(
     explicit_bucket_boundaries_advisory=HTTP_DURATION_HISTOGRAM_BUCKETS,
 )
 
+_sms_legacy_proportion_delivered_within = _meter.create_gauge(
+    "provider.sms.legacy.proportion_delivered_within",
+    unit="1",
+    description="Proportion of SMS messages sent in the last time_window.evaluation seconds "
+    "that were delivered within time_window.delivery seconds. BEWARE this is a flawed metric as "
+    "it includes notifications sent too recently to be able to determine this for sensibly, "
+    "however this is the measure currently used by the SMS provider balancer for better or "
+    "worse.",
+)
+
 
 def record_request_duration[**P, T](
     notification_type: str, provider_name: str
@@ -43,3 +53,14 @@ def record_request_duration[**P, T](
         return wrapper
 
     return decorator
+
+
+def record_sms_legacy_proportion_delivered_within(
+    proportion: float, provider_name: str, delivery_window: int, evaluation_window: int
+) -> None:
+    attributes: dict[str, AttributeValue] = {
+        "provider.name": provider_name,
+        "time_window.evaluation": evaluation_window,
+        "time_window.delivery": delivery_window,
+    }
+    _sms_legacy_proportion_delivered_within.set(proportion, attributes)

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -67,6 +67,7 @@ from app.dao.notifications_dao import SlowProviderDeliveryReport
 from app.dao.provider_details_dao import get_provider_details_by_identifier
 from app.dao.template_email_files_dao import dao_get_template_email_file_by_id
 from app.models import Event, InboundNumber, Notification
+from app.otel_metrics.provider import _sms_legacy_proportion_delivered_within
 from tests.app import load_example_csv
 from tests.app.db import (
     create_email_branding,
@@ -232,6 +233,7 @@ def test_generate_sms_delivery_stats(slow_delivery_config_option, expect_check_s
         SlowProviderDeliveryReport(provider="mmg", slow_ratio=0.4, slow_notifications=40, total_notifications=100),
         SlowProviderDeliveryReport(provider="firetext", slow_ratio=0.8, slow_notifications=80, total_notifications=100),
     ]
+    set_sms_proportion_delivered_within_mock = mocker.patch.object(_sms_legacy_proportion_delivered_within, "set")
     mocker.patch(
         "app.celery.scheduled_tasks.get_slow_text_message_delivery_reports_by_provider",
         return_value=slow_delivery_reports,
@@ -246,6 +248,15 @@ def test_generate_sms_delivery_stats(slow_delivery_config_option, expect_check_s
     assert mock_check_slow_delivery.call_args_list == (
         [mocker.call(slow_delivery_reports)] if expect_check_slow_delivery else []
     )
+
+    assert set_sms_proportion_delivered_within_mock.mock_calls == [
+        mocker.call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 60}),
+        mocker.call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 60}),
+        mocker.call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 300}),
+        mocker.call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 300}),
+        mocker.call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 600}),
+        mocker.call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 600}),
+    ]
 
 
 @pytest.mark.parametrize("consecutive_failures,should_log", ((1, False), (9, False), (10, True)))


### PR DESCRIPTION
As reflected in the metric's `description`, this is an imperfect measure but it most closely reflects the current sms balancer algorithm's view of the world.

This replaces a similar metric that was recorded here but got removed with all rest of the statsd stuff.

Because we don't know which instance this celery job is going to run on, this metric will need some promql magic to make it appear as a single continuous metric.

Depends on https://github.com/alphagov/notifications-aws/pull/3042 to work properly.