### PR TITLE
SMS providers, research mode: supply basic auth credentials with callbacks to delivery status endpoint

### DIFF
--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -1,6 +1,9 @@
 import uuid
+from collections.abc import Mapping
 from contextvars import ContextVar
 from datetime import datetime
+from typing import Any
+from urllib.parse import urljoin
 
 import requests
 from flask import current_app, jsonify
@@ -13,6 +16,7 @@ from app import memo_resetters, notify_celery, signing
 from app.celery.process_ses_receipts_tasks import process_ses_results
 from app.config import QueueNames
 from app.constants import SMS_TYPE
+from app.utils import add_authentication_to_url
 
 # thread-local copies of persistent requests.Session
 _requests_session_context_var: ContextVar[requests.Session] = ContextVar("research_mode_requests_session")
@@ -32,17 +36,19 @@ perm_fail_email = "perm-fail@simulator.notify"
 temp_fail_email = "temp-fail@simulator.notify"
 
 
-def send_sms_response(provider, reference, to):
+def send_sms_response(provider: str, reference: str, to: str) -> None:
     if provider == "mmg":
         body = mmg_callback(reference, to)
         headers = {"Content-type": "application/json"}
+        basic_auth_credentials = current_app.config["RESEARCH_MODE_SELF_CALLBACK_MMG_BASIC_AUTH_CREDENTIALS"]
     else:
         headers = {"Content-type": "application/x-www-form-urlencoded"}
         body = firetext_callback(reference, to)
+        basic_auth_credentials = current_app.config["RESEARCH_MODE_SELF_CALLBACK_FIRETEXT_BASIC_AUTH_CREDENTIALS"]
         # to simulate getting a temporary_failure from firetext
         # we need to send a pending status updated then a permanent-failure
         if body["status"] == "2":  # pending status
-            make_request(SMS_TYPE, provider, body, headers)
+            make_request(SMS_TYPE, provider, body, headers, basic_auth_credentials=basic_auth_credentials)
             # 1 is a declined status for firetext, will result in a temp-failure
             body = {
                 "mobile": to,
@@ -52,7 +58,7 @@ def send_sms_response(provider, reference, to):
                 "reference": reference,
             }
 
-    make_request(SMS_TYPE, provider, body, headers)
+    make_request(SMS_TYPE, provider, body, headers, basic_auth_credentials=basic_auth_credentials)
 
 
 def send_email_response(reference, to, service_id):
@@ -148,18 +154,39 @@ def _create_fake_letter_callback_data(notification_id: uuid.UUID, billable_units
     }
 
 
-def make_request(notification_type, provider, data, headers):
-    api_call = f"{current_app.config['API_HOST_NAME_INTERNAL']}/notifications/{notification_type}/{provider}"
+def make_request(
+    notification_type: str,
+    provider: str,
+    data: Mapping[str, Any],
+    headers: Mapping[str, str],
+    basic_auth_credentials: tuple[str, str] | None = None,
+):
+    base_url = current_app.config["API_HOST_NAME_INTERNAL"]
+    if basic_auth_credentials is not None:
+        base_url = add_authentication_to_url(
+            current_app.config["API_HOST_NAME_INTERNAL"],
+            *basic_auth_credentials,
+        )
+    final_url = urljoin(base_url, f"/notifications/{notification_type}/{provider}")
 
     try:
-        response = requests_session.request("POST", api_call, headers=headers, data=data, timeout=60)  # type: ignore[attr-defined]
+        response = requests_session.request(  # type: ignore[attr-defined]
+            "POST",
+            final_url,
+            headers={
+                "User-agent": "notifications-research-mode",
+                **headers,
+            },
+            data=data,
+            timeout=60,
+        )
         response.raise_for_status()
     except requests.HTTPError as e:
         current_app.logger.error(
             "API POST request on %s failed with status %s",
-            api_call,
+            final_url,
             e.response.status_code,
-            extra={"url": api_call, "status_code": e.response.status_code},
+            extra={"url": final_url, "status_code": e.response.status_code},
         )
         raise e
     finally:

