### PR TITLE
Add --quiet flag to uv pip compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,8 @@ refreeze-requirements: ## Upgrade unpinned requirements
 freeze-requirements: ## Pin all requirements including sub dependencies into requirements.txt
 	uv pip install "`cat requirements.in | grep 'notifications-utils @'`"
 	python -c "from notifications_utils.version_tools import copy_config; copy_config()"
-	uv pip compile requirements.in -o requirements.txt $(EXTRA_UV_PIP_COMPILE_FLAGS)
-	uv pip compile requirements_for_test.in -o requirements_for_test.txt $(EXTRA_UV_PIP_COMPILE_FLAGS)
+	uv pip compile --quiet requirements.in -o requirements.txt $(EXTRA_UV_PIP_COMPILE_FLAGS)
+	uv pip compile --quiet requirements_for_test.in -o requirements_for_test.txt $(EXTRA_UV_PIP_COMPILE_FLAGS)
 	uv pip sync requirements_for_test.txt
 
 .PHONY: show-outdated-requirements


### PR DESCRIPTION
It produces a lot of output which fills the terminal.

Often I want to do `make bump-utils freeze-requirements` but have to do a lot of scrolling back to see the useful output of `bump-utils`.

Running `uv pip sync` also produces some output about which packages have changed, so I don’t think we need similar output from the `compile` command.

This has been applied to the `Makefile`s in most other apps already.