### PR TITLE
Add NHS Notify org type with no free allowance

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -199,6 +199,7 @@ ORG_TYPE_LOCAL = "local"
 ORG_TYPE_NHS_CENTRAL = "nhs_central"
 ORG_TYPE_NHS_LOCAL = "nhs_local"
 ORG_TYPE_NHS_GP = "nhs_gp"
+ORG_TYPE_NHS_NOTIFY = "nhs_notify"
 ORG_TYPE_EMERGENCY_SERVICE = "emergency_service"
 ORG_TYPE_SCHOOL_OR_COLLEGE = "school_or_college"
 ORG_TYPE_OTHER = "other"
@@ -208,13 +209,14 @@ ORGANISATION_TYPES = [
     ORG_TYPE_NHS_CENTRAL,
     ORG_TYPE_NHS_LOCAL,
     ORG_TYPE_NHS_GP,
+    ORG_TYPE_NHS_NOTIFY,
     ORG_TYPE_EMERGENCY_SERVICE,
     ORG_TYPE_SCHOOL_OR_COLLEGE,
     ORG_TYPE_OTHER,
 ]
 CROWN_ORGANISATION_TYPES = ["nhs_central"]
-NON_CROWN_ORGANISATION_TYPES = ["local", "nhs_local", "nhs_gp", "emergency_service", "school_or_college"]
-NHS_ORGANISATION_TYPES = ["nhs_central", "nhs_local", "nhs_gp"]
+NON_CROWN_ORGANISATION_TYPES = ["local", "nhs_local", "nhs_gp", "nhs_notify", "emergency_service", "school_or_college"]
+NHS_ORGANISATION_TYPES = ["nhs_central", "nhs_local", "nhs_gp", "nhs_notify"]
 
 
 # Service permissions

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0558_add_nhs_notify_org_type
+0559_set_nhs_notify_allowance

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0557_create_ft_service_stats
+0558_add_nhs_notify_org_type

--- a/migrations/versions/0558_add_nhs_notify_org_type.py
+++ b/migrations/versions/0558_add_nhs_notify_org_type.py
@@ -1,0 +1,19 @@
+"""
+Create Date: 2026-07-31 09:47:18.388849
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0558_add_nhs_notify_org_type'
+down_revision = '0557_create_ft_service_stats'
+
+
+def upgrade():
+    op.execute("INSERT INTO organisation_types (name, is_crown) VALUES ('nhs_notify', false)")
+
+
+def downgrade():
+    op.execute("UPDATE organisation SET organisation_type = 'nhs_central' WHERE organisation_type = 'nhs_notify'")
+    op.execute("DELETE FROM organisation_types WHERE name = 'nhs_notify'")

--- a/migrations/versions/0559_set_nhs_notify_allowance.py
+++ b/migrations/versions/0559_set_nhs_notify_allowance.py
@@ -1,0 +1,29 @@
+"""
+Create Date: 2026-07-31 10:11:51.069316
+"""
+
+import uuid
+
+from alembic import op
+
+revision = '0559_set_nhs_notify_allowance'
+down_revision = '0558_add_nhs_notify_org_type'
+
+
+def upgrade():
+    """
+    The free allowance is set from 2016 even though it's a new org type for consistency and to avoid
+    potential bugs if trying to view historic usage
+    """
+    op.execute(
+        "INSERT INTO default_annual_allowance"
+        "(id, valid_from_financial_year_start, organisation_type, allowance, notification_type) "
+        f"VALUES('{uuid.uuid4()}', 2016, 'nhs_notify', 0, 'sms')"
+    )
+
+
+def downgrade():
+    op.execute(
+        "DELETE FROM default_annual_allowance WHERE " \
+        "valid_from_financial_year_start = 2016 AND organisation_type = 'nhs_notify'"
+    )

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -307,7 +307,7 @@ def test_post_create_organisation_existing_name_raises_400(admin_request, sample
             },
             (
                 "organisation_type foo is not one of "
-                "[central, local, nhs_central, nhs_local, nhs_gp, emergency_service, school_or_college, "
+                "[central, local, nhs_central, nhs_local, nhs_gp, nhs_notify, emergency_service, school_or_college, "
                 "other]"
             ),
         ),


### PR DESCRIPTION
This adds a new org type of `nhs_notify` and sets its default free allowance to 0.