--- a/app/clients/sms/firetext.py
+++ b/app/clients/sms/firetext.py
@@ -5,6 +5,7 @@ import requests
 
 from app.clients.sms import SmsClient, SmsClientResponseException
 from app.otel_metrics.provider import record_request_duration
+from app.utils import add_authentication_to_url
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,11 @@ class FiretextClient(SmsClient):
         self.international_api_key = self.current_app.config.get("FIRETEXT_INTERNATIONAL_API_KEY")
         self.url = self.current_app.config.get("FIRETEXT_URL")
         self.receipt_url = self.current_app.config.get("FIRETEXT_RECEIPT_URL")
+        if self.receipt_url and self.current_app.config["FIRETEXT_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS"]:
+            self.receipt_url = add_authentication_to_url(
+                self.receipt_url,
+                *self.current_app.config["FIRETEXT_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS"],
+            )
 
     @record_request_duration(notification_type="sms", provider_name="firetext")
     def try_send_sms(self, to, content, reference, international, sender):

--- a/app/clients/sms/mmg.py
+++ b/app/clients/sms/mmg.py
@@ -5,6 +5,7 @@ from notifications_utils.json import RelaxedContainerJSONEncoder as RCJSONEncode
 
 from app.clients.sms import SmsClient, SmsClientResponseException
 from app.otel_metrics.provider import record_request_duration
+from app.utils import add_authentication_to_url
 
 # For some extra context, see google drive: GOV.UK Notify -> SMS suppliers -> Detailed failure statuses
 mmg_response_map = {
@@ -89,6 +90,11 @@ class MMGClient(SmsClient):
         self.api_key = self.current_app.config.get("MMG_API_KEY")
         self.mmg_url = self.current_app.config.get("MMG_URL")
         self.receipt_url = self.current_app.config.get("MMG_RECEIPT_URL")
+        if self.receipt_url and self.current_app.config["MMG_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS"]:
+            self.receipt_url = add_authentication_to_url(
+                self.receipt_url,
+                *self.current_app.config["MMG_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS"],
+            )
 
     @record_request_duration(notification_type="sms", provider_name="mmg")
     def try_send_sms(self, to, content, reference, international, sender):

--- a/app/config.py
+++ b/app/config.py
@@ -140,6 +140,9 @@ class Config:
     # Firetext Callback URL for delivery receipts
     # If this is not set, Firetext will send to the URL that is set in the Firetext dashboard
     FIRETEXT_RECEIPT_URL = os.getenv("FIRETEXT_RECEIPT_URL")
+    FIRETEXT_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS = json.loads(
+        os.environ.get("FIRETEXT_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS") or "null"
+    )
 
     # Prefix to identify queues in SQS
     NOTIFICATION_QUEUE_PREFIX = os.getenv("NOTIFICATION_QUEUE_PREFIX")

--- a/app/config.py
+++ b/app/config.py
@@ -552,6 +552,13 @@ class Config:
     FIRETEXT_URL = os.environ.get("FIRETEXT_URL", "https://www.firetext.co.uk/api/sendsms/json")
     SES_STUB_URL = os.environ.get("SES_STUB_URL")
 
+    RESEARCH_MODE_SELF_CALLBACK_MMG_BASIC_AUTH_CREDENTIALS = json.loads(
+        os.environ.get("RESEARCH_MODE_SELF_CALLBACK_MMG_BASIC_AUTH_CREDENTIALS") or "null"
+    )
+    RESEARCH_MODE_SELF_CALLBACK_FIRETEXT_BASIC_AUTH_CREDENTIALS = json.loads(
+        os.environ.get("RESEARCH_MODE_SELF_CALLBACK_FIRETEXT_BASIC_AUTH_CREDENTIALS") or "null"
+    )
+
     DVLA_API_BASE_URL = os.environ.get("DVLA_API_BASE_URL", "https://uat.driver-vehicle-licensing.api.gov.uk")
     DVLA_API_TLS_CIPHERS = os.environ.get("DVLA_API_TLS_CIPHERS")
 

--- a/app/config.py
+++ b/app/config.py
@@ -132,6 +132,9 @@ class Config:
     # MMG Callback URL for delivery receipts
     # If this is not set, MMG will send to the URL that they have set up in their system
     MMG_RECEIPT_URL = os.getenv("MMG_RECEIPT_URL")
+    MMG_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS = json.loads(
+        os.environ.get("MMG_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS") or "null"
+    )
 
     # Firetext API Key
     FIRETEXT_API_KEY = os.getenv("FIRETEXT_API_KEY")

--- a/app/utils.py
+++ b/app/utils.py
@@ -6,7 +6,7 @@ from functools import wraps
 from inspect import signature
 from itertools import islice
 from typing import Any, overload
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 from uuid import UUID
 
 from flask import current_app, url_for
@@ -87,6 +87,19 @@ def url_with_token(data, url: str, base_url: str | None = None) -> str:
     )
     base_url = (base_url or current_app.config["ADMIN_BASE_URL"]) + url
     return urljoin(base_url, token)
