### PR TITLE
`generate_sms_delivery_stats`: rename just-introduced-but-incorrectly-named metric

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -90,7 +90,7 @@ from app.models import (
     User,
 )
 from app.notifications.process_notifications import persist_notification, send_notification_to_queue
-from app.otel_metrics.provider import record_sms_legacy_proportion_delivered_within
+from app.otel_metrics.provider import record_sms_legacy_not_delivered_within
 from app.utils import get_london_midnight_in_utc
 
 
@@ -259,9 +259,7 @@ def generate_sms_delivery_stats():
         )
 
         for report in providers_slow_delivery_reports:
-            record_sms_legacy_proportion_delivered_within(
-                report.slow_ratio, report.provider, delivery_interval * 60, 15 * 60
-            )
+            record_sms_legacy_not_delivered_within(report.slow_ratio, report.provider, delivery_interval * 60, 15 * 60)
 
         # For the 5-minute delivery interval, let's check the percentage of all text messages sent that were slow.
         # TODO: delete this when we have a way to raise these alerts from eg grafana, prometheus, something else.

--- a/app/otel_metrics/provider.py
+++ b/app/otel_metrics/provider.py
@@ -15,12 +15,12 @@ _request_duration = _meter.create_histogram(
     explicit_bucket_boundaries_advisory=HTTP_DURATION_HISTOGRAM_BUCKETS,
 )
 
-_sms_legacy_proportion_delivered_within = _meter.create_gauge(
-    "provider.sms.legacy.proportion_delivered_within",
+_sms_legacy_not_delivered_within = _meter.create_gauge(
+    "provider.sms.legacy.not_delivered_within",
     unit="1",
     description="Proportion of SMS messages sent in the last time_window.evaluation seconds "
-    "that were delivered within time_window.delivery seconds. BEWARE this is a flawed metric as "
-    "it includes notifications sent too recently to be able to determine this for sensibly, "
+    "that were not delivered within time_window.delivery seconds. BEWARE this is a flawed metric "
+    "as it includes notifications sent too recently to be able to determine this for sensibly, "
     "however this is the measure currently used by the SMS provider balancer for better or "
     "worse.",
 )
@@ -55,12 +55,12 @@ def record_request_duration[**P, T](
     return decorator
 
 
-def record_sms_legacy_proportion_delivered_within(
-    proportion: float, provider_name: str, delivery_window: int, evaluation_window: int
+def record_sms_legacy_not_delivered_within(
+    ratio: float, provider_name: str, delivery_window: int, evaluation_window: int
 ) -> None:
     attributes: dict[str, AttributeValue] = {
         "provider.name": provider_name,
         "time_window.evaluation": evaluation_window,
         "time_window.delivery": delivery_window,
     }
-    _sms_legacy_proportion_delivered_within.set(proportion, attributes)
+    _sms_legacy_not_delivered_within.set(ratio, attributes)

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -67,7 +67,7 @@ from app.dao.notifications_dao import SlowProviderDeliveryReport
 from app.dao.provider_details_dao import get_provider_details_by_identifier
 from app.dao.template_email_files_dao import dao_get_template_email_file_by_id
 from app.models import Event, InboundNumber, Notification
-from app.otel_metrics.provider import _sms_legacy_proportion_delivered_within
+from app.otel_metrics.provider import _sms_legacy_not_delivered_within
 from tests.app import load_example_csv
 from tests.app.db import (
     create_email_branding,
@@ -233,7 +233,7 @@ def test_generate_sms_delivery_stats(slow_delivery_config_option, expect_check_s
         SlowProviderDeliveryReport(provider="mmg", slow_ratio=0.4, slow_notifications=40, total_notifications=100),
         SlowProviderDeliveryReport(provider="firetext", slow_ratio=0.8, slow_notifications=80, total_notifications=100),
     ]
-    set_sms_proportion_delivered_within_mock = mocker.patch.object(_sms_legacy_proportion_delivered_within, "set")
+    set_sms_not_delivered_within_mock = mocker.patch.object(_sms_legacy_not_delivered_within, "set")
     mocker.patch(
         "app.celery.scheduled_tasks.get_slow_text_message_delivery_reports_by_provider",
         return_value=slow_delivery_reports,
@@ -249,7 +249,7 @@ def test_generate_sms_delivery_stats(slow_delivery_config_option, expect_check_s
         [mocker.call(slow_delivery_reports)] if expect_check_slow_delivery else []
     )
 
-    assert set_sms_proportion_delivered_within_mock.mock_calls == [
+    assert set_sms_not_delivered_within_mock.mock_calls == [
         mocker.call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 60}),
         mocker.call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 60}),
         mocker.call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 300}),


### PR DESCRIPTION
This is of course the proportion of notifications *not* delivered within a time window.

Also remove the word "proportion" because stating the units as `1` makes otel/prometheus append `_ratio` onto the metric name anyway, so the tautology is confusing. I don't love the use of the word "ratio" to describe something that's actually a fraction, but this seems to be the word picked by the metrics community.