### PR TITLE
Bump utils to 125.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@124.2.0
+# This file was automatically copied from notifications-utils@125.0.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -115,7 +115,7 @@ def process_job(self, job_id, sender_id=None, shatter_batch_size=DEFAULT_SHATTER
         extra={"job_id": job_id, "notification_count": job.notification_count},
     )
 
-    for shatter_batch in batched(recipient_csv.get_rows(), n=shatter_batch_size):
+    for shatter_batch in batched(recipient_csv, n=shatter_batch_size):
         batch_args_kwargs = [
             get_id_task_args_kwargs_for_job_row(row, template, job, service, sender_id=sender_id)[1]
             for row in shatter_batch
@@ -608,7 +608,7 @@ def process_incomplete_job(job_id, shatter_batch_size=DEFAULT_SHATTER_JOB_ROWS_B
     recipient_csv, template, sender_id = get_recipient_csv_and_template_and_sender_id(job)
 
     for shatter_batch in batched(
-        (row for row in recipient_csv.get_rows() if row.index > resume_from_row),
+        (row for row in recipient_csv if row.index > resume_from_row),
         n=shatter_batch_size,
     ):
         batch_args_kwargs = [

--- a/app/commands.py
+++ b/app/commands.py
@@ -777,7 +777,7 @@ def process_row_from_job(job_id, job_row_number):
         s3.get_job_from_s3(str(job.service_id), str(job.id)),
         template_type=template.template_type,
         placeholders=template.placeholders,
-    ).get_rows():
+    ):
         if row.index == job_row_number:
             notification_id, task_args_kwargs = get_id_task_args_kwargs_for_job_row(row, template, job, job.service)
 

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil~=6.0
 notifications-python-client~=12.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@124.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@125.0.1
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -809,7 +809,7 @@ mistune==0.8.4 \
 notifications-python-client==12.1.0 \
     --hash=sha256:bc44987acbb72de4cded700447d0d246c020dcd0f0311ff2ca884ce1c4001b76
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ace9443c2800adc8107f3bb8ac32e483724612d6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a4e315988da7cefbd56f53f51da900c95ded471f
     # via -r requirements.in
 opentelemetry-api==1.44.0 \
     --hash=sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1161,7 +1161,7 @@ mypy-extensions==1.1.0 \
 notifications-python-client==12.1.0 \
     --hash=sha256:bc44987acbb72de4cded700447d0d246c020dcd0f0311ff2ca884ce1c4001b76
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ace9443c2800adc8107f3bb8ac32e483724612d6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a4e315988da7cefbd56f53f51da900c95ded471f
     # via -r requirements.txt
 opentelemetry-api==1.44.0 \
     --hash=sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@124.2.0
+# This file was automatically copied from notifications-utils@125.0.1
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@124.2.0
+# This file was automatically copied from notifications-utils@125.0.1
 
 extend-exclude = [
     "migrations/versions/",

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@124.2.0
+# This file was automatically copied from notifications-utils@125.0.1
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
 ## 125.0.1

* Fixes a number of bugs with counting characters in text message templates

 ## 125.0.0

* Removes `RecipientCSV.rows_as_list` and `RecipientCSV.get_rows()`. Use `for row in recipient_csv_instance:`, `len(recipient_csv_instance)`, etc. instead

 ## 124.2.1

* Fix antivirus scan when the uploaded file is a Werkzeug `FileStorage` (requests 2.34)

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/124.2.0...125.0.1