+
+
+def add_authentication_to_url(url: str, username: str, password: str) -> str:
+    original_parseresult = urlparse(url)
+    return original_parseresult._replace(
+        netloc="".join(
+            (
+                f"{username}:{password}@",
+                original_parseresult.hostname or "",
+                ("" if original_parseresult.port is None else f":{original_parseresult.port}"),
+            )
+        ),
+    ).geturl()
 
 
 def get_template_instance(template: dict[str, Any], values: dict[str, Any]) -> Template:

--- a/tests/app/celery/test_research_mode_tasks.py
+++ b/tests/app/celery/test_research_mode_tasks.py
@@ -1,4 +1,5 @@
 import uuid
+from base64 import b64encode
 from unittest.mock import ANY
 
 import pytest
@@ -18,19 +19,39 @@ from app.celery.research_mode_tasks import (
     ses_notification_callback,
 )
 from app.config import QueueNames
+from tests.conftest import set_config_values
 
 
+@pytest.mark.parametrize(
+    "basic_auth_creds, expected_url_auth_part, expected_auth_header",
+    (
+        (None, "", None),
+        (["user123", "pass321"], "user123:pass321@", f"Basic {b64encode(b'user123:pass321').decode('ascii')}"),
+    ),
+)
 @freeze_time("2017-07-17T12:14:03.646")
-def test_make_mmg_callback(notify_api, rmock):
-    endpoint = "http://localhost:6011/notifications/sms/mmg"
+def test_make_mmg_callback(notify_api, rmock, basic_auth_creds, expected_url_auth_part, expected_auth_header):
+    endpoint = f"http://{expected_url_auth_part}localhost:6011/notifications/sms/mmg"
     rmock.request("POST", endpoint, json={"status": "success"}, status_code=200)
-    send_sms_response("mmg", "1234", "07700900001")
 
-    assert rmock.called
+    with set_config_values(
+        notify_api,
+        {
+            "RESEARCH_MODE_SELF_CALLBACK_FIRETEXT_BASIC_AUTH_CREDENTIALS": ["dont", "use"],
+            "RESEARCH_MODE_SELF_CALLBACK_MMG_BASIC_AUTH_CREDENTIALS": basic_auth_creds,
+        },
+    ):
+        send_sms_response("mmg", "1234", "07700900001")
+
+    assert len(rmock.request_history) == 1
     assert rmock.request_history[0].url == endpoint
     payload = json.loads(rmock.request_history[0].text)
     assert payload["MSISDN"] == "07700900001"
     assert payload["deliverytime"] == "2017-07-17 13:14:03"
