### PR TITLE
update_reply_to_email_address: look up the reply-to by service ID too

### DIFF
--- a/app/dao/service_email_reply_to_dao.py
+++ b/app/dao/service_email_reply_to_dao.py
@@ -44,6 +44,8 @@ def add_reply_to_email_address_for_service(service_id, email_address, is_default
 
 @autocommit
 def update_reply_to_email_address(service_id, reply_to_id, email_address, is_default):
+    reply_to_update = dao_get_reply_to_by_id(reply_to_id=reply_to_id, service_id=service_id)
+
     old_default = _get_existing_default(service_id)
     if is_default:
         _reset_old_default_to_false(old_default)
@@ -51,7 +53,6 @@ def update_reply_to_email_address(service_id, reply_to_id, email_address, is_def
         if old_default.id == reply_to_id:
             raise InvalidRequest("You must have at least one reply to email address as the default.", 400)
 
-    reply_to_update = ServiceEmailReplyTo.query.get(reply_to_id)
     reply_to_update.email_address = email_address
     reply_to_update.is_default = is_default
     db.session.add(reply_to_update)

--- a/tests/app/dao/test_service_email_reply_to_dao.py
+++ b/tests/app/dao/test_service_email_reply_to_dao.py
@@ -179,6 +179,39 @@ def test_update_reply_to_email_address_raises_exception_if_single_reply_to_and_s
         )
 
 
+def test_update_reply_to_email_address_raises_sqlalchemy_error_when_reply_to_belongs_to_another_service(
+    sample_service,
+):
+    another_service = create_service(service_name="another service")
+    create_reply_to_email(service=sample_service, email_address="default@example.com")
+    other_service_reply_to = create_reply_to_email(service=another_service, email_address="other-service@example.com")
+
+    with pytest.raises(SQLAlchemyError):
+        update_reply_to_email_address(
+            service_id=sample_service.id,
+            reply_to_id=other_service_reply_to.id,
+            email_address="changed@example.com",
+            is_default=True,
+        )
+
+    assert other_service_reply_to.email_address == "other-service@example.com"
+
+
+def test_update_reply_to_email_address_raises_sqlalchemy_error_when_reply_to_is_archived(sample_service):
+    create_reply_to_email(service=sample_service, email_address="default@example.com")
+    archived_reply_to = create_reply_to_email(
+        service=sample_service, email_address="archived@example.com", is_default=False, archived=True
+    )
+
+    with pytest.raises(SQLAlchemyError):
+        update_reply_to_email_address(
+            service_id=sample_service.id,
+            reply_to_id=archived_reply_to.id,
+            email_address="changed@example.com",
+            is_default=False,
+        )
+
+
 def test_dao_get_reply_to_by_id(sample_service):
     reply_to = create_reply_to_email(service=sample_service, email_address="email@address.com")
     result = dao_get_reply_to_by_id(reply_to_id=reply_to.id, service_id=sample_service.id)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2750,6 +2750,26 @@ def test_update_service_reply_to_email_address_404s_when_invalid_service_id(admi
     assert response["message"] == "No result found"
 
 
+def test_update_service_reply_to_email_address_404s_when_reply_to_belongs_to_another_service(
+    admin_request, sample_service
+):
+    another_service = create_service(service_name="another service")
+    create_reply_to_email(service=sample_service, email_address="default@example.com")
+    other_service_reply_to = create_reply_to_email(service=another_service, email_address="other-service@example.com")
+
+    response = admin_request.post(
+        "service.update_service_reply_to_email_address",
+        service_id=sample_service.id,
+        reply_to_email_id=other_service_reply_to.id,
+        _data={"email_address": "changed@example.com", "is_default": True},
+        _expected_status=404,
+    )
+
+    assert response["result"] == "error"
+    assert response["message"] == "No result found"
+    assert other_service_reply_to.email_address == "other-service@example.com"
+
+
 def test_delete_service_reply_to_email_address_archives_an_email_reply_to(
     sample_service, admin_request, notify_db_session
 ):


### PR DESCRIPTION
## Summary

`update_reply_to_email_address` fetched the row with `ServiceEmailReplyTo.query.get(reply_to_id)`, using the ID on its own. 
It now uses `dao_get_reply_to_by_id(reply_to_id, service_id)`, so the reply-to has to belong to the service in the URL.

This came from a scan report which detected the issue: The admin app checks that the user is allowed to edit the service, but the internal API never checked that the reply-to belonged to that service. 

I also added a test case for `test_update_reply_to_email_address_raises_sqlalchemy_error_when_reply_to_is_archived` to make it clear that with this new way of querying, a reply-to can no longer be edited from admin, if it's archived / deleted which is the correct behaviour