### PR TITLE
Add migration to enable replica identity using index on notifications

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0561_add_go_live_admin_template
+0562_enable_replica_id_index

--- a/migrations/versions/0562_enable_replica_id_index.py
+++ b/migrations/versions/0562_enable_replica_id_index.py
@@ -1,0 +1,15 @@
+"""
+Create Date: 2026-08-17 00:00:00
+"""
+
+from alembic import op
+
+revision = "0562_enable_replica_id_index"
+down_revision = "0561_add_go_live_admin_template"
+
+
+def upgrade():
+    op.execute("ALTER TABLE notifications REPLICA IDENTITY USING INDEX ix_notifications_id_status;")
+
+def downgrade():
+    op.execute("ALTER TABLE notifications REPLICA IDENTITY DEFAULT;")


### PR DESCRIPTION
This will allow us to listen to changes made to the index `ix_notifications_id_status` (id, notification_status).

This is needed to update the `ft_service_stats` when the notification status changes. Without this change, we would not see the old value and therefore will not know which counter to decrease.