### PR TITLE
fix: record API key revoker via created_by_id on revoke

### DIFF
--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -17,9 +17,11 @@ def save_model_api_key(api_key):
 
 @autocommit
 @version_class(ApiKey)
-def expire_api_key(service_id, api_key_id):
+def expire_api_key(service_id, api_key_id, created_by_id=None):
     api_key = ApiKey.query.filter_by(id=api_key_id, service_id=service_id).one()
     api_key.expiry_date = datetime.utcnow()
+    if created_by_id is not None:
+        api_key.created_by_id = created_by_id
     db.session.add(api_key)
 
 

--- a/app/service/api_key_schema.py
+++ b/app/service/api_key_schema.py
@@ -1,0 +1,12 @@
+from app.schema_validation.definitions import uuid
+
+post_revoke_api_key_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "POST schema for revoking an API key",
+    "type": "object",
+    "properties": {
+        "created_by": uuid,
+    },
+    "required": [],
+    "additionalProperties": False,
+}

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -156,6 +156,7 @@ from app.schemas import (
     service_schema,
 )
 from app.service import statistics
+from app.service.api_key_schema import post_revoke_api_key_schema
 from app.service.report_request_schema import add_report_request_schema
 from app.service.send_notification import (
     send_one_off_notification,
@@ -353,7 +354,9 @@ def create_api_key(service_id=None):
 
 @service_blueprint.route("/<uuid:service_id>/api-key/revoke/<uuid:api_key_id>", methods=["POST"])
 def revoke_api_key(service_id, api_key_id):
-    expire_api_key(service_id=service_id, api_key_id=api_key_id)
+    data = request.get_json(silent=True) or {}
+    validate(data, post_revoke_api_key_schema)
+    expire_api_key(service_id=service_id, api_key_id=api_key_id, created_by_id=data.get("created_by"))
     return jsonify(), 202
 
 

--- a/tests/app/dao/test_api_key_dao.py
+++ b/tests/app/dao/test_api_key_dao.py
@@ -13,6 +13,7 @@ from app.dao.api_key_dao import (
     save_model_api_key,
 )
 from app.models import ApiKey
+from tests.app.db import create_user
 
 
 def test_save_api_key_should_create_new_api_key_and_history(sample_service):
@@ -48,6 +49,24 @@ def test_expire_api_key_should_update_the_api_key_and_create_history_record(noti
     sorted_all_history = sorted(all_history, key=lambda hist: hist.version)
     sorted_all_history[0].version = 1
     sorted_all_history[1].version = 2
+
+
+def test_expire_api_key_records_revoker_in_created_by_id(sample_api_key):
+    revoker = create_user(email="revoker@digital.cabinet-office.gov.uk")
+    original_creator_id = sample_api_key.created_by_id
+
+    expire_api_key(
+        service_id=sample_api_key.service_id,
+        api_key_id=sample_api_key.id,
+        created_by_id=revoker.id,
+    )
+
+    all_history = sorted(sample_api_key.get_history_model().query.all(), key=lambda hist: hist.version)
+    assert all_history[0].created_by_id == original_creator_id
+    assert all_history[1].created_by_id == revoker.id
+
+    api_key = ApiKey.query.get(sample_api_key.id)
+    assert api_key.created_by_id == revoker.id
 
 
 def test_get_api_key_should_raise_exception_when_api_key_does_not_exist(sample_service, fake_uuid):

--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -62,14 +62,31 @@ def test_revoke_should_expire_api_key_for_service(notify_api, sample_api_key):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             assert ApiKey.query.count() == 1
+            revoker = create_user(email="revoker@digital.cabinet-office.gov.uk")
             auth_header = create_admin_authorization_header()
             response = client.post(
                 url_for("service.revoke_api_key", service_id=sample_api_key.service_id, api_key_id=sample_api_key.id),
-                headers=[auth_header],
+                data=json.dumps({"created_by": str(revoker.id)}),
+                headers=[("Content-Type", "application/json"), auth_header],
             )
             assert response.status_code == 202
             api_keys_for_service = ApiKey.query.get(sample_api_key.id)
             assert api_keys_for_service.expiry_date is not None
+            assert api_keys_for_service.created_by_id == revoker.id
+
+
+def test_revoke_api_key_without_created_by_still_revokes(client, sample_api_key):
+    original_creator_id = sample_api_key.created_by_id
+    auth_header = create_admin_authorization_header()
+    response = client.post(
+        url_for("service.revoke_api_key", service_id=sample_api_key.service_id, api_key_id=sample_api_key.id),
+        data=json.dumps({}),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+    assert response.status_code == 202
+    api_key = ApiKey.query.get(sample_api_key.id)
+    assert api_key.expiry_date is not None
+    assert api_key.created_by_id == original_creator_id
 
 
 def test_api_key_should_create_multiple_new_api_key_for_service(notify_api, sample_service):


### PR DESCRIPTION
### Summary

**Changes on this PR**
We never recorded who revoked a key, so in this PR we're just propagating that information to the database. We are doing this by following the existing pattern of  storing that information on `created_by_id` field.

**Note:** older historical revoke events will show the wrong user (the key creator), because we did not store the revoker separately in the past. This change fixes that for new revokes going forward, but it cannot retroactively fix old row.
The same will happen for `handle archive_service()` -> this is a platform admin functionality, so there is no user name being passed on as part of this flow.

A bit of context on how the tables for `api_keys` and `api_keys_history` work:

We store API keys in two places:
- api_keys = the current/latest state of each key (one row per key)
- api_keys_history = a snapshot history of changes (new row each time the key changes)

**So when a key is revoked:**
- the row in api_keys is updated to show it is now revoked
- a new row is added to api_keys_history to record that revoked version

On admin, audit events are built from the API’s history data (api_key_history), not from the live api_keys row.
So if you want to know what happened over time, look at history; if you want the current state now, look at api_keys.

https://trello.com/c/BwLKBEc4/645-api-key-history-shows-incorrect-data


