### PR TITLE
Process replication slot changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ celerybeat-schedule
 docker-compose.yml
 .env
 application.log.json
+celerybeat-schedule-*

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -99,6 +99,7 @@ from app.otel_metrics.provider import (
     record_updated_at,
 )
 from app.utils import get_london_midnight_in_utc
+from app.dao.replication_slot_changes_dao import dao_process_replication_slot_changes
 
 
 @notify_celery.task(name="run-scheduled-jobs")
@@ -950,3 +951,4 @@ def process_replication_slot_changes():
     print('---------------------------------------------')
     print("Processing replication slot changes..........")
     print('---------------------------------------------')
+    dao_process_replication_slot_changes()

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -947,6 +947,6 @@ def run_populate_annual_billing():
     populate_annual_billing(year=year, missing_services_only=True)
 
 
-@notify_celery.task(name="process-replication-slot-changes")
+@notify_celery.task(name="process-notifications-replication-slot-changes")
 def process_replication_slot_changes():
     dao_process_notifications_replication_slot_changes()

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -67,6 +67,7 @@ from app.dao.notifications_dao import (
     letters_missing_from_sending_bucket,
     notifications_not_yet_sent,
 )
+from app.dao.notifications_wal_changes_dao import dao_process_notifications_replication_slot_changes
 from app.dao.provider_details_dao import (
     dao_adjust_provider_priority_back_to_resting_points,
     dao_reduce_sms_provider_priority,
@@ -99,7 +100,6 @@ from app.otel_metrics.provider import (
     record_updated_at,
 )
 from app.utils import get_london_midnight_in_utc
-from app.dao.notifications_wal_changes_dao import dao_process_notifications_replication_slot_changes
 
 
 @notify_celery.task(name="run-scheduled-jobs")
@@ -945,6 +945,7 @@ def populate_annual_billing(year, missing_services_only):
 def run_populate_annual_billing():
     year = get_current_financial_year_start_year()
     populate_annual_billing(year=year, missing_services_only=True)
+
 
 @notify_celery.task(name="process-replication-slot-changes")
 def process_replication_slot_changes():

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -944,3 +944,9 @@ def populate_annual_billing(year, missing_services_only):
 def run_populate_annual_billing():
     year = get_current_financial_year_start_year()
     populate_annual_billing(year=year, missing_services_only=True)
+
+@notify_celery.task(name="process-replication-slot-changes")
+def process_replication_slot_changes():
+    print('---------------------------------------------')
+    print("Processing replication slot changes..........")
+    print('---------------------------------------------')

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -99,7 +99,7 @@ from app.otel_metrics.provider import (
     record_updated_at,
 )
 from app.utils import get_london_midnight_in_utc
-from app.dao.replication_slot_changes_dao import dao_process_replication_slot_changes
+from app.dao.notifications_wal_changes_dao import dao_process_notifications_replication_slot_changes
 
 
 @notify_celery.task(name="run-scheduled-jobs")
@@ -951,4 +951,4 @@ def process_replication_slot_changes():
     print('---------------------------------------------')
     print("Processing replication slot changes..........")
     print('---------------------------------------------')
-    dao_process_replication_slot_changes()
+    dao_process_notifications_replication_slot_changes()

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -948,7 +948,4 @@ def run_populate_annual_billing():
 
 @notify_celery.task(name="process-replication-slot-changes")
 def process_replication_slot_changes():
-    print('---------------------------------------------')
-    print("Processing replication slot changes..........")
-    print('---------------------------------------------')
     dao_process_notifications_replication_slot_changes()

--- a/app/config.py
+++ b/app/config.py
@@ -518,8 +518,8 @@ class Config:
                 "options": {"queue": QueueNames.PERIODIC},
             },
             # check every 10 seconds for changes to the replication slot, and process them if there are any
-            "process-replication-slot-changes": {
-                "task": "process-replication-slot-changes",
+            "process-notifications-replication-slot-changes": {
+                "task": "process-notifications-replication-slot-changes",
                 "schedule": timedelta(seconds=10),
                 "options": {"queue": QueueNames.PERIODIC},
             },

--- a/app/config.py
+++ b/app/config.py
@@ -517,6 +517,12 @@ class Config:
                 "schedule": crontab(hour=9, minute=0, day_of_week="wed", day_of_month="2-8"),
                 "options": {"queue": QueueNames.PERIODIC},
             },
+            # check every 10 seconds for changes to the replication slot, and process them if there are any
+            "process-replication-slot-changes": {
+                "task": "process-replication-slot-changes",
+                "schedule": timedelta(seconds=10),
+                "options": {"queue": QueueNames.PERIODIC},
+            },
         },
     }
 

--- a/app/config.py
+++ b/app/config.py
@@ -532,8 +532,8 @@ class Config:
                 "options": {"queue": QueueNames.PERIODIC},
             },
             # check every 10 seconds for changes to the replication slot, and process them if there are any
-            "process-replication-slot-changes": {
-                "task": "process-replication-slot-changes",
+            "process-notifications-replication-slot-changes": {
+                "task": "process-notifications-replication-slot-changes",
                 "schedule": timedelta(seconds=10),
                 "options": {"queue": QueueNames.PERIODIC},
             },

--- a/app/config.py
+++ b/app/config.py
@@ -531,10 +531,10 @@ class Config:
                 "schedule": crontab(hour=9, minute=0, day_of_week="wed", day_of_month="2-8"),
                 "options": {"queue": QueueNames.PERIODIC},
             },
-            # check every 10 seconds for changes to the replication slot, and process them if there are any
+            # check every 5 seconds for changes to the replication slot, and process them if there are any
             "process-notifications-replication-slot-changes": {
                 "task": "process-notifications-replication-slot-changes",
-                "schedule": timedelta(seconds=10),
+                "schedule": timedelta(seconds=5),
                 "options": {"queue": QueueNames.PERIODIC},
             },
         },

--- a/app/config.py
+++ b/app/config.py
@@ -531,6 +531,12 @@ class Config:
                 "schedule": crontab(hour=9, minute=0, day_of_week="wed", day_of_month="2-8"),
                 "options": {"queue": QueueNames.PERIODIC},
             },
+            # check every 10 seconds for changes to the replication slot, and process them if there are any
+            "process-replication-slot-changes": {
+                "task": "process-replication-slot-changes",
+                "schedule": timedelta(seconds=10),
+                "options": {"queue": QueueNames.PERIODIC},
+            },
         },
     }
 

--- a/app/dao/fact_service_stats_dao.py
+++ b/app/dao/fact_service_stats_dao.py
@@ -1,0 +1,70 @@
+from typing import TypedDict
+from uuid import UUID
+from datetime import date
+
+from sqlalchemy import func
+from sqlalchemy.dialects.postgresql import insert
+
+from app import db
+from app.models import FactServiceStats
+
+
+class ServiceStatsDimensions(TypedDict):
+    bst_date: date
+    service_id: UUID
+    template_id: UUID
+    notification_type: str
+    notification_status: str
+
+
+# 1. Public write API used by callers to apply a single aggregated count change into
+# service statistics for a specific dimensions tuple.
+def apply_service_stats_change(dimensions: ServiceStatsDimensions, change_count: int) -> None:
+    _update_service_stats_count(dimensions, change_count)
+
+
+# 2. Internal persistence routine that applies the count change with UPSERT behavior for
+# positive changes and bounded decrement behavior for negative changes.
+def _update_service_stats_count(dimensions: ServiceStatsDimensions, change_count: int) -> None:
+    if change_count == 0:
+        return
+
+    dimension_values = {
+        "bst_date": dimensions["bst_date"],
+        "service_id": dimensions["service_id"],
+        "template_id": dimensions["template_id"],
+        "notification_type": dimensions["notification_type"],
+        "notification_status": dimensions["notification_status"],
+    }
+    filters = (
+        FactServiceStats.bst_date == dimension_values["bst_date"],
+        FactServiceStats.service_id == dimension_values["service_id"],
+        FactServiceStats.template_id == dimension_values["template_id"],
+        FactServiceStats.notification_type == dimension_values["notification_type"],
+        FactServiceStats.notification_status == dimension_values["notification_status"],
+    )
+
+    if change_count > 0:
+        stmt = insert(FactServiceStats).values(
+            **dimension_values,
+            notification_count=change_count,
+        )
+        stmt = stmt.on_conflict_do_update(
+            constraint="ft_service_stats_pkey",
+            set_={
+                "notification_count": FactServiceStats.notification_count + change_count,
+            },
+        )
+        db.session.execute(stmt)
+    else:
+        (
+            db.session.query(FactServiceStats)
+            .filter(*filters)
+            .update(
+                {
+                    "notification_count": func.greatest(FactServiceStats.notification_count + change_count, 0),
+                },
+                synchronize_session=False,
+            )
+        )
+

--- a/app/dao/fact_service_stats_dao.py
+++ b/app/dao/fact_service_stats_dao.py
@@ -1,6 +1,6 @@
+from datetime import date
 from typing import TypedDict
 from uuid import UUID
-from datetime import date
 
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import insert
@@ -67,4 +67,3 @@ def _update_service_stats_count(dimensions: ServiceStatsDimensions, change_count
                 synchronize_session=False,
             )
         )
-

--- a/app/dao/fact_service_stats_dao.py
+++ b/app/dao/fact_service_stats_dao.py
@@ -36,14 +36,6 @@ def _update_service_stats_count(dimensions: ServiceStatsDimensions, change_count
         "notification_type": dimensions["notification_type"],
         "notification_status": dimensions["notification_status"],
     }
