### PR TITLE
Bump utils to 131.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@130.2.0
+# This file was automatically copied from notifications-utils@131.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil~=6.0
 notifications-python-client~=12.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@130.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@131.0.0
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -862,7 +862,7 @@ mistune==0.8.4 \
 notifications-python-client==12.1.0 \
     --hash=sha256:bc44987acbb72de4cded700447d0d246c020dcd0f0311ff2ca884ce1c4001b76
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@e767615df76fddaf7986cc9c1195ac8099840126
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0293b8f06dc3ff7c7a62995a42609b2c673ba92c
     # via -r requirements.in
 opentelemetry-api==1.44.0 \
     --hash=sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1312,7 +1312,7 @@ mypy-extensions==1.1.0 \
 notifications-python-client==12.1.0 \
     --hash=sha256:bc44987acbb72de4cded700447d0d246c020dcd0f0311ff2ca884ce1c4001b76
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@e767615df76fddaf7986cc9c1195ac8099840126
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0293b8f06dc3ff7c7a62995a42609b2c673ba92c
     # via -r requirements.txt
 opentelemetry-api==1.44.0 \
     --hash=sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@130.2.0
+# This file was automatically copied from notifications-utils@131.0.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@130.2.0
+# This file was automatically copied from notifications-utils@131.0.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@130.2.0
+# This file was automatically copied from notifications-utils@131.0.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
 ## 131.0.0

* Removes `RecipientCSV.rows`, `RecipientCSV._rows_as_list` (use, for example `for r in RecipientCSV(…)` instead)

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/130.2.0...131.0.0