### PR TITLE
add `get_banded_slow_text_message_delivery_reports_by_provider`, record result in `generate_sms_delivery_stats`

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -2,6 +2,7 @@ import csv
 import io
 from collections import defaultdict
 from datetime import date, datetime, timedelta
+from itertools import pairwise
 
 import jinja2
 import sentry_sdk
@@ -62,6 +63,7 @@ from app.dao.notifications_dao import (
     dao_letters_in_technical_failure,
     dao_old_letters_with_created_status,
     dao_precompiled_letters_still_pending_virus_check,
+    get_banded_slow_text_message_delivery_reports_by_provider,
     get_slow_text_message_delivery_reports_by_provider,
     is_delivery_slow_for_providers,
     letters_missing_from_sending_bucket,
@@ -95,6 +97,7 @@ from app.notifications.process_notifications import persist_notification, send_n
 from app.otel_metrics.provider import (
     record_info,
     record_priority,
+    record_sms_banded_not_delivered_within,
     record_sms_legacy_not_delivered_within,
     record_updated_at,
 )
@@ -258,6 +261,9 @@ def _check_slow_text_message_delivery_reports_and_raise_error_if_needed(reports:
         redis_store.set(CacheKeys.NUMBER_OF_TIMES_OVER_SLOW_SMS_DELIVERY_THRESHOLD, 0)
 
 
+_sms_slow_delivery_bands = tuple(pairwise(timedelta(seconds=30) * 2**i for i in range(6)))
+
+
 @notify_celery.task(name="generate-sms-delivery-stats")
 def generate_sms_delivery_stats():
     for delivery_interval in (1, 5, 10):
@@ -272,6 +278,20 @@ def generate_sms_delivery_stats():
         # TODO: delete this when we have a way to raise these alerts from eg grafana, prometheus, something else.
         if delivery_interval == 5 and current_app.should_check_slow_text_message_delivery:
             _check_slow_text_message_delivery_reports_and_raise_error_if_needed(providers_slow_delivery_reports)
+
+    for provider_name, reports in get_banded_slow_text_message_delivery_reports_by_provider(
+        _sms_slow_delivery_bands,
+        session=db.session_bulk,
+    ).items():
+        for report in reports:
+            record_sms_banded_not_delivered_within(
+                report.slow_ratio,
+                report.slow_notifications,
+                report.total_notifications,
+                provider_name,
+                report.delivered_within.total_seconds(),
+                report.sent_after_ago.total_seconds(),
+            )
 
     for provider in get_provider_details_by_notification_type(SMS_TYPE, False):
         record_priority(provider.priority, provider.identifier)

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -1,8 +1,8 @@
 import uuid
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
-from itertools import groupby
+from itertools import chain, groupby
 from operator import attrgetter
 
 from botocore.exceptions import ClientError
@@ -686,6 +686,107 @@ def get_slow_text_message_delivery_reports_by_provider(
         )
 
     return providers_slow_delivery_reports
+
+
+@dataclass
+class BandedSlowProviderDeliveryReport:
+    provider: str
+    slow_ratio: float
+    slow_notifications: int
+    total_notifications: int
+    sent_after_ago: timedelta
+    delivered_within: timedelta
+
+
+@retryable_query()
+def get_banded_slow_text_message_delivery_reports_by_provider(
+    bands: Sequence[tuple[timedelta, timedelta]],
+    *,
+    created_sent_difference_allowance: timedelta = timedelta(minutes=15),
+    session: Session | scoped_session = db.session,
+) -> Mapping[str, Sequence[BandedSlowProviderDeliveryReport]]:
+    for delivered_within, sent_after_ago in bands:
+        if sent_after_ago <= delivered_within:
+            raise ValueError("sent_after_ago must be greater than delivered_within")
+
+    uniform_now = datetime.utcnow()
+
+    created_after = uniform_now - (
+        max(sent_after_ago for delivered_within, sent_after_ago in bands) + created_sent_difference_allowance
+    )
+
+    # created_at can't be after sent_at so no allowance needed here
+    created_before = uniform_now - min(delivered_within for delivered_within, sent_after_ago in bands)
+
+    band_terms = tuple(
+        chain.from_iterable(
+            (
+                func.count()
+                .filter(
+                    and_(
+                        Notification.sent_at >= uniform_now - sent_after_ago,
+                        Notification.sent_at < uniform_now - delivered_within,
+                        or_(
+                            Notification.status != NOTIFICATION_DELIVERED,
+                            Notification.updated_at - Notification.sent_at >= delivered_within,
+                        ),
+                    )
+                )
+                .label(f"count_slow_band_{i}"),
+                func.count()
+                .filter(
+                    and_(
+                        Notification.sent_at >= uniform_now - sent_after_ago,
+                        Notification.sent_at < uniform_now - delivered_within,
+                    )
+                )
+                .label(f"count_total_band_{i}"),
+            )
+            for i, (delivered_within, sent_after_ago) in enumerate(bands)
+        )
+    )
+
+    # all bands collected in a single query using multiple count() aggregations each with
+    # different FILTER clauses corresponding to their bands. this is because a lot of the
+    # retrieved notifications will overlap due to the significant
+    # created_sent_difference_allowance and this way we can calculate all bands in a single
+    # pass.
+    slow_notification_counts = (
+        session.query(
+            ProviderDetails.identifier.label("provider_identifier"),
+            *band_terms,
+        )
+        .select_from(ProviderDetails)
+        .outerjoin(
+            Notification,
+            and_(
+                Notification.notification_type == SMS_TYPE,
+                Notification.sent_by == ProviderDetails.identifier,
+                # filtering by created_at has the additional benefit of being able to use created_at's index
+                Notification.created_at >= created_after,
+                Notification.created_at < created_before,
+                Notification.status.in_([NOTIFICATION_DELIVERED, NOTIFICATION_PENDING, NOTIFICATION_SENDING]),
+                Notification.key_type != KEY_TYPE_TEST,
+            ),
+        )
+        .filter(ProviderDetails.notification_type == "sms", ProviderDetails.active)
+        .group_by(ProviderDetails.identifier)
+    )
+
+    return {
+        row.provider_identifier: tuple(
+            BandedSlowProviderDeliveryReport(
+                provider=row.provider_identifier,
+                slow_ratio=getattr(row, f"count_slow_band_{i}") / (getattr(row, f"count_total_band_{i}") or 1),
+                slow_notifications=getattr(row, f"count_slow_band_{i}"),
+                total_notifications=getattr(row, f"count_total_band_{i}"),
+                sent_after_ago=sent_after_ago,
+                delivered_within=delivered_within,
+            )
+            for i, (delivered_within, sent_after_ago) in enumerate(bands)
+        )
+        for row in slow_notification_counts
+    }
 
 
 @autocommit

--- a/app/otel_metrics/provider.py
+++ b/app/otel_metrics/provider.py
@@ -26,6 +26,29 @@ _sms_legacy_not_delivered_within = _meter.create_gauge(
     "worse.",
 )
 
+_sms_banded_not_delivered_within = _meter.create_gauge(
+    "provider.sms.banded.not_delivered_within",
+    unit="1",
+    description="Proportion of SMS messages sent in a time window of length time_window.evaluation "
+    "seconds (ending time_window.delay seconds before the time of measurement) which took more "
+    "than time_window.delivery seconds to be delivered and for us to receive the receipt.",
+)
+
+_sms_banded_not_delivered_within_absolute = _meter.create_gauge(
+    "provider.sms.banded.not_delivered_within_absolute",
+    unit="{notification}",
+    description="Number of SMS messages sent in a time window of length time_window.evaluation "
+    "seconds (ending time_window.delay seconds before the time of measurement) which took more "
+    "than time_window.delivery seconds to be delivered and for us to receive the receipt.",
+)
+
+_sms_banded_not_delivered_within_total = _meter.create_gauge(
+    "provider.sms.banded.not_delivered_within_total",
+    unit="{notification}",
+    description="Number of SMS messages sent in a time window of length time_window.evaluation "
+    "seconds (ending time_window.delay seconds before the time of measurement).",
+)
+
 _priority = _meter.create_gauge(
     "provider.priority",
     unit="1",
@@ -83,6 +106,25 @@ def record_sms_legacy_not_delivered_within(
         "time_window.delivery": delivery_window,
     }
     _sms_legacy_not_delivered_within.set(ratio, attributes)
+
+
+def record_sms_banded_not_delivered_within(
+    ratio: float,
+    slow_notifications: int,
+    total_notifications: int,
+    provider_name: str,
+    delivered_within: int,
+    sent_after_ago: int,
+) -> None:
+    attributes: dict[str, AttributeValue] = {
+        "provider.name": provider_name,
+        "time_window.evaluation": sent_after_ago - delivered_within,
+        "time_window.delivery": delivered_within,
+        "time_window.delay": delivered_within,
+    }
+    _sms_banded_not_delivered_within.set(ratio, attributes)
+    _sms_banded_not_delivered_within_absolute.set(slow_notifications, attributes)
+    _sms_banded_not_delivered_within_total.set(total_notifications, attributes)
 
 
 def record_priority(

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -65,7 +65,7 @@ from app.constants import (
 )
 from app.dao.annual_billing_dao import set_default_free_allowance_for_service
 from app.dao.jobs_dao import dao_get_job_by_id
-from app.dao.notifications_dao import SlowProviderDeliveryReport
+from app.dao.notifications_dao import BandedSlowProviderDeliveryReport, SlowProviderDeliveryReport
 from app.dao.provider_details_dao import get_provider_details_by_identifier
 from app.dao.template_email_files_dao import dao_get_template_email_file_by_id
 from app.models import Event, InboundNumber, Notification
@@ -74,6 +74,15 @@ from app.otel_metrics.provider import (
 )
 from app.otel_metrics.provider import (
     _priority as provider_priority_metric,
+)
+from app.otel_metrics.provider import (
+    _sms_banded_not_delivered_within as provider_sms_banded_not_delivered_within_metric,
+)
+from app.otel_metrics.provider import (
+    _sms_banded_not_delivered_within_absolute as provider_sms_banded_not_delivered_within_absolute_metric,
+)
+from app.otel_metrics.provider import (
+    _sms_banded_not_delivered_within_total as provider_sms_banded_not_delivered_within_total_metric,
 )
 from app.otel_metrics.provider import (
     _sms_legacy_not_delivered_within as provider_sms_legacy_not_delivered_within_metric,
@@ -259,6 +268,15 @@ def test_generate_sms_delivery_stats(slow_delivery_config_option, expect_check_s
     sms_not_delivered_within_metric_set_mock = mocker.patch.object(
         provider_sms_legacy_not_delivered_within_metric, "set"
     )
+    sms_banded_not_delivered_within_metric_set_mock = mocker.patch.object(
+        provider_sms_banded_not_delivered_within_metric, "set"
+    )
+    sms_banded_not_delivered_within_absolute_metric_set_mock = mocker.patch.object(
+        provider_sms_banded_not_delivered_within_absolute_metric, "set"
+    )
+    sms_banded_not_delivered_within_total_metric_set_mock = mocker.patch.object(
+        provider_sms_banded_not_delivered_within_total_metric, "set"
+    )
     priority_metric_mock = mocker.patch.object(provider_priority_metric, "set")
     updated_at_metric_mock = mocker.patch.object(provider_updated_at_metric, "set")
     info_metric_mock = mocker.patch.object(provider_info_metric, "set")
@@ -271,6 +289,50 @@ def test_generate_sms_delivery_stats(slow_delivery_config_option, expect_check_s
         "app.celery.scheduled_tasks.get_slow_text_message_delivery_reports_by_provider",
         return_value=slow_delivery_reports,
     )
+
+    banded_slow_delivery_reports = {
+        "mmg": (
+            BandedSlowProviderDeliveryReport(
+                provider="mmg",
+                slow_ratio=0.4,
+                slow_notifications=40,
+                total_notifications=100,
+                sent_after_ago=timedelta(seconds=120),
+                delivered_within=timedelta(seconds=60),
+            ),
+            BandedSlowProviderDeliveryReport(
+                provider="mmg",
+                slow_ratio=0.45,
+                slow_notifications=45,
+                total_notifications=100,
+                sent_after_ago=timedelta(seconds=240),
+                delivered_within=timedelta(seconds=120),
+            ),
+        ),
+        "firetext": (
+            BandedSlowProviderDeliveryReport(
+                provider="firetext",
+                slow_ratio=0.8,
+                slow_notifications=80,
+                total_notifications=100,
+                sent_after_ago=timedelta(seconds=120),
+                delivered_within=timedelta(seconds=60),
+            ),
+            BandedSlowProviderDeliveryReport(
+                provider="firetext",
+                slow_ratio=0.85,
+                slow_notifications=85,
+                total_notifications=100,
+                sent_after_ago=timedelta(seconds=240),
+                delivered_within=timedelta(seconds=120),
+            ),
+        ),
+    }
+    mocker.patch(
+        "app.celery.scheduled_tasks.get_banded_slow_text_message_delivery_reports_by_provider",
+        return_value=banded_slow_delivery_reports,
+    )
+
     mock_check_slow_delivery = mocker.patch(
         "app.celery.scheduled_tasks._check_slow_text_message_delivery_reports_and_raise_error_if_needed"
     )
@@ -279,7 +341,7 @@ def test_generate_sms_delivery_stats(slow_delivery_config_option, expect_check_s
         generate_sms_delivery_stats()
 
     assert mock_check_slow_delivery.call_args_list == (
-        [mocker.call(slow_delivery_reports)] if expect_check_slow_delivery else []
+        [call(slow_delivery_reports)] if expect_check_slow_delivery else []
     )
 
     # normalizing order of following calls by sorting by sorted attribute k/v pairs
@@ -288,35 +350,167 @@ def test_generate_sms_delivery_stats(slow_delivery_config_option, expect_check_s
         sms_not_delivered_within_metric_set_mock.mock_calls, key=lambda c: sorted(c.args[1].items())
     ) == sorted(
         (
-            mocker.call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 60}),
-            mocker.call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 60}),
-            mocker.call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 300}),
-            mocker.call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 300}),
-            mocker.call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 600}),
-            mocker.call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 600}),
+            call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 60}),
+            call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 60}),
+            call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 300}),
+            call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 300}),
+            call(0.4, {"provider.name": "mmg", "time_window.evaluation": 900, "time_window.delivery": 600}),
+            call(0.8, {"provider.name": "firetext", "time_window.evaluation": 900, "time_window.delivery": 600}),
+        ),
+        key=lambda c: sorted(c.args[1].items()),
+    )
+
+    assert sorted(
+        sms_banded_not_delivered_within_metric_set_mock.mock_calls, key=lambda c: sorted(c.args[1].items())
+    ) == sorted(
+        (
+            call(
+                0.8,
+                {
+                    "provider.name": "firetext",
+                    "time_window.evaluation": 60.0,
+                    "time_window.delivery": 60.0,
+                    "time_window.delay": 60.0,
+                },
+            ),
+            call(
+                0.85,
+                {
+                    "provider.name": "firetext",
+                    "time_window.evaluation": 120.0,
+                    "time_window.delivery": 120.0,
+                    "time_window.delay": 120.0,
+                },
+            ),
+            call(
+                0.4,
+                {
+                    "provider.name": "mmg",
+                    "time_window.evaluation": 60.0,
+                    "time_window.delivery": 60.0,
+                    "time_window.delay": 60.0,
+                },
+            ),
+            call(
+                0.45,
+                {
+                    "provider.name": "mmg",
+                    "time_window.evaluation": 120.0,
+                    "time_window.delivery": 120.0,
+                    "time_window.delay": 120.0,
+                },
+            ),
+        ),
+        key=lambda c: sorted(c.args[1].items()),
+    )
+
+    assert sorted(
+        sms_banded_not_delivered_within_absolute_metric_set_mock.mock_calls, key=lambda c: sorted(c.args[1].items())
+    ) == sorted(
+        (
+            call(
+                80,
+                {
+                    "provider.name": "firetext",
+                    "time_window.evaluation": 60.0,
+                    "time_window.delivery": 60.0,
+                    "time_window.delay": 60.0,
+                },
+            ),
+            call(
+                85,
+                {
+                    "provider.name": "firetext",
+                    "time_window.evaluation": 120.0,
+                    "time_window.delivery": 120.0,
+                    "time_window.delay": 120.0,
+                },
+            ),
+            call(
+                40,
+                {
+                    "provider.name": "mmg",
+                    "time_window.evaluation": 60.0,
+                    "time_window.delivery": 60.0,
+                    "time_window.delay": 60.0,
+                },
+            ),
+            call(
+                45,
+                {
+                    "provider.name": "mmg",
+                    "time_window.evaluation": 120.0,
+                    "time_window.delivery": 120.0,
+                    "time_window.delay": 120.0,
+                },
+            ),
+        ),
+        key=lambda c: sorted(c.args[1].items()),
+    )
+
+    assert sorted(
+        sms_banded_not_delivered_within_total_metric_set_mock.mock_calls, key=lambda c: sorted(c.args[1].items())
+    ) == sorted(
+        (
+            call(
+                100,
+                {
+                    "provider.name": "firetext",
+                    "time_window.evaluation": 60.0,
+                    "time_window.delivery": 60.0,
+                    "time_window.delay": 60.0,
+                },
+            ),
+            call(
+                100,
+                {
+                    "provider.name": "firetext",
+                    "time_window.evaluation": 120.0,
+                    "time_window.delivery": 120.0,
+                    "time_window.delay": 120.0,
+                },
+            ),
+            call(
+                100,
+                {
+                    "provider.name": "mmg",
+                    "time_window.evaluation": 60.0,
+                    "time_window.delivery": 60.0,
+                    "time_window.delay": 60.0,
+                },
+            ),
+            call(
+                100,
+                {
+                    "provider.name": "mmg",
+                    "time_window.evaluation": 120.0,
+                    "time_window.delivery": 120.0,
+                    "time_window.delay": 120.0,
+                },
+            ),
         ),
         key=lambda c: sorted(c.args[1].items()),
     )
 
     assert sorted(priority_metric_mock.mock_calls, key=lambda c: sorted(c.args[1].items())) == sorted(
         (
-            mocker.call(0, {"provider.name": "firetext"}),
-            mocker.call(100, {"provider.name": "mmg"}),
+            call(0, {"provider.name": "firetext"}),
+            call(100, {"provider.name": "mmg"}),
         ),
         key=lambda c: sorted(c.args[1].items()),
     )
 
     assert sorted(updated_at_metric_mock.mock_calls, key=lambda c: sorted(c.args[1].items())) == sorted(
         (
-            mocker.call(RestrictedAny(lambda x: x < datetime.utcnow().timestamp()), {"provider.name": "firetext"}),
-            mocker.call(RestrictedAny(lambda x: x < datetime.utcnow().timestamp()), {"provider.name": "mmg"}),
+            call(RestrictedAny(lambda x: x < datetime.utcnow().timestamp()), {"provider.name": "firetext"}),
+            call(RestrictedAny(lambda x: x < datetime.utcnow().timestamp()), {"provider.name": "mmg"}),
         ),
         key=lambda c: sorted(c.args[1].items()),
     )
 
     assert sorted(info_metric_mock.mock_calls, key=lambda c: sorted(c.args[1].items())) == sorted(
         (
-            mocker.call(
+            call(
                 1,
                 {
                     "provider.name": "firetext",
@@ -325,7 +519,7 @@ def test_generate_sms_delivery_stats(slow_delivery_config_option, expect_check_s
                     "notification.type": "sms",
                 },
             ),
-            mocker.call(
+            call(
                 1,
                 {
                     "provider.name": "mmg",

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -15,6 +15,7 @@ from app.constants import (
     KEY_TYPE_TEST,
     NOTIFICATION_DELIVERED,
     NOTIFICATION_PENDING,
+    NOTIFICATION_PERMANENT_FAILURE,
     NOTIFICATION_SENDING,
     NOTIFICATION_SENT,
     NOTIFICATION_STATUS_TYPES,
@@ -23,6 +24,7 @@ from app.constants import (
     SMS_TYPE,
 )
 from app.dao.notifications_dao import (
+    BandedSlowProviderDeliveryReport,
     dao_create_notification,
     dao_delete_notifications_by_id,
     dao_get_last_notification_added_for_job_id,
@@ -40,6 +42,7 @@ from app.dao.notifications_dao import (
     dao_timeout_notifications,
     dao_update_notification,
     dao_update_notifications_by_reference,
+    get_banded_slow_text_message_delivery_reports_by_provider,
     get_notification_by_id,
     get_notification_by_job_and_job_row_number,
     get_notification_with_personalisation,
@@ -1082,6 +1085,376 @@ def test_delivery_is_delivery_slow_for_providers_filters_out_notifications_it_sh
     create_notification(**create_slow_notification_with)
     result = is_delivery_slow_for_providers(10, 5, 0.1)
     assert result["mmg"] == expected_result
+
+
+def _tds(s):
+    return timedelta(seconds=s)
+
+
+@pytest.mark.parametrize(
+    "bands,notifications,expected_result",
+    (
+        (
+            (
+                (_tds(60), _tds(120)),
+                (_tds(120), _tds(240)),
+            ),
+            (
+                (_tds(55), NOTIFICATION_SENDING, None, {"sent_by": "mmg"}),  # excluded
+                (_tds(61), NOTIFICATION_SENDING, None, {"sent_by": "mmg"}),  # slow
+                (_tds(118), NOTIFICATION_DELIVERED, _tds(5), {"sent_by": "mmg"}),  # ok
+                (_tds(123), NOTIFICATION_PENDING, _tds(5), {"sent_by": "mmg"}),  # slow
+                (_tds(124), NOTIFICATION_DELIVERED, _tds(5), {"sent_by": "mmg"}),  # ok
+                (_tds(125), NOTIFICATION_DELIVERED, _tds(5), {"sent_by": "mmg"}),  # ok
+                (_tds(128), NOTIFICATION_DELIVERED, _tds(61), {"sent_by": "mmg"}),  # ok
+                (_tds(236), NOTIFICATION_DELIVERED, _tds(130), {"sent_by": "mmg"}),  # slow
+                (_tds(244), NOTIFICATION_DELIVERED, _tds(130), {"sent_by": "mmg"}),  # excluded
+                (_tds(65), NOTIFICATION_SENDING, None, {"sent_by": "firetext"}),  # slow
+                (_tds(66), NOTIFICATION_DELIVERED, _tds(5), {"sent_by": "firetext"}),  # ok
+                (_tds(111), NOTIFICATION_DELIVERED, _tds(66), {"sent_by": "firetext"}),  # slow
+                (_tds(112), NOTIFICATION_PENDING, _tds(5), {"sent_by": "firetext"}),  # slow
+                (_tds(122), NOTIFICATION_PENDING, _tds(5), {"sent_by": "firetext"}),  # slow
+                (_tds(222), NOTIFICATION_DELIVERED, _tds(5), {"sent_by": "firetext"}),  # ok
+                (_tds(223), NOTIFICATION_DELIVERED, _tds(121), {"sent_by": "firetext"}),  # slow
+                (_tds(224), NOTIFICATION_DELIVERED, _tds(115), {"sent_by": "firetext"}),  # ok
+            ),
+            {
+                "mmg": (
+                    BandedSlowProviderDeliveryReport(
+                        provider="mmg",
+                        slow_ratio=0.5,
+                        slow_notifications=1,
+                        total_notifications=2,
+                        delivered_within=_tds(60),
+                        sent_after_ago=_tds(120),
+                    ),
+                    BandedSlowProviderDeliveryReport(
+                        provider="mmg",
+                        slow_ratio=0.4,
+                        slow_notifications=2,
+                        total_notifications=5,
+                        delivered_within=_tds(120),
+                        sent_after_ago=_tds(240),
+                    ),
+                ),
+                "firetext": (
+                    BandedSlowProviderDeliveryReport(
+                        provider="firetext",
+                        slow_ratio=0.75,
+                        slow_notifications=3,
+                        total_notifications=4,
+                        delivered_within=_tds(60),
+                        sent_after_ago=_tds(120),
+                    ),
+                    BandedSlowProviderDeliveryReport(
+                        provider="firetext",
+                        slow_ratio=0.5,
+                        slow_notifications=2,
+                        total_notifications=4,
+                        delivered_within=_tds(120),
+                        sent_after_ago=_tds(240),
+                    ),
+                ),
+            },
+        ),
+        (
+            ((_tds(30), _tds(60)),),
+            (
+                (_tds(29), NOTIFICATION_SENDING, None, {"sent_by": "mmg"}),  # excluded
+                (_tds(30), NOTIFICATION_DELIVERED, _tds(1), {"sent_by": "mmg"}),  # excluded
+                (_tds(32), NOTIFICATION_TEMPORARY_FAILURE, _tds(31), {"sent_by": "mmg"}),  # excluded
+                (_tds(35), NOTIFICATION_PERMANENT_FAILURE, _tds(31), {"sent_by": "mmg"}),  # excluded
+                (_tds(36), NOTIFICATION_SENDING, None, {"sent_by": "mmg", "key_type": KEY_TYPE_TEST}),  # excluded
+                (_tds(60.1), NOTIFICATION_PENDING, _tds(1), {"sent_by": "mmg"}),  # excluded
+                (_tds(40), NOTIFICATION_SENT, _tds(32), {"sent_by": "firetext"}),  # excluded
+                (_tds(41), NOTIFICATION_PENDING, _tds(10), {"sent_by": "firetext"}),  # slow
+                (_tds(60), NOTIFICATION_DELIVERED, _tds(1), {"sent_by": "firetext"}),  # ok
+            ),
+            {
+                "mmg": (
+                    BandedSlowProviderDeliveryReport(
+                        provider="mmg",
+                        slow_ratio=0.0,
+                        slow_notifications=0,
+                        total_notifications=0,
+                        delivered_within=_tds(30),
+                        sent_after_ago=_tds(60),
+                    ),
+                ),
+                "firetext": (
+                    BandedSlowProviderDeliveryReport(
+                        provider="firetext",
+                        slow_ratio=0.5,
+                        slow_notifications=1,
+                        total_notifications=2,
+                        delivered_within=_tds(30),
+                        sent_after_ago=_tds(60),
+                    ),
+                ),
+            },
+        ),
+        (
+            (
+                (_tds(30), _tds(60)),
+                (_tds(60), _tds(70)),
+                (_tds(70), _tds(80)),
+            ),
+            (
+                (_tds(31), NOTIFICATION_DELIVERED, _tds(30), {"sent_by": "mmg"}),  # slow
+                (_tds(60), NOTIFICATION_DELIVERED, _tds(60), {"sent_by": "mmg"}),  # slow
+                (_tds(70), NOTIFICATION_DELIVERED, _tds(70), {"sent_by": "mmg"}),  # slow
+                (_tds(80), NOTIFICATION_DELIVERED, _tds(80), {"sent_by": "mmg"}),  # slow
+                (_tds(40), NOTIFICATION_PENDING, _tds(10), {"sent_by": "firetext"}),  # slow
+            ),
+            {
+                "mmg": (
+                    BandedSlowProviderDeliveryReport(
+                        provider="mmg",
+                        slow_ratio=1.0,
+                        slow_notifications=2,
+                        total_notifications=2,
+                        delivered_within=_tds(30),
+                        sent_after_ago=_tds(60),
+                    ),
+                    BandedSlowProviderDeliveryReport(
+                        provider="mmg",
+                        slow_ratio=1.0,
+                        slow_notifications=1,
+                        total_notifications=1,
+                        delivered_within=_tds(60),
+                        sent_after_ago=_tds(70),
+                    ),
+                    BandedSlowProviderDeliveryReport(
+                        provider="mmg",
+                        slow_ratio=1.0,
+                        slow_notifications=1,
+                        total_notifications=1,
+                        delivered_within=_tds(70),
+                        sent_after_ago=_tds(80),
+                    ),
+                ),
+                "firetext": (
+                    BandedSlowProviderDeliveryReport(
+                        provider="firetext",
+                        slow_ratio=1.0,
+                        slow_notifications=1,
+                        total_notifications=1,
+                        delivered_within=_tds(30),
+                        sent_after_ago=_tds(60),
+                    ),
+                    BandedSlowProviderDeliveryReport(
+                        provider="firetext",
+                        slow_ratio=0.0,
+                        slow_notifications=0,
+                        total_notifications=0,
+                        delivered_within=_tds(60),
+                        sent_after_ago=_tds(70),
+                    ),
+                    BandedSlowProviderDeliveryReport(
+                        provider="firetext",
+                        slow_ratio=0.0,
+                        slow_notifications=0,
+                        total_notifications=0,
+                        delivered_within=_tds(70),
+                        sent_after_ago=_tds(80),
+                    ),
+                ),
+            },
+        ),
+    ),
+)
+@pytest.mark.parametrize(
+    "session,expected_bind_key",
+    (
+        (db.session, None),
+        (db.session_bulk, "bulk"),
+    ),
+    ids=("default", "bulk"),
+)
+@freeze_time()
+def test_get_banded_slow_text_message_delivery_reports_by_provider(
+    notify_db_session, sample_template, bands, notifications, session, expected_result, expected_bind_key
+):
+    uniform_now = datetime.now()
+
+    for created_sent_delta, status, updated_at_delta, options in notifications:
+        created_sent = uniform_now - created_sent_delta
+        create_notification(
+            template=sample_template,
+            sent_at=created_sent,
+            created_at=created_sent,
+            status=status,
+            updated_at=created_sent + (updated_at_delta or timedelta()),
+            **options,
+        )
+
+    with QueryRecorder() as query_recorder:
+        assert get_banded_slow_text_message_delivery_reports_by_provider(bands, session=session) == expected_result
+
+    assert {query_info.bind_key for query_info in query_recorder.queries} == {expected_bind_key}
+
+
+@pytest.mark.parametrize(
+    "bands,notifications,expected_result",
+    (
+        (
+            ((_tds(60), _tds(120)),),
+            (
+                (_tds(60), _tds(55), NOTIFICATION_SENDING, None, {"sent_by": "mmg"}),  # excluded
+                (_tds(61), _tds(55), NOTIFICATION_SENDING, None, {"sent_by": "mmg"}),  # excluded
+                (_tds(62), _tds(60), NOTIFICATION_SENDING, None, {"sent_by": "mmg"}),  # excluded
+                (_tds(63), _tds(61), NOTIFICATION_SENDING, None, {"sent_by": "mmg"}),  # slow
+                (_tds(130), _tds(110), NOTIFICATION_SENDING, None, {"sent_by": "mmg"}),  # slow
+                (_tds(300), _tds(120), NOTIFICATION_SENDING, None, {"sent_by": "mmg"}),  # slow
+                (_tds(1120), _tds(119), NOTIFICATION_DELIVERED, _tds(1), {"sent_by": "mmg"}),  # excluded
+                (_tds(60), _tds(59), NOTIFICATION_DELIVERED, _tds(1), {"sent_by": "firetext"}),  # excluded
+                (_tds(61), _tds(60), NOTIFICATION_DELIVERED, _tds(1), {"sent_by": "firetext"}),  # excluded
+                (_tds(100), _tds(70), NOTIFICATION_DELIVERED, _tds(1), {"sent_by": "firetext"}),  # ok
+                (_tds(100), _tds(70), NOTIFICATION_DELIVERED, _tds(65), {"sent_by": "firetext"}),  # slow
+                (_tds(300), _tds(50), NOTIFICATION_DELIVERED, _tds(1), {"sent_by": "firetext"}),  # excluded
+            ),
+            {
+                "mmg": (
+                    BandedSlowProviderDeliveryReport(
+                        provider="mmg",
+                        slow_ratio=1.0,
+                        slow_notifications=3,
+                        total_notifications=3,
+                        delivered_within=_tds(60),
+                        sent_after_ago=_tds(120),
+                    ),
+                ),
+                "firetext": (
+                    BandedSlowProviderDeliveryReport(
+                        provider="firetext",
+                        slow_ratio=0.5,
+                        slow_notifications=1,
+                        total_notifications=2,
+                        delivered_within=_tds(60),
+                        sent_after_ago=_tds(120),
+                    ),
+                ),
+            },
+        ),
+        (
+            (
+                # misordered and overlapping bands should "work" but aren't advisable
+                (_tds(80), _tds(90)),
+                (_tds(60), _tds(140)),
+                (_tds(25), _tds(50)),
+            ),
+            (
+                (_tds(24), _tds(23), NOTIFICATION_DELIVERED, _tds(1), {"sent_by": "mmg"}),  # excluded
+                (_tds(25), _tds(24), NOTIFICATION_DELIVERED, _tds(1), {"sent_by": "mmg"}),  # excluded
+                (_tds(26), _tds(25), NOTIFICATION_DELIVERED, _tds(1), {"sent_by": "mmg"}),  # excluded
+                (_tds(27), _tds(26), NOTIFICATION_DELIVERED, _tds(1), {"sent_by": "mmg"}),  # ok
+                (_tds(28), _tds(27), NOTIFICATION_PENDING, _tds(26), {"sent_by": "mmg"}),  # slow
+                (_tds(95), _tds(85), NOTIFICATION_DELIVERED, _tds(61), {"sent_by": "mmg"}),  # 2 bands, ok/slow
+                (_tds(1000), _tds(86), NOTIFICATION_DELIVERED, _tds(1), {"sent_by": "mmg"}),  # 2 bands, ok/ok
+                (_tds(1000.1), _tds(86.1), NOTIFICATION_DELIVERED, _tds(1), {"sent_by": "mmg"}),  # 2 bands, ok/ok
+                (_tds(1000.2), _tds(86.2), NOTIFICATION_DELIVERED, _tds(1), {"sent_by": "mmg"}),  # 2 bands, ok/ok
+                (_tds(1001), _tds(87), NOTIFICATION_SENDING, None, {"sent_by": "mmg"}),  # 2 bands, slow/slow
+                (_tds(1100), _tds(88), NOTIFICATION_SENDING, None, {"sent_by": "mmg"}),  # excluded
+                (_tds(1101), _tds(110), NOTIFICATION_SENDING, None, {"sent_by": "mmg"}),  # excluded
+                (_tds(800), _tds(111), NOTIFICATION_DELIVERED, _tds(60), {"sent_by": "mmg"}),  # ok
+                (_tds(55), _tds(54), NOTIFICATION_SENDING, None, {"sent_by": "firetext"}),  # excluded
+                (_tds(90), _tds(55), NOTIFICATION_SENDING, None, {"sent_by": "firetext"}),  # excluded
+                (_tds(300), _tds(56), NOTIFICATION_SENDING, None, {"sent_by": "firetext"}),  # excluded
+                (_tds(301), _tds(57), NOTIFICATION_DELIVERED, _tds(56), {"sent_by": "firetext"}),  # excluded
+                (_tds(302), _tds(62), NOTIFICATION_DELIVERED, _tds(10), {"sent_by": "firetext"}),  # ok
+            ),
+            {
+                "mmg": (
+                    BandedSlowProviderDeliveryReport(
+                        provider="mmg",
+                        slow_ratio=0.2,
+                        slow_notifications=1,
+                        total_notifications=5,
+                        delivered_within=_tds(80),
+                        sent_after_ago=_tds(90),
+                    ),
+                    BandedSlowProviderDeliveryReport(
+                        provider="mmg",
+                        slow_ratio=0.5,
+                        slow_notifications=3,
+                        total_notifications=6,
+                        delivered_within=_tds(60),
+                        sent_after_ago=_tds(140),
+                    ),
+                    BandedSlowProviderDeliveryReport(
+                        provider="mmg",
+                        slow_ratio=0.5,
+                        slow_notifications=1,
+                        total_notifications=2,
+                        delivered_within=_tds(25),
+                        sent_after_ago=_tds(50),
+                    ),
+                ),
+                "firetext": (
+                    BandedSlowProviderDeliveryReport(
+                        provider="firetext",
+                        slow_ratio=0.0,
+                        slow_notifications=0,
+                        total_notifications=0,
+                        delivered_within=_tds(80),
+                        sent_after_ago=_tds(90),
+                    ),
+                    BandedSlowProviderDeliveryReport(
+                        provider="firetext",
+                        slow_ratio=0.0,
+                        slow_notifications=0,
+                        total_notifications=1,
+                        delivered_within=_tds(60),
+                        sent_after_ago=_tds(140),
+                    ),
+                    BandedSlowProviderDeliveryReport(
+                        provider="firetext",
+                        slow_ratio=0.0,
+                        slow_notifications=0,
+                        total_notifications=0,
+                        delivered_within=_tds(25),
+                        sent_after_ago=_tds(50),
+                    ),
+                ),
+            },
+        ),
+    ),
+)
+@pytest.mark.parametrize(
+    "session,expected_bind_key",
+    (
+        (db.session, None),
+        (db.session_bulk, "bulk"),
+    ),
+    ids=("default", "bulk"),
+)
+@freeze_time()
+def test_get_banded_slow_text_message_delivery_reports_by_provider_created_at_sent_at(
+    notify_db_session, sample_template, bands, notifications, session, expected_result, expected_bind_key
+):
+    uniform_now = datetime.now()
+
+    for created_delta, sent_delta, status, updated_at_delta, options in notifications:
+        created_at = uniform_now - created_delta
+        sent_at = uniform_now - sent_delta
+        create_notification(
+            template=sample_template,
+            sent_at=sent_at,
+            created_at=created_at,
+            status=status,
+            updated_at=sent_at + (updated_at_delta or timedelta()),
+            **options,
+        )
+
+    with QueryRecorder() as query_recorder:
+        assert (
+            get_banded_slow_text_message_delivery_reports_by_provider(
+                bands, created_sent_difference_allowance=timedelta(minutes=15), session=session
+            )
+            == expected_result
+        )
+
+    assert {query_info.bind_key for query_info in query_recorder.queries} == {expected_bind_key}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
https://trello.com/c/1Q7z3GH3/1568-investigate-and-decide-what-to-do-next-re-balancer-behaviour-during-vodafone-network-outage

This is a candidate building block for a new sms balancer slow delivery metric that is capable of measuring delivery delay in a series of "bands" that each trade off severity of delay measured with fast responses to interruption.

It also notably uses `sent_at` rather than `created_at` to calculate delivery delay, preventing it from being sensitive to delivery delays at our end.

Here we simply expose the separate components of this measure as an otel metric, allowing us to experiment with real data for determining e.g. methods off combining the bands into a single representative figure which we might later be able to make balancing decisions based on.

Sending these queries to the replica to avoid any possibility these could seriously affect the primary database.

In this PR I've chosen bands systematically rather than using "human-feeling" boundaries of e.g. 1m, 5m, 15m. The smallest band I've chosen counts how many notifications took more than 30s to deliver in the time window 30s ago to 1m ago. Each successive band is double the size of the previous, and has a delivery threshold similarly twice the size, up to a band counting messages that took more than 8m to deliver looking back up to 16m ago.