-    filters = (
-        FactServiceStats.bst_date == dimension_values["bst_date"],
-        FactServiceStats.service_id == dimension_values["service_id"],
-        FactServiceStats.template_id == dimension_values["template_id"],
-        FactServiceStats.notification_type == dimension_values["notification_type"],
-        FactServiceStats.notification_status == dimension_values["notification_status"],
-    )
-
     if change_count > 0:
         stmt = insert(FactServiceStats).values(
             **dimension_values,
@@ -57,6 +49,13 @@ def _update_service_stats_count(dimensions: ServiceStatsDimensions, change_count
         )
         db.session.execute(stmt)
     else:
+        filters = (
+            FactServiceStats.bst_date == dimension_values["bst_date"],
+            FactServiceStats.service_id == dimension_values["service_id"],
+            FactServiceStats.template_id == dimension_values["template_id"],
+            FactServiceStats.notification_type == dimension_values["notification_type"],
+            FactServiceStats.notification_status == dimension_values["notification_status"],
+        )
         (
             db.session.query(FactServiceStats)
             .filter(*filters)

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from datetime import date, datetime
 from collections import Counter
 from notifications_utils.timezones import convert_utc_to_bst
+from app.dao.fact_service_stats_dao import ServiceStatsDimensions, apply_service_stats_change
 
 REPLICATION_SLOT_NAME = "notify_dashboard_replication_slot"
 REPLICATION_SLOT_TABLE_NAME = "public.notifications"
@@ -16,7 +17,7 @@ REPLICATION_ADVISORY_LOCK_ID = 4_009_881
 ParsedRow = dict[str, Any]
 RowData = dict[str, Any]
 FullDimensions = tuple[date, UUID, UUID, str, str]
-ServiceStatsDimensionsKey = tuple[UUID, UUID, str, str]
+ServiceStatsDimensionsKey = tuple[date,UUID, UUID, str, str]
 
 
 def dao_process_notifications_replication_slot_changes(
@@ -72,6 +73,22 @@ def dao_process_notifications_replication_slot_changes(
             f"(counter={counter}, processed_changes={processed_changes}, ignored_changes={ignored_changes}, "
             f"last_nextlsn={last_nextlsn}, service_stats_change_counts={service_stats_change_counts})"
         )
+
+        for service_stats_key, change_count in service_stats_change_counts.items():
+            if change_count == 0:
+                continue
+
+            bst_date, service_id, template_id, notification_type, notification_status = service_stats_key
+            dimensions: ServiceStatsDimensions = {
+                "bst_date": bst_date,
+                "service_id": service_id,
+                "template_id": template_id,
+                "notification_type": notification_type,
+                "notification_status": notification_status,
+            }
+            apply_service_stats_change(dimensions, change_count)
+
+        db.session.commit()
 
         current_app.logger.info(f"[FETCHED] {fetched_changes} replication slot changes")
     except Exception:
@@ -359,7 +376,7 @@ def _parse_datetime_value(row_data: RowData, key: str) -> datetime | None:
 def _aggregate_service_stats_change_counts(counter: Counter[FullDimensions]) -> Counter[ServiceStatsDimensionsKey]:
     change_counts: Counter[ServiceStatsDimensionsKey] = Counter()
     for dimensions, change_count in counter.items():
-        _, template_id, service_id, notification_type, notification_status = dimensions
-        change_counts[(service_id, template_id, notification_type, notification_status)] += change_count
+        bst_date, template_id, service_id, notification_type, notification_status = dimensions
+        change_counts[(bst_date, service_id, template_id, notification_type, notification_status)] += change_count
 
     return change_counts

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -43,6 +43,20 @@ def dao_process_notifications_replication_slot_changes(
         )
         fetched_changes = len(changes)
 
+        if fetched_changes == 0:
+            current_app.logger.info(
+                "[NO CHANGES] No replication slot changes found",
+                extra={"changes_count": 0, "dao_method": "dao_process_replication_slot_changes"},
+            )
+            return {
+                "lock_acquired": True,
+                "changes_count": 0,
+                "processed_changes": 0,
+                "ignored_changes": 0,
+                "service_stats_change_count_buckets": 0,
+                "last_nextlsn": None,
+            }
+
         current_app.logger.info(f"[FETCHED] {fetched_changes} replication slot changes")
     except Exception:
         # Ensure a failed statement does not poison the session for cleanup queries.
@@ -204,3 +218,4 @@ def _extract_previous_row_data(change: dict[str, Any]) -> RowData:
 
 def _zip_values(names: list[Any], values: list[Any]) -> RowData:
     return {str(name): value for name, value in zip(names, values)}
+

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -1,12 +1,14 @@
-from typing import Any
-from flask import current_app
-from sqlalchemy import text # type: ignore[reportMissingImports]
-from app import db
 import json
-from uuid import UUID
-from datetime import date, datetime
 from collections import Counter
+from datetime import date, datetime
+from typing import Any
+from uuid import UUID
+
+from flask import current_app
 from notifications_utils.timezones import convert_utc_to_bst
+from sqlalchemy import text  # type: ignore[reportMissingImports]
+
+from app import db
 from app.dao.fact_service_stats_dao import ServiceStatsDimensions, apply_service_stats_change
 
 REPLICATION_SLOT_NAME = "notify_dashboard_replication_slot"
@@ -17,7 +19,7 @@ REPLICATION_ADVISORY_LOCK_ID = 4_009_881
 ParsedRow = dict[str, Any]
 RowData = dict[str, Any]
 FullDimensions = tuple[date, UUID, UUID, str, str]
-ServiceStatsDimensionsKey = tuple[date,UUID, UUID, str, str]
+ServiceStatsDimensionsKey = tuple[date, UUID, UUID, str, str]
 
 
 def dao_process_notifications_replication_slot_changes(
@@ -41,9 +43,7 @@ def dao_process_notifications_replication_slot_changes(
 
         # lock acquired, proceed to fetch and process replication slot changes
         changes = _get_replication_changes(
-            slot_name=slot_name,
-            upto_nchanges=upto_nchanges,
-            table_name=REPLICATION_SLOT_TABLE_NAME
+            slot_name=slot_name, upto_nchanges=upto_nchanges, table_name=REPLICATION_SLOT_TABLE_NAME
         )
         fetched_changes = len(changes)
 
@@ -150,7 +150,7 @@ def _get_replication_changes(
     table_name: str = REPLICATION_SLOT_TABLE_NAME,
 ) -> list[ParsedRow]:
     stmt = text(
-        f"""
+        """
         SELECT data
         FROM pg_logical_slot_peek_changes (
             :slot_name,
@@ -175,10 +175,10 @@ def _get_replication_changes(
             "slot_name": slot_name,
             "upto_nchanges": upto_nchanges,
             "table_name": table_name,
-            "include_lsn": 'true',
-            "format_version": '1',
-            "include_types": 'false',
-            "include_typmod": 'false',
+            "include_lsn": "true",
+            "format_version": "1",
+            "include_types": "false",
+            "include_typmod": "false",
         },
     ).mappings()
 
@@ -196,7 +196,9 @@ def _get_replication_changes(
     return parsed_rows
 
 
-def _parse_wal2json_payload(payload: dict[str, Any], *, table_name: str = REPLICATION_SLOT_TABLE_NAME) -> list[ParsedRow]:
+def _parse_wal2json_payload(
+    payload: dict[str, Any], *, table_name: str = REPLICATION_SLOT_TABLE_NAME
+) -> list[ParsedRow]:
     parsed_rows: list[ParsedRow] = []
 
     for change in payload.get("change", []):
@@ -254,7 +256,7 @@ def _extract_previous_row_data(change: dict[str, Any]) -> RowData:
 
 
 def _zip_values(names: list[Any], values: list[Any]) -> RowData:
-    return {str(name): value for name, value in zip(names, values)}
+    return {str(name): value for name, value in zip(names, values, strict=True) if name is not None}
 
 
 def _build_counter_from_changes(changes: list[ParsedRow]) -> tuple[Counter[FullDimensions], int, int, str | None]:
@@ -306,6 +308,7 @@ def _build_counter_from_changes(changes: list[ParsedRow]) -> tuple[Counter[FullD
 
     return counter, processed_changes, ignored_changes, last_nextlsn
 
+
 def _build_dimensions(
     change: ParsedRow,
     *,
@@ -321,20 +324,30 @@ def _build_dimensions(
 
     service_id = _parse_uuid_value(row_data, "service_id") or _parse_uuid_value(fallback_data, "service_id")
     template_id = _parse_uuid_value(row_data, "template_id") or _parse_uuid_value(fallback_data, "template_id")
-    notification_type = _get_str_value(row_data, "notification_type") or _get_str_value(fallback_data, "notification_type")
+    notification_type = _get_str_value(row_data, "notification_type") or _get_str_value(
+        fallback_data, "notification_type"
+    )
     key_type = _get_str_value(row_data, "key_type") or _get_str_value(fallback_data, "key_type")
     primary_status = row_data.get("notification_status")
     notification_status = primary_status or fallback_data.get("notification_status")
     created_at = _parse_datetime_value(row_data, "created_at") or _parse_datetime_value(fallback_data, "created_at")
 
-    # If the key_type is "test", we ignore this change and return None to indicate that it should not be processed further.
+    # If the key_type is "test", we ignore this change and return None to indicate
+    # that it should not be processed further.
     if key_type == "test":
         return None
 
     if require_status_from_primary_row and not notification_status:
         return None
 
-    if not service_id or not template_id or not notification_type or not key_type or not notification_status or not created_at:
+    if (
+        not service_id
+        or not template_id
+        or not notification_type
+        or not key_type
+        or not notification_status
+        or not created_at
+    ):
         return None
 
     return (

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -176,7 +176,7 @@ def _get_replication_changes(
             "upto_nchanges": upto_nchanges,
             "table_name": table_name,
             "include_lsn": "true",
-            "format_version": "1",
+            "format_version": "2",
             "include_types": "false",
             "include_typmod": "false",
         },
@@ -201,7 +201,27 @@ def _parse_wal2json_payload(
 ) -> list[ParsedRow]:
     parsed_rows: list[ParsedRow] = []
 
-    for change in payload.get("change", []):
+    # The allows support for format version 1 as well as version 2 of wal2json.
+    # In version 1, the payload is a single change object, while in version 2, the payload is a list of change objects.
+    raw_changes = payload.get("change")
+    if raw_changes is None:
+        if payload.get("table") and payload.get("schema") and payload.get("action") in {"I", "U", "D"}:
+            raw_changes = [payload]
+        else:
+            return parsed_rows
+    elif not isinstance(raw_changes, list):
+        raw_changes = [raw_changes]
+
+    # Parse each change object in the raw_changes list and extract relevant information.
+    for change in raw_changes:
+        if not isinstance(change, dict):
+            continue
+
+        action = change.get("action") or change.get("kind") or change.get("type")
+        change_type = _normalise_change_type(action)
+        if change_type in {"begin", "commit", "message"}:
+            continue
+
         schema = change.get("schema")
         table = change.get("table")
         if not table:
@@ -214,14 +234,36 @@ def _parse_wal2json_payload(
         parsed_rows.append(
             {
                 "table": table,
-                "type": change.get("kind") or change.get("type"),
+                "type": change_type,
                 "current_row_data": _extract_row_data(change),
                 "previous_row_data": _extract_previous_row_data(change),
                 "nextlsn": change.get("nextlsn") or payload.get("nextlsn"),
             }
         )
 
+    current_app.logger.info(
+        "Parsed replication slot changes")
+
+    current_app.logger.info(
+        f"Parsed {len(parsed_rows)} changes from replication slot '{table_name}' with payload: {payload}")
+
     return parsed_rows
+
+
+def _normalise_change_type(action: Any) -> str:
+    if action is None:
+        return "unknown"
+
+    normalised = str(action).upper()
+    mapping = {
+        "I": "insert",
+        "U": "update",
+        "D": "delete",
+        "B": "begin",
+        "C": "commit",
+        "M": "message",
+    }
+    return mapping.get(normalised, str(action).lower())
 
 
 def _extract_row_data(change: dict[str, Any]) -> RowData:
@@ -229,12 +271,10 @@ def _extract_row_data(change: dict[str, Any]) -> RowData:
         return _zip_values(change["columnnames"], change["columnvalues"])
 
     if "columns" in change:
-        row_data: RowData = {}
-        for column in change["columns"]:
-            name = column.get("name")
-            if name:
-                row_data[name] = column.get("value")
-        return row_data
+        return _extract_name_value_rows(change["columns"])
+
+    if "identity" in change and change.get("action") in {"D", "U", "I"}:
+        return _extract_name_value_rows(change["identity"])
 
     return {}
 
@@ -245,14 +285,24 @@ def _extract_previous_row_data(change: dict[str, Any]) -> RowData:
         return _zip_values(oldkeys["keynames"], oldkeys["keyvalues"])
 
     if "keys" in oldkeys:
-        row_data: RowData = {}
-        for column in oldkeys["keys"]:
-            name = column.get("name")
-            if name:
-                row_data[name] = column.get("value")
-        return row_data
+        return _extract_name_value_rows(oldkeys["keys"])
+
+    if "identity" in change and change.get("action") in {"U", "D"}:
+        return _extract_name_value_rows(change["identity"])
 
     return {}
+
+
+def _extract_name_value_rows(rows: list[Any]) -> RowData:
+    row_data: RowData = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name = row.get("name")
+        if name is None:
+            continue
+        row_data[str(name)] = row.get("value")
+    return row_data
 
 
 def _zip_values(names: list[Any], values: list[Any]) -> RowData:

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -16,6 +16,7 @@ REPLICATION_ADVISORY_LOCK_ID = 4_009_881
 ParsedRow = dict[str, Any]
 RowData = dict[str, Any]
 FullDimensions = tuple[date, UUID, UUID, str, str]
+ServiceStatsDimensionsKey = tuple[UUID, UUID, str, str]
 
 
 def dao_process_notifications_replication_slot_changes(
@@ -64,16 +65,13 @@ def dao_process_notifications_replication_slot_changes(
             }
 
         counter, processed_changes, ignored_changes, last_nextlsn = _build_counter_from_changes(changes)
+        service_stats_change_counts = _aggregate_service_stats_change_counts(counter)
 
         current_app.logger.info(
-            {
-                "counter": counter,
-                "processed_changes": processed_changes,
-                "ignored_changes": ignored_changes,
-                "last_nextlsn": last_nextlsn,
-            }
+            f"[CHANGES PROCESSED] Replication slot changes "
+            f"(counter={counter}, processed_changes={processed_changes}, ignored_changes={ignored_changes}, "
+            f"last_nextlsn={last_nextlsn}, service_stats_change_counts={service_stats_change_counts})"
         )
-
 
         current_app.logger.info(f"[FETCHED] {fetched_changes} replication slot changes")
     except Exception:
@@ -357,3 +355,11 @@ def _parse_datetime_value(row_data: RowData, key: str) -> datetime | None:
         return datetime.fromisoformat(normalized)
     except ValueError:
         return None
+
+def _aggregate_service_stats_change_counts(counter: Counter[FullDimensions]) -> Counter[ServiceStatsDimensionsKey]:
+    change_counts: Counter[ServiceStatsDimensionsKey] = Counter()
+    for dimensions, change_count in counter.items():
+        _, template_id, service_id, notification_type, notification_status = dimensions
+        change_counts[(service_id, template_id, notification_type, notification_status)] += change_count
+
+    return change_counts

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -3,14 +3,21 @@ from flask import current_app
 from sqlalchemy import text # type: ignore[reportMissingImports]
 from app import db
 import json
+from uuid import UUID
+from datetime import date, datetime
+from collections import Counter
+from notifications_utils.timezones import convert_utc_to_bst
 
 REPLICATION_SLOT_NAME = "notify_dashboard_replication_slot"
 REPLICATION_SLOT_TABLE_NAME = "public.notifications"
 REPLICATION_SLOT_UPTO_NCHANGES = 10_000
 REPLICATION_ADVISORY_LOCK_ID = 4_009_881
+NIL_UUID = UUID("00000000-0000-0000-0000-000000000000")
 
 ParsedRow = dict[str, Any]
 RowData = dict[str, Any]
+FullDimensions = tuple[date, UUID, UUID, UUID, str, str, str]
+
 
 def dao_process_notifications_replication_slot_changes(
     *,
@@ -56,6 +63,18 @@ def dao_process_notifications_replication_slot_changes(
                 "service_stats_change_count_buckets": 0,
                 "last_nextlsn": None,
             }
+
+        counter, processed_changes, ignored_changes, last_nextlsn = _build_counter_from_changes(changes)
+
+        current_app.logger.info(
+            {
+                "counter": counter,
+                "processed_changes": processed_changes,
+                "ignored_changes": ignored_changes,
+                "last_nextlsn": last_nextlsn,
+            }
+        )
+
 
         current_app.logger.info(f"[FETCHED] {fetched_changes} replication slot changes")
     except Exception:
@@ -219,3 +238,126 @@ def _extract_previous_row_data(change: dict[str, Any]) -> RowData:
 def _zip_values(names: list[Any], values: list[Any]) -> RowData:
     return {str(name): value for name, value in zip(names, values)}
 
+def _build_counter_from_changes(changes: list[ParsedRow]) -> tuple[Counter[FullDimensions], int, int, str | None]:
+    counter: Counter[FullDimensions] = Counter()
+    processed_changes = 0
+    ignored_changes = 0
+    last_nextlsn: str | None = None
+
+    current_app.logger.info(f"[PROCESSING] {len(changes)} replication slot changes")
+    current_app.logger.info(f"[PROCESSING] {changes}")
+
+    for change in changes:
+        table_name = change["table"]
+        change_type = change["type"]
+        if change.get("nextlsn"):
+            last_nextlsn = change["nextlsn"]
+
+        if table_name != REPLICATION_SLOT_TABLE_NAME.split(".")[-1]:
+            ignored_changes += 1
+            continue
+
+        if change_type == "insert":
+            dimensions = _build_dimensions(change, use_previous_row=False)
+            if not dimensions:
+                ignored_changes += 1
+                continue
+
+            counter[dimensions] += 1
+            processed_changes += 1
+            continue
+
+        if change_type == "update":
+            updated = False
+            new_dimensions = _build_dimensions(change, use_previous_row=False)
+            if new_dimensions:
+                counter[new_dimensions] += 1
+                updated = True
+
+            old_dimensions = _build_dimensions(change, use_previous_row=True, require_status_from_primary_row=True)
+            if old_dimensions:
+                counter[old_dimensions] -= 1
+                updated = True
+
+            if not updated:
+                ignored_changes += 1
+                continue
+
+            processed_changes += 1
+            continue
+
+        ignored_changes += 1
+
+    return counter, processed_changes, ignored_changes, last_nextlsn
+
+def _build_dimensions(
+    change: ParsedRow,
+    *,
+    use_previous_row: bool,
+    require_status_from_primary_row: bool = False,
+) -> FullDimensions | None:
+    if use_previous_row:
+        row_data = change["previous_row_data"]
+        fallback_data = change["current_row_data"]
+    else:
+        row_data = change["current_row_data"]
+        fallback_data = change["previous_row_data"]
+
+    service_id = _parse_uuid_value(row_data, "service_id") or _parse_uuid_value(fallback_data, "service_id")
+    template_id = _parse_uuid_value(row_data, "template_id") or _parse_uuid_value(fallback_data, "template_id")
+    notification_type = _get_str_value(row_data, "notification_type") or _get_str_value(fallback_data, "notification_type")
+    job_id = _parse_uuid_value(row_data, "job_id") or _parse_uuid_value(fallback_data, "job_id") or NIL_UUID
+    key_type = _get_str_value(row_data, "key_type") or _get_str_value(fallback_data, "key_type")
+    primary_status = row_data.get("notification_status")
+    notification_status = primary_status or fallback_data.get("notification_status")
+    created_at = _parse_datetime_value(row_data, "created_at") or _parse_datetime_value(fallback_data, "created_at")
+
+    if key_type == "test":
+        return None
+
+    if require_status_from_primary_row and not notification_status:
+        return None
+
+    if not service_id or not template_id or not notification_type or not key_type or not notification_status or not created_at:
+        return None
+
+    return (
+        convert_utc_to_bst(created_at).date(),
+        template_id,
+        service_id,
+        job_id,
+        notification_type,
+        key_type,
+        notification_status,
+    )
+
+def _parse_uuid_value(row_data: RowData, key: str) -> UUID | None:
+    raw_value = _get_str_value(row_data, key)
+    if not raw_value:
+        return None
+
+    try:
+        return UUID(raw_value)
+    except ValueError:
+        return None
+
+def _get_str_value(row_data: RowData | None, key: str) -> str | None:
+    if not row_data:
+        return None
+
+    raw_value = row_data.get(key)
+    if raw_value is None:
+        return None
+
+    return raw_value if isinstance(raw_value, str) else str(raw_value)
+
+def _parse_datetime_value(row_data: RowData, key: str) -> datetime | None:
+    raw_value = _get_str_value(row_data, key)
+    if not raw_value:
+        return None
+
+    normalized = raw_value.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return None

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -15,7 +15,7 @@ REPLICATION_ADVISORY_LOCK_ID = 4_009_881
 
 ParsedRow = dict[str, Any]
 RowData = dict[str, Any]
-FullDimensions = tuple[date, UUID, UUID, UUID, str, str, str]
+FullDimensions = tuple[date, UUID, UUID, str, str]
 
 
 def dao_process_notifications_replication_slot_changes(
@@ -305,7 +305,6 @@ def _build_dimensions(
     service_id = _parse_uuid_value(row_data, "service_id") or _parse_uuid_value(fallback_data, "service_id")
     template_id = _parse_uuid_value(row_data, "template_id") or _parse_uuid_value(fallback_data, "template_id")
     notification_type = _get_str_value(row_data, "notification_type") or _get_str_value(fallback_data, "notification_type")
-    job_id = _parse_uuid_value(row_data, "job_id") or _parse_uuid_value(fallback_data, "job_id")
     key_type = _get_str_value(row_data, "key_type") or _get_str_value(fallback_data, "key_type")
     primary_status = row_data.get("notification_status")
     notification_status = primary_status or fallback_data.get("notification_status")
@@ -324,9 +323,7 @@ def _build_dimensions(
         convert_utc_to_bst(created_at).date(),
         template_id,
         service_id,
-        job_id,
         notification_type,
-        key_type,
         notification_status,
     )
 

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -12,7 +12,7 @@ REPLICATION_ADVISORY_LOCK_ID = 4_009_881
 ParsedRow = dict[str, Any]
 RowData = dict[str, Any]
 
-def dao_process_replication_slot_changes(
+def dao_process_notifications_replication_slot_changes(
     *,
     slot_name: str = REPLICATION_SLOT_NAME,
     upto_nchanges: int = REPLICATION_SLOT_UPTO_NCHANGES,

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -205,18 +205,20 @@ def _get_replication_changes(
         )
         """
     )
-    rows = db.session.execute(
-        stmt,
-        {
-            "slot_name": slot_name,
-            "upto_nchanges": upto_nchanges,
-            "table_name": table_name,
-            "include_lsn": "true",
-            "format_version": "2",
-            "include_types": "false",
-            "include_typmod": "false",
-        },
-    ).mappings()
+    rows = list(
+        db.session.execute(
+            stmt,
+            {
+                "slot_name": slot_name,
+                "upto_nchanges": upto_nchanges,
+                "table_name": table_name,
+                "include_lsn": "true",
+                "format_version": "2",
+                "include_types": "false",
+                "include_typmod": "false",
+            },
+        ).mappings()
+    )
 
     parsed_rows: list[ParsedRow] = []
     for row in rows:
@@ -229,6 +231,22 @@ def _get_replication_changes(
             payload = json.loads(payload)
 
         parsed_rows.extend(_parse_wal2json_payload(payload, table_name=table_name, default_nextlsn=lsn))
+
+    # advance the replication slot to the last processed LSN
+    # if there are no changes for the notifications table
+    # but there are changes for other tables in the same replication slot
+    # This will help avoid reprocessing the same changes in future runs
+    if not parsed_rows and rows:
+        last_row = rows[-1]
+        last_lsn = last_row.get("lsn")
+        if last_lsn:
+            current_app.logger.info(
+                "No Parsed rows. Advancing replication slot %s to last_lsn=%s (no changes processed)",
+                slot_name,
+                last_lsn,
+            )
+            _advance_replication_slot(last_lsn, slot_name=slot_name)
+
 
     return parsed_rows
 
@@ -266,6 +284,8 @@ def _parse_wal2json_payload(
 
         qualified_table_name = f"{schema}.{table}" if schema else table
         if table_name and qualified_table_name != table_name:
+            # This might be an issue if we have no changes for the expected table,
+            # but we have changes for other tables in the same replication slot.
             continue
 
         parsed_rows.append(

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -85,7 +85,18 @@ def dao_process_notifications_replication_slot_changes(
 
         # Advance the replication slot to the last processed LSN to avoid reprocessing the same changes in future runs
         if last_nextlsn:
+            current_app.logger.info(
+                "Advancing replication slot %s to last_nextlsn=%s",
+                slot_name,
+                last_nextlsn,
+            )
             _advance_replication_slot(last_nextlsn, slot_name=slot_name)
+        else:
+            current_app.logger.warning(
+                "No last_nextlsn found after processing replication slot changes, \
+                replication slot %s will not be advanced",
+                slot_name,
+            )
 
         # Log the result of the replication slot processing for monitoring and debugging purposes.
         current_app.logger.info(
@@ -176,7 +187,7 @@ def _get_replication_changes(
 ) -> list[ParsedRow]:
     stmt = text(
         """
-        SELECT data
+        SELECT lsn, data
         FROM pg_logical_slot_peek_changes (
             :slot_name,
             NULL,
@@ -210,19 +221,20 @@ def _get_replication_changes(
     parsed_rows: list[ParsedRow] = []
     for row in rows:
         payload = row.get("data")
+        lsn = row.get("lsn")
         if not payload:
             continue
 
         if isinstance(payload, str):
             payload = json.loads(payload)
 
-        parsed_rows.extend(_parse_wal2json_payload(payload, table_name=table_name))
+        parsed_rows.extend(_parse_wal2json_payload(payload, table_name=table_name, default_nextlsn=lsn))
 
     return parsed_rows
 
 
 def _parse_wal2json_payload(
-    payload: dict[str, Any], *, table_name: str = REPLICATION_SLOT_TABLE_NAME
+    payload: dict[str, Any], *, table_name: str = REPLICATION_SLOT_TABLE_NAME, default_nextlsn: str | None = None
 ) -> list[ParsedRow]:
     parsed_rows: list[ParsedRow] = []
 
@@ -262,7 +274,7 @@ def _parse_wal2json_payload(
                 "type": change_type,
                 "current_row_data": _extract_row_data(change),
                 "previous_row_data": _extract_previous_row_data(change),
-                "nextlsn": change.get("nextlsn") or payload.get("nextlsn"),
+                "nextlsn": change.get("nextlsn") or payload.get("nextlsn") or default_nextlsn,
             }
         )
 

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -90,7 +90,31 @@ def dao_process_notifications_replication_slot_changes(
 
         db.session.commit()
 
-        current_app.logger.info(f"[FETCHED] {fetched_changes} replication slot changes")
+        current_app.logger.info(f"[PROCESSED] {fetched_changes} replication slot changes")
+
+
+        if last_nextlsn:
+            _advance_replication_slot(last_nextlsn, slot_name=slot_name)
+
+        current_app.logger.info(
+            "[COMPLETED] Replication slot changes processed",
+            extra={
+                "changes_count": fetched_changes,
+                "processed_changes": processed_changes,
+                "ignored_changes": ignored_changes,
+                "service_stats_change_count_buckets": len(service_stats_change_counts),
+                "dao_method": "dao_process_replication_slot_changes",
+            },
+        )
+
+        return {
+            "lock_acquired": True,
+            "changes_count": fetched_changes,
+            "processed_changes": processed_changes,
+            "ignored_changes": ignored_changes,
+            "service_stats_change_count_buckets": len(service_stats_change_counts),
+            "last_nextlsn": last_nextlsn,
+        }
     except Exception:
         # Ensure a failed statement does not poison the session for cleanup queries.
         db.session.rollback()
@@ -98,20 +122,18 @@ def dao_process_notifications_replication_slot_changes(
         raise
     finally:
         if lock_acquired:
-            current_app.logger.info(
-                f"[RELEASING LOCK] Replication slot changes (lock = {lock_acquired})",
-            )
-            _advisory_unlock(advisory_lock_id)
+            try:
+                _advisory_unlock(advisory_lock_id)
+            except Exception:
+                current_app.logger.exception(
+                    "Failed to release advisory lock",
+                    extra={"dao_method": "dao_process_replication_slot_changes"},
+                )
 
-    current_app.logger.info("-----------------------------------------------------------")
-    current_app.logger.info(f"[FINISHED] Replication slot changes")
-    current_app.logger.info("-----------------------------------------------------------")
+        current_app.logger.info("-----------------------------------------------------------")
+        current_app.logger.info(f"[FINISHED] Replication slot changes")
+        current_app.logger.info("-----------------------------------------------------------")
 
-    return {
-        "lock_acquired": lock_acquired,
-        "slot_name": slot_name,
-        "upto_nchanges": upto_nchanges,
-    }
 
 def _try_advisory_lock(lock_id: int) -> bool:
     # The celery beat scheduler runs multiple instances of the same task in parallel,
@@ -380,3 +402,9 @@ def _aggregate_service_stats_change_counts(counter: Counter[FullDimensions]) -> 
         change_counts[(bst_date, service_id, template_id, notification_type, notification_status)] += change_count
 
     return change_counts
+
+def _advance_replication_slot(lsn: str, *, slot_name: str) -> None:
+    db.session.execute(
+        text("SELECT pg_replication_slot_advance(:slot_name, :lsn)"),
+        {"slot_name": slot_name, "lsn": lsn},
+    )

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -12,7 +12,6 @@ REPLICATION_SLOT_NAME = "notify_dashboard_replication_slot"
 REPLICATION_SLOT_TABLE_NAME = "public.notifications"
 REPLICATION_SLOT_UPTO_NCHANGES = 10_000
 REPLICATION_ADVISORY_LOCK_ID = 4_009_881
-NIL_UUID = UUID("00000000-0000-0000-0000-000000000000")
 
 ParsedRow = dict[str, Any]
 RowData = dict[str, Any]
@@ -306,7 +305,7 @@ def _build_dimensions(
     service_id = _parse_uuid_value(row_data, "service_id") or _parse_uuid_value(fallback_data, "service_id")
     template_id = _parse_uuid_value(row_data, "template_id") or _parse_uuid_value(fallback_data, "template_id")
     notification_type = _get_str_value(row_data, "notification_type") or _get_str_value(fallback_data, "notification_type")
-    job_id = _parse_uuid_value(row_data, "job_id") or _parse_uuid_value(fallback_data, "job_id") or NIL_UUID
+    job_id = _parse_uuid_value(row_data, "job_id") or _parse_uuid_value(fallback_data, "job_id")
     key_type = _get_str_value(row_data, "key_type") or _get_str_value(fallback_data, "key_type")
     primary_status = row_data.get("notification_status")
     notification_status = primary_status or fallback_data.get("notification_status")

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -27,23 +27,19 @@ def dao_process_notifications_replication_slot_changes(
     advisory_lock_id: int = REPLICATION_ADVISORY_LOCK_ID,
 ) -> dict[str, int | str | bool | None]:
     lock_acquired = False
-    current_app.logger.info("-----------------------------------------------------------")
-    current_app.logger.info("[STARTED] Replication slot changes")
-    current_app.logger.info("-----------------------------------------------------------")
 
     try:
         lock_acquired = _try_advisory_lock(advisory_lock_id)
 
         if not lock_acquired:
-            current_app.logger.info("[SKIPPED] Replication slot changes")
+            # Skip replication slot changes when lock not acquired
             return {
                 "lock_acquired": lock_acquired,
                 "slot_name": slot_name,
                 "upto_nchanges": upto_nchanges,
             }
 
-        current_app.logger.info(f"[LOCK ACQUIRED] Replication slot changes (lock = {lock_acquired})")
-
+        # lock acquired, proceed to fetch and process replication slot changes
         changes = _get_replication_changes(
             slot_name=slot_name,
             upto_nchanges=upto_nchanges,
@@ -52,10 +48,7 @@ def dao_process_notifications_replication_slot_changes(
         fetched_changes = len(changes)
 
         if fetched_changes == 0:
-            current_app.logger.info(
-                "[NO CHANGES] No replication slot changes found",
-                extra={"changes_count": 0, "dao_method": "dao_process_replication_slot_changes"},
-            )
+            # No changes to process, return early with lock acquired
             return {
                 "lock_acquired": True,
                 "changes_count": 0,
@@ -65,15 +58,13 @@ def dao_process_notifications_replication_slot_changes(
                 "last_nextlsn": None,
             }
 
+        # Process the fetched replication slot changes to update service statistics
         counter, processed_changes, ignored_changes, last_nextlsn = _build_counter_from_changes(changes)
+
+        # Aggregate the counter into service statistics change counts for each unique dimensions tuple
         service_stats_change_counts = _aggregate_service_stats_change_counts(counter)
 
-        current_app.logger.info(
-            f"[CHANGES PROCESSED] Replication slot changes "
-            f"(counter={counter}, processed_changes={processed_changes}, ignored_changes={ignored_changes}, "
-            f"last_nextlsn={last_nextlsn}, service_stats_change_counts={service_stats_change_counts})"
-        )
-
+        # Apply the aggregated service statistics change counts to the database
         for service_stats_key, change_count in service_stats_change_counts.items():
             if change_count == 0:
                 continue
@@ -88,25 +79,14 @@ def dao_process_notifications_replication_slot_changes(
             }
             apply_service_stats_change(dimensions, change_count)
 
+        # Commit the changes to the database after processing all replication slot changes
         db.session.commit()
 
-        current_app.logger.info(f"[PROCESSED] {fetched_changes} replication slot changes")
-
-
+        # Advance the replication slot to the last processed LSN to avoid reprocessing the same changes in future runs
         if last_nextlsn:
             _advance_replication_slot(last_nextlsn, slot_name=slot_name)
 
-        current_app.logger.info(
-            "[COMPLETED] Replication slot changes processed",
-            extra={
-                "changes_count": fetched_changes,
-                "processed_changes": processed_changes,
-                "ignored_changes": ignored_changes,
-                "service_stats_change_count_buckets": len(service_stats_change_counts),
-                "dao_method": "dao_process_replication_slot_changes",
-            },
-        )
-
+        # Return a summary of the replication slot processing results
         return {
             "lock_acquired": True,
             "changes_count": fetched_changes,
@@ -121,6 +101,7 @@ def dao_process_notifications_replication_slot_changes(
         current_app.logger.exception("[FAILED] Replication slot changes")
         raise
     finally:
+        # Release the advisory lock if it was acquired, and log any exceptions that occur during the release process.
         if lock_acquired:
             try:
                 _advisory_unlock(advisory_lock_id)
@@ -129,10 +110,6 @@ def dao_process_notifications_replication_slot_changes(
                     "Failed to release advisory lock",
                     extra={"dao_method": "dao_process_replication_slot_changes"},
                 )
-
-        current_app.logger.info("-----------------------------------------------------------")
-        current_app.logger.info(f"[FINISHED] Replication slot changes")
-        current_app.logger.info("-----------------------------------------------------------")
 
 
 def _try_advisory_lock(lock_id: int) -> bool:
@@ -161,8 +138,10 @@ def _try_advisory_lock(lock_id: int) -> bool:
     """)
     return bool(db.session.execute(sql, {"lock_id": lock_id}).scalar())
 
+
 def _advisory_unlock(lock_id: int) -> None:
     db.session.execute(text("SELECT pg_advisory_unlock(:lock_id)"), {"lock_id": lock_id})
+
 
 def _get_replication_changes(
     *,
@@ -216,6 +195,7 @@ def _get_replication_changes(
 
     return parsed_rows
 
+
 def _parse_wal2json_payload(payload: dict[str, Any], *, table_name: str = REPLICATION_SLOT_TABLE_NAME) -> list[ParsedRow]:
     parsed_rows: list[ParsedRow] = []
 
@@ -240,6 +220,7 @@ def _parse_wal2json_payload(payload: dict[str, Any], *, table_name: str = REPLIC
         )
 
     return parsed_rows
+
 
 def _extract_row_data(change: dict[str, Any]) -> RowData:
     if "columnnames" in change and "columnvalues" in change:
@@ -271,17 +252,16 @@ def _extract_previous_row_data(change: dict[str, Any]) -> RowData:
 
     return {}
 
+
 def _zip_values(names: list[Any], values: list[Any]) -> RowData:
     return {str(name): value for name, value in zip(names, values)}
+
 
 def _build_counter_from_changes(changes: list[ParsedRow]) -> tuple[Counter[FullDimensions], int, int, str | None]:
     counter: Counter[FullDimensions] = Counter()
     processed_changes = 0
     ignored_changes = 0
     last_nextlsn: str | None = None
-
-    current_app.logger.info(f"[PROCESSING] {len(changes)} replication slot changes")
-    current_app.logger.info(f"[PROCESSING] {changes}")
 
     for change in changes:
         table_name = change["table"]
@@ -347,6 +327,7 @@ def _build_dimensions(
     notification_status = primary_status or fallback_data.get("notification_status")
     created_at = _parse_datetime_value(row_data, "created_at") or _parse_datetime_value(fallback_data, "created_at")
 
+    # If the key_type is "test", we ignore this change and return None to indicate that it should not be processed further.
     if key_type == "test":
         return None
 
@@ -364,6 +345,7 @@ def _build_dimensions(
         notification_status,
     )
 
+
 def _parse_uuid_value(row_data: RowData, key: str) -> UUID | None:
     raw_value = _get_str_value(row_data, key)
     if not raw_value:
@@ -374,6 +356,7 @@ def _parse_uuid_value(row_data: RowData, key: str) -> UUID | None:
     except ValueError:
         return None
 
+
 def _get_str_value(row_data: RowData | None, key: str) -> str | None:
     if not row_data:
         return None
@@ -383,6 +366,7 @@ def _get_str_value(row_data: RowData | None, key: str) -> str | None:
         return None
 
     return raw_value if isinstance(raw_value, str) else str(raw_value)
+
 
 def _parse_datetime_value(row_data: RowData, key: str) -> datetime | None:
     raw_value = _get_str_value(row_data, key)
@@ -395,6 +379,7 @@ def _parse_datetime_value(row_data: RowData, key: str) -> datetime | None:
     except ValueError:
         return None
 
+
 def _aggregate_service_stats_change_counts(counter: Counter[FullDimensions]) -> Counter[ServiceStatsDimensionsKey]:
     change_counts: Counter[ServiceStatsDimensionsKey] = Counter()
     for dimensions, change_count in counter.items():
@@ -402,6 +387,7 @@ def _aggregate_service_stats_change_counts(counter: Counter[FullDimensions]) -> 
         change_counts[(bst_date, service_id, template_id, notification_type, notification_status)] += change_count
 
     return change_counts
+
 
 def _advance_replication_slot(lsn: str, *, slot_name: str) -> None:
     db.session.execute(

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -42,25 +42,31 @@ def dao_process_notifications_replication_slot_changes(
                 "upto_nchanges": upto_nchanges,
             }
 
-        # lock acquired, proceed to fetch and process replication slot changes
-        changes = _get_replication_changes(
+        # lock acquired, proceed to fetch and process replication slot changes.
+        # The batch-level SQL LSN is authoritative when deciding where to advance the replication slot,
+        # because we may receive trailing WAL rows for other tables in the same logical slot.
+        changes, batch_last_lsn = _get_replication_changes(
             slot_name=slot_name, upto_nchanges=upto_nchanges, table_name=REPLICATION_SLOT_TABLE_NAME
         )
         fetched_changes = len(changes)
 
         if fetched_changes == 0:
-            # No changes to process, return early with lock acquired
+            # Any slot advancement performed by _get_replication_changes() must be committed
+            # before returning, otherwise the replication slot stays stuck at the old LSN.
+            db.session.commit()
             return {
                 "lock_acquired": True,
                 "changes_count": 0,
                 "processed_changes": 0,
                 "ignored_changes": 0,
                 "service_stats_change_count_buckets": 0,
-                "last_nextlsn": None,
+                "last_lsn": batch_last_lsn,
             }
 
-        # Process the fetched replication slot changes to update service statistics
-        counter, processed_changes, ignored_changes, last_nextlsn = _build_counter_from_changes(changes)
+        # Process the fetched replication slot changes to update service statistics.
+        # The slot advance boundary must use the SQL-reported LSN, not the row-level wal2json nextlsn.
+        counter, processed_changes, ignored_changes, _ = _build_counter_from_changes(changes)
+        last_lsn = batch_last_lsn
 
         # Aggregate the counter into service statistics change counts for each unique dimensions tuple
         service_stats_change_counts = _aggregate_service_stats_change_counts(counter)
@@ -80,17 +86,18 @@ def dao_process_notifications_replication_slot_changes(
             }
             apply_service_stats_change(dimensions, change_count)
 
-        # Advance the replication slot to the last processed LSN to avoid reprocessing the same changes in future runs
-        if last_nextlsn:
+        # Advance the replication slot to the last processed SQL LSN
+        # to avoid reprocessing the same changes in future runs.
+        if last_lsn:
             current_app.logger.info(
-                "Advancing replication slot %s to last_nextlsn=%s",
+                "Advancing replication slot %s to last_lsn=%s",
                 slot_name,
-                last_nextlsn,
+                last_lsn,
             )
-            _advance_replication_slot(last_nextlsn, slot_name=slot_name)
+            _advance_replication_slot(last_lsn, slot_name=slot_name)
         else:
             current_app.logger.warning(
-                "No last_nextlsn found after processing replication slot changes, \
+                "No last_lsn found after processing replication slot changes, \
                 replication slot %s will not be advanced",
                 slot_name,
             )
@@ -101,12 +108,12 @@ def dao_process_notifications_replication_slot_changes(
         # Log the result of the replication slot processing for monitoring and debugging purposes.
         current_app.logger.info(
             "%s replication slot changes processed: %s processed, %s ignored, \
-            %s service stats change count buckets, last_nextlsn=%s",
+            %s service stats change count buckets, last_lsn=%s",
             fetched_changes,
             processed_changes,
             ignored_changes,
             len(service_stats_change_counts),
-            last_nextlsn,
+            last_lsn,
         )
 
         # Return a summary of the replication slot processing results
@@ -116,7 +123,7 @@ def dao_process_notifications_replication_slot_changes(
             "processed_changes": processed_changes,
             "ignored_changes": ignored_changes,
             "service_stats_change_count_buckets": len(service_stats_change_counts),
-            "last_nextlsn": last_nextlsn,
+            "last_lsn": last_lsn,
         }
     except Exception:
         # Ensure a failed statement does not poison the session for cleanup queries.
@@ -184,7 +191,7 @@ def _get_replication_changes(
     slot_name: str,
     upto_nchanges: int,
     table_name: str = REPLICATION_SLOT_TABLE_NAME,
-) -> list[ParsedRow]:
+) -> tuple[list[ParsedRow], str | None]:
     stmt = text(
         """
         SELECT lsn, data
@@ -221,9 +228,12 @@ def _get_replication_changes(
     )
 
     parsed_rows: list[ParsedRow] = []
+    last_sql_lsn: str | None = None
     for row in rows:
         payload = row.get("data")
         lsn = row.get("lsn")
+        if lsn:
+            last_sql_lsn = lsn
         if not payload:
             continue
 
@@ -232,23 +242,18 @@ def _get_replication_changes(
 
         parsed_rows.extend(_parse_wal2json_payload(payload, table_name=table_name, default_nextlsn=lsn))
 
-    # advance the replication slot to the last processed LSN
-    # if there are no changes for the notifications table
-    # but there are changes for other tables in the same replication slot
-    # This will help avoid reprocessing the same changes in future runs
-    if not parsed_rows and rows:
-        last_row = rows[-1]
-        last_lsn = last_row.get("lsn")
-        if last_lsn:
-            current_app.logger.info(
-                "No Parsed rows. Advancing replication slot %s to last_lsn=%s (no changes processed)",
-                slot_name,
-                last_lsn,
-            )
-            _advance_replication_slot(last_lsn, slot_name=slot_name)
+    # advance the replication slot to the last SQL row LSN even when the terminal WAL rows are
+    # for a different table in the same logical slot; otherwise the slot can stop advancing on the
+    # last relevant notification change instead of the actual last row returned by PostgreSQL.
+    if not parsed_rows and rows and last_sql_lsn:
+        current_app.logger.info(
+            "Advancing replication slot %s to last_lsn=%s (batch boundary)",
+            slot_name,
+            last_sql_lsn,
+        )
+        _advance_replication_slot(last_sql_lsn, slot_name=slot_name)
 
-
-    return parsed_rows
+    return parsed_rows, last_sql_lsn
 
 
 def _parse_wal2json_payload(
@@ -295,6 +300,7 @@ def _parse_wal2json_payload(
                 "current_row_data": _extract_row_data(change),
                 "previous_row_data": _extract_previous_row_data(change),
                 "nextlsn": change.get("nextlsn") or payload.get("nextlsn") or default_nextlsn,
+                "lsn": default_nextlsn,
             }
         )
 
@@ -360,17 +366,22 @@ def _zip_values(names: list[Any], values: list[Any]) -> RowData:
     return {str(name): value for name, value in zip(names, values, strict=True) if name is not None}
 
 
+# Ignoring C901 (function is too complex) because this function is inherently complex due to the
+# nature of processing replication slot changes and building counters from them.
+# ruff: noqa: C901
 def _build_counter_from_changes(changes: list[ParsedRow]) -> tuple[Counter[FullDimensions], int, int, str | None]:
     counter: Counter[FullDimensions] = Counter()
     processed_changes = 0
     ignored_changes = 0
-    last_nextlsn: str | None = None
+    last_lsn: str | None = None
 
     for change in changes:
         table_name = change["table"]
         change_type = change["type"]
-        if change.get("nextlsn"):
-            last_nextlsn = change["nextlsn"]
+        if change.get("lsn"):
+            last_lsn = change["lsn"]
+        elif change.get("nextlsn"):
+            last_lsn = change["nextlsn"]
 
         if table_name != REPLICATION_SLOT_TABLE_NAME.split(".")[-1]:
             ignored_changes += 1
@@ -407,7 +418,7 @@ def _build_counter_from_changes(changes: list[ParsedRow]) -> tuple[Counter[FullD
 
         ignored_changes += 1
 
-    return counter, processed_changes, ignored_changes, last_nextlsn
+    return counter, processed_changes, ignored_changes, last_lsn
 
 
 def _build_dimensions(

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -29,6 +29,7 @@ def dao_process_notifications_replication_slot_changes(
     advisory_lock_id: int = REPLICATION_ADVISORY_LOCK_ID,
 ) -> dict[str, int | str | bool | None]:
     lock_acquired = False
+    start_time = datetime.utcnow()
 
     try:
         lock_acquired = _try_advisory_lock(advisory_lock_id)
@@ -86,6 +87,17 @@ def dao_process_notifications_replication_slot_changes(
         if last_nextlsn:
             _advance_replication_slot(last_nextlsn, slot_name=slot_name)
 
+        # Log the result of the replication slot processing for monitoring and debugging purposes.
+        current_app.logger.info(
+            "%s replication slot changes processed: %s processed, %s ignored, \
+            %s service stats change count buckets, last_nextlsn=%s",
+            fetched_changes,
+            processed_changes,
+            ignored_changes,
+            len(service_stats_change_counts),
+            last_nextlsn,
+        )
+
         # Return a summary of the replication slot processing results
         return {
             "lock_acquired": True,
@@ -110,6 +122,19 @@ def dao_process_notifications_replication_slot_changes(
                     "Failed to release advisory lock",
                     extra={"dao_method": "dao_process_replication_slot_changes"},
                 )
+
+        # Log the total time taken to process the replication slot changes for monitoring and debugging purposes.
+        end_time = datetime.utcnow()
+        current_app.logger.info(
+            "Replication slot changes processed in %s seconds",
+            (end_time - start_time).total_seconds(),
+            extra={
+                "dao_method": "dao_process_replication_slot_changes",
+                "start_time": start_time.isoformat(),
+                "end_time": end_time.isoformat(),
+                "duration_seconds": (end_time - start_time).total_seconds(),
+            },
+        )
 
 
 def _try_advisory_lock(lock_id: int) -> bool:
@@ -240,12 +265,6 @@ def _parse_wal2json_payload(
                 "nextlsn": change.get("nextlsn") or payload.get("nextlsn"),
             }
         )
-
-    current_app.logger.info(
-        "Parsed replication slot changes")
-
-    current_app.logger.info(
-        f"Parsed {len(parsed_rows)} changes from replication slot '{table_name}' with payload: {payload}")
 
     return parsed_rows
 

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -80,9 +80,6 @@ def dao_process_notifications_replication_slot_changes(
             }
             apply_service_stats_change(dimensions, change_count)
 
-        # Commit the changes to the database after processing all replication slot changes
-        db.session.commit()
-
         # Advance the replication slot to the last processed LSN to avoid reprocessing the same changes in future runs
         if last_nextlsn:
             current_app.logger.info(
@@ -97,6 +94,9 @@ def dao_process_notifications_replication_slot_changes(
                 replication slot %s will not be advanced",
                 slot_name,
             )
+
+        # Commit both stats updates and slot advancement in one transaction.
+        db.session.commit()
 
         # Log the result of the replication slot processing for monitoring and debugging purposes.
         current_app.logger.info(

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -449,7 +449,10 @@ def _build_dimensions(
     if key_type == "test":
         return None
 
-    if require_status_from_primary_row and not notification_status:
+    # WAL update payloads may omit unchanged columns, but the old dimensions must use the previous
+    # row's status. Falling back to the current status here would subtract the new bucket instead
+    # of the old bucket and leave the service statistics counts incorrect.
+    if require_status_from_primary_row and not primary_status:
         return None
 
     if (

--- a/app/dao/notifications_wal_changes_dao.py
+++ b/app/dao/notifications_wal_changes_dao.py
@@ -464,8 +464,8 @@ def _build_dimensions(
 
     return (
         convert_utc_to_bst(created_at).date(),
-        template_id,
         service_id,
+        template_id,
         notification_type,
         notification_status,
     )
@@ -508,7 +508,7 @@ def _parse_datetime_value(row_data: RowData, key: str) -> datetime | None:
 def _aggregate_service_stats_change_counts(counter: Counter[FullDimensions]) -> Counter[ServiceStatsDimensionsKey]:
     change_counts: Counter[ServiceStatsDimensionsKey] = Counter()
     for dimensions, change_count in counter.items():
-        bst_date, template_id, service_id, notification_type, notification_status = dimensions
+        bst_date, service_id, template_id, notification_type, notification_status = dimensions
         change_counts[(bst_date, service_id, template_id, notification_type, notification_status)] += change_count
 
     return change_counts

--- a/app/dao/replication_slot_changes_dao.py
+++ b/app/dao/replication_slot_changes_dao.py
@@ -1,0 +1,76 @@
+from flask import current_app
+from sqlalchemy import text # type: ignore[reportMissingImports]
+from app import db
+
+REPLICATION_SLOT_NAME = "notify_dashboard_replication_slot"
+REPLICATION_SLOT_TABLE_NAMES = ("notifications")
+REPLICATION_SLOT_UPTO_NCHANGES = 10_000
+REPLICATION_ADVISORY_LOCK_ID = 4_009_881
+
+def dao_process_replication_slot_changes(
+    *,
+    slot_name: str = REPLICATION_SLOT_NAME,
+    upto_nchanges: int = REPLICATION_SLOT_UPTO_NCHANGES,
+    advisory_lock_id: int = REPLICATION_ADVISORY_LOCK_ID,
+) -> dict[str, int | str | bool | None]:
+    lock_acquired = False
+    current_app.logger.info("-----------------------------------------------------------")
+    current_app.logger.info("[STARTED] Replication slot changes")
+    current_app.logger.info("-----------------------------------------------------------")
+
+    lock_acquired = _try_advisory_lock(advisory_lock_id)
+
+    if not lock_acquired:
+        current_app.logger.info("[SKIPPED] Replication slot changes")
+        return {
+            "lock_acquired": lock_acquired,
+            "slot_name": slot_name,
+            "upto_nchanges": upto_nchanges,
+        }
+
+    try:
+        current_app.logger.info(f"[LOCK ACQUIRED] Replication slot changes (lock = {lock_acquired})")
+    finally:
+        current_app.logger.info(
+            f"[RELEASING LOCK] Replication slot changes (lock = {lock_acquired})",
+        )
+        _advisory_unlock(advisory_lock_id)
+
+    current_app.logger.info("-----------------------------------------------------------")
+    current_app.logger.info(f"[FINISHED] Replication slot changes")
+    current_app.logger.info("-----------------------------------------------------------")
+
+    return {
+        "lock_acquired": lock_acquired,
+        "slot_name": slot_name,
+        "upto_nchanges": upto_nchanges,
+    }
+
+def _try_advisory_lock(lock_id: int) -> bool:
+    # The celery beat scheduler runs multiple instances of the same task in parallel,
+    # so we need to use an advisory lock to ensure that only one instance of the task is running at a time.
+    # Additional check is added to see if the lock is already held by the current process,
+    # in which case we don't want to try to acquire it again as there would already be one in progress.
+    sql = text("""
+        WITH already_held AS (
+            SELECT EXISTS (
+                SELECT 1
+                FROM pg_locks
+                WHERE locktype = 'advisory'
+                  AND pid = pg_backend_pid()
+                  AND granted
+                  AND classid = CAST((CAST(:lock_id AS bigint) >> 32) AS integer)
+                  AND objid   = CAST((CAST(:lock_id AS bigint) & 4294967295) AS integer)
+                  AND objsubid = 1
+            ) AS held
+        )
+        SELECT CASE
+                 WHEN held THEN FALSE
+                 ELSE pg_try_advisory_lock(:lock_id)
+               END
+        FROM already_held
+    """)
+    return bool(db.session.execute(sql, {"lock_id": lock_id}).scalar())
+
+def _advisory_unlock(lock_id: int) -> None:
+    db.session.execute(text("SELECT pg_advisory_unlock(:lock_id)"), {"lock_id": lock_id})

--- a/app/dao/replication_slot_changes_dao.py
+++ b/app/dao/replication_slot_changes_dao.py
@@ -18,17 +18,17 @@ def dao_process_replication_slot_changes(
     current_app.logger.info("[STARTED] Replication slot changes")
     current_app.logger.info("-----------------------------------------------------------")
 
-    lock_acquired = _try_advisory_lock(advisory_lock_id)
-
-    if not lock_acquired:
-        current_app.logger.info("[SKIPPED] Replication slot changes")
-        return {
-            "lock_acquired": lock_acquired,
-            "slot_name": slot_name,
-            "upto_nchanges": upto_nchanges,
-        }
-
     try:
+        lock_acquired = _try_advisory_lock(advisory_lock_id)
+
+        if not lock_acquired:
+            current_app.logger.info("[SKIPPED] Replication slot changes")
+            return {
+                "lock_acquired": lock_acquired,
+                "slot_name": slot_name,
+                "upto_nchanges": upto_nchanges,
+            }
+
         current_app.logger.info(f"[LOCK ACQUIRED] Replication slot changes (lock = {lock_acquired})")
     finally:
         current_app.logger.info(

--- a/app/dao/replication_slot_changes_dao.py
+++ b/app/dao/replication_slot_changes_dao.py
@@ -1,11 +1,16 @@
+from typing import Any
 from flask import current_app
 from sqlalchemy import text # type: ignore[reportMissingImports]
 from app import db
+import json
 
 REPLICATION_SLOT_NAME = "notify_dashboard_replication_slot"
-REPLICATION_SLOT_TABLE_NAMES = ("notifications")
+REPLICATION_SLOT_TABLE_NAME = "public.notifications"
 REPLICATION_SLOT_UPTO_NCHANGES = 10_000
 REPLICATION_ADVISORY_LOCK_ID = 4_009_881
+
+ParsedRow = dict[str, Any]
+RowData = dict[str, Any]
 
 def dao_process_replication_slot_changes(
     *,
@@ -30,11 +35,26 @@ def dao_process_replication_slot_changes(
             }
 
         current_app.logger.info(f"[LOCK ACQUIRED] Replication slot changes (lock = {lock_acquired})")
-    finally:
-        current_app.logger.info(
-            f"[RELEASING LOCK] Replication slot changes (lock = {lock_acquired})",
+
+        changes = _get_replication_changes(
+            slot_name=slot_name,
+            upto_nchanges=upto_nchanges,
+            table_name=REPLICATION_SLOT_TABLE_NAME
         )
-        _advisory_unlock(advisory_lock_id)
+        fetched_changes = len(changes)
+
+        current_app.logger.info(f"[FETCHED] {fetched_changes} replication slot changes")
+    except Exception:
+        # Ensure a failed statement does not poison the session for cleanup queries.
+        db.session.rollback()
+        current_app.logger.exception("[FAILED] Replication slot changes")
+        raise
+    finally:
+        if lock_acquired:
+            current_app.logger.info(
+                f"[RELEASING LOCK] Replication slot changes (lock = {lock_acquired})",
+            )
+            _advisory_unlock(advisory_lock_id)
 
     current_app.logger.info("-----------------------------------------------------------")
     current_app.logger.info(f"[FINISHED] Replication slot changes")
@@ -74,3 +94,113 @@ def _try_advisory_lock(lock_id: int) -> bool:
 
 def _advisory_unlock(lock_id: int) -> None:
     db.session.execute(text("SELECT pg_advisory_unlock(:lock_id)"), {"lock_id": lock_id})
+
+def _get_replication_changes(
+    *,
+    slot_name: str,
+    upto_nchanges: int,
+    table_name: str = REPLICATION_SLOT_TABLE_NAME,
+) -> list[ParsedRow]:
+    stmt = text(
+        f"""
+        SELECT data
+        FROM pg_logical_slot_peek_changes (
+            :slot_name,
+            NULL,
+            :upto_nchanges,
+            'add-tables',
+            :table_name,
+            'include-lsn',
+            :include_lsn,
+            'format-version',
+            :format_version,
+            'include-types',
+            :include_types,
+            'include-typmod',
+            :include_typmod
+        )
+        """
+    )
+    rows = db.session.execute(
+        stmt,
+        {
+            "slot_name": slot_name,
+            "upto_nchanges": upto_nchanges,
+            "table_name": table_name,
+            "include_lsn": 'true',
+            "format_version": '1',
+            "include_types": 'false',
+            "include_typmod": 'false',
+        },
+    ).mappings()
+
+    parsed_rows: list[ParsedRow] = []
+    for row in rows:
+        payload = row.get("data")
+        if not payload:
+            continue
+
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+
+        parsed_rows.extend(_parse_wal2json_payload(payload, table_name=table_name))
+
+    return parsed_rows
+
+def _parse_wal2json_payload(payload: dict[str, Any], *, table_name: str = REPLICATION_SLOT_TABLE_NAME) -> list[ParsedRow]:
+    parsed_rows: list[ParsedRow] = []
+
+    for change in payload.get("change", []):
+        schema = change.get("schema")
+        table = change.get("table")
+        if not table:
+            continue
+
+        qualified_table_name = f"{schema}.{table}" if schema else table
+        if table_name and qualified_table_name != table_name:
+            continue
+
+        parsed_rows.append(
+            {
+                "table": table,
+                "type": change.get("kind") or change.get("type"),
+                "current_row_data": _extract_row_data(change),
+                "previous_row_data": _extract_previous_row_data(change),
+                "nextlsn": change.get("nextlsn") or payload.get("nextlsn"),
+            }
+        )
+
+    return parsed_rows
+
+def _extract_row_data(change: dict[str, Any]) -> RowData:
+    if "columnnames" in change and "columnvalues" in change:
+        return _zip_values(change["columnnames"], change["columnvalues"])
+
+    if "columns" in change:
+        row_data: RowData = {}
+        for column in change["columns"]:
+            name = column.get("name")
+            if name:
+                row_data[name] = column.get("value")
+        return row_data
+
+    return {}
+
+
+def _extract_previous_row_data(change: dict[str, Any]) -> RowData:
+    oldkeys = change.get("oldkeys") or {}
+    if "keynames" in oldkeys and "keyvalues" in oldkeys:
+        return _zip_values(oldkeys["keynames"], oldkeys["keyvalues"])
+
+    if "keys" in oldkeys:
+        row_data: RowData = {}
+        for column in oldkeys["keys"]:
+            name = column.get("name")
+            if name:
+                row_data[name] = column.get("value")
+        return row_data
+
+    return {}
+
+def _zip_values(names: list[Any], values: list[Any]) -> RowData:
+    return {str(name): value for name, value in zip(names, values)}

--- a/app/models.py
+++ b/app/models.py
@@ -2924,4 +2924,3 @@ class ReportRequest(db.Model):
             created_at=self.created_at.strftime(DATETIME_FORMAT),
             updated_at=get_dt_string_or_none(self.updated_at),
         )
-

--- a/app/models.py
+++ b/app/models.py
@@ -2416,6 +2416,42 @@ class FactNotificationStatus(db.Model):
     )
 
 
+class FactServiceStats(db.Model):
+    __tablename__ = "ft_service_stats"
+
+    bst_date = db.Column(db.Date, index=True, primary_key=True, nullable=False)
+    service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), primary_key=True, nullable=False)
+    template_id = db.Column(UUID(as_uuid=True), db.ForeignKey("templates.id"), primary_key=True, nullable=False)
+    notification_type = db.Column(notification_types, primary_key=True, nullable=False)
+    notification_status = db.Column(
+        db.Text,
+        db.ForeignKey("notification_status_types.name"),
+        primary_key=True,
+        nullable=False,
+    )
+    notification_count = db.Column(db.BigInteger(), nullable=False, server_default=db.text("0"))
+
+    __table_args__ = (
+        Index(
+            "ix_ft_service_stats",
+            "bst_date",
+            "service_id",
+            "template_id",
+            "notification_type",
+            "notification_status",
+            unique=True,
+        ),
+        Index(
+            "ix_ft_service_template_stats",
+            "bst_date",
+            "template_id",
+            "notification_type",
+            "notification_status",
+            unique=True,
+        ),
+    )
+
+
 class FactProcessingTime(db.Model):
     __tablename__ = "ft_processing_time"
 
@@ -2888,3 +2924,4 @@ class ReportRequest(db.Model):
             created_at=self.created_at.strftime(DATETIME_FORMAT),
             updated_at=get_dt_string_or_none(self.updated_at),
         )
+

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -39,6 +39,7 @@ from app.celery.scheduled_tasks import (
     delete_verify_codes,
     generate_sms_delivery_stats,
     populate_annual_billing,
+    process_replication_slot_changes,
     replay_created_notifications,
     run_populate_annual_billing,
     run_scheduled_jobs,
@@ -1824,3 +1825,11 @@ def test_run_populate_annual_billing_uses_correct_year(mocker, notify_api):
     run_populate_annual_billing()
 
     populate_annual_billing.assert_called_once_with(year=2021, missing_services_only=True)
+
+
+def test_should_process_replication_slot_changes_task(notify_db_session, mocker):
+    mocker.patch("app.celery.scheduled_tasks.dao_process_notifications_replication_slot_changes")
+
+    process_replication_slot_changes()
+
+    scheduled_tasks.dao_process_notifications_replication_slot_changes.assert_called_once_with()

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -39,6 +39,7 @@ from app.celery.scheduled_tasks import (
     delete_verify_codes,
     generate_sms_delivery_stats,
     populate_annual_billing,
+    process_replication_slot_changes,
     replay_created_notifications,
     run_populate_annual_billing,
     run_scheduled_jobs,
@@ -1838,3 +1839,11 @@ def test_run_populate_annual_billing_uses_correct_year(mocker, notify_api):
     run_populate_annual_billing()
 
     populate_annual_billing.assert_called_once_with(year=2021, missing_services_only=True)
+
+
+def test_should_process_replication_slot_changes_task(notify_db_session, mocker):
+    mocker.patch("app.celery.scheduled_tasks.dao_process_notifications_replication_slot_changes")
+
+    process_replication_slot_changes()
+
+    scheduled_tasks.dao_process_notifications_replication_slot_changes.assert_called_once_with()

--- a/tests/app/dao/test_fact_service_stats_dao.py
+++ b/tests/app/dao/test_fact_service_stats_dao.py
@@ -1,0 +1,95 @@
+from datetime import date
+from uuid import uuid4
+
+from sqlalchemy.dialects.postgresql.dml import Insert
+
+from app.dao.fact_service_stats_dao import apply_service_stats_change
+from app.models import FactServiceStats
+
+
+def test_apply_service_stats_change_for_non_zero_change(mocker):
+    dimensions = {
+        "bst_date": date(2026, 8, 6),
+        "service_id": uuid4(),
+        "template_id": uuid4(),
+        "notification_type": "sms",
+        "notification_status": "delivered",
+    }
+    mock_execute = mocker.patch("app.dao.fact_service_stats_dao.db.session.execute")
+
+    apply_service_stats_change(dimensions, 4)
+
+    mock_execute.assert_called_once()
+    statement = mock_execute.call_args.args[0]
+    params = statement.compile().params
+
+    assert isinstance(statement, Insert)
+    assert statement.table == FactServiceStats.__table__
+    assert params["bst_date"] == dimensions["bst_date"]
+    assert params["service_id"] == dimensions["service_id"]
+    assert params["template_id"] == dimensions["template_id"]
+    assert params["notification_type"] == dimensions["notification_type"]
+    assert params["notification_status"] == dimensions["notification_status"]
+    assert params["notification_count"] == 4
+
+    # This is needed because the on_conflict_do_update() method generates
+    # a parameter name like "notification_count_1" for the update clause,
+    # so we need to check that one of the parameters starts with "notification_count_" and has the value 4.
+    assert any(key.startswith("notification_count_") and value == 4 for key, value in params.items())
+
+
+def test_apply_service_stats_change_for_zero_change(mocker):
+    dimensions = {
+        "bst_date": date(2026, 8, 6),
+        "service_id": uuid4(),
+        "template_id": uuid4(),
+        "notification_type": "sms",
+        "notification_status": "delivered",
+    }
+    mock_execute = mocker.patch("app.dao.fact_service_stats_dao.db.session.execute")
+    mock_query = mocker.patch("app.dao.fact_service_stats_dao.db.session.query")
+
+    apply_service_stats_change(dimensions, 0)
+
+    mock_execute.assert_not_called()
+    mock_query.assert_not_called()
+
+
+def test_apply_service_stats_change_for_negative_change(mocker):
+    dimensions = {
+        "bst_date": date(2026, 8, 6),
+        "service_id": uuid4(),
+        "template_id": uuid4(),
+        "notification_type": "sms",
+        "notification_status": "delivered",
+    }
+    mock_execute = mocker.patch("app.dao.fact_service_stats_dao.db.session.execute")
+    mock_query = mocker.patch("app.dao.fact_service_stats_dao.db.session.query")
+
+    apply_service_stats_change(dimensions, -3)
+
+    # check that the correct methods are called on the mock objects
+    mock_execute.assert_not_called()
+    mock_query.assert_called_once()
+    mock_query.assert_called_with(FactServiceStats)
+
+    # check filters passed to the query match the dimensions
+    filter_args = mock_query.return_value.filter.call_args.args
+    actual_filters = {arg.left.key: arg.right.value for arg in filter_args}
+    assert actual_filters == dimensions
+
+    # check that the update was called with the correct values
+    mock_query.return_value.filter.return_value.update.assert_called_once()
+    update_call = mock_query.return_value.filter.return_value.update.call_args
+    assert update_call.kwargs == {"synchronize_session": False}
+
+    # check that the update expression uses the greatest function to ensure the count does not go below zero
+    # also checks that the parameters passed to the greatest function include the negative change and zero
+    # this is because the update expression is: func.greatest(FactServiceStats.notification_count + change_count, 0)
+    update_values = update_call.args[0]
+    expression = update_values["notification_count"]
+    compiled = expression.compile()
+
+    assert getattr(expression, "name", None) == "greatest"
+    assert any(value == -3 for value in compiled.params.values())
+    assert any(value == 0 for value in compiled.params.values())

--- a/tests/app/dao/test_notifications_wal_changes_dao.py
+++ b/tests/app/dao/test_notifications_wal_changes_dao.py
@@ -1,0 +1,387 @@
+from collections import Counter
+from datetime import UTC, date, datetime
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.dao import notifications_wal_changes_dao as dao
+
+
+def _build_change(
+    *,
+    table: str = "notifications",
+    change_type: str = "insert",
+    current_row_data: dict | None = None,
+    previous_row_data: dict | None = None,
+    nextlsn: str | None = None,
+) -> dict:
+    return {
+        "table": table,
+        "type": change_type,
+        "current_row_data": current_row_data or {},
+        "previous_row_data": previous_row_data or {},
+        "nextlsn": nextlsn,
+    }
+
+
+def test_zip_values():
+    assert dao._zip_values(["a", None, "c"], [1, 2, 3]) == {"a": 1, "c": 3}
+
+
+def test_extract_row_data_from_columnnames_and_columnvalues():
+    change = {"columnnames": ["service_id", "notification_type"], "columnvalues": ["abc", "sms"]}
+
+    assert dao._extract_row_data(change) == {"service_id": "abc", "notification_type": "sms"}
+
+
+def test_extract_row_data_from_columns():
+    change = {
+        "columns": [
+            {"name": "service_id", "value": "abc"},
+            {"name": "notification_type", "value": "email"},
+            {"name": None, "value": "ignored"},
+        ]
+    }
+
+    assert dao._extract_row_data(change) == {"service_id": "abc", "notification_type": "email"}
+
+
+def test_extract_row_data_returns_empty_when_not_present():
+    assert dao._extract_row_data({}) == {}
+
+
+def test_extract_previous_row_data_from_keynames_and_keyvalues():
+    change = {"oldkeys": {"keynames": ["notification_status"], "keyvalues": ["created"]}}
+
+    assert dao._extract_previous_row_data(change) == {"notification_status": "created"}
+
+
+def test_extract_previous_row_data_from_keys():
+    change = {
+        "oldkeys": {
+            "keys": [
+                {"name": "notification_status", "value": "sending"},
+                {"name": None, "value": "ignored"},
+            ]
+        }
+    }
+
+    assert dao._extract_previous_row_data(change) == {"notification_status": "sending"}
+
+
+def test_extract_previous_row_data_returns_empty_when_not_present():
+    assert dao._extract_previous_row_data({}) == {}
+
+
+def test_parse_wal2json_payload_filters_table_and_maps_fields(mocker):
+    mock_row = mocker.patch("app.dao.notifications_wal_changes_dao._extract_row_data", return_value={"a": 1})
+    mock_previous = mocker.patch(
+        "app.dao.notifications_wal_changes_dao._extract_previous_row_data", return_value={"b": 2}
+    )
+    payload = {
+        "nextlsn": "0/AA",
+        "change": [
+            {"schema": "public", "table": "notifications", "kind": "insert"},
+            {"schema": "public", "table": "other", "kind": "insert"},
+            {"table": "notifications", "type": "update", "nextlsn": "0/BB"},
+            {"schema": "public"},
+        ],
+    }
+
+    result = dao._parse_wal2json_payload(payload, table_name="public.notifications")
+
+    assert result == [
+        {
+            "table": "notifications",
+            "type": "insert",
+            "current_row_data": {"a": 1},
+            "previous_row_data": {"b": 2},
+            "nextlsn": "0/AA",
+        }
+    ]
+    assert mock_row.call_count == 1
+    assert mock_previous.call_count == 1
+
+
+def test_get_replication_changes_parses_rows_and_payload_formats(mocker):
+    mappings_rows = [
+        {"data": '{"change": [{"schema": "public", "table": "notifications", "kind": "insert"}]}'},
+        {"data": {"change": [{"schema": "public", "table": "notifications", "kind": "update"}]}},
+        {"data": None},
+    ]
+
+    execute_result = mocker.Mock()
+    execute_result.mappings.return_value = mappings_rows
+    mock_execute = mocker.patch("app.dao.notifications_wal_changes_dao.db.session.execute", return_value=execute_result)
+    mock_parser = mocker.patch(
+        "app.dao.notifications_wal_changes_dao._parse_wal2json_payload",
+        side_effect=[[{"table": "notifications", "type": "insert"}], [{"table": "notifications", "type": "update"}]],
+    )
+
+    result = dao._get_replication_changes(slot_name="slot", upto_nchanges=20, table_name="public.notifications")
+
+    assert result == [{"table": "notifications", "type": "insert"}, {"table": "notifications", "type": "update"}]
+    assert mock_execute.call_count == 1
+    assert mock_parser.call_count == 2
+
+
+def test_parse_uuid_value():
+    value = str(uuid4())
+    assert dao._parse_uuid_value({"service_id": value}, "service_id") == UUID(value)
+    assert dao._parse_uuid_value({"service_id": "not-a-uuid"}, "service_id") is None
+    assert dao._parse_uuid_value({}, "service_id") is None
+
+
+def test_get_str_value():
+    assert dao._get_str_value({"a": "x"}, "a") == "x"
+    assert dao._get_str_value({"a": 42}, "a") == "42"
+    assert dao._get_str_value({"a": None}, "a") is None
+    assert dao._get_str_value(None, "a") is None
+
+
+def test_parse_datetime_value():
+    assert dao._parse_datetime_value({"created_at": "2026-08-06T10:00:00Z"}, "created_at") == datetime(
+        2026, 8, 6, 10, 0, 0, tzinfo=UTC
+    )
+    assert dao._parse_datetime_value({"created_at": "invalid"}, "created_at") is None
+    assert dao._parse_datetime_value({}, "created_at") is None
+
+
+def test_build_dimensions_returns_tuple(mocker):
+    service_id = str(uuid4())
+    template_id = str(uuid4())
+    created_at = datetime(2026, 8, 6, 10, 0, 0, tzinfo=UTC)
+    mock_convert = mocker.patch("app.dao.notifications_wal_changes_dao.convert_utc_to_bst", return_value=created_at)
+    change = _build_change(
+        current_row_data={
+            "service_id": service_id,
+            "template_id": template_id,
+            "notification_type": "sms",
+            "key_type": "normal",
+            "notification_status": "delivered",
+            "created_at": "2026-08-06T10:00:00Z",
+        }
+    )
+
+    result = dao._build_dimensions(change, use_previous_row=False)
+
+    assert result == (date(2026, 8, 6), UUID(template_id), UUID(service_id), "sms", "delivered")
+    mock_convert.assert_called_once_with(created_at)
+
+
+def test_build_dimensions_uses_fallback_row_when_primary_missing(mocker):
+    service_id = str(uuid4())
+    template_id = str(uuid4())
+    mocker.patch(
+        "app.dao.notifications_wal_changes_dao.convert_utc_to_bst",
+        return_value=datetime(2026, 8, 7, 0, 0, tzinfo=UTC),
+    )
+    change = _build_change(
+        current_row_data={},
+        previous_row_data={
+            "service_id": service_id,
+            "template_id": template_id,
+            "notification_type": "email",
+            "key_type": "normal",
+            "notification_status": "failed",
+            "created_at": "2026-08-07T00:00:00Z",
+        },
+    )
+
+    result = dao._build_dimensions(change, use_previous_row=False)
+
+    assert result == (date(2026, 8, 7), UUID(template_id), UUID(service_id), "email", "failed")
+
+
+def test_build_dimensions_returns_none_for_test_key_type():
+    change = _build_change(current_row_data={"key_type": "test"})
+
+    assert dao._build_dimensions(change, use_previous_row=False) is None
+
+
+def test_build_dimensions_returns_none_when_required_fields_missing():
+    change = _build_change(current_row_data={"key_type": "normal"})
+
+    assert dao._build_dimensions(change, use_previous_row=False) is None
+
+
+def test_build_counter_from_changes():
+    service_id = str(uuid4())
+    template_id = str(uuid4())
+    base = {
+        "service_id": service_id,
+        "template_id": template_id,
+        "notification_type": "sms",
+        "key_type": "normal",
+        "created_at": "2026-08-06T10:00:00Z",
+    }
+
+    changes = [
+        _build_change(
+            change_type="insert", current_row_data={**base, "notification_status": "created"}, nextlsn="0/01"
+        ),
+        _build_change(
+            change_type="update",
+            current_row_data={**base, "notification_status": "delivered"},
+            previous_row_data={**base, "notification_status": "created"},
+            nextlsn="0/02",
+        ),
+        _build_change(table="other", change_type="insert", current_row_data={**base, "notification_status": "created"}),
+        _build_change(
+            change_type="delete", current_row_data={**base, "notification_status": "created"}, nextlsn="0/03"
+        ),
+    ]
+
+    counter, processed_changes, ignored_changes, last_nextlsn = dao._build_counter_from_changes(changes)
+
+    created_key = dao._build_dimensions(changes[0], use_previous_row=False)
+    delivered_key = dao._build_dimensions(changes[1], use_previous_row=False)
+
+    assert counter[created_key] == 0
+    assert counter[delivered_key] == 1
+    assert processed_changes == 2
+    assert ignored_changes == 2
+    assert last_nextlsn == "0/03"
+
+
+def test_aggregate_service_stats_change_counts_reorders_dimensions():
+    service_id = uuid4()
+    template_id = uuid4()
+    full_dimensions = (date(2026, 8, 6), template_id, service_id, "sms", "delivered")
+
+    result = dao._aggregate_service_stats_change_counts(Counter({full_dimensions: 4}))
+
+    assert result[(date(2026, 8, 6), service_id, template_id, "sms", "delivered")] == 4
+
+
+def test_try_advisory_lock(mocker):
+    execute_result = mocker.Mock()
+    execute_result.scalar.return_value = True
+    mock_execute = mocker.patch("app.dao.notifications_wal_changes_dao.db.session.execute", return_value=execute_result)
+
+    result = dao._try_advisory_lock(123)
+
+    assert result is True
+    assert mock_execute.call_count == 1
+
+
+def test_advisory_unlock(mocker):
+    mock_execute = mocker.patch("app.dao.notifications_wal_changes_dao.db.session.execute")
+
+    dao._advisory_unlock(123)
+
+    mock_execute.assert_called_once()
+
+
+def test_advance_replication_slot(mocker):
+    mock_execute = mocker.patch("app.dao.notifications_wal_changes_dao.db.session.execute")
+
+    dao._advance_replication_slot("0/AA", slot_name="slot")
+
+    mock_execute.assert_called_once()
+
+
+def test_dao_process_notifications_replication_slot_changes_when_lock_not_acquired(mocker):
+    mock_try_lock = mocker.patch("app.dao.notifications_wal_changes_dao._try_advisory_lock", return_value=False)
+    mock_get_changes = mocker.patch("app.dao.notifications_wal_changes_dao._get_replication_changes")
+    mock_unlock = mocker.patch("app.dao.notifications_wal_changes_dao._advisory_unlock")
+
+    result = dao.dao_process_notifications_replication_slot_changes(
+        slot_name="slot", upto_nchanges=200, advisory_lock_id=9
+    )
+
+    assert result == {"lock_acquired": False, "slot_name": "slot", "upto_nchanges": 200}
+    mock_try_lock.assert_called_once_with(9)
+    mock_get_changes.assert_not_called()
+    mock_unlock.assert_not_called()
+
+
+def test_dao_process_notifications_replication_slot_changes_when_no_changes(mocker):
+    mocker.patch("app.dao.notifications_wal_changes_dao._try_advisory_lock", return_value=True)
+    mocker.patch("app.dao.notifications_wal_changes_dao._get_replication_changes", return_value=[])
+    mock_commit = mocker.patch("app.dao.notifications_wal_changes_dao.db.session.commit")
+    mock_unlock = mocker.patch("app.dao.notifications_wal_changes_dao._advisory_unlock")
+
+    result = dao.dao_process_notifications_replication_slot_changes(advisory_lock_id=11)
+
+    assert result == {
+        "lock_acquired": True,
+        "changes_count": 0,
+        "processed_changes": 0,
+        "ignored_changes": 0,
+        "service_stats_change_count_buckets": 0,
+        "last_nextlsn": None,
+    }
+    mock_commit.assert_not_called()
+    mock_unlock.assert_called_once_with(11)
+
+
+def test_dao_process_notifications_replication_slot_changes_success(mocker):
+    dimensions_key = (date(2026, 8, 6), uuid4(), uuid4(), "sms", "delivered")
+    mocker.patch("app.dao.notifications_wal_changes_dao._try_advisory_lock", return_value=True)
+    mocker.patch("app.dao.notifications_wal_changes_dao._get_replication_changes", return_value=[{"x": 1}, {"x": 2}])
+    mocker.patch(
+        "app.dao.notifications_wal_changes_dao._build_counter_from_changes",
+        return_value=(Counter(), 2, 0, "0/AB"),
+    )
+    mocker.patch(
+        "app.dao.notifications_wal_changes_dao._aggregate_service_stats_change_counts",
+        return_value=Counter({dimensions_key: 3, (date(2026, 8, 6), uuid4(), uuid4(), "email", "failed"): 0}),
+    )
+    mock_apply = mocker.patch("app.dao.notifications_wal_changes_dao.apply_service_stats_change")
+    mock_commit = mocker.patch("app.dao.notifications_wal_changes_dao.db.session.commit")
+    mock_advance = mocker.patch("app.dao.notifications_wal_changes_dao._advance_replication_slot")
+    mock_unlock = mocker.patch("app.dao.notifications_wal_changes_dao._advisory_unlock")
+
+    result = dao.dao_process_notifications_replication_slot_changes(slot_name="slot")
+
+    assert result == {
+        "lock_acquired": True,
+        "changes_count": 2,
+        "processed_changes": 2,
+        "ignored_changes": 0,
+        "service_stats_change_count_buckets": 2,
+        "last_nextlsn": "0/AB",
+    }
+    mock_apply.assert_called_once()
+    apply_args = mock_apply.call_args.args
+    assert apply_args[1] == 3
+    assert apply_args[0] == {
+        "bst_date": dimensions_key[0],
+        "service_id": dimensions_key[1],
+        "template_id": dimensions_key[2],
+        "notification_type": dimensions_key[3],
+        "notification_status": dimensions_key[4],
+    }
+    mock_commit.assert_called_once()
+    mock_advance.assert_called_once_with("0/AB", slot_name="slot")
+    mock_unlock.assert_called_once()
+
+
+def test_dao_process_notifications_replication_slot_changes_rollback_and_reraises(mocker):
+    mocker.patch("app.dao.notifications_wal_changes_dao._try_advisory_lock", return_value=True)
+    mocker.patch("app.dao.notifications_wal_changes_dao._get_replication_changes", side_effect=RuntimeError("boom"))
+    mock_rollback = mocker.patch("app.dao.notifications_wal_changes_dao.db.session.rollback")
+    mock_logger = mocker.patch("app.dao.notifications_wal_changes_dao.current_app.logger.exception")
+    mock_unlock = mocker.patch("app.dao.notifications_wal_changes_dao._advisory_unlock")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        dao.dao_process_notifications_replication_slot_changes(advisory_lock_id=77)
+
+    mock_rollback.assert_called_once()
+    mock_logger.assert_called_once_with("[FAILED] Replication slot changes")
+    mock_unlock.assert_called_once_with(77)
+
+
+def test_dao_process_notifications_replication_slot_changes_logs_unlock_failure(mocker):
+    mocker.patch("app.dao.notifications_wal_changes_dao._try_advisory_lock", return_value=True)
+    mocker.patch("app.dao.notifications_wal_changes_dao._get_replication_changes", return_value=[])
+    mocker.patch("app.dao.notifications_wal_changes_dao._advisory_unlock", side_effect=RuntimeError("unlock failed"))
+    mock_logger = mocker.patch("app.dao.notifications_wal_changes_dao.current_app.logger.exception")
+
+    dao.dao_process_notifications_replication_slot_changes(advisory_lock_id=88)
+
+    assert mock_logger.call_count == 1
+    logger_args = mock_logger.call_args
+    assert logger_args.args[0] == "Failed to release advisory lock"
+    assert logger_args.kwargs == {"extra": {"dao_method": "dao_process_replication_slot_changes"}}

--- a/tests/app/dao/test_notifications_wal_changes_dao.py
+++ b/tests/app/dao/test_notifications_wal_changes_dao.py
@@ -125,6 +125,18 @@ def test_get_replication_changes_parses_rows_and_payload_formats(mocker):
     assert mock_parser.call_count == 2
 
 
+def test_get_replication_changes_keeps_sql_lsn(mocker):
+    mappings_rows = [{"lsn": "0/AB", "data": {"change": [{"schema": "public", "table": "notifications", "kind": "insert"}]}}]
+
+    execute_result = mocker.Mock()
+    execute_result.mappings.return_value = mappings_rows
+    mocker.patch("app.dao.notifications_wal_changes_dao.db.session.execute", return_value=execute_result)
+
+    result = dao._get_replication_changes(slot_name="slot", upto_nchanges=20, table_name="public.notifications")
+
+    assert result[0]["lsn"] == "0/AB"
+
+
 def test_parse_wal2json_payload_supports_format_2_rows():
     payload = {
         "action": "I",

--- a/tests/app/dao/test_notifications_wal_changes_dao.py
+++ b/tests/app/dao/test_notifications_wal_changes_dao.py
@@ -97,6 +97,7 @@ def test_parse_wal2json_payload_filters_table_and_maps_fields(mocker):
             "current_row_data": {"a": 1},
             "previous_row_data": {"b": 2},
             "nextlsn": "0/AA",
+            "lsn": None,
         }
     ]
     assert mock_row.call_count == 1
@@ -105,9 +106,9 @@ def test_parse_wal2json_payload_filters_table_and_maps_fields(mocker):
 
 def test_get_replication_changes_parses_rows_and_payload_formats(mocker):
     mappings_rows = [
-        {"data": '{"change": [{"schema": "public", "table": "notifications", "kind": "insert"}]}'},
-        {"data": {"change": [{"schema": "public", "table": "notifications", "kind": "update"}]}},
-        {"data": None},
+        {"lsn": "0/AA", "data": '{"change": [{"schema": "public", "table": "notifications", "kind": "insert"}]}'},
+        {"lsn": "0/BB", "data": {"change": [{"schema": "public", "table": "notifications", "kind": "update"}]}},
+        {"lsn": "0/CC", "data": None},
     ]
 
     execute_result = mocker.Mock()
@@ -118,23 +119,31 @@ def test_get_replication_changes_parses_rows_and_payload_formats(mocker):
         side_effect=[[{"table": "notifications", "type": "insert"}], [{"table": "notifications", "type": "update"}]],
     )
 
-    result = dao._get_replication_changes(slot_name="slot", upto_nchanges=20, table_name="public.notifications")
+    result, last_lsn = dao._get_replication_changes(
+        slot_name="slot", upto_nchanges=20, table_name="public.notifications"
+    )
 
     assert result == [{"table": "notifications", "type": "insert"}, {"table": "notifications", "type": "update"}]
+    assert last_lsn == "0/CC"
     assert mock_execute.call_count == 1
     assert mock_parser.call_count == 2
 
 
 def test_get_replication_changes_keeps_sql_lsn(mocker):
-    mappings_rows = [{"lsn": "0/AB", "data": {"change": [{"schema": "public", "table": "notifications", "kind": "insert"}]}}]
+    mappings_rows = [
+        {"lsn": "0/AB", "data": {"change": [{"schema": "public", "table": "notifications", "kind": "insert"}]}}
+    ]
 
     execute_result = mocker.Mock()
     execute_result.mappings.return_value = mappings_rows
     mocker.patch("app.dao.notifications_wal_changes_dao.db.session.execute", return_value=execute_result)
 
-    result = dao._get_replication_changes(slot_name="slot", upto_nchanges=20, table_name="public.notifications")
+    result, last_lsn = dao._get_replication_changes(
+        slot_name="slot", upto_nchanges=20, table_name="public.notifications"
+    )
 
     assert result[0]["lsn"] == "0/AB"
+    assert last_lsn == "0/AB"
 
 
 def test_get_replication_changes_handles_non_indexable_result_rows(mocker):
@@ -145,9 +154,12 @@ def test_get_replication_changes_handles_non_indexable_result_rows(mocker):
     mocker.patch("app.dao.notifications_wal_changes_dao.db.session.execute", return_value=execute_result)
     mock_advance = mocker.patch("app.dao.notifications_wal_changes_dao._advance_replication_slot")
 
-    result = dao._get_replication_changes(slot_name="slot", upto_nchanges=20, table_name="public.notifications")
+    result, last_lsn = dao._get_replication_changes(
+        slot_name="slot", upto_nchanges=20, table_name="public.notifications"
+    )
 
     assert result == []
+    assert last_lsn == "0/AB"
     mock_advance.assert_called_once_with("0/AB", slot_name="slot")
 
 
@@ -279,22 +291,22 @@ def test_build_counter_from_changes():
     }
 
     changes = [
-        _build_change(
-            change_type="insert", current_row_data={**base, "notification_status": "created"}, nextlsn="0/01"
-        ),
+        _build_change(change_type="insert", current_row_data={**base, "notification_status": "created"}, nextlsn="0/01")
+        | {"lsn": "0/01"},
         _build_change(
             change_type="update",
             current_row_data={**base, "notification_status": "delivered"},
             previous_row_data={**base, "notification_status": "created"},
             nextlsn="0/02",
-        ),
-        _build_change(table="other", change_type="insert", current_row_data={**base, "notification_status": "created"}),
-        _build_change(
-            change_type="delete", current_row_data={**base, "notification_status": "created"}, nextlsn="0/03"
-        ),
+        )
+        | {"lsn": "0/02"},
+        _build_change(table="other", change_type="insert", current_row_data={**base, "notification_status": "created"})
+        | {"lsn": "0/03"},
+        _build_change(change_type="delete", current_row_data={**base, "notification_status": "created"}, nextlsn="0/04")
+        | {"lsn": "0/04"},
     ]
 
-    counter, processed_changes, ignored_changes, last_nextlsn = dao._build_counter_from_changes(changes)
+    counter, processed_changes, ignored_changes, last_lsn = dao._build_counter_from_changes(changes)
 
     created_key = dao._build_dimensions(changes[0], use_previous_row=False)
     delivered_key = dao._build_dimensions(changes[1], use_previous_row=False)
@@ -303,7 +315,29 @@ def test_build_counter_from_changes():
     assert counter[delivered_key] == 1
     assert processed_changes == 2
     assert ignored_changes == 2
-    assert last_nextlsn == "0/03"
+    assert last_lsn == "0/04"
+
+
+def test_build_counter_uses_sql_lsn_for_slot_advance_not_row_nextlsn():
+    change = {
+        "table": "notifications",
+        "type": "insert",
+        "current_row_data": {
+            "service_id": str(uuid4()),
+            "template_id": str(uuid4()),
+            "notification_type": "sms",
+            "key_type": "normal",
+            "notification_status": "created",
+            "created_at": "2026-08-06T10:00:00Z",
+        },
+        "previous_row_data": {},
+        "nextlsn": "0/row-next",
+        "lsn": "0/sql-reported",
+    }
+
+    _, _, _, last_lsn = dao._build_counter_from_changes([change])
+
+    assert last_lsn == "0/sql-reported"
 
 
 def test_aggregate_service_stats_change_counts_reorders_dimensions():
@@ -360,7 +394,7 @@ def test_dao_process_notifications_replication_slot_changes_when_lock_not_acquir
 
 def test_dao_process_notifications_replication_slot_changes_when_no_changes(mocker):
     mocker.patch("app.dao.notifications_wal_changes_dao._try_advisory_lock", return_value=True)
-    mocker.patch("app.dao.notifications_wal_changes_dao._get_replication_changes", return_value=[])
+    mocker.patch("app.dao.notifications_wal_changes_dao._get_replication_changes", return_value=([], "0/AB"))
     mock_commit = mocker.patch("app.dao.notifications_wal_changes_dao.db.session.commit")
     mock_unlock = mocker.patch("app.dao.notifications_wal_changes_dao._advisory_unlock")
 
@@ -372,9 +406,9 @@ def test_dao_process_notifications_replication_slot_changes_when_no_changes(mock
         "processed_changes": 0,
         "ignored_changes": 0,
         "service_stats_change_count_buckets": 0,
-        "last_nextlsn": None,
+        "last_lsn": "0/AB",
     }
-    mock_commit.assert_not_called()
+    mock_commit.assert_called_once()
     mock_unlock.assert_called_once_with(11)
 
 
@@ -382,7 +416,9 @@ def test_dao_process_notifications_replication_slot_changes_success(mocker):
     dimensions_key = (date(2026, 8, 6), uuid4(), uuid4(), "sms", "delivered")
     call_order: list[str] = []
     mocker.patch("app.dao.notifications_wal_changes_dao._try_advisory_lock", return_value=True)
-    mocker.patch("app.dao.notifications_wal_changes_dao._get_replication_changes", return_value=[{"x": 1}, {"x": 2}])
+    mocker.patch(
+        "app.dao.notifications_wal_changes_dao._get_replication_changes", return_value=([{"x": 1}, {"x": 2}], "0/AB")
+    )
     mocker.patch(
         "app.dao.notifications_wal_changes_dao._build_counter_from_changes",
         return_value=(Counter(), 2, 0, "0/AB"),
@@ -413,7 +449,7 @@ def test_dao_process_notifications_replication_slot_changes_success(mocker):
         "processed_changes": 2,
         "ignored_changes": 0,
         "service_stats_change_count_buckets": 2,
-        "last_nextlsn": "0/AB",
+        "last_lsn": "0/AB",
     }
     mock_apply.assert_called_once()
     apply_args = mock_apply.call_args.args
@@ -448,7 +484,7 @@ def test_dao_process_notifications_replication_slot_changes_rollback_and_reraise
 
 def test_dao_process_notifications_replication_slot_changes_logs_unlock_failure(mocker):
     mocker.patch("app.dao.notifications_wal_changes_dao._try_advisory_lock", return_value=True)
-    mocker.patch("app.dao.notifications_wal_changes_dao._get_replication_changes", return_value=[])
+    mocker.patch("app.dao.notifications_wal_changes_dao._get_replication_changes", return_value=([], None))
     mocker.patch("app.dao.notifications_wal_changes_dao._advisory_unlock", side_effect=RuntimeError("unlock failed"))
     mock_logger = mocker.patch("app.dao.notifications_wal_changes_dao.current_app.logger.exception")
 

--- a/tests/app/dao/test_notifications_wal_changes_dao.py
+++ b/tests/app/dao/test_notifications_wal_changes_dao.py
@@ -125,6 +125,42 @@ def test_get_replication_changes_parses_rows_and_payload_formats(mocker):
     assert mock_parser.call_count == 2
 
 
+def test_parse_wal2json_payload_supports_format_2_rows():
+    payload = {
+        "action": "I",
+        "schema": "public",
+        "table": "notifications",
+        "columns": [
+            {"name": "service_id", "value": "550e8400-e29b-41d4-a716-446655440000"},
+            {"name": "template_id", "value": "550e8400-e29b-41d4-a716-446655440001"},
+            {"name": "notification_type", "value": "sms"},
+            {"name": "key_type", "value": "normal"},
+            {"name": "notification_status", "value": "created"},
+            {"name": "created_at", "value": "2026-08-12T10:00:00Z"},
+        ],
+    }
+
+    result = dao._parse_wal2json_payload(payload, table_name="public.notifications")
+
+    assert len(result) == 1
+    assert result[0]["table"] == "notifications"
+    assert result[0]["type"] == "insert"
+    assert result[0]["current_row_data"]["notification_type"] == "sms"
+    assert result[0]["current_row_data"]["notification_status"] == "created"
+
+
+def test_get_replication_changes_uses_format_version_2(mocker):
+    execute_result = mocker.Mock()
+    execute_result.mappings.return_value = [{"data": {"change": []}}]
+    mock_execute = mocker.patch("app.dao.notifications_wal_changes_dao.db.session.execute", return_value=execute_result)
+    mocker.patch("app.dao.notifications_wal_changes_dao._parse_wal2json_payload", return_value=[])
+
+    dao._get_replication_changes(slot_name="slot", upto_nchanges=20, table_name="public.notifications")
+
+    assert mock_execute.call_count == 1
+    assert mock_execute.call_args.args[1]["format_version"] == "2"
+
+
 def test_parse_uuid_value():
     value = str(uuid4())
     assert dao._parse_uuid_value({"service_id": value}, "service_id") == UUID(value)

--- a/tests/app/dao/test_notifications_wal_changes_dao.py
+++ b/tests/app/dao/test_notifications_wal_changes_dao.py
@@ -137,6 +137,20 @@ def test_get_replication_changes_keeps_sql_lsn(mocker):
     assert result[0]["lsn"] == "0/AB"
 
 
+def test_get_replication_changes_handles_non_indexable_result_rows(mocker):
+    mappings_rows = [{"lsn": "0/AB", "data": {"change": [{"schema": "public", "table": "other", "kind": "insert"}]}}]
+
+    execute_result = mocker.Mock()
+    execute_result.mappings.return_value = iter(mappings_rows)
+    mocker.patch("app.dao.notifications_wal_changes_dao.db.session.execute", return_value=execute_result)
+    mock_advance = mocker.patch("app.dao.notifications_wal_changes_dao._advance_replication_slot")
+
+    result = dao._get_replication_changes(slot_name="slot", upto_nchanges=20, table_name="public.notifications")
+
+    assert result == []
+    mock_advance.assert_called_once_with("0/AB", slot_name="slot")
+
+
 def test_parse_wal2json_payload_supports_format_2_rows():
     payload = {
         "action": "I",

--- a/tests/app/dao/test_notifications_wal_changes_dao.py
+++ b/tests/app/dao/test_notifications_wal_changes_dao.py
@@ -366,6 +366,7 @@ def test_dao_process_notifications_replication_slot_changes_when_no_changes(mock
 
 def test_dao_process_notifications_replication_slot_changes_success(mocker):
     dimensions_key = (date(2026, 8, 6), uuid4(), uuid4(), "sms", "delivered")
+    call_order: list[str] = []
     mocker.patch("app.dao.notifications_wal_changes_dao._try_advisory_lock", return_value=True)
     mocker.patch("app.dao.notifications_wal_changes_dao._get_replication_changes", return_value=[{"x": 1}, {"x": 2}])
     mocker.patch(
@@ -376,9 +377,18 @@ def test_dao_process_notifications_replication_slot_changes_success(mocker):
         "app.dao.notifications_wal_changes_dao._aggregate_service_stats_change_counts",
         return_value=Counter({dimensions_key: 3, (date(2026, 8, 6), uuid4(), uuid4(), "email", "failed"): 0}),
     )
-    mock_apply = mocker.patch("app.dao.notifications_wal_changes_dao.apply_service_stats_change")
-    mock_commit = mocker.patch("app.dao.notifications_wal_changes_dao.db.session.commit")
-    mock_advance = mocker.patch("app.dao.notifications_wal_changes_dao._advance_replication_slot")
+    mock_apply = mocker.patch(
+        "app.dao.notifications_wal_changes_dao.apply_service_stats_change",
+        side_effect=lambda *_args, **_kwargs: call_order.append("apply"),
+    )
+    mock_commit = mocker.patch(
+        "app.dao.notifications_wal_changes_dao.db.session.commit",
+        side_effect=lambda: call_order.append("commit"),
+    )
+    mock_advance = mocker.patch(
+        "app.dao.notifications_wal_changes_dao._advance_replication_slot",
+        side_effect=lambda *_args, **_kwargs: call_order.append("advance"),
+    )
     mock_unlock = mocker.patch("app.dao.notifications_wal_changes_dao._advisory_unlock")
 
     result = dao.dao_process_notifications_replication_slot_changes(slot_name="slot")
@@ -404,6 +414,7 @@ def test_dao_process_notifications_replication_slot_changes_success(mocker):
     mock_commit.assert_called_once()
     mock_advance.assert_called_once_with("0/AB", slot_name="slot")
     mock_unlock.assert_called_once()
+    assert call_order.index("advance") < call_order.index("commit")
 
 
 def test_dao_process_notifications_replication_slot_changes_rollback_and_reraises(mocker):

--- a/tests/app/dao/test_notifications_wal_changes_dao.py
+++ b/tests/app/dao/test_notifications_wal_changes_dao.py
@@ -239,7 +239,7 @@ def test_build_dimensions_returns_tuple(mocker):
 
     result = dao._build_dimensions(change, use_previous_row=False)
 
-    assert result == (date(2026, 8, 6), UUID(template_id), UUID(service_id), "sms", "delivered")
+    assert result == (date(2026, 8, 6), UUID(service_id), UUID(template_id), "sms", "delivered")
     mock_convert.assert_called_once_with(created_at)
 
 
@@ -264,7 +264,7 @@ def test_build_dimensions_uses_fallback_row_when_primary_missing(mocker):
 
     result = dao._build_dimensions(change, use_previous_row=False)
 
-    assert result == (date(2026, 8, 7), UUID(template_id), UUID(service_id), "email", "failed")
+    assert result == (date(2026, 8, 7), UUID(service_id), UUID(template_id), "email", "failed")
 
 
 def test_build_dimensions_returns_none_for_test_key_type():
@@ -343,7 +343,7 @@ def test_build_counter_uses_sql_lsn_for_slot_advance_not_row_nextlsn():
 def test_aggregate_service_stats_change_counts_reorders_dimensions():
     service_id = uuid4()
     template_id = uuid4()
-    full_dimensions = (date(2026, 8, 6), template_id, service_id, "sms", "delivered")
+    full_dimensions = (date(2026, 8, 6), service_id, template_id, "sms", "delivered")
 
     result = dao._aggregate_service_stats_change_counts(Counter({full_dimensions: 4}))
 

--- a/tests/app/dao/test_notifications_wal_changes_dao.py
+++ b/tests/app/dao/test_notifications_wal_changes_dao.py
@@ -267,6 +267,29 @@ def test_build_dimensions_uses_fallback_row_when_primary_missing(mocker):
     assert result == (date(2026, 8, 7), UUID(service_id), UUID(template_id), "email", "failed")
 
 
+def test_build_dimensions_requires_status_from_primary_row(mocker):
+    service_id = str(uuid4())
+    template_id = str(uuid4())
+    mocker.patch(
+        "app.dao.notifications_wal_changes_dao.convert_utc_to_bst",
+        return_value=datetime(2026, 8, 7, 0, 0, tzinfo=UTC),
+    )
+    change = _build_change(
+        current_row_data={"notification_status": "delivered"},
+        previous_row_data={
+            "service_id": service_id,
+            "template_id": template_id,
+            "notification_type": "email",
+            "key_type": "normal",
+            "created_at": "2026-08-07T00:00:00Z",
+        },
+    )
+
+    result = dao._build_dimensions(change, use_previous_row=True, require_status_from_primary_row=True)
+
+    assert result is None
+
+
 def test_build_dimensions_returns_none_for_test_key_type():
     change = _build_change(current_row_data={"key_type": "test"})
 
@@ -316,6 +339,31 @@ def test_build_counter_from_changes():
     assert processed_changes == 2
     assert ignored_changes == 2
     assert last_lsn == "0/04"
+
+
+def test_build_counter_does_not_subtract_new_status_when_previous_status_is_missing():
+    service_id = str(uuid4())
+    template_id = str(uuid4())
+    base = {
+        "service_id": service_id,
+        "template_id": template_id,
+        "notification_type": "sms",
+        "key_type": "normal",
+        "created_at": "2026-08-06T10:00:00Z",
+    }
+    change = _build_change(
+        change_type="update",
+        current_row_data={**base, "notification_status": "delivered"},
+        previous_row_data=base,
+    )
+
+    counter, processed_changes, ignored_changes, _ = dao._build_counter_from_changes([change])
+
+    delivered_key = dao._build_dimensions(change, use_previous_row=False)
+
+    assert counter[delivered_key] == 1
+    assert processed_changes == 1
+    assert ignored_changes == 0
 
 
 def test_build_counter_uses_sql_lsn_for_slot_advance_not_row_nextlsn():

--- a/tests/app/dao/test_notifications_wal_changes_dao.py
+++ b/tests/app/dao/test_notifications_wal_changes_dao.py
@@ -4,7 +4,10 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from app.constants import EMAIL_TYPE, NOTIFICATION_CREATED, NOTIFICATION_DELIVERED, SMS_TYPE
 from app.dao import notifications_wal_changes_dao as dao
+from app.models import FactServiceStats
+from tests.app.db import create_service, create_template
 
 
 def _build_change(
@@ -542,3 +545,126 @@ def test_dao_process_notifications_replication_slot_changes_logs_unlock_failure(
     logger_args = mock_logger.call_args
     assert logger_args.args[0] == "Failed to release advisory lock"
     assert logger_args.kwargs == {"extra": {"dao_method": "dao_process_replication_slot_changes"}}
+
+
+def _row_data(*, service_id: UUID, template_id: UUID, notification_type: str, notification_status: str) -> dict:
+    return {
+        "service_id": str(service_id),
+        "template_id": str(template_id),
+        "notification_type": notification_type,
+        "key_type": "normal",
+        "notification_status": notification_status,
+        "created_at": "2026-08-06T12:00:00+00:00",
+    }
+
+
+def test_dao_process_notifications_replication_slot_changes_bulk_inserts_and_updates(mocker, notify_db_session):
+    # Simulate 1000 WAL changes (mostly inserts, some status-transition updates) spread across
+    # multiple services/templates/notification types/statuses, and verify the resulting
+    # FactServiceStats counts are exactly correct for every dimension bucket.
+    services = [create_service(service_name=f"WAL bulk service {i}") for i in range(3)]
+    row_groups = [
+        (service.id, create_template(service, template_type=notification_type).id, notification_type)
+        for service in services
+        for notification_type in (SMS_TYPE, EMAIL_TYPE)
+    ]
+    statuses = (NOTIFICATION_CREATED, NOTIFICATION_DELIVERED)
+    bst_date = date(2026, 8, 6)
+
+    expected: Counter[tuple[date, UUID, UUID, str, str]] = Counter()
+    changes: list[dict] = []
+
+    # 900 inserts spread evenly across the 24 (group, status) buckets, giving every bucket
+    # enough headroom that later update-driven decrements can never push it negative.
+    insert_count = 900
+    for i in range(insert_count):
+        service_id, template_id, notification_type = row_groups[i % len(row_groups)]
+        # Status index must not be derived from the same modulus as the group index, otherwise
+        # each group always lands on the same status (6 is a multiple of 2).
+        notification_status = statuses[(i // len(row_groups)) % len(statuses)]
+        changes.append(
+            _build_change(
+                current_row_data=_row_data(
+                    service_id=service_id,
+                    template_id=template_id,
+                    notification_type=notification_type,
+                    notification_status=notification_status,
+                )
+            )
+        )
+        expected[(bst_date, service_id, template_id, notification_type, notification_status)] += 1
+
+    # 100 status-transition updates: each moves one count from one status to the other status
+    # within the same service/template/notification_type bucket.
+    update_count = 100
+    for i in range(update_count):
+        service_id, template_id, notification_type = row_groups[i % len(row_groups)]
+        new_status = statuses[(i // len(row_groups)) % len(statuses)]
+        old_status = statuses[(i // len(row_groups) + 1) % len(statuses)]
+        changes.append(
+            _build_change(
+                change_type="update",
+                current_row_data=_row_data(
+                    service_id=service_id,
+                    template_id=template_id,
+                    notification_type=notification_type,
+                    notification_status=new_status,
+                ),
+                previous_row_data=_row_data(
+                    service_id=service_id,
+                    template_id=template_id,
+                    notification_type=notification_type,
+                    notification_status=old_status,
+                ),
+            )
+        )
+        expected[(bst_date, service_id, template_id, notification_type, new_status)] += 1
+        expected[(bst_date, service_id, template_id, notification_type, old_status)] -= 1
+
+    assert len(changes) == 1000
+    assert all(count > 0 for count in expected.values())
+
+    mocker.patch("app.dao.notifications_wal_changes_dao._get_replication_changes", return_value=(changes, "0/1000"))
+    mock_advance = mocker.patch("app.dao.notifications_wal_changes_dao._advance_replication_slot")
+
+    result = dao.dao_process_notifications_replication_slot_changes(slot_name="test-slot")
+
+    assert result == {
+        "lock_acquired": True,
+        "changes_count": 1000,
+        "processed_changes": 1000,
+        "ignored_changes": 0,
+        "service_stats_change_count_buckets": len(expected),
+        "last_lsn": "0/1000",
+    }
+    mock_advance.assert_called_once_with("0/1000", slot_name="test-slot")
+
+    template_ids = [template_id for _, template_id, _ in row_groups]
+    stats_rows = FactServiceStats.query.filter(FactServiceStats.template_id.in_(template_ids)).all()
+    actual = {
+        (
+            row.bst_date,
+            row.service_id,
+            row.template_id,
+            row.notification_type,
+            row.notification_status,
+        ): row.notification_count
+        for row in stats_rows
+    }
+
+    # Check every dimension bucket's count individually so a mismatch points straight at the
+    # offending (service, template, notification_type, notification_status) combination.
+    for key, expected_count in expected.items():
+        bst_date_key, service_id, template_id, notification_type, notification_status = key
+        assert key in actual, (
+            f"missing FactServiceStats row for service={service_id} template={template_id} "
+            f"notification_type={notification_type} status={notification_status}"
+        )
+        assert actual[key] == expected_count, (
+            f"count mismatch for service={service_id} template={template_id} "
+            f"notification_type={notification_type} status={notification_status}: "
+            f"expected {expected_count}, got {actual[key]}"
+        )
+
+    assert actual.keys() == expected.keys()
+    assert sum(actual.values()) == sum(expected.values())

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from celery.schedules import crontab
 from sqlalchemy import text
 
@@ -96,3 +98,10 @@ def test_celery_config_contains_archived_template_email_file_cleanup_task():
     assert task_config["task"] == "remove-archived-template-email-files-from-s3"
     assert task_config["options"]["queue"] == QueueNames.PERIODIC
     assert task_config["schedule"] == crontab(hour=4, minute=40)
+
+
+def test_celery_config_contains_process_notifications_replication_slot_changes_task():
+    task_config = Config.CELERY["beat_schedule"]["process-notifications-replication-slot-changes"]
+    assert task_config["task"] == "process-notifications-replication-slot-changes"
+    assert task_config["options"]["queue"] == QueueNames.PERIODIC
+    assert task_config["schedule"] == timedelta(seconds=10)

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -111,4 +111,4 @@ def test_celery_config_contains_process_notifications_replication_slot_changes_t
     task_config = Config.CELERY["beat_schedule"]["process-notifications-replication-slot-changes"]
     assert task_config["task"] == "process-notifications-replication-slot-changes"
     assert task_config["options"]["queue"] == QueueNames.PERIODIC
-    assert task_config["schedule"] == timedelta(seconds=10)
+    assert task_config["schedule"] == timedelta(seconds=5)

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from celery.schedules import crontab
 from sqlalchemy import text
 
@@ -103,3 +105,10 @@ def test_celery_config_contains_archived_letter_attachments_cleanup_task():
     assert task_config["task"] == "remove-archived-letter-attachments-from-s3"
     assert task_config["options"]["queue"] == QueueNames.PERIODIC
     assert task_config["schedule"] == crontab(hour=4, minute=30)
+
+
+def test_celery_config_contains_process_notifications_replication_slot_changes_task():
+    task_config = Config.CELERY["beat_schedule"]["process-notifications-replication-slot-changes"]
+    assert task_config["task"] == "process-notifications-replication-slot-changes"
+    assert task_config["options"]["queue"] == QueueNames.PERIODIC
+    assert task_config["schedule"] == timedelta(seconds=10)


### PR DESCRIPTION
** DO NOT MERGE UNTIL #4946 IS MERGED IN FIRST** 

## What

The application code for processing slot changes for notifications table

## Why

This is needed to process WAL logs in the database

## Test results

Ran a load test on `dev-c` - this is the result after 2400 emails.

```sql
SELECT
	(SELECT count(*) FROM pg_logical_slot_peek_changes('notify_dashboard_replication_slot', NULL, NULL)) AS still_processing,
    (SELECT SUM(notification_count) FROM ft_service_stats) AS ft_stats_count,
    COUNT(*) AS notif_count,
    (SELECT SUM(notification_count) FROM ft_service_stats where notification_status = 'created') AS ft_created_count,
    COUNT(CASE WHEN notification_status = 'created' THEN 1 END) AS notif_created_count,
    (SELECT SUM(notification_count) FROM ft_service_stats where notification_status = 'sending') AS ft_sending_count,
    COUNT(CASE WHEN notification_status = 'sending' THEN 1 END) AS notif_sending_count,
    (SELECT SUM(notification_count) FROM ft_service_stats where notification_status = 'delivered') AS ft_delivered_count,
    COUNT(CASE WHEN notification_status = 'delivered' THEN 1 END) AS notif_delivered_count,
    (SELECT SUM(notification_count) FROM ft_service_stats where notification_status = 'temporary-failure') AS ft_temp_fail_count,
    COUNT(CASE WHEN notification_status = 'temporary-failure' THEN 1 END) AS notif_temp_fail_count,
    (SELECT SUM(notification_count) FROM ft_service_stats where notification_status = 'permanent-failure') AS ft_perm_fail_count,
    COUNT(CASE WHEN notification_status = 'permanent-failure' THEN 1 END) AS notif_perm_fail_count
FROM
    public.notifications;
```


<table>
    <tr>
        <th>still_processing</th>
        <th>ft_stats_count</th>
        <th>notif_count</th>
        <th>ft_created_count</th>
        <th>notif_created_count</th>
        <th>ft_sending_count</th>
        <th>notif_sending_count</th>
        <th>ft_delivered_count</th>
        <th>notif_delivered_count</th>
        <th>ft_temp_fail_count</th>
        <th>notif_temp_fail_count</th>
        <th>ft_perm_fail_count</th>
        <th>notif_perm_fail_count</th>
    </tr>
    <tr>
        <td>0</td>
        <td>2400</td>
        <td>2400</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>1206</td>
        <td>1206</td>
        <td>234</td>
        <td>234</td>
        <td>960</td>
        <td>960</td>
    </tr>
</table>

## How it works

<img width="3747" height="2535" alt="605101533-57f970e2-60d7-462a-9fbd-b24d553d6663" src="https://github.com/user-attachments/assets/d9857943-5951-417f-9a94-f9077970756e" />
