### PR TITLE
`process_mmg_response`, `process_firetext_response`: protect views with basic auth

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -291,7 +291,7 @@ def register_blueprint(application):
     application.register_blueprint(status_blueprint)
 
     # delivery receipts
-    sms_callback_blueprint.before_request(requires_no_auth)
+    sms_callback_blueprint.before_request(requires_no_auth)  # basic auth enforced at view level
     application.register_blueprint(sms_callback_blueprint)
 
     # inbound sms

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -36,6 +36,10 @@ from sqlalchemy.orm import declarative_base
 from werkzeug.exceptions import HTTPException as WerkzeugHTTPException
 from werkzeug.local import LocalProxy
 
+# things up here must be declared before rest of app is imported to satisfy circular import
+# ruff: noqa: E402
+memo_resetters: list[Callable] = []
+
 from app.clients import NotificationProviderClients
 from app.clients.document_download import DocumentDownloadClient
 from app.clients.email.aws_ses import AwsSesClient
@@ -65,8 +69,6 @@ CONCURRENT_REQUESTS = Gauge(
     "concurrent_web_request_count",
     "How many concurrent requests are currently being served",
 )
-
-memo_resetters: list[Callable] = []
 
 #
 # "clients" that need thread-local copies

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -1,6 +1,9 @@
 import time
 import uuid
+from collections.abc import Callable
+from functools import wraps
 
