### PR TITLE
Add `confirmed_service_name` column to services table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -607,6 +607,7 @@ class Service(db.Model, Versioned):
     go_live_user = db.relationship("User", foreign_keys=[go_live_user_id])
     go_live_at = db.Column(db.DateTime, nullable=True)
     has_active_go_live_request = db.Column(db.Boolean, default=False, nullable=False)
+    confirmed_service_name = db.Column(db.Boolean, default=False, nullable=False)
     confirmed_unique = db.Column(db.Boolean, default=False, nullable=False)
 
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), index=True, nullable=True)

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0562_enable_replica_id_index
+0563_confirmed_service_name_col

--- a/migrations/versions/0563_confirmed_service_name_col.py
+++ b/migrations/versions/0563_confirmed_service_name_col.py
@@ -1,0 +1,18 @@
+"""
+Create Date: 2026-09-03 13:45:41.137308
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0563_confirmed_service_name_col'
+down_revision = '0562_enable_replica_id_index'
+
+
+def upgrade():
+    op.add_column("services", sa.Column("confirmed_service_name", sa.Boolean(), nullable=False, server_default=sa.false()))
+    op.add_column("services_history", sa.Column("confirmed_service_name", sa.Boolean(), nullable=False, server_default=sa.false()))
+
+def downgrade():
+    op.drop_column("services_history", "confirmed_service_name")
+    op.drop_column("services", "confirmed_service_name")

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -265,6 +265,7 @@ def test_get_service_by_id(admin_request, sample_service):
         "billing_contact_names",
         "billing_reference",
         "confirmed_email_sender_name",
+        "confirmed_service_name",
         "confirmed_unique",
         "consent_to_research",
         "contact_link",


### PR DESCRIPTION
This adds a new boolean column, `confirmed_service_name`, to the `services` and `services_history` tables with a default of `False`.

We currently have a page users see when requesting to go live which talks about the service name and free allowance and populates the `is_unique` column. We want to split this into two separate pages - one that asks the user to confirm the service name is understandable, and one which asks them to confirm they meet the terms of the free allowance.

We will use the existing `is_unique` column to store whether they have confirmed they meet the terms of the free allowance, and this new column will be used to store whether they have confirmed the service name is clear.

**After deployment**
- [x] Clear services cache