### PR TITLE
Update nightly pending-virus-check task to alert on letters which didn't get scanned after the max no. of retries

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -85,6 +85,7 @@ from app.models import (
     EmailBranding,
     Event,
     Job,
+    Notification,
     Organisation,
     Service,
     User,
@@ -355,30 +356,79 @@ def replay_created_notifications() -> None:
 
 
 @notify_celery.task(name="check-if-letters-still-pending-virus-check")
-def check_if_letters_still_pending_virus_check(max_minutes_ago_to_check: int = 30):
+def check_if_letters_still_pending_virus_check(max_minutes_ago_to_check: int = 30) -> None:
     # this task runs every ten minutes, so allowing a couple of runs
     # if this task doesn't run for some reason, we may need to manually trigger it with a longer max_minutes_ago value
     letters_missing_from_scan_bucket = _attempt_to_rescan_letters_pending_virus_check(max_minutes_ago_to_check)
 
     if letters_missing_from_scan_bucket:
-        letter_ids = [(str(letter.id), letter.reference) for letter in letters_missing_from_scan_bucket]
-
-        msg = f"""{len(letters_missing_from_scan_bucket)} precompiled letters have been pending-virus-check for over
-            10 minutes
-            We couldn't find them in the scan bucket. We'll need to find out where the files are and kick them off
-            again or move them to technical failure.
-
-            Notifications: {sorted(letter_ids)}"""
-
         if current_app.should_send_zendesk_alerts:  # type: ignore[attr-defined]
             ticket = NotifySupportTicket(
                 subject=f"[{current_app.config['NOTIFY_ENVIRONMENT']}] Letters still pending virus check",
-                message=msg,
+                message=_message_about_letters_pending_virus_check(
+                    letters_to_alert_on_but_not_retry=[],
+                    letters_missing_from_scan_bucket=letters_missing_from_scan_bucket,
+                ),
                 ticket_type=NotifySupportTicket.TYPE_TASK,
                 notify_ticket_type=NotifyTicketType.TECHNICAL,
                 notify_task_type="notify_task_letters_pending_scan",
             )
             zendesk_client.send_ticket_to_zendesk(ticket)  # type: ignore[attr-defined]
+
+
+@notify_celery.task(name="check-if-letters-still-pending-virus-check-nightly")
+def check_if_letters_still_pending_virus_check_nightly(
+    max_minutes_ago_to_check_only: int = 7200,
+    max_minutes_ago_to_check_and_rescan: int = 4320,
+) -> None:
+    """
+    This looks for letters pending-virus-check between two time periods.
+    For the older time period, we don't attempt to rescan any letters found, we create a Zendesk ticket about them.
+
+    For the more recent time period, we do the same as the `check-if-letters-still-pending-virus-check` task -
+    attempt to reprocess the letters, but create a Zendesk ticket if the letters couldn't be found.
+
+    This task aims to catch any letters that are still pending-virus-check and have slipped through the net
+    """
+    if max_minutes_ago_to_check_only <= max_minutes_ago_to_check_and_rescan:
+        raise ValueError("max_minutes_ago_to_check_only must be greater than max_minutes_ago_to_check_and_rescan")
+
+    # Check for letters over 3 days old that we won't attempt to rescan or find
+    letters_to_alert_on_but_not_retry = []
+    for letter in dao_precompiled_letters_still_pending_virus_check(
+        max_minutes_ago_to_check=max_minutes_ago_to_check_only,
+        min_minutes_ago_to_check=max_minutes_ago_to_check_and_rescan,
+    ):
+        letters_to_alert_on_but_not_retry.append(letter)
+        current_app.logger.warning(
+            "Letter notification %s is stuck in pending-virus-check and has reached the maximum number of retries.",
+            letter.id,
+            extra={"notification_id": letter.id},
+        )
+
+    # Attempt to reprocess letters less than 3 days old that are still pending-virus-check
+    letters_missing_from_scan_bucket = _attempt_to_rescan_letters_pending_virus_check(
+        max_minutes_ago_to_check=max_minutes_ago_to_check_and_rescan
+    )
+
+    # Create a Zendesk ticket about letters pending-virus-check if necessary
+    has_letters_to_alert_on = letters_to_alert_on_but_not_retry or letters_missing_from_scan_bucket
+    if not has_letters_to_alert_on or not current_app.should_send_zendesk_alerts:  # type: ignore[attr-defined]
+        return
+
+    zendesk_ticket_message = _message_about_letters_pending_virus_check(
+        letters_to_alert_on_but_not_retry=letters_to_alert_on_but_not_retry,
+        letters_missing_from_scan_bucket=letters_missing_from_scan_bucket,
+    )
+
+    ticket = NotifySupportTicket(
+        subject=f"[{current_app.config['NOTIFY_ENVIRONMENT']}] Letters still pending virus check",
+        message=zendesk_ticket_message,
+        ticket_type=NotifySupportTicket.TYPE_TASK,
+        notify_ticket_type=NotifyTicketType.TECHNICAL,
+        notify_task_type="notify_task_letters_pending_scan",
+    )
+    zendesk_client.send_ticket_to_zendesk(ticket)  # type: ignore[attr-defined]
 
 
 def _attempt_to_rescan_letters_pending_virus_check(max_minutes_ago_to_check):
@@ -410,6 +460,38 @@ def _attempt_to_rescan_letters_pending_virus_check(max_minutes_ago_to_check):
             letters_not_in_scan_bucket.append(letter)
 
     return letters_not_in_scan_bucket
+
+
+def _message_about_letters_pending_virus_check(
+    letters_to_alert_on_but_not_retry: list[Notification],
+    letters_missing_from_scan_bucket: list[Notification],
+) -> str:
+    msg = ""
+
+    if letters_to_alert_on_but_not_retry:
+        letter_ids = [(str(letter.id), letter.reference) for letter in letters_to_alert_on_but_not_retry]
+
+        msg += f"""
+                {len(letters_to_alert_on_but_not_retry)} precompiled letters have been pending-virus-check for
+                over 3 days and have reached the maximum number of retries for letters in this state. We will need
+                to decide whether to manually retry the letters again, or to change their status to permanent-failure
+
+                Notifications: {sorted(letter_ids)}\n\n\n
+            """
+
+    if letters_missing_from_scan_bucket:
+        letter_ids = [(str(letter.id), letter.reference) for letter in letters_missing_from_scan_bucket]
+
+        msg += f"""
+            {len(letters_missing_from_scan_bucket)} precompiled letters have been pending-virus-check for over
+            10 minutes. We couldn't find them in the scan bucket. We'll need to find out if the files were slow to
+            process and are now in the expected state. If not we'll need to find out where the files are and kick
+            them off again or move them to technical failure.
+
+            Notifications: {sorted(letter_ids)}
+        """
+
+    return msg
 
 
 @notify_celery.task(name="check-if-letters-still-in-created")

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -358,7 +358,31 @@ def replay_created_notifications() -> None:
 def check_if_letters_still_pending_virus_check(max_minutes_ago_to_check: int = 30):
     # this task runs every ten minutes, so allowing a couple of runs
     # if this task doesn't run for some reason, we may need to manually trigger it with a longer max_minutes_ago value
-    letters = []
+    letters_missing_from_scan_bucket = _attempt_to_rescan_letters_pending_virus_check(max_minutes_ago_to_check)
+
+    if letters_missing_from_scan_bucket:
+        letter_ids = [(str(letter.id), letter.reference) for letter in letters_missing_from_scan_bucket]
+
+        msg = f"""{len(letters_missing_from_scan_bucket)} precompiled letters have been pending-virus-check for over
+            10 minutes
+            We couldn't find them in the scan bucket. We'll need to find out where the files are and kick them off
+            again or move them to technical failure.
+
+            Notifications: {sorted(letter_ids)}"""
+
+        if current_app.should_send_zendesk_alerts:  # type: ignore[attr-defined]
+            ticket = NotifySupportTicket(
+                subject=f"[{current_app.config['NOTIFY_ENVIRONMENT']}] Letters still pending virus check",
+                message=msg,
+                ticket_type=NotifySupportTicket.TYPE_TASK,
+                notify_ticket_type=NotifyTicketType.TECHNICAL,
+                notify_task_type="notify_task_letters_pending_scan",
+            )
+            zendesk_client.send_ticket_to_zendesk(ticket)  # type: ignore[attr-defined]
+
+
+def _attempt_to_rescan_letters_pending_virus_check(max_minutes_ago_to_check):
+    letters_not_in_scan_bucket = []
     for letter in dao_precompiled_letters_still_pending_virus_check(max_minutes_ago_to_check):
         # find letter in the scan bucket
         filename = generate_letter_pdf_filename(
@@ -383,26 +407,9 @@ def check_if_letters_still_pending_virus_check(max_minutes_ago_to_check: int = 3
                 letter.id,
                 extra={"notification_id": letter.id},
             )
-            letters.append(letter)
+            letters_not_in_scan_bucket.append(letter)
 
-    if len(letters) > 0:
-        letter_ids = [(str(letter.id), letter.reference) for letter in letters]
-
-        msg = f"""{len(letters)} precompiled letters have been pending-virus-check for over 10 minutes
-            We couldn't find them in the scan bucket. We'll need to find out where the files are and kick them off
-            again or move them to technical failure.
-
-            Notifications: {sorted(letter_ids)}"""
-
-        if current_app.should_send_zendesk_alerts:  # type: ignore[attr-defined]
-            ticket = NotifySupportTicket(
-                subject=f"[{current_app.config['NOTIFY_ENVIRONMENT']}] Letters still pending virus check",
-                message=msg,
-                ticket_type=NotifySupportTicket.TYPE_TASK,
-                notify_ticket_type=NotifyTicketType.TECHNICAL,
-                notify_task_type="notify_task_letters_pending_scan",
-            )
-            zendesk_client.send_ticket_to_zendesk(ticket)  # type: ignore[attr-defined]
+    return letters_not_in_scan_bucket
 
 
 @notify_celery.task(name="check-if-letters-still-in-created")

--- a/app/config.py
+++ b/app/config.py
@@ -437,10 +437,14 @@ class Config:
                 "options": {"queue": QueueNames.PERIODIC},
             },
             "check-if-letters-still-pending-virus-check-nightly": {
-                "task": "check-if-letters-still-pending-virus-check",
+                "task": "check-if-letters-still-pending-virus-check-nightly",
                 "schedule": crontab(hour=20, minute=0),
-                # check back three entire days, once per day, just in case things slipped through the net somehow
-                "kwargs": {"max_minutes_ago_to_check": 60 * 24 * 3},
+                # check back 5 entire days, attempting to rescan the last 3 days, once per day,
+                # just in case things slipped through the net somehow
+                "kwargs": {
+                    "max_minutes_ago_to_check_only": 60 * 24 * 5,
+                    "max_minutes_ago_to_check_and_rescan": 60 * 24 * 3,
+                },
                 "options": {"queue": QueueNames.PERIODIC},
             },
             "check-for-services-with-high-failure-rates-or-sending-to-tv-numbers": {

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -1000,14 +1000,17 @@ def letters_missing_from_sending_bucket(
     return notifications
 
 
-def dao_precompiled_letters_still_pending_virus_check(max_minutes_ago_to_check):
+def dao_precompiled_letters_still_pending_virus_check(
+    max_minutes_ago_to_check: int,
+    min_minutes_ago_to_check: int = 10,
+):
     earliest_timestamp_to_check = datetime.utcnow() - timedelta(minutes=max_minutes_ago_to_check)
-    ten_minutes_ago = datetime.utcnow() - timedelta(minutes=10)
+    latest_timestamp_to_check = datetime.utcnow() - timedelta(minutes=min_minutes_ago_to_check)
 
     notifications = (
         Notification.query.filter(
-            Notification.created_at > earliest_timestamp_to_check,
-            Notification.created_at < ten_minutes_ago,
+            Notification.created_at >= earliest_timestamp_to_check,
+            Notification.created_at < latest_timestamp_to_check,
             Notification.status == NOTIFICATION_PENDING_VIRUS_CHECK,
             Notification.notification_type == LETTER_TYPE,
         )

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -31,6 +31,7 @@ from app.celery.scheduled_tasks import (
     check_if_letters_in_technical_failure,
     check_if_letters_still_in_created,
     check_if_letters_still_pending_virus_check,
+    check_if_letters_still_pending_virus_check_nightly,
     check_job_status,
     delete_invitations,
     delete_old_records_from_events_table,
@@ -633,9 +634,12 @@ def test_check_if_letters_still_pending_virus_check_raises_zendesk_if_files_cant
         notify_ticket_type=NotifyTicketType.TECHNICAL,
         notify_task_type="notify_task_letters_pending_scan",
     )
-    assert "2 precompiled letters have been pending-virus-check" in mock_create_ticket.call_args.kwargs["message"]
-    assert f"{(str(notification_1.id), notification_1.reference)}" in mock_create_ticket.call_args.kwargs["message"]
-    assert f"{(str(notification_2.id), notification_2.reference)}" in mock_create_ticket.call_args.kwargs["message"]
+    ticket_message = mock_create_ticket.call_args.kwargs["message"]
+    assert "2 precompiled letters have been pending-virus-check" in ticket_message
+    assert f"{(str(notification_1.id), notification_1.reference)}" in ticket_message
+    assert f"{(str(notification_2.id), notification_2.reference)}" in ticket_message
+    assert "have reached the maximum number of retries" not in ticket_message
+    assert "We couldn't find them in the scan bucket" in ticket_message
     mock_send_ticket_to_zendesk.assert_called_once()
 
 
@@ -690,9 +694,230 @@ def test_check_if_letters_still_pending_virus_check_with_letters_both_missing_fr
         notify_ticket_type=NotifyTicketType.TECHNICAL,
         notify_task_type="notify_task_letters_pending_scan",
     )
-    assert "1 precompiled letters have been pending-virus-check" in mock_create_ticket.call_args.kwargs["message"]
-    assert f"{(str(notification_1.id), notification_1.reference)}" not in mock_create_ticket.call_args.kwargs["message"]
-    assert f"{(str(notification_2.id), notification_2.reference)}" in mock_create_ticket.call_args.kwargs["message"]
+    ticket_message = mock_create_ticket.call_args.kwargs["message"]
+    assert "1 precompiled letters have been pending-virus-check" in ticket_message
+    assert f"{(str(notification_1.id), notification_1.reference)}" not in ticket_message
+    assert f"{(str(notification_2.id), notification_2.reference)}" in ticket_message
+    assert "have reached the maximum number of retries" not in ticket_message
+    assert "We couldn't find them in the scan bucket" in ticket_message
+
+    mock_send_ticket_to_zendesk.assert_called_once()
+
+
+def test_check_if_letters_still_pending_virus_check_nightly_raises_error_if_args_in_wrong_order():
+    with pytest.raises(ValueError):
+        check_if_letters_still_pending_virus_check_nightly(
+            max_minutes_ago_to_check_only=500,
+            max_minutes_ago_to_check_and_rescan=1000,
+        )
+
+
+@freeze_time("2026-05-30 14:00:00")
+def test_check_if_letters_still_pending_virus_check_nightly_when_all_letters_can_be_processed(
+    sample_letter_template,
+    mocker,
+):
+    mock_file_exists = mocker.patch("app.aws.s3.file_exists", return_value=True)
+    mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
+    mock_celery = mocker.patch("app.celery.scheduled_tasks.notify_celery.send_task")
+
+    create_notification(
+        template=sample_letter_template,
+        status=NOTIFICATION_PENDING_VIRUS_CHECK,
+        created_at=datetime.utcnow() - timedelta(minutes=10, seconds=1),
+        reference="one",
+    )
+    create_notification(
+        template=sample_letter_template,
+        status=NOTIFICATION_PENDING_VIRUS_CHECK,
+        created_at=datetime.utcnow() - timedelta(minutes=9, seconds=59),
+        reference="still has time to send",
+    )
+    expected_filename = "NOTIFY.ONE.D.2.C.20260530134959.PDF"
+
+    check_if_letters_still_pending_virus_check_nightly()
+
+    mock_file_exists.assert_called_once_with("test-letters-scan", expected_filename)
+
+    mock_celery.assert_called_once_with(
+        name=TaskNames.SCAN_FILE,
+        kwargs={"filename": expected_filename},
+        queue=QueueNames.ANTIVIRUS,
+        MessageGroupId=str(sample_letter_template.service_id),
+    )
+    assert mock_create_ticket.called is False
+
+
+@freeze_time("2026-05-30 14:00:00")
+def test_check_if_letters_still_pending_virus_check_nightly_alerts_on_old_letters_that_wont_be_retried(
+    sample_letter_template,
+    mocker,
+):
+    mock_file_exists = mocker.patch("app.aws.s3.file_exists", return_value=False)
+    mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
+    mock_celery = mocker.patch("app.celery.scheduled_tasks.notify_celery.send_task")
+    mock_send_ticket_to_zendesk = mocker.patch(
+        "app.celery.scheduled_tasks.zendesk_client.send_ticket_to_zendesk",
+        autospec=True,
+    )
+
+    create_notification(
+        template=sample_letter_template,
+        status=NOTIFICATION_DELIVERED,
+        created_at=datetime.utcnow() - timedelta(days=4),
+        reference="ignore as status in delivered",
+    )
+    notification_1 = create_notification(
+        template=sample_letter_template,
+        status=NOTIFICATION_PENDING_VIRUS_CHECK,
+        created_at=datetime.utcnow() - timedelta(days=3, seconds=1),
+        reference="one",
+    )
+    notification_2 = create_notification(
+        template=sample_letter_template,
+        status=NOTIFICATION_PENDING_VIRUS_CHECK,
+        created_at=datetime.utcnow() - timedelta(days=5),
+        reference="two",
+    )
+
+    check_if_letters_still_pending_virus_check_nightly()
+
+    assert not mock_file_exists.called
+    assert not mock_celery.called
+
+    mock_create_ticket.assert_called_once_with(
+        ANY,
+        subject="[test] Letters still pending virus check",
+        message=ANY,
+        ticket_type="task",
+        notify_ticket_type=NotifyTicketType.TECHNICAL,
+        notify_task_type="notify_task_letters_pending_scan",
+    )
+    ticket_message = mock_create_ticket.call_args.kwargs["message"]
+    assert "2 precompiled letters have been pending-virus-check" in ticket_message
+    assert f"{(str(notification_1.id), notification_1.reference)}" in ticket_message
+    assert f"{(str(notification_2.id), notification_2.reference)}" in ticket_message
+    assert "have reached the maximum number of retries" in ticket_message
+    assert "We couldn't find them in the scan bucket" not in ticket_message
+    mock_send_ticket_to_zendesk.assert_called_once()
+
+
+@freeze_time("2026-05-30 14:00:00")
+def test_check_if_letters_still_pending_virus_check_nightly_warns_about_letters_not_in_scan_bucket(
+    sample_letter_template,
+    mocker,
+):
+    mock_file_exists = mocker.patch("app.aws.s3.file_exists", side_effect=[False, True])
+    mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
+    mock_celery = mocker.patch("app.celery.scheduled_tasks.notify_celery.send_task")
+    mock_send_ticket_to_zendesk = mocker.patch(
+        "app.celery.scheduled_tasks.zendesk_client.send_ticket_to_zendesk",
+        autospec=True,
+    )
+    notification_1 = create_notification(
+        template=sample_letter_template,
+        status=NOTIFICATION_PENDING_VIRUS_CHECK,
+        created_at=datetime.utcnow() - timedelta(seconds=601),
+        reference="one",
+    )
+    # notification_2 is returned first from dao function, so is the file not found
+    notification_2 = create_notification(
+        template=sample_letter_template,
+        status=NOTIFICATION_PENDING_VIRUS_CHECK,
+        created_at=datetime.utcnow() - timedelta(seconds=1000),
+        reference="two",
+    )
+
+    check_if_letters_still_pending_virus_check_nightly()
+
+    assert mock_file_exists.call_count == 2
+    mock_file_exists.assert_has_calls(
+        [
+            call("test-letters-scan", "NOTIFY.ONE.D.2.C.20260530134959.PDF"),
+            call("test-letters-scan", "NOTIFY.TWO.D.2.C.20260530134320.PDF"),
+        ],
+        any_order=True,
+    )
+
+    mock_celery.assert_called_once_with(
+        name=TaskNames.SCAN_FILE,
+        kwargs={"filename": "NOTIFY.ONE.D.2.C.20260530134959.PDF"},
+        queue=QueueNames.ANTIVIRUS,
+        MessageGroupId=str(sample_letter_template.service_id),
+    )
+
+    mock_create_ticket.assert_called_once_with(
+        ANY,
+        subject="[test] Letters still pending virus check",
+        message=ANY,
+        ticket_type="task",
+        notify_ticket_type=NotifyTicketType.TECHNICAL,
+        notify_task_type="notify_task_letters_pending_scan",
+    )
+    ticket_message = mock_create_ticket.call_args.kwargs["message"]
+    assert "1 precompiled letters have been pending-virus-check" in ticket_message
+    assert f"{(str(notification_1.id), notification_1.reference)}" not in ticket_message
+    assert f"{(str(notification_2.id), notification_2.reference)}" in ticket_message
+    assert "have reached the maximum number of retries" not in ticket_message
+    assert "We couldn't find them in the scan bucket" in ticket_message
+
+    mock_send_ticket_to_zendesk.assert_called_once()
+
+
+@freeze_time("2026-05-30 14:00:00")
+def test_check_if_letters_still_pending_virus_check_nightly_with_both_types_of_zendesk_warning(
+    sample_letter_template,
+    mocker,
+):
+    mock_file_exists = mocker.patch("app.aws.s3.file_exists", return_value=False)
+    mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
+    mock_celery = mocker.patch("app.celery.scheduled_tasks.notify_celery.send_task")
+    mock_send_ticket_to_zendesk = mocker.patch(
+        "app.celery.scheduled_tasks.zendesk_client.send_ticket_to_zendesk",
+        autospec=True,
+    )
+    # notification_1 is too old to be rescanned
+    notification_1 = create_notification(
+        template=sample_letter_template,
+        status=NOTIFICATION_PENDING_VIRUS_CHECK,
+        created_at=datetime.utcnow() - timedelta(days=4),
+        reference="one",
+    )
+    # notification_2 cannot be found in the scan bucket
+    notification_2 = create_notification(
+        template=sample_letter_template,
+        status=NOTIFICATION_PENDING_VIRUS_CHECK,
+        created_at=datetime.utcnow() - timedelta(seconds=1000),
+        reference="two",
+    )
+
+    check_if_letters_still_pending_virus_check_nightly()
+
+    assert mock_file_exists.call_count == 1
+    mock_file_exists.assert_has_calls(
+        [
+            call("test-letters-scan", "NOTIFY.TWO.D.2.C.20260530134320.PDF"),
+        ],
+    )
+
+    assert mock_celery.called is False
+
+    mock_create_ticket.assert_called_once_with(
+        ANY,
+        subject="[test] Letters still pending virus check",
+        message=ANY,
+        ticket_type="task",
+        notify_ticket_type=NotifyTicketType.TECHNICAL,
+        notify_task_type="notify_task_letters_pending_scan",
+    )
+    normalized_ticket_message = " ".join(mock_create_ticket.call_args.kwargs["message"].split())
+    assert "1 precompiled letters have been pending-virus-check for over 10 minutes" in normalized_ticket_message
+    assert "1 precompiled letters have been pending-virus-check for over 3 days" in normalized_ticket_message
+    assert f"{(str(notification_1.id), notification_1.reference)}" in normalized_ticket_message
+    assert f"{(str(notification_2.id), notification_2.reference)}" in normalized_ticket_message
+    assert "have reached the maximum number of retries" in normalized_ticket_message
+    assert "We couldn't find them in the scan bucket" in normalized_ticket_message
+
     mock_send_ticket_to_zendesk.assert_called_once()
 
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -639,6 +639,63 @@ def test_check_if_letters_still_pending_virus_check_raises_zendesk_if_files_cant
     mock_send_ticket_to_zendesk.assert_called_once()
 
 
+@freeze_time("2026-05-30 14:00:00")
+def test_check_if_letters_still_pending_virus_check_with_letters_both_missing_from_scan_bucket_and_in_it(
+    sample_letter_template,
+    mocker,
+):
+    mock_file_exists = mocker.patch("app.aws.s3.file_exists", side_effect=[False, True])
+    mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
+    mock_celery = mocker.patch("app.celery.scheduled_tasks.notify_celery.send_task")
+    mock_send_ticket_to_zendesk = mocker.patch(
+        "app.celery.scheduled_tasks.zendesk_client.send_ticket_to_zendesk",
+        autospec=True,
+    )
+    notification_1 = create_notification(
+        template=sample_letter_template,
+        status=NOTIFICATION_PENDING_VIRUS_CHECK,
+        created_at=datetime.utcnow() - timedelta(seconds=601),
+        reference="one",
+    )
+    notification_2 = create_notification(
+        template=sample_letter_template,
+        status=NOTIFICATION_PENDING_VIRUS_CHECK,
+        created_at=datetime.utcnow() - timedelta(seconds=1000),
+        reference="two",
+    )
+
+    check_if_letters_still_pending_virus_check()
+
+    assert mock_file_exists.call_count == 2
+    mock_file_exists.assert_has_calls(
+        [
+            call("test-letters-scan", "NOTIFY.ONE.D.2.C.20260530134959.PDF"),
+            call("test-letters-scan", "NOTIFY.TWO.D.2.C.20260530134320.PDF"),
+        ],
+        any_order=True,
+    )
+
+    mock_celery.assert_called_once_with(
+        name=TaskNames.SCAN_FILE,
+        kwargs={"filename": "NOTIFY.ONE.D.2.C.20260530134959.PDF"},
+        queue=QueueNames.ANTIVIRUS,
+        MessageGroupId=str(sample_letter_template.service_id),
+    )
+
+    mock_create_ticket.assert_called_once_with(
+        ANY,
+        subject="[test] Letters still pending virus check",
+        message=ANY,
+        ticket_type="task",
+        notify_ticket_type=NotifyTicketType.TECHNICAL,
+        notify_task_type="notify_task_letters_pending_scan",
+    )
+    assert "1 precompiled letters have been pending-virus-check" in mock_create_ticket.call_args.kwargs["message"]
+    assert f"{(str(notification_1.id), notification_1.reference)}" not in mock_create_ticket.call_args.kwargs["message"]
+    assert f"{(str(notification_2.id), notification_2.reference)}" in mock_create_ticket.call_args.kwargs["message"]
+    mock_send_ticket_to_zendesk.assert_called_once()
+
+
 @freeze_time("2019-05-30 14:00:00")
 def test_check_if_letters_still_in_created_during_bst(sample_letter_template, caplog, mocker):
     mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -35,6 +35,7 @@ from app.dao.notifications_dao import (
     dao_get_notifications_by_recipient_or_reference,
     dao_get_notifications_processing_time_stats,
     dao_letters_in_technical_failure,
+    dao_precompiled_letters_still_pending_virus_check,
     dao_record_letter_despatched_on_by_id,
     dao_timeout_notifications,
     dao_update_notification,
@@ -2196,3 +2197,42 @@ def test_dao_letters_in_technical_failure(sample_letter_template, sample_email_t
 
     assert len(results) == 2
     assert {n.id for n in results} == {letter_tf_1.id, letter_tf_2.id}
+
+
+@freeze_time("2026-07-01 13:00:00")
+def test_dao_precompiled_letters_still_pending_virus_check(
+    sample_letter_template,
+    sample_email_template,
+    notify_db_session,
+):
+    sample_letter_template.hidden = True
+
+    # only these letters in the correct time period are returned
+    letter_1 = create_notification(
+        created_at=datetime(2026, 7, 1, 12, 00), template=sample_letter_template, status="pending-virus-check"
+    )
+    letter_2 = create_notification(
+        created_at=datetime(2026, 7, 1, 12, 1), template=sample_letter_template, status="pending-virus-check"
+    )
+    letter_3 = create_notification(
+        created_at=datetime(2026, 7, 1, 12, 44), template=sample_letter_template, status="pending-virus-check"
+    )
+    # letters just before or after the time period
+    create_notification(
+        created_at=datetime(2026, 7, 1, 11, 59), template=sample_letter_template, status="pending-virus-check"
+    )
+    create_notification(
+        created_at=datetime(2026, 7, 1, 12, 45), template=sample_letter_template, status="pending-virus-check"
+    )
+    # letters with the wrong status
+    create_notification(created_at=datetime(2026, 7, 1, 12, 30), template=sample_letter_template, status="delivered")
+    create_notification(created_at=datetime(2026, 7, 1, 12, 30), template=sample_letter_template, status="created")
+    # non-letter
+    create_notification(created_at=datetime(2026, 7, 1, 12, 30), template=sample_email_template, status="created")
+
+    notify_db_session.commit()
+
+    assert dao_precompiled_letters_still_pending_virus_check(
+        max_minutes_ago_to_check=60,
+        min_minutes_ago_to_check=15,
+    ) == [letter_1, letter_2, letter_3]


### PR DESCRIPTION
The first two commits refactor the code to allow for changes (see commit messages
for details). The main change is in the third commit:

We were calling the `check-if-letters-still-pending-virus-check` task
both every ten minutes and each night. We used that task to attempt to retry
letters stuck in the `pending-virus-check` state over the last 3 days.

We had no way of knowing if a letter was still `pending-virus-check`
after 3 days because we just stop retrying at this point, and there was
no alerting. This splits the task for letters pending virus check into
two. The task that runs every 10 minutes stays the same. The task that
runs once every evening does what it used to (checks and attempts to
reprocess letters that were up to 3 days old) but it now also alerts us
to letters between 3 and 5 days old that are still
`pending-virus-check`. For these letters, we don't attempt to proprocess
(since we will have already tried that many times), we just add the
details to a Zendesk ticket.

With other recent changes to retries, we're very unlikely to have
letters which are still `pending-virus-check` after 3 days and no longer
being retried, but if it does happen we will now know about it.

[Trello card](https://trello.com/c/AWTosg45/1856-ensure-the-check-for-letters-pending-virus-check-will-alert-us-to-any-of-letters-that-are-stuck-pending-virus-check-for-days)