### PR TITLE
migration: Add document_download_filepath column to notifications table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1585,6 +1585,8 @@ class Notification(db.Model):
 
     unsubscribe_link = db.Column(db.String, nullable=True)
 
+    document_download_filepath = db.Column(JSONB(none_as_null=True), nullable=True)
+
     __table_args__ = (
         db.ForeignKeyConstraint(
             ["template_id", "template_version"],

--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0562_enable_replica_id_index
+0563_add_filepath_notifications

--- a/migrations/versions/0563_add_filepath_notifications.py
+++ b/migrations/versions/0563_add_filepath_notifications.py
@@ -1,0 +1,15 @@
+"""
+Create Date: 2026-09-07 00:00:00
+"""
+
+from alembic import op
+
+revision = "0563_add_filepath_notifications"
+down_revision = "0562_enable_replica_id_index"
+
+
+def upgrade():
+    op.execute("ALTER TABLE notifications ADD COLUMN document_download_filepath jsonb")
+
+def downgrade():
+    op.execute("ALTER TABLE notifications DROP COLUMN document_download_filepath")


### PR DESCRIPTION
As part of the work to block files that have sent in jobs by document download, we need a way of storing the one or many files that may be sent using the document download via UI feature (we may also want to store this for documents uploaded via the api, but this is a less pressing concern - but we may just want to have it there for consistency).

Storing as a JSONB type because a template with files can have 0, 1 or many files, and our past experience has shown that we need the ability to selectively get the object names for specific files