### PR TITLE
Revert "process_mmg_response, process_firetext_response: use log_only for basic auth"

### DIFF
--- a/app/notifications/notifications_sms_callback.py
+++ b/app/notifications/notifications_sms_callback.py
@@ -15,7 +15,7 @@ register_errors(sms_callback_blueprint)
 
 
 @sms_callback_blueprint.route("/mmg", methods=["POST"])
-@view_requires_basic_auth("MMG_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS", log_only=True)
+@view_requires_basic_auth("MMG_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS")
 def process_mmg_response():
     uniform_now = datetime.utcnow()
     client_name = "MMG"
@@ -56,7 +56,7 @@ def process_mmg_response():
 
 
 @sms_callback_blueprint.route("/firetext", methods=["POST"])
-@view_requires_basic_auth("FIRETEXT_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS", log_only=True)
+@view_requires_basic_auth("FIRETEXT_DELIVERY_STATUS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS")
 def process_firetext_response():
     uniform_now = datetime.utcnow()
     client_name = "Firetext"

--- a/tests/app/notifications/test_notifications_sms_callbacks.py
+++ b/tests/app/notifications/test_notifications_sms_callbacks.py
@@ -37,7 +37,7 @@ def mmg_post(client, data):
     )
 
 
-def test_firetext_callback_needs_auth(client, mocker, caplog):
+def test_firetext_callback_needs_auth(client, mocker):
     mocker.patch("app.notifications.notifications_sms_callback.process_sms_client_response")
     data = "mobile=441234123123&status=0&reference=notification_id&time=2016-03-10 14:17:00"
 
@@ -48,8 +48,7 @@ def test_firetext_callback_needs_auth(client, mocker, caplog):
             ("Content-Type", "application/x-www-form-urlencoded"),
         ],
     )
-    assert response.status_code == 200
-    assert "Suppressing basic auth failure" in caplog.text
+    assert response.status_code == 401
 
 
 def test_firetext_callback_should_return_400_if_empty_reference(client):
@@ -160,7 +159,7 @@ def test_firetext_callback_including_a_code_should_return_200_and_call_task_with
     )
 
 
-def test_mmg_callback_needs_auth(client, mocker, sample_notification, caplog):
+def test_mmg_callback_needs_auth(client, mocker, sample_notification):
     mocker.patch("app.notifications.notifications_sms_callback.process_sms_client_response")
     data = json.dumps(
         {
@@ -179,8 +178,7 @@ def test_mmg_callback_needs_auth(client, mocker, sample_notification, caplog):
             ("Content-Type", "application/json"),
         ],
     )
-    assert response.status_code == 200
-    assert "Suppressing basic auth failure" in caplog.text
+    assert response.status_code == 401
 
 
 def test_process_mmg_response_returns_400_for_malformed_data(client):


### PR DESCRIPTION
https://github.com/alphagov/notifications-api/pull/4931 doesn't appear to be producing any warnings in the log messages, so let's start enforcing this now.