+from cachetools.func import lfu_cache
 from flask import current_app, g, request
 from gds_metrics import Histogram
 from notifications_python_client.authentication import (
@@ -16,6 +19,8 @@ from notifications_python_client.errors import (
 )
 from sqlalchemy.orm.exc import NoResultFound
 
+from app import memo_resetters
+from app.hashing import check_hash
 from app.serialised_models import SerialisedService
 
 GENERAL_TOKEN_ERROR_MESSAGE = "Invalid token: make sure your API token matches the example at https://docs.notifications.service.gov.uk/rest-api.html#authorisation-header"
@@ -191,3 +196,73 @@ def _get_token_issuer(auth_token):
     except TokenDecodeError as e:
         raise AuthError(GENERAL_TOKEN_ERROR_MESSAGE, 403) from e
     return issuer
+
+
+# caching check_hash isn't ideal from a security POV as it does mean we'll be holding the plaintext
+# password in-memory once it is used, but performing a bcrypt operation on every request may be quite
+# punishing and/or open us up to some DoS attacks. using an LFU cache (rather than LRU) should at
+# least stop a DoS attack being able to push our real requests' passwords out of the cache too easily.
+_cached_check_hash = lfu_cache(maxsize=64, typed=True)(check_hash)
+
+
+memo_resetters.append(lambda: _cached_check_hash.cache_clear())
+
+
+def requires_basic_auth(
+    credentials_config_key: str, check_hash_callable: Callable[[str, str], bool] = _cached_check_hash
+) -> None:
+    """
+    `credentials_config_key` is expected to be a key in the flask app config containing a mapping
+    of usernames to bcrypt hashes of their basic auth passwords. a very low bcrypt difficulty can
+    be used in the hashes if performance is a concern.
+
+    For use as a `before_request` function, apply `credentials_config_key` with `functools.partial`.
+    """
+    auth = request.authorization
+    creds_dict = current_app.config.get(credentials_config_key) or {}
+
+    if (not auth) or auth.type != "basic":
+        current_app.logger.warning(
+            "Request expecting basic auth from %s received no authorization header",
+            credentials_config_key,
+            extra={"credentials_config_key": credentials_config_key},
+        )
+        raise AuthError("Unauthorized: basic authorization must be provided", 401)
+
+    if auth.username not in creds_dict:
+        current_app.logger.warning(
+            "Request's basic auth username %s not found in %s",
+            auth.username,
+            credentials_config_key,
+            extra={"credentials_config_key": credentials_config_key, "username": auth.username},
+        )
+        raise AuthError("Unauthorized: basic authorisation failed", 403)
+
+    if not check_hash_callable(auth.password or "", creds_dict[auth.username]):
+        current_app.logger.warning(
+            "Request's basic auth password for username %s does not match that found in %s",
+            auth.username,
+            credentials_config_key,
+            extra={"credentials_config_key": credentials_config_key, "username": auth.username},
+        )
+        raise AuthError("Unauthorized: basic authorisation failed", 403)
+
+
+def view_requires_basic_auth[**A, R](
+    credentials_config_key: str, check_hash_callable: Callable[[str, str], bool] = _cached_check_hash
+) -> Callable[[Callable[A, R]], Callable[A, R]]:
+    """
+    Returns a decorator function that will run `requires_basic_auth` before its wrapped function.
+
+    For use applying `requires_basic_auth` to single views.
+    """
+
+    def basic_auth_decorator(inner: Callable[A, R]) -> Callable[A, R]:
+        @wraps(inner)
+        def view_wrapper(*args, **kwargs):
+            requires_basic_auth(credentials_config_key, check_hash_callable)
+            return inner(*args, **kwargs)
+
+        return view_wrapper
+
+    return basic_auth_decorator

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -1,6 +1,7 @@
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Generator
+from contextlib import contextmanager, nullcontext
 from functools import wraps
 
 from cachetools.func import lfu_cache
@@ -208,8 +209,19 @@ _cached_check_hash = lfu_cache(maxsize=64, typed=True)(check_hash)
 memo_resetters.append(lambda: _cached_check_hash.cache_clear())
 
 
+@contextmanager
+def _suppress_and_log_autherror() -> Generator:
+    try:
+        yield
+    except AuthError as e:
+        current_app.logger.warning("Suppressing basic auth failure: %s", str(e), extra={"exception": str(e)})
+
+
 def requires_basic_auth(
-    credentials_config_key: str, check_hash_callable: Callable[[str, str], bool] = _cached_check_hash
+    credentials_config_key: str,
+    check_hash_callable: Callable[[str, str], bool] = _cached_check_hash,
+    *,
+    log_only: bool = False,
 ) -> None:
     """
     `credentials_config_key` is expected to be a key in the flask app config containing a mapping
@@ -221,35 +233,39 @@ def requires_basic_auth(
     auth = request.authorization
     creds_dict = current_app.config.get(credentials_config_key) or {}
 
-    if (not auth) or auth.type != "basic":
-        current_app.logger.warning(
-            "Request expecting basic auth from %s received no authorization header",
-            credentials_config_key,
-            extra={"credentials_config_key": credentials_config_key},
-        )
-        raise AuthError("Unauthorized: basic authorization must be provided", 401)
+    with _suppress_and_log_autherror() if log_only else nullcontext():
+        if (not auth) or auth.type != "basic":
+            current_app.logger.warning(
+                "Request expecting basic auth from %s received no authorization header",
+                credentials_config_key,
+                extra={"credentials_config_key": credentials_config_key},
+            )
+            raise AuthError("Unauthorized: basic authorization must be provided", 401)
 
-    if auth.username not in creds_dict:
-        current_app.logger.warning(
-            "Request's basic auth username %s not found in %s",
-            auth.username,
-            credentials_config_key,
-            extra={"credentials_config_key": credentials_config_key, "username": auth.username},
-        )
-        raise AuthError("Unauthorized: basic authorisation failed", 403)
+        if auth.username not in creds_dict:
+            current_app.logger.warning(
+                "Request's basic auth username %s not found in %s",
+                auth.username,
+                credentials_config_key,
+                extra={"credentials_config_key": credentials_config_key, "username": auth.username},
+            )
+            raise AuthError("Unauthorized: basic authorisation failed", 403)
 
-    if not check_hash_callable(auth.password or "", creds_dict[auth.username]):
-        current_app.logger.warning(
-            "Request's basic auth password for username %s does not match that found in %s",
-            auth.username,
-            credentials_config_key,
-            extra={"credentials_config_key": credentials_config_key, "username": auth.username},
-        )
-        raise AuthError("Unauthorized: basic authorisation failed", 403)
+        if not check_hash_callable(auth.password or "", creds_dict[auth.username]):
+            current_app.logger.warning(
+                "Request's basic auth password for username %s does not match that found in %s",
+                auth.username,
+                credentials_config_key,
+                extra={"credentials_config_key": credentials_config_key, "username": auth.username},
+            )
+            raise AuthError("Unauthorized: basic authorisation failed", 403)
 
 
 def view_requires_basic_auth[**A, R](
-    credentials_config_key: str, check_hash_callable: Callable[[str, str], bool] = _cached_check_hash
+    credentials_config_key: str,
+    check_hash_callable: Callable[[str, str], bool] = _cached_check_hash,
+    *,
+    log_only: bool = False,
 ) -> Callable[[Callable[A, R]], Callable[A, R]]:
     """
     Returns a decorator function that will run `requires_basic_auth` before its wrapped function.
@@ -260,7 +276,7 @@ def view_requires_basic_auth[**A, R](
     def basic_auth_decorator(inner: Callable[A, R]) -> Callable[A, R]:
         @wraps(inner)
         def view_wrapper(*args, **kwargs):
-            requires_basic_auth(credentials_config_key, check_hash_callable)
+            requires_basic_auth(credentials_config_key, check_hash_callable, log_only=log_only)
             return inner(*args, **kwargs)
 
         return view_wrapper

--- a/app/config.py
+++ b/app/config.py
@@ -135,6 +135,10 @@ class Config:
     MMG_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS = json.loads(
         os.environ.get("MMG_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS") or "null"
     )
+    # expected to be a dict of usernames -> bcrypt hash of password
+    MMG_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS = json.loads(
+        os.environ.get("MMG_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS") or "{}"
+    )
 
     # Firetext API Key
     FIRETEXT_API_KEY = os.getenv("FIRETEXT_API_KEY")
@@ -145,6 +149,10 @@ class Config:
     FIRETEXT_RECEIPT_URL = os.getenv("FIRETEXT_RECEIPT_URL")
     FIRETEXT_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS = json.loads(
         os.environ.get("FIRETEXT_DELIVERY_STATUS_CALLBACK_BASIC_AUTH_CREDENTIALS") or "null"
+    )
+    # expected to be a dict of usernames -> bcrypt hash of password
+    FIRETEXT_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS = json.loads(
+        os.environ.get("FIRETEXT_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS") or "{}"
     )
 
     # Prefix to identify queues in SQS

--- a/app/notifications/notifications_sms_callback.py
+++ b/app/notifications/notifications_sms_callback.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from flask import Blueprint, json, jsonify, request
 from notifications_utils.timezones import local_timezone
 
+from app.authentication.auth import view_requires_basic_auth
 from app.celery.process_sms_client_response_tasks import (
     process_sms_client_response,
 )
@@ -14,6 +15,7 @@ register_errors(sms_callback_blueprint)
 
 
 @sms_callback_blueprint.route("/mmg", methods=["POST"])
+@view_requires_basic_auth("MMG_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS")
 def process_mmg_response():
     uniform_now = datetime.utcnow()
     client_name = "MMG"
@@ -54,6 +56,7 @@ def process_mmg_response():
 
 
 @sms_callback_blueprint.route("/firetext", methods=["POST"])
+@view_requires_basic_auth("FIRETEXT_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS")
 def process_firetext_response():
     uniform_now = datetime.utcnow()
     client_name = "Firetext"

--- a/app/notifications/notifications_sms_callback.py
+++ b/app/notifications/notifications_sms_callback.py
@@ -15,7 +15,7 @@ register_errors(sms_callback_blueprint)
 
 
 @sms_callback_blueprint.route("/mmg", methods=["POST"])
-@view_requires_basic_auth("MMG_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS")
+@view_requires_basic_auth("MMG_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS", log_only=True)
 def process_mmg_response():
     uniform_now = datetime.utcnow()
     client_name = "MMG"
@@ -56,7 +56,7 @@ def process_mmg_response():
 
 
 @sms_callback_blueprint.route("/firetext", methods=["POST"])
-@view_requires_basic_auth("FIRETEXT_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS")
+@view_requires_basic_auth("FIRETEXT_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS", log_only=True)
 def process_firetext_response():
     uniform_now = datetime.utcnow()
     client_name = "Firetext"

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -1,11 +1,13 @@
 import time
 import uuid
+from contextlib import suppress
 
 import jwt
 import pytest
 from flask import g, request
 from jwt.exceptions import InvalidIssuerError, MissingRequiredClaimError
 from notifications_python_client.authentication import create_jwt_token
+from werkzeug.datastructures import Authorization
 
 from app import db
 from app.authentication.auth import (
@@ -15,6 +17,7 @@ from app.authentication.auth import (
     _get_auth_token,
     _get_token_issuer,
     requires_auth,
+    requires_basic_auth,
     requires_internal_auth,
 )
 from app.dao.api_key_dao import (
@@ -23,6 +26,7 @@ from app.dao.api_key_dao import (
     get_unsigned_secrets,
 )
 from app.dao.services_dao import dao_fetch_service_by_id
+from app.hashing import hashpw
 from tests import (
     create_admin_authorization_header,
     create_service_authorization_header,
@@ -356,3 +360,74 @@ def test_requires_internal_auth_sets_global_variables(
     request.headers = {"Authorization": f"Bearer {internal_jwt_token}"}
     requires_my_internal_app_auth()
     assert g.service_id == "my-internal-app"
+
+
+def test_requires_basic_auth_missing_auth_empty_dict(notify_api, client):
+    notify_api.config["FOO_BAR_BAZ"] = {}
+
+    with pytest.raises(AuthError, check=lambda e: e.code == 401):
+        requires_basic_auth("FOO_BAR_BAZ")
+
+
+def test_requires_basic_auth_missing_auth_config(notify_api, client):
+    with suppress(KeyError):
+        del notify_api.config["FOO_BAR_BAZ"]
+
+    with pytest.raises(AuthError, check=lambda e: e.code == 401):
+        requires_basic_auth("FOO_BAR_BAZ")
+
+
+def test_requires_basic_auth_non_basic_auth(notify_api, client):
+    notify_api.config["FOO_BAR_BAZ"] = {}
+    request.headers = {"Authorization": Authorization("bearer", token="1234").to_header()}
+
+    with pytest.raises(AuthError, check=lambda e: e.code == 401):
+        requires_basic_auth("FOO_BAR_BAZ")
+
+
+def test_requires_basic_auth_unknown_username(notify_api, client):
+    notify_api.config["FOO_BAR_BAZ"] = {
+        "foo123": hashpw("bar123"),
+    }
+    request.headers = {
+        "Authorization": Authorization("basic", data={"username": "blah", "password": "fooblah"}).to_header()
+    }
+
+    with pytest.raises(AuthError, check=lambda e: e.code == 403):
+        requires_basic_auth("FOO_BAR_BAZ")
+
+
+def test_requires_basic_auth_incorrect_password(notify_api, client):
+    notify_api.config["FOO_BAR_BAZ"] = {
+        "foo123": hashpw("bar123"),
+    }
+    request.headers = {
+        "Authorization": Authorization("basic", data={"username": "foo123", "password": "Bar321"}).to_header()
+    }
+
+    with pytest.raises(AuthError, check=lambda e: e.code == 403):
+        requires_basic_auth("FOO_BAR_BAZ")
+
+
+def test_requires_basic_auth_mismatched_password(notify_api, client):
+    notify_api.config["FOO_BAR_BAZ"] = {
+        "foo123": hashpw("bar123"),
+        "foo456": hashpw("bar456"),
+    }
+    request.headers = {
+        "Authorization": Authorization("basic", data={"username": "foo123", "password": "bar456"}).to_header()
+    }
+
+    with pytest.raises(AuthError, check=lambda e: e.code == 403):
+        requires_basic_auth("FOO_BAR_BAZ")
+
+
+def test_requires_basic_auth_correct_password(notify_api, client):
+    notify_api.config["FOO_BAR_BAZ"] = {
+        "foo123": hashpw("bar123"),
+    }
+    request.headers = {
+        "Authorization": Authorization("basic", data={"username": "foo123", "password": "bar123"}).to_header()
+    }
+
+    assert requires_basic_auth("FOO_BAR_BAZ") is None

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -6,6 +6,7 @@ import pytest
 from flask import g, request
 from jwt.exceptions import InvalidIssuerError, MissingRequiredClaimError
 from notifications_python_client.authentication import create_jwt_token
+from werkzeug.datastructures import Authorization
 
 from app import db
 from app.authentication.auth import (
@@ -15,6 +16,7 @@ from app.authentication.auth import (
     _get_auth_token,
     _get_token_issuer,
     requires_auth,
+    requires_basic_auth,
     requires_internal_auth,
 )
 from app.dao.api_key_dao import (
@@ -23,6 +25,7 @@ from app.dao.api_key_dao import (
     get_unsigned_secrets,
 )
 from app.dao.services_dao import dao_fetch_service_by_id
+from app.hashing import hashpw
 from tests import (
     create_admin_authorization_header,
     create_service_authorization_header,
@@ -356,3 +359,66 @@ def test_requires_internal_auth_sets_global_variables(
     request.headers = {"Authorization": f"Bearer {internal_jwt_token}"}
     requires_my_internal_app_auth()
     assert g.service_id == "my-internal-app"
+
+
+def test_requires_basic_auth_missing_auth(notify_api, client):
+    notify_api.config["FOO_BAR_BAZ"] = {}
+
+    with pytest.raises(AuthError, check=lambda e: e.code == 401):
+        requires_basic_auth("FOO_BAR_BAZ")
+
+
+def test_requires_basic_auth_non_basic_auth(notify_api, client):
+    notify_api.config["FOO_BAR_BAZ"] = {}
+    request.headers = {"Authorization": Authorization("bearer", token="1234").to_header()}
+
+    with pytest.raises(AuthError, check=lambda e: e.code == 401):
+        requires_basic_auth("FOO_BAR_BAZ")
+
+
+def test_requires_basic_auth_unknown_username(notify_api, client):
+    notify_api.config["FOO_BAR_BAZ"] = {
+        "foo123": hashpw("bar123"),
+    }
+    request.headers = {
+        "Authorization": Authorization("basic", data={"username": "blah", "password": "fooblah"}).to_header()
+    }
+
+    with pytest.raises(AuthError, check=lambda e: e.code == 403):
+        requires_basic_auth("FOO_BAR_BAZ")
+
+
+def test_requires_basic_auth_incorrect_password(notify_api, client):
+    notify_api.config["FOO_BAR_BAZ"] = {
+        "foo123": hashpw("bar123"),
+    }
+    request.headers = {
+        "Authorization": Authorization("basic", data={"username": "foo123", "password": "Bar321"}).to_header()
+    }
+
+    with pytest.raises(AuthError, check=lambda e: e.code == 403):
+        requires_basic_auth("FOO_BAR_BAZ")
+
+
+def test_requires_basic_auth_mismatched_password(notify_api, client):
+    notify_api.config["FOO_BAR_BAZ"] = {
+        "foo123": hashpw("bar123"),
+        "foo456": hashpw("bar456"),
+    }
+    request.headers = {
+        "Authorization": Authorization("basic", data={"username": "foo123", "password": "bar456"}).to_header()
+    }
+
+    with pytest.raises(AuthError, check=lambda e: e.code == 403):
+        requires_basic_auth("FOO_BAR_BAZ")
+
+
+def test_requires_basic_auth_correct_password(notify_api, client):
+    notify_api.config["FOO_BAR_BAZ"] = {
+        "foo123": hashpw("bar123"),
+    }
+    request.headers = {
+        "Authorization": Authorization("basic", data={"username": "foo123", "password": "bar123"}).to_header()
+    }
+
+    assert requires_basic_auth("FOO_BAR_BAZ") is None

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -1,6 +1,6 @@
 import time
 import uuid
-from contextlib import suppress
+from contextlib import nullcontext, suppress
 
 import jwt
 import pytest
@@ -362,30 +362,40 @@ def test_requires_internal_auth_sets_global_variables(
     assert g.service_id == "my-internal-app"
 
 
-def test_requires_basic_auth_missing_auth_empty_dict(notify_api, client):
+@pytest.mark.parametrize("log_only", (False, True))
+def test_requires_basic_auth_missing_auth_empty_dict(notify_api, client, caplog, log_only):
     notify_api.config["FOO_BAR_BAZ"] = {}
 
-    with pytest.raises(AuthError, check=lambda e: e.code == 401):
-        requires_basic_auth("FOO_BAR_BAZ")
+    with nullcontext() if log_only else pytest.raises(AuthError, check=lambda e: e.code == 401):
+        assert requires_basic_auth("FOO_BAR_BAZ", log_only=log_only) is None
+
+    assert ("Suppressing basic auth failure" in caplog.text) is log_only
 
 
-def test_requires_basic_auth_missing_auth_config(notify_api, client):
+@pytest.mark.parametrize("log_only", (False, True))
+def test_requires_basic_auth_missing_auth_config(notify_api, client, caplog, log_only):
     with suppress(KeyError):
         del notify_api.config["FOO_BAR_BAZ"]
 
-    with pytest.raises(AuthError, check=lambda e: e.code == 401):
-        requires_basic_auth("FOO_BAR_BAZ")
+    with nullcontext() if log_only else pytest.raises(AuthError, check=lambda e: e.code == 401):
+        assert requires_basic_auth("FOO_BAR_BAZ", log_only=log_only) is None
+
+    assert ("Suppressing basic auth failure" in caplog.text) is log_only
 
 
-def test_requires_basic_auth_non_basic_auth(notify_api, client):
+@pytest.mark.parametrize("log_only", (False, True))
+def test_requires_basic_auth_non_basic_auth(notify_api, client, caplog, log_only):
     notify_api.config["FOO_BAR_BAZ"] = {}
     request.headers = {"Authorization": Authorization("bearer", token="1234").to_header()}
 
-    with pytest.raises(AuthError, check=lambda e: e.code == 401):
-        requires_basic_auth("FOO_BAR_BAZ")
+    with nullcontext() if log_only else pytest.raises(AuthError, check=lambda e: e.code == 401):
+        assert requires_basic_auth("FOO_BAR_BAZ", log_only=log_only) is None
+
+    assert ("Suppressing basic auth failure" in caplog.text) is log_only
 
 
-def test_requires_basic_auth_unknown_username(notify_api, client):
+@pytest.mark.parametrize("log_only", (False, True))
+def test_requires_basic_auth_unknown_username(notify_api, client, caplog, log_only):
     notify_api.config["FOO_BAR_BAZ"] = {
         "foo123": hashpw("bar123"),
     }
@@ -393,11 +403,14 @@ def test_requires_basic_auth_unknown_username(notify_api, client):
         "Authorization": Authorization("basic", data={"username": "blah", "password": "fooblah"}).to_header()
     }
 
-    with pytest.raises(AuthError, check=lambda e: e.code == 403):
-        requires_basic_auth("FOO_BAR_BAZ")
+    with nullcontext() if log_only else pytest.raises(AuthError, check=lambda e: e.code == 403):
+        assert requires_basic_auth("FOO_BAR_BAZ", log_only=log_only) is None
+
+    assert ("Suppressing basic auth failure" in caplog.text) is log_only
 
 
-def test_requires_basic_auth_incorrect_password(notify_api, client):
+@pytest.mark.parametrize("log_only", (False, True))
+def test_requires_basic_auth_incorrect_password(notify_api, client, caplog, log_only):
     notify_api.config["FOO_BAR_BAZ"] = {
         "foo123": hashpw("bar123"),
     }
@@ -405,11 +418,14 @@ def test_requires_basic_auth_incorrect_password(notify_api, client):
         "Authorization": Authorization("basic", data={"username": "foo123", "password": "Bar321"}).to_header()
     }
 
-    with pytest.raises(AuthError, check=lambda e: e.code == 403):
-        requires_basic_auth("FOO_BAR_BAZ")
+    with nullcontext() if log_only else pytest.raises(AuthError, check=lambda e: e.code == 403):
+        assert requires_basic_auth("FOO_BAR_BAZ", log_only=log_only) is None
+
+    assert ("Suppressing basic auth failure" in caplog.text) is log_only
 
 
-def test_requires_basic_auth_mismatched_password(notify_api, client):
+@pytest.mark.parametrize("log_only", (False, True))
+def test_requires_basic_auth_mismatched_password(notify_api, client, caplog, log_only):
     notify_api.config["FOO_BAR_BAZ"] = {
         "foo123": hashpw("bar123"),
         "foo456": hashpw("bar456"),
@@ -418,11 +434,14 @@ def test_requires_basic_auth_mismatched_password(notify_api, client):
         "Authorization": Authorization("basic", data={"username": "foo123", "password": "bar456"}).to_header()
     }
 
-    with pytest.raises(AuthError, check=lambda e: e.code == 403):
-        requires_basic_auth("FOO_BAR_BAZ")
+    with nullcontext() if log_only else pytest.raises(AuthError, check=lambda e: e.code == 403):
+        assert requires_basic_auth("FOO_BAR_BAZ", log_only=log_only) is None
+
+    assert ("Suppressing basic auth failure" in caplog.text) is log_only
 
 
-def test_requires_basic_auth_correct_password(notify_api, client):
+@pytest.mark.parametrize("log_only", (False, True))
+def test_requires_basic_auth_correct_password(notify_api, client, caplog, log_only):
     notify_api.config["FOO_BAR_BAZ"] = {
         "foo123": hashpw("bar123"),
     }
@@ -430,4 +449,6 @@ def test_requires_basic_auth_correct_password(notify_api, client):
         "Authorization": Authorization("basic", data={"username": "foo123", "password": "bar123"}).to_header()
     }
 
-    assert requires_basic_auth("FOO_BAR_BAZ") is None
+    assert requires_basic_auth("FOO_BAR_BAZ", log_only=log_only) is None
+
+    assert "Suppressing basic auth failure" not in caplog.text

--- a/tests/app/notifications/test_notifications_sms_callbacks.py
+++ b/tests/app/notifications/test_notifications_sms_callbacks.py
@@ -37,7 +37,7 @@ def mmg_post(client, data):
     )
 
 
-def test_firetext_callback_needs_auth(client, mocker):
+def test_firetext_callback_needs_auth(client, mocker, caplog):
     mocker.patch("app.notifications.notifications_sms_callback.process_sms_client_response")
     data = "mobile=441234123123&status=0&reference=notification_id&time=2016-03-10 14:17:00"
 
@@ -48,7 +48,8 @@ def test_firetext_callback_needs_auth(client, mocker):
             ("Content-Type", "application/x-www-form-urlencoded"),
         ],
     )
-    assert response.status_code == 401
+    assert response.status_code == 200
+    assert "Suppressing basic auth failure" in caplog.text
 
 
 def test_firetext_callback_should_return_400_if_empty_reference(client):
@@ -159,7 +160,7 @@ def test_firetext_callback_including_a_code_should_return_200_and_call_task_with
     )
 
 
-def test_mmg_callback_needs_auth(client, mocker, sample_notification):
+def test_mmg_callback_needs_auth(client, mocker, sample_notification, caplog):
     mocker.patch("app.notifications.notifications_sms_callback.process_sms_client_response")
     data = json.dumps(
         {
@@ -178,7 +179,8 @@ def test_mmg_callback_needs_auth(client, mocker, sample_notification):
             ("Content-Type", "application/json"),
         ],
     )
-    assert response.status_code == 401
+    assert response.status_code == 200
+    assert "Suppressing basic auth failure" in caplog.text
 
 
 def test_process_mmg_response_returns_400_for_malformed_data(client):

--- a/tests/app/notifications/test_notifications_sms_callbacks.py
+++ b/tests/app/notifications/test_notifications_sms_callbacks.py
@@ -1,26 +1,54 @@
 from flask import json
 from freezegun import freeze_time
+from werkzeug.datastructures import Authorization
 
 from app.celery.process_sms_client_response_tasks import process_sms_client_response
+from app.hashing import hashpw
 from app.notifications.notifications_sms_callback import validate_callback_data
 
 
 def firetext_post(client, data):
+    client.application.config["FIRETEXT_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS"] = {
+        "foo123": hashpw("bar123"),
+    }
+
     return client.post(
-        path="/notifications/sms/firetext", data=data, headers=[("Content-Type", "application/x-www-form-urlencoded")]
+        path="/notifications/sms/firetext",
+        data=data,
+        headers=[
+            ("Content-Type", "application/x-www-form-urlencoded"),
+            ("Authorization", Authorization("basic", data={"username": "foo123", "password": "bar123"})),
+        ],
     )
 
 
 def mmg_post(client, data):
-    return client.post(path="/notifications/sms/mmg", data=data, headers=[("Content-Type", "application/json")])
+    client.application.config["MMG_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS"] = {
+        "foo123": hashpw("bar123"),
+    }
+
+    return client.post(
+        path="/notifications/sms/mmg",
+        data=data,
+        headers=[
+            ("Content-Type", "application/json"),
+            ("Authorization", Authorization("basic", data={"username": "foo123", "password": "bar123"})),
+        ],
+    )
 
 
-def test_firetext_callback_should_not_need_auth(client, mocker):
+def test_firetext_callback_needs_auth(client, mocker):
     mocker.patch("app.notifications.notifications_sms_callback.process_sms_client_response")
     data = "mobile=441234123123&status=0&reference=notification_id&time=2016-03-10 14:17:00"
 
-    response = firetext_post(client, data)
-    assert response.status_code == 200
+    response = client.post(
+        path="/notifications/sms/firetext",
+        data=data,
+        headers=[
+            ("Content-Type", "application/x-www-form-urlencoded"),
+        ],
+    )
+    assert response.status_code == 401
 
 
 def test_firetext_callback_should_return_400_if_empty_reference(client):
@@ -131,7 +159,7 @@ def test_firetext_callback_including_a_code_should_return_200_and_call_task_with
     )
 
 
-def test_mmg_callback_should_not_need_auth(client, mocker, sample_notification):
+def test_mmg_callback_needs_auth(client, mocker, sample_notification):
     mocker.patch("app.notifications.notifications_sms_callback.process_sms_client_response")
     data = json.dumps(
         {
@@ -143,8 +171,14 @@ def test_mmg_callback_should_not_need_auth(client, mocker, sample_notification):
         }
     )
 
-    response = mmg_post(client, data)
-    assert response.status_code == 200
+    response = client.post(
+        path="/notifications/sms/mmg",
+        data=data,
+        headers=[
+            ("Content-Type", "application/json"),
+        ],
+    )
+    assert response.status_code == 401
 
 
 def test_process_mmg_response_returns_400_for_malformed_data(client):


### PR DESCRIPTION
https://trello.com/c/94Q38sgQ/1546-implement-authentication-for-delivery-receipt-callback-endpoints

The existing pattern for auth-protecting views is via `before_request` functions applied to their blueprints, but this doesn't provide the opportunity for configuring each individually, and we need to do that to point each view at its respective config variable supplying "allowed" credentials. So while `requires_basic_auth` is _usable_ as a `before_request` hook (if you use `functools.partial` to supply its config variable), it's better used via its `view_requires_basic_auth` wrapper decorator.

Another notable design decision here is to accept bcrypt hashes of the basic auth passwords corresponding to each username as configuration (multiple username/password pairs are of course supported to enable smooth credential rotation). While this is of questionable value seeing as the wider application needs to have access to the plaintext passwords used in callbacks by both providers and "research mode", technically api-web *doesn't* need access to these. So keeping them as hashes adds a small amount of protection.

To mitigate this causing a performance problem (having to perform a deliberately-expensive password hash for each request is not the normal use-case for password hashing, but it's hard to avoid with basic auth), the `check_hash` function is wrapped in a least-frequently-used in-memory cache. This has some security tradeoffs because it means a plaintext password will end up being kept in memory once it has been used, but it should mean most requests with correct credentials have zero hashing cost.

This mustn't be merged until we're absolutely sure we've got all the other parts in place and working.