### PR TITLE
Add WAL configuration for logical replication with wal2json output plugin

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -164,6 +164,7 @@ RUN \
 # add WAL configuration to postgresql.conf to enable logical replication
 RUN printf '%s\n' \
     "wal_level = logical" \
+    "output_plugin_libraries = 'wal2json'" \
     "max_replication_slots = 10" \
     "max_wal_senders = 10" \
     "max_slot_wal_keep_size = 1GB" \


### PR DESCRIPTION
This is to fix the following error:

```
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.InsufficientPrivilege) library "wal2json" may not be used as an output plugin
HINT:  If it is safe for all REPLICATION users to use this library as an output plugin, add it to "output_plugin_libraries" and reload the server configuration.
```

From PostgresSQL 15.9 onwards (https://www.postgresql.org/docs/release/15.19/):
> Restrict logical decoding output plugins to the set specified by a new server parameter output_plugin_libraries (Jacob Champion) [§](https://postgr.es/c/99f205407)
>
> Previously, a replication user could select any loadable library for logical decoding, allowing exploits of various sorts. To allow locking this down without breaking setups that worked before, introduce a whitelist of allowed output plugins.
>
> By default, only the output plugins shipped as part of PostgreSQL (pgoutput and test_decoding) are included in output_plugin_libraries. Installations that rely on other output plugins must add them after updating the server, for example
>
> output_plugin_libraries = 'pgoutput, test_decoding, my_trusted_decoder'
Additionally, pg_upgrade --check will fail if the output_plugin_libraries parameter on the new cluster does not permit the plugins of logical replication slots on the old cluster, when migrating from versions 17 and later. Make necessary additions to the new cluster's setting before performing pg_upgrade.
>
> The PostgreSQL Project thanks Vladimir Tokarev and Yu Kunpeng for reporting this problem. (CVE-2026-6471)