### PR TITLE
inbound sms: remove old ad-hoc basic auth code, activate enforcement by new decorator

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -840,8 +840,6 @@ def functional_test_fixtures():
     It expects the following config to be set:
 
         NOTIFY_ENVIRONMENT
-        MMG_INBOUND_SMS_USERNAME
-        MMG_INBOUND_SMS_AUTH
         MMG_INBOUND_SMS_CALLBACK_BASIC_AUTH_CREDENTIALS
         SQLALCHEMY_DATABASE_URI
         REDIS_URL

--- a/app/config.py
+++ b/app/config.py
@@ -550,9 +550,6 @@ class Config:
     FREE_SMS_TIER_FRAGMENT_COUNT = 250000
 
     SMS_INBOUND_WHITELIST = json.loads(os.environ.get("SMS_INBOUND_WHITELIST", "[]"))
-    FIRETEXT_INBOUND_SMS_AUTH = json.loads(os.environ.get("FIRETEXT_INBOUND_SMS_AUTH", "[]"))
-    MMG_INBOUND_SMS_AUTH = json.loads(os.environ.get("MMG_INBOUND_SMS_AUTH", "[]"))
-    MMG_INBOUND_SMS_USERNAME = json.loads(os.environ.get("MMG_INBOUND_SMS_USERNAME", "[]"))
     # both expected to be a dict of usernames -> bcrypt hash of password
     MMG_INBOUND_SMS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS = json.loads(
         os.environ.get("MMG_INBOUND_SMS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS", "{}")
@@ -689,8 +686,6 @@ class Development(Config):
     TOKEN_SECRET_KEY = "5YNWU0e_pN5ZyaSZvBd5uZb_sZlrVDFeOjiea6dq4zQ="
     DANGEROUS_SALT = "dev-notify-salt"
 
-    MMG_INBOUND_SMS_AUTH = ["testkey"]
-    MMG_INBOUND_SMS_USERNAME = ["username"]
     MMG_INBOUND_SMS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS = {
         "username": "$2b$04$JqCB477L3RTbIiENavb2EOPyv9dkWdL0XjSSCftcw7wynETJa/HgO",  # "testkey"
     }
@@ -768,7 +763,6 @@ class Test(Development):
     API_HOST_NAME_INTERNAL = "http://localhost:6011"
 
     SMS_INBOUND_WHITELIST = ["203.0.113.195"]
-    FIRETEXT_INBOUND_SMS_AUTH = ["testkey"]
     TEMPLATE_PREVIEW_API_HOST = "http://localhost:9999"
 
     MMG_URL = "https://example.com/mmg"

--- a/app/functional_tests_fixtures/__init__.py
+++ b/app/functional_tests_fixtures/__init__.py
@@ -555,8 +555,8 @@ def _create_db_objects(
         "FUNCTIONAL_TEST_LETTER_TEMPLATE_ID": letter_template.id,
         "FUNCTIONAL_TEST_SMS_NO_PLACEHOLDER_TEMPLATE_ID": sms_no_placeholder_template.id,
         "FUNCTIONAL_TEST_EMAIL_NO_PLACEHOLDER_TEMPLATE_ID": email_no_placeholder_template.id,
-        "MMG_INBOUND_SMS_USERNAME": current_app.config["MMG_INBOUND_SMS_USERNAME"][0],
-        "MMG_INBOUND_SMS_AUTH": current_app.config["MMG_INBOUND_SMS_AUTH"][0],
+        "MMG_INBOUND_SMS_USERNAME": current_app.config["MMG_INBOUND_SMS_CALLBACK_BASIC_AUTH_CREDENTIALS"][0],
+        "MMG_INBOUND_SMS_AUTH": current_app.config["MMG_INBOUND_SMS_CALLBACK_BASIC_AUTH_CREDENTIALS"][1],
         "REQUEST_BIN_API_TOKEN": request_bin_api_token,
         # API client integration test environment variables
         "SERVICE_ID": service.id,

--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from urllib.parse import unquote
 
-from flask import Blueprint, abort, current_app, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
 from gds_metrics.metrics import Counter
 
 from app.authentication.auth import view_requires_basic_auth
@@ -22,7 +22,7 @@ INBOUND_SMS_COUNTER = Counter("inbound_sms", "Total number of inbound SMS receiv
 
 
 @receive_notifications_blueprint.route("/notifications/sms/receive/mmg", methods=["POST"])
-@view_requires_basic_auth("MMG_INBOUND_SMS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS", log_only=True)
+@view_requires_basic_auth("MMG_INBOUND_SMS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS")
 def receive_mmg_sms():
     """
     {
@@ -34,22 +34,6 @@ def receive_mmg_sms():
     }
     """
     post_data = request.get_json()
-
-    auth = request.authorization
-
-    if not auth:
-        current_app.logger.warning("Inbound sms (MMG) no auth header")
-        abort(401)
-    elif (
-        auth.username not in current_app.config["MMG_INBOUND_SMS_USERNAME"]
-        or auth.password not in current_app.config["MMG_INBOUND_SMS_AUTH"]
-    ):
-        current_app.logger.warning(
-            "Inbound sms (MMG) incorrect username (%s) or password",
-            auth.username,
-            extra={"username": auth.username},
-        )
-        abort(403)
 
     inbound_number = strip_leading_forty_four(post_data["Number"])
 
@@ -86,21 +70,9 @@ def receive_mmg_sms():
 
 
 @receive_notifications_blueprint.route("/notifications/sms/receive/firetext", methods=["POST"])
-@view_requires_basic_auth("FIRETEXT_INBOUND_SMS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS", log_only=True)
+@view_requires_basic_auth("FIRETEXT_INBOUND_SMS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS")
 def receive_firetext_sms():
     post_data = request.form
-
-    auth = request.authorization
-    if not auth:
-        current_app.logger.warning("Inbound sms (Firetext) no auth header")
-        abort(401)
-    elif auth.username != "notify" or auth.password not in current_app.config["FIRETEXT_INBOUND_SMS_AUTH"]:
-        current_app.logger.warning(
-            "Inbound sms (Firetext) incorrect username (%s) or password",
-            auth.username,
-            extra={"username": auth.username},
-        )
-        abort(403)
 
     inbound_number = strip_leading_forty_four(post_data["destination"])
 

--- a/tests/app/functional_test_fixtures/test_functional_test_fixtures.py
+++ b/tests/app/functional_test_fixtures/test_functional_test_fixtures.py
@@ -42,8 +42,7 @@ def test_create_db_objects_sets_db_up(notify_api, notify_service):
         with set_config_values(
             notify_api,
             {
-                "MMG_INBOUND_SMS_USERNAME": ["test_mmg_username"],
-                "MMG_INBOUND_SMS_AUTH": ["test_mmg_password"],
+                "MMG_INBOUND_SMS_CALLBACK_BASIC_AUTH_CREDENTIALS": ["test_mmg_username", "test_mmg_password"],
                 "INTERNAL_CLIENT_API_KEYS": {"notify-functional-tests": ["functional-tests-secret-key"]},
                 "ADMIN_BASE_URL": "http://localhost:6012",
                 "API_HOST_NAME": "http://localhost:6011",
@@ -147,8 +146,7 @@ def test_create_db_objects_creates_dedicated_performance_service_with_limits_and
     with set_config_values(
         notify_api,
         {
-            "MMG_INBOUND_SMS_USERNAME": ["test_mmg_username"],
-            "MMG_INBOUND_SMS_AUTH": ["test_mmg_password"],
+            "MMG_INBOUND_SMS_CALLBACK_BASIC_AUTH_CREDENTIALS": ["test_mmg_username", "test_mmg_password"],
             "INTERNAL_CLIENT_API_KEYS": {"notify-functional-tests": ["functional-tests-secret-key"]},
             "ADMIN_BASE_URL": "http://localhost:6012",
             "API_HOST_NAME": "http://localhost:6011",
@@ -199,8 +197,7 @@ def test_create_db_objects_renames_sanitised_org_and_recreates_canonical_org(not
     with set_config_values(
         notify_api,
         {
-            "MMG_INBOUND_SMS_USERNAME": ["test_mmg_username"],
-            "MMG_INBOUND_SMS_AUTH": ["test_mmg_password"],
+            "MMG_INBOUND_SMS_CALLBACK_BASIC_AUTH_CREDENTIALS": ["test_mmg_username", "test_mmg_password"],
             "INTERNAL_CLIENT_API_KEYS": {"notify-functional-tests": ["functional-tests-secret-key"]},
             "ADMIN_BASE_URL": "http://localhost:6012",
             "API_HOST_NAME": "http://localhost:6011",
@@ -253,8 +250,7 @@ def test_create_db_objects_renames_sanitised_services_and_reclaims_inbound_numbe
     with set_config_values(
         notify_api,
         {
-            "MMG_INBOUND_SMS_USERNAME": ["test_mmg_username"],
-            "MMG_INBOUND_SMS_AUTH": ["test_mmg_password"],
+            "MMG_INBOUND_SMS_CALLBACK_BASIC_AUTH_CREDENTIALS": ["test_mmg_username", "test_mmg_password"],
             "INTERNAL_CLIENT_API_KEYS": {"notify-functional-tests": ["functional-tests-secret-key"]},
             "ADMIN_BASE_URL": "http://localhost:6012",
             "API_HOST_NAME": "http://localhost:6011",
@@ -293,8 +289,7 @@ def test_create_db_objects_clears_caches_after_sanitised_fixture_renames(notify_
     with set_config_values(
         notify_api,
         {
-            "MMG_INBOUND_SMS_USERNAME": ["test_mmg_username"],
-            "MMG_INBOUND_SMS_AUTH": ["test_mmg_password"],
+            "MMG_INBOUND_SMS_CALLBACK_BASIC_AUTH_CREDENTIALS": ["test_mmg_username", "test_mmg_password"],
             "INTERNAL_CLIENT_API_KEYS": {"notify-functional-tests": ["functional-tests-secret-key"]},
             "ADMIN_BASE_URL": "http://localhost:6012",
             "API_HOST_NAME": "http://localhost:6011",

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -6,6 +6,7 @@ from flask import json
 from freezegun import freeze_time
 
 from app.constants import EMAIL_TYPE, INBOUND_SMS_TYPE, SMS_TYPE
+from app.hashing import hashpw
 from app.models import InboundSms
 from app.notifications.receive_notifications import (
     create_inbound_sms_object,
@@ -22,25 +23,25 @@ from tests.app.db import (
 from tests.conftest import set_config
 
 
-def firetext_post(client, data, auth=True, password="testkey"):
+def firetext_post(client, data, auth=True, username="notify", password="testkey"):
     headers = [
         ("Content-Type", "application/x-www-form-urlencoded"),
     ]
 
     if auth:
-        auth_value = base64.b64encode(f"notify:{password}".encode()).decode("utf-8")
+        auth_value = base64.b64encode(f"{username}:{password}".encode()).decode("utf-8")
         headers.append(("Authorization", "Basic " + auth_value))
 
     return client.post(path="/notifications/sms/receive/firetext", data=data, headers=headers)
 
 
-def mmg_post(client, data, auth=True, password="testkey"):
+def mmg_post(client, data, auth=True, username="username", password="testkey"):
     headers = [
         ("Content-Type", "application/json"),
     ]
 
     if auth:
-        auth_value = base64.b64encode(f"username:{password}".encode()).decode("utf-8")
+        auth_value = base64.b64encode(f"{username}:{password}".encode()).decode("utf-8")
         headers.append(("Authorization", "Basic " + auth_value))
 
     return client.post(path="/notifications/sms/receive/mmg", data=json.dumps(data), headers=headers)
@@ -423,20 +424,17 @@ def test_strip_leading_country_code(number, expected):
 
 
 @pytest.mark.parametrize(
-    "auth, keys, status_code",
+    "username, password, expected_status_code, expected_side_effect",
     [
-        ["testkey", ["testkey"], 200],
-        ["", ["testkey"], 401],
-        ["wrong", ["testkey"], 403],
-        ["testkey1", ["testkey1", "testkey2"], 200],
-        ["testkey2", ["testkey1", "testkey2"], 200],
-        ["wrong", ["testkey1", "testkey2"], 403],
-        ["", [], 401],
-        ["testkey", [], 403],
+        (None, None, 401, False),
+        ("foo123", "bah000", 403, False),
+        ("foo123", "blah321", 200, True),
     ],
 )
-def test_firetext_inbound_sms_auth(notify_db_session, notify_api, client, mocker, auth, keys, status_code):
-    mocker.patch(
+def test_firetext_inbound_sms_auth(
+    notify_db_session, notify_api, client, mocker, username, password, expected_status_code, expected_side_effect
+):
+    mocked_apply_async = mocker.patch(
         "app.notifications.receive_notifications.service_callback_tasks.send_inbound_sms_to_service.apply_async"
     )
 
@@ -449,26 +447,32 @@ def test_firetext_inbound_sms_auth(notify_db_session, notify_api, client, mocker
 
     data = "source=07999999999&destination=07111111111&message=this is a message&time=2017-01-01 12:00:00"
 
-    with set_config(notify_api, "FIRETEXT_INBOUND_SMS_AUTH", keys):
-        response = firetext_post(client, data, auth=bool(auth), password=auth)
-        assert response.status_code == status_code
+    with set_config(
+        notify_api,
+        "FIRETEXT_INBOUND_SMS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS",
+        {
+            "foo123": hashpw("blah321"),
+            "456bar": hashpw("BAZ012"),
+        },
+    ):
+        response = firetext_post(client, data, auth=username is not None, username=username, password=password)
+        assert response.status_code == expected_status_code
+        assert mocked_apply_async.called is expected_side_effect
+        assert bool(InboundSms.query.all()) is expected_side_effect
 
 
 @pytest.mark.parametrize(
-    "auth, keys, status_code",
+    "username, password, expected_status_code, expected_side_effect",
     [
-        ["testkey", ["testkey"], 200],
-        ["", ["testkey"], 401],
-        ["wrong", ["testkey"], 403],
-        ["testkey1", ["testkey1", "testkey2"], 200],
-        ["testkey2", ["testkey1", "testkey2"], 200],
-        ["wrong", ["testkey1", "testkey2"], 403],
-        ["", [], 401],
-        ["testkey", [], 403],
+        (None, None, 401, False),
+        ("foo123", "bah000", 403, False),
+        ("foo123", "blah321", 200, True),
     ],
 )
-def test_mmg_inbound_sms_auth(notify_db_session, notify_api, client, mocker, auth, keys, status_code):
-    mocker.patch(
+def test_mmg_inbound_sms_auth(
+    notify_db_session, notify_api, client, mocker, username, password, expected_status_code, expected_side_effect
+):
+    mocked_apply_async = mocker.patch(
         "app.notifications.receive_notifications.service_callback_tasks.send_inbound_sms_to_service.apply_async"
     )
 
@@ -489,9 +493,18 @@ def test_mmg_inbound_sms_auth(notify_db_session, notify_api, client, mocker, aut
         "DateRecieved": "2012-06-27 12:33:00",
     }
 
-    with set_config(notify_api, "MMG_INBOUND_SMS_AUTH", keys):
-        response = mmg_post(client, data, auth=bool(auth), password=auth)
-        assert response.status_code == status_code
+    with set_config(
+        notify_api,
+        "MMG_INBOUND_SMS_CALLBACK_ALLOWED_BASIC_AUTH_CREDENTIALS",
+        {
+            "foo123": hashpw("blah321"),
+            "456bar": hashpw("BAZ012"),
+        },
+    ):
+        response = mmg_post(client, data, auth=username is not None, username=username, password=password)
+        assert response.status_code == expected_status_code
+        assert mocked_apply_async.called is expected_side_effect
+        assert bool(InboundSms.query.all()) is expected_side_effect
 
 
 def test_create_inbound_sms_object_works_with_alphanumeric_sender(sample_service_full_permissions):


### PR DESCRIPTION
https://trello.com/c/94Q38sgQ/1546-implement-authentication-for-delivery-receipt-callback-endpoints

This includes removal of old-style config variables used by old code.

We can be quite sure this will work because neither staging or prod are currently emitting any error messages from the decorator in `log_only` mode.

After this, the only thing left for this story is tidying up of old variables/credentials etc.