+
+    assert [req.headers.get("Authorization") for req in rmock.request_history] == [
+        expected_auth_header for _ in rmock.request_history
+    ]
 
 
 def test_callback_logs_on_api_call_failure(notify_api, rmock, caplog):
@@ -46,28 +67,56 @@ def test_callback_logs_on_api_call_failure(notify_api, rmock, caplog):
 
 
 @pytest.mark.parametrize(
-    "phone_number, number_of_calls, statuses, detailed_status_code",
+    "basic_auth_creds, expected_url_auth_part, expected_auth_header",
+    (
+        (None, "", None),
+        (["user123", "pass321"], "user123:pass321@", f"Basic {b64encode(b'user123:pass321').decode('ascii')}"),
+    ),
+)
+@pytest.mark.parametrize(
+    "phone_number, expected_statuses, expected_detailed_status_code",
     [
-        ("07700900001", 1, ["0"], None),
-        ("07700900002", 1, ["1"], None),
-        ("07700900003", 2, ["2", "1"], "102"),
-        ("07700900236", 1, ["0"], None),
+        ("07700900001", ["0"], None),
+        ("07700900002", ["1"], None),
+        ("07700900003", ["2", "1"], "102"),
+        ("07700900236", ["0"], None),
     ],
 )
-def test_make_firetext_callback(notify_api, rmock, phone_number, number_of_calls, statuses, detailed_status_code):
-    endpoint = "http://localhost:6011/notifications/sms/firetext"
+def test_make_firetext_callback(
+    notify_api,
+    rmock,
+    phone_number,
+    basic_auth_creds,
+    expected_statuses,
+    expected_detailed_status_code,
+    expected_url_auth_part,
+    expected_auth_header,
+):
+    endpoint = f"http://{expected_url_auth_part}localhost:6011/notifications/sms/firetext"
     rmock.request("POST", endpoint, json="some data", status_code=200)
-    send_sms_response("firetext", "1234", phone_number)
+
+    with set_config_values(
+        notify_api,
+        {
+            "RESEARCH_MODE_SELF_CALLBACK_MMG_BASIC_AUTH_CREDENTIALS": ["dont", "use"],
+            "RESEARCH_MODE_SELF_CALLBACK_FIRETEXT_BASIC_AUTH_CREDENTIALS": basic_auth_creds,
+        },
+    ):
+        send_sms_response("firetext", "1234", phone_number)
 
     assert rmock.called
-    assert len(rmock.request_history) == number_of_calls
+    assert len(rmock.request_history) == len(expected_statuses)
     assert rmock.request_history[0].url == endpoint
     assert f"mobile={phone_number}" in rmock.request_history[0].text
-    for i, status in enumerate(statuses):
+    for i, status in enumerate(expected_statuses):
         assert f"status={status}" in rmock.request_history[i].text
 
-    if detailed_status_code:
-        assert f"detailed_status_code={detailed_status_code}" in rmock.request_history[1].text
+    if expected_detailed_status_code:
+        assert f"detailed_status_code={expected_detailed_status_code}" in rmock.request_history[1].text
+
+    assert [req.headers.get("Authorization") for req in rmock.request_history] == [
+        expected_auth_header for _ in rmock.request_history
+    ]
 
 
 @freeze_time("2017-11-17T12:14:03.646")

--- a/tests/app/clients/test_firetext.py
+++ b/tests/app/clients/test_firetext.py
@@ -1,13 +1,22 @@
+from unittest.mock import Mock
 from urllib.parse import parse_qs
 
 import pytest
 import requests_mock
 from requests.exceptions import ConnectTimeout, ReadTimeout
 
