### PR TITLE
Bump utils to 127.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@125.0.1
+# This file was automatically copied from notifications-utils@127.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -60,14 +60,14 @@ def send_sms_to_provider(notification: Notification) -> None:
             show_prefix=service.prefix_sms,
         )
 
-        if non_compatible_characters := SanitiseSMS.get_non_compatible_characters(template.unsanitised_content):
+        if non_gsm_characters := SanitiseSMS.get_non_gsm_characters(template.unsanitised_content):
             current_app.logger.warning(
                 "%s character(s) replaced with ? in SMS content for service %s and notification %s",
-                len(non_compatible_characters),
+                len(non_gsm_characters),
                 service.id,
                 notification.id,
                 extra={
-                    "non_compatible_character_count": len(non_compatible_characters),
+                    "non_compatible_character_count": len(non_gsm_characters),
                     "service_id": service.id,
                     "notification_id": notification.id,
                 },

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil~=6.0
 notifications-python-client~=12.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@125.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@127.0.0
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -862,7 +862,7 @@ mistune==0.8.4 \
 notifications-python-client==12.1.0 \
     --hash=sha256:bc44987acbb72de4cded700447d0d246c020dcd0f0311ff2ca884ce1c4001b76
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a4e315988da7cefbd56f53f51da900c95ded471f
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a9af02ae77c034bb6b20e7a01909e2c789ae3ddf
     # via -r requirements.in
 opentelemetry-api==1.44.0 \
     --hash=sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1312,7 +1312,7 @@ mypy-extensions==1.1.0 \
 notifications-python-client==12.1.0 \
     --hash=sha256:bc44987acbb72de4cded700447d0d246c020dcd0f0311ff2ca884ce1c4001b76
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a4e315988da7cefbd56f53f51da900c95ded471f
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a9af02ae77c034bb6b20e7a01909e2c789ae3ddf
     # via -r requirements.txt
 opentelemetry-api==1.44.0 \
     --hash=sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@125.0.1
+# This file was automatically copied from notifications-utils@127.0.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@125.0.1
+# This file was automatically copied from notifications-utils@127.0.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@125.0.1
+# This file was automatically copied from notifications-utils@127.0.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
 ## 127.0.0

* Removes `SanitiseText.get_non_compatible_characters()` (for text message content use `SanitiseText.get_non_gsm_characters()` instead)

 ## 126.0.1

* Runs `remove_whitespace_before_punctuation` before GSM-7-encoding in subclasses of `BaseSMSTemplate`

 ## 126.0.0

* Removes `formatters.sms_encode` (use `sanitise_text.SantiseSMS.encode` directly instead)

 ## 125.1.1

* Ran `make refreeze-requirements` during dependency day

 ## 125.1.0

* `NotifyTask`: measure thread time used by celery task execution, annotate this on to completion log messages and emit a metric.

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/125.0.1...127.0.0