### PR TITLE
add `block_ofcom_protected_block` service permission to `service_permission_types` table

### DIFF
--- a/migrations/.current-alembic-head
+++ b/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-0563_confirmed_service_name_col
+0564_block_ofcom_protected

--- a/migrations/versions/0564_block_ofcom_protected.py
+++ b/migrations/versions/0564_block_ofcom_protected.py
@@ -1,0 +1,17 @@
+"""
+Create Date: 2026-09-09 00:00:00.000000
+"""
+
+from alembic import op
+
+revision = "0564_block_ofcom_protected"
+down_revision = "0563_confirmed_service_name_col"
+
+
+def upgrade():
+    op.execute("INSERT INTO service_permission_types VALUES ('block_ofcom_protected_block')")
+
+
+def downgrade():
+    op.execute("DELETE FROM service_permissions WHERE permission = 'block_ofcom_protected_block'")
+    op.execute("DELETE FROM service_permission_types WHERE name = 'block_ofcom_protected_block'")


### PR DESCRIPTION


blocking sending to protected blocks should be considered experimental currently - we don't want to apply it notify-wide, but only as and when services request it