### PR TITLE
feat: document personalisation on get template responses

### DIFF
--- a/app/v2/template/template_schemas.py
+++ b/app/v2/template/template_schemas.py
@@ -26,6 +26,13 @@ get_template_by_id_response = {
         "subject": {"type": ["string", "null"]},
         "name": {"type": "string"},
         "postage": {"type": "string", "format": "postage"},
+        "personalisation": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {"required": {"type": "boolean"}},
+            },
+        },
     },
     "required": ["id", "type", "created_at", "updated_at", "version", "created_by", "body", "name"],
 }

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -266,6 +266,12 @@ def test_sms_notification_serializes_without_subject(client, sample_template):
 def test_email_notification_serializes_with_subject(client, sample_email_template):
     res = sample_email_template.serialize_for_v2()
     assert res["subject"] == "Email Subject"
+    assert res["personalisation"] == {}
+
+
+def test_template_serializes_personalisation_placeholders(client, sample_email_template_with_placeholders):
+    res = sample_email_template_with_placeholders.serialize_for_v2()
+    assert res["personalisation"] == {"name": {"required": True}}
 
 
 def test_letter_notification_serializes_with_subject(client, sample_letter_template):

--- a/tests/app/v2/template/test_get_template.py
+++ b/tests/app/v2/template/test_get_template.py
@@ -76,6 +76,17 @@ def test_get_template_by_id_returns_200(
                 "content": {"required": True},
             },
         ),
+        (
+            {
+                "template_type": EMAIL_TYPE,
+                "subject": "Hello ((name))",
+                "content": "Hello ((name)) again. Your ref is ((reference)).",
+            },
+            {
+                "name": {"required": True},
+                "reference": {"required": True},
+            },
+        ),
     ],
 )
 @pytest.mark.parametrize("version_kwargs", valid_version_kwargs)

--- a/tests/app/v2/template/test_template_schemas.py
+++ b/tests/app/v2/template/test_template_schemas.py
@@ -13,7 +13,7 @@ from app.v2.template.template_schemas import (
     post_template_preview_response,
 )
 
-valid_json_get_response = {
+valid_json_get_response: dict[str, object] = {
     "id": str(uuid.uuid4()),
     "type": SMS_TYPE,
     "created_at": "2017-01-10T18:25:43.511Z",
@@ -22,9 +22,10 @@ valid_json_get_response = {
     "created_by": "someone@test.com",
     "body": "some body",
     "name": "some name",
+    "personalisation": {},
 }
 
-valid_json_get_response_with_optionals = {
+valid_json_get_response_with_optionals: dict[str, object] = {
     "id": str(uuid.uuid4()),
     "type": EMAIL_TYPE,
     "created_at": "2017-01-10T18:25:43.511Z",
@@ -35,6 +36,7 @@ valid_json_get_response_with_optionals = {
     "subject": "some subject",
     "name": "some name",
     "postage": "first",
+    "personalisation": {"name": {"required": True}},
 }
 
 valid_request_args = [{"id": str(uuid.uuid4()), "version": 1}, {"id": str(uuid.uuid4())}]


### PR DESCRIPTION
## Summary
- GET template already returned `personalisation`, a map of placeholder names like `{"name": {"required": true}}`.
- This change documents that field in the API schema and tests. It does not add a new field.
