### PR TITLE
Linting: Fix ISC004 Unparenthesized implicit string concatenation in collection

### DIFF
--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -1213,16 +1213,20 @@ MockServicesWithHighFailureRate = namedtuple(
                 "Service 123 has had a high permanent-failure rate (0.3) for text messages in the last 24 hours",
                 "Service 456 has had a high permanent-failure rate (0.7) for text messages in the last 24 hours",
             ],
-            "2 service(s) have had high permanent-failure rates for sms messages in last 24 hours:\n"
-            f"service: {Config.ADMIN_BASE_URL}/services/123 failure rate: 0.3,\n"
-            f"service: {Config.ADMIN_BASE_URL}/services/456 failure rate: 0.7,\n",
+            (
+                "2 service(s) have had high permanent-failure rates for sms messages in last 24 hours:\n"
+                f"service: {Config.ADMIN_BASE_URL}/services/123 failure rate: 0.3,\n"
+                f"service: {Config.ADMIN_BASE_URL}/services/456 failure rate: 0.7,\n"
+            ),
         ],
         [
             [],
             [MockServicesSendingToTVNumbers("123", 567)],
             ["Service 123 has sent 567 text messages to tv numbers in the last 24 hours"],
-            "1 service(s) have sent over 500 sms messages to tv numbers in last 24 hours:\n"
-            f"service: {Config.ADMIN_BASE_URL}/services/123 count of sms to tv numbers: 567,\n",
+            (
+                "1 service(s) have sent over 500 sms messages to tv numbers in last 24 hours:\n"
+                f"service: {Config.ADMIN_BASE_URL}/services/123 count of sms to tv numbers: 567,\n"
+            ),
         ],
         [
             [MockServicesWithHighFailureRate("123", 0.3)],
@@ -1231,10 +1235,12 @@ MockServicesWithHighFailureRate = namedtuple(
                 "Service 123 has had a high permanent-failure rate (0.3) for text messages in the last 24 hours",
                 "Service 456 has sent 567 text messages to tv numbers in the last 24 hours",
             ],
-            "1 service(s) have had high permanent-failure rates for sms messages in last 24 hours:\n"
-            f"service: {Config.ADMIN_BASE_URL}/services/123 failure rate: 0.3,\n"
-            "1 service(s) have sent over 500 sms messages to tv numbers in last 24 hours:\n"
-            f"service: {Config.ADMIN_BASE_URL}/services/456 count of sms to tv numbers: 567,\n",
+            (
+                "1 service(s) have had high permanent-failure rates for sms messages in last 24 hours:\n"
+                f"service: {Config.ADMIN_BASE_URL}/services/123 failure rate: 0.3,\n"
+                "1 service(s) have sent over 500 sms messages to tv numbers in last 24 hours:\n"
+                f"service: {Config.ADMIN_BASE_URL}/services/456 count of sms to tv numbers: 567,\n"
+            ),
         ],
     ],
 )

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -4356,14 +4356,16 @@ def test_get_service_join_request_by_id_when_request_is_not_found(admin_request,
             ["invalid_permission"],
             "approved",
             None,
-            "permissions invalid_permission is not one of "
-            "[manage_users, "
-            "manage_templates, "
-            "manage_settings, "
-            "send_texts, send_emails, "
-            "send_letters, "
-            "manage_api_keys, "
-            "view_activity]",
+            (
+                "permissions invalid_permission is not one of "
+                "[manage_users, "
+                "manage_templates, "
+                "manage_settings, "
+                "send_texts, send_emails, "
+                "send_letters, "
+                "manage_api_keys, "
+                "view_activity]"
+            ),
         ),
         (
             uuid.uuid4(),


### PR DESCRIPTION
Ruff is going to make this rule on by default in version 0.16.0

Let’s get ahead of that by fixing this now