### PR TITLE
chore: `dao_get_template_email_file_by_id` look up the file by service and template ID

### DIFF
--- a/app/dao/template_email_files_dao.py
+++ b/app/dao/template_email_files_dao.py
@@ -51,10 +51,17 @@ def dao_get_template_email_files_by_template_id(template_id, template_version=No
     ).all()
 
 
-@autocommit
-def dao_get_template_email_file_by_id(service_id, template_id, template_email_file_id):
+@retryable_query()
+def dao_get_template_email_file_by_id(
+    session: Session | scoped_session = db.session,
+    *,
+    service_id,
+    template_id,
+    template_email_file_id,
+):
     return (
-        TemplateEmailFile.query.join(Template, Template.id == TemplateEmailFile.template_id)
+        session.query(TemplateEmailFile)
+        .join(Template, Template.id == TemplateEmailFile.template_id)
         .filter(
             TemplateEmailFile.id == template_email_file_id,
             Template.service_id == service_id,

--- a/app/dao/template_email_files_dao.py
+++ b/app/dao/template_email_files_dao.py
@@ -52,8 +52,16 @@ def dao_get_template_email_files_by_template_id(template_id, template_version=No
 
 
 @autocommit
-def dao_get_template_email_file_by_id(template_email_file_id):
-    return TemplateEmailFile.query.filter(TemplateEmailFile.id == template_email_file_id).one()
+def dao_get_template_email_file_by_id(service_id, template_id, template_email_file_id):
+    return (
+        TemplateEmailFile.query.join(Template, Template.id == TemplateEmailFile.template_id)
+        .filter(
+            TemplateEmailFile.id == template_email_file_id,
+            Template.service_id == service_id,
+            TemplateEmailFile.template_id == template_id,
+        )
+        .one()
+    )
 
 
 @retryable_query()

--- a/app/dao/template_email_files_dao.py
+++ b/app/dao/template_email_files_dao.py
@@ -53,11 +53,10 @@ def dao_get_template_email_files_by_template_id(template_id, template_version=No
 
 @retryable_query()
 def dao_get_template_email_file_by_id(
-    session: Session | scoped_session = db.session,
-    *,
     service_id,
     template_id,
     template_email_file_id,
+    session: Session | scoped_session = db.session,
 ):
     return (
         session.query(TemplateEmailFile)

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -167,7 +167,11 @@ def update_template(service_id, template_id):  # noqa: C901
         file_ids_to_archive = data.get("archive_email_file_ids")
     if file_ids_to_archive:
         for file_id in file_ids_to_archive:
-            file_to_archive = dao_get_template_email_file_by_id(file_id)
+            file_to_archive = dao_get_template_email_file_by_id(
+                service_id,
+                template_id,
+                file_id,
+            )
             dao_archive_template_email_file(
                 file_to_archive=file_to_archive,
                 archived_by_id=data.get("created_by"),

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -168,9 +168,9 @@ def update_template(service_id, template_id):  # noqa: C901
     if file_ids_to_archive:
         for file_id in file_ids_to_archive:
             file_to_archive = dao_get_template_email_file_by_id(
-                service_id,
-                template_id,
-                file_id,
+                service_id=service_id,
+                template_id=template_id,
+                template_email_file_id=file_id,
             )
             dao_archive_template_email_file(
                 file_to_archive=file_to_archive,

--- a/app/template_email_files/rest.py
+++ b/app/template_email_files/rest.py
@@ -3,6 +3,7 @@ import datetime
 from flask import Blueprint, jsonify, request
 from notifications_utils.insensitive_dict import InsensitiveSet
 
+from app import db
 from app.constants import EMAIL_TYPE
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.template_email_files_dao import (
@@ -63,7 +64,13 @@ def get_template_email_files(service_id, template_id):
 
 @template_email_files_blueprint.route("/<uuid:template_email_file_id>")
 def get_template_email_file_by_id(service_id, template_id, template_email_file_id):
-    file = dao_get_template_email_file_by_id(service_id, template_id, template_email_file_id)
+    file = dao_get_template_email_file_by_id(
+        session=db.session_bulk,
+        retry_attempts=2,
+        service_id=service_id,
+        template_id=template_id,
+        template_email_file_id=template_email_file_id,
+    )
     return jsonify(data=template_email_files_schema.dump(file)), 200
 
 

--- a/app/template_email_files/rest.py
+++ b/app/template_email_files/rest.py
@@ -63,7 +63,7 @@ def get_template_email_files(service_id, template_id):
 
 @template_email_files_blueprint.route("/<uuid:template_email_file_id>")
 def get_template_email_file_by_id(service_id, template_id, template_email_file_id):
-    file = dao_get_template_email_file_by_id(template_email_file_id)
+    file = dao_get_template_email_file_by_id(service_id, template_id, template_email_file_id)
     return jsonify(data=template_email_files_schema.dump(file)), 200
 
 

--- a/app/template_email_files/rest.py
+++ b/app/template_email_files/rest.py
@@ -65,11 +65,11 @@ def get_template_email_files(service_id, template_id):
 @template_email_files_blueprint.route("/<uuid:template_email_file_id>")
 def get_template_email_file_by_id(service_id, template_id, template_email_file_id):
     file = dao_get_template_email_file_by_id(
-        session=db.session_bulk,
-        retry_attempts=2,
         service_id=service_id,
         template_id=template_id,
         template_email_file_id=template_email_file_id,
+        session=db.session_bulk,
+        retry_attempts=2,
     )
     return jsonify(data=template_email_files_schema.dump(file)), 200
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -149,9 +149,13 @@ def test_archive_pending_files_only_scopes_stale_files(sample_email_template, pe
     )
     with freeze_time("2016-01-02 01:00:01.00000" if pending_expiry_exceeded else "2016-01-02 00:00:00.00000"):
         archive_pending_files()
-    expected_archived_file = dao_get_template_email_file_by_id(str(pending_file.id))
-    expected_pending_file_already_archived = dao_get_template_email_file_by_id(str(pending_file_already_archived.id))
-    expected_live_file = dao_get_template_email_file_by_id(str(live_file.id))
+    service_id = str(sample_email_template.service_id)
+    template_id = str(sample_email_template.id)
+    expected_archived_file = dao_get_template_email_file_by_id(service_id, template_id, str(pending_file.id))
+    expected_pending_file_already_archived = dao_get_template_email_file_by_id(
+        service_id, template_id, str(pending_file_already_archived.id)
+    )
+    expected_live_file = dao_get_template_email_file_by_id(service_id, template_id, str(live_file.id))
     assert not expected_live_file.archived_at
     assert expected_pending_file_already_archived.archived_at == datetime.fromisoformat("2016-01-01 03:30:00.000000")
     assert len(caplog.messages) == 1

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -151,11 +151,21 @@ def test_archive_pending_files_only_scopes_stale_files(sample_email_template, pe
         archive_pending_files()
     service_id = str(sample_email_template.service_id)
     template_id = str(sample_email_template.id)
-    expected_archived_file = dao_get_template_email_file_by_id(service_id, template_id, str(pending_file.id))
-    expected_pending_file_already_archived = dao_get_template_email_file_by_id(
-        service_id, template_id, str(pending_file_already_archived.id)
+    expected_archived_file = dao_get_template_email_file_by_id(
+        service_id=service_id,
+        template_id=template_id,
+        template_email_file_id=str(pending_file.id),
     )
-    expected_live_file = dao_get_template_email_file_by_id(service_id, template_id, str(live_file.id))
+    expected_pending_file_already_archived = dao_get_template_email_file_by_id(
+        service_id=service_id,
+        template_id=template_id,
+        template_email_file_id=str(pending_file_already_archived.id),
+    )
+    expected_live_file = dao_get_template_email_file_by_id(
+        service_id=service_id,
+        template_id=template_id,
+        template_email_file_id=str(live_file.id),
+    )
     assert not expected_live_file.archived_at
     assert expected_pending_file_already_archived.archived_at == datetime.fromisoformat("2016-01-01 03:30:00.000000")
     assert len(caplog.messages) == 1

--- a/tests/app/dao/test_template_email_files_dao.py
+++ b/tests/app/dao/test_template_email_files_dao.py
@@ -52,7 +52,16 @@ def test_create_template_email_files_dao(sample_email_template, sample_service):
     assert not template_email_file.pending
 
 
-def test_dao_get_template_email_file_by_id(sample_template_email_file_not_pending, sample_service):
+@pytest.mark.parametrize(
+    "session,expected_bind_key",
+    (
+        (db.session, None),
+        (db.session_bulk, "bulk"),
+    ),
+)
+def test_dao_get_template_email_file_by_id(
+    sample_template_email_file_not_pending, sample_service, session, expected_bind_key
+):
     # additional file for new template, get method shouldn't return this file
     new_template = create_template(service=sample_service, template_type=EMAIL_TYPE, template_name="template_two")
     create_template_email_file(
@@ -61,11 +70,20 @@ def test_dao_get_template_email_file_by_id(sample_template_email_file_not_pendin
         filename="file_two.pdf",
         link_text="click this other link",
     )
-    template_email_file_fetched = dao_get_template_email_file_by_id(
-        str(sample_service.id),
-        str(sample_template_email_file_not_pending.template_id),
-        str(sample_template_email_file_not_pending.id),
-    )
+
+    service_id = str(sample_service.id)
+    template_id = str(sample_template_email_file_not_pending.template_id)
+    template_email_file_id = str(sample_template_email_file_not_pending.id)
+
+    with QueryRecorder() as query_recorder:
+        template_email_file_fetched = dao_get_template_email_file_by_id(
+            session=session,
+            service_id=service_id,
+            template_id=template_id,
+            template_email_file_id=template_email_file_id,
+        )
+
+    assert {query_info.bind_key for query_info in query_recorder.queries} == {expected_bind_key}
     assert template_email_file_fetched.id == sample_template_email_file_not_pending.id
     assert template_email_file_fetched.filename == sample_template_email_file_not_pending.filename
     assert template_email_file_fetched.link_text == sample_template_email_file_not_pending.link_text
@@ -81,18 +99,35 @@ def test_dao_get_template_email_file_by_id(sample_template_email_file_not_pendin
 def test_dao_get_template_email_file_by_id_returns_none_when_not_found(sample_service, sample_email_template):
     with pytest.raises(NoResultFound):
         dao_get_template_email_file_by_id(
-            str(sample_service.id), str(sample_email_template.id), "2117b6ab-0219-4bfa-aaa4-a3248dafa1a0"
+            service_id=str(sample_service.id),
+            template_id=str(sample_email_template.id),
+            template_email_file_id="2117b6ab-0219-4bfa-aaa4-a3248dafa1a0",
         )
 
 
+@pytest.mark.parametrize(
+    "session,expected_bind_key",
+    (
+        (db.session, None),
+        (db.session_bulk, "bulk"),
+    ),
+)
 def test_dao_get_template_email_file_by_id_filtered_by_template_id(
-    sample_template_email_file_not_pending, sample_email_template, sample_service
+    sample_template_email_file_not_pending, sample_email_template, sample_service, session, expected_bind_key
 ):
-    template_email_file_fetched = dao_get_template_email_file_by_id(
-        str(sample_service.id),
-        str(sample_email_template.id),
-        str(sample_template_email_file_not_pending.id),
-    )
+    service_id = str(sample_service.id)
+    template_email_file_id = str(sample_template_email_file_not_pending.id)
+    template_id = str(sample_email_template.id)
+
+    with QueryRecorder() as query_recorder:
+        template_email_file_fetched = dao_get_template_email_file_by_id(
+            session=session,
+            service_id=service_id,
+            template_id=template_id,
+            template_email_file_id=template_email_file_id,
+        )
+
+    assert {query_info.bind_key for query_info in query_recorder.queries} == {expected_bind_key}
     assert template_email_file_fetched.id == sample_template_email_file_not_pending.id
 
 
@@ -103,9 +138,9 @@ def test_dao_get_template_email_file_by_id_raises_when_file_belongs_to_another_t
 
     with pytest.raises(NoResultFound):
         dao_get_template_email_file_by_id(
-            str(sample_service.id),
-            str(other_template.id),
-            str(sample_template_email_file_not_pending.id),
+            service_id=str(sample_service.id),
+            template_id=str(other_template.id),
+            template_email_file_id=str(sample_template_email_file_not_pending.id),
         )
 
 
@@ -116,9 +151,9 @@ def test_dao_get_template_email_file_by_id_raises_when_file_belongs_to_another_s
 
     with pytest.raises(NoResultFound):
         dao_get_template_email_file_by_id(
-            str(other_service.id),
-            str(sample_email_template.id),
-            str(sample_template_email_file_not_pending.id),
+            service_id=str(other_service.id),
+            template_id=str(sample_email_template.id),
+            template_email_file_id=str(sample_template_email_file_not_pending.id),
         )
 
 

--- a/tests/app/dao/test_template_email_files_dao.py
+++ b/tests/app/dao/test_template_email_files_dao.py
@@ -16,7 +16,12 @@ from app.dao.template_email_files_dao import (
 )
 from app.dao.templates_dao import dao_update_template
 from app.models import Template, TemplateEmailFile
-from tests.app.db import create_archived_template_email_file, create_template, create_template_email_file
+from tests.app.db import (
+    create_archived_template_email_file,
+    create_service,
+    create_template,
+    create_template_email_file,
+)
 from tests.utils import QueryRecorder
 
 
@@ -56,7 +61,11 @@ def test_dao_get_template_email_file_by_id(sample_template_email_file_not_pendin
         filename="file_two.pdf",
         link_text="click this other link",
     )
-    template_email_file_fetched = dao_get_template_email_file_by_id(str(sample_template_email_file_not_pending.id))
+    template_email_file_fetched = dao_get_template_email_file_by_id(
+        str(sample_service.id),
+        str(sample_template_email_file_not_pending.template_id),
+        str(sample_template_email_file_not_pending.id),
+    )
     assert template_email_file_fetched.id == sample_template_email_file_not_pending.id
     assert template_email_file_fetched.filename == sample_template_email_file_not_pending.filename
     assert template_email_file_fetched.link_text == sample_template_email_file_not_pending.link_text
@@ -69,9 +78,48 @@ def test_dao_get_template_email_file_by_id(sample_template_email_file_not_pendin
     assert not template_email_file_fetched.pending
 
 
-def test_dao_get_template_email_file_by_id_returns_none_when_not_found():
+def test_dao_get_template_email_file_by_id_returns_none_when_not_found(sample_service, sample_email_template):
     with pytest.raises(NoResultFound):
-        dao_get_template_email_file_by_id("2117b6ab-0219-4bfa-aaa4-a3248dafa1a0")
+        dao_get_template_email_file_by_id(
+            str(sample_service.id), str(sample_email_template.id), "2117b6ab-0219-4bfa-aaa4-a3248dafa1a0"
+        )
+
+
+def test_dao_get_template_email_file_by_id_filtered_by_template_id(
+    sample_template_email_file_not_pending, sample_email_template, sample_service
+):
+    template_email_file_fetched = dao_get_template_email_file_by_id(
+        str(sample_service.id),
+        str(sample_email_template.id),
+        str(sample_template_email_file_not_pending.id),
+    )
+    assert template_email_file_fetched.id == sample_template_email_file_not_pending.id
+
+
+def test_dao_get_template_email_file_by_id_raises_when_file_belongs_to_another_template(
+    sample_template_email_file_not_pending, sample_service
+):
+    other_template = create_template(service=sample_service, template_type=EMAIL_TYPE, template_name="template_two")
+
+    with pytest.raises(NoResultFound):
+        dao_get_template_email_file_by_id(
+            str(sample_service.id),
+            str(other_template.id),
+            str(sample_template_email_file_not_pending.id),
+        )
+
+
+def test_dao_get_template_email_file_by_id_raises_when_file_belongs_to_another_service(
+    sample_template_email_file_not_pending, sample_email_template
+):
+    other_service = create_service(service_name="another service")
+
+    with pytest.raises(NoResultFound):
+        dao_get_template_email_file_by_id(
+            str(other_service.id),
+            str(sample_email_template.id),
+            str(sample_template_email_file_not_pending.id),
+        )
 
 
 def test_dao_get_template_email_files_by_template_id(

--- a/tests/app/dao/test_template_email_files_dao.py
+++ b/tests/app/dao/test_template_email_files_dao.py
@@ -77,10 +77,10 @@ def test_dao_get_template_email_file_by_id(
 
     with QueryRecorder() as query_recorder:
         template_email_file_fetched = dao_get_template_email_file_by_id(
-            session=session,
             service_id=service_id,
             template_id=template_id,
             template_email_file_id=template_email_file_id,
+            session=session,
         )
 
     assert {query_info.bind_key for query_info in query_recorder.queries} == {expected_bind_key}
@@ -121,10 +121,10 @@ def test_dao_get_template_email_file_by_id_filtered_by_template_id(
 
     with QueryRecorder() as query_recorder:
         template_email_file_fetched = dao_get_template_email_file_by_id(
-            session=session,
             service_id=service_id,
             template_id=template_id,
             template_email_file_id=template_email_file_id,
+            session=session,
         )
 
     assert {query_info.bind_key for query_info in query_recorder.queries} == {expected_bind_key}

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1080,6 +1080,31 @@ def test_update_template_content_and_archive_just_one_of_two_email_files(
     assert remaining_file.template_version == 1
 
 
+def test_update_template_does_not_archive_email_file_from_another_template(
+    client, sample_email_template_with_template_email_files, sample_user, sample_service
+):
+    template = sample_email_template_with_template_email_files
+    other_template = create_template(service=sample_service, template_type=EMAIL_TYPE, template_name="other template")
+    other_file = create_template_email_file(
+        other_template.id, created_by_id=sample_user.id, filename="other.pdf", pending=False
+    )
+
+    auth_header = create_admin_authorization_header()
+    data = {
+        "content": "New content",
+        "created_by": str(sample_user.id),
+        "archive_email_file_ids": [str(other_file.id)],
+    }
+    response = client.post(
+        f"/service/{template.service_id}/template/{template.id}",
+        data=json.dumps(data),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+
+    assert response.status_code == 404
+    assert other_file.archived_at is None
+
+
 def test_update_template_reply_to(client, sample_letter_template):
     auth_header = create_admin_authorization_header()
     letter_contact = create_letter_contact(sample_letter_template.service, "Edinburgh, ED1 1AA")

--- a/tests/app/template_email_files/test_rest.py
+++ b/tests/app/template_email_files/test_rest.py
@@ -4,9 +4,10 @@ import uuid
 import freezegun
 import pytest
 
+from app.constants import EMAIL_TYPE
 from app.dao.templates_dao import dao_update_template
 from app.models import TemplateEmailFile, TemplateEmailFileHistory
-from tests.app.db import create_template_email_file
+from tests.app.db import create_service, create_template, create_template_email_file
 
 
 @freezegun.freeze_time("2025-07-01 11:09:00.000000")
@@ -317,6 +318,40 @@ def test_get_template_email_file_by_id_when_file_does_not_exist_returns_404(
         service_id=sample_service.id,
         _expected_status=404,
     )
+
+
+def test_get_template_email_file_by_id_when_file_belongs_to_another_template_returns_404(
+    sample_template_email_file_not_pending, sample_service, admin_request
+):
+    other_template = create_template(service=sample_service, template_type=EMAIL_TYPE, template_name="other template")
+
+    response = admin_request.get(
+        "template_email_files.get_template_email_file_by_id",
+        template_id=other_template.id,
+        template_email_file_id=sample_template_email_file_not_pending.id,
+        service_id=sample_service.id,
+        _expected_status=404,
+    )
+
+    assert response["result"] == "error"
+    assert response["message"] == "No result found"
+
+
+def test_get_template_email_file_by_id_when_file_belongs_to_another_service_returns_404(
+    sample_template_email_file_not_pending, sample_email_template, admin_request
+):
+    other_service = create_service(service_name="another service")
+
+    response = admin_request.get(
+        "template_email_files.get_template_email_file_by_id",
+        template_id=sample_email_template.id,
+        template_email_file_id=sample_template_email_file_not_pending.id,
+        service_id=other_service.id,
+        _expected_status=404,
+    )
+
+    assert response["result"] == "error"
+    assert response["message"] == "No result found"
 
 
 def test_update_template_email_file(


### PR DESCRIPTION
## Summary
`dao_get_template_email_file_by_id` now takes in service and template ID as arguments.

This came from the scan report which said: The endpoint looked files up by file ID alone, so the service and template in the URL were ignored. The admin app already does the authorisation checks, so this is not exploitable and was triaged as low, but we want the DAO to filter by service ID like it does elsewhere.
Checking the template ID as well is worth having because of restricted template folders: within one service a user can be allowed to see one template but not another, so the file should have to belong to the template in the URL, not just the service.

Additionally, I added a read replica to the dao function, as it can be used by primary database or replica depending on the flow of higher functions

https://trello.com/c/NXqWA36L/755-template-email-file-endpoints-do-not-bind-template-file-ids-to-the-route-service-template
