### PR TITLE
exclude tv numbers from logging when `persist_notification` is called

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@131.0.0
+# This file was automatically copied from notifications-utils@131.1.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -180,7 +180,7 @@ def persist_notification(
         try:
             number = PhoneNumber(strip_and_remove_obscure_whitespace(notification.to))
             five_digit_prefix = str(number.number.national_number)[:5]
-            if number.is_number_in_S7_protected_range():
+            if number.is_number_in_S7_protected_range() and not number.is_tv_number(number.number):
                 current_app.logger.info(
                     "Service %s tried to send to UK mobile number in ofcom protected range. Prefix without leading zero: %s",  # noqa: E501
                     service.id,

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ psutil~=6.0
 notifications-python-client~=12.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@131.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@131.1.0
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -862,7 +862,7 @@ mistune==0.8.4 \
 notifications-python-client==12.1.0 \
     --hash=sha256:bc44987acbb72de4cded700447d0d246c020dcd0f0311ff2ca884ce1c4001b76
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0293b8f06dc3ff7c7a62995a42609b2c673ba92c
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a1c07910c5a3460e7e8f64688bf0f52c6d1b1096
     # via -r requirements.in
 opentelemetry-api==1.44.0 \
     --hash=sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1312,7 +1312,7 @@ mypy-extensions==1.1.0 \
 notifications-python-client==12.1.0 \
     --hash=sha256:bc44987acbb72de4cded700447d0d246c020dcd0f0311ff2ca884ce1c4001b76
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0293b8f06dc3ff7c7a62995a42609b2c673ba92c
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a1c07910c5a3460e7e8f64688bf0f52c6d1b1096
     # via -r requirements.txt
 opentelemetry-api==1.44.0 \
     --hash=sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@131.0.0
+# This file was automatically copied from notifications-utils@131.1.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@131.0.0
+# This file was automatically copied from notifications-utils@131.1.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -623,9 +623,11 @@ def test_persist_notification_increments_cache_for_international_sms_if_the_cach
 @pytest.mark.parametrize(
     "unformatted_recipient, normalised_recipient, prefix, should_log",
     [
-        ("+447111111111", "447111111111", "71111", True),
-        ("+447988957616", "447988957616", "", False),
-        ("+48697894064", "48697894064", "", False),
+        ("+447111111111", "447111111111", "71111", True),  # protected block number
+        ("+447700900001", "447700900001", "", False),  # normal tv number
+        ("+447700900111", "447700900111", "", False),  # smoke test number
+        ("+447988957616", "447988957616", "", False),  # non-protected uk number
+        ("+48697894064", "48697894064", "", False),  # international number
     ],
 )
 def test_persist_notification_logs_when_sms_sent_to_uk_number_in_ofcom_protected_range(

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@131.0.0
+# This file was automatically copied from notifications-utils@131.1.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
we shouldn't want to block sending to tv numbers (https://www.ofcom.org.uk/phones-and-broadband/phone-numbers/numbers-for-drama) when blocking protected block numbers, as there are legitimate reasons users may want to send to them (they are often used for testing)