-from app.clients.sms.firetext import (
-    SmsClientResponseException,
-    get_firetext_responses,
-)
+from app.clients.sms.firetext import FiretextClient, SmsClientResponseException, get_firetext_responses
+
+
+@pytest.fixture(scope="function")
+def mock_firetext_configured_app():
+    config = {
+        "FIRETEXT_URL": "https://example.com/firetext",
+        "FIRETEXT_API_KEY": "foo",
+        "FIRETEXT_INTERNATIONAL_API_KEY": "international",
+        "FROM_NUMBER": "bar",
+    }
+    return Mock(config=config)
 
 
 @pytest.mark.parametrize(
@@ -35,13 +44,15 @@ def test_get_firetext_responses_raises_KeyError_if_unrecognised_status_code():
     assert "99" in str(e.value)
 
 
-def test_try_send_sms_successful_returns_firetext_response(mocker, mock_firetext_client):
+def test_try_send_sms_successful_returns_firetext_response(mock_firetext_configured_app):
+    firetext_client = FiretextClient(mock_firetext_configured_app)
+
     to = content = reference = "foo"
     response_dict = {"data": [], "description": "SMS successfully queued", "code": 0, "responseData": 1}
 
     with requests_mock.Mocker() as request_mock:
         request_mock.post("https://example.com/firetext", json=response_dict, status_code=200)
-        response = mock_firetext_client.try_send_sms(to, content, reference, False, "sender")
+        response = firetext_client.try_send_sms(to, content, reference, False, "sender")
 
     response_json = response.json()
     assert response.status_code == 200
@@ -49,7 +60,9 @@ def test_try_send_sms_successful_returns_firetext_response(mocker, mock_firetext
     assert response_json["description"] == "SMS successfully queued"
 
 
-def test_try_send_sms_calls_firetext_correctly(mocker, mock_firetext_client):
+def test_try_send_sms_calls_firetext_correctly(mock_firetext_configured_app):
+    firetext_client = FiretextClient(mock_firetext_configured_app)
+
     to = "+447234567890"
     content = "my message"
     reference = "my reference"
@@ -59,7 +72,7 @@ def test_try_send_sms_calls_firetext_correctly(mocker, mock_firetext_client):
 
     with requests_mock.Mocker() as request_mock:
         request_mock.post("https://example.com/firetext", json=response_dict, status_code=200)
-        mock_firetext_client.try_send_sms(to, content, reference, False, "bar")
+        firetext_client.try_send_sms(to, content, reference, False, "bar")
 
     assert request_mock.call_count == 1
     assert request_mock.request_history[0].url == "https://example.com/firetext"
@@ -74,7 +87,16 @@ def test_try_send_sms_calls_firetext_correctly(mocker, mock_firetext_client):
     assert "receipt" not in request_args
 
 
-def test_try_send_sms_calls_firetext_correctly_with_receipts(mocker, mock_firetext_client_with_receipts):
+@pytest.mark.parametrize("basic_auth_credentials", (None, ("foo123", "foo321")))
+def test_try_send_sms_calls_firetext_correctly_with_receipts(mock_firetext_configured_app, basic_auth_credentials):
+    mock_firetext_configured_app.config.update(
+        {
+            "FIRETEXT_RECEIPT_URL": "https://www.example.com:1234/notifications/sms/firetext",
+            "FIRETEXT_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS": basic_auth_credentials,
+        }
+    )
+    firetext_client = FiretextClient(mock_firetext_configured_app)
+
     to = content = reference = "foo"
     response_dict = {
         "code": 0,
@@ -82,13 +104,22 @@ def test_try_send_sms_calls_firetext_correctly_with_receipts(mocker, mock_firete
 
     with requests_mock.Mocker() as request_mock:
         request_mock.post("https://example.com/firetext", json=response_dict, status_code=200)
-        mock_firetext_client_with_receipts.try_send_sms(to, content, reference, False, "bar")
+        firetext_client.try_send_sms(to, content, reference, False, "bar")
 
+    assert len(request_mock.request_history) == 1
     request_args = parse_qs(request_mock.request_history[0].text)
-    assert request_args["receipt"][0] == "https://www.example.com/notifications/sms/firetext"
+    if basic_auth_credentials is None:
+        assert request_args["receipt"][0] == "https://www.example.com:1234/notifications/sms/firetext"
+    else:
+        assert (
+            request_args["receipt"][0]
+            == f"https://{':'.join(basic_auth_credentials)}@www.example.com:1234/notifications/sms/firetext"
+        )
 
 
-def test_try_send_sms_calls_firetext_correctly_for_international(mocker, mock_firetext_client):
+def test_try_send_sms_calls_firetext_correctly_for_international(mocker, mock_firetext_configured_app):
+    firetext_client = FiretextClient(mock_firetext_configured_app)
+
     to = "+607234567890"
     content = "my message"
     reference = "my reference"
@@ -98,7 +129,7 @@ def test_try_send_sms_calls_firetext_correctly_for_international(mocker, mock_fi
 
     with requests_mock.Mocker() as request_mock:
         request_mock.post("https://example.com/firetext", json=response_dict, status_code=200)
-        mock_firetext_client.try_send_sms(to, content, reference, True, "bar")
+        firetext_client.try_send_sms(to, content, reference, True, "bar")
 
     assert request_mock.call_count == 1
     assert request_mock.request_history[0].url == "https://example.com/firetext"
@@ -112,54 +143,64 @@ def test_try_send_sms_calls_firetext_correctly_for_international(mocker, mock_fi
     assert request_args["reference"][0] == reference
 
 
-def test_try_send_sms_raises_if_firetext_rejects(mocker, mock_firetext_client):
+def test_try_send_sms_raises_if_firetext_rejects(mocker, mock_firetext_configured_app):
+    firetext_client = FiretextClient(mock_firetext_configured_app)
+
     to = content = reference = "foo"
     response_dict = {"data": [], "description": "Some kind of error", "code": 1, "responseData": ""}
 
     with pytest.raises(SmsClientResponseException) as exc, requests_mock.Mocker() as request_mock:
         request_mock.post("https://example.com/firetext", json=response_dict, status_code=200)
-        mock_firetext_client.try_send_sms(to, content, reference, False, "sender")
+        firetext_client.try_send_sms(to, content, reference, False, "sender")
 
     assert "Invalid response JSON" in str(exc.value)
 
 
-def test_try_send_sms_raises_if_firetext_rejects_with_unexpected_data(mocker, mock_firetext_client):
+def test_try_send_sms_raises_if_firetext_rejects_with_unexpected_data(mocker, mock_firetext_configured_app):
+    firetext_client = FiretextClient(mock_firetext_configured_app)
+
     to = content = reference = "foo"
     response_dict = {"something": "gone bad"}
 
     with pytest.raises(SmsClientResponseException) as exc, requests_mock.Mocker() as request_mock:
         request_mock.post("https://example.com/firetext", json=response_dict, status_code=400)
-        mock_firetext_client.try_send_sms(to, content, reference, False, "sender")
+        firetext_client.try_send_sms(to, content, reference, False, "sender")
 
     assert "Request failed" in str(exc.value)
 
 
-def test_try_send_sms_raises_if_firetext_fails_to_return_json(notify_api, mock_firetext_client):
+def test_try_send_sms_raises_if_firetext_fails_to_return_json(notify_api, mock_firetext_configured_app):
+    firetext_client = FiretextClient(mock_firetext_configured_app)
+
     to = content = reference = "foo"
     response_dict = 'NOT AT ALL VALID JSON {"key" : "value"}}'
 
     with pytest.raises(SmsClientResponseException) as exc, requests_mock.Mocker() as request_mock:
         request_mock.post("https://example.com/firetext", text=response_dict, status_code=200)
-        mock_firetext_client.try_send_sms(to, content, reference, False, "sender")
+        firetext_client.try_send_sms(to, content, reference, False, "sender")
 
     assert "Invalid response JSON" in str(exc.value)
 
 
-def test_try_send_sms_raises_if_firetext_rejects_with_connect_timeout(rmock, mock_firetext_client):
+def test_try_send_sms_raises_if_firetext_rejects_with_connect_timeout(rmock, mock_firetext_configured_app):
+    firetext_client = FiretextClient(mock_firetext_configured_app)
+
     to = content = reference = "foo"
 
     with pytest.raises(SmsClientResponseException) as exc:
         rmock.register_uri("POST", "https://example.com/firetext", exc=ConnectTimeout)
-        mock_firetext_client.try_send_sms(to, content, reference, False, "sender")
+        firetext_client.try_send_sms(to, content, reference, False, "sender")
 
     assert "Request failed" in str(exc.value)
 
 
-def test_try_send_sms_raises_if_firetext_rejects_with_read_timeout(rmock, mock_firetext_client):
+def test_try_send_sms_raises_if_firetext_rejects_with_read_timeout(rmock, mock_firetext_configured_app):
+    firetext_client = FiretextClient(mock_firetext_configured_app)
+
     to = content = reference = "foo"
 
     with pytest.raises(SmsClientResponseException) as exc:
         rmock.register_uri("POST", "https://example.com/firetext", exc=ReadTimeout)
-        mock_firetext_client.try_send_sms(to, content, reference, False, "sender")
+        firetext_client.try_send_sms(to, content, reference, False, "sender")
 
     assert "Request failed" in str(exc.value)

--- a/tests/app/clients/test_mmg.py
+++ b/tests/app/clients/test_mmg.py
@@ -1,9 +1,22 @@
+from unittest.mock import Mock
+
 import pytest
 import requests_mock
 from requests.exceptions import ConnectTimeout, ReadTimeout
 
 from app import mmg_client
-from app.clients.sms.mmg import SmsClientResponseException, get_mmg_responses
+from app.clients.sms.mmg import MMGClient, SmsClientResponseException, get_mmg_responses
+
+
+@pytest.fixture(scope="function")
+def mock_mmg_configured_app_with_receipts():
+    return Mock(
+        config={
+            "MMG_URL": "https://example.com/mmg",
+            "MMG_API_KEY": "foo",
+            "MMG_RECEIPT_URL": "https://www.example.com:4321/notifications/sms/mmg",
+        }
+    )
 
 
 @pytest.mark.parametrize(
@@ -52,16 +65,32 @@ def test_try_send_sms_successful_returns_mmg_response(notify_api, mocker):
     assert response_json["Reference"] == 12345678
 
 
-def test_try_send_sms_successful_with_custom_receipts(notify_api, mock_mmg_client_with_receipts):
+@pytest.mark.parametrize("basic_auth_credentials", (None, ("user123", "pass321")))
+def test_try_send_sms_successful_with_custom_receipts(
+    notify_api, mock_mmg_configured_app_with_receipts, basic_auth_credentials
+):
+    mock_mmg_configured_app_with_receipts.config.update(
+        {
+            "MMG_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS": basic_auth_credentials,
+        }
+    )
+    mock_configured_mmg_client = MMGClient(mock_mmg_configured_app_with_receipts)
+
     to = content = reference = "foo"
     response_dict = {"Reference": 12345678}
 
     with requests_mock.Mocker() as request_mock:
         request_mock.post("https://example.com/mmg", json=response_dict, status_code=200)
-        mock_mmg_client_with_receipts.try_send_sms(to, content, reference, False, "sender")
+        mock_configured_mmg_client.try_send_sms(to, content, reference, False, "sender")
 
     request_args = request_mock.request_history[0].json()
-    assert request_args["delurl"] == "https://www.example.com/notifications/sms/mmg"
+    if basic_auth_credentials is None:
+        assert request_args["delurl"] == "https://www.example.com:4321/notifications/sms/mmg"
+    else:
+        assert (
+            request_args["delurl"]
+            == f"https://{':'.join(basic_auth_credentials)}@www.example.com:4321/notifications/sms/mmg"
+        )
 
 
 def test_try_send_sms_calls_mmg_correctly(notify_api, mocker):

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -16,7 +16,6 @@ from kombu.serialization import dumps
 from sqlalchemy.orm.session import make_transient
 
 from app import db
-from app.clients.sms.firetext import FiretextClient
 from app.clients.sms.mmg import MMGClient
 from app.config import QueueNames
 from app.constants import (
@@ -640,35 +639,6 @@ def fake_uuid():
 @pytest.fixture(scope="function")
 def mmg_provider():
     return ProviderDetails.query.filter_by(identifier="mmg").one()
-
-
-def create_mock_firetext_config(mocker, additional_config=None):
-    config = {
-        "FIRETEXT_URL": "https://example.com/firetext",
-        "FIRETEXT_API_KEY": "foo",
-        "FIRETEXT_INTERNATIONAL_API_KEY": "international",
-        "FROM_NUMBER": "bar",
-    }
-    if additional_config:
-        config.update(additional_config)
-    return mocker.Mock(config=config)
-
-
-def create_mock_firetext_client(mock_config):
-    return FiretextClient(mock_config)
-
-
-@pytest.fixture(scope="function")
-def mock_firetext_client(mocker):
-    mock_config = create_mock_firetext_config(mocker)
-    return create_mock_firetext_client(mock_config)
-
-
-@pytest.fixture(scope="function")
-def mock_firetext_client_with_receipts(mocker):
-    additional_config = {"FIRETEXT_RECEIPT_URL": "https://www.example.com/notifications/sms/firetext"}
-    mock_config = create_mock_firetext_config(mocker, additional_config)
-    return create_mock_firetext_client(mock_config)
 
 
 @pytest.fixture(scope="function")

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -16,7 +16,6 @@ from kombu.serialization import dumps
 from sqlalchemy.orm.session import make_transient
 
 from app import db
-from app.clients.sms.mmg import MMGClient
 from app.config import QueueNames
 from app.constants import (
     ALL_TYPE,
@@ -639,18 +638,6 @@ def fake_uuid():
 @pytest.fixture(scope="function")
 def mmg_provider():
     return ProviderDetails.query.filter_by(identifier="mmg").one()
-
-
-@pytest.fixture(scope="function")
-def mock_mmg_client_with_receipts(mocker):
-    current_app = mocker.Mock(
-        config={
-            "MMG_URL": "https://example.com/mmg",
-            "MMG_API_KEY": "foo",
-            "MMG_RECEIPT_URL": "https://www.example.com/notifications/sms/mmg",
-        }
-    )
-    return MMGClient(current_app)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
The first active step of https://trello.com/c/94Q38sgQ/1546-implement-authentication-for-delivery-receipt-callback-endpoints

This causes `FiretextClient` and `MMGClient` to insert basic auth credentials (supplied via `FIRETEXT_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS` & `MMG_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS`) into the "callback url" we give to the outbound SMS requests. It depends on https://github.com/alphagov/notifications-aws/pull/3062 and needs to be rolled out _well before_ we start actually heeding/enforcing the basic auth at the endpoint (later PR). How long before? The maximum length of time we expect to wait for an SMS's receipt (is this 3 days?).

It also makes our "research mode" (used for test notifications) use basic auth credentials (supplied via `RESEARCH_MODE_SELF_CALLBACK_MMG_BASIC_AUTH_CREDENTIALS` & `RESEARCH_MODE_SELF_CALLBACK_FIRETEXT_BASIC_AUTH_CREDENTIALS`) for its "fake" delivery status callbacks.

It also does a small amount of unit test refactoring to make the use of fixtures for these areas less weird.

You'll possibly notice that this doesn't follow the same (weird) scheme by which username/passwords are supplied for the "inbound sms" system, and that's deliberate. Follow-up PRs will switch inbound sms basic auth to use this new mechanism, because it has fewer unusual quirks.

The PRs that form this story have been tested together in all-singing, all-dancing mode, operating correctly on dev-d.