### PR TITLE
Make sure `document_download_count` is always `None` not `0`

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -416,7 +416,7 @@ def save_email(self, service_id, notification_id, encoded_notification, sender_i
         version=notification["template_version"],
     )
 
-    document_download_count = len(template.email_file_objects) if len(template.email_file_objects) > 0 else None
+    document_download_count = len(template.email_file_objects) or None
 
     personalisation = add_email_file_links_to_personalisation(
         template=template, personalisation=notification.get("personalisation", {}), recipient=notification["to"]

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -168,7 +168,7 @@ def persist_notification(
         reply_to_text=reply_to_text,
         unsubscribe_link=unsubscribe_link,
         billable_units=billable_units,
-        document_download_count=document_download_count,
+        document_download_count=document_download_count or None,
         updated_at=updated_at,
     )
     if notification_type == SMS_TYPE:

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -58,7 +58,7 @@ def _get_reference_from_personalisation(personalisation):
 def send_one_off_notification(service_id, post_data):
     service = dao_fetch_service_by_id(service_id, with_users=False)
     template = dao_get_template_by_id_and_service_id(template_id=post_data["template_id"], service_id=service_id)
-    document_download_count = len(template.email_files) if len(template.email_files) > 0 else None
+    document_download_count = len(template.email_files) or None
 
     personalisation = post_data.get("personalisation", None)
 

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -255,7 +255,7 @@ def process_sms_or_email_notification(
         # the total count should be the number of files an api user has added + the number already in the template
         document_download_count += len(template.email_file_objects)
     else:
-        document_download_count = len(template.email_file_objects)
+        document_download_count = len(template.email_file_objects) or None
 
     # validate content length after url is replaced in personalisation.
     check_is_message_too_long(template_with_content)

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -252,10 +252,9 @@ def process_sms_or_email_notification(
     if document_download_count:
         # We changed personalisation which means we need to update the content
         template_with_content.values = personalisation
-        # the total count should be the number of files an api user has added + the number already in the template
-        document_download_count += len(template.email_file_objects)
-    else:
-        document_download_count = len(template.email_file_objects) or None
+
+    # the total count should be the number of files an api user has added + the number already in the template
+    document_download_count += len(template.email_file_objects)
 
     # validate content length after url is replaced in personalisation.
     check_is_message_too_long(template_with_content)
@@ -313,7 +312,7 @@ def process_document_uploads(personalisation_data, service, send_to: str, simula
     """
     file_keys = [k for k, v in (personalisation_data or {}).items() if isinstance(v, dict) and "file" in v]
     if not file_keys:
-        return personalisation_data, None
+        return personalisation_data, 0
 
     # Make sure that all data for file uploads matches our expected schema.
     # We can't (feasibly) do this at the start of the request because the JSON Schema required would throw error

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -59,7 +59,7 @@ def test_post_sms_notification_returns_201(api_client_request, sample_template_w
     assert notifications[0].status == NOTIFICATION_CREATED
     notification_id = notifications[0].id
     assert notifications[0].postage is None
-    assert notifications[0].document_download_count == 0
+    assert notifications[0].document_download_count is None
     assert resp_json["id"] == str(notification_id)
     assert resp_json["reference"] == reference
     assert resp_json["content"]["body"] == sample_template_with_placeholders.content.replace("(( Name))", "Jo")
@@ -518,7 +518,7 @@ def test_post_email_notification_returns_201(
     assert resp_json["reference"] == reference
     assert notification.reference is None
     assert notification.reply_to_text is None
-    assert notification.document_download_count == 0
+    assert notification.document_download_count is None
     assert resp_json["content"]["body"] == sample_email_template_with_placeholders.content.replace("((name))", "Bob")
     assert resp_json["content"]["subject"] == sample_email_template_with_placeholders.subject.replace("((name))", "Bob")
     assert resp_json["content"]["from_email"] == "{}@{}".format(


### PR DESCRIPTION
In https://github.com/alphagov/notifications-api/pull/4929#discussion_r3830982375 we decided that `0` should be avoided, for compatibility with the existing data.

In the review I missed that the PR changed the `POST` code path, not just the one-off/batch code paths.

This means we will incorrectly be getting some `0`s rather than `None`s. This commit fixes that.

***

I spotted this while also clearing up some conditionals. Hopefully making them easier to read makes bugs like this less likely.