### PR TITLE
Add migration to create logical replication slot

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0563_confirmed_service_name_col
+0564_create_replacation_slot

--- a/migrations/versions/0564_create_replacation_slot.py
+++ b/migrations/versions/0564_create_replacation_slot.py
@@ -1,0 +1,43 @@
+"""
+Create Date: 2026-08-17 00:00:00
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "0564_create_replacation_slot"
+down_revision = "0563_confirmed_service_name_col"
+slot_name = "notify_dashboard_replication_slot"
+
+def upgrade():
+    bind = op.get_bind()
+    with op.get_context().autocommit_block():
+        bind.execute(
+            text(
+                f"""
+                SELECT pg_create_logical_replication_slot('{slot_name}', 'wal2json')
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM pg_replication_slots
+                    WHERE slot_name = '{slot_name}'
+                )
+                """
+            )
+        )
+
+
+def downgrade():
+    bind = op.get_bind()
+    with op.get_context().autocommit_block():
+        bind.execute(
+            text(
+                f"""
+                SELECT pg_drop_replication_slot('{slot_name}')
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM pg_replication_slots
+                    WHERE slot_name = '{slot_name}'
+                )
+                """
+            )
+        )


### PR DESCRIPTION
This creates a wal2json replication slot to allow us to listen to changes to the notifications table.