### PR TITLE
`generate_sms_delivery_stats`: also produce direct provider metrics

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -70,6 +70,7 @@ from app.dao.notifications_dao import (
 from app.dao.provider_details_dao import (
     dao_adjust_provider_priority_back_to_resting_points,
     dao_reduce_sms_provider_priority,
+    get_provider_details_by_notification_type,
 )
 from app.dao.services_dao import (
     dao_fetch_service_by_id,
@@ -91,7 +92,12 @@ from app.models import (
     User,
 )
 from app.notifications.process_notifications import persist_notification, send_notification_to_queue
-from app.otel_metrics.provider import record_sms_legacy_not_delivered_within
+from app.otel_metrics.provider import (
+    record_info,
+    record_priority,
+    record_sms_legacy_not_delivered_within,
+    record_updated_at,
+)
 from app.utils import get_london_midnight_in_utc
 
 
@@ -266,6 +272,11 @@ def generate_sms_delivery_stats():
         # TODO: delete this when we have a way to raise these alerts from eg grafana, prometheus, something else.
         if delivery_interval == 5 and current_app.should_check_slow_text_message_delivery:
             _check_slow_text_message_delivery_reports_and_raise_error_if_needed(providers_slow_delivery_reports)
+
+    for provider in get_provider_details_by_notification_type(SMS_TYPE, False):
+        record_priority(provider.priority, provider.identifier)
+        record_updated_at(provider.updated_at, provider.identifier)
+        record_info(provider.identifier, provider.active, provider.supports_international, provider.notification_type)
 
 
 @notify_celery.task(name="tend-providers-back-to-middle")

--- a/app/otel_metrics/provider.py
+++ b/app/otel_metrics/provider.py
@@ -1,3 +1,4 @@
+import datetime
 import functools
 from collections.abc import Callable
 from time import monotonic
@@ -23,6 +24,24 @@ _sms_legacy_not_delivered_within = _meter.create_gauge(
     "as it includes notifications sent too recently to be able to determine this for sensibly, "
     "however this is the measure currently used by the SMS provider balancer for better or "
     "worse.",
+)
+
+_priority = _meter.create_gauge(
+    "provider.priority",
+    unit="1",
+    description="Observed priority value of a Provider",
+)
+
+_updated_at = _meter.create_gauge(
+    "provider.updated_at",
+    unit="s",
+    description="Unix epoch timestamp of Provider's last update",
+)
+
+_info = _meter.create_gauge(
+    "provider.info",
+    unit="1",
+    description="Observed metadata values of a Provider",
 )
 
 
@@ -64,3 +83,38 @@ def record_sms_legacy_not_delivered_within(
         "time_window.delivery": delivery_window,
     }
     _sms_legacy_not_delivered_within.set(ratio, attributes)
+
+
+def record_priority(
+    priority: int,
+    provider_name: str,
+) -> None:
+    attributes: dict[str, AttributeValue] = {
+        "provider.name": provider_name,
+    }
+    _priority.set(priority, attributes)
+
+
+def record_updated_at(
+    updated_at: datetime.datetime,
+    provider_name: str,
+) -> None:
+    attributes: dict[str, AttributeValue] = {
+        "provider.name": provider_name,
+    }
+    _updated_at.set(updated_at.timestamp(), attributes)
+
+
+def record_info(
+    provider_name: str,
+    active: bool,
+    supports_international: bool,
+    notification_type: str,
+) -> None:
+    attributes: dict[str, AttributeValue] = {
+        "provider.name": provider_name,
+        "provider.active": active,
+        "provider.supports_international": supports_international,
+        "notification.type": notification_type,
+    }
+    _info.set(1, attributes)

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -15,6 +15,7 @@ from notifications_utils.clients.zendesk.zendesk_client import (
     NotifySupportTicketStatus,
     NotifyTicketType,
 )
+from notifications_utils.testing.comparisons import RestrictedAny
 from redis.exceptions import LockError
 
 from app.celery import scheduled_tasks
@@ -68,7 +69,18 @@ from app.dao.notifications_dao import SlowProviderDeliveryReport
 from app.dao.provider_details_dao import get_provider_details_by_identifier
 from app.dao.template_email_files_dao import dao_get_template_email_file_by_id
 from app.models import Event, InboundNumber, Notification
-from app.otel_metrics.provider import _sms_legacy_not_delivered_within
+from app.otel_metrics.provider import (
+    _info as provider_info_metric,
+)
+from app.otel_metrics.provider import (
+    _priority as provider_priority_metric,
+)
+from app.otel_metrics.provider import (
+    _sms_legacy_not_delivered_within as provider_sms_legacy_not_delivered_within_metric,
+)
+from app.otel_metrics.provider import (
+    _updated_at as provider_updated_at_metric,
+)
 from tests.app import load_example_csv
 from tests.app.db import (
     create_email_branding,
@@ -229,12 +241,18 @@ def test_switch_current_sms_provider_on_slow_delivery_does_nothing_if_no_need(
         ),
     ),
 )
-def test_generate_sms_delivery_stats(slow_delivery_config_option, expect_check_slow_delivery, mocker, notify_api):
+def test_generate_sms_delivery_stats(slow_delivery_config_option, expect_check_slow_delivery, notify_api, mocker):
+    sms_not_delivered_within_metric_set_mock = mocker.patch.object(
+        provider_sms_legacy_not_delivered_within_metric, "set"
+    )
+    priority_metric_mock = mocker.patch.object(provider_priority_metric, "set")
+    updated_at_metric_mock = mocker.patch.object(provider_updated_at_metric, "set")
+    info_metric_mock = mocker.patch.object(provider_info_metric, "set")
+
     slow_delivery_reports = [
         SlowProviderDeliveryReport(provider="mmg", slow_ratio=0.4, slow_notifications=40, total_notifications=100),
         SlowProviderDeliveryReport(provider="firetext", slow_ratio=0.8, slow_notifications=80, total_notifications=100),
     ]
-    set_sms_not_delivered_within_mock = mocker.patch.object(_sms_legacy_not_delivered_within, "set")
     mocker.patch(
         "app.celery.scheduled_tasks.get_slow_text_message_delivery_reports_by_provider",
         return_value=slow_delivery_reports,
@@ -250,14 +268,61 @@ def test_generate_sms_delivery_stats(slow_delivery_config_option, expect_check_s
         [mocker.call(slow_delivery_reports)] if expect_check_slow_delivery else []
     )
 
-    assert set_sms_not_delivered_within_mock.mock_calls == [
-        mocker.call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 60}),
-        mocker.call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 60}),
-        mocker.call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 300}),
-        mocker.call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 300}),
-        mocker.call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 600}),
-        mocker.call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 600}),
-    ]
+    # normalizing order of following calls by sorting by sorted attribute k/v pairs
+
+    assert sorted(
+        sms_not_delivered_within_metric_set_mock.mock_calls, key=lambda c: sorted(c.args[1].items())
+    ) == sorted(
+        (
+            mocker.call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 60}),
+            mocker.call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 60}),
+            mocker.call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 300}),
+            mocker.call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 300}),
+            mocker.call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 600}),
+            mocker.call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 600}),
+        ),
+        key=lambda c: sorted(c.args[1].items()),
+    )
+
+    assert sorted(priority_metric_mock.mock_calls, key=lambda c: sorted(c.args[1].items())) == sorted(
+        (
+            mocker.call(0, {"provider.name": "firetext"}),
+            mocker.call(100, {"provider.name": "mmg"}),
+        ),
+        key=lambda c: sorted(c.args[1].items()),
+    )
+
+    assert sorted(updated_at_metric_mock.mock_calls, key=lambda c: sorted(c.args[1].items())) == sorted(
+        (
+            mocker.call(RestrictedAny(lambda x: x < datetime.utcnow().timestamp()), {"provider.name": "firetext"}),
+            mocker.call(RestrictedAny(lambda x: x < datetime.utcnow().timestamp()), {"provider.name": "mmg"}),
+        ),
+        key=lambda c: sorted(c.args[1].items()),
+    )
+
+    assert sorted(info_metric_mock.mock_calls, key=lambda c: sorted(c.args[1].items())) == sorted(
+        (
+            mocker.call(
+                1,
+                {
+                    "provider.name": "firetext",
+                    "provider.active": True,
+                    "provider.supports_international": False,
+                    "notification.type": "sms",
+                },
+            ),
+            mocker.call(
+                1,
+                {
+                    "provider.name": "mmg",
+                    "provider.active": True,
+                    "provider.supports_international": True,
+                    "notification.type": "sms",
+                },
+            ),
+        ),
+        key=lambda c: sorted(c.args[1].items()),
+    )
 
 
 @pytest.mark.parametrize("consecutive_failures,should_log", ((1, False), (9, False), (10, True)))


### PR DESCRIPTION
These are based on the current state of the `ProviderDetails` table and combined together should be able to reveal most of the behaviour of the balancer directly.

With the current metrics we can only see the "results" of what the balancer is doing - behind the noise of random selection. These new metrics should show us what the balancer is *intending* to do and when it is being updated.

These metrics will also need to be treated like other otel metrics created by `generate_sms_delivery_stats`, i.e. using `last_over_time()` to fuse together timeseries that occur on different worker instances.

Tested on dev-b.
<img width="1530" height="771" alt="Screenshot 2026-08-11 at 14 33 34" src="https://github.com/user-attachments/assets/01f5dcce-b17e-4aa8-973e-d03092cebd3a" />
