### PR TITLE
Update PostgreSQL WAL configuration to include default output plugins

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -164,7 +164,7 @@ RUN \
 # add WAL configuration to postgresql.conf to enable logical replication
 RUN printf '%s\n' \
     "wal_level = logical" \
-    "output_plugin_libraries = 'wal2json'" \
+    "output_plugin_libraries = 'pgoutput, test_decoding, wal2json'" \
     "max_replication_slots = 10" \
     "max_wal_senders = 10" \
     "max_slot_wal_keep_size = 1GB" \


### PR DESCRIPTION
This was missed out when setting the parameter in https://github.com/alphagov/notifications-api